### PR TITLE
[fix] account for "draft" shapes when preserving selection state during replacePageContent

### DIFF
--- a/examples/tldraw-example/src/multiplayer/useMultiplayerState.ts
+++ b/examples/tldraw-example/src/multiplayer/useMultiplayerState.ts
@@ -4,6 +4,7 @@ import * as React from 'react'
 import type { TldrawApp, TDUser, TDShape, TDBinding, TDDocument } from '@tldraw/tldraw'
 import { useRedo, useUndo, useRoom, useUpdateMyPresence } from '@liveblocks/react'
 import { LiveMap, LiveObject } from '@liveblocks/client'
+import { Utils } from '@tldraw/core'
 
 declare const window: Window & { app: TldrawApp }
 
@@ -11,143 +12,14 @@ export function useMultiplayerState(roomId: string) {
   const [app, setApp] = React.useState<TldrawApp>()
   const [error, setError] = React.useState<Error>()
   const [loading, setLoading] = React.useState(true)
-  const rExpectingUpdate = React.useRef(false)
 
   const room = useRoom()
   const onUndo = useUndo()
   const onRedo = useRedo()
   const updateMyPresence = useUpdateMyPresence()
 
-  // Document Changes --------
-
   const rLiveShapes = React.useRef<LiveMap<string, TDShape>>()
   const rLiveBindings = React.useRef<LiveMap<string, TDBinding>>()
-
-  React.useEffect(() => {
-    const unsubs: (() => void)[] = []
-
-    if (!(app && room)) return
-    // Handle errors
-    unsubs.push(room.subscribe('error', (error) => setError(error)))
-
-    // Handle changes to other users' presence
-    unsubs.push(
-      room.subscribe('others', (others) => {
-        app.updateUsers(
-          others
-            .toArray()
-            .filter((other) => other.presence)
-            .map((other) => other.presence!.user)
-            .filter(Boolean)
-        )
-      })
-    )
-
-    // Handle events from the room
-    unsubs.push(
-      room.subscribe(
-        'event',
-        (e: { connectionId: number; event: { name: string; userId: string } }) => {
-          switch (e.event.name) {
-            case 'exit': {
-              app?.removeUser(e.event.userId)
-              break
-            }
-          }
-        }
-      )
-    )
-
-    // Send the exit event when the tab closes
-    function handleExit() {
-      if (!(room && app?.room)) return
-      room?.broadcastEvent({ name: 'exit', userId: app.room.userId })
-    }
-
-    window.addEventListener('beforeunload', handleExit)
-    unsubs.push(() => window.removeEventListener('beforeunload', handleExit))
-
-    // Setup the document's storage and subscriptions
-    async function setupDocument() {
-      const storage = await room.getStorage<any>()
-
-      // Initialize (get or create) shapes and bindings maps
-
-      let lShapes: LiveMap<string, TDShape> = storage.root.get('shapes')
-      if (!lShapes) {
-        storage.root.set('shapes', new LiveMap<string, TDShape>())
-        lShapes = storage.root.get('shapes')
-      }
-      rLiveShapes.current = lShapes
-
-      let lBindings: LiveMap<string, TDBinding> = storage.root.get('bindings')
-      if (!lBindings) {
-        storage.root.set('bindings', new LiveMap<string, TDBinding>())
-        lBindings = storage.root.get('bindings')
-      }
-      rLiveBindings.current = lBindings
-
-      // Subscribe to changes
-      function handleChanges() {
-        if (rExpectingUpdate.current) {
-          rExpectingUpdate.current = false
-          return
-        }
-
-        app?.replacePageContent(
-          Object.fromEntries(lShapes.entries()),
-          Object.fromEntries(lBindings.entries())
-        )
-      }
-
-      unsubs.push(room.subscribe(lShapes, handleChanges))
-      unsubs.push(room.subscribe(lBindings, handleChanges))
-
-      // Update the document with initial content
-      handleChanges()
-
-      // Migrate previous versions
-      const version = storage.root.get('version')
-
-      if (!version) {
-        // The doc object will only be present if the document was created
-        // prior to the current multiplayer implementation. At this time, the
-        // document was a single LiveObject named 'doc'. If we find a doc,
-        // then we need to move the shapes and bindings over to the new structures
-        // and then mark the doc as migrated.
-        const doc = storage.root.get('doc') as LiveObject<{
-          uuid: string
-          document: TDDocument
-          migrated?: boolean
-        }>
-
-        // No doc? No problem. This was likely a newer document
-        if (doc) {
-          const {
-            document: {
-              pages: {
-                page: { shapes, bindings },
-              },
-            },
-          } = doc.toObject()
-
-          Object.values(shapes).forEach((shape) => lShapes.set(shape.id, shape))
-          Object.values(bindings).forEach((binding) => lBindings.set(binding.id, binding))
-        }
-      }
-
-      // Save the version number for future migrations
-      storage.root.set('version', 2)
-
-      setLoading(false)
-    }
-
-    setupDocument()
-
-    return () => {
-      unsubs.forEach((unsub) => unsub())
-    }
-  }, [room, app])
 
   // Callbacks --------------
 
@@ -190,8 +62,6 @@ export function useMultiplayerState(roomId: string) {
             lBindings.set(binding.id, binding)
           }
         })
-
-        rExpectingUpdate.current = true
       })
     },
     [room]
@@ -204,6 +74,132 @@ export function useMultiplayerState(roomId: string) {
     },
     [updateMyPresence]
   )
