### PR TITLE
example(ui-options): starting to render custom UI

### DIFF
--- a/examples/tldraw-example/src/app.tsx
+++ b/examples/tldraw-example/src/app.tsx
@@ -25,7 +25,7 @@ const pages: ({ path: string; component: any; title: string } | '---')[] = [
   '---',
   { path: '/basic', component: Basic, title: 'Basic' },
   { path: '/dark-mode', component: DarkMode, title: 'Dark mode' },
-  { path: '/ui-options', component: UIOptions, title: 'Customizing user interfcace' },
+  { path: '/ui-options', component: UIOptions, title: 'Custom UI' },
   { path: '/persisted', component: Persisted, title: 'Persisting state with an ID' },
   { path: '/loading-files', component: LoadingFiles, title: 'Using the file system' },
   { path: '/file-system', component: FileSystem, title: 'Loading files' },

--- a/examples/tldraw-example/src/ui-options.tsx
+++ b/examples/tldraw-example/src/ui-options.tsx
@@ -55,6 +55,7 @@ export default function UIOptions() {
         showPages={false}
         showMenu={false}
       />
+      {/* When we have an app, show the custom UI */}
       {app && (
         <AppContext.Provider value={app}>
           <div

--- a/examples/tldraw-example/src/ui-options.tsx
+++ b/examples/tldraw-example/src/ui-options.tsx
@@ -1,16 +1,71 @@
+import { TDShapeType, TDToolType, Tldraw, TldrawApp } from '@tldraw/tldraw'
 import * as React from 'react'
-import { Tldraw } from '@tldraw/tldraw'
+
+function SelectButton({
+  type,
+  tldrawApp,
+  children,
+}: React.PropsWithChildren<{
+  type: TDToolType
+  tldrawApp?: TldrawApp
+}>) {
+  return (
+    <button
+      onClick={() => {
+        tldrawApp?.selectTool(type)
+      }}
+      style={{
+        border: '1px solid #333',
+        // @TODO: have the button re-render when tldrawApp.currentTool.type changes, else active states won't work
+        background: tldrawApp?.currentTool?.type === type ? 'papayawhip' : 'transparent',
+        fontSize: '1.5rem',
+        padding: '0.3em 0.8em',
+        borderRadius: '0.15em',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
 
 export default function UIOptions() {
+  const [tldrawApp, setApp] = React.useState<TldrawApp>()
+
+  const handleMount = React.useCallback((app: TldrawApp) => {
+    setApp(app)
+  }, [])
+
   return (
     <div className="tldraw">
+      <div
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          gap: '1em',
+          zIndex: 100,
+          bottom: '1em',
+          left: '1em',
+        }}
+      >
+        <SelectButton type="select" tldrawApp={tldrawApp}>
+          Select
+        </SelectButton>
+        <SelectButton type="erase" tldrawApp={tldrawApp}>
+          Erase
+        </SelectButton>
+        <SelectButton type={TDShapeType.Sticky} tldrawApp={tldrawApp}>
+          Card
+        </SelectButton>
+      </div>
+
       <Tldraw
+        onMount={handleMount}
         showUI={true}
-        showMenu={true}
-        showPages={true}
-        showStyles={true}
-        showTools={true}
+        showStyles={false}
+        showTools={false}
         showZoom={true}
+        showPages={false}
+        showMenu={false}
       />
     </div>
   )


### PR DESCRIPTION
Closes #724 

My idea for the custom UI example is to have a minimal canvas with only the select, erase and sticky tools, and undo/redo & zoom controls.

I want to keep it minimal to allow users to focus on the important bits, so the UI won't be pretty 😬

**TODO:**
- [ ] Find a way to re-render buttons and update their styling once the `app.currentTool` changes. Should we control the entire `TldrawApp`'s state in order to do this?