### PR TITLE
fix: prevent pasting while panning with the middle mouse button on linux

### DIFF
--- a/packages/tldraw/src/constants.ts
+++ b/packages/tldraw/src/constants.ts
@@ -88,6 +88,8 @@ export const USER_COLORS = [
 export const isSafari =
   typeof Window === 'undefined' ? false : /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
+export const isLinux = typeof Window === 'undefined' ? false : /linux/i.test(navigator.userAgent)
+
 export const IMAGE_EXTENSIONS = ['.png', '.svg', '.jpg', '.jpeg', '.gif']
 
 export const VIDEO_EXTENSIONS = isSafari ? [] : ['.mp4', '.webm']

--- a/packages/tldraw/src/state/__snapshots__/TldrawApp.spec.ts.snap
+++ b/packages/tldraw/src/state/__snapshots__/TldrawApp.spec.ts.snap
@@ -402,6 +402,7 @@ TldrawTestApp {
   "isCreating": false,
   "isDirty": false,
   "isForcePanning": false,
+  "isPastePrevented": false,
   "isPaused": false,
   "isPointing": false,
   "justSent": false,
@@ -497,6 +498,7 @@ TldrawTestApp {
   "pointer": -1,
   "pressKey": [Function],
   "prevSelectedIds": Array [],
+  "preventPaste": [Function],
   "previousPoint": Array [
     0,
     0,


### PR DESCRIPTION
fix #737

Based on [Excalidraw#1402](https://github.com/excalidraw/excalidraw/pull/1402/files)

Completely disables pasting on linux while panning with the middle mouse button or holding space + 50ms after.