### PR TITLE
[improvement] Add basic support for copying text

### DIFF
--- a/packages/core/src/hooks/useBoundsEvents.tsx
+++ b/packages/core/src/hooks/useBoundsEvents.tsx
@@ -9,7 +9,7 @@ export function useBoundsEvents() {
       if (!inputs.pointerIsValid(e)) return
 
       if (e.button === 2) {
-        callbacks.onRightPointShape?.(inputs.pointerDown(e, 'bounds'), e)
+        callbacks.onRightPointBounds?.(inputs.pointerDown(e, 'bounds'), e)
         return
       }
 

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1561,7 +1561,14 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     const shapes = ids.map((id) => this.getShape(id, pageId))
     const commonBounds = Utils.getCommonBounds(shapes.map(TLDR.getRotatedBounds))
     const padding = 16
+
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs')
+    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style')
+
+    style.textContent = `@import url('https://fonts.googleapis.com/css2?family=Caveat+Brush&family=Source+Code+Pro&family=Source+Sans+Pro&family=Source+Serif+Pro&display=swap');`
+    defs.appendChild(style)
+    svg.appendChild(defs)
 
     function getSvgElementForShape(shape: TDShape) {
       const util = TLDR.getShapeUtil(shape)

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1448,15 +1448,11 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     const shapes = ids.map((id) => this.getShape(id, pageId))
 
     function getSvgElementForShape(shape: TDShape) {
-      const elm = document.getElementById(shape.id + '_svg')
+      const util = TLDR.getShapeUtil(shape)
+      const element = util.getSvgElement(shape)
+      const bounds = util.getBounds(shape)
 
-      if (!elm) return
-
-      // TODO: Create SVG elements for text
-
-      const element = elm?.cloneNode(true) as SVGElement
-
-      const bounds = TLDR.getShapeUtil(shape).getBounds(shape)
+      if (!element) return
 
       element.setAttribute(
         'transform',

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1558,9 +1558,10 @@ export class TldrawApp extends StateManager<TDSnapshot> {
   copySvg = (ids = this.selectedIds, pageId = this.currentPageId) => {
     if (ids.length === 0) ids = Object.keys(this.page.shapes)
 
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-
     const shapes = ids.map((id) => this.getShape(id, pageId))
+    const commonBounds = Utils.getCommonBounds(shapes.map(TLDR.getRotatedBounds))
+    const padding = 16
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
     function getSvgElementForShape(shape: TDShape) {
       const util = TLDR.getShapeUtil(shape)
@@ -1571,9 +1572,11 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
       element.setAttribute(
         'transform',
-        `translate(${shape.point[0]}, ${shape.point[1]}) rotate(${
-          ((shape.rotation || 0) * 180) / Math.PI
-        }, ${bounds.width / 2}, ${bounds.height / 2})`
+        `translate(${padding + shape.point[0] - commonBounds.minX}, ${
+          padding + shape.point[1] - commonBounds.minY
+        }) rotate(${((shape.rotation || 0) * 180) / Math.PI}, ${bounds.width / 2}, ${
+          bounds.height / 2
+        })`
       )
 
       return element
@@ -1604,23 +1607,14 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       }
     })
 
-    const bounds = Utils.getCommonBounds(shapes.map(TLDR.getRotatedBounds))
-    const padding = 16
-
     // Resize the element to the bounding box
     svg.setAttribute(
       'viewBox',
-      [
-        bounds.minX - padding,
-        bounds.minY - padding,
-        bounds.width + padding * 2,
-        bounds.height + padding * 2,
-      ].join(' ')
+      [0, 0, commonBounds.width + padding * 2, commonBounds.height + padding * 2].join(' ')
     )
 
-    svg.setAttribute('width', String(bounds.width))
-
-    svg.setAttribute('height', String(bounds.height))
+    svg.setAttribute('width', String(commonBounds.width))
+    svg.setAttribute('height', String(commonBounds.height))
 
     const s = new XMLSerializer()
 

--- a/packages/tldraw/src/state/__snapshots__/TLDrawApp.spec.ts.snap
+++ b/packages/tldraw/src/state/__snapshots__/TLDrawApp.spec.ts.snap
@@ -202,6 +202,6 @@ Array [
 ]
 `;
 
-exports[`TldrawTestApp When copying to SVG Copies grouped shapes.: copied svg with group 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-16 -16 232 232\\" width=\\"200\\" height=\\"200\\"><g/></svg>"`;
+exports[`TldrawTestApp When copying to SVG Copies grouped shapes.: copied svg with group 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 232 232\\" width=\\"200\\" height=\\"200\\"><g/></svg>"`;
 
-exports[`TldrawTestApp When copying to SVG Copies shapes.: copied svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-20.741879096242684 -20.741879096242684 236.74 236.74\\" width=\\"204.74\\" height=\\"204.74\\"/>"`;
+exports[`TldrawTestApp When copying to SVG Copies shapes.: copied svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 236.74 236.74\\" width=\\"204.74\\" height=\\"204.74\\"/>"`;

--- a/packages/tldraw/src/state/__snapshots__/TLDrawApp.spec.ts.snap
+++ b/packages/tldraw/src/state/__snapshots__/TLDrawApp.spec.ts.snap
@@ -202,6 +202,6 @@ Array [
 ]
 `;
 
-exports[`TldrawTestApp When copying to SVG Copies grouped shapes.: copied svg with group 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 232 232\\" width=\\"200\\" height=\\"200\\"><g/></svg>"`;
+exports[`TldrawTestApp When copying to SVG Copies grouped shapes.: copied svg with group 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 232 232\\" width=\\"200\\" height=\\"200\\"><defs><style>@import url('https://fonts.googleapis.com/css2?family=Caveat+Brush&amp;family=Source+Code+Pro&amp;family=Source+Sans+Pro&amp;family=Source+Serif+Pro&amp;display=swap');</style></defs><g/></svg>"`;
 
-exports[`TldrawTestApp When copying to SVG Copies shapes.: copied svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 236.74 236.74\\" width=\\"204.74\\" height=\\"204.74\\"/>"`;
+exports[`TldrawTestApp When copying to SVG Copies shapes.: copied svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 236.74 236.74\\" width=\\"204.74\\" height=\\"204.74\\"><defs><style>@import url('https://fonts.googleapis.com/css2?family=Caveat+Brush&amp;family=Source+Code+Pro&amp;family=Source+Sans+Pro&amp;family=Source+Serif+Pro&amp;display=swap');</style></defs></svg>"`;

--- a/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
+++ b/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
@@ -10,6 +10,7 @@ import { styled } from '~styles'
 import { Vec } from '@tldraw/vec'
 import { GHOSTED_OPACITY } from '~constants'
 import { TLDR } from '~state/TLDR'
+import { getTextSvgElement } from '../shared/getTextSvgElement'
 
 type T = StickyShape
 type E = HTMLDivElement
@@ -231,6 +232,24 @@ export class StickyUtil extends TDShapeUtil<T, E> {
 
   transformSingle = (shape: T): Partial<T> => {
     return shape
+  }
+
+  getSvgElement = (shape: T): SVGElement | void => {
+    const bounds = this.getBounds(shape)
+    const textElm = getTextSvgElement(shape, bounds)
+    const style = getStickyShapeStyle(shape.style)
+    textElm.setAttribute('fill', style.color)
+
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+    rect.setAttribute('width', bounds.width + '')
+    rect.setAttribute('height', bounds.height + '')
+    rect.setAttribute('fill', style.fill)
+
+    g.appendChild(rect)
+    g.appendChild(textElm)
+
+    return g
   }
 }
 

--- a/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
@@ -179,4 +179,8 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
   onDoubleClickBoundsHandle?: (shape: T) => Partial<T> | void
 
   onSessionComplete?: (shape: T) => Partial<T> | void
+
+  getSvgElement = (shape: T): SVGElement | void => {
+    return document.getElementById(shape.id + '_svg')?.cloneNode(true) as SVGElement
+  }
 }

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -316,8 +316,8 @@ export class TextUtil extends TDShapeUtil<T, E> {
   getSvgElement = (shape: T): SVGElement | void => {
     const bounds = this.getBounds(shape)
     const elm = getTextSvgElement(shape, bounds)
-    elm.setAttribute('fill', getShapeStyle(shape.style).fill)
-    return
+    elm.setAttribute('fill', getShapeStyle(shape.style).stroke)
+    return elm
   }
 }
 

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as React from 'react'
 import { Utils, HTMLContainer, TLBounds } from '@tldraw/core'
-import {
-  defaultTextStyle,
-  getShapeStyle,
-  getFontFace,
-  getFontSize,
-  getFontStyle,
-} from '../shared/shape-styles'
+import { defaultTextStyle, getShapeStyle, getFontStyle } from '../shared/shape-styles'
 import { TextShape, TDMeta, TDShapeType, TransformInfo, AlignStyle } from '~types'
 import { TextAreaUtils } from '../shared'
 import { BINDING_DISTANCE, GHOSTED_OPACITY } from '~constants'
@@ -16,6 +10,7 @@ import { styled } from '~styles'
 import { Vec } from '@tldraw/vec'
 import { TLDR } from '~state/TLDR'
 import { getTextAlign } from '../shared/getTextAlign'
+import { getTextSvgElement } from '../shared/getTextSvgElement'
 
 type T = TextShape
 type E = HTMLDivElement
@@ -158,20 +153,10 @@ export class TextUtil extends TDShapeUtil<T, E> {
         }
       }, [isEditing])
 
-      const rInnerWrapper = React.useRef<HTMLDivElement>(null)
-
-      React.useEffect(() => {
-        const element = this.getSvgElement(shape)
-        if (element) {
-          rInnerWrapper.current?.appendChild(element)
-        }
-      }, [rInnerWrapper, shape])
-
       return (
         <HTMLContainer ref={ref} {...events}>
           <Wrapper isGhost={isGhost} isEditing={isEditing} onPointerDown={handlePointerDown}>
             <InnerWrapper
-              ref={rInnerWrapper}
               style={{
                 font,
                 color: styles.stroke,
@@ -329,45 +314,10 @@ export class TextUtil extends TDShapeUtil<T, E> {
   }
 
   getSvgElement = (shape: T): SVGElement | void => {
-    const { text, style } = shape
     const bounds = this.getBounds(shape)
-    const font = getFontStyle(shape.style)
-    const fontSize = getFontSize(shape.style.size, shape.style.font)
-
-    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
-
-    const LINE_HEIGHT = fontSize * 1.3
-
-    const textLines = text.split('\n').map((line, i) => {
-      const textElm = document.createElementNS('http://www.w3.org/2000/svg', 'text')
-      textElm.textContent = line
-      textElm.setAttribute('font', font)
-      textElm.setAttribute('font-size', fontSize + 'px')
-      textElm.setAttribute('text-anchor', 'start')
-      textElm.setAttribute('alignment-baseline', 'central')
-      textElm.setAttribute('fill', style.color)
-      textElm.setAttribute('text-align', getTextAlign(style.textAlign))
-      textElm.setAttribute('y', LINE_HEIGHT * (0.5 + i) + '')
-      g.appendChild(textElm)
-
-      return textElm
-    })
-
-    if (style.textAlign === AlignStyle.Middle) {
-      textLines.forEach((textElm) => {
-        textElm.setAttribute('x', bounds.width / 2 + '')
-        textElm.setAttribute('text-align', 'center')
-        textElm.setAttribute('text-anchor', 'middle')
-      })
-    } else if (style.textAlign === AlignStyle.End) {
-      textLines.forEach((textElm) => {
-        textElm.setAttribute('x', bounds.width + '')
-        textElm.setAttribute('text-align', 'right')
-        textElm.setAttribute('text-anchor', 'end')
-      })
-    }
-
-    return g
+    const elm = getTextSvgElement(shape, bounds)
+    elm.setAttribute('fill', getShapeStyle(shape.style).fill)
+    return
   }
 }
 

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -1,0 +1,44 @@
+import type { TLBounds } from '@tldraw/core'
+import { AlignStyle, StickyShape, TextShape } from '~types'
+import { getFontSize, getFontStyle } from '.'
+import { getTextAlign } from './getTextAlign'
+
+export function getTextSvgElement(shape: TextShape | StickyShape, bounds: TLBounds) {
+  const { text, style } = shape
+  const font = getFontStyle(shape.style)
+  const fontSize = getFontSize(shape.style.size, shape.style.font)
+
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+
+  const LINE_HEIGHT = fontSize * 1.3
+
+  const textLines = text.split('\n').map((line, i) => {
+    const textElm = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    textElm.textContent = line
+    textElm.setAttribute('font', font)
+    textElm.setAttribute('font-size', fontSize + 'px')
+    textElm.setAttribute('text-anchor', 'start')
+    textElm.setAttribute('alignment-baseline', 'central')
+    textElm.setAttribute('text-align', getTextAlign(style.textAlign))
+    textElm.setAttribute('y', LINE_HEIGHT * (0.5 + i) + '')
+    g.appendChild(textElm)
+
+    return textElm
+  })
+
+  if (style.textAlign === AlignStyle.Middle) {
+    textLines.forEach((textElm) => {
+      textElm.setAttribute('x', bounds.width / 2 + '')
+      textElm.setAttribute('text-align', 'center')
+      textElm.setAttribute('text-anchor', 'middle')
+    })
+  } else if (style.textAlign === AlignStyle.End) {
+    textLines.forEach((textElm) => {
+      textElm.setAttribute('x', bounds.width + '')
+      textElm.setAttribute('text-align', 'right')
+      textElm.setAttribute('text-anchor', 'end')
+    })
+  }
+
+  return g
+}

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -1,11 +1,10 @@
 import type { TLBounds } from '@tldraw/core'
 import { AlignStyle, StickyShape, TextShape } from '~types'
-import { getFontSize, getFontStyle } from '.'
+import { getFontFace, getFontSize } from './shape-styles'
 import { getTextAlign } from './getTextAlign'
 
 export function getTextSvgElement(shape: TextShape | StickyShape, bounds: TLBounds) {
   const { text, style } = shape
-  const font = getFontStyle(shape.style)
   const fontSize = getFontSize(shape.style.size, shape.style.font)
 
   const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
@@ -15,7 +14,7 @@ export function getTextSvgElement(shape: TextShape | StickyShape, bounds: TLBoun
   const textLines = text.split('\n').map((line, i) => {
     const textElm = document.createElementNS('http://www.w3.org/2000/svg', 'text')
     textElm.textContent = line
-    textElm.setAttribute('font', font)
+    textElm.setAttribute('font-family', getFontFace(style.font))
     textElm.setAttribute('font-size', fontSize + 'px')
     textElm.setAttribute('text-anchor', 'start')
     textElm.setAttribute('alignment-baseline', 'central')

--- a/packages/tldraw/src/state/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/state/tools/SelectTool/SelectTool.ts
@@ -551,6 +551,7 @@ export class SelectTool extends BaseTool<Status> {
 
   onRightPointShape: TLPointerEventHandler = (info) => {
     if (!this.app.isSelected(info.target)) {
+      console.log(info.target)
       this.app.select(info.target)
     }
   }


### PR DESCRIPTION
This PR is a rough first step toward copying text. The SVG code now includes the font imports, so the fonts will be installed if the device is online or if the device has those fonts installed locally.