### PR TITLE
[fix] Only delete bindings if they were attached to a deleted group shape

### DIFF
--- a/packages/tldraw/src/state/commands/groupShapes/groupShapes.ts
+++ b/packages/tldraw/src/state/commands/groupShapes/groupShapes.ts
@@ -149,11 +149,13 @@ export function groupShapes(
 
   const { bindings } = app
 
+  const deletedGroupIdsSet = new Set(deletedGroupIds)
+
   // We also need to delete bindings that reference the deleted shapes
   bindings.forEach((binding) => {
     for (const id of [binding.toId, binding.fromId]) {
       // If the binding references a deleted shape...
-      if (afterShapes[id] === undefined) {
+      if (deletedGroupIdsSet.has(id)) {
         // Delete this binding
         beforeBindings[binding.id] = binding
         afterBindings[binding.id] = undefined

--- a/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
+++ b/packages/tldraw/src/state/sessions/TransformSingleSession/TransformSingleSession.ts
@@ -228,8 +228,6 @@ export class TransformSingleSession extends BaseSession {
 
     if (initialShape.isLocked) return
 
-    console.log('completed', this.app.originPoint, this.app.currentPoint)
-
     if (this.isCreate && Vec.dist(this.app.originPoint, this.app.currentPoint) < 2) {
       return this.cancel()
     }


### PR DESCRIPTION
This PR fixes the bug described here: https://github.com/tldraw/tldraw/issues/616

In this PR, shapes that become part of groups will not lose their associated bindings.