### PR TITLE
fix: add deletion to the history after backspace is pressed

### DIFF
--- a/examples/core-example-advanced/src/state/actions/bindings/getBoundHandlePoint.ts
+++ b/examples/core-example-advanced/src/state/actions/bindings/getBoundHandlePoint.ts
@@ -29,6 +29,9 @@ export function getBoundHandlePoint(
     // If the other handle is also bound to a shape, use that other shape's center instead
     // of the handle's actual point
     const otherToShape = data.page.shapes[oppositeBinding.toId]
+
+    if (!otherToShape) return
+
     oppositePoint = getShapeUtils(otherToShape).getCenter(otherToShape)
   } else {
     oppositePoint = Vec.add(fromShape.point, oppositeHandle.point)

--- a/examples/core-example-advanced/src/state/actions/bindings/updateBoundShapes.ts
+++ b/examples/core-example-advanced/src/state/actions/bindings/updateBoundShapes.ts
@@ -27,12 +27,14 @@ export const updateBoundShapes: Action = (data) => {
     const boundHandle = fromShape.handles[binding.handleId]
     const intersection = getBoundHandlePoint(data, fromShape, toShape, boundHandle.id)
 
-    if (!Vec.isEqual(boundHandle.point, intersection)) {
-      boundHandle.point = Vec.sub(intersection, fromShape.point)
-      const handles = Object.values(fromShape.handles)
-      const offset = Utils.getCommonTopLeft(handles.map((handle) => handle.point))
-      fromShape.point = Vec.add(fromShape.point, offset)
-      handles.forEach((handle) => (handle.point = Vec.sub(handle.point, offset)))
+    if (intersection) {
+      if (!Vec.isEqual(boundHandle.point, intersection)) {
+        boundHandle.point = Vec.sub(intersection, fromShape.point)
+        const handles = Object.values(fromShape.handles)
+        const offset = Utils.getCommonTopLeft(handles.map((handle) => handle.point))
+        fromShape.point = Vec.add(fromShape.point, offset)
+        handles.forEach((handle) => (handle.point = Vec.sub(handle.point, offset)))
+      }
     }
   }
 

--- a/examples/core-example-advanced/src/state/machine.ts
+++ b/examples/core-example-advanced/src/state/machine.ts
@@ -47,7 +47,7 @@ export const machine = createState({
             SELECTED_ALL: 'selectAllShapes',
             DESELECTED_ALL: 'deselectAllShapes',
             CANCELLED: ['deselectAllShapes', 'updateBoundShapes'],
-            DELETED: ['deleteSelectedShapes', 'updateBoundShapes'],
+            DELETED: ['deleteSelectedShapes', 'addToHistory'],
             UNDO: 'undo',
             REDO: 'redo',
             HOVERED_SHAPE: 'setHoveredShape',

--- a/examples/core-example-advanced/src/state/machine.ts
+++ b/examples/core-example-advanced/src/state/machine.ts
@@ -47,7 +47,7 @@ export const machine = createState({
             SELECTED_ALL: 'selectAllShapes',
             DESELECTED_ALL: 'deselectAllShapes',
             CANCELLED: ['deselectAllShapes', 'updateBoundShapes'],
-            DELETED: ['deleteSelectedShapes', 'addToHistory'],
+            DELETED: ['deleteSelectedShapes', 'updateBoundShapes', 'addToHistory'],
             UNDO: 'undo',
             REDO: 'redo',
             HOVERED_SHAPE: 'setHoveredShape',


### PR DESCRIPTION
This fixes a bug where the shape would reappear (i.e., the deletion would not be saved) if you click the backspace button and immediately refresh the page.