### PR TITLE
[fix] Bug with assets when copying to multiplayer room

### DIFF
--- a/packages/tldraw/src/components/TopPanel/MultiplayerMenu/MultiplayerMenu.tsx
+++ b/packages/tldraw/src/components/TopPanel/MultiplayerMenu/MultiplayerMenu.tsx
@@ -44,7 +44,7 @@ export const MultiplayerMenu = React.memo(function MultiplayerMenu() {
   }, [])
 
   const handleCopyToMultiplayerProject = React.useCallback(async () => {
-    const nextDocument = { ...app.document }
+    const nextDocument = Utils.deepClone(app.document)
 
     app.setIsLoading(true)
 


### PR DESCRIPTION
Previously, copying shapes to a multiplayer room would modify the asset src for any images (replacing the local source with a URL). This is correct for the new document (to be used for the multiplayer room) but it should not effect the local ("copying from") document.