### PR TITLE
fix: copy group shapes as svg

### DIFF
--- a/packages/tldraw/src/state/__snapshots__/tlstate.spec.ts.snap
+++ b/packages/tldraw/src/state/__snapshots__/tlstate.spec.ts.snap
@@ -125,4 +125,14 @@ Array [
 ]
 `;
 
+exports[`TLDrawState Selection When selecting all selects all: selected all 1`] = `
+Array [
+  "rect1",
+  "rect2",
+  "rect3",
+]
+`;
+
+exports[`TLDrawState When copying to SVG Copies grouped shapes.: copied svg with group 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-16 -16 232 232\\" width=\\"200\\" height=\\"200\\"><g/></svg>"`;
+
 exports[`TLDrawState When copying to SVG Copies shapes.: copied svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-20.741879096242684 -20.741879096242684 236.74 236.74\\" width=\\"204.74\\" height=\\"204.74\\"/>"`;

--- a/packages/tldraw/src/state/tlstate.spec.ts
+++ b/packages/tldraw/src/state/tlstate.spec.ts
@@ -113,7 +113,17 @@ describe('TLDrawState', () => {
 
     it.todo('re-creates shapes on redo after creating')
 
-    it.todo('selects all')
+    describe('When selecting all', () => {
+      it('selects all', () => {
+        const tlstate = new TLDrawState().loadDocument(mockDocument).selectAll()
+        expect(tlstate.selectedIds).toMatchSnapshot('selected all')
+      })
+
+      it('does not select children of a group', () => {
+        const tlstate = new TLDrawState().loadDocument(mockDocument).selectAll().group()
+        expect(tlstate.selectedIds.length).toBe(1)
+      })
+    })
 
     // Single click on a selected shape to select just that shape
 

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -986,9 +986,7 @@ export class TLDrawState extends StateManager<Data> {
     function getSvgElementForShape(shape: TLDrawShape) {
       const elm = document.getElementById(shape.id + '_svg')
 
-      if (!elm) {
-        throw Error("Can't copy an element without an id_svg id")
-      }
+      if (!elm) return
 
       // TODO: Create SVG elements for text
 
@@ -1015,7 +1013,8 @@ export class TLDrawState extends StateManager<Data> {
         shape.children
           .map((childId) => this.getShape(childId, pageId))
           .map(getSvgElementForShape)
-          .forEach((element) => g.appendChild(element))
+          .filter(Boolean)
+          .forEach((element) => g.appendChild(element!))
 
         // Add the group element to the SVG
         svg.appendChild(g)
@@ -1338,13 +1337,22 @@ export class TLDrawState extends StateManager<Data> {
   /**
    * Select all shapes on the page.
    */
-  selectAll = (): this => {
+  selectAll = (pageId = this.currentPageId): this => {
     if (this.session) return this
-    this.setSelectedIds(Object.keys(this.page.shapes))
+
+    // Select only shapes that are the direct child of the page
+    this.setSelectedIds(
+      Object.values(this.document.pages[pageId].shapes)
+        .filter((shape) => shape.parentId === pageId)
+        .map((shape) => shape.id)
+    )
+
     this.addToSelectHistory(this.selectedIds)
+
     if (this.appState.activeTool !== 'select') {
       this.selectTool('select')
     }
+
     return this
   }
 


### PR DESCRIPTION
This PR fixes a bug where groups were not being copied. Groups are copied as a <g> element with their children as descendants.

![Kapture 2021-09-23 at 10 23 58](https://user-images.githubusercontent.com/23072548/134483730-b488a331-5250-48cd-9d55-368f98a20b13.gif)

Closes https://github.com/tldraw/tldraw-v1/issues/526

### Change type

- [x] `bugfix` 

### Test plan

1. Create a group of shapes.
2. Copy the group as SVG.
3. Verify the SVG contains a <g> element with children.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where group shapes were not correctly exported to SVG.