### PR TITLE
fix: browser-fs-access should not be dynamically import in dist

### DIFF
--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { TDDocument, TDFile } from '~types'
 import type { FileSystemHandle } from 'browser-fs-access'
+import * as browserFS from 'browser-fs-access'
 import { get as getFromIdb, set as setToIdb } from 'idb-keyval'
 import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS } from '~constants'
 
@@ -47,8 +48,6 @@ export async function saveToFileSystem(document: TDDocument, fileHandle: FileSys
   }
 
   // Save to file system
-  // @ts-ignore
-  const browserFS = await import('browser-fs-access')
   const fileSave = browserFS.fileSave
   const newFileHandle = await fileSave(
     blob,
@@ -71,8 +70,6 @@ export async function openFromFileSystem(): Promise<null | {
   document: TDDocument
 }> {
   // Get the blob
-  // @ts-ignore
-  const browserFS = await import('browser-fs-access')
   const fileOpen = browserFS.fileOpen
   const blob = await fileOpen({
     description: 'Tldraw File',
@@ -107,8 +104,6 @@ export async function openFromFileSystem(): Promise<null | {
 }
 
 export async function openAssetFromFileSystem() {
-  // @ts-ignore
-  const browserFS = await import('browser-fs-access')
   const fileOpen = browserFS.fileOpen
   return fileOpen({
     description: 'Image or Video',


### PR DESCRIPTION
In https://github.com/tldraw/tldraw/pull/653, dependency `browser-fs-access` is installed via npm, but it is still dynamically imported, which is NOT being transformed at all after build/bundling.

Please see the screenshot, which is copied from `@tldraw/tldraw` version 1.11.0 in `index.js` (via npmjs or local build):
<img width="493" alt="image" src="https://user-images.githubusercontent.com/584378/165787997-8b4f9ff1-2e9b-42df-95fb-5a0f6b8f82ab.png">

I think leaving dynamic import in the dist is not  something that a user would expect.
