### PR TITLE
fix(arrow): expand bounds based on interpolated points

### DIFF
--- a/packages/core/src/components/container/container.tsx
+++ b/packages/core/src/components/container/container.tsx
@@ -15,7 +15,7 @@ export const Container = React.memo(
     const rBounds = usePosition(bounds, rotation)
 
     return (
-      <div id={id} ref={rBounds} className={className + ' tl-positioned'}>
+      <div id={id} ref={rBounds} className={['tl-positioned', className || ''].join(' ')}>
         {children}
       </div>
     )

--- a/packages/core/src/components/handles/handle.tsx
+++ b/packages/core/src/components/handles/handle.tsx
@@ -12,26 +12,22 @@ interface HandleProps {
 export const Handle = React.memo(({ id, point }: HandleProps) => {
   const events = useHandleEvents(id)
 
-  const bounds = React.useMemo(
-    () =>
-      Utils.translateBounds(
+  return (
+    <Container
+      bounds={Utils.translateBounds(
         {
           minX: 0,
           minY: 0,
-          maxX: 32,
-          maxY: 32,
-          width: 32,
-          height: 32,
+          maxX: 0,
+          maxY: 0,
+          width: 0,
+          height: 0,
         },
         point
-      ),
-    [point]
-  )
-
-  return (
-    <Container bounds={bounds}>
+      )}
+    >
       <SVGContainer>
-        <g className="tl-handles" {...events}>
+        <g className="tl-handle" {...events}>
           <circle className="tl-handle-bg" pointerEvents="all" />
           <circle className="tl-counter-scaled tl-handle" pointerEvents="none" r={4} />
         </g>

--- a/packages/core/src/components/shape/shape.tsx
+++ b/packages/core/src/components/shape/shape.tsx
@@ -25,12 +25,7 @@ export const Shape = <T extends TLShape, E extends Element, M>({
   const events = useShapeEvents(shape.id, isCurrentParent)
 
   return (
-    <Container
-      id={shape.id}
-      className={'tl-shape' + (isCurrentParent ? 'tl-current-parent' : '')}
-      bounds={bounds}
-      rotation={shape.rotation}
-    >
+    <Container id={shape.id} className="tl-shape" bounds={bounds} rotation={shape.rotation}>
       <RenderedShape
         shape={shape}
         isBinding={isBinding}

--- a/packages/core/src/hooks/useStyle.tsx
+++ b/packages/core/src/hooks/useStyle.tsx
@@ -113,7 +113,7 @@ const tlcss = css`
     --tl-scale: calc(1 / var(--tl-zoom));
     --tl-camera-x: 0px;
     --tl-camera-y: 0px;
-    --tl-padding: calc(64px * var(--tl-scale));
+    --tl-padding: calc(64px * max(1, var(--tl-scale)));
     position: relative;
     top: 0px;
     left: 0px;
@@ -279,23 +279,23 @@ const tlcss = css`
     stroke-width: 2px;
   }
 
-  .tl-handles {
+  .tl-handle {
     pointer-events: all;
   }
 
-  .tl-handles:hover > .tl-handle-bg {
+  .tl-handle:hover .tl-handle-bg {
     fill: var(--tl-selectFill);
   }
 
-  .tl-handles:hover > .tl-handle-bg > * {
+  .tl-handle:hover .tl-handle-bg > * {
     stroke: var(--tl-selectFill);
   }
 
-  .tl-handles:active > .tl-handle-bg {
+  .tl-handle:active .tl-handle-bg {
     fill: var(--tl-selectFill);
   }
 
-  .tl-handles:active > .tl-handle-bg > * {
+  .tl-handle:active .tl-handle-bg > * {
     stroke: var(--tl-selectFill);
   }
 
@@ -309,7 +309,7 @@ const tlcss = css`
     fill: transparent;
     stroke: none;
     pointer-events: all;
-    r: calc(20 / max(1, var(--tl-zoom)));
+    r: calc(20px / max(1, var(--tl-zoom)));
   }
 
   .tl-binding-indicator {

--- a/packages/core/src/shapes/createShape.tsx
+++ b/packages/core/src/shapes/createShape.tsx
@@ -206,8 +206,13 @@ export const ShapeUtil = function <T extends TLShape, E extends Element, M = any
   Object.assign(this, fn.call(this))
   Object.assign(this, fn.call(this))
 
-  this.getBounds = this.getBounds.bind(this)
-  this.Component = this.Component.bind(this)
+  // Make sure all functions are bound to this
+  for (const entry of Object.entries(this)) {
+    if (entry[1] instanceof Function) {
+      this[entry[0] as keyof typeof this] = this[entry[0]].bind(this)
+    }
+  }
+
   this._Component = React.forwardRef(this.Component)
 
   return this

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "./dist/types",
     "rootDir": "src",
     "baseUrl": "src",
-    "emitDeclarationOnly": false,
     "paths": {
       "+*": ["./*"],
       "@tldraw/vec": ["../vec"],

--- a/packages/intersect/tsconfig.json
+++ b/packages/intersect/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "./dist/types",
     "rootDir": "src",
     "baseUrl": "src",
-    "emitDeclarationOnly": false,
     "paths": {
       "@tldraw/vec": ["../vec"]
     }

--- a/packages/tldraw/src/state/session/sessions/arrow/arrow.session.ts
+++ b/packages/tldraw/src/state/session/sessions/arrow/arrow.session.ts
@@ -10,6 +10,7 @@ import {
 import { Vec } from '@tldraw/vec'
 import { Utils } from '@tldraw/core'
 import { TLDR } from '~state/tldr'
+import { ThickArrowDownIcon } from '@radix-ui/react-icons'
 
 export class ArrowSession implements Session {
   id = 'transform_single'
@@ -18,6 +19,7 @@ export class ArrowSession implements Session {
   delta = [0, 0]
   offset = [0, 0]
   origin: number[]
+  topLeft: number[]
   initialShape: ArrowShape
   handleId: 'start' | 'end'
   bindableShapeIds: string[]
@@ -33,6 +35,7 @@ export class ArrowSession implements Session {
     this.origin = point
     this.handleId = handleId
     this.initialShape = TLDR.getShape<ArrowShape>(data, shapeId, data.appState.currentPageId)
+    this.topLeft = this.initialShape.point
     this.bindableShapeIds = TLDR.getBindableShapeIds(data)
 
     const initialBindingId = this.initialShape.handles[this.handleId].bindingId
@@ -66,7 +69,9 @@ export class ArrowSession implements Session {
     }
 
     // First update the handle's next point
-    const change = TLDR.getShapeUtils<ArrowShape>(shape.type).onHandleChange(
+    const utils = TLDR.getShapeUtils<ArrowShape>(shape.type)
+
+    const change = utils.onHandleChange(
       shape,
       {
         [handleId]: handle,

--- a/packages/tldraw/src/state/session/sessions/handle/handle.session.ts
+++ b/packages/tldraw/src/state/session/sessions/handle/handle.session.ts
@@ -9,6 +9,7 @@ export class HandleSession implements Session {
   status = TLDrawStatus.TranslatingHandle
   commandId: string
   delta = [0, 0]
+  topLeft: number[]
   origin: number[]
   shiftKey = false
   initialShape: ShapesWithProp<'handles'>
@@ -17,6 +18,7 @@ export class HandleSession implements Session {
   constructor(data: Data, handleId: string, point: number[], commandId = 'move_handle') {
     const { currentPageId } = data.appState
     const shapeId = TLDR.getSelectedIds(data, currentPageId)[0]
+    this.topLeft = point
     this.origin = point
     this.handleId = handleId
     this.initialShape = TLDR.getShape(data, shapeId, currentPageId)
@@ -43,6 +45,7 @@ export class HandleSession implements Session {
     }
 
     // First update the handle's next point
+
     const change = TLDR.getShapeUtils(shape).onHandleChange(
       shape,
       {

--- a/packages/tldraw/tsconfig.json
+++ b/packages/tldraw/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "./dist/types",
     "rootDir": "src",
     "baseUrl": "src",
-    "emitDeclarationOnly": false,
     "paths": {
       "~*": ["./*"],
       "@tldraw/core": ["../core"],


### PR DESCRIPTION
This PR changes the bounding box for curved arrow shapes so that it is based on more points (20) along the curve of the arrow. This fixes a bug where the arrow shape could escape its SVG box.

### Change type

- [x] `bugfix`

### Test plan

1. Create a curved arrow and verify the bounding box correctly encapsulates the curve at extreme angles.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where curved arrows could extend beyond their selection bounds.