### PR TITLE
fix: Broken screenshot image link

### DIFF
--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/tldraw/tldraw/raw/main/assets/card-repo.png"/>
 </div>
 
-![A screenshot of the tldraw web app](./assets/screenshot.png)
+![A screenshot of the tldraw web app](https://github.com/tldraw/tldraw/raw/main/assets/screenshot.png)
 
 Welcome to the [tldraw](https://tldraw.com) monorepo.
 


### PR DESCRIPTION
fix: Broken screenshot image

Before:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/13457494/173629180-89a8b0cb-ba8b-431b-9c3a-db4ca5c8b6af.png">

After:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/13457494/173629460-1621ae23-a195-4b9e-b3b3-55fa1142b3b3.png">
