### PR TITLE
feat: add up and downstream controls for links

### DIFF
--- a/packages/core/src/components/bounds/link-handle.tsx
+++ b/packages/core/src/components/bounds/link-handle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useTLContext } from '+hooks'
+import { useBoundsHandleEvents, useTLContext } from '+hooks'
 import type { TLBounds } from '+types'
 
 interface LinkHandleProps {
@@ -9,35 +9,40 @@ interface LinkHandleProps {
   bounds: TLBounds
 }
 
-export function LinkHandle({ size, bounds, targetSize, isHidden }: LinkHandleProps) {
-  const { callbacks, inputs } = useTLContext()
-
-  const handleClick = React.useCallback(
-    (e: React.PointerEvent<SVGCircleElement>) => {
-      e.stopPropagation()
-      const info = inputs.pointerDown(e, 'link')
-      callbacks.onPointLinkHandle?.(info, e)
-    },
-    [callbacks.onPointLinkHandle]
-  )
+export function LinkHandle({ size, bounds, isHidden }: LinkHandleProps) {
+  const leftEvents = useBoundsHandleEvents('left')
+  const centerEvents = useBoundsHandleEvents('center')
+  const rightEvents = useBoundsHandleEvents('right')
 
   return (
-    <g cursor="grab">
-      <circle
-        className="tl-transparent"
-        cx={bounds.width / 2}
-        cy={bounds.height + size * 2}
-        r={targetSize}
-        pointerEvents={isHidden ? 'none' : 'all'}
-        onPointerDown={handleClick}
-      />
-      <path
-        className="tl-rotate-handle"
-        transform={`translate(${bounds.width / 2 - size / 2}, ${bounds.height + size * 1.7})`}
-        d={`M 0,0 L ${size},0 ${size / 2},${size} Z`}
-        pointerEvents="none"
-        opacity={isHidden ? 0 : 1}
-      />
+    <g
+      cursor="grab"
+      transform={`translate(${bounds.width / 2 - size * 4}, ${bounds.height + size * 2})`}
+    >
+      <g className="tl-transparent" pointerEvents={isHidden ? 'none' : 'all'}>
+        <rect x={0} y={0} width={size * 2} height={size * 2} {...leftEvents} />
+        <rect x={size * 3} y={0} width={size * 2} height={size * 2} {...centerEvents} />
+        <rect x={size * 6} y={0} width={size * 2} height={size * 2} {...rightEvents} />
+      </g>
+      <g className="tl-rotate-handle" transform={`translate(${size / 2}, ${size / 2})`}>
+        <path
+          d={`M 0,${size / 2} L ${size},${size} ${size},0 Z`}
+          pointerEvents="none"
+          opacity={isHidden ? 0 : 1}
+        />
+        <path
+          transform={`translate(${size * 3}, 0)`}
+          d={`M 0,0 L ${size},0 ${size / 2},${size} Z`}
+          pointerEvents="none"
+          opacity={isHidden ? 0 : 1}
+        />
+        <path
+          transform={`translate(${size * 6}, 0)`}
+          d={`M ${size},${size / 2} L 0,0 0,${size} Z`}
+          pointerEvents="none"
+          opacity={isHidden ? 0 : 1}
+        />
+      </g>
     </g>
   )
 }

--- a/packages/core/src/hooks/useBoundsHandleEvents.tsx
+++ b/packages/core/src/hooks/useBoundsHandleEvents.tsx
@@ -2,7 +2,9 @@ import * as React from 'react'
 import type { TLBoundsEdge, TLBoundsCorner } from '+types'
 import { useTLContext } from './useTLContext'
 
-export function useBoundsHandleEvents(id: TLBoundsCorner | TLBoundsEdge | 'rotate') {
+export function useBoundsHandleEvents(
+  id: TLBoundsCorner | TLBoundsEdge | 'rotate' | 'center' | 'left' | 'right'
+) {
   const { callbacks, inputs } = useTLContext()
 
   const onPointerDown = React.useCallback(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -164,7 +164,7 @@ export type TLCanvasEventHandler = (info: TLPointerInfo<'canvas'>, e: React.Poin
 export type TLBoundsEventHandler = (info: TLPointerInfo<'bounds'>, e: React.PointerEvent) => void
 
 export type TLBoundsHandleEventHandler = (
-  info: TLPointerInfo<TLBoundsCorner | TLBoundsEdge | 'rotate'>,
+  info: TLPointerInfo<TLBoundsCorner | TLBoundsEdge | 'rotate' | 'center' | 'left' | 'right'>,
   e: React.PointerEvent
 ) => void
 
@@ -231,7 +231,6 @@ export interface TLCallbacks<T extends TLShape> {
   onRenderCountChange: (ids: string[]) => void
   onError: (error: Error) => void
   onBoundsChange: (bounds: TLBounds) => void
-  onPointLinkHandle: TLPointerEventHandler
 
   // Keyboard event handlers
   onKeyDown: TLKeyboardEventHandler

--- a/packages/tldraw/src/components/tldraw/tldraw.tsx
+++ b/packages/tldraw/src/components/tldraw/tldraw.tsx
@@ -276,7 +276,6 @@ function InnerTldraw({
           onShapeChange={tlstate.onShapeChange}
           onShapeBlur={tlstate.onShapeBlur}
           onShapeClone={tlstate.onShapeClone}
-          onPointLinkHandle={tlstate.onPointLinkHandle}
           onBoundsChange={tlstate.updateBounds}
           onKeyDown={tlstate.onKeyDown}
           onKeyUp={tlstate.onKeyUp}

--- a/packages/tldraw/src/state/session/sessions/translate/translate.session.spec.ts
+++ b/packages/tldraw/src/state/session/sessions/translate/translate.session.spec.ts
@@ -339,5 +339,7 @@ describe('When snapping', () => {
 })
 
 describe('When translating linked shapes', () => {
-  it.todo('Translates all shapes that are chain-linked to the selected shapes')
+  it.todo('translates all linked shapes when center is dragged')
+  it.todo('translates all upstream linked shapes when left is dragged')
+  it.todo('translates all downstream linked shapes when right is dragged')
 })

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -2341,9 +2341,6 @@ export class TLDrawState extends StateManager<Data> {
 
   onShapeClone: TLShapeCloneHandler = (info, e) => this.currentTool.onShapeClone?.(info, e)
 
-  onPointLinkHandle: TLPointerEventHandler = (info, e) =>
-    this.currentTool.onPointLinkHandle?.(info, e)
-
   onRenderCountChange = (ids: string[]) => {
     const appState = this.getAppState()
     if (appState.isEmptyCanvas && ids.length > 0) {

--- a/packages/tldraw/src/state/tool/BaseTool/BaseTool.ts
+++ b/packages/tldraw/src/state/tool/BaseTool/BaseTool.ts
@@ -192,5 +192,4 @@ export abstract class BaseTool<T extends string = any> {
   // Misc
   onShapeBlur?: TLShapeBlurHandler
   onShapeClone?: TLShapeCloneHandler
-  onPointLinkHandle?: TLPointerEventHandler
 }

--- a/packages/tldraw/src/state/tool/SelectTool/SelectTool.spec.ts
+++ b/packages/tldraw/src/state/tool/SelectTool/SelectTool.spec.ts
@@ -7,3 +7,9 @@ describe('SelectTool', () => {
     new SelectTool(tlstate)
   })
 })
+
+describe('When double clicking link controls', () => {
+  it.todo('selects all linked shapes when center is double clicked')
+  it.todo('selects all upstream linked shapes when left is double clicked')
+  it.todo('selects all downstream linked shapes when right is double clicked')
+})


### PR DESCRIPTION
This PR adds controls for up and downstream links. 

When a bound shape is selected, a user can:
- drag the left control to move all shapes upstream (pointing to, recursively) of the selected shapes
- drag the right control to move all shapes downstream (pointing from, recursively) of the selected shapes
- drag the centre control to move shapes in both directions

![Kapture 2021-10-19 at 10 46 05](https://user-images.githubusercontent.com/23072548/137899348-9fadc39f-dea1-4bbf-8e27-75d165fd4269.gif)

- double click the left control to select all shapes upstream (pointing to, recursively) of the selected shapes (shift to include arrows)
- double click the right control to select all shapes downstream (pointing from, recursively) of the selected shapes  (shift to include arrows)
- double click the centre control to select shapes in both directions (shift to include arrows)

![Kapture 2021-10-19 at 11 59 31](https://user-images.githubusercontent.com/23072548/137899377-7e0a5f37-f704-4448-a96c-bcae4c718947.gif)

This PR also includes a fix for toggling arrow decorations.

### Change type

- [x] `feature` 

### Test plan

1. Select a bound shape and drag the left/right/center controls to verify recursive movement.
2. Double click the controls (with and without shift) to verify recursive selection.

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added up and downstream controls for links to move or select connected shapes recursively.