### PR TITLE
Fix: Alt + click copying an image/video shape and undoing causes crash

### DIFF
--- a/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
+++ b/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
@@ -54,6 +54,8 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
     [app]
   )
 
+  const close = React.useCallback(() => setIsOpen(false), [])
+
   function stopPropagation(e: React.KeyboardEvent<HTMLDivElement>) {
     e.stopPropagation()
   }
@@ -85,18 +87,20 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
           </SmallIcon>
         </IconButton>
       </Dialog.Trigger>
-      <StyledDialogOverlay />
-      <StyledDialogContent dir="ltr" onKeyDown={stopPropagation} onKeyUp={stopPropagation}>
-        <DialogAction onSelect={handleRename}>Rename</DialogAction>
-        <DialogAction onSelect={handleDuplicate}>Duplicate</DialogAction>
-        <DialogAction disabled={!canDelete} onSelect={handleDelete}>
-          Delete
-        </DialogAction>
-        <Divider />
-        <Dialog.Cancel asChild>
-          <RowButton>Cancel</RowButton>
-        </Dialog.Cancel>
-      </StyledDialogContent>
+      <Dialog.Portal>
+        <StyledDialogOverlay onPointerDown={close} />
+        <StyledDialogContent dir="ltr" onKeyDown={stopPropagation} onKeyUp={stopPropagation}>
+          <DialogAction onSelect={handleRename}>Rename</DialogAction>
+          <DialogAction onSelect={handleDuplicate}>Duplicate</DialogAction>
+          <DialogAction disabled={!canDelete} onSelect={handleDelete}>
+            Delete
+          </DialogAction>
+          <Divider />
+          <Dialog.Cancel asChild>
+            <RowButton>Cancel</RowButton>
+          </Dialog.Cancel>
+        </StyledDialogContent>
+      </Dialog.Portal>
     </Dialog.Root>
   )
 }
@@ -127,12 +131,8 @@ export const StyledDialogContent = styled(Dialog.Content, {
 export const StyledDialogOverlay = styled(Dialog.Overlay, {
   backgroundColor: 'rgba(0, 0, 0, .15)',
   position: 'fixed',
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-  width: '100%',
-  height: '100%',
+  pointerEvents: 'all',
+  inset: 0,
 })
 
 function DialogAction({

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -50,7 +50,8 @@ import {
   saveToFileSystem,
   openAssetFromFileSystem,
   fileToBase64,
-  getSizeFromSrc,
+  getImageSizeFromSrc,
+  getVideoSizeFromSrc,
 } from './data'
 import { TLDR } from './TLDR'
 import { shapeUtils } from '~state/shapes'
@@ -2876,11 +2877,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         src = await fileToBase64(file)
       }
       if (typeof src === 'string') {
-        const size = isImage
-          ? await getSizeFromSrc(src).catch((e) => {
-              throw e
-            })
-          : [401.42, 401.42] // special
+        const size = isImage ? await getImageSizeFromSrc(src) : await getVideoSizeFromSrc(src)
         const match = Object.values(this.document.assets).find(
           (asset) => asset.type === assetType && asset.src === src
         )

--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -129,11 +129,20 @@ export function fileToBase64(file: Blob): Promise<string | ArrayBuffer | null> {
   })
 }
 
-export function getSizeFromSrc(src: string): Promise<number[]> {
+export function getImageSizeFromSrc(src: string): Promise<number[]> {
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.onload = () => resolve([img.width, img.height])
     img.onerror = () => reject(new Error('Could not get image size'))
     img.src = src
+  })
+}
+
+export function getVideoSizeFromSrc(src: string): Promise<number[]> {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video')
+    video.onloadedmetadata = () => resolve([video.videoWidth, video.videoHeight])
+    video.onerror = () => reject(new Error('Could not get video size'))
+    video.src = src
   })
 }

--- a/packages/tldraw/src/state/shapes/ImageUtil/ImageUtil.tsx
+++ b/packages/tldraw/src/state/shapes/ImageUtil/ImageUtil.tsx
@@ -58,16 +58,6 @@ export class ImageUtil extends TDShapeUtil<T, E> {
         wrapper.style.height = `${height}px`
       }, [size])
 
-      const onImageLoad = React.useCallback(() => {
-        const wrapper = rWrapper.current
-        const image = rImage.current
-        if (!(image && wrapper)) return
-        const { width, height } = image
-        wrapper.style.width = `${width}px`
-        wrapper.style.height = `${height}px`
-        onShapeChange?.({ id: shape.id, size: [width, height] })
-      }, [])
-
       return (
         <HTMLContainer ref={ref} {...events}>
           {isBinding && (
@@ -94,7 +84,7 @@ export class ImageUtil extends TDShapeUtil<T, E> {
               src={(asset as TDImageAsset).src}
               alt="tl_image_asset"
               draggable={false}
-              onLoad={onImageLoad}
+              // onLoad={onImageLoad}
             />
           </Wrapper>
         </HTMLContainer>

--- a/packages/tldraw/src/state/shapes/VideoUtil/VideoUtil.tsx
+++ b/packages/tldraw/src/state/shapes/VideoUtil/VideoUtil.tsx
@@ -62,23 +62,6 @@ export class VideoUtil extends TDShapeUtil<T, E> {
         wrapper.style.height = `${height}px`
       }, [size])
 
-      const onImageLoad = React.useCallback(() => {
-        const wrapper = rWrapper.current
-        const video = rVideo.current
-        if (!(video && wrapper)) return
-        if (!Vec.isEqual(size, [401.42, 401.42])) return
-        const { videoWidth, videoHeight } = video
-        wrapper.style.width = `${videoWidth}px`
-        wrapper.style.height = `${videoHeight}px`
-        const newSize = [videoWidth, videoHeight]
-        const delta = Vec.sub(size, newSize)
-        onShapeChange?.({
-          id: shape.id,
-          point: Vec.add(shape.point, Vec.div(delta, 2)),
-          size: [videoWidth, videoHeight],
-        })
-      }, [size])
-
       React.useLayoutEffect(() => {
         const video = rVideo.current
         if (!video) return
@@ -144,7 +127,6 @@ export class VideoUtil extends TDShapeUtil<T, E> {
               onPlay={handlePlay}
               onPause={handlePause}
               onTimeUpdate={handleSetCurrentTime}
-              onLoadedMetadata={onImageLoad}
             >
               <source src={(asset as TDVideoAsset).src} />
             </VideoElement>


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/502

The call to onShapeChange was creating a patch of {id: '', size: [xx,xx]} which was then causing the crash in useShapeTree during undo.

I don't believe this call is needed as the size is fetched and stored for images inside onAssetAdd.
I've also added a function to fetch the video size inside onAssetAdd so the onShapeChange call isn't needed for videos either.



