### PR TITLE
feat(arrow): add start arrow binding

### DIFF
--- a/packages/tldraw/src/state/session/sessions/arrow/arrow.session.spec.ts
+++ b/packages/tldraw/src/state/session/sessions/arrow/arrow.session.spec.ts
@@ -168,4 +168,26 @@ describe('When creating with an arrow session', () => {
 
     expect(tlstate.getShape('arrow1')).toBe(undefined)
   })
+
+  it('Creates a start binding if possible', () => {
+    const tlstate = new TLDrawState()
+      .createShapes(
+        { type: TLDrawShapeType.Rectangle, id: 'rect1', point: [200, 200], size: [200, 200] },
+        { type: TLDrawShapeType.Rectangle, id: 'rect2', point: [400, 200], size: [200, 200] },
+        { type: TLDrawShapeType.Arrow, id: 'arrow1', point: [250, 250] }
+      )
+      .select('arrow1')
+      .startSession(SessionType.Arrow, [250, 250], 'end', true)
+      .updateSession([450, 250])
+      .completeSession()
+
+    const arrow = tlstate.shapes.find((shape) => shape.type === TLDrawShapeType.Arrow) as ArrowShape
+
+    expect(arrow).toBeTruthy()
+
+    expect(tlstate.bindings.length).toBe(2)
+
+    expect(arrow.handles.start.bindingId).not.toBe(undefined)
+    expect(arrow.handles.end.bindingId).not.toBe(undefined)
+  })
 })

--- a/packages/tldraw/src/state/session/sessions/transform-single/transform-single.session.ts
+++ b/packages/tldraw/src/state/session/sessions/transform-single/transform-single.session.ts
@@ -74,15 +74,24 @@ export class TransformSingleSession implements Session {
   cancel = (data: Data) => {
     const { initialShape } = this.snapshot
 
-    const shapes = {} as Record<string, Partial<TLDrawShape>>
+    const shapes = {} as Record<string, TLDrawShape | undefined>
 
-    shapes[initialShape.id] = initialShape
+    if (this.isCreate) {
+      shapes[initialShape.id] = undefined
+    } else {
+      shapes[initialShape.id] = initialShape
+    }
 
     return {
       document: {
         pages: {
           [data.appState.currentPageId]: {
             shapes,
+          },
+        },
+        pageStates: {
+          [data.appState.currentPageId]: {
+            selectedIds: this.isCreate ? [] : [initialShape.id],
           },
         },
       },

--- a/packages/tldraw/src/state/session/sessions/transform/transform.session.ts
+++ b/packages/tldraw/src/state/session/sessions/transform/transform.session.ts
@@ -106,6 +106,11 @@ export class TransformSession implements Session {
             shapes,
           },
         },
+        pageStates: {
+          [data.appState.currentPageId]: {
+            selectedIds: this.isCreate ? [] : shapeBounds.map((shape) => shape.id),
+          },
+        },
       },
     }
   }

--- a/packages/tldraw/src/state/tlstate.spec.ts
+++ b/packages/tldraw/src/state/tlstate.spec.ts
@@ -331,7 +331,7 @@ describe('TLDrawState', () => {
 
       const tlu = new TLStateUtils(tlstate)
       tlu.clickShape('rect1')
-      expect(tlstate.selectedGroupId).toBeUndefined()
+      expect((tlstate.currentTool as SelectTool).selectedGroupId).toBeUndefined()
       expect(tlstate.selectedIds).toStrictEqual(['groupA'])
     })
 
@@ -354,7 +354,7 @@ describe('TLDrawState', () => {
       const tlu = new TLStateUtils(tlstate)
       tlu.doubleClickShape('rect1')
       tlu.clickShape('rect3')
-      expect(tlstate.selectedGroupId).toBeUndefined()
+      expect((tlstate.currentTool as SelectTool).selectedGroupId).toBeUndefined()
       expect(tlstate.selectedIds).toStrictEqual(['rect3'])
     })
 

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -1624,7 +1624,7 @@ export class TLDrawState extends StateManager<Data> {
     const result = this.session.start(this.state)
 
     if (result) {
-      return this.patchState(
+      this.patchState(
         {
           ...result,
           appState: {
@@ -1635,7 +1635,8 @@ export class TLDrawState extends StateManager<Data> {
       )
     }
 
-    return this.setStatus(this.session.status)
+    return this
+    // return this.setStatus(this.session.status)
   }
 
   /**

--- a/packages/tldraw/src/state/tool/BaseTool/BaseTool.ts
+++ b/packages/tldraw/src/state/tool/BaseTool/BaseTool.ts
@@ -47,7 +47,11 @@ export abstract class BaseTool<T extends string = any> {
 
   onCancel = () => {
     this.state.cancelSession()
-    this.setStatus(Status.Idle)
+    if (this.status === Status.Idle) {
+      this.state.selectTool('select')
+    } else {
+      this.setStatus(Status.Idle)
+    }
   }
 
   getNextChildIndex = () => {
@@ -86,6 +90,11 @@ export abstract class BaseTool<T extends string = any> {
   /* ---------------------- Keys ---------------------- */
 
   onKeyDown: TLKeyboardEventHandler = (key, info) => {
+    if (key === 'Escape') {
+      this.onCancel()
+      return
+    }
+
     /* noop */
     if (key === 'Meta' || key === 'Control' || key === 'Alt') {
       this.state.updateSession(


### PR DESCRIPTION
This PR adds the ability to create a start binding when creating a new arrow. The start arrow will be anchored to the center of the hovered shape.

![Kapture 2021-10-16 at 15 30 30](https://user-images.githubusercontent.com/23072548/137591384-890976a1-9665-466d-a093-a836f4fc0d3b.gif)

### Change type

- [x] `feature`

### Test plan

1. Create a new arrow starting from inside an existing shape.
2. Verify the arrow start is bound to that shape.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Added support for start arrow binding when creating new arrows.