### PR TITLE
[fix] zoom shortcuts

### DIFF
--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -83,7 +83,7 @@
 			{
 				"key": "cmd+numpad0",
 				"title": "Zoom Out",
-				"command": "tldraw.tldr.zoomReset",
+				"command": "tldraw.tldr.resetZoom",
 				"category": "tldraw",
 				"enablement": "resourceExtname == .tldr"
 			}
@@ -93,24 +93,6 @@
 				"command": "tldraw.tldr.new",
 				"title": "New File",
 				"category": "tldraw"
-			},
-			{
-				"command": "tldraw.tldr.zoomIn",
-				"title": "Zoom In",
-				"category": "tldraw",
-				"enablement": "resourceExtname == .tldr"
-			},
-			{
-				"command": "tldraw.tldr.zoomOut",
-				"title": "Zoom Out",
-				"category": "tldraw",
-				"enablement": "resourceExtname == .tldr"
-			},
-			{
-				"command": "tldraw.tldr.zoomReset",
-				"title": "Zoom Reset",
-				"category": "tldraw",
-				"enablement": "resourceExtname == .tldr"
 			}
 		]
 	},

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -51,11 +51,74 @@
 				]
 			}
 		],
+		"keybindings": [
+			{
+				"key": "cmd+numpad_add",
+				"title": "Zoom In",
+				"command": "tldraw.tldr.zoomIn",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "shift+cmd+=",
+				"title": "Zoom In",
+				"command": "tldraw.tldr.zoomIn",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "cmd+=",
+				"title": "Zoom In",
+				"command": "tldraw.tldr.zoomIn",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "cmd+numpad_subtract",
+				"title": "Zoom Out",
+				"command": "tldraw.tldr.zoomOut",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "shift+cmd+-",
+				"title": "Zoom Out",
+				"command": "tldraw.tldr.zoomOut",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "cmd+-",
+				"title": "Zoom Out",
+				"command": "tldraw.tldr.zoomOut",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"key": "cmd+numpad0",
+				"title": "Zoom Out",
+				"command": "tldraw.tldr.zoomReset",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			}
+		],
 		"commands": [
 			{
 				"command": "tldraw.tldr.new",
-				"title": "New tldraw File",
+				"title": "New File",
 				"category": "tldraw"
+			},
+			{
+				"command": "tldraw.tldr.zoomIn",
+				"title": "Zoom In",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"command": "tldraw.tldr.zoomOut",
+				"title": "Zoom Out",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
 			}
 		]
 	},

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -60,13 +60,6 @@
 				"enablement": "resourceExtname == .tldr"
 			},
 			{
-				"key": "shift+cmd+=",
-				"title": "Zoom In",
-				"command": "tldraw.tldr.zoomIn",
-				"category": "tldraw",
-				"enablement": "resourceExtname == .tldr"
-			},
-			{
 				"key": "cmd+=",
 				"title": "Zoom In",
 				"command": "tldraw.tldr.zoomIn",
@@ -75,13 +68,6 @@
 			},
 			{
 				"key": "cmd+numpad_subtract",
-				"title": "Zoom Out",
-				"command": "tldraw.tldr.zoomOut",
-				"category": "tldraw",
-				"enablement": "resourceExtname == .tldr"
-			},
-			{
-				"key": "shift+cmd+-",
 				"title": "Zoom Out",
 				"command": "tldraw.tldr.zoomOut",
 				"category": "tldraw",

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -119,6 +119,12 @@
 				"title": "Zoom Out",
 				"category": "tldraw",
 				"enablement": "resourceExtname == .tldr"
+			},
+			{
+				"command": "tldraw.tldr.zoomReset",
+				"title": "Zoom Reset",
+				"category": "tldraw",
+				"enablement": "resourceExtname == .tldr"
 			}
 		]
 	},

--- a/apps/vscode/extension/src/TldrawEditorProvider.ts
+++ b/apps/vscode/extension/src/TldrawEditorProvider.ts
@@ -31,6 +31,18 @@ export class TldrawEditorProvider implements vscode.CustomTextEditorProvider {
       )
     })
 
+    vscode.commands.registerCommand('tldraw.tldr.zoomIn', () => {
+      // Noop
+    })
+
+    vscode.commands.registerCommand('tldraw.tldr.zoomOut', () => {
+      // Noop
+    })
+
+    vscode.commands.registerCommand('tldraw.tldr.resetZoom', () => {
+      // Noop
+    })
+
     // Register our editor provider, indicating to VS Code that we can
     // handle files with the .tldr extension.
     return vscode.window.registerCustomEditorProvider(

--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -226,7 +226,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   // Camera
 
   useHotkeys(
-    'ctrl+=,⌘+=',
+    'ctrl+=,⌘+=,ctrl+num_subtract,⌘+num_subtract',
     (e) => {
       if (!canHandleEvent()) return
       app.zoomIn()
@@ -237,12 +237,22 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   )
 
   useHotkeys(
-    'ctrl+-,⌘+-',
+    'ctrl+-,⌘+-,ctrl+num_add,⌘+num_add',
     (e) => {
       if (!canHandleEvent()) return
 
       app.zoomOut()
       e.preventDefault()
+    },
+    undefined,
+    [app]
+  )
+
+  useHotkeys(
+    'shift+0,ctrl+numpad_0,⌘+numpad_0',
+    () => {
+      if (!canHandleEvent()) return
+      app.resetZoom()
     },
     undefined,
     [app]
@@ -263,16 +273,6 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
     () => {
       if (!canHandleEvent()) return
       app.zoomToSelection()
-    },
-    undefined,
-    [app]
-  )
-
-  useHotkeys(
-    'shift+0',
-    () => {
-      if (!canHandleEvent()) return
-      app.resetZoom()
     },
     undefined,
     [app]

--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -229,7 +229,6 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
     'ctrl+=,⌘+=',
     (e) => {
       if (!canHandleEvent()) return
-
       app.zoomIn()
       e.preventDefault()
     },


### PR DESCRIPTION
This PR overrides the default keyboard shortcuts for zoom in, out, and reset in the VS Code extension.

It also adds the numpad keys to the app's shortcuts for zoom in, out, and reset.