### PR TITLE
fix(arrow): resolve binding and bending issues

### DIFF
--- a/packages/tldraw/src/state/session/sessions/arrow/arrow.session.spec.ts
+++ b/packages/tldraw/src/state/session/sessions/arrow/arrow.session.spec.ts
@@ -190,4 +190,31 @@ describe('When creating with an arrow session', () => {
     expect(arrow.handles.start.bindingId).not.toBe(undefined)
     expect(arrow.handles.end.bindingId).not.toBe(undefined)
   })
+
+  it('Removes a binding when dragged away', () => {
+    const tlstate = new TLDrawState()
+      .createShapes(
+        { type: TLDrawShapeType.Rectangle, id: 'rect1', point: [200, 200], size: [200, 200] },
+        { type: TLDrawShapeType.Rectangle, id: 'rect2', point: [400, 200], size: [200, 200] },
+        { type: TLDrawShapeType.Arrow, id: 'arrow1', point: [250, 250] }
+      )
+      .select('arrow1')
+      .startSession(SessionType.Arrow, [250, 250], 'end', true)
+      .updateSession([450, 250])
+      .completeSession()
+      .select('arrow1')
+      .startSession(SessionType.Arrow, [250, 250], 'start', false)
+      .updateSession([0, 0])
+      .completeSession()
+
+    const arrow = tlstate.shapes.find((shape) => shape.type === TLDrawShapeType.Arrow) as ArrowShape
+
+    expect(arrow).toBeTruthy()
+
+    expect(tlstate.bindings.length).toBe(1)
+
+    expect(arrow.handles.start.point).toStrictEqual([0, 0])
+    expect(arrow.handles.start.bindingId).toBe(undefined)
+    expect(arrow.handles.end.bindingId).not.toBe(undefined)
+  })
 })

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -227,7 +227,9 @@ export class TLDrawState extends StateManager<Data> {
 
           // If binding is undefined, delete the binding
           Object.keys(page.bindings).forEach((id) => {
-            if (!page.bindings[id]) delete page.bindings[id]
+            if (!page.bindings[id]) {
+              delete page.bindings[id]
+            }
           })
 
           // Find which shapes have changed
@@ -242,6 +244,10 @@ export class TLDrawState extends StateManager<Data> {
 
           // Update all of the bindings we've just collected
           bindingsToUpdate.forEach((binding) => {
+            if (!page.bindings[binding.id]) {
+              return
+            }
+
             const toShape = page.shapes[binding.toId]
             const fromShape = page.shapes[binding.fromId]
 
@@ -1648,7 +1654,7 @@ export class TLDrawState extends StateManager<Data> {
     if (!session) return this
     const patch = session.update(this.state, point, shiftKey, altKey, metaKey)
     if (!patch) return this
-    return this.patchState(patch, `session:updateSession.id}`)
+    return this.patchState(patch, `session:${session?.constructor.name}`)
   }
 
   /**
@@ -2199,6 +2205,8 @@ export class TLDrawState extends StateManager<Data> {
 
     if (this.state.room) {
       const { users, userId } = this.state.room
+
+      if (Object.values(users).length === 1) return
 
       this.updateUsers(
         [

--- a/packages/tldraw/src/state/tool/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/state/tool/SelectTool/SelectTool.ts
@@ -41,7 +41,7 @@ export class SelectTool extends BaseTool<Status> {
 
   selectedGroupId?: string
 
-  pointedHandleId?: 'start' | 'end'
+  pointedHandleId?: 'start' | 'end' | 'bend'
 
   pointedBoundsHandle?: TLBoundsCorner | TLBoundsEdge | 'rotate'
 
@@ -303,12 +303,12 @@ export class SelectTool extends BaseTool<Status> {
 
         if (!selectedShape) return
 
-        const point = this.state.getPagePoint(info.origin)
+        const point = this.state.getPagePoint(info.point)
 
-        if (selectedShape.type === TLDrawShapeType.Arrow) {
-          this.state.startSession(SessionType.Arrow, point, this.pointedHandleId)
-        } else {
+        if (this.pointedHandleId === 'bend') {
           this.state.startSession(SessionType.Handle, point, this.pointedHandleId)
+        } else {
+          this.state.startSession(SessionType.Arrow, point, this.pointedHandleId, false)
         }
       }
       return


### PR DESCRIPTION
This PR fixes a few bugs related to arrow binding.

## 1

A bug where arrows with an initial binding could not be immediately be changed.

![Kapture 2021-10-16 at 19 34 52](https://user-images.githubusercontent.com/23072548/137598554-a8da40be-584c-4706-af58-f8a01b9df883.gif)

![Kapture 2021-10-16 at 19 37 46](https://user-images.githubusercontent.com/23072548/137598633-32df1585-97b3-48fd-a300-b3412fa2f49a.gif)

## 2

A shape's bend handle would not bend the arrow.

![Kapture 2021-10-16 at 19 40 04](https://user-images.githubusercontent.com/23072548/137598664-cc3fec7d-e828-479a-b244-b8964e4afbdb.gif)

### Change type

- [x] `bugfix` 

### Test plan

1. Create an arrow with an initial binding and attempt to change it immediately.
2. Use a shape's bend handle and ensure the arrow bends correctly.

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed bugs related to arrow binding and bending handles.