### PR TITLE
feat(extension): activate on tldraw.json filetype

### DIFF
--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -46,6 +46,9 @@
 				"selector": [
 					{
 						"filenamePattern": "*.tldr"
+					},
+					{
+						"filenamePattern": "*.tldr.json"
 					}
 				]
 			}


### PR DESCRIPTION
## Motivation

Compatibility with existing JSON based workflows, see #700 

## Changes

See https://github.com/excalidraw/excalidraw-vscode/blob/master/extension/package.json#L186-L197 for reference

## Testing

Given a .TLDR file, change extension to .tldr.json . File should open in extension instead of in default text editor when selected.