### PR TITLE
exit dialog when pressing enter

### DIFF
--- a/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
+++ b/packages/tldraw/src/components/TopPanel/PageOptionsDialog/PageOptionsDialog.tsx
@@ -80,6 +80,7 @@ export function PageOptionsDialog({ page, onOpen, onClose }: PageOptionsDialogPr
         } else {
           rInitialName.current = rCurrentName.current
           app.renamePage(page.id, rCurrentName.current.trim())
+          setIsOpen(false)
         }
 
         break


### PR DESCRIPTION
When a renaming a page, pressing the enter should rename the page and close the dialog
