### PR TITLE
Bugfix: onPointerDown not called

### DIFF
--- a/packages/core/src/hooks/useShapeEvents.tsx
+++ b/packages/core/src/hooks/useShapeEvents.tsx
@@ -5,7 +5,8 @@ import { TLContext } from '~hooks'
 export function useShapeEvents(id: string) {
   const { rPageState, rSelectionBounds, callbacks, inputs } = React.useContext(TLContext)
 
-  return React.useMemo(() => ({
+  return React.useMemo(
+    () => ({
       onPointerDown: (e: React.PointerEvent) => {
         if (!inputs.pointerIsValid(e)) return
 
@@ -30,6 +31,7 @@ export function useShapeEvents(id: string) {
           !rPageState.current.selectedIds.includes(id)
         ) {
           callbacks.onPointBounds?.(inputs.pointerDown(e, 'bounds'), e)
+          callbacks.onPointShape?.(info, e)
           callbacks.onPointerDown?.(info, e)
           return
         }
@@ -82,6 +84,8 @@ export function useShapeEvents(id: string) {
         if (!inputs.pointerIsValid(e)) return
         const info = inputs.pointerEnter(e, id)
         callbacks.onUnhoverShape?.(info, e)
-      }
-    }), [inputs, callbacks, id])
+      },
+    }),
+    [inputs, callbacks, id]
+  )
 }

--- a/packages/core/src/hooks/useShapeEvents.tsx
+++ b/packages/core/src/hooks/useShapeEvents.tsx
@@ -30,7 +30,7 @@ export function useShapeEvents(id: string) {
           !rPageState.current.selectedIds.includes(id)
         ) {
           callbacks.onPointBounds?.(inputs.pointerDown(e, 'bounds'), e)
-          callbacks.onPointShape?.(info, e)
+          callbacks.onPointerDown?.(info, e)
           return
         }
 


### PR DESCRIPTION
Issue:
When a shape is clicked through the selection bounds without being selected onPointerDown is not called.

I am not sure if the idea is to call both onPointBounds and onPointShape, but from the comment I guess that onPointerDown was supposed to be called instead of onPointShape. 