### PR TITLE
fix: shape parent id on duplicate page

### DIFF
--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -3,12 +3,14 @@ import type { TldrawApp } from '~state/TldrawApp'
 import type { TldrawCommand } from '~types'
 
 export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
-  const newId = Utils.uniqueId()
   const {
     currentPageId,
-    page,
     pageState: { camera },
   } = app
+
+  const page = app.document.pages[pageId]
+
+  const newId = Utils.uniqueId()
 
   const nextPage = {
     ...page,
@@ -20,8 +22,7 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
           id,
           {
             ...shape,
-            // the shape parentId should always be the newId
-            parentId: newId,
+            parentId: shape.parentId === page.id ? newId : shape.parentId,
           },
         ]
       })

--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -20,7 +20,8 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
           id,
           {
             ...shape,
-            parentId: shape.parentId === pageId ? newId : shape.parentId,
+            // the shape parentId should always be the newId
+            parentId: newId,
           },
         ]
       })


### PR DESCRIPTION
Fix shape parent id on duplicated page