### PR TITLE
[fix] clone while editing bug

### DIFF
--- a/packages/tldraw/src/state/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/state/tools/SelectTool/SelectTool.ts
@@ -195,7 +195,11 @@ export class SelectTool extends BaseTool<Status> {
         break
       }
       case 'Tab': {
-        if (this.status === Status.Idle && this.app.selectedIds.length === 1) {
+        if (
+          !this.app.pageState.editingId &&
+          this.status === Status.Idle &&
+          this.app.selectedIds.length === 1
+        ) {
           const [selectedId] = this.app.selectedIds
           const clonedShape = this.getShapeClone(selectedId, 'right')
 


### PR DESCRIPTION
This PR fixes the issue raised here https://github.com/tldraw/tldraw/issues/474, where pressing Tab while editing would clone the selected shape.