### PR TITLE
fix: make room optional

### DIFF
--- a/packages/tldraw/src/types.ts
+++ b/packages/tldraw/src/types.ts
@@ -65,7 +65,7 @@ export interface Data {
     status: string
   }
   document: TLDrawDocument
-  room: {
+  room?: {
     id: string
     userId: string
     users: Record<string, TLDrawUser>


### PR DESCRIPTION
This PR fixes an issue where the app would crash if `state.room` was not present. We want to make this optional in the data for times when the client is not connected to a multiplayer room, though at the moment it is still added to the data for a new page.

### Change type

- [x] `bugfix` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Make room data optional to prevent crashes when not connected to multiplayer.