### PR TITLE
feat: minify JSON for optimised .tldr exports

### DIFF
--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -52,6 +52,7 @@
     "@tldraw/intersect": "^1.4.3",
     "@tldraw/vec": "^1.4.3",
     "idb-keyval": "^6.0.3",
+    "jsonminify": "^0.4.2",
     "perfect-freehand": "^1.0.16",
     "puppeteer": "^13.0.1",
     "react-hotkeys-hook": "^3.4.0",
@@ -62,6 +63,7 @@
     "@swc-node/jest": "^1.3.3",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@types/jsonminify": "^0.4.1",
     "tsconfig-replace-paths": "^0.0.11"
   },
   "jest": {

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -447,7 +447,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     }
 
     // Cleanup assets
-    if (!('assets' in next.document)) next.document.assets = {}
+    // if (!('assets' in next.document)) next.document.assets = {}
 
     Object.keys(next.document.assets).forEach((id) => {
       if (!next.document.assets[id]) {

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -300,7 +300,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
    * @returns The final state
    */
   protected cleanup = (state: TDSnapshot, prev: TDSnapshot): TDSnapshot => {
-    const next = { ...state }
+    const next: TDSnapshot = { ...state }
 
     // Remove deleted shapes and bindings (in Commands, these will be set to undefined)
     if (next.document !== prev.document) {
@@ -447,7 +447,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     }
 
     // Cleanup assets
-    // if (!('assets' in next.document)) next.document.assets = {}
+    if (!('assets' in next.document)) next.document.assets = {}
 
     Object.keys(next.document.assets).forEach((id) => {
       if (!next.document.assets[id]) {

--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -34,9 +34,16 @@ export async function saveToFileSystem(document: TDDocument, fileHandle: FileSys
     assets: {},
   }
 
-  // Serialize to JSON
-  const jsonStr = JSON.stringify(file, null, 2)
-  const json = process.env.NODE_ENV === 'production' ? JSON.minify(jsonStr) : jsonStr
+  try {
+    minify(JSON.stringify(file))
+  } catch (e) {
+    console.error(e)
+  }
+
+  const json =
+    process.env.NODE_ENV === 'development'
+      ? minify(JSON.stringify(file))
+      : JSON.stringify(file, null, 2)
 
   // Create blob
   const blob = new Blob([json], {

--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -3,6 +3,7 @@ import type { TDDocument, TDFile } from '~types'
 import type { FileSystemHandle } from './browser-fs-access'
 import { get as getFromIdb, set as setToIdb } from 'idb-keyval'
 import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS } from '~constants'
+import minify from 'jsonminify'
 
 const options = { mode: 'readwrite' as const }
 
@@ -34,7 +35,8 @@ export async function saveToFileSystem(document: TDDocument, fileHandle: FileSys
   }
 
   // Serialize to JSON
-  const json = JSON.stringify(file, null, 2)
+  const jsonStr = JSON.stringify(file, null, 2)
+  const json = process.env.NODE_ENV === 'production' ? JSON.minify(jsonStr) : jsonStr
 
   // Create blob
   const blob = new Blob([json], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,6 +3698,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jsonminify@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonminify/-/jsonminify-0.4.1.tgz#c4615a6116f8a4231ef0af4b163cb450886db4f1"
+  integrity sha512-CkbsT83tCMuFefGh+aXlsunetd66yN62QxtjBfk4lX4zMVBPRlWyHQvZvIPOMUznVA7MXdt6RtqHa9fra1PlCw==
+
 "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -9966,6 +9971,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonminify@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/jsonminify/-/jsonminify-0.4.2.tgz#fe6fb09391227e856f8c7c0761ff11b497b61fe8"
+  integrity sha512-mEtP5ECD0293D+s45JhDutqF5mFCkWY8ClrPFxjSFR2KUoantofky7noSzyKnAnD9Gd8pXHZSUd5bgzLDUBbfA==
 
 jsonparse@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
* added jsonminify to minify JSON strings
* only works in production
---
* TldrawApp.ts L:450 commented out for the time being
* There is an issue with incorrect type inference for `next.document.assets` as `never`, which causes package build to fail

![image](https://user-images.githubusercontent.com/39856034/149626763-51c4e5e6-ddb6-4777-9311-a46123e7f58e.png)

* The line was introduced in PR #468 

Issue ref for this PR: #418 