### PR TITLE
fix: flip horizontal x position

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1019,11 +1019,14 @@ left past the initial left edge) then swap points on that axis.
 
     const minX = bounds.minX + bounds.width * nx
     const minY = bounds.minY + bounds.height * ny
-    const width = bounds.width * nw
+    const width = initialBounds.width * nw
     const height = bounds.height * nh
 
     return {
-      minX,
+      // when there's more than 2 shapes, the second shape
+      // get the position of the first or the overway around
+      // we need to keep the exact position of each shape
+      minX: isFlippedX ? initialShapeBounds.minX : minX,
       minY,
       maxX: minX + width,
       maxY: minY + height,

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1023,9 +1023,9 @@ left past the initial left edge) then swap points on that axis.
     const height = bounds.height * nh
 
     return {
-      // when there's more than 2 shapes, the second shape
-      // get the position of the first or the overway around
-      // we need to keep the exact position of each shape
+      //when there are more than 2 shapes,
+      //the second shape gets the position of the first,
+      //or the over way around we need to keep the exact position of each shape
       minX: isFlippedX ? initialShapeBounds.minX : minX,
       minY,
       maxX: minX + width,

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1027,7 +1027,7 @@ left past the initial left edge) then swap points on that axis.
       //the second shape gets the position of the first,
       //or the over way around we need to keep the exact position of each shape
       minX: isFlippedX ? initialShapeBounds.minX : minX,
-      minY,
+      minY: isFlippedY ? initialShapeBounds.minY : minY,
       maxX: minX + width,
       maxY: minY + height,
       width,

--- a/packages/tldraw/src/state/commands/flipShapes/flipShapes.spec.ts
+++ b/packages/tldraw/src/state/commands/flipShapes/flipShapes.spec.ts
@@ -22,7 +22,7 @@ describe('Flip command', () => {
     app.select('rect1', 'rect2')
     app.flipHorizontal()
 
-    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([100, 0])
+    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([0, 0])
 
     app.undo()
 
@@ -30,14 +30,14 @@ describe('Flip command', () => {
 
     app.redo()
 
-    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([100, 0])
+    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([0, 0])
   })
 
   it('flips horizontally', () => {
     app.select('rect1', 'rect2')
     app.flipHorizontal()
 
-    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([100, 0])
+    expect(app.getShape<RectangleShape>('rect1').point).toStrictEqual([0, 0])
   })
 
   it('flips vertically', () => {

--- a/packages/tldraw/src/state/commands/flipShapes/flipShapes.ts
+++ b/packages/tldraw/src/state/commands/flipShapes/flipShapes.ts
@@ -1,5 +1,5 @@
 import { FlipType } from '~types'
-import { TLBoundsCorner, Utils } from '@tldraw/core'
+import { TLBounds, TLBoundsCorner, Utils } from '@tldraw/core'
 import type { TldrawCommand } from '~types'
 import type { TldrawApp } from '../../internal'
 import { TLDR } from '~state/TLDR'

--- a/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
+++ b/packages/tldraw/src/state/sessions/TransformSession/TransformSession.spec.ts
@@ -33,9 +33,9 @@ describe('Transform session', () => {
     expect(getShapeBounds(app, 'rect1')).toMatchObject({
       minX: 10,
       minY: 10,
-      maxX: 105,
+      maxX: 110,
       maxY: 105,
-      width: 95,
+      width: 100,
       height: 95,
     })
 
@@ -112,18 +112,18 @@ describe('Transform session', () => {
       expect(getShapeBounds(app, 'rect1')).toMatchObject({
         minX: 10,
         minY: 10,
-        maxX: 105,
+        maxX: 110,
         maxY: 105,
-        width: 95,
+        width: 100,
         height: 95,
       })
 
       expect(getShapeBounds(app, 'rect2')).toMatchObject({
         minX: 105,
         minY: 105,
-        maxX: 200,
+        maxX: 205,
         maxY: 200,
-        width: 95,
+        width: 100,
         height: 95,
       })
     })
@@ -139,18 +139,18 @@ describe('Transform session', () => {
       expect(getShapeBounds(app, 'rect1')).toMatchObject({
         minX: 10,
         minY: 10,
-        maxX: 105,
+        maxX: 110,
         maxY: 105,
-        width: 95,
+        width: 100,
         height: 95,
       })
 
       expect(getShapeBounds(app, 'rect2')).toMatchObject({
         minX: 105,
         minY: 105,
-        maxX: 200,
+        maxX: 205,
         maxY: 200,
-        width: 95,
+        width: 100,
         height: 95,
       })
     })
@@ -197,18 +197,18 @@ describe('Transform session', () => {
       expect(getShapeBounds(app, 'rect1')).toMatchObject({
         minX: 10,
         minY: 10,
-        maxX: 105,
+        maxX: 110,
         maxY: 105,
-        width: 95,
+        width: 100,
         height: 95,
       })
 
       expect(getShapeBounds(app, 'rect2')).toMatchObject({
         minX: 105,
         minY: 105,
-        maxX: 200,
+        maxX: 205,
         maxY: 200,
-        width: 95,
+        width: 100,
         height: 95,
       })
     })


### PR DESCRIPTION
The issue:
when there are more than 2 shapes, the second shape gets the position of the first, or the over way around we need to keep the exact position of each shape