### PR TITLE
Extract SVGs size from viewBox attibute

### DIFF
--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -129,6 +129,18 @@ export function fileToBase64(file: Blob): Promise<string | ArrayBuffer | null> {
   })
 }
 
+export function fileToText(file: Blob): Promise<string | ArrayBuffer | null> {
+  return new Promise((resolve, reject) => {
+    if (file) {
+      const reader = new FileReader()
+      reader.readAsText(file)
+      reader.onload = () => resolve(reader.result)
+      reader.onerror = (error) => reject(error)
+      reader.onabort = (error) => reject(error)
+    }
+  })
+}
+
 export function getImageSizeFromSrc(src: string): Promise<number[]> {
   return new Promise((resolve, reject) => {
     const img = new Image()


### PR DESCRIPTION
As Browsers do handle SVG Dimensions pretty different, i.e. FireFox renders and SVG as 0x0 when it does not have a `width` or `height` attributes.
This litte change attempts to extract the `viewBox` attract and takes the sizing from there.
If the size can not be detected via `viewBox` it'll still use the default logic from `getImageSizeFromSrc` to get the image size.