### PR TITLE
[fix] brush selection on groups

### DIFF
--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -49,7 +49,7 @@
     "@radix-ui/react-radio-group": "^0.1.1",
     "@radix-ui/react-tooltip": "^0.1.1",
     "@stitches/react": "^1.2.5",
-    "@tldraw/core": "^1.1.0",
+    "@tldraw/core": "^1.1.1",
     "@tldraw/intersect": "latest",
     "@tldraw/vec": "latest",
     "perfect-freehand": "^1.0.16",

--- a/packages/tldraw/src/state/sessions/BrushSession/BrushSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/BrushSession/BrushSession.spec.ts
@@ -53,13 +53,24 @@ describe('Brush session', () => {
     const app = new TldrawTestApp()
       .loadDocument(mockDocument)
       .selectNone()
-      .loadDocument(mockDocument)
-      .selectNone()
       .movePointer([-10, -10])
       .startSession(SessionType.Brush)
       .movePointer({ x: 10, y: 10, shiftKey: false, altKey: false, ctrlKey: true })
       .completeSession()
 
     expect(app.selectedIds.length).toBe(0)
+  })
+
+  it('selects groups rather than grouped shapes', () => {
+    const app = new TldrawTestApp()
+      .loadDocument(mockDocument)
+      .selectAll()
+      .group()
+      .movePointer([-10, -10])
+      .startSession(SessionType.Brush)
+      .movePointer({ x: 100, y: 100 })
+      .stopPointing()
+
+    expect(app.selectedIds.length).toBe(1)
   })
 })

--- a/packages/tldraw/src/state/sessions/BrushSession/BrushSession.ts
+++ b/packages/tldraw/src/state/sessions/BrushSession/BrushSession.ts
@@ -15,6 +15,7 @@ export class BrushSession extends BaseSession {
 
   constructor(app: TldrawApp) {
     super(app)
+    const { currentPageId } = app
     this.initialSelectedIds = new Set(this.app.selectedIds)
     this.shapesToTest = this.app.shapes
       .filter(
@@ -22,7 +23,7 @@ export class BrushSession extends BaseSession {
           !(
             shape.isLocked ||
             shape.isHidden ||
-            shape.children !== undefined ||
+            shape.parentId !== currentPageId ||
             this.initialSelectedIds.has(shape.id) ||
             this.initialSelectedIds.has(shape.parentId)
           )
@@ -52,8 +53,6 @@ export class BrushSession extends BaseSession {
     const selectedIds = new Set(initialSelectedIds)
 
     shapesToTest.forEach(({ id, selectId }) => {
-      if (selectedIds.has(id)) return
-
       const { metaKey } = this.app
 
       const shape = this.app.getShape(id)

--- a/packages/tldraw/tsconfig.json
+++ b/packages/tldraw/tsconfig.json
@@ -8,7 +8,8 @@
     "rootDir": "src",
     "baseUrl": "src",
     "paths": {
-      "~*": ["./*"]
+      "~*": ["./*"],
+      "@tldraw/core": ["../core"]
     }
   },
   "typedocOptions": {


### PR DESCRIPTION
This PR fixes the behavior of the select tool when brush selecting grouped shapes. When the brush hits a group, it will select the group; the brush will ignore the children of groups. It closes https://github.com/tldraw/tldraw/issues/314.

There is likely a followup PR to allow brush selection when "drilled into" a group.