### PR TITLE
fix: restore selection on undo / redo

### DIFF
--- a/packages/tldraw/src/state/command/align/align.command.ts
+++ b/packages/tldraw/src/state/command/align/align.command.ts
@@ -58,6 +58,11 @@ export function align(data: Data, ids: string[], type: AlignType): TLDrawCommand
             shapes: before,
           },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
@@ -65,6 +70,11 @@ export function align(data: Data, ids: string[], type: AlignType): TLDrawCommand
         pages: {
           [currentPageId]: {
             shapes: after,
+          },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
           },
         },
       },

--- a/packages/tldraw/src/state/command/distribute/distribute.command.ts
+++ b/packages/tldraw/src/state/command/distribute/distribute.command.ts
@@ -24,12 +24,22 @@ export function distribute(data: Data, ids: string[], type: DistributeType): TLD
         pages: {
           [currentPageId]: { shapes: before },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
       document: {
         pages: {
           [currentPageId]: { shapes: after },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/flip/flip.command.ts
+++ b/packages/tldraw/src/state/command/flip/flip.command.ts
@@ -64,12 +64,22 @@ export function flip(data: Data, ids: string[], type: FlipType): TLDrawCommand {
         pages: {
           [data.appState.currentPageId]: { shapes: before },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
       document: {
         pages: {
           [data.appState.currentPageId]: { shapes: after },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/group/group.command.ts
+++ b/packages/tldraw/src/state/command/group/group.command.ts
@@ -199,7 +199,7 @@ export function group(
         },
         pageStates: {
           [pageId]: {
-            selectedIds: TLDR.getSelectedIds(data, pageId),
+            selectedIds: ids,
           },
         },
       },

--- a/packages/tldraw/src/state/command/move/move.command.ts
+++ b/packages/tldraw/src/state/command/move/move.command.ts
@@ -221,14 +221,24 @@ export function move(data: Data, ids: string[], type: MoveType): TLDrawCommand {
     before: {
       document: {
         pages: {
-          [data.appState.currentPageId]: { shapes: result.before },
+          [currentPageId]: { shapes: result.before },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },
     after: {
       document: {
         pages: {
-          [data.appState.currentPageId]: { shapes: result.after },
+          [currentPageId]: { shapes: result.after },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/reset-bounds/reset-bounds.command.ts
+++ b/packages/tldraw/src/state/command/reset-bounds/reset-bounds.command.ts
@@ -2,6 +2,8 @@ import type { Data, TLDrawCommand } from '~types'
 import { TLDR } from '~state/tldr'
 
 export function resetBounds(data: Data, ids: string[], pageId: string): TLDrawCommand {
+  const { currentPageId } = data.appState
+
   const { before, after } = TLDR.mutateShapes(
     data,
     ids,
@@ -16,12 +18,22 @@ export function resetBounds(data: Data, ids: string[], pageId: string): TLDrawCo
         pages: {
           [data.appState.currentPageId]: { shapes: before },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
       document: {
         pages: {
           [data.appState.currentPageId]: { shapes: after },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/rotate/rotate.command.spec.ts
+++ b/packages/tldraw/src/state/command/rotate/rotate.command.spec.ts
@@ -40,3 +40,20 @@ describe('Rotate command', () => {
 
   it.todo('Rotates shapes with handles.')
 })
+
+describe('when running the command', () => {
+  it('restores selection on undo', () => {
+    const tlstate = new TLDrawState()
+      .loadDocument(mockDocument)
+      .select('rect1')
+      .rotate()
+      .deselectAll()
+      .undo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
+
+    tlstate.deselectAll().redo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
+  })
+})

--- a/packages/tldraw/src/state/command/rotate/rotate.command.ts
+++ b/packages/tldraw/src/state/command/rotate/rotate.command.ts
@@ -50,7 +50,10 @@ export function rotate(data: Data, ids: string[], delta = -PI2 / 4): TLDrawComma
           [currentPageId]: { shapes: before },
         },
         pageStates: {
-          [currentPageId]: { boundsRotation: beforeBoundsRotation },
+          [currentPageId]: {
+            selectedIds: ids,
+            boundsRotation: beforeBoundsRotation,
+          },
         },
       },
     },
@@ -60,7 +63,10 @@ export function rotate(data: Data, ids: string[], delta = -PI2 / 4): TLDrawComma
           [currentPageId]: { shapes: after },
         },
         pageStates: {
-          [currentPageId]: { boundsRotation: afterBoundsRotation },
+          [currentPageId]: {
+            selectedIds: ids,
+            boundsRotation: afterBoundsRotation,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/stretch/stretch.command.spec.ts
+++ b/packages/tldraw/src/state/command/stretch/stretch.command.spec.ts
@@ -64,3 +64,20 @@ describe('Stretch command', () => {
     expect(tlstate.getShape<RectangleShape>('rect2').size).toStrictEqual([100, 200])
   })
 })
+
+describe('when running the command', () => {
+  it('restores selection on undo', () => {
+    const tlstate = new TLDrawState()
+      .loadDocument(mockDocument)
+      .select('rect1', 'rect2')
+      .stretch(StretchType.Horizontal)
+      .deselectAll()
+      .undo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1', 'rect2'])
+
+    tlstate.deselectAll().redo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1', 'rect2'])
+  })
+})

--- a/packages/tldraw/src/state/command/stretch/stretch.command.ts
+++ b/packages/tldraw/src/state/command/stretch/stretch.command.ts
@@ -6,6 +6,8 @@ import { TLDR } from '~state/tldr'
 export function stretch(data: Data, ids: string[], type: StretchType): TLDrawCommand {
   const { currentPageId } = data.appState
 
+  const selectedIds = TLDR.getSelectedIds(data, currentPageId)
+
   const initialShapes = ids.map((id) => TLDR.getShape(data, id, currentPageId))
 
   const boundsForShapes = initialShapes.map((shape) => TLDR.getBounds(shape))
@@ -63,12 +65,22 @@ export function stretch(data: Data, ids: string[], type: StretchType): TLDrawCom
         pages: {
           [currentPageId]: { shapes: before },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds,
+          },
+        },
       },
     },
     after: {
       document: {
         pages: {
           [currentPageId]: { shapes: after },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/style/style.command.spec.ts
+++ b/packages/tldraw/src/state/command/style/style.command.spec.ts
@@ -3,11 +3,10 @@ import { mockDocument } from '~test'
 import { SizeStyle } from '~types'
 
 describe('Style command', () => {
-  const tlstate = new TLDrawState()
-  tlstate.loadDocument(mockDocument)
-  tlstate.select('rect1')
-
   it('does, undoes and redoes command', () => {
+    const tlstate = new TLDrawState()
+    tlstate.loadDocument(mockDocument)
+    tlstate.select('rect1')
     expect(tlstate.getShape('rect1').style.size).toEqual(SizeStyle.Medium)
 
     tlstate.style({ size: SizeStyle.Small })
@@ -45,5 +44,22 @@ describe('Style command', () => {
       expect(tlstate.getShape('rect1').style.size).toEqual(SizeStyle.Small)
       expect(tlstate.getShape('rect2').style.size).toEqual(SizeStyle.Small)
     })
+  })
+})
+
+describe('when running the command', () => {
+  it('restores selection on undo', () => {
+    const tlstate = new TLDrawState()
+      .loadDocument(mockDocument)
+      .select('rect1')
+      .style({ size: SizeStyle.Small })
+      .deselectAll()
+      .undo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
+
+    tlstate.deselectAll().redo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
   })
 })

--- a/packages/tldraw/src/state/command/style/style.command.ts
+++ b/packages/tldraw/src/state/command/style/style.command.ts
@@ -22,6 +22,11 @@ export function style(data: Data, ids: string[], changes: Partial<ShapeStyles>):
             shapes: before,
           },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
       appState: {
         currentStyle: { ...data.appState.currentStyle },
@@ -32,6 +37,11 @@ export function style(data: Data, ids: string[], changes: Partial<ShapeStyles>):
         pages: {
           [currentPageId]: {
             shapes: after,
+          },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
           },
         },
       },

--- a/packages/tldraw/src/state/command/toggle-decoration/toggle-decoration.command.ts
+++ b/packages/tldraw/src/state/command/toggle-decoration/toggle-decoration.command.ts
@@ -45,12 +45,22 @@ export function toggleDecoration(
         pages: {
           [currentPageId]: { shapes: beforeShapes },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
       document: {
         pages: {
           [currentPageId]: { shapes: afterShapes },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },

--- a/packages/tldraw/src/state/command/toggle/toggle.command.spec.ts
+++ b/packages/tldraw/src/state/command/toggle/toggle.command.spec.ts
@@ -60,3 +60,20 @@ describe('Toggle command', () => {
     expect(tlstate.getShape<RectangleShape>('rect1').isAspectRatioLocked).toBe(false)
   })
 })
+
+describe('when running the command', () => {
+  it('restores selection on undo', () => {
+    const tlstate = new TLDrawState()
+      .loadDocument(mockDocument)
+      .select('rect1')
+      .toggleHidden()
+      .deselectAll()
+      .undo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
+
+    tlstate.deselectAll().redo()
+
+    expect(tlstate.selectedIds).toEqual(['rect1'])
+  })
+})

--- a/packages/tldraw/src/state/command/toggle/toggle.command.ts
+++ b/packages/tldraw/src/state/command/toggle/toggle.command.ts
@@ -3,7 +3,9 @@ import { TLDR } from '~state/tldr'
 
 export function toggle(data: Data, ids: string[], prop: keyof TLDrawShape): TLDrawCommand {
   const { currentPageId } = data.appState
+
   const initialShapes = ids.map((id) => TLDR.getShape(data, id, currentPageId))
+
   const isAllToggled = initialShapes.every((shape) => shape[prop])
 
   const { before, after } = TLDR.mutateShapes(
@@ -24,6 +26,11 @@ export function toggle(data: Data, ids: string[], prop: keyof TLDrawShape): TLDr
             shapes: before,
           },
         },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
+        },
       },
     },
     after: {
@@ -31,6 +38,11 @@ export function toggle(data: Data, ids: string[], prop: keyof TLDrawShape): TLDr
         pages: {
           [currentPageId]: {
             shapes: after,
+          },
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
           },
         },
       },

--- a/packages/tldraw/src/state/command/translate/translate.command.ts
+++ b/packages/tldraw/src/state/command/translate/translate.command.ts
@@ -67,14 +67,24 @@ export function translate(data: Data, ids: string[], delta: number[]): TLDrawCom
     before: {
       document: {
         pages: {
-          [data.appState.currentPageId]: before,
+          [currentPageId]: before,
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },
     after: {
       document: {
         pages: {
-          [data.appState.currentPageId]: after,
+          [currentPageId]: after,
+        },
+        pageStates: {
+          [currentPageId]: {
+            selectedIds: ids,
+          },
         },
       },
     },


### PR DESCRIPTION
This PR adds selected ids to the command that did not have them before (with the exception of `updateShapes`).

### Change type

- [x] `bugfix` 

### Test plan

1. Perform various commands (align, distribute, flip, group, move, rotate, stretch, style, toggle).
2. Undo and redo the actions.
3. Verify that the selection is correctly restored.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where selection was not correctly restored on undo/redo for certain commands.