### PR TITLE
feat(vscode): update document when file changes

### DIFF
--- a/vscode/editor/src/app.tsx
+++ b/vscode/editor/src/app.tsx
@@ -38,8 +38,8 @@ export default function App(): JSX.Element {
   // When the file changes from VS Code's side, update the editor's document.
   React.useEffect(() => {
     function handleMessage(event: MessageEvent) {
-      if (event.type === EXTENSION_EVENT.FILE_UPDATED) {
-        const { document } = event.data as TLDrawFile
+      if (event.data.type === EXTENSION_EVENT.FILE_UPDATED) {
+        const { document } = JSON.parse(event.data.text) as TLDrawFile
         const state = rTLDrawState.current!
         state.updateDocument(document)
       }

--- a/vscode/editor/src/types.ts
+++ b/vscode/editor/src/types.ts
@@ -3,5 +3,6 @@ export enum UI_EVENT {
 }
 
 export enum EXTENSION_EVENT {
+  OPENED_FILE = 'OPENED_FILE',
   FILE_UPDATED = 'FILE_UPDATED',
 }

--- a/vscode/extension/src/TLDrawEditorProvider.ts
+++ b/vscode/extension/src/TLDrawEditorProvider.ts
@@ -163,7 +163,7 @@ export class TLDrawEditorProvider implements vscode.CustomTextEditorProvider {
           const nextFile = JSON.parse(e.text) as TLDrawFile
 
           // There's no reason to sanitize if the file contents are still an empty file.
-          if( document.getText() !== "" ){
+          if (document.getText() !== '') {
             const prevFile = JSON.parse(document.getText()) as TLDrawFile
             nextFile.document = sanitizeDocument(prevFile.document, nextFile.document)
           }


### PR DESCRIPTION
This PR adds the ability for external changes to the document to be reflected in open VS Code files. The mechanism should be exactly the same as how we're handling changes in multiplayer, except that we won't be doing any conflict resolution—which might present some interesting bugs.

### Change type

- [x] `feature`

### Test plan

1. Open a tldraw file in VS Code.
2. Modify the file externally (e.g., via another editor or git).
3. Observe the changes reflecting in the VS Code editor.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- VS Code: Update document when file changes externally