### PR TITLE
Add shift+click to draw straight lines between points

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1356,12 +1356,8 @@ left past the initial left edge) then swap points on that axis.
       .reduce(
         (acc, point, i, arr) => {
           if (i === max) {
-            if (closed) {
-              acc.push('Z')
-            }
-          } else {
-            acc.push(point, Vec.med(point, arr[i + 1]))
-          }
+            if (closed) acc.push('Z')
+          } else acc.push(point, Vec.med(point, arr[i + 1]))
           return acc
         },
         ['M', points[0], 'Q']

--- a/packages/tldraw/src/state/sessions/DrawSession/DrawSession.ts
+++ b/packages/tldraw/src/state/sessions/DrawSession/DrawSession.ts
@@ -27,19 +27,19 @@ export class DrawSession extends BaseSession {
     const currentPoint = [0, 0, originPoint[2] ?? 0.5]
     const delta = Vec.sub(originPoint, this.topLeft)
     const initialPoints = this.initialShape.points.map((pt) => Vec.sub(pt, delta).concat(pt[2]))
-    const prevPoint = initialPoints[initialPoints.length - 1]
-    this.isExtending = prevPoint !== undefined
-    let newPoints: number[][]
+    this.isExtending = initialPoints.length > 0
+    const newPoints: number[][] = []
     if (this.isExtending) {
-      newPoints = [prevPoint, prevPoint]
+      const prevPoint = initialPoints[initialPoints.length - 1]
+      newPoints.push(prevPoint, prevPoint)
       // Continuing with shift
       const len = Math.ceil(Vec.dist(prevPoint, currentPoint) / 16)
-      for (let i = 0; i < len - 1; i++) {
+      for (let i = 0; i < len; i++) {
         const t = i / (len - 1)
         newPoints.push(Vec.lrp(prevPoint, currentPoint, t).concat(prevPoint[2]))
       }
     } else {
-      newPoints = [currentPoint]
+      newPoints.push(currentPoint)
     }
     // Add a first point but don't update the shape yet. We'll update
     // when the draw session ends; if the user hasn't added additional

--- a/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
+++ b/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
@@ -62,14 +62,9 @@ export function getDrawStrokePathTDSnapshot(shape: DrawShape) {
  */
 export function getSolidStrokePathTDSnapshot(shape: DrawShape) {
   const { points } = shape
-
   if (points.length < 2) return 'M 0 0 L 0 0'
-
   const options = getFreehandOptions(shape)
-
   const strokePoints = getDrawStrokePoints(shape, options).map((pt) => pt.point.slice(0, 2))
-
   const path = Utils.getSvgPathFromStroke(strokePoints, false)
-
   return path
 }

--- a/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
+++ b/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
@@ -1,4 +1,5 @@
 import { Utils } from '@tldraw/core'
+import Vec from '@tldraw/vec'
 import { getStrokeOutlinePoints, getStrokePoints, StrokeOptions } from 'perfect-freehand'
 import type { DrawShape } from '~types'
 import { getShapeStyle } from '../shared/shape-styles'
@@ -59,7 +60,8 @@ export function getSolidStrokePathTDSnapshot(shape: DrawShape) {
   if (points.length < 2) return 'M 0 0 L 0 0'
   const options = getFreehandOptions(shape)
   const strokePoints = getDrawStrokePoints(shape, options).map((pt) => pt.point.slice(0, 2))
-  strokePoints.push(points[points.length - 1].slice(0, 2))
+  const last = points[points.length - 1].slice(0, 2)
+  if (!Vec.isEqual(strokePoints[0], last)) strokePoints.push(last)
   const path = Utils.getSvgPathFromStroke(strokePoints, false)
   return path
 }

--- a/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
+++ b/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
@@ -45,15 +45,9 @@ export function getDrawStrokePoints(shape: DrawShape, options: StrokeOptions) {
  */
 export function getDrawStrokePathTDSnapshot(shape: DrawShape) {
   if (shape.points.length < 2) return ''
-
   const options = getFreehandOptions(shape)
-
   const strokePoints = getDrawStrokePoints(shape, options)
-
-  const stroke = getStrokeOutlinePoints(strokePoints, options)
-
-  const path = Utils.getSvgPathFromStroke(stroke)
-
+  const path = Utils.getSvgPathFromStroke(getStrokeOutlinePoints(strokePoints, options))
   return path
 }
 
@@ -65,6 +59,7 @@ export function getSolidStrokePathTDSnapshot(shape: DrawShape) {
   if (points.length < 2) return 'M 0 0 L 0 0'
   const options = getFreehandOptions(shape)
   const strokePoints = getDrawStrokePoints(shape, options).map((pt) => pt.point.slice(0, 2))
+  strokePoints.push(points[points.length - 1].slice(0, 2))
   const path = Utils.getSvgPathFromStroke(strokePoints, false)
   return path
 }

--- a/packages/tldraw/src/state/tools/DrawTool/DrawTool.ts
+++ b/packages/tldraw/src/state/tools/DrawTool/DrawTool.ts
@@ -1,12 +1,38 @@
 import { Utils, TLPointerEventHandler } from '@tldraw/core'
 import { Draw } from '~state/shapes'
 import { SessionType, TDShapeType } from '~types'
-import { BaseTool, Status } from '../BaseTool'
+import { BaseTool } from '../BaseTool'
+
+enum Status {
+  Idle = 'idle',
+  Creating = 'creating',
+  Extending = 'extending',
+  Pinching = 'pinching',
+}
 
 export class DrawTool extends BaseTool {
   type = TDShapeType.Draw as const
 
-  private lastPoint?: number[]
+  private lastShapeId?: string
+
+  onEnter = () => {
+    this.lastShapeId = undefined
+  }
+
+  onCancel = () => {
+    switch (this.status) {
+      case Status.Idle: {
+        this.app.selectTool('select')
+        break
+      }
+      default: {
+        this.setStatus(Status.Idle)
+        break
+      }
+    }
+
+    this.app.cancelSession()
+  }
 
   /* ----------------- Event Handlers ----------------- */
 
@@ -16,31 +42,39 @@ export class DrawTool extends BaseTool {
       currentPoint,
       appState: { currentPageId, currentStyle },
     } = this.app
-    const childIndex = this.getNextChildIndex()
-    const id = Utils.uniqueId()
-    const newShape = Draw.create({
-      id,
-      parentId: currentPageId,
-      childIndex,
-      point: [...currentPoint, info.pressure || 0.5],
-      style: { ...currentStyle },
-    })
-    this.app.patchCreate([newShape])
-    this.app.startSession(SessionType.Draw, id, info.shiftKey ? this.lastPoint : undefined)
-    this.setStatus(Status.Creating)
+    if (info.shiftKey && this.lastShapeId) {
+      // Extend the previous shape
+      this.app.startSession(SessionType.Draw, this.lastShapeId)
+      this.setStatus(Status.Extending)
+    } else {
+      // Create a new shape
+      const childIndex = this.getNextChildIndex()
+      const id = Utils.uniqueId()
+      const newShape = Draw.create({
+        id,
+        parentId: currentPageId,
+        childIndex,
+        point: currentPoint,
+        style: { ...currentStyle },
+      })
+      this.lastShapeId = id
+      this.app.patchCreate([newShape])
+      this.app.startSession(SessionType.Draw, id)
+      this.setStatus(Status.Creating)
+    }
   }
 
   onPointerMove: TLPointerEventHandler = () => {
-    if (this.status === Status.Creating) {
-      this.app.updateSession()
+    switch (this.status) {
+      case Status.Extending:
+      case Status.Creating: {
+        this.app.updateSession()
+      }
     }
   }
 
   onPointerUp: TLPointerEventHandler = () => {
-    if (this.status === Status.Creating) {
-      this.app.completeSession()
-      this.lastPoint = [...this.app.currentPoint]
-    }
+    this.app.completeSession()
     this.setStatus(Status.Idle)
   }
 }

--- a/packages/tldraw/src/state/tools/DrawTool/DrawTool.ts
+++ b/packages/tldraw/src/state/tools/DrawTool/DrawTool.ts
@@ -6,20 +6,18 @@ import { BaseTool, Status } from '../BaseTool'
 export class DrawTool extends BaseTool {
   type = TDShapeType.Draw as const
 
+  private lastPoint?: number[]
+
   /* ----------------- Event Handlers ----------------- */
 
   onPointerDown: TLPointerEventHandler = (info) => {
     if (this.status !== Status.Idle) return
-
     const {
       currentPoint,
       appState: { currentPageId, currentStyle },
     } = this.app
-
     const childIndex = this.getNextChildIndex()
-
     const id = Utils.uniqueId()
-
     const newShape = Draw.create({
       id,
       parentId: currentPageId,
@@ -27,11 +25,8 @@ export class DrawTool extends BaseTool {
       point: [...currentPoint, info.pressure || 0.5],
       style: { ...currentStyle },
     })
-
     this.app.patchCreate([newShape])
-
-    this.app.startSession(SessionType.Draw, id)
-
+    this.app.startSession(SessionType.Draw, id, info.shiftKey ? this.lastPoint : undefined)
     this.setStatus(Status.Creating)
   }
 
@@ -44,8 +39,8 @@ export class DrawTool extends BaseTool {
   onPointerUp: TLPointerEventHandler = () => {
     if (this.status === Status.Creating) {
       this.app.completeSession()
+      this.lastPoint = [...this.app.currentPoint]
     }
-
     this.setStatus(Status.Idle)
   }
 }

--- a/packages/vec/src/index.ts
+++ b/packages/vec/src/index.ts
@@ -486,7 +486,6 @@ export class Vec {
    * @param A The first point.
    * @param B The second point.
    * @param steps The number of points to return.
-   * @param ease An easing function to apply to the simulated pressure.
    */
   static pointsBetween = (A: number[], B: number[], steps = 6): number[][] => {
     return Array.from(Array(steps)).map((_, i) => {


### PR DESCRIPTION
This PR allows "shift+clicking" to extend a previous draw shape.

![Kapture 2022-01-01 at 19 33 06](https://user-images.githubusercontent.com/23072548/147861325-8fe30e43-3dc6-41e9-ac4b-d4fe8b23b61c.gif)

When the draw tool is active, and after completing at least one shape, a user can hold shift while pointing to continue adding points to their previous draw shape rather than creating a new draw shape.