### PR TITLE
Fix group error

### DIFF
--- a/packages/tldraw/src/state/commands/groupShapes/groupShapes.ts
+++ b/packages/tldraw/src/state/commands/groupShapes/groupShapes.ts
@@ -10,6 +10,8 @@ export function groupShapes(
   groupId: string,
   pageId: string
 ): TldrawCommand | undefined {
+  if (ids.length < 2) return
+
   const beforeShapes: Record<string, Patch<TDShape | undefined>> = {}
   const afterShapes: Record<string, Patch<TDShape | undefined>> = {}
 
@@ -30,10 +32,9 @@ export function groupShapes(
       shapesToGroup.push(shape)
     } else {
       const childIds = shape.children.filter((id) => !app.getShape(id).isLocked)
-
       otherEffectedGroups.push(shape)
       idsToGroup.push(...childIds)
-      shapesToGroup.push(...childIds.map((id) => app.getShape(id)))
+      shapesToGroup.push(...childIds.map((id) => app.getShape(id)).filter(Boolean))
     }
   }
 


### PR DESCRIPTION
This is (should be) a fix for a bug in groups seen here: https://sentry.io/share/issue/ffead777fe4642f28d17d9b971de3a5d/.

My sense is that there may be an underlying issue where a group shape's children array is not correctly updated when shapes are deleted, however this should fix the reported crash.