### PR TITLE
[feature] resize from center

### DIFF
--- a/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
@@ -1,5 +1,5 @@
 import { mockDocument, TldrawTestApp } from '~test'
-import { TLBoundsCorner, Utils } from '@tldraw/core'
+import { TLBoundsCorner, TLBoundsEdge, Utils } from '@tldraw/core'
 import { TLDR } from '~state/TLDR'
 import { TDShapeType, TDStatus } from '~types'
 
@@ -243,4 +243,78 @@ describe('When snapping', () => {
   it.todo('Snaps to a shape on screen')
   it.todo('Does not snap to a shape off screen.')
   it.todo('Snaps while panning.')
+})
+
+describe('When holding alt', () => {
+  it('resizes edge from center', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(
+      Utils.getCommonBounds(app.shapes.map(TLDR.getBounds))
+    )
+
+    app
+      .selectAll()
+      .pointBoundsHandle(TLBoundsEdge.Left, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(Utils.getCommonBounds(app.shapes.map(TLDR.getBounds)))
+
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes edge from center while holding shift', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(
+      Utils.getCommonBounds(app.shapes.map(TLDR.getBounds))
+    )
+
+    app
+      .selectAll()
+      .pointBoundsHandle(TLBoundsEdge.Left, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, shiftKey: true, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(Utils.getCommonBounds(app.shapes.map(TLDR.getBounds)))
+
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes corner from center', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(
+      Utils.getCommonBounds(app.shapes.map(TLDR.getBounds))
+    )
+
+    app
+      .selectAll()
+      .pointBoundsHandle(TLBoundsCorner.TopLeft, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(Utils.getCommonBounds(app.shapes.map(TLDR.getBounds)))
+
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes corner from center while holding shift', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(
+      Utils.getCommonBounds(app.shapes.map(TLDR.getBounds))
+    )
+
+    app
+      .selectAll()
+      .pointBoundsHandle(TLBoundsCorner.TopLeft, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, shiftKey: true, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(Utils.getCommonBounds(app.shapes.map(TLDR.getBounds)))
+
+    expect(beforeCenter).toEqual(afterCenter)
+  })
 })

--- a/packages/tldraw/src/state/sessions/TransformSession/TransformSession.ts
+++ b/packages/tldraw/src/state/sessions/TransformSession/TransformSession.ts
@@ -111,6 +111,7 @@ export class TransformSession extends BaseSession {
         previousPoint,
         originPoint,
         shiftKey,
+        altKey,
         metaKey,
         settings: { isSnapping },
       },
@@ -118,7 +119,9 @@ export class TransformSession extends BaseSession {
 
     const shapes = {} as Record<string, TDShape>
 
-    const delta = Vec.sub(currentPoint, originPoint)
+    const delta = altKey
+      ? Vec.mul(Vec.sub(currentPoint, originPoint), 2)
+      : Vec.sub(currentPoint, originPoint)
 
     let newBounds = Utils.getTransformedBoundingBox(
       initialCommonBounds,
@@ -127,6 +130,13 @@ export class TransformSession extends BaseSession {
       0,
       shiftKey || isAllAspectRatioLocked
     )
+
+    if (altKey) {
+      newBounds = {
+        ...newBounds,
+        ...Utils.centerBounds(newBounds, Utils.getBoundsCenter(initialCommonBounds)),
+      }
+    }
 
     // Should we snap?
 

--- a/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.spec.ts
@@ -1,6 +1,7 @@
 import { mockDocument, TldrawTestApp } from '~test'
-import { TLBoundsCorner } from '@tldraw/core'
+import { TLBoundsCorner, TLBoundsEdge, Utils } from '@tldraw/core'
 import { TDStatus } from '~types'
+import { TLDR } from '~state/TLDR'
 
 describe('Transform single session', () => {
   it('begins, updateSession', () => {
@@ -38,4 +39,67 @@ describe('When snapping', () => {
   it.todo('Snaps to a shape on screen')
   it.todo('Does not snap to a shape off screen.')
   it.todo('Snaps while panning.')
+})
+
+describe('When holding alt', () => {
+  it('resizes edge from center', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+
+    app
+      .select('rect1')
+      .pointBoundsHandle(TLBoundsEdge.Left, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes edge from center while holding shift', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+
+    app
+      .select('rect1')
+      .pointBoundsHandle(TLBoundsEdge.Left, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, shiftKey: true, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes corner from center', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+
+    app
+      .select('rect1')
+      .pointBoundsHandle(TLBoundsCorner.TopLeft, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+    expect(beforeCenter).toEqual(afterCenter)
+  })
+
+  it('resizes corner from center while holding shift', () => {
+    const app = new TldrawTestApp().loadDocument(mockDocument)
+
+    const beforeCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+
+    app
+      .select('rect1')
+      .pointBoundsHandle(TLBoundsCorner.TopLeft, { x: 0, y: 0 })
+      .movePointer({ x: 20, y: 10, shiftKey: true, altKey: true })
+      .completeSession()
+
+    const afterCenter = Utils.getBoundsCenter(app.getShapeBounds('rect1'))
+    expect(beforeCenter).toEqual(afterCenter)
+  })
 })

--- a/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
+++ b/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
@@ -78,13 +78,16 @@ export class TransformSingleSession extends BaseSession {
         previousPoint,
         originPoint,
         shiftKey,
+        altKey,
         metaKey,
       },
     } = this
 
     if (initialShape.isLocked) return void null
 
-    const delta = Vec.sub(currentPoint, originPoint)
+    const delta = altKey
+      ? Vec.mul(Vec.sub(currentPoint, originPoint), 2)
+      : Vec.sub(currentPoint, originPoint)
 
     const shapes = {} as Record<string, Partial<TDShape>>
 
@@ -99,6 +102,13 @@ export class TransformSingleSession extends BaseSession {
       shape.rotation,
       shiftKey || shape.isAspectRatioLocked || utils.isAspectRatioLocked
     )
+
+    if (altKey) {
+      newBounds = {
+        ...newBounds,
+        ...Utils.centerBounds(newBounds, Utils.getBoundsCenter(initialShapeBounds)),
+      }
+    }
 
     // Should we snap?
 


### PR DESCRIPTION
When transforming shapes, hold the alt key to keep the original center position.

![Kapture 2021-11-17 at 11 04 21](https://user-images.githubusercontent.com/23072548/142189106-2dc77cfa-1a02-4b72-9ad7-ec2135a72608.gif)


