### PR TITLE
improvement(editor): update group hover logic for children

### DIFF
--- a/packages/tldraw/src/components/page-options-dialog/page-options-dialog.tsx
+++ b/packages/tldraw/src/components/page-options-dialog/page-options-dialog.tsx
@@ -67,10 +67,10 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
 
   React.useEffect(() => {
     if (isOpen) {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         rInput.current?.focus()
         rInput.current?.select()
-      }, 0)
+      })
     }
   }, [isOpen])
 

--- a/packages/tldraw/src/shape/shapes/text/text.tsx
+++ b/packages/tldraw/src/shape/shapes/text/text.tsx
@@ -149,11 +149,11 @@ export const Text = new ShapeUtil<TextShape, HTMLDivElement, TLDrawMeta>(() => (
 
     React.useEffect(() => {
       if (isEditing) {
-        setTimeout(() => {
+        requestAnimationFrame(() => {
           const elm = rInput.current!
           elm.focus()
           elm.select()
-        }, 0)
+        })
       } else {
         const elm = rInput.current!
         elm.setSelectionRange(0, 0)

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -2598,7 +2598,7 @@ export class TLDrawState extends StateManager<Data> {
 
   onUnhoverShape: TLPointerEventHandler = (info) => {
     const { currentPageId } = this
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       if (currentPageId === this.currentPageId && this.pageState.hoveredId === info.target) {
         this.patchState(
           {
@@ -2613,7 +2613,7 @@ export class TLDrawState extends StateManager<Data> {
           `unhovered_shape:${info.target}`
         )
       }
-    }, 10)
+    })
   }
 
   // Bounds (bounding box background)


### PR DESCRIPTION
Shapes with children will now have `isHovered` as `true` if any child is hovered or selected.

### Change type

- [x] `improvement`

### Test plan

1. Create a group of shapes.
2. Hover over a child shape within the group.
3. Verify the group displays as hovered.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved logic for when to display a group as hovered when children are interacted with.