### PR TITLE
improvement(multiplayer): refine presence and add onUserChange

### DIFF
--- a/packages/core/src/components/canvas/canvas.tsx
+++ b/packages/core/src/components/canvas/canvas.tsx
@@ -80,7 +80,9 @@ export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
               hideHandles={hideHandles}
               meta={meta}
             />
-            {users && userId && <UsersIndicators userId={userId} users={users} meta={meta} />}
+            {users && userId && (
+              <UsersIndicators userId={userId} users={users} page={page} meta={meta} />
+            )}
             {pageState.brush && <Brush brush={pageState.brush} />}
             {users && <Users userId={userId} users={users} />}
           </div>

--- a/packages/core/src/components/page/page.tsx
+++ b/packages/core/src/components/page/page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react'
 import type { TLBinding, TLPage, TLPageState, TLShape, TLShapeUtil } from '+types'
-import { useSelection, useShapeTree, useHandles, useTLContext } from '+hooks'
+import { useSelection, useShapeTree, useTLContext } from '+hooks'
 import { Bounds } from '+components/bounds'
 import { BoundsBg } from '+components/bounds/bounds-bg'
 import { Handles } from '+components/handles'

--- a/packages/core/src/components/users-indicators/users-indicators.tsx
+++ b/packages/core/src/components/users-indicators/users-indicators.tsx
@@ -1,17 +1,23 @@
 import * as React from 'react'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ShapeIndicator } from '+components/shape-indicator'
-import type { TLShape, TLUsers } from '+types'
+import type { TLPage, TLShape, TLUsers } from '+types'
 import Utils from '+utils'
 import { useTLContext } from '+hooks'
 
 interface UserIndicatorProps<T extends TLShape> {
+  page: TLPage<any, any>
   userId: string
   users: TLUsers<T>
   meta: any
 }
 
-export function UsersIndicators<T extends TLShape>({ userId, users, meta }: UserIndicatorProps<T>) {
+export function UsersIndicators<T extends TLShape>({
+  userId,
+  users,
+  meta,
+  page,
+}: UserIndicatorProps<T>) {
   const { shapeUtils } = useTLContext()
 
   return (
@@ -20,7 +26,9 @@ export function UsersIndicators<T extends TLShape>({ userId, users, meta }: User
         .filter(Boolean)
         .filter((user) => user.id !== userId && user.selectedIds.length > 0)
         .map((user) => {
-          const shapes = user.activeShapes //.map((id) => page.shapes[id])
+          const shapes = user.selectedIds.map((id) => page.shapes[id]).filter(Boolean)
+
+          if (shapes.length === 0) return null
 
           const bounds = Utils.getCommonBounds(
             shapes.map((shape) => shapeUtils[shape.type].getBounds(shape))

--- a/packages/core/src/components/users/users.tsx
+++ b/packages/core/src/components/users/users.tsx
@@ -11,7 +11,7 @@ export function Users({ userId, users }: UserProps) {
   return (
     <>
       {Object.values(users)
-        .filter((user) => user.id !== userId)
+        .filter((user) => user && user.id !== userId)
         .map((user) => (
           <User key={user.id} user={user} />
         ))}

--- a/packages/tldraw/src/components/tldraw/tldraw.tsx
+++ b/packages/tldraw/src/components/tldraw/tldraw.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { IdProvider } from '@radix-ui/react-id'
 import { Renderer } from '@tldraw/core'
 import css from '~styles'
-import { Data, TLDrawDocument, TLDrawStatus } from '~types'
+import { Data, TLDrawDocument, TLDrawStatus, TLDrawUser } from '~types'
 import { TLDrawState } from '~state'
 import {
   TLDrawContext,
@@ -83,6 +83,8 @@ export interface TLDrawProps {
    * (optional) A callback to run when the component's state changes.
    */
   onChange?: TLDrawState['_onChange']
+
+  onUserChange?: (state: TLDrawState, user: TLDrawUser) => void
 }
 
 export function TLDraw({
@@ -94,16 +96,19 @@ export function TLDraw({
   showPages = true,
   onMount,
   onChange,
+  onUserChange,
 }: TLDrawProps) {
   const [sId, setSId] = React.useState(id)
 
-  const [tlstate, setTlstate] = React.useState(() => new TLDrawState(id, onChange, onMount))
+  const [tlstate, setTlstate] = React.useState(
+    () => new TLDrawState(id, onMount, onChange, onUserChange)
+  )
   const [context, setContext] = React.useState(() => ({ tlstate, useSelector: tlstate.useStore }))
 
   React.useEffect(() => {
     if (id === sId) return
     // If a new id is loaded, replace the entire state
-    const newState = new TLDrawState(id, onChange, onMount)
+    const newState = new TLDrawState(id, onMount, onChange, onUserChange)
     setTlstate(newState)
     setContext({ tlstate: newState, useSelector: newState.useStore })
     setSId(id)


### PR DESCRIPTION
This PR rolls back some of the changes to live multiplayer presence and fixes various bugs related to multiplayer. It also adds the `onUserChange` method to avoid pushing changes to the user's own presence state through state patches.

### Change type

- [x] `improvement`

### Test plan

1. Open a multiplayer room in two tabs and verify presence indicators update correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved multiplayer presence handling and fixed related bugs.