### PR TITLE
chore: change listening port from 5000 to 5420

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ A binding is a connection **from** one shape and **to** another shape. At the mo
 
 - Run `yarn start` to start the development server for the package and for the example.
 
-- Open `localhost:5000` to view the example project.
+- Open `localhost:5420` to view the example project.
 
 - Run `yarn test` to execute unit tests via [Jest](https://jestjs.io).
 

--- a/example/esbuild.config.mjs
+++ b/example/esbuild.config.mjs
@@ -35,7 +35,7 @@ esbuild
   .catch(() => process.exit(1))
 
 serve.start({
-  port: 5000,
+  port: 5420,
   root: './dist',
   live: true,
 })

--- a/example/scripts/dev.mjs
+++ b/example/scripts/dev.mjs
@@ -26,13 +26,12 @@ async function main() {
         },
         watch: {
           onRebuild(err) {
-            serve.update()
             err ? error('❌ Failed') : log('✅ Updated')
           },
         },
       },
       {
-        port: 5000,
+        port: 5420,
         root: './dist',
         live: true,
       }

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -221,7 +221,7 @@ A binding is a connection **from** one shape and **to** another shape. At the mo
 
 - Run `yarn start` to start the development server for the package and for the example.
 
-- Open `localhost:5000` to view the example project.
+- Open `localhost:5420` to view the example project.
 
 - Run `yarn test` to execute unit tests via [Jest](https://jestjs.io).
 

--- a/vscode/editor/esbuild.config.mjs
+++ b/vscode/editor/esbuild.config.mjs
@@ -35,7 +35,7 @@ esbuild
   .catch(() => process.exit(1))
 
 serve.start({
-  port: 5000,
+  port: 5420,
   root: './dist',
   live: true,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6009,7 +6009,7 @@ electron-util@^0.17.2:
     electron-is-dev "^1.1.0"
     new-github-issue-url "^0.2.1"
 
-electron@^15.3.0:
+electron@15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.0.tgz#f9803c5a05b2dac12efc6d4203492c7e204b4819"
   integrity sha512-YLzaKCFmSniNlz9+NUTNs7ssPyDc+bYOCYZ0b/D6DjVkOeIFz4SR8EYKqlOc8TcqlDNu18BbWqz6zbJPyAAURg==


### PR DESCRIPTION
This is due to a conflict with port 5000 on MacOS Monterey. [Learn more](https://developer.apple.com/forums/thread/682332).

### Change type

- [x] `other`

### Test plan

1. Run the dev server and verify it starts on port 5420.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Changed default dev port from 5000 to 5420 to avoid macOS Monterey conflicts.