+
+  // Document Changes --------
+
+  React.useEffect(() => {
+    const unsubs: (() => void)[] = []
+    if (!(app && room)) return
+    // Handle errors
+    unsubs.push(room.subscribe('error', (error) => setError(error)))
+
+    // Handle changes to other users' presence
+    unsubs.push(
+      room.subscribe('others', (others) => {
+        app.updateUsers(
+          others
+            .toArray()
+            .filter((other) => other.presence)
+            .map((other) => other.presence!.user)
+            .filter(Boolean)
+        )
+      })
+    )
+
+    // Handle events from the room
+    unsubs.push(
+      room.subscribe(
+        'event',
+        (e: { connectionId: number; event: { name: string; userId: string } }) => {
+          switch (e.event.name) {
+            case 'exit': {
+              app?.removeUser(e.event.userId)
+              break
+            }
+          }
+        }
+      )
+    )
+
+    // Send the exit event when the tab closes
+    function handleExit() {
+      if (!(room && app?.room)) return
+      room?.broadcastEvent({ name: 'exit', userId: app.room.userId })
+    }
+
+    window.addEventListener('beforeunload', handleExit)
+    unsubs.push(() => window.removeEventListener('beforeunload', handleExit))
+
+    let stillAlive = true
+
+    // Setup the document's storage and subscriptions
+    async function setupDocument() {
+      const storage = await room.getStorage<any>()
+
+      // Initialize (get or create) shapes and bindings maps
+
+      let lShapes: LiveMap<string, TDShape> = storage.root.get('shapes')
+      if (!lShapes) {
+        storage.root.set('shapes', new LiveMap<string, TDShape>())
+        lShapes = storage.root.get('shapes')
+      }
+      rLiveShapes.current = lShapes
+
+      let lBindings: LiveMap<string, TDBinding> = storage.root.get('bindings')
+      if (!lBindings) {
+        storage.root.set('bindings', new LiveMap<string, TDBinding>())
+        lBindings = storage.root.get('bindings')
+      }
+      rLiveBindings.current = lBindings
+
+      // Migrate previous versions
+      const version = storage.root.get('version')
+
+      if (!version) {
+        // The doc object will only be present if the document was created
+        // prior to the current multiplayer implementation. At this time, the
+        // document was a single LiveObject named 'doc'. If we find a doc,
+        // then we need to move the shapes and bindings over to the new structures
+        // and then mark the doc as migrated.
+        const doc = storage.root.get('doc') as LiveObject<{
+          uuid: string
+          document: TDDocument
+          migrated?: boolean
+        }>
+
+        // No doc? No problem. This was likely a newer document
+        if (doc) {
+          const {
+            document: {
+              pages: {
+                page: { shapes, bindings },
+              },
+            },
+          } = doc.toObject()
+
+          Object.values(shapes).forEach((shape) => lShapes.set(shape.id, shape))
+          Object.values(bindings).forEach((binding) => lBindings.set(binding.id, binding))
+        }
+      }
+
+      // Save the version number for future migrations
+      storage.root.set('version', 2)
+
+      // Subscribe to changes
+      const handleChanges = () => {
+        app?.replacePageContent(
+          Object.fromEntries(lShapes.entries()),
+          Object.fromEntries(lBindings.entries())
+        )
+      }
+
+      if (stillAlive) {
+        unsubs.push(room.subscribe(lShapes, handleChanges))
+
+        // Update the document with initial content
+        handleChanges()
+
+        setLoading(false)
+      }
+    }
+
+    setupDocument()
+
+    return () => {
+      stillAlive = false
+      unsubs.forEach((unsub) => unsub())
+    }
+  }, [app])
 
   return {
     onUndo,

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -714,7 +714,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
             ...current.document.pageStates,
             [pageId]: {
               ...current.document.pageStates[pageId],
-              selectedIds,
+              selectedIds: selectedIds.filter((id) => nextShapes[id] !== undefined),
               hoveredId: hoveredId
                 ? nextShapes[hoveredId] === undefined
                   ? undefined

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -560,6 +560,16 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         keepShapes[editingId] = this.getShape(editingId)
       }
 
+      const nextShapes = {
+        ...shapes,
+        ...keepShapes
+      }
+
+      const nextBindings = {
+        ...bindings,
+        ...keepBindings
+      }
+
       const next: TDSnapshot = {
         ...current,
         document: {
@@ -567,29 +577,23 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           pages: {
             [pageId]: {
               ...current.document.pages[pageId],
-              shapes: {
-                ...shapes,
-                ...keepShapes,
-              },
-              bindings: {
-                ...bindings,
-                ...keepBindings,
-              },
+              shapes: nextShapes,
+              bindings: nextBindings
             },
           },
           pageStates: {
             ...current.document.pageStates,
             [pageId]: {
               ...current.document.pageStates[pageId],
-              selectedIds: selectedIds.filter((id) => shapes[id] !== undefined),
+              selectedIds: selectedIds.filter((id) => nextShapes[id] !== undefined),
               hoveredId: hoveredId
-                ? shapes[hoveredId] === undefined
+                ? nextShapes[hoveredId] === undefined
                   ? undefined
                   : hoveredId
                 : undefined,
               editingId: editingId,
               bindingId: bindingId
-                ? bindings[bindingId] === undefined
+                ? nextBindings[bindingId] === undefined
                   ? undefined
                   : bindingId
                 : undefined,


### PR DESCRIPTION
An additional fix for #425.

In this PR, I'll use the term "draft shapes" to refer to shapes that are in the Tldraw state, but aren't yet committed to the "final" state/storage/multiplayer/etc.

I believe the replacePageContent function also needs to consider "keepShapes" when preserving selectedIds. If not, selectedIds referring to draft shapes are not preserved. In the next call to replacePageContent, draft shapes relying on the previous selection state are forcibly removed, resulting in a crash when an in-progress session tries to access the shape it's manipulating.

This fix should prevent the crash that occurs when a session is interleaved with replacePageContent. I also applied the same logic to hoveredId and bindingId, though to be honest, I'm not sure it's necessary for those two fields.