### PR TITLE
fix: resolve bug on group cloning

### DIFF
--- a/packages/tldraw/src/state/session/sessions/translate/translate.session.spec.ts
+++ b/packages/tldraw/src/state/session/sessions/translate/translate.session.spec.ts
@@ -298,6 +298,21 @@ describe('Translate session', () => {
         .updateSession([20, 20], false, false)
         .updateSession([20, 20], false, true)
         .completeSession()
+
+      expect(tlstate.shapes.filter((shape) => shape.type === TLDrawShapeType.Group).length).toBe(2)
+    })
+
+    it('deletes clones when not cloning anymore', () => {
+      tlstate
+        .loadDocument(mockDocument)
+        .select('rect1', 'rect2')
+        .group()
+        .startSession(SessionType.Translate, [10, 10])
+        .updateSession([20, 20], false, true)
+        .updateSession([20, 20], false, false)
+        .completeSession()
+
+      expect(tlstate.shapes.filter((shape) => shape.type === TLDrawShapeType.Group).length).toBe(1)
     })
 
     it('clones the shapes and children when selecting a group and a different shape', () => {

--- a/packages/tldraw/src/state/session/sessions/translate/translate.session.ts
+++ b/packages/tldraw/src/state/session/sessions/translate/translate.session.ts
@@ -12,6 +12,7 @@ import {
   GroupShape,
   SessionType,
   ArrowBinding,
+  TLDrawShapeType,
 } from '~types'
 import { SLOW_SPEED, SNAP_DISTANCE } from '~state/constants'
 import { TLDR } from '~state/tldr'
@@ -273,9 +274,8 @@ export class TranslateSession extends Session {
 
         bindingsToDelete.forEach((binding) => (nextBindings[binding.id] = undefined))
 
-        // Delete the clones
+        // Remove the clones from parents
         clones.forEach((clone) => {
-          nextShapes[clone.id] = undefined
           if (clone.parentId !== currentPageId) {
             nextShapes[clone.parentId] = {
               ...nextShapes[clone.parentId],
@@ -283,6 +283,9 @@ export class TranslateSession extends Session {
             }
           }
         })
+
+        // Delete the clones (including any parent clones)
+        clones.forEach((clone) => (nextShapes[clone.id] = undefined))
 
         // Move the original shapes back to the cursor position
         initialShapes.forEach((shape) => {


### PR DESCRIPTION
This PR fixes cloning for groups.

### Change type

- [x] `bugfix`

### Test plan

1. Create a group of shapes.
2. Clone the group.
3. Verify the cloned group and its children are correctly positioned and stateful.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where cloning groups would fail or behave unexpectedly.