### PR TITLE
fix(menu): remove extra divider in context menu

### DIFF
--- a/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
@@ -133,23 +133,18 @@ export const ContextMenu = ({ children }: ContextMenuProps): JSX.Element => {
               <CMRowButton onSelect={handleDuplicate} kbd="#D">
                 Duplicate
               </CMRowButton>
-              <Divider />
+              {(hasTwoOrMore || hasGroupSelected) && <Divider />}
               {hasTwoOrMore && (
-                <>
-                  <CMRowButton onSelect={handleGroup} kbd="#G">
-                    Group
-                  </CMRowButton>
-                  <Divider />
-                </>
+                <CMRowButton onSelect={handleGroup} kbd="#G">
+                  Group
+                </CMRowButton>
               )}
               {hasGroupSelected && (
-                <>
-                  <CMRowButton onSelect={handleGroup} kbd="#⇧G">
-                    Ungroup
-                  </CMRowButton>
-                  <Divider />
-                </>
+                <CMRowButton onSelect={handleGroup} kbd="#⇧G">
+                  Ungroup
+                </CMRowButton>
               )}
+              <Divider />
               <ContextMenuSubMenu label="Move">
                 <CMRowButton onSelect={handleMoveToFront} kbd="⇧]">
                   To Front


### PR DESCRIPTION
This PR removes an unnecessary double divider appearing in the context menu.

### Change type

- [x] `bugfix` 

### Test plan

1. Open the context menu on a shape.
2. Verify that there is only one divider between the relevant sections.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where an extra divider appeared in the context menu.

## Issue (2 divider in context menu)
![image](https://user-images.githubusercontent.com/354596/140590924-8e01ab85-9d66-44d9-bb5c-95582b570d6f.png)
## After fix
![group](https://user-images.githubusercontent.com/354596/140590944-445c1e03-8962-4e10-9050-afa10af54f73.gif)

## Open Question
Shall we need a divider above group (between Duplicate & Group)