### PR TITLE
Fix: Typecript build error in the helpPanel (introduced by PR #873)

### DIFF
--- a/packages/tldraw/src/components/ToolsPanel/HelpPanel.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/HelpPanel.tsx
@@ -34,7 +34,7 @@ export function HelpPanel() {
     <Popover.Root>
       <PopoverAnchor dir="ltr" debug={isDebugMode} side={side} bp={breakpoints}>
         <Popover.Trigger dir="ltr" asChild>
-          <HelpButton debug={isDebugMode}>
+          <HelpButton>
             <QuestionMarkIcon />
           </HelpButton>
         </Popover.Trigger>


### PR DESCRIPTION
This fix an error at the build time, introduced by PR #873, see comment https://github.com/tldraw/tldraw/pull/873#discussion_r936057662?

```
src/components/ToolsPanel/HelpPanel.tsx(37,23): error TS2769: No overload matches this call.
@tldraw/tldraw:build:packages:   Overload 1 of 3, '(props: Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }): ReactElement<...> | null', gave the following error.
@tldraw/tldraw:build:packages:     Type '{ children: Element; debug: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }'.
@tldraw/tldraw:build:packages:       Property 'debug' does not exist on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }'.
@tldraw/tldraw:build:packages:   Overload 2 of 3, '(props: Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }): ReactElement<...> | null', gave the following error.
@tldraw/tldraw:build:packages:     Type '{ children: Element; debug: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }'.
@tldraw/tldraw:build:packages:       Property 'debug' does not exist on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css" | "as"> & TransformProps<...> & { ...; }'.
@tldraw/tldraw:build:packages:   Overload 3 of 3, '(props: Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css"> & TransformProps<...> & { ...; }): ReactElement<...> | null', gave the following error.
@tldraw/tldraw:build:packages:     Type '{ children: Element; debug: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css"> & TransformProps<...> & { ...; }'.
@tldraw/tldraw:build:packages:       Property 'debug' does not exist on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, "key" | keyof ButtonHTMLAttributes<...>> & { ...; }, "css"> & TransformProps<...> & { ...; }'.

```
