### PR TITLE
fix: toggle focus click and kbd

### DIFF
--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -10,6 +10,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
     (ignoreMenus = false) => {
       const elm = ref.current
       if (ignoreMenus && (app.isMenuOpen || app.settings.keepStyleMenuOpen)) return true
+      elm?.focus()
       return elm && (document.activeElement === elm || elm.contains(document.activeElement))
     },
     [ref]


### PR DESCRIPTION
What happens is when you toggle focus mode the activeElement and the current element is not the same anymore, to be able to use kdb shortcuts again we need to focus the current element so we can toggle the focus mode using the kdb shortcut