### PR TITLE
chore: remove typedoc and docs scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 /build/
 /tmp/
 .idea/*
-/docs/
 
 coverage
 *.log

--- a/apps/electron/tsconfig.json
+++ b/apps/electron/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
@@ -16,9 +16,5 @@
     {
       "path": "../../packages/tldraw"
     }
-  ],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  ]
 }

--- a/apps/vscode/editor/tsconfig.json
+++ b/apps/vscode/editor/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "src",
@@ -15,9 +15,5 @@
     {
       "path": "../../../packages/tldraw"
     }
-  ],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  ]
 }

--- a/examples/core-example-advanced/tsconfig.json
+++ b/examples/core-example-advanced/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": ".",
@@ -12,9 +12,5 @@
       "*": ["src/*"]
     }
   },
-  "references": [{ "path": "../../packages/core" }],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  "references": [{ "path": "../../packages/core" }]
 }

--- a/examples/core-example/tsconfig.json
+++ b/examples/core-example/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": ".",
@@ -14,9 +14,5 @@
       "*": ["src/*"]
     }
   },
-  "references": [{ "path": "../../packages/core" }],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  "references": [{ "path": "../../packages/core" }]
 }

--- a/examples/tldraw-example/tsconfig.json
+++ b/examples/tldraw-example/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": ".",
@@ -22,9 +22,5 @@
     {
       "path": "../../packages/tldraw"
     }
-  ],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "test": "turbo run test --stream",
     "test:ci": "turbo run test:ci --stream",
     "test:watch": "turbo run test:watch --stream",
-    "docs": "turbo run docs",
-    "docs:watch": "turbo run docs --watch",
     "postinstall": "husky install",
     "clean": "turbo run clean",
     "pre-commit": "lint-staged",
@@ -63,7 +61,6 @@
     "source-map-loader": "^3.0.1",
     "tslib": "^2.4.0",
     "turbo": "^1.1.2",
-    "typedoc": "^0.22.15",
     "typescript": "^4.7.3",
     "webpack": "^5.68.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,8 +33,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "jest",
     "test:ci": "jest --ci --runInBand --updateSnapshot",
-    "test:watch": "jest --watchAll",
-    "docs": "typedoc"
+    "test:watch": "jest --watchAll"
   },
   "dependencies": {
     "@tldraw/intersect": "^1.7.1",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/core/tsconfig.dev.json
+++ b/packages/core/tsconfig.dev.json
@@ -8,8 +8,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "experimentalDecorators": true,
     "useDefineForClassFields": true,
@@ -11,9 +11,5 @@
       "~*": ["./src/*"]
     }
   },
-  "references": [{ "path": "../vec" }, { "path": "../intersect" }],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  "references": [{ "path": "../vec" }, { "path": "../intersect" }]
 }

--- a/packages/curve/tsconfig.build.json
+++ b/packages/curve/tsconfig.build.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/curve/tsconfig.dev.json
+++ b/packages/curve/tsconfig.dev.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/curve/tsconfig.json
+++ b/packages/curve/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "src",
     "baseUrl": "."
-  },
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
   }
 }

--- a/packages/intersect/tsconfig.build.json
+++ b/packages/intersect/tsconfig.build.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/intersect/tsconfig.dev.json
+++ b/packages/intersect/tsconfig.dev.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/intersect/tsconfig.json
+++ b/packages/intersect/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "src",
     "baseUrl": "."
   },
-  "references": [{ "path": "../vec" }],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  "references": [{ "path": "../vec" }]
 }

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -33,8 +33,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "jest",
     "test:ci": "jest --ci --runInBand --updateSnapshot",
-    "test:watch": "jest --watchAll",
-    "docs": "typedoc"
+    "test:watch": "jest --watchAll"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/packages/tldraw/tsconfig.build.json
+++ b/packages/tldraw/tsconfig.build.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "skipLibCheck": true,

--- a/packages/tldraw/tsconfig.dev.json
+++ b/packages/tldraw/tsconfig.dev.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "skipLibCheck": true,

--- a/packages/tldraw/tsconfig.json
+++ b/packages/tldraw/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "include": ["src", "./src/translations/*.json"],
   "compilerOptions": {
     "skipLibCheck": true,
@@ -11,9 +11,5 @@
       "~*": ["./src/*"]
     }
   },
-  "references": [{ "path": "../vec" }, { "path": "../intersect" }, { "path": "../core" }],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
-  }
+  "references": [{ "path": "../vec" }, { "path": "../intersect" }, { "path": "../core" }]
 }

--- a/packages/vec/tsconfig.build.json
+++ b/packages/vec/tsconfig.build.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/vec/tsconfig.dev.json
+++ b/packages/vec/tsconfig.dev.json
@@ -7,8 +7,7 @@
     "**/*.spec.tsx",
     "**/*.spec.ts",
     "src/test",
-    "dist",
-    "docs"
+    "dist"
   ],
   "compilerOptions": {
     "composite": false,

--- a/packages/vec/tsconfig.json
+++ b/packages/vec/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "docs"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "src",
     "baseUrl": "."
-  },
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -23,10 +23,6 @@
     "start:vscode": {
       "cache": false
     },
-    "docs": {
-      "dependsOn": ["^build"],
-      "outputs": ["docs"]
-    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7079,7 +7079,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.2.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@7.2.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -8490,11 +8490,6 @@ json5@^2.1.2, json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
-jsonc-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
-  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
-
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -8826,11 +8821,6 @@ lru_map@^0.3.3:
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
-lunr@^2.3.9:
-  version "2.3.9"
-  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
-  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
-
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -8877,11 +8867,6 @@ markdown-it@^12.3.2:
     linkify-it "^3.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
-
-marked@^4.0.12:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.15.tgz#0216b7c9d5fcf6ac5042343c41d81a8b1b5e1b4a"
-  integrity sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==
 
 matcher@^3.0.0:
   version "3.0.0"
@@ -10743,15 +10728,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
-  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
-  dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -11637,17 +11613,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc@^0.22.15:
-  version "0.22.15"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.15.tgz#c6ad7ed9d017dc2c3a06c9189cb392bd8e2d8c3f"
-  integrity sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==
-  dependencies:
-    glob "^7.2.0"
-    lunr "^2.3.9"
-    marked "^4.0.12"
-    minimatch "^5.0.1"
-    shiki "^0.10.1"
-
 typescript@^3.9.7:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
@@ -11939,16 +11904,6 @@ vsce@^2.2.0:
     xml2js "^0.4.23"
     yauzl "^2.3.1"
     yazl "^2.2.2"
-
-vscode-oniguruma@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
-  integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
-
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
As mentioned in #716, this PR removes `typedoc` and all `docs`-related stuff, though I did leave `docs/` in `.gitignore` just to avoid potential contributor confusion.