### PR TITLE
[fix] mobile layout

### DIFF
--- a/packages/tldraw/src/components/Primitives/ToolButton/ToolButton.tsx
+++ b/packages/tldraw/src/components/Primitives/ToolButton/ToolButton.tsx
@@ -184,7 +184,9 @@ export const StyledToolButton = styled('button', {
       false: {},
     },
     bp: {
-      mobile: {},
+      mobile: {
+        padding: 0,
+      },
       small: {},
     },
   },
@@ -193,8 +195,8 @@ export const StyledToolButton = styled('button', {
       variant: 'primary',
       bp: 'mobile',
       css: {
-        height: '40px',
-        width: '40px',
+        height: 40,
+        width: 36,
         [`& ${StyledToolButtonInner} > svg`]: {
           width: 16,
           height: 16,

--- a/packages/tldraw/src/components/Primitives/ToolButton/ToolButton.tsx
+++ b/packages/tldraw/src/components/Primitives/ToolButton/ToolButton.tsx
@@ -112,6 +112,8 @@ export const StyledToolButtonInner = styled('div', {
   userSelect: 'none',
   boxSizing: 'border-box',
   border: '1px solid transparent',
+  '-webkit-tap-highlight-color': 'transparent',
+  'tap-highlight-color': 'transparent',
 })
 
 export const StyledToolButton = styled('button', {
@@ -130,6 +132,8 @@ export const StyledToolButton = styled('button', {
   border: 'none',
   height: '40px',
   width: '40px',
+  '-webkit-tap-highlight-color': 'transparent',
+  'tap-highlight-color': 'transparent',
 
   [`&:disabled ${StyledToolButtonInner}`]: {
     opacity: 0.618,

--- a/packages/tldraw/src/components/ToolsPanel/HelpPanel.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/HelpPanel.tsx
@@ -88,13 +88,16 @@ const HelpButton = styled('button', {
   borderRadius: '100%',
   position: 'fixed',
   right: 10,
-  display: 'grid',
-  placeItems: 'center',
+  padding: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   border: 'none',
   backgroundColor: 'white',
   cursor: 'pointer',
   boxShadow: '$panel',
   bottom: 10,
+  color: '$text',
   variants: {
     debug: {
       true: {},

--- a/packages/tldraw/src/components/ToolsPanel/PrimaryTools.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/PrimaryTools.tsx
@@ -14,6 +14,8 @@ import { ToolButtonWithTooltip } from '~components/Primitives/ToolButton'
 import { Panel } from '~components/Primitives/Panel'
 import { ShapesMenu } from './ShapesMenu'
 import { EraserIcon } from '~components/Primitives/icons'
+import { styled } from '~styles/stitches.config'
+import { breakpoints } from '~components/breakpoints'
 
 const activeToolSelector = (s: TDSnapshot) => s.appState.activeTool
 const toolLockedSelector = (s: TDSnapshot) => s.appState.isToolLocked
@@ -59,7 +61,12 @@ export const PrimaryTools = React.memo(function PrimaryTools() {
   const panelStyle = dockPosition === 'bottom' || dockPosition === 'top' ? 'row' : 'column'
 
   return (
-    <Panel side="center" id="TD-PrimaryTools" style={{ flexDirection: panelStyle }}>
+    <StyledPanel
+      side="center"
+      id="TD-PrimaryTools"
+      style={{ flexDirection: panelStyle }}
+      bp={breakpoints}
+    >
       <ToolButtonWithTooltip
         kbd={'1'}
         label={intl.formatMessage({ id: 'select' })}
@@ -120,6 +127,20 @@ export const PrimaryTools = React.memo(function PrimaryTools() {
       <ToolButtonWithTooltip label="Image" onClick={uploadMedias} id="TD-PrimaryTools-Image">
         <ImageIcon />
       </ToolButtonWithTooltip>
-    </Panel>
+    </StyledPanel>
   )
+})
+
+const StyledPanel = styled(Panel, {
+  variants: {
+    bp: {
+      mobile: {
+        padding: '$0',
+        borderRadius: '$3',
+      },
+      small: {
+        padding: '$2',
+      },
+    },
+  },
 })

--- a/packages/tldraw/src/components/ToolsPanel/ToolsPanel.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/ToolsPanel.tsx
@@ -51,7 +51,7 @@ const StyledToolsPanelContainer = styled('div', {
   width: '100%',
   minWidth: 0,
   maxWidth: '100%',
-  height: '64px',
+  height: 64,
   gap: '$4',
   display: 'flex',
   justifyContent: 'center',
@@ -96,7 +96,7 @@ const StyledToolsPanelContainer = styled('div', {
       side: 'top',
       bp: 'large',
       css: {
-        top: '10px',
+        top: 10,
       },
     },
     {


### PR DESCRIPTION
This PR fixes the increasingly tight toolbar on mobile layouts (iOS in particular).

Before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/23072548/180596620-73979085-389d-4976-8065-ded12c3cafbd.png">

After:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/23072548/180596630-d010737a-dc17-4bac-b728-c4a37a8d88a1.png">
