### PR TITLE
fix(shape): Can't trigger pointer event when the shape is extend from HTMLContainer

### DIFF
--- a/packages/core/src/hooks/useStyle.tsx
+++ b/packages/core/src/hooks/useStyle.tsx
@@ -196,7 +196,6 @@ const tlcss = css`
     top: 0px;
     left: 0px;
     transform-origin: center center;
-    pointer-events: none;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION

- remove `pointer-event:none` which prevent the pointer event in HTMLContainer

Closes #601