### PR TITLE
fix(arrows): resolve resize cursor issues

### DIFF
--- a/packages/core/src/components/bounds/bounds.tsx
+++ b/packages/core/src/components/bounds/bounds.tsx
@@ -32,9 +32,9 @@ export function Bounds({
 
   const smallDimension = Math.min(bounds.width, bounds.height) * zoom
   // If the bounds are small, don't show the rotate handle
-  const showRotateHandle = !isLocked && smallDimension > 32
+  const showRotateHandle = !isHidden && !isLocked && smallDimension > 32
   // If the bounds are very small, don't show the corner handles
-  const showHandles = !isLocked && smallDimension > 16
+  const showHandles = !isHidden && !isLocked && smallDimension > 16
 
   return (
     <Container bounds={bounds} rotation={rotation}>

--- a/packages/core/src/components/bounds/corner-handle.tsx
+++ b/packages/core/src/components/bounds/corner-handle.tsx
@@ -3,10 +3,10 @@ import { useBoundsHandleEvents } from '+hooks'
 import { TLBoundsCorner, TLBounds } from '+types'
 
 const cornerBgClassnames = {
-  [TLBoundsCorner.TopLeft]: 'tl-transparent tl-cursor-nwse',
-  [TLBoundsCorner.TopRight]: 'tl-transparent tl-cursor-nesw',
-  [TLBoundsCorner.BottomRight]: 'tl-transparent tl-cursor-nwse',
-  [TLBoundsCorner.BottomLeft]: 'tl-transparent tl-cursor-nesw',
+  [TLBoundsCorner.TopLeft]: 'tl-cursor-nwse',
+  [TLBoundsCorner.TopRight]: 'tl-cursor-nesw',
+  [TLBoundsCorner.BottomRight]: 'tl-cursor-nwse',
+  [TLBoundsCorner.BottomLeft]: 'tl-cursor-nesw',
 }
 
 interface CornerHandleProps {
@@ -27,7 +27,7 @@ export const CornerHandle = React.memo(
     return (
       <g opacity={isHidden ? 0 : 1}>
         <rect
-          className={cornerBgClassnames[corner]}
+          className={'tl-transparent ' + (isHidden ? '' : cornerBgClassnames[corner])}
           x={(isLeft ? -1 : bounds.width + 1) - targetSize}
           y={(isTop ? -1 : bounds.height + 1) - targetSize}
           width={targetSize * 2}

--- a/packages/core/src/components/bounds/edge-handle.tsx
+++ b/packages/core/src/components/bounds/edge-handle.tsx
@@ -3,10 +3,10 @@ import { useBoundsHandleEvents } from '+hooks'
 import { TLBoundsEdge, TLBounds } from '+types'
 
 const edgeClassnames = {
-  [TLBoundsEdge.Top]: 'tl-transparent tl-edge-handle tl-cursor-ns',
-  [TLBoundsEdge.Right]: 'tl-transparent tl-edge-handle tl-cursor-ew',
-  [TLBoundsEdge.Bottom]: 'tl-transparent tl-edge-handle tl-cursor-ns',
-  [TLBoundsEdge.Left]: 'tl-transparent tl-edge-handle tl-cursor-ew',
+  [TLBoundsEdge.Top]: 'tl-cursor-ns',
+  [TLBoundsEdge.Right]: 'tl-cursor-ew',
+  [TLBoundsEdge.Bottom]: 'tl-cursor-ns',
+  [TLBoundsEdge.Left]: 'tl-cursor-ew',
 }
 
 interface EdgeHandleProps {
@@ -29,7 +29,7 @@ export const EdgeHandle = React.memo(
     return (
       <rect
         pointerEvents={isHidden ? 'none' : 'all'}
-        className={edgeClassnames[edge]}
+        className={'tl-transparent tl-edge-handle ' + (isHidden ? '' : edgeClassnames[edge])}
         opacity={isHidden ? 0 : 1}
         x={isHorizontal ? size / 2 : (isFarEdge ? width + 1 : -1) - size / 2}
         y={isHorizontal ? (isFarEdge ? height + 1 : -1) - size / 2 : size / 2}


### PR DESCRIPTION
This PR fixes the bug described here: https://github.com/tldraw/tldraw-v1/issues/454

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow and verify the resize cursors appear correctly on handles.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where resize cursors were incorrect on arrows.