### PR TITLE
fix: resolve redo shortcut misconfiguration

### DIFF
--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -227,7 +227,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   )
 
   useHotkeys(
-    'ctrl+shift-z,⌘+shift+z',
+    'ctrl+shift+z,⌘+shift+z',
     () => {
       if (!canHandleEvent(true)) return
 


### PR DESCRIPTION
Fixes the issue tldraw/tldraw-v1#281 which also shows up in the www app. Could not try within the VS Code Extension though.

### Change type

- [x] `bugfix` 

### Test plan

1. Verify that the redo keyboard shortcut works as expected in the web application.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a misconfiguration with the redo keyboard shortcut.