### PR TITLE
[fix] Erasing bound shapes

### DIFF
--- a/packages/tldraw/src/state/sessions/EraseSession/EraseSession.ts
+++ b/packages/tldraw/src/state/sessions/EraseSession/EraseSession.ts
@@ -161,7 +161,10 @@ export class EraseSession extends BaseSession {
                 ...after.shapes[shape.id],
                 handles: {
                   ...after.shapes[shape.id]?.handles,
-                  [handle.id]: undefined,
+                  [handle.id]: {
+                    ...handle,
+                    bindingId: undefined,
+                  },
                 },
               }
             }


### PR DESCRIPTION
This PR fixes the "missing handle" bug when erasing bounds shapes. #415. Thanks to @AdventureBeard for the spot!