### PR TITLE
fix(tldraw): enable initial currentPageId prop

### DIFF
--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -163,11 +163,9 @@ export function Tldraw({
         onSessionEnd,
       },
       {
-        ...TldrawApp.defaultState,
-        document: document ?? TldrawApp.defaultDocument,
+        document,
         appState: {
-          ...TldrawApp.defaultState.appState,
-          currentPageId: currentPageId ?? TldrawApp.defaultState.appState.currentPageId,
+          currentPageId,
         },
       }
     )
@@ -202,11 +200,9 @@ export function Tldraw({
         onSessionEnd,
       },
       {
-        ...TldrawApp.defaultState,
-        document: document ?? TldrawApp.defaultDocument,
+        document,
         appState: {
-          ...TldrawApp.defaultState.appState,
-          currentPageId: currentPageId ?? TldrawApp.defaultState.appState.currentPageId,
+          currentPageId,
         },
       }
     )

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -139,55 +139,77 @@ export function Tldraw({
 
   // Create a new app when the component mounts.
   const [app, setApp] = React.useState(() => {
-    const app = new TldrawApp(id, {
-      onMount,
-      onChange,
-      onChangePresence,
-      onNewProject,
-      onSaveProject,
-      onSaveProjectAs,
-      onOpenProject,
-      onOpenMedia,
-      onUndo,
-      onRedo,
-      onPersist,
-      onPatch,
-      onCommand,
-      onChangePage,
-      onAssetDelete,
-      onAssetCreate,
-      onAssetUpload,
-      onSessionStart,
-      onSessionEnd,
-    })
+    const app = new TldrawApp(
+      id,
+      {
+        onMount,
+        onChange,
+        onChangePresence,
+        onNewProject,
+        onSaveProject,
+        onSaveProjectAs,
+        onOpenProject,
+        onOpenMedia,
+        onUndo,
+        onRedo,
+        onPersist,
+        onPatch,
+        onCommand,
+        onChangePage,
+        onAssetDelete,
+        onAssetCreate,
+        onAssetUpload,
+        onSessionStart,
+        onSessionEnd,
+      },
+      {
+        ...TldrawApp.defaultState,
+        document: document ?? TldrawApp.defaultDocument,
+        appState: {
+          ...TldrawApp.defaultState.appState,
+          currentPageId: currentPageId ?? TldrawApp.defaultState.appState.currentPageId,
+        },
+      }
+    )
     return app
   })
 
   // Create a new app if the `id` prop changes.
   React.useLayoutEffect(() => {
     if (id === sId) return
-    const newApp = new TldrawApp(id, {
-      onMount,
-      onChange,
-      onChangePresence,
-      onNewProject,
-      onSaveProject,
-      onSaveProjectAs,
-      onOpenProject,
-      onOpenMedia,
-      onUndo,
-      onRedo,
-      onPersist,
-      onPatch,
-      onCommand,
-      onChangePage,
-      onAssetDelete,
-      onAssetCreate,
-      onAssetUpload,
-      onExport,
-      onSessionStart,
-      onSessionEnd,
-    })
+    const newApp = new TldrawApp(
+      id,
+      {
+        onMount,
+        onChange,
+        onChangePresence,
+        onNewProject,
+        onSaveProject,
+        onSaveProjectAs,
+        onOpenProject,
+        onOpenMedia,
+        onUndo,
+        onRedo,
+        onPersist,
+        onPatch,
+        onCommand,
+        onChangePage,
+        onAssetDelete,
+        onAssetCreate,
+        onAssetUpload,
+        onExport,
+        onSessionStart,
+        onSessionEnd,
+      },
+      {
+        ...TldrawApp.defaultState,
+        document: document ?? TldrawApp.defaultDocument,
+        appState: {
+          ...TldrawApp.defaultState.appState,
+          currentPageId: currentPageId ?? TldrawApp.defaultState.appState.currentPageId,
+        },
+      }
+    )
 
     setSId(id)
 

--- a/packages/tldraw/src/state/TldrawApp.spec.ts
+++ b/packages/tldraw/src/state/TldrawApp.spec.ts
@@ -1,5 +1,5 @@
-import { TldrawTestApp, mockDocument } from '~test'
-import { ArrowShape, ColorStyle, SessionType, TDShapeType } from '~types'
+import { mockDocument, TldrawTestApp } from '~test'
+import { ArrowShape, ColorStyle, SessionType, TDDocument, TDShapeType } from '~types'
 import { deepCopy } from './StateManager/copy'
 import type { SelectTool } from './tools/SelectTool'
 
@@ -767,5 +767,65 @@ describe('When space panning', () => {
     app.releaseKey(' ')
     app.stopPointing()
     expect(app.currentTool.status).toBe('idle')
+  })
+})
+
+describe('initial state', () => {
+  it('should have a default state', () => {
+    const app = new TldrawTestApp()
+    expect(app.state).toEqual(TldrawTestApp.defaultState)
+  })
+
+  it('should allow for overriding the default state', () => {
+    const document: TDDocument = {
+      id: 'some-doc',
+      name: 'Some Doc',
+      version: TldrawTestApp.version,
+      assets: {},
+      pages: {
+        page1: {
+          id: 'page1',
+          name: 'Page 1',
+          shapes: {},
+          bindings: {},
+        },
+        page2: {
+          id: 'page2',
+          name: 'Page 2',
+          shapes: {},
+          bindings: {},
+        },
+      },
+      pageStates: {
+        page1: {
+          id: 'page1',
+          camera: {
+            point: [0, 0],
+            zoom: 1,
+          },
+          selectedIds: [],
+        },
+        page2: {
+          id: 'page2',
+          camera: {
+            point: [0, 0],
+            zoom: 1,
+          },
+          selectedIds: [],
+        },
+      },
+    }
+
+    const app = new TldrawTestApp(undefined, undefined, {
+      ...TldrawTestApp.defaultState,
+      document,
+      appState: {
+        ...TldrawTestApp.defaultState.appState,
+        currentPageId: 'page2',
+      },
+    })
+
+    expect(app.currentPageId).toBe('page2')
+    expect(app.document).toEqual(document)
   })
 })

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -250,8 +250,8 @@ export class TldrawApp extends StateManager<TDSnapshot> {
     center: [0, 0],
   }
 
-  constructor(id?: string, callbacks = {} as TDCallbacks) {
-    super(TldrawApp.defaultState, id, TldrawApp.version, (prev, next, prevVersion) => {
+  constructor(id?: string, callbacks = {} as TDCallbacks, initialState = TldrawApp.defaultState) {
+    super(initialState, id, TldrawApp.version, (prev, next, prevVersion) => {
       return migrate(
         {
           ...next,

--- a/packages/tldraw/src/state/utils.spec.ts
+++ b/packages/tldraw/src/state/utils.spec.ts
@@ -1,0 +1,27 @@
+import { safeMerge } from './utils'
+
+describe('safeMerge', () => {
+  test('ignores undefined source values', () => {
+    expect(safeMerge({ a: 1, b: 2 }, { a: undefined })).toEqual({ a: 1, b: 2 })
+  })
+
+  test('replaces target values with source values', () => {
+    expect(safeMerge({ a: 1, b: 2 }, { a: 3, b: 4 })).toEqual({ a: 3, b: 4 })
+  })
+
+  test('replaces target arrays with source arrays', () => {
+    expect(safeMerge({ a: [1] }, { a: [2] })).toEqual({ a: [2] })
+  })
+
+  test('merges nested objects', () => {
+    expect(safeMerge({ a: { b: 1 } }, { a: { b: 2 } })).toEqual({ a: { b: 2 } })
+  })
+
+  test('ignores nested undefined source values', () => {
+    expect(safeMerge({ a: { b: 1, c: 2 } }, { a: { b: undefined } })).toEqual({ a: { b: 1, c: 2 } })
+  })
+
+  test('replaces nested target arrays with source arrays', () => {
+    expect(safeMerge({ a: { b: [1] } }, { a: { b: [2] } })).toEqual({ a: { b: [2] } })
+  })
+})

--- a/packages/tldraw/src/state/utils.ts
+++ b/packages/tldraw/src/state/utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Deeply merge two objects together, ignoring `undefined` values in `source`.
+ */
+export const safeMerge = <T, U>(target: T, source: U): T => {
+  const entries = Object.entries(source) as [keyof T, U[keyof U]][]
+  return entries.reduce((acc, [key, value]) => {
+    // if value is undefined, keep target value
+    if (value === undefined) {
+      return acc
+    }
+
+    // if value and target value are objects, merge them
+    if (
+      Object.prototype.toString.call(value) === '[object Object]' &&
+      Object.prototype.toString.call(target[key]) === '[object Object]'
+    ) {
+      return {
+        ...acc,
+        [key]: safeMerge(target[key], value),
+      }
+    }
+
+    // otherwise, use the source value
+    return {
+      ...acc,
+      [key]: value,
+    }
+  }, target)
+}


### PR DESCRIPTION
This PR fixes #723 

Opening this as a draft because I'm really not sure what the best approach would be here.

#723 occurs because `TldrawApp` initializes its state from `TldrawApp.defaultState` which doesn't reflect the reality of our intentions if we're passing custom `document`/`currentPageId` props to `Tldraw`:

Us: Hey `Tldraw`, please render `page1` from our `customDocument`
`Tldraw`: Sure thing! Rendering `page` from `TldrawApp.defaultDocument`

---

For an initial attempt, I added a third `initialState` argument to `TldrawApp#constructor` that defaults to `TldrawApp.defaultState`. I then added a new object in the initializers in `Tldraw` using `TldrawApp.defaultState`, overriding specifically the `document` and `appState.currentPageId` keys since those are the only parts of initial state relevant to `Tldraw`.

This allows us to set the custom initial state we need without any breaking changes. The downside is that the initialization piece is gross af imo. Consumers probably shouldn't need to spread `TldrawApp.defaultState` like that, but I couldn't think of a better way to handle it. 

I had considered making `initialState` optional and deep merging it into `TldrawApp.defaultState` when provided, but since we need to _replace_ `defaultState.document` with `props.document` if it exists, deep merging isn't an option here. We could make the new argument an object of type `{ document: TDDocument; currentPageId: string }` and do the spreading ourselves inside `TldrawApp`, but that feels too specific to only the `Tldraw` use case.

Would love some additional thoughts or context to help shape this into a better solution!