### PR TITLE
[fix] remove dots when clicking with geometric shape tool

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.spec.ts
+++ b/packages/tldraw/src/state/TldrawApp.spec.ts
@@ -452,7 +452,10 @@ describe('TldrawTestApp', () => {
 
       const prevA = app.shapes.map((shape) => shape.id)
 
-      app.pointCanvas({ x: 0, y: 0 }).movePointer({ x: 100, y: 100 }).stopPointing()
+      app
+        .pointCanvas({ x: 0, y: 0 })
+        .movePointer({ x: 100, y: 100 })
+        .stopPointing('canvas', [100, 100])
 
       const newIdA = app.shapes.map((shape) => shape.id).find((id) => !prevA.includes(id))!
       const shapeA = app.getShape(newIdA)
@@ -467,7 +470,10 @@ describe('TldrawTestApp', () => {
 
       const prevB = app.shapes.map((shape) => shape.id)
 
-      app.pointCanvas({ x: 0, y: 0 }).movePointer({ x: 100, y: 100 }).stopPointing()
+      app
+        .pointCanvas({ x: 0, y: 0 })
+        .movePointer({ x: 100, y: 100 })
+        .stopPointing('canvas', [100, 100])
 
       const newIdB = app.shapes.map((shape) => shape.id).find((id) => !prevB.includes(id))!
       const shapeB = app.getShape(newIdB)

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -3135,7 +3135,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
   onPointerMove: TLPointerEventHandler = (info, e) => {
     this.previousPoint = this.currentPoint
     this.updateInputs(info, e)
-
     if (this.isForcePanning && this.isPointing) {
       this.onPan?.({ ...info, delta: Vec.neg(info.delta) }, e as unknown as WheelEvent)
       return

--- a/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
@@ -216,12 +216,13 @@ describe('Transform session', () => {
 })
 
 describe('When creating with a transform session', () => {
-  it('Deletes the shape on undo', () => {
+  it.only('Deletes the shape on undo', () => {
     const app = new TldrawTestApp()
       .selectTool(TDShapeType.Rectangle)
       .pointCanvas([0, 0])
+      .movePointer([5, 5])
       .movePointer([10, 10])
-      .stopPointing()
+      .stopPointing('canvas', [10, 10])
 
     expect(app.shapes.length).toBe(1)
 

--- a/packages/tldraw/src/state/sessions/TransformSession/TransformSession.ts
+++ b/packages/tldraw/src/state/sessions/TransformSession/TransformSession.ts
@@ -269,6 +269,10 @@ export class TransformSession extends BaseSession {
 
     if (!hasUnlockedShapes) return
 
+    if (this.isCreate && Vec.dist(this.app.originPoint, this.app.currentPoint) < 2) {
+      return this.cancel()
+    }
+
     const beforeShapes: Record<string, TDShape | undefined> = {}
     const afterShapes: Record<string, TDShape> = {}
 

--- a/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
+++ b/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
@@ -228,6 +228,12 @@ export class TransformSingleSession extends BaseSession {
 
     if (initialShape.isLocked) return
 
+    console.log('completed', this.app.originPoint, this.app.currentPoint)
+
+    if (this.isCreate && Vec.dist(this.app.originPoint, this.app.currentPoint) < 2) {
+      return this.cancel()
+    }
+
     const beforeShapes = {} as Record<string, Partial<TDShape> | undefined>
     const afterShapes = {} as Record<string, Partial<TDShape>>
 


### PR DESCRIPTION
This PR fixes a bug where clicking with a geometric shape tool (e.g. Rectangle) would create a tiny version of that tool. See https://github.com/tldraw/tldraw/issues/602.

 In this PR, a pointer must have moved at least 2 pixels or else the shape will be cancelled on pointer up.