### PR TITLE
Fix: Only assets that are actually deleted call `onAssetDelete`

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2588,8 +2588,21 @@ export class TldrawApp extends StateManager<TDSnapshot> {
    */
   delete = (ids = this.selectedIds): this => {
     if (ids.length === 0) return this
-    ids.forEach((id) => this.getShape(id).assetId && this.callbacks.onAssetDelete?.(id))
-    return this.setState(Commands.deleteShapes(this, ids))
+    const drawCommand = Commands.deleteShapes(this, ids)
+
+    if (drawCommand.before.document?.assets && drawCommand.after.document?.assets) {
+      const beforeAssetIds = Object.keys(drawCommand.before.document.assets).filter(
+        (k) => !!drawCommand.before.document!.assets![k]
+      )
+      const afterAssetIds = Object.keys(drawCommand.after.document.assets).filter(
+        (k) => !!drawCommand.after.document!.assets![k]
+      )
+
+      const intersection = beforeAssetIds.filter((x) => !afterAssetIds.includes(x))
+      intersection.forEach((id) => this.callbacks.onAssetDelete?.(id))
+    }
+
+    return this.setState(drawCommand)
   }
 
   /**

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2590,7 +2590,11 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     if (ids.length === 0) return this
     const drawCommand = Commands.deleteShapes(this, ids)
 
-    if (drawCommand.before.document?.assets && drawCommand.after.document?.assets) {
+    if (
+      this.callbacks.onAssetDelete &&
+      drawCommand.before.document?.assets &&
+      drawCommand.after.document?.assets
+    ) {
       const beforeAssetIds = Object.keys(drawCommand.before.document.assets).filter(
         (k) => !!drawCommand.before.document!.assets![k]
       )
@@ -2599,7 +2603,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       )
 
       const intersection = beforeAssetIds.filter((x) => !afterAssetIds.includes(x))
-      intersection.forEach((id) => this.callbacks.onAssetDelete?.(id))
+      intersection.forEach((id) => this.callbacks.onAssetDelete!(id))
     }
 
     return this.setState(drawCommand)

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2585,6 +2585,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
    */
   delete = (ids = this.selectedIds): this => {
     if (ids.length === 0) return this
+    ids.forEach((id) => this.getShape(id).assetId && this.callbacks.onAssetDelete?.(id))
     return this.setState(Commands.deleteShapes(this, ids))
   }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/55190601/149623323-8dc03fdb-a63c-46fe-a185-c8d2da7d0e88.mp4

Logging: Assets that are actually deleted. `onAssetDelete` will be called on these asset IDs

Note how deleting duplicate asset shapes results in an empty array (no IDs to delete as the asset is being used in another shape).

Addressing: 
- https://github.com/tldraw/tldraw/pull/505#issuecomment-1013388316