### PR TITLE
fix(top-panel): resolve touch event blocking

### DIFF
--- a/packages/tldraw/src/components/TopPanel/TopPanel.tsx
+++ b/packages/tldraw/src/components/TopPanel/TopPanel.tsx
@@ -52,8 +52,13 @@ const StyledTopPanel = styled('div', {
   right: 0,
   display: 'flex',
   flexDirection: 'row',
+  pointerEvents: 'none',
+  '& > *': {
+    pointerEvents: 'all',
+  },
 })
 
 const StyledSpacer = styled('div', {
   flexGrow: 2,
+  pointerEvents: 'none',
 })


### PR DESCRIPTION
This PR fixes touch events on the top panel, which were being blocked from the canvas previously.

### Change type

- [x] `bugfix` 

### Test plan

1. Interact with the top panel on a touch device and verify events are no longer blocked.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where touch events on the top panel were blocked.