### PR TITLE
[fix] label

### DIFF
--- a/packages/tldraw/src/state/TLDR.ts
+++ b/packages/tldraw/src/state/TLDR.ts
@@ -1063,7 +1063,7 @@ export class TLDR {
     return text
       .replace(TLDR.fixNewLines, '\n')
       .split('\n')
-      .map((x) => x || '')
+      .map((x) => x || ' ')
       .join('\n')
   }
 

--- a/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
+++ b/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
@@ -92,11 +92,19 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
         decorations = {},
         style,
       } = shape
+
+      const hasLabel = !!(label?.trim()?.length ?? 0 > 0)
+
       const isStraightLine = Vec.dist(bend.point, Vec.toFixed(Vec.med(start.point, end.point))) < 1
+
       const font = getFontStyle(style)
+
       const styles = getShapeStyle(style, meta.isDarkMode)
-      const labelSize = label || isEditing ? getTextLabelSize(label, font) : [0, 0]
+
+      const labelSize = hasLabel || isEditing ? getTextLabelSize(label, font) : [0, 0]
+
       const bounds = this.getBounds(shape)
+
       const dist = React.useMemo(() => {
         const { start, bend, end } = shape.handles
         if (isStraightLine) return Vec.dist(start.point, end.point)
@@ -106,10 +114,12 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
         const length = getArcLength(center, radius, start.point, end.point)
         return Math.abs(length)
       }, [shape.handles])
+
       const scale = Math.max(
         0.5,
         Math.min(1, Math.max(dist / (labelSize[1] + 128), dist / (labelSize[0] + 128)))
       )
+
       const offset = React.useMemo(() => {
         const bounds = this.getBounds(shape)
         const offset = Vec.sub(
@@ -118,13 +128,16 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
         )
         return offset
       }, [shape, scale])
+
       const handleLabelChange = React.useCallback(
         (label: string) => {
           onShapeChange?.({ id, label })
         },
         [onShapeChange]
       )
+
       const Component = isStraightLine ? StraightArrow : CurvedArrow
+
       return (
         <FullWrapper ref={ref} {...events}>
           <TextLabel
@@ -163,7 +176,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
             <g
               pointerEvents="none"
               opacity={isGhost ? GHOSTED_OPACITY : 1}
-              mask={label || isEditing ? `url(#${shape.id}_clip)` : ``}
+              mask={hasLabel || isEditing ? `url(#${shape.id}_clip)` : ``}
             >
               <Component
                 id={id}
@@ -191,9 +204,13 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
       label,
       handles: { start, bend, end },
     } = shape
+
+    const hasLabel = !!(label?.trim()?.length ?? 0 > 0)
+
     const font = getFontStyle(style)
-    const labelSize = label ? getTextLabelSize(label, font) : [0, 0]
+    const labelSize = hasLabel ? getTextLabelSize(label!, font) : [0, 0]
     const isStraightLine = Vec.dist(bend.point, Vec.toFixed(Vec.med(start.point, end.point))) < 1
+
     const dist = React.useMemo(() => {
       const { start, bend, end } = shape.handles
       if (isStraightLine) return Vec.dist(start.point, end.point)
@@ -203,24 +220,29 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
       const length = getArcLength(center, radius, start.point, end.point)
       return Math.abs(length)
     }, [shape.handles])
+
     const scale = Math.max(
       0.5,
       Math.min(1, Math.max(dist / (labelSize[1] + 128), dist / (labelSize[0] + 128)))
     )
+
     const offset = React.useMemo(() => {
       const bounds = this.getBounds(shape)
       const offset = Vec.sub(shape.handles.bend.point, [bounds.width / 2, bounds.height / 2])
       return offset
     }, [shape, scale])
+
     return (
       <>
-        <LabelMask
-          id={shape.id}
-          scale={scale}
-          offset={offset}
-          bounds={bounds}
-          labelSize={labelSize}
-        />
+        {hasLabel && (
+          <LabelMask
+            id={shape.id}
+            scale={scale}
+            offset={offset}
+            bounds={bounds}
+            labelSize={labelSize}
+          />
+        )}
         <path
           d={getArrowPath(
             style,
@@ -230,9 +252,9 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
             decorations?.start,
             decorations?.end
           )}
-          mask={label ? `url(#${shape.id}_clip)` : ``}
+          mask={hasLabel ? `url(#${shape.id}_clip)` : ``}
         />
-        {label && (
+        {hasLabel && (
           <rect
             x={bounds.width / 2 - (labelSize[0] / 2) * scale + offset[0]}
             y={bounds.height / 2 - (labelSize[1] / 2) * scale + offset[1]}

--- a/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
+++ b/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
@@ -93,7 +93,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
         style,
       } = shape
 
-      const hasLabel = !!(label?.trim()?.length ?? 0 > 0)
+      const hasLabel = label?.trim()?.length ?? 0 > 0
 
       const isStraightLine = Vec.dist(bend.point, Vec.toFixed(Vec.med(start.point, end.point))) < 1
 
@@ -205,7 +205,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
       handles: { start, bend, end },
     } = shape
 
-    const hasLabel = !!(label?.trim()?.length ?? 0 > 0)
+    const hasLabel = label?.trim()?.length ?? 0 > 0
 
     const font = getFontStyle(style)
     const labelSize = hasLabel ? getTextLabelSize(label!, font) : [0, 0]


### PR DESCRIPTION
This PR fixes a bug introduced by #834 that would appear when pressing shift+enter within a label.

Before:
![Kapture 2022-07-21 at 16 57 26](https://user-images.githubusercontent.com/23072548/180259658-907f3995-b7a1-470e-8703-665c2ad99c6c.gif)

After:
![Kapture 2022-07-21 at 16 59 00](https://user-images.githubusercontent.com/23072548/180259930-61965817-20c3-4e33-b9bd-2ed8879460c9.gif)
