### PR TITLE
[feature] add erase line

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "@tldraw/vec": "^1.7.0",
     "@use-gesture/react": "^10.2.14",
     "mobx-react-lite": "^3.2.3",
+    "perfect-freehand": "^1.0.16",
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -30,12 +30,14 @@ import { UsersIndicators } from '~components/UsersIndicators'
 import { SnapLines } from '~components/SnapLines/SnapLines'
 import { Grid } from '~components/Grid'
 import { Overlay } from '~components/Overlay'
+import { EraseLine } from '~components/EraseLine'
 
 interface CanvasProps<T extends TLShape, M extends Record<string, unknown>> {
   page: TLPage<T, TLBinding>
   pageState: TLPageState
   assets: TLAssets
   snapLines?: TLSnapLine[]
+  eraseLine?: number[][]
   grid?: number
   users?: TLUsers<T>
   userId?: string
@@ -64,6 +66,7 @@ export const Canvas = observer(function _Canvas<
   pageState,
   assets,
   snapLines,
+  eraseLine,
   grid,
   users,
   userId,
@@ -134,6 +137,7 @@ export const Canvas = observer(function _Canvas<
           {users && <Users userId={userId} users={users} />}
         </div>
         <Overlay camera={pageState.camera}>
+          {eraseLine && <EraseLine points={eraseLine} />}
           {snapLines && <SnapLines snapLines={snapLines} />}
         </Overlay>
       </div>

--- a/packages/core/src/components/EraseLine/EraseLine.tsx
+++ b/packages/core/src/components/EraseLine/EraseLine.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { observer } from 'mobx-react-lite'
+import getStroke from 'perfect-freehand'
+import Utils from '~utils'
+
+export interface UiEraseLintProps {
+  points: number[][]
+}
+
+export type UiEraseLineComponent = (props: UiEraseLintProps) => any | null
+
+export const EraseLine = observer(function EraserLine({ points }: UiEraseLintProps) {
+  if (points.length === 0) return null
+
+  const d = Utils.getSvgPathFromStroke(getStroke(points, { size: 16, start: { taper: 200 } }))
+
+  return <path d={d} className="tl-erase-line" />
+})

--- a/packages/core/src/components/EraseLine/index.ts
+++ b/packages/core/src/components/EraseLine/index.ts
@@ -1,0 +1,1 @@
+export * from './EraseLine'

--- a/packages/core/src/components/Renderer/Renderer.tsx
+++ b/packages/core/src/components/Renderer/Renderer.tsx
@@ -57,6 +57,10 @@ export interface RendererProps<T extends TLShape, M = any> extends Partial<TLCal
    */
   snapLines?: TLSnapLine[]
   /**
+   * (optional) The current erase line to render.
+   */
+  eraseLine?: number[][]
+  /**
    * (optional) The current user's id, used to identify the user.
    */
   userId?: string
@@ -141,6 +145,7 @@ export const Renderer = observer(function _Renderer<
   theme,
   meta,
   snapLines,
+  eraseLine,
   grid,
   containerRef,
   performanceMode,
@@ -196,6 +201,7 @@ export const Renderer = observer(function _Renderer<
         pageState={pageState}
         assets={assets}
         snapLines={snapLines}
+        eraseLine={eraseLine}
         grid={grid}
         users={users}
         userId={userId}

--- a/packages/core/src/hooks/useStyle.tsx
+++ b/packages/core/src/hooks/useStyle.tsx
@@ -367,6 +367,13 @@ export const TLCSS = css`
   .tl-grid-dot {
     fill: var(--tl-grid);
   }
+  .tl-erase-line {
+    stroke-linejoin: round;
+    stroke-linecap: round;
+    pointer-events: none;
+    fill: var(--tl-grid);
+    opacity: 0.32;
+  }
 `
 
 export function useTLTheme(theme?: Partial<TLTheme>, selector?: string) {

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -431,6 +431,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
             pageState={pageState}
             assets={assets}
             snapLines={appState.snapLines}
+            eraseLine={appState.eraseLine}
             grid={GRID_SIZE}
             users={room?.users}
             userId={room?.userId}

--- a/packages/tldraw/src/state/StateManager/StateManager.ts
+++ b/packages/tldraw/src/state/StateManager/StateManager.ts
@@ -198,7 +198,7 @@ export class StateManager<T extends Record<string, any>> {
    * @param patch The patch to apply.
    * @param id (optional) An id for this patch.
    */
-  protected patchState = (patch: Patch<T>, id?: string): this => {
+  patchState = (patch: Patch<T>, id?: string): this => {
     this.applyPatch(patch, id)
     if (this.onPatch) {
       this.onPatch(this._state, id)

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -4103,6 +4103,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       isToolLocked: false,
       isMenuOpen: false,
       isEmptyCanvas: false,
+      eraseLine: [],
       snapLines: [],
       isLoading: false,
       disableAssets: false,

--- a/packages/tldraw/src/types.ts
+++ b/packages/tldraw/src/types.ts
@@ -105,6 +105,7 @@ export interface TDSnapshot {
     isMenuOpen: boolean
     status: string
     snapLines: TLSnapLine[]
+    eraseLine: number[][]
     isLoading: boolean
     disableAssets: boolean
     selectByContain?: boolean


### PR DESCRIPTION
This PR adds an "erase line" that trails behind the eraser.

![Kapture 2022-06-01 at 13 12 37](https://user-images.githubusercontent.com/23072548/171401824-eb27bb9d-47e0-4c50-9bcd-77d3080193b7.gif)

This PR also:

- improves the performance of the eraser tool
- adds perfect-freehand as a core dependency
- adds the EraseLine component to the core
- exposes `app.patchState` as `public`—it was previously `protected`