### PR TITLE
Fixed bug related to locked tools & select tool

### DIFF
--- a/packages/tldraw/src/components/ToolsPanel/PrimaryTools.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/PrimaryTools.tsx
@@ -87,6 +87,7 @@ export const PrimaryTools = React.memo(function PrimaryTools(): JSX.Element {
         kbd={'7'}
         label={TDShapeType.Text}
         onClick={selectTextTool}
+        isLocked={isToolLocked}
         isActive={activeTool === TDShapeType.Text}
       >
         <TextIcon />

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1839,9 +1839,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
     this.addToSelectHistory(this.selectedIds)
 
-    if (this.appState.activeTool !== 'select') {
-      this.selectTool('select')
-    }
+    this.selectTool('select')
 
     return this
   }
@@ -2730,6 +2728,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     if (Date.now() - this.editingStartTime < 50) return
 
     const { editingId } = this.pageState
+    const { isToolLocked } = this.getAppState()
 
     if (editingId) {
       // If we're editing text, then delete the text if it's empty
@@ -2738,7 +2737,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       if (shape.type === TDShapeType.Text) {
         if (shape.text.trim().length <= 0) {
           this.patchState(Commands.deleteShapes(this, [editingId]).after, 'delete_empty_text')
-        } else {
+        } else if (!isToolLocked) {
           this.select(editingId)
         }
       }


### PR DESCRIPTION
Fixed two bug related to select tool & locked mode

- closes #327  (cmd + a while locked mode)
- locked mode of text node

![11-fixed-select-bug](https://user-images.githubusercontent.com/354596/142751475-dc4776d4-52ab-4ded-bc73-bdf571efa7d8.gif)