### PR TITLE
fix: remove immediate undo entry on shape creation

### DIFF
--- a/packages/tldraw/src/state/tlstate.spec.ts
+++ b/packages/tldraw/src/state/tlstate.spec.ts
@@ -70,8 +70,6 @@ describe('TLDrawState', () => {
 
       const newGroup = newShapes.find((shape) => shape.type === TLDrawShapeType.Group)
 
-      console.log(newGroup)
-
       const newChildIds = newShapes
         .filter((shape) => shape.type !== TLDrawShapeType.Group)
         .map((shape) => shape.id)

--- a/packages/tldraw/src/state/tlstate.ts
+++ b/packages/tldraw/src/state/tlstate.ts
@@ -1931,6 +1931,16 @@ export class TLDrawState extends StateManager<Data> {
   }
 
   /**
+   * Patch in a new set of shapes
+   * @param shapes
+   * @param bindings
+   */
+  patchCreate = (shapes: TLDrawShape[] = [], bindings: TLDrawBinding[] = []): this => {
+    if (shapes.length === 0) return this
+    return this.patchState(Commands.create(this.state, shapes, bindings).after)
+  }
+
+  /**
    * Delete one or more shapes.
    * @param ids The ids of the shapes to delete.
    * @command

--- a/packages/tldraw/src/state/tool/ArrowTool/ArrowTool.ts
+++ b/packages/tldraw/src/state/tool/ArrowTool/ArrowTool.ts
@@ -28,7 +28,7 @@ export class ArrowTool extends BaseTool {
       style: { ...currentStyle },
     })
 
-    this.state.createShapes(newShape)
+    this.state.patchCreate([newShape])
 
     this.state.startSession(SessionType.Arrow, pagePoint, 'end', true)
 

--- a/packages/tldraw/src/state/tool/DrawTool/DrawTool.ts
+++ b/packages/tldraw/src/state/tool/DrawTool/DrawTool.ts
@@ -34,7 +34,7 @@ export class DrawTool extends BaseTool {
       style: { ...currentStyle },
     })
 
-    this.state.createShapes(newShape)
+    this.state.patchCreate([newShape])
 
     this.state.startSession(SessionType.Draw, pagePoint, id)
 

--- a/packages/tldraw/src/state/tool/EllipseTool/EllipseTool.ts
+++ b/packages/tldraw/src/state/tool/EllipseTool/EllipseTool.ts
@@ -1,5 +1,5 @@
 import Vec from '@tldraw/vec'
-import { Utils, TLPointerEventHandler, TLKeyboardEventHandler, TLBoundsCorner } from '@tldraw/core'
+import { Utils, TLPointerEventHandler, TLBoundsCorner } from '@tldraw/core'
 import { Ellipse } from '~shape/shapes'
 import { SessionType, TLDrawShapeType } from '~types'
 import { BaseTool, Status } from '../BaseTool'
@@ -28,7 +28,7 @@ export class EllipseTool extends BaseTool {
       style: { ...currentStyle },
     })
 
-    this.state.createShapes(newShape)
+    this.state.patchCreate([newShape])
 
     this.state.startSession(
       SessionType.TransformSingle,

--- a/packages/tldraw/src/state/tool/RectangleTool/RectangleTool.ts
+++ b/packages/tldraw/src/state/tool/RectangleTool/RectangleTool.ts
@@ -28,7 +28,7 @@ export class RectangleTool extends BaseTool {
       style: { ...currentStyle },
     })
 
-    this.state.createShapes(newShape)
+    this.state.patchCreate([newShape])
 
     this.state.startSession(
       SessionType.TransformSingle,


### PR DESCRIPTION
This PR removes an immediate undo redo entry when creating a shape.

### Change type

- [x] `bugfix` 

### Test plan

1. Create a shape (arrow, draw, ellipse, or rectangle).
2. Verify that an unnecessary undo entry is not created immediately upon start.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where creating a shape would sometimes create an extra undo/redo entry.