### PR TITLE
fix(keybindings): update vscode keybindings with windows alternatives

### DIFF
--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -52,47 +52,48 @@
 		],
 		"keybindings": [
 			{
-				"key": "cmd+shift+d",
+				"key": "ctrl+shift+d",
+				"mac": "cmd+shift+d",
 				"title": "Toggle Dark Mode",
 				"command": "tldraw.tldr.toggleDarkMode",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
-				"key": "cmd+numpad_add",
-				"win": "ctrl+numpad_add",
+				"key": "ctrl+numpad_add",
+				"mac": "cmd+numpad_add",
 				"title": "Zoom In",
 				"command": "tldraw.tldr.zoomIn",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
-				"key": "cmd+=",
-				"win": "ctrl+=",
+				"key": "ctrl+=",
+				"mac": "cmd+=",
 				"title": "Zoom In",
 				"command": "tldraw.tldr.zoomIn",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
-				"key": "cmd+numpad_subtract",
-				"win": "ctrl+numpad_subtract",
+				"key": "ctrl+numpad_subtract",
+				"mac": "cmd+numpad_subtract",
 				"title": "Zoom Out",
 				"command": "tldraw.tldr.zoomOut",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
-				"key": "cmd+-",
-				"win": "ctrl+-",
+				"key": "ctrl+-",
+				"mac": "cmd+-",
 				"title": "Zoom Out",
 				"command": "tldraw.tldr.zoomOut",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
-				"key": "cmd+numpad0",
-				"win": "ctrl+numpad0",
+				"key": "ctrl+numpad0",
+				"mac": "cmd+numpad0",
 				"title": "Reset Zoom",
 				"command": "tldraw.tldr.resetZoom",
 				"category": "tldraw",

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -53,13 +53,14 @@
 		"keybindings": [
 			{
 				"key": "cmd+shift+d",
-				"title": "Zoom In",
+				"title": "Toggle Dark Mode",
 				"command": "tldraw.tldr.toggleDarkMode",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"
 			},
 			{
 				"key": "cmd+numpad_add",
+				"win": "ctrl+numpad_add",
 				"title": "Zoom In",
 				"command": "tldraw.tldr.zoomIn",
 				"category": "tldraw",
@@ -67,6 +68,7 @@
 			},
 			{
 				"key": "cmd+=",
+				"win": "ctrl+=",
 				"title": "Zoom In",
 				"command": "tldraw.tldr.zoomIn",
 				"category": "tldraw",
@@ -74,6 +76,7 @@
 			},
 			{
 				"key": "cmd+numpad_subtract",
+				"win": "ctrl+numpad_subtract",
 				"title": "Zoom Out",
 				"command": "tldraw.tldr.zoomOut",
 				"category": "tldraw",
@@ -81,6 +84,7 @@
 			},
 			{
 				"key": "cmd+-",
+				"win": "ctrl+-",
 				"title": "Zoom Out",
 				"command": "tldraw.tldr.zoomOut",
 				"category": "tldraw",
@@ -88,7 +92,8 @@
 			},
 			{
 				"key": "cmd+numpad0",
-				"title": "Zoom Out",
+				"win": "ctrl+numpad0",
+				"title": "Reset Zoom",
 				"command": "tldraw.tldr.resetZoom",
 				"category": "tldraw",
 				"when": "resourceExtname == .tldr"


### PR DESCRIPTION
Update keybindings for VSCode extension with Windows alternatives.

Thanks to @steveruizok and @tyriar for pointing out the code in question.

Resolves #540 

(The contributing guide says to fill out the "Ready for Review" template but I didn't see one; my apologies if I didn't do this correctly.)

<3