### PR TITLE
[fix] Change value of FontStyle.Serif from "erif" to "serif"

### DIFF
--- a/packages/tldraw/src/types.ts
+++ b/packages/tldraw/src/types.ts
@@ -460,7 +460,7 @@ export enum AlignStyle {
 export enum FontStyle {
   Script = 'script',
   Sans = 'sans',
-  Serif = 'erif',
+  Serif = 'serif',
   Mono = 'mono',
 }
 


### PR DESCRIPTION
Correcting (extremely inconsequential) typo on internal value of enum.