### PR TITLE
fix(draw): resolve drawing shift on fast starts

### DIFF
--- a/packages/tldraw/src/state/sessions/DrawSession/DrawSession.ts
+++ b/packages/tldraw/src/state/sessions/DrawSession/DrawSession.ts
@@ -28,6 +28,7 @@ export class DrawSession extends Session {
     // when the draw session ends; if the user hasn't added additional
     // points, this single point will be interpreted as a "dot" shape.
     this.points = [[0, 0, point[2] || 0.5]]
+    this.shiftedPoints = [...this.points]
   }
 
   start = () => void null
@@ -122,10 +123,7 @@ export class DrawSession extends Session {
       // If the new top left is the same as the previous top left,
       // we don't need to shift anything: we just shift the new point
       // and add it to the shifted points array.
-      points = [
-        ...this.shiftedPoints,
-        Vec.sub(newPoint, Vec.sub(topLeft, this.origin)).concat(newPoint[2]),
-      ]
+      points = [...this.shiftedPoints, Vec.sub(newPoint, delta).concat(newPoint[2])]
     }
 
     this.shiftedPoints = points


### PR DESCRIPTION
This PR fixes a long-time bug in the drawing tool where a mark that starts quickly will appear to "shift" relative to its top left corner.

![Kapture 2021-11-12 at 22 17 14](https://user-images.githubusercontent.com/23072548/141541303-a69f7308-6a71-413b-a82d-314855bd76b2.gif)

### Change type

- [x] `bugfix` 

### Test plan

1. Start a drawing mark quickly and verify it does not shift relative to its origin.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where drawing marks could shift position when starting a stroke quickly.