### PR TITLE
[fix] overflow in menus

### DIFF
--- a/packages/tldraw/src/components/Primitives/DropdownMenu/DMContent.tsx
+++ b/packages/tldraw/src/components/Primitives/DropdownMenu/DMContent.tsx
@@ -37,6 +37,8 @@ export const StyledContent = styled(MenuContent, {
   width: 'fit-content',
   height: 'fit-content',
   minWidth: 0,
+  maxHeight: '75vh',
+  overflowY: 'scroll',
   '& *': {
     boxSizing: 'border-box',
   },

--- a/packages/tldraw/src/components/TopPanel/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/components/TopPanel/PageMenu/PageMenu.tsx
@@ -9,7 +9,6 @@ import { DMContent, DMDivider } from '~components/Primitives/DropdownMenu'
 import { SmallIcon } from '~components/Primitives/SmallIcon'
 import { RowButton } from '~components/Primitives/RowButton'
 import { ToolButton } from '~components/Primitives/ToolButton'
-import { preventEvent } from '~components/preventEvent'
 
 const sortedSelector = (s: TDSnapshot) =>
   Object.values(s.document.pages).sort((a, b) => (a.childIndex || 0) - (b.childIndex || 0))


### PR DESCRIPTION
This PR adds an (extremely minimal) for cases where a menu's content overflows its height. See https://github.com/tldraw/tldraw/issues/607

 The menu will now scroll in those cases. This could be visually improved!