### PR TITLE
Fix missing text shape props in onShapeChange

### DIFF
--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -86,6 +86,7 @@ export class TextUtil extends TDShapeUtil<T, E> {
           }
 
           onShapeChange?.({
+            ...shape,
             id: shape.id,
             point: Vec.sub(shape.point, delta),
             text: TLDR.normalizeText(e.currentTarget.value),


### PR DESCRIPTION
Passing text shapes through `onShapeChange` strips all their props except `id`, `point`, and `text`. The missing properties are, however, necessary for proper undo state patching, which causes the exception in #515.

Passing all text shape props through `onShapeChange` fixes #515.