### PR TITLE
[improvement] ⌨️ Changing keyboard shortcuts for pen and oval

### DIFF
--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -23,7 +23,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   )
 
   useHotkeys(
-    'd,2',
+    'p,2',
     () => {
       if (!canHandleEvent()) return
       app.selectTool(TDShapeType.Draw)
@@ -53,7 +53,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   )
 
   useHotkeys(
-    'i,5',
+    'o,5',
     () => {
       if (!canHandleEvent()) return
       app.selectTool(TDShapeType.Ellipse)


### PR DESCRIPTION
Coming from Adobe, Figma and other drawing applications, it bugs me that the shortcuts for drawing is d (usually Pen = p), and for circle/oval is i (usually O = circle) 

Suggested changes are committed here.   