### PR TITLE
Add garbage collection system for assets

### DIFF
--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -30,6 +30,7 @@ import { UsersIndicators } from '~components/UsersIndicators'
 import { SnapLines } from '~components/SnapLines/SnapLines'
 import { Grid } from '~components/Grid'
 import { Overlay } from '~components/Overlay'
+import { useExitEvents } from '~hooks/useExitEvents'
 
 interface CanvasProps<T extends TLShape, M extends Record<string, unknown>> {
   page: TLPage<T, TLBinding>
@@ -98,6 +99,8 @@ export const Canvas = observer(function _Canvas<
   usePerformanceCss(performanceMode, rContainer)
 
   useKeyEvents()
+
+  useExitEvents()
 
   const events = useCanvasEvents()
 

--- a/packages/core/src/hooks/useExitEvents.tsx
+++ b/packages/core/src/hooks/useExitEvents.tsx
@@ -1,0 +1,17 @@
+import { useTLContext } from '../hooks'
+import * as React from 'react'
+
+export function useExitEvents() {
+  const { callbacks } = useTLContext()
+
+  React.useEffect(() => {
+    const handleBeforeunload = (e: BeforeUnloadEvent) => {
+      callbacks.onBeforeUnload?.(e)
+    }
+
+    window.addEventListener('beforeunload', handleBeforeunload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeunload)
+    }
+  }, [callbacks])
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,7 @@ export type TLAssets = Record<string, TLAsset>
 export interface TLAsset {
   id: string
   type: string
+  garbage: boolean
 }
 
 export type Patch<T> = Partial<{ [P in keyof T]: T | Partial<T> | Patch<T[P]> }>
@@ -241,6 +242,7 @@ export interface TLCallbacks<T extends TLShape> {
   onRenderCountChange: (ids: string[]) => void
   onError: (error: Error) => void
   onBoundsChange: (bounds: TLBounds) => void
+  onBeforeUnload: (e: BeforeUnloadEvent) => void
 
   // Keyboard event handlers
   onKeyDown: TLKeyboardEventHandler

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -121,6 +121,7 @@ export function Tldraw({
   onAssetCreate,
   onAssetDelete,
   onExport,
+  onExit,
 }: TldrawProps) {
   const [sId, setSId] = React.useState(id)
 
@@ -145,6 +146,7 @@ export function Tldraw({
       onChangePage,
       onAssetDelete,
       onAssetCreate,
+      onExit,
     })
     return app
   })
@@ -173,6 +175,7 @@ export function Tldraw({
       onAssetDelete,
       onAssetCreate,
       onExport,
+      onExit,
     })
     setSId(id)
     setApp(newApp)
@@ -227,6 +230,7 @@ export function Tldraw({
       onAssetDelete,
       onAssetCreate,
       onExport,
+      onExit,
     }
   }, [
     onMount,
@@ -248,6 +252,7 @@ export function Tldraw({
     onAssetDelete,
     onAssetCreate,
     onExport,
+    onExit,
   ])
 
   // Use the `key` to ensure that new selector hooks are made when the id changes
@@ -438,6 +443,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
           onKeyUp={app.onKeyUp}
           onDragOver={app.onDragOver}
           onDrop={app.onDrop}
+          onBeforeUnload={app.onBeforeUnload}
         />
       </ContextMenu>
       {showUI && (

--- a/packages/tldraw/src/state/StateManager/StateManager.ts
+++ b/packages/tldraw/src/state/StateManager/StateManager.ts
@@ -231,6 +231,7 @@ export class StateManager<T extends Record<string, any>> {
     this.applyPatch(command.after, id)
     if (this.onCommand) this.onCommand(this._state, id)
     this.persist(id)
+
     return this
   }
 

--- a/packages/tldraw/src/state/commands/deleteShapes/deleteShapes.ts
+++ b/packages/tldraw/src/state/commands/deleteShapes/deleteShapes.ts
@@ -4,7 +4,7 @@ import { removeShapesFromPage } from '../shared/removeShapesFromPage'
 
 const removeAssetsFromDocument = (assets: TDAssets, idsToRemove: string[]) => {
   const afterAssets: Record<string, TDAsset | undefined> = { ...assets }
-  idsToRemove.forEach((id) => (afterAssets[id] = undefined))
+  idsToRemove.forEach((id) => afterAssets[id] && (afterAssets[id]!.garbage = true))
   return afterAssets
 }
 


### PR DESCRIPTION
## The problem 

When the user deletes an asset, we want to also remove it from the S3 bucket. However, if the user hits Undo, we do not want to re-upload the asset. 

## The solution

Instead of removing the asset from the asset table. It is marked with the `garbage` flag. The garbage flag is only set when the asset is orphaned. 

## Todo

- [ ] Figure out a garbage collection strategy 