### PR TITLE
Adds link to translation guide

### DIFF
--- a/packages/tldraw/src/components/TopPanel/LanguageMenu/LanguageMenu.tsx
+++ b/packages/tldraw/src/components/TopPanel/LanguageMenu/LanguageMenu.tsx
@@ -1,6 +1,9 @@
+import { ExternalLinkIcon } from '@radix-ui/react-icons'
 import * as React from 'react'
-import { useIntl } from 'react-intl'
-import { DMCheckboxItem, DMSubMenu } from '~components/Primitives/DropdownMenu'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { DMCheckboxItem, DMDivider, DMItem, DMSubMenu } from '~components/Primitives/DropdownMenu'
+import { HeartIcon } from '~components/Primitives/icons/HeartIcon'
+import { SmallIcon } from '~components/Primitives/SmallIcon'
 import { useTldrawApp } from '~hooks'
 import { TDLanguage, TRANSLATIONS } from '~translations'
 import { TDSnapshot } from '~types'
@@ -31,6 +34,19 @@ export function LanguageMenu() {
           {label}
         </DMCheckboxItem>
       ))}
+      <DMDivider />
+      <a
+        href="https://github.com/tldraw/tldraw/blob/develop/guides/translation.md"
+        target="_blank"
+        rel="nofollow"
+      >
+        <DMItem id="TD-MenuItem-Translation-Link">
+          <FormattedMessage id="translation.link" />
+          <SmallIcon>
+            <ExternalLinkIcon />
+          </SmallIcon>
+        </DMItem>
+      </a>
     </DMSubMenu>
   )
 }

--- a/packages/tldraw/src/translations/main.json
+++ b/packages/tldraw/src/translations/main.json
@@ -87,6 +87,7 @@
   "backward": "Backward",
   "back": "Back",
   "language": "Language",
+  "translation.link": "Learn More",
   "dock.position": "Dock Position",
   "bottom": "Bottom",
   "left": "Left",


### PR DESCRIPTION
This PR adds a link to the repository's translation guide as the last item in the language menu.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/23072548/177754260-c73b3597-c693-4645-9ef0-7f2017006c21.png">
