### PR TITLE
[fix] multiplayer (sorta)

### DIFF
--- a/examples/tldraw-example/src/multiplayer/useMultiplayerState.ts
+++ b/examples/tldraw-example/src/multiplayer/useMultiplayerState.ts
@@ -121,7 +121,7 @@ export function useMultiplayerState(roomId: string) {
           migrated?: boolean
         }>
 
-        // No doc? No problem. This was likely
+        // No doc? No problem. This was likely a newer document
         if (doc) {
           const {
             document: {

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -357,14 +357,16 @@ const InnerTldraw = React.memo(function InnerTldraw({
 
   const page = document.pages[appState.currentPageId]
   const pageState = document.pageStates[page.id]
-  const { selectedIds } = state.document.pageStates[page.id]
+  const { selectedIds } = pageState
 
   const isHideBoundsShape =
-    pageState.selectedIds.length === 1 &&
+    selectedIds.length === 1 &&
+    page.shapes[selectedIds[0]] &&
     TLDR.getShapeUtil(page.shapes[selectedIds[0]].type).hideBounds
 
   const isHideResizeHandlesShape =
     selectedIds.length === 1 &&
+    page.shapes[selectedIds[0]] &&
     TLDR.getShapeUtil(page.shapes[selectedIds[0]].type).hideResizeHandles
 
   const isInSession = app.session !== undefined

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -548,6 +548,18 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     this.useStore.setState((current) => {
       const { hoveredId, editingId, bindingId, selectedIds } = current.document.pageStates[pageId]
 
+      const keepShapes: Record<string, TDShape> = {}
+      const keepBindings: Record<string, TDShape> = {}
+
+      if (this.session) {
+        selectedIds.forEach((id) => (keepShapes[id] = this.getShape(id)))
+        // Bindings too!
+      }
+
+      if (editingId) {
+        keepShapes[editingId] = this.getShape(editingId)
+      }
+
       const next = {
         ...current,
         document: {
@@ -555,8 +567,14 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           pages: {
             [pageId]: {
               ...current.document.pages[pageId],
-              shapes,
-              bindings,
+              shapes: {
+                ...shapes,
+                ...keepShapes,
+              },
+              bindings: {
+                ...bindings,
+                ...keepBindings,
+              },
             },
           },
           pageStates: {
@@ -569,11 +587,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
                   ? undefined
                   : hoveredId
                 : undefined,
-              editingId: editingId
-                ? shapes[editingId] === undefined
-                  ? undefined
-                  : hoveredId
-                : undefined,
+              editingId: editingId,
               bindingId: bindingId
                 ? bindings[bindingId] === undefined
                   ? undefined

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -553,7 +553,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
       if (this.session) {
         selectedIds.forEach((id) => (keepShapes[id] = this.getShape(id)))
-        // Bindings too!
+        Object.assign(keepBindings, this.bindings) // ROUGH
       }
 
       if (editingId) {

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -560,7 +560,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         keepShapes[editingId] = this.getShape(editingId)
       }
 
-      const next = {
+      const next: TDSnapshot = {
         ...current,
         document: {
           ...current.document,

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -549,7 +549,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       const { hoveredId, editingId, bindingId, selectedIds } = current.document.pageStates[pageId]
 
       const keepShapes: Record<string, TDShape> = {}
-      const keepBindings: Record<string, TDShape> = {}
+      const keepBindings: Record<string, TDBinding> = {}
 
       if (this.session) {
         selectedIds.forEach((id) => (keepShapes[id] = this.getShape(id)))


### PR DESCRIPTION
This PR is a red-hot fix for some multiplayer crashes. Basically if you've been creating or editing a shape but haven't persisted it yet, then any change that comes in and that doesn't include that shape will blow it out, causing a crash. Your editing shapes should not be able to be deleted from under you.

It's not a complete fix (the logic around bindings should be improved) but it's an urgent one.