### PR TITLE
Fix: Persist app settings on creating new project or reloading the app

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.spec.ts
+++ b/packages/tldraw/src/state/TldrawApp.spec.ts
@@ -4,6 +4,21 @@ import { ArrowShape, ColorStyle, SessionType, TDShapeType } from '~types'
 import type { SelectTool } from './tools/SelectTool'
 
 describe('TldrawTestApp', () => {
+  
+  describe('When creating a new project...', () => {
+    it('persists the app settings', () => {
+      const app = new TldrawTestApp().loadDocument(mockDocument)
+      app.setSetting('isDarkMode', true)
+      app.setSetting('isDebugMode', false)
+      app.setSetting('isPenMode', false)
+      const settings = app.settings
+
+      app.newProject()
+
+      expect(app.settings).toEqual(settings)
+    })
+  })
+
   describe('When copying and pasting...', () => {
     it('copies a shape', () => {
       new TldrawTestApp().loadDocument(mockDocument).selectNone().copy(['rect1'])

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1360,6 +1360,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           currentPageId: Object.keys(document.pages)[0],
           disableAssets: this.disableAssets,
         },
+        settings: this.settings,
       },
       'loaded_document'
     )

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1364,7 +1364,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           currentPageId: Object.keys(document.pages)[0],
           disableAssets: this.disableAssets,
         },
-        settings: this.settings,
       },
       'loaded_document'
     )


### PR DESCRIPTION
This PR fixes  the issue raised here: #482 , where app settings wouldn't persist on creating a new project or reloading the app.