### PR TITLE
fix: improve zoom to selection and zoom to fit logic

### DIFF
--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -1396,7 +1396,7 @@ export class TLDrawState extends StateManager<Data> {
     )
 
     zoom =
-      this.pageState.camera.zoom === zoom || this.pageState.camera.zoom <= 1
+      this.pageState.camera.zoom === zoom || this.pageState.camera.zoom < 1
         ? Math.min(1, zoom)
         : zoom
 
@@ -1425,7 +1425,7 @@ export class TLDrawState extends StateManager<Data> {
     )
 
     zoom =
-      this.pageState.camera.zoom === zoom || this.pageState.camera.zoom <= 1
+      this.pageState.camera.zoom === zoom || this.pageState.camera.zoom < 1
         ? Math.min(1, zoom)
         : zoom
 


### PR DESCRIPTION
This PR improves the "zoom to fit" and "zoom to selection" methods.
 
When either method is executed, the following logic applies:

- IF the camera has a value less than 100%
- OR if the computed zoom is the same as the current zoom
- THEN zoom to 100%
- ELSE zoom to fill the screen

![Kapture 2021-10-17 at 09 30 56](https://user-images.githubusercontent.com/23072548/137618752-3517a20f-53a8-4c94-a1ad-0c34c4d36429.gif)

In most cases, zooming to 100% is a better experience. However, this logic allows a user to press the command twice to toggle between a "filled" zoom view and a 100% zoomed view.

### Change type

- [x] `bugfix` 

### Test plan

1. Select an object and use the "zoom to selection" command.
2. Observe that it zooms to 100% if current zoom is < 100%.
3. Observe that it toggles between fill and 100% on subsequent presses.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved the behavior of zoom to fit and zoom to selection to toggle between 100% and fill.