### PR TITLE
Fix error on file save/save-as

### DIFF
--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -48,7 +48,8 @@ export async function saveToFileSystem(document: TDDocument, fileHandle: FileSys
 
   // Save to file system
   // @ts-ignore
-  const fileSave = await import('./browser-fs-access').default.fileSave
+  const browserFS = await import('./browser-fs-access')
+  const fileSave = browserFS.fileSave
   const newFileHandle = await fileSave(
     blob,
     {
@@ -128,6 +129,7 @@ export function fileToBase64(file: Blob): Promise<string | ArrayBuffer | null> {
 
 export function getSizeFromSrc(src: string): Promise<number[]> {
   return new Promise((resolve, reject) => {
+    console.log(src)
     const img = new Image()
     img.onload = () => resolve([img.width, img.height])
     img.onerror = () => reject(new Error('Could not get image size'))

--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -129,7 +129,6 @@ export function fileToBase64(file: Blob): Promise<string | ArrayBuffer | null> {
 
 export function getSizeFromSrc(src: string): Promise<number[]> {
   return new Promise((resolve, reject) => {
-    console.log(src)
     const img = new Image()
     img.onload = () => resolve([img.width, img.height])
     img.onerror = () => reject(new Error('Could not get image size'))

--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -72,7 +72,8 @@ export async function openFromFileSystem(): Promise<null | {
 }> {
   // Get the blob
   // @ts-ignore
-  const fileOpen = await import('./browser-fs-access').fileOpen
+  const browserFS = await import('./browser-fs-access')
+  const fileOpen = browserFS.fileOpen
   const blob = await fileOpen({
     description: 'Tldraw File',
     extensions: [`.tldr`],
@@ -107,7 +108,8 @@ export async function openFromFileSystem(): Promise<null | {
 
 export async function openAssetFromFileSystem() {
   // @ts-ignore
-  const fileOpen = await import('./browser-fs-access').fileOpen
+  const browserFS = await import('./browser-fs-access')
+  const fileOpen = browserFS.fileOpen
   return fileOpen({
     description: 'Image or Video',
     extensions: [...IMAGE_EXTENSIONS, ...VIDEO_EXTENSIONS],


### PR DESCRIPTION
Fixes #495 

## Reason for error
The `browser-fs-access` module doesn't seem to have a default export. 