### PR TITLE
feat(drawing): add a color swatch

### DIFF
--- a/packages/tldraw/src/components/Primitives/TextField/TextField.tsx
+++ b/packages/tldraw/src/components/Primitives/TextField/TextField.tsx
@@ -2,17 +2,17 @@ import * as React from 'react'
 import { styled } from '~styles'
 import { SmallIcon } from '../SmallIcon'
 
-export interface TextFieldProps {
+export interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   value: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   placeholder?: string
   icon?: React.ReactElement
 }
 
-export const TextField = ({ value, onChange, placeholder = '', icon }: TextFieldProps) => {
+export const TextField = ({ value, onChange, placeholder = '', icon, ...rest }: TextFieldProps) => {
   return (
     <StyledInputWrapper>
-      <StyledInput value={value} onChange={onChange} placeholder={placeholder} />
+      <StyledInput value={value} onChange={onChange} placeholder={placeholder} {...rest} />
       {icon ? <StyledInputIcon>{icon}</StyledInputIcon> : null}
     </StyledInputWrapper>
   )

--- a/packages/tldraw/src/state/shapes/DrawUtil/DrawUtil.tsx
+++ b/packages/tldraw/src/state/shapes/DrawUtil/DrawUtil.tsx
@@ -153,7 +153,7 @@ export class DrawUtil extends TDShapeUtil<T, E> {
             />
             <path
               d={pathTDSnapshot}
-              fill={shouldFill ? fill : 'none'}
+              fill={shouldFill ? drawColor : 'none'}
               stroke="none"
               strokeWidth={Math.min(4, strokeWidth * 2)}
               strokeLinejoin="round"
@@ -163,7 +163,7 @@ export class DrawUtil extends TDShapeUtil<T, E> {
             <path
               d={pathTDSnapshot}
               fill="none"
-              stroke={stroke}
+              stroke={drawColor}
               strokeWidth={sw}
               strokeDasharray={strokeDasharray}
               strokeDashoffset={strokeDashoffset}

--- a/packages/tldraw/src/state/shapes/DrawUtil/DrawUtil.tsx
+++ b/packages/tldraw/src/state/shapes/DrawUtil/DrawUtil.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core'
 import { Vec } from '@tldraw/vec'
-import { defaultStyle, getShapeStyle } from '../shared/shape-styles'
+import { defaultStyle, getDrawStyle } from '../shared/shape-styles'
 import { DrawShape, DashStyle, TDShapeType, TransformInfo, TDMeta } from '~types'
 import { TDShapeUtil } from '../TDShapeUtil'
 import {
@@ -65,8 +65,8 @@ export class DrawUtil extends TDShapeUtil<T, E> {
           : getSolidStrokePathTDSnapshot(shape)
       }, [points, style.size, style.dash, isComplete])
 
-      const styles = getShapeStyle(style, meta.isDarkMode)
-      const { stroke, fill, strokeWidth } = styles
+      const styles = getDrawStyle(style, meta.isDarkMode)
+      const { stroke, fill, strokeWidth, drawColor } = styles
 
       // For very short lines, draw a point instead of a line
       const bounds = this.getBounds(shape)
@@ -80,8 +80,8 @@ export class DrawUtil extends TDShapeUtil<T, E> {
           <SVGContainer ref={ref} id={shape.id + '_svg'} {...events}>
             <circle
               r={sw}
-              fill={stroke}
-              stroke={stroke}
+              fill={drawColor}
+              stroke={drawColor}
               pointerEvents="all"
               opacity={isGhost ? GHOSTED_OPACITY : 1}
             />
@@ -106,7 +106,7 @@ export class DrawUtil extends TDShapeUtil<T, E> {
                 <path
                   d={polygonPathTDSnapshot}
                   stroke="none"
-                  fill={fill}
+                  fill={drawColor}
                   strokeLinejoin="round"
                   strokeLinecap="round"
                   pointerEvents="none"
@@ -114,8 +114,8 @@ export class DrawUtil extends TDShapeUtil<T, E> {
               )}
               <path
                 d={pathTDSnapshot}
-                fill={stroke}
-                stroke={stroke}
+                fill={drawColor}
+                stroke={drawColor}
                 strokeWidth={strokeWidth / 2}
                 strokeLinejoin="round"
                 strokeLinecap="round"

--- a/packages/tldraw/src/state/shapes/shared/shape-styles.ts
+++ b/packages/tldraw/src/state/shapes/shared/shape-styles.ts
@@ -171,6 +171,29 @@ export function getShapeStyle(
   }
 }
 
+export function getDrawStyle(
+  style: ShapeStyles,
+  isDarkMode?: boolean
+): {
+  stroke: string
+  fill: string
+  strokeWidth: number
+  drawColor: string
+} {
+  const { color, size, isFilled, drawColor } = style
+
+  const strokeWidth = getStrokeWidth(size)
+
+  const theme: Theme = isDarkMode ? 'dark' : 'light'
+
+  return {
+    stroke: strokes[theme][color],
+    fill: isFilled ? fills[theme][color] : 'none',
+    strokeWidth,
+    drawColor: drawColor!,
+  }
+}
+
 export const defaultStyle: ShapeStyles = {
   color: ColorStyle.Black,
   size: SizeStyle.Small,

--- a/packages/tldraw/src/types.ts
+++ b/packages/tldraw/src/types.ts
@@ -464,6 +464,7 @@ export type ShapeStyles = {
   textAlign?: AlignStyle
   isFilled?: boolean
   scale?: number
+  drawColor?: string
 }
 
 export enum TDAssetType {


### PR DESCRIPTION
A suggestion for this issue from @ericsia
https://github.com/tldraw/tldraw/issues/644 about a color swatch for the drawing tool
here is a preview of the feature
<img width="279" alt="Screen Shot 2022-05-20 at 09 54 13" src="https://user-images.githubusercontent.com/46365844/169470846-1f379b5d-7ccd-4e8e-90b1-17ef4c642eed.png">

