### PR TITLE
[fix] iOS safari clipboard / text position

### DIFF
--- a/packages/tldraw/src/state/IdbClipboard.ts
+++ b/packages/tldraw/src/state/IdbClipboard.ts
@@ -1,0 +1,17 @@
+import { get, set, del } from 'idb-keyval'
+
+// Used for clipboard
+
+const ID = 'tldraw_clipboard'
+
+export async function getClipboard(): Promise<string | undefined> {
+  return get(ID)
+}
+
+export async function setClipboard(item: string): Promise<void> {
+  return set(ID, item)
+}
+
+export function clearClipboard(): Promise<void> {
+  return del(ID)
+}

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1998,7 +1998,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
     getClipboard().then((clipboard) => {
       if (clipboard) {
-        console.log('hey!')
         pasteAsHTML(clipboard)
       }
     })
@@ -2013,8 +2012,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           // look for png data.
 
           const pngData = await item.getType('text/png')
-
-          console.log(pngData)
 
           if (pngData) {
             const file = new File([pngData], 'image.png')

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -80,6 +80,7 @@ import { ArrowTool } from './tools/ArrowTool'
 import { StickyTool } from './tools/StickyTool'
 import { StateManager } from './StateManager'
 import { clearPrevSize } from './shapes/shared/getTextSize'
+import { getClipboard, setClipboard } from './IdbClipboard'
 
 const uuid = Utils.uniqueId()
 
@@ -1778,6 +1779,8 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
     const tldrawString = `<tldraw>${jsonString}</tldraw>`
 
+    setClipboard(tldrawString)
+
     if (e) {
       e.clipboardData?.setData('text/html', tldrawString)
     }
@@ -1993,6 +1996,12 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       }
     }
 
+    getClipboard().then((clipboard) => {
+      if (clipboard) {
+        pasteAsHTML(clipboard)
+      }
+    })
+
     if (navigator.clipboard) {
       const items = await navigator.clipboard.read()
 
@@ -2002,12 +2011,12 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         for (const item of items) {
           // First, look for tldraw json in html.
 
-          const htmlData = await item.getType('text/html')
+          // const htmlData = await item.getType('text/html')
 
-          if (htmlData) {
-            let html = await htmlData.text()
-            pasteAsHTML(html)
-          }
+          // if (htmlData) {
+          //   let html = await htmlData.text()
+          //   pasteAsHTML(html)
+          // }
 
           // Next, look for plain text data.
 

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -12,10 +12,12 @@ export function getTextSvgElement(text: string, style: ShapeStyles, bounds: TLBo
     const textElm = document.createElementNS('http://www.w3.org/2000/svg', 'text')
     textElm.textContent = line
     textElm.setAttribute('y', LINE_HEIGHT * fontSize * (0.5 + i) + '')
-    textElm.setAttribute('letter-spacing', '-0.03px')
+    textElm.setAttribute('letter-spacing', fontSize * -0.03 + '')
     textElm.setAttribute('font-size', fontSize + 'px')
     textElm.setAttribute('font-family', getFontFace(style.font).slice(1, -1))
     textElm.setAttribute('text-align', getTextAlign(style.textAlign))
+    textElm.setAttribute('text-align', getTextAlign(style.textAlign))
+    textElm.setAttribute('alignment-baseline', 'central')
     g.appendChild(textElm)
 
     return textElm
@@ -37,8 +39,8 @@ export function getTextSvgElement(text: string, style: ShapeStyles, bounds: TLBo
       break
     }
     case AlignStyle.Start: {
+      g.setAttribute('text-align', 'left')
       g.setAttribute('text-anchor', 'start')
-      g.setAttribute('alignment-baseline', 'central')
     }
   }
 


### PR DESCRIPTION
Slightly ridiculous, but we're going to use indexeddb for the clipboard, too.

This also fixes text positioning in export images.