### PR TITLE
Removes duplicate "Using the File System" link

### DIFF
--- a/examples/tldraw-example/src/app.tsx
+++ b/examples/tldraw-example/src/app.tsx
@@ -79,9 +79,6 @@ export default function App(): JSX.Element {
                   <Link to="/loading-files">Loading Files</Link>
                 </li>
                 <li>
-                  <Link to="/file-system">Using the File System</Link>
-                </li>
-                <li>
                   <Link to="/controlled">Controlled via Props</Link>
                 </li>
                 <li>


### PR DESCRIPTION
In the tldraw-example app (the link is already on line 73)