### PR TITLE
fix: Remove the "capitalize" on the dock positions

### DIFF
--- a/packages/tldraw/src/components/TopPanel/PreferencesMenu/PreferencesMenu.tsx
+++ b/packages/tldraw/src/components/TopPanel/PreferencesMenu/PreferencesMenu.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { DMCheckboxItem, DMDivider, DMSubMenu } from '~components/Primitives/DropdownMenu'
 import { useTldrawApp } from '~hooks'
 import { TDDockPosition, TDSnapshot } from '~types'
-import { styled } from '~styles'
 
 const settingsSelector = (s: TDSnapshot) => s.settings
 
@@ -146,16 +145,10 @@ export function PreferencesMenu() {
             onCheckedChange={() => handleChangeDockPosition(position as TDDockPosition)}
             id={`TD-MenuItem-DockPosition-${position}`}
           >
-            <StyledText>
-              <FormattedMessage id={position} />
-            </StyledText>
+            <FormattedMessage id={position} />
           </DMCheckboxItem>
         ))}
       </DMSubMenu>
     </DMSubMenu>
   )
 }
-
-const StyledText = styled('span', {
-  textTransform: 'capitalize',
-})


### PR DESCRIPTION
Hi,

I noticed that the dock positions have a forced "capitalize". It's necessary?

I think that each language should be able to choose via the translation file.
For example in French the effect is not desirable: "À Gauche" vs "À gauche".
Probably in other languages too.

This PR remove it.
