### PR TITLE
Set id as assetId when uploading an asset

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -3421,7 +3421,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           let assetId: string
 
           if (!match) {
-            assetId = Utils.uniqueId()
+            assetId = id
 
             const asset = {
               id: assetId,


### PR DESCRIPTION
This way `onAssetCreate` and `onAssetDelete` get called with the same id, allowing us to delete files in `onAssetDelete` that we’re uploaded in `onAssetCreate`. Currently, a new `assetId` is generated that doesn't match the `id`.

Maybe another solution would be to call `onAssetDelete` with both `id` and `assetId`?