### PR TITLE
Improve UX for renaming text fields

### DIFF
--- a/packages/tldraw/src/components/Primitives/TextField/TextField.tsx
+++ b/packages/tldraw/src/components/Primitives/TextField/TextField.tsx
@@ -2,21 +2,20 @@ import * as React from 'react'
 import { styled } from '~styles'
 import { SmallIcon } from '../SmallIcon'
 
-export interface TextFieldProps {
-  value: string
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  placeholder?: string
+export interface TextFieldProps extends React.HTMLProps<HTMLInputElement> {
   icon?: React.ReactElement
 }
 
-export const TextField = ({ value, onChange, placeholder = '', icon }: TextFieldProps) => {
-  return (
-    <StyledInputWrapper>
-      <StyledInput value={value} onChange={onChange} placeholder={placeholder} />
-      {icon ? <StyledInputIcon>{icon}</StyledInputIcon> : null}
-    </StyledInputWrapper>
-  )
-}
+export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
+  ({ icon, ...rest }, ref) => {
+    return (
+      <StyledInputWrapper>
+        <StyledInput {...rest} ref={ref} />
+        {icon ? <StyledInputIcon>{icon}</StyledInputIcon> : null}
+      </StyledInputWrapper>
+    )
+  }
+)
 
 const StyledInputWrapper = styled('div', {
   position: 'relative',

--- a/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
+++ b/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
@@ -33,15 +33,17 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
 
   const rInput = React.useRef<HTMLInputElement>(null)
 
+  const handleClose = React.useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
   const handleDuplicate = React.useCallback(() => {
     app.duplicatePage(page.id)
-    onClose?.()
   }, [app])
 
   const handleDelete = React.useCallback(() => {
     if (window.confirm(`Are you sure you want to delete this page?`)) {
       app.deletePage(page.id)
-      onClose?.()
     }
   }, [app])
 
@@ -57,27 +59,79 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
     [app]
   )
 
-  const close = React.useCallback(() => setIsOpen(false), [])
-
   function stopPropagation(e: React.KeyboardEvent<HTMLDivElement>) {
     e.stopPropagation()
   }
 
-  // TODO: Replace with text input
-  function handleRename(event: React.ChangeEvent<HTMLInputElement>) {
-    setPageName(event.target.value)
-    app.renamePage(page.id, event.target.value || page.name || 'Page')
-  }
+  const rInitialName = React.useRef(page.name || 'Page')
+  const rCurrentName = React.useRef(rInitialName.current)
+
+  const handleTextFieldChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.trimStart()
+    rCurrentName.current = value
+    setPageName(value)
+  }, [])
+
+  const handleTextFieldKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Enter': {
+        if (rCurrentName.current === rInitialName.current) {
+          setIsOpen(false)
+        } else {
+          rInitialName.current = rCurrentName.current
+          app.renamePage(page.id, rCurrentName.current.trim())
+        }
+
+        break
+      }
+      case 'Escape': {
+        // If the name hasn't changed, close the menu
+        if (rCurrentName.current === rInitialName.current) {
+          setIsOpen(false)
+          return
+        }
+
+        // If the name has changed, revert the change
+        rCurrentName.current = rInitialName.current
+        setPageName(rInitialName.current)
+
+        // ...and refocus the input
+        requestAnimationFrame(() => {
+          const elm = rInput.current
+          if (elm) {
+            elm.focus()
+            elm.setSelectionRange(0, elm.value.length)
+          }
+        })
+        break
+      }
+    }
+  }, [])
+
+  const rWasOpen = React.useRef(false)
 
   React.useEffect(() => {
     if (isOpen) {
+      rWasOpen.current = true
+      rInitialName.current = page.name || 'Page'
+      rCurrentName.current = rInitialName.current
+
       requestAnimationFrame(() => {
         const elm = rInput.current
         if (elm) {
           elm.focus()
-          elm.select()
+          elm.setSelectionRange(0, elm.value.length)
         }
       })
+    } else if (rWasOpen.current) {
+      onClose?.()
+    }
+
+    return () => {
+      if (rCurrentName.current !== rInitialName.current) {
+        rInitialName.current = rCurrentName.current
+        app.renamePage(page.id, rCurrentName.current)
+      }
     }
   }, [isOpen])
 
@@ -93,12 +147,14 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
       <Dialog.Portal
       // container={the current app's tl-container}
       >
-        <StyledDialogOverlay onPointerDown={close} />
+        <StyledDialogOverlay onPointerDown={handleClose} />
         <StyledDialogContent dir="ltr" onKeyDown={stopPropagation} onKeyUp={stopPropagation}>
           <TextField
+            ref={rInput}
             placeholder={intl.formatMessage({ id: 'page.name' })}
             value={pageName}
-            onChange={handleRename}
+            onChange={handleTextFieldChange}
+            onKeyDown={handleTextFieldKeyDown}
             icon={<Pencil1Icon />}
           />
           <Divider />


### PR DESCRIPTION
This PR improves the UX when renaming pages. Enter will confirm a rename. Escape will cancel the rename.