### PR TITLE
[fix] brush appearance when using CAD mode

### DIFF
--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -369,6 +369,10 @@ const InnerTldraw = React.memo(function InnerTldraw({
   const hideCloneHandles =
     isInSession || !isSelecting || !settings.showCloneHandles || pageState.camera.zoom < 0.2
 
+  const showDashedBrush = settings.isCadSelectMode
+    ? !appState.selectByContain
+    : appState.selectByContain
+
   return (
     <StyledLayout ref={rWrapper} tabIndex={-0} className={settings.isDarkMode ? dark : ''}>
       <Loading />
@@ -395,7 +399,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
           hideCloneHandles={hideCloneHandles}
           hideRotateHandles={!settings.showRotateHandles}
           hideGrid={!settings.showGrid}
-          showDashedBrush={appState.selectByContain}
+          showDashedBrush={showDashedBrush}
           performanceMode={app.session?.performanceMode}
           onPinchStart={app.onPinchStart}
           onPinchEnd={app.onPinchEnd}

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -333,13 +333,23 @@ const InnerTldraw = React.memo(function InnerTldraw({
     return { isDarkMode: settings.isDarkMode }
   }, [settings.isDarkMode])
 
+  const showDashedBrush = !settings.isCadSelectMode && appState.selectByContain
+
   // Custom theme, based on darkmode
   const theme = React.useMemo(() => {
-    if (settings.isDarkMode) {
+    const { selectByContain } = appState
+    const { isDarkMode, isCadSelectMode } = settings
+
+    if (isDarkMode) {
+      const brushBase = isCadSelectMode
+        ? selectByContain
+          ? '168, 175, 189'
+          : '168, 189, 170'
+        : '180, 180, 180'
       return {
-        brushFill: 'rgba(180, 180, 180, .05)',
-        brushStroke: 'rgba(180, 180, 180, .25)',
-        brushDashStroke: 'rgba(180, 180, 180, .6)',
+        brushFill: `rgba(${brushBase}, .05)`,
+        brushStroke: `rgba(${brushBase}, .25)`,
+        brushDashStroke: `rgba(${brushBase}, .6)`,
         selected: 'rgba(38, 150, 255, 1.000)',
         selectFill: 'rgba(38, 150, 255, 0.05)',
         background: '#212529',
@@ -347,8 +357,14 @@ const InnerTldraw = React.memo(function InnerTldraw({
       }
     }
 
-    return {}
-  }, [settings.isDarkMode])
+    const brushBase = isCadSelectMode ? (selectByContain ? '0, 89, 242' : '51, 163, 23') : '0,0,0'
+
+    return {
+      brushFill: `rgba(${brushBase}, .05)`,
+      brushStroke: `rgba(${brushBase}, .25)`,
+      brushDashStroke: `rgba(${brushBase}, .6)`,
+    }
+  }, [settings.isDarkMode, settings.isCadSelectMode, appState.selectByContain])
 
   const isInSession = app.session !== undefined
 
@@ -368,10 +384,6 @@ const InnerTldraw = React.memo(function InnerTldraw({
 
   const hideCloneHandles =
     isInSession || !isSelecting || !settings.showCloneHandles || pageState.camera.zoom < 0.2
-
-  const showDashedBrush = settings.isCadSelectMode
-    ? !appState.selectByContain
-    : appState.selectByContain
 
   return (
     <StyledLayout ref={rWrapper} tabIndex={-0} className={settings.isDarkMode ? dark : ''}>

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -333,7 +333,9 @@ const InnerTldraw = React.memo(function InnerTldraw({
     return { isDarkMode: settings.isDarkMode }
   }, [settings.isDarkMode])
 
-  const showDashedBrush = !settings.isCadSelectMode && appState.selectByContain
+  const showDashedBrush = settings.isCadSelectMode
+    ? !appState.selectByContain
+    : appState.selectByContain
 
   // Custom theme, based on darkmode
   const theme = React.useMemo(() => {

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -343,12 +343,12 @@ const InnerTldraw = React.memo(function InnerTldraw({
     if (isDarkMode) {
       const brushBase = isCadSelectMode
         ? selectByContain
-          ? '168, 175, 189'
-          : '168, 189, 170'
+          ? '69, 155, 255'
+          : '105, 209, 73'
         : '180, 180, 180'
       return {
-        brushFill: `rgba(${brushBase}, .05)`,
-        brushStroke: `rgba(${brushBase}, .25)`,
+        brushFill: `rgba(${brushBase}, ${isCadSelectMode ? 0.08 : 0.05})`,
+        brushStroke: `rgba(${brushBase}, ${isCadSelectMode ? 0.5 : 0.25})`,
         brushDashStroke: `rgba(${brushBase}, .6)`,
         selected: 'rgba(38, 150, 255, 1.000)',
         selectFill: 'rgba(38, 150, 255, 0.05)',
@@ -360,8 +360,8 @@ const InnerTldraw = React.memo(function InnerTldraw({
     const brushBase = isCadSelectMode ? (selectByContain ? '0, 89, 242' : '51, 163, 23') : '0,0,0'
 
     return {
-      brushFill: `rgba(${brushBase}, .05)`,
-      brushStroke: `rgba(${brushBase}, .25)`,
+      brushFill: `rgba(${brushBase}, ${isCadSelectMode ? 0.08 : 0.05})`,
+      brushStroke: `rgba(${brushBase}, ${isCadSelectMode ? 0.4 : 0.25})`,
       brushDashStroke: `rgba(${brushBase}, .6)`,
     }
   }, [settings.isDarkMode, settings.isCadSelectMode, appState.selectByContain])


### PR DESCRIPTION
This PR adds correct styles for the brush when CAD mode is enabled.

https://user-images.githubusercontent.com/23072548/157427428-200f03e9-dab2-405c-a69c-347e9713e054.mp4

When CAD mode is enabled:

- When in "contain" mode (left -> right), the brush should have a BLUE fill / stroke and have a SOLID stroke.
- When in "collide" mode (right -> left), the brush should have a GREEN fill / stroke and have a DASHED stroke.


When CAD mode is NOT enabled:

- When in "contain" mode (left -> right), the brush should have a DASHED stroke.
- When in "collide" mode (right -> left), the brush should have a SOLID stroke.
