### PR TITLE
fix: keep the `outfile` filename the same as where it was used

### DIFF
--- a/examples/core-example/scripts/dev.mjs
+++ b/examples/core-example/scripts/dev.mjs
@@ -17,7 +17,7 @@ async function main() {
     await esbuildServe(
       {
         entryPoints: ['src/index.tsx'],
-        outfile: 'dist/bundle.js',
+        outfile: 'dist/index.js',
         bundle: true,
         minify: false,
         sourcemap: true,


### PR DESCRIPTION
## where it was used

https://github.com/tldraw/tldraw/blob/0a23ad61b663489ff477e6f98ceafdacf0423981/examples/core-example/src/index.html#L12