### PR TITLE
[fix] intersection bug

### DIFF
--- a/packages/core/src/TLShapeUtil/TLShapeUtil.tsx
+++ b/packages/core/src/TLShapeUtil/TLShapeUtil.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import Utils from '../utils'
 import type { TLBounds, TLComponentProps, TLForwardedRef, TLShape, TLUser } from '../types'
-import { intersectPolylineBounds } from '@tldraw/intersect'
+import { intersectPolygonBounds, intersectPolylineBounds } from '@tldraw/intersect'
 
 export abstract class TLShapeUtil<T extends TLShape, E extends Element = any, M = any> {
   refMap = new Map<string, React.RefObject<E>>()
@@ -42,7 +42,7 @@ export abstract class TLShapeUtil<T extends TLShape, E extends Element = any, M 
     const corners = Utils.getRotatedCorners(shapeBounds, shape.rotation)
     return (
       corners.every((point) => Utils.pointInBounds(point, bounds)) ||
-      intersectPolylineBounds(corners, bounds).length > 0
+      intersectPolygonBounds(corners, bounds).length > 0
     )
   }
 

--- a/packages/tldraw/src/state/TldrawApp.spec.ts
+++ b/packages/tldraw/src/state/TldrawApp.spec.ts
@@ -664,7 +664,9 @@ describe('TldrawTestApp', () => {
       const shapes = mockDocument.pages.page1.shapes
       const bindings = mockDocument.pages.page1.bindings
       const app = new TldrawTestApp('multiplayer', {
-        onChangePage: () => {},
+        onChangePage: () => {
+          //
+        },
       }).createPage()
       app.replacePageContent(shapes, bindings)
 
@@ -676,7 +678,9 @@ describe('TldrawTestApp', () => {
       const shapes = mockDocument.pages.page1.shapes
       const bindings = mockDocument.pages.page1.bindings
       const app = new TldrawTestApp('multiplayer', {
-        onChangePage: () => {},
+        onChangePage: () => {
+          //
+        },
       }).createPage()
       app.setSetting('isDebugMode', true)
       app.replacePageContent(shapes, bindings)
@@ -684,5 +688,15 @@ describe('TldrawTestApp', () => {
       expect(app.shapes).toEqual(Object.values(shapes))
       expect(app.bindings).toEqual(Object.values(bindings))
     })
+  })
+
+  describe('When selecting a box', () => {
+    const app = new TldrawTestApp()
+    app
+      .createShapes({ id: 'box1', type: TDShapeType.Rectangle, point: [0, 0], size: [100, 100] })
+      .pointCanvas([-50, 20])
+      .movePointer([50, 50])
+      .movePointer([50, 51])
+      .expectSelectedIdsToBe(['box1'])
   })
 })

--- a/packages/tldraw/src/state/sessions/BrushSession/BrushSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/BrushSession/BrushSession.spec.ts
@@ -8,7 +8,7 @@ describe('Brush session', () => {
       .selectNone()
       .movePointer([-48, -48])
       .startSession(SessionType.Brush)
-      .movePointer([48, 48])
+      .movePointer([10, 10])
       .completeSession()
     expect(app.status).toBe(TDStatus.Idle)
     expect(app.selectedIds.length).toBe(1)

--- a/packages/tldraw/src/state/sessions/BrushSession/BrushSession.ts
+++ b/packages/tldraw/src/state/sessions/BrushSession/BrushSession.ts
@@ -33,6 +33,8 @@ export class BrushSession extends BaseSession {
         bounds: this.app.getShapeUtil(shape).getBounds(shape),
         selectId: shape.id, //TLDR.getTopParentId(data, shape.id, currentPageId),
       }))
+
+    this.update()
   }
 
   start = (): TldrawPatch | undefined => void null

--- a/packages/tldraw/tsconfig.json
+++ b/packages/tldraw/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "~*": ["./src/*"]
+      "~*": ["./src/*"],
+      "@tldraw/core": ["../../packages/core"]
     }
   },
   "references": [{ "path": "../vec" }, { "path": "../intersect" }, { "path": "../core" }],

--- a/packages/tldraw/tsconfig.json
+++ b/packages/tldraw/tsconfig.json
@@ -7,8 +7,7 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "~*": ["./src/*"],
-      "@tldraw/core": ["../../packages/core"]
+      "~*": ["./src/*"]
     }
   },
   "references": [{ "path": "../vec" }, { "path": "../intersect" }, { "path": "../core" }],


### PR DESCRIPTION
This PR fixes a bug in bounds/bounds intersections on the base TLShape. 

We test each edge of the bounding box A for an intersection with each other edge of the bounding box B. Previously certain hit tests would fail as we testing against a poly_line_ rather than a poly_gon_, meaning that you could sneak a box in the left side.

![image](https://user-images.githubusercontent.com/23072548/146569435-d1737dfb-85ca-4317-89a5-154873a4f1c1.png)

This is now fixed!
