### PR TITLE
[fix] dark mode support for image export

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2127,7 +2127,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     const getSvgElementForShape = (shape: TDShape) => {
       const util = TLDR.getShapeUtil(shape)
       const bounds = util.getBounds(shape)
-      const elm = util.getSvgElement(shape)
+      const elm = util.getSvgElement(shape, this.settings.isDarkMode)
 
       if (!elm) return
 
@@ -2202,7 +2202,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     if (opts.transparentBackground) {
       svg.style.setProperty('background-color', 'transparent')
     } else {
-      svg.style.setProperty('background-color', '#ffffff')
+      svg.style.setProperty('background-color', this.settings.isDarkMode ? '#212529' : '#ffffff')
     }
 
     svg

--- a/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
+++ b/packages/tldraw/src/state/shapes/StickyUtil/StickyUtil.tsx
@@ -270,11 +270,11 @@ export class StickyUtil extends TDShapeUtil<T, E> {
     return shape
   }
 
-  getSvgElement = (shape: T): SVGElement | void => {
+  getSvgElement = (shape: T, isDarkMode: boolean): SVGElement | void => {
     const bounds = this.getBounds(shape)
     const textBounds = Utils.expandBounds(bounds, -PADDING)
     const textElm = getTextSvgElement(shape.text, shape.style, textBounds)
-    const style = getStickyShapeStyle(shape.style)
+    const style = getStickyShapeStyle(shape.style, isDarkMode)
     textElm.setAttribute('fill', style.color)
     textElm.setAttribute('transform', `translate(${PADDING}, ${PADDING})`)
 

--- a/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
@@ -177,7 +177,7 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
 
   onSessionComplete?: (shape: T) => Partial<T> | void
 
-  getSvgElement = (shape: T): SVGElement | void => {
+  getSvgElement = (shape: T, isDarkMode: boolean): SVGElement | void => {
     const elm = document.getElementById(shape.id + '_svg')?.cloneNode(true) as SVGElement
     if (!elm) return // possibly in test mode
     if ('label' in shape && (shape as any).label) {
@@ -185,7 +185,7 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
       const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
       const bounds = this.getBounds(shape)
       const labelElm = getTextSvgElement(s['label'], shape.style, bounds)
-      labelElm.setAttribute('fill', getShapeStyle(shape.style).stroke)
+      labelElm.setAttribute('fill', getShapeStyle(shape.style, isDarkMode).stroke)
       const font = getFontStyle(shape.style)
       const size = getTextLabelSize(s['label'], font)
       labelElm.setAttribute('transform-origin', 'top left')

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -333,10 +333,11 @@ export class TextUtil extends TDShapeUtil<T, E> {
     }
   }
 
-  getSvgElement = (shape: T): SVGElement | void => {
+  getSvgElement = (shape: T, isDarkMode: boolean): SVGElement | void => {
     const bounds = this.getBounds(shape)
+    const style = getShapeStyle(shape.style, isDarkMode)
     const elm = getTextSvgElement(shape.text, shape.style, bounds)
-    elm.setAttribute('fill', getShapeStyle(shape.style).stroke)
+    elm.setAttribute('fill', style.stroke)
     return elm
   }
 }


### PR DESCRIPTION
This PR fixes a few bugs with exporting images from dark mode.

- text labels now show the correct color depending on mode
- the background color for JPG/webp is now the mode's canvas color