### PR TITLE
fix(paste): do not warn in production

### DIFF
--- a/packages/tldraw/src/state/TLDR.ts
+++ b/packages/tldraw/src/state/TLDR.ts
@@ -15,6 +15,7 @@ import { Vec } from '@tldraw/vec'
 import type { TDShapeUtil } from './shapes/TDShapeUtil'
 import { getShapeUtil } from './shapes'
 
+const isDev = process.env.NODE_ENV === 'development'
 export class TLDR {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static getShapeUtil<T extends TDShape>(type: T['type']): TDShapeUtil<T>
@@ -865,8 +866,8 @@ export class TLDR {
     return shapes.length === 0
       ? 1
       : shapes
-          .filter((shape) => shape.parentId === pageId)
-          .sort((a, b) => b.childIndex - a.childIndex)[0].childIndex + 1
+        .filter((shape) => shape.parentId === pageId)
+        .sort((a, b) => b.childIndex - a.childIndex)[0].childIndex + 1
   }
 
   /* -------------------------------------------------- */
@@ -891,4 +892,16 @@ export class TLDR {
       throw new Error()
     }
   }
+
+  static warn(e: any) {
+    if (isDev) {
+      console.warn(e);
+    }
+  }
+  static error(e: any) {
+    if (isDev) {
+      console.error(e)
+    }
+  }
+
 }

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -391,12 +391,12 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         }
 
         if (nextPageState.bindingId && !page.bindings[nextPageState.bindingId]) {
-          console.warn('Could not find the binding binding!', pageId)
+          TLDR.warn(`Could not find the binding of ${pageId}`)
           delete nextPageState.bindingId
         }
 
         if (nextPageState.editingId && !page.shapes[nextPageState.editingId]) {
-          console.warn('Could not find the editing shape!')
+          TLDR.warn('Could not find the editing shape!')
           delete nextPageState.editingId
         }
 
@@ -1529,7 +1529,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
           pasteInCurrentPage(data.shapes, data.bindings)
         } catch (e) {
-          console.warn(e)
+          TLDR.warn(e)
 
           const shapeId = Utils.uniqueId()
 
@@ -1984,7 +1984,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
   startSession = <T extends SessionType>(type: T, ...args: SessionArgsOfType<T>): this => {
     if (this.readOnly && type !== SessionType.Brush) return this
     if (this.session) {
-      console.warn(`Already in a session! (${this.session.constructor.name})`)
+      TLDR.warn(`Already in a session! (${this.session.constructor.name})`)
       this.cancelSession()
     }
 

--- a/packages/tldraw/src/state/shapes/ArrowUtil/arrowHelpers.ts
+++ b/packages/tldraw/src/state/shapes/ArrowUtil/arrowHelpers.ts
@@ -5,6 +5,7 @@ import getStroke from 'perfect-freehand'
 import { EASINGS } from '~constants'
 import { getShapeStyle } from '../shared/shape-styles'
 import type { ArrowShape, TldrawHandle } from '~types'
+import { TLDR } from '../../TLDR'
 
 export function getArrowArcPath(
   start: TldrawHandle,
@@ -159,7 +160,7 @@ export function getCurvedArrowHeadPoints(
   const ints = intersectCircleCircle(A, r1 * 0.618, C, r2).points
 
   if (!ints) {
-    console.warn('Could not find an intersection for the arrow head.')
+    TLDR.warn('Could not find an intersection for the arrow head.')
     return { left: A, right: A }
   }
 
@@ -175,7 +176,7 @@ export function getCurvedArrowHeadPoints(
 export function getStraightArrowHeadPoints(A: number[], B: number[], r: number) {
   const ints = intersectCircleLineSegment(A, r, A, B).points
   if (!ints) {
-    console.warn('Could not find an intersection for the arrow head.')
+    TLDR.warn('Could not find an intersection for the arrow head.')
     return { left: A, right: A }
   }
 


### PR DESCRIPTION
- when paste the content from clipboard, if the content is not JSON, the `JSON.parse` parse error will be thrown. The info should not be in production build.

Closes #400