### PR TITLE
Chore: command format prettier run, yarn workspace run, build run !

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 assets
 **/assets
+**/coverage
 **/dist
 **/extension/editor
 **/out

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@swc-node/jest": "^1.4.3",
+    "@ggallon/prettier-plugin-sort-imports": "^3.4.2-canary.0",
     "@tldraw/lfg": "latest",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.14",
@@ -63,9 +64,6 @@
     "turbo": "^1.1.2",
     "typescript": "^4.7.3",
     "webpack": "^5.68.0"
-  },
-  "resolutions": {
-    "@trivago/prettier-plugin-sort-imports/**/@babel/parser": "^7.17.0"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,6 +1874,14 @@
     intl-messageformat "10.0.1"
     tslib "2.4.0"
 
+"@ggallon/prettier-plugin-sort-imports@^3.4.2-canary.0":
+  version "3.4.2-canary.0"
+  resolved "https://registry.yarnpkg.com/@ggallon/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.4.2-canary.0.tgz#46fac68966ec27367fca0feb5bb627b19218a022"
+  integrity sha512-wb0xyAGce5j8FFh9f7c0+Cpog2tzz5zkNQGcuRgheesC/F5HC5Dl0sWw4sETbgBNfDLNPyQfP9YktGQ9TC/CFA==
+  dependencies:
+    javascript-natural-sort "^0.7.1"
+    lodash "^4.17.21"
+
 "@grpc/grpc-js@^1.3.2":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.5.5.tgz#f850a1bb7de8a1d0bb4821aabd3655d1c928d4c6"
@@ -7977,6 +7985,11 @@ jake@^10.8.5:
     chalk "^4.0.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
+
+javascript-natural-sort@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
 
 jest-changed-files@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
Hi @steveruizok , @with-heart,

After several researches, unpacking of the yarn.lock and tests, the problem revealed in the issue https://github.com/tldraw/tldraw/issues/875#issue-1326090768: `error An unexpected error occurred: "expected workspace package to exist for \"@xxxxx/xxxxx\""` has several factors... 
- One of them appeared with versions higher than yarn 1.18.0
https://github.com/yarnpkg/yarn/issues/7807, the test with this version works, but it's a terrible workaround.
- Rebuilding `yarn.lock` works, but fails during construction with the appearance of error typescripts, due to a dependency conflict
- Incompatibility of locked dependencies in **@trivago/prettier-plugin-sort-imports** https://github.com/trivago/prettier-plugin-sort-imports/issues/141 was a possibility, but with another great forck @ianvs/prettier-plugin-sort-imports, still errors when building....
- I created my own fork of the library to adapt the dependencies with exactly the same versions as in @tldraw, again as soon as the `yarn.lock` is changed, errors during the build occur
- Finally, I moved the @babel* dependencies in peers dependencies, the `yarn.lock` doesn't modify the part with @babel packages anymore.... It works !

For me, there is a problem of incompatibility between the different versions @babel, and yarn can't handle correctly the version resolutions. In all the comments I could read, all have a problem, but there is no miracle solution.

I propose to do by the end of the month a check of the dependencies and to update them in a uniform and recent way to have a stable `yarn.lock` again