### PR TITLE
fix: update tldraw to respond to dark mode prop

### DIFF
--- a/examples/tldraw-example/src/app.tsx
+++ b/examples/tldraw-example/src/app.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Routes, Route, Link } from 'react-router-dom'
 import Basic from './basic'
+import DarkMode from './dark-mode'
 import ReadOnly from './readonly'
 import PropsControl from './props-control'
 import ApiControl from './api-control'
@@ -24,6 +25,8 @@ export default function App(): JSX.Element {
         <Route path="/develop" element={<Develop />} />
 
         <Route path="/basic" element={<Basic />} />
+
+        <Route path="/dark-mode" element={<DarkMode />} />
 
         <Route path="/ui-options" element={<UIOptions />} />
 
@@ -62,6 +65,9 @@ export default function App(): JSX.Element {
                 <hr />
                 <li>
                   <Link to="/basic">Basic</Link>
+                </li>
+                <li>
+                  <Link to="/basic">Dark Mode</Link>
                 </li>
                 <li>
                   <Link to="/ui-options">UI Options</Link>

--- a/examples/tldraw-example/src/app.tsx
+++ b/examples/tldraw-example/src/app.tsx
@@ -67,7 +67,7 @@ export default function App(): JSX.Element {
                   <Link to="/basic">Basic</Link>
                 </li>
                 <li>
-                  <Link to="/basic">Dark Mode</Link>
+                  <Link to="/dark-mode">Dark Mode</Link>
                 </li>
                 <li>
                   <Link to="/ui-options">UI Options</Link>

--- a/examples/tldraw-example/src/dark-mode.tsx
+++ b/examples/tldraw-example/src/dark-mode.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+import { Tldraw } from '@tldraw/tldraw'
+
+export default function DarkMode(): JSX.Element {
+  return (
+    <div className="tldraw">
+      <Tldraw darkMode />
+    </div>
+  )
+}

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -107,6 +107,7 @@ export function Tldraw({
   readOnly = false,
   showSponsorLink = false,
   disableAssets = false,
+  darkMode = false,
   onMount,
   onChange,
   onChangePresence,
@@ -211,6 +212,13 @@ export function Tldraw({
   React.useEffect(() => {
     app.readOnly = readOnly
   }, [app, readOnly])
+
+  // Toggle the app's darkMode when the `darkMode` prop changes.
+  React.useEffect(() => {
+    if (darkMode !== app.settings.isDarkMode){
+      app.toggleDarkMode()
+    }
+  }, [app, darkMode])
 
   // Update the app's callbacks when any callback changes.
   React.useEffect(() => {


### PR DESCRIPTION
Tldraw doesn't currently respond to the dark mode prop if it is passed in or changes. This fixes that and updates `tldraw-example` to include a dark mode example 