### PR TITLE
update conflicting ungroup shortcut

### DIFF
--- a/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
@@ -154,7 +154,7 @@ export const ContextMenu = ({ onBlur, children }: ContextMenuProps): JSX.Element
                 </CMRowButton>
               )}
               {hasGroupSelected && (
-                <CMRowButton onClick={handleGroup} kbd="#⇧G">
+                <CMRowButton onClick={handleGroup} kbd="#G">
                   Ungroup
                 </CMRowButton>
               )}

--- a/packages/tldraw/src/components/TopPanel/PreferencesMenu/PreferencesMenu.tsx
+++ b/packages/tldraw/src/components/TopPanel/PreferencesMenu/PreferencesMenu.tsx
@@ -47,7 +47,7 @@ export function PreferencesMenu() {
       <DMCheckboxItem checked={settings.isDarkMode} onCheckedChange={toggleDarkMode} kbd="#⇧D">
         Dark Mode
       </DMCheckboxItem>
-      <DMCheckboxItem checked={settings.isFocusMode} onCheckedChange={toggleFocusMode} kbd="⇧.">
+      <DMCheckboxItem checked={settings.isFocusMode} onCheckedChange={toggleFocusMode} kbd="#.">
         Focus Mode
       </DMCheckboxItem>
       <DMCheckboxItem checked={settings.isDebugMode} onCheckedChange={toggleDebugMode}>
@@ -66,7 +66,11 @@ export function PreferencesMenu() {
       <DMCheckboxItem checked={settings.showCloneHandles} onCheckedChange={toggleCloneControls}>
         Clone Handles
       </DMCheckboxItem>
-      <DMCheckboxItem checked={settings.showGrid} onCheckedChange={toggleGrid} kbd="#⇧G">
+      <DMCheckboxItem
+        checked={settings.showGrid}
+        onCheckedChange={toggleGrid}
+        kbd="#⇧G"
+      >
         Grid
       </DMCheckboxItem>
       <DMCheckboxItem checked={settings.isSnapping} onCheckedChange={toggleisSnapping}>


### PR DESCRIPTION
* change ungroup shorcut to ctrl+g to prevent enabling grid
* update `kbd` prop of focus mode to ctrl+g to be inline with functionality

Issue ref: #422 