### PR TITLE
[feature] Transparent or white background on export

### DIFF
--- a/apps/www/pages/api/export.ts
+++ b/apps/www/pages/api/export.ts
@@ -74,6 +74,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         app.selectAll()
         app.zoomToSelection()
         app.selectNone()
+        const tlContainer = document.getElementsByClassName('tl-container').item(0) as HTMLElement;
+        if (tlContainer) {
+          tlContainer.style.background = 'transparent';
+        }
       } catch (e) {
         err = e.message
       }
@@ -83,6 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     const imageBuffer = await page.screenshot({
       type,
+      omitBackground: true
     })
     await browser.close()
     res.status(200).send(imageBuffer)


### PR DESCRIPTION
https://github.com/tldraw/tldraw/issues/522

Makes background transparent for formats that support it(png). Otherwise the background is set to white(jpg).

Example(cropped) images:
![jpeg-before](https://user-images.githubusercontent.com/109486/152717571-e3da0b75-ffef-4990-9471-32ca4ac7b5d6.jpeg)
![jpeg-after](https://user-images.githubusercontent.com/109486/152717572-85f1a04b-41da-457c-98b7-c1e3a28ebc4f.jpeg)
![png-before](https://user-images.githubusercontent.com/109486/152717573-24426750-1c8b-4223-8f1a-a35e7687e22e.png)
![png-after](https://user-images.githubusercontent.com/109486/152717575-f4508b04-5480-40d5-9783-e0e0e564f998.png)

