### PR TITLE
fix clipboard.read error on Firefox

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -1881,7 +1881,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     })
 
     if (navigator.clipboard) {
-      const items = await navigator.clipboard.read()
+      const items = 'read' in navigator.clipboard ? await navigator.clipboard.read() : []
 
       if (items.length === 0) return
 


### PR DESCRIPTION
See more @ https://stackoverflow.com/questions/67440036/navigator-clipboard-readtext-is-not-working-in-js/67442777#67442777