### PR TITLE
fix: preserve spaces in sticky and text shapes

### DIFF
--- a/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
+++ b/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
@@ -235,8 +235,11 @@ export class StickyUtil extends TLDrawShapeUtil<T, E> {
 const PADDING = 16
 const MIN_CONTAINER_HEIGHT = 200
 
+const fixNewLines = /\r?\n|\r/g
+const fixSpaces = / /g
+
 function normalizeText(text: string) {
-  return text.replace(/\r?\n|\r/g, '\n')
+  return text.replace(fixNewLines, '\n').replace(fixSpaces, '\u00a0')
 }
 
 const StyledStickyContainer = styled('div', {

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -280,8 +280,11 @@ export class TextUtil extends TLDrawShapeUtil<T, E> {
 
 const LETTER_SPACING = -1.5
 
+const fixNewLines = /\r?\n|\r/g
+const fixSpaces = / /g
+
 function normalizeText(text: string) {
-  return text.replace(/\r?\n|\r/g, '\n')
+  return text.replace(fixNewLines, '\n').replace(fixSpaces, '\u00a0')
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR replaces spaces with non breaking spaces in Text and Sticky shapes, in order to preserve the result between the textarea text and the normal div text.

### Change type

- [x] `bugfix` 

### Test plan

1. Create a sticky note or text shape.
2. Enter text with multiple consecutive spaces.
3. Verify that the spaces are preserved correctly in the rendered view.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where spaces in sticky notes and text shapes were not being preserved correctly.