### PR TITLE
fix: undo action on Safari

### DIFF
--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -250,7 +250,8 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
 
   useHotkeys(
     '⌘+z,ctrl+z',
-    () => {
+    (e) => {
+      e.preventDefault();
       if (!canHandleEvent(true)) return
 
       if (app.session) {


### PR DESCRIPTION
Adds `event.preventDefault` to disable opening of the previously closed tab on Safari on undo action.

Closes #593.