### PR TITLE
Fix alt zoom

### DIFF
--- a/packages/core/src/hooks/useZoomEvents.ts
+++ b/packages/core/src/hooks/useZoomEvents.ts
@@ -34,6 +34,8 @@ export function useZoomEvents<T extends HTMLElement>(zoom: number, ref: React.Re
   useGesture(
     {
       onWheel: ({ delta, event: e }) => {
+        e.preventDefault()
+
         if (e.altKey && e.buttons === 0) {
           const point = inputs.pointer?.point ?? [bounds.width / 2, bounds.height / 2]
 
@@ -42,8 +44,6 @@ export function useZoomEvents<T extends HTMLElement>(zoom: number, ref: React.Re
           callbacks.onZoom?.({ ...info, delta: [...point, -e.deltaY] }, e)
           return
         }
-
-        e.preventDefault()
 
         if (inputs.isPinching) return
 

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2665,7 +2665,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         ? info.delta[2] / 100
         : info.delta[2] / 2
 
-    this.zoomBy(delta, info.delta)
+    this.zoomBy(delta, this.centerPoint)
     this.onPointerMove(info, e as unknown as React.PointerEvent)
   }
 


### PR DESCRIPTION
This PR addresses the alt-zoom issue raised in #413. This is more of a patch than a fix: alt+wheel will zoom to the center of the screen, rather than to the cursor as ctrl+wheel will do. The distance of the zoom is also somewhat a work in progress, as I haven't found a way to test yet.