### PR TITLE
[improvement] faster svg paths

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-extra-semi */
 import { Vec } from '@tldraw/vec'
+import { StrokePoint } from 'perfect-freehand'
 import type React from 'react'
 import type { Patch, TLBoundsWithCenter } from '~index'
 import { Snap, SnapPoints, TLBounds, TLBoundsCorner, TLBoundsEdge } from '~types'
@@ -1332,32 +1333,66 @@ left past the initial left edge) then swap points on that axis.
     }
   }
 
-  // Regex to trim numbers to 2 decimal places
-  static TRIM_NUMBERS = /(\s?[A-Z]?,?-?[0-9]*\.[0-9]{0,2})(([0-9]|e|-)*)/g
-
   /**
    * Turn an array of points into a path of quadradic curves.
-   * @param stroke ;
+   * @param points - the points returned from perfect-freehand
+   * @param closed - whether to close the stroke
    */
   static getSvgPathFromStroke(points: number[][], closed = true): string {
-    if (!points.length) {
+    const len = points.length
+
+    if (!len) {
       return ''
     }
 
-    const max = points.length - 1
+    const first = points[0]
+    let result = `M${first[0].toFixed(3)},${first[1].toFixed(3)}Q`
 
-    return points
-      .reduce(
-        (acc, point, i, arr) => {
-          if (i === max) {
-            if (closed) acc.push('Z')
-          } else acc.push(point, Vec.med(point, arr[i + 1]))
-          return acc
-        },
-        ['M', points[0], 'Q']
-      )
-      .join(' ')
-      .replaceAll(this.TRIM_NUMBERS, '$1')
+    for (let i = 0, max = len - 1; i < max; i++) {
+      const a = points[i]
+      const b = points[i + 1]
+      result += `${a[0].toFixed(3)},${a[1].toFixed(3)} ${average(a[0], b[0]).toFixed(3)},${average(
+        a[1],
+        b[1]
+      ).toFixed(3)} `
+    }
+
+    if (closed) {
+      result += 'Z'
+    }
+
+    return result
+  }
+
+  /**
+   * Turn an array of stroke points into a path of quadradic curves.
+   * @param points - the stroke points returned from perfect-freehand
+   * @param closed - whether to close the stroke
+   */
+  static getSvgPathFromStrokePoints(points: StrokePoint[], closed = true): string {
+    const len = points.length
+
+    if (!len) {
+      return ''
+    }
+
+    const first = points[0].point
+    let result = `M${first[0].toFixed(3)},${first[1].toFixed(3)}Q`
+
+    for (let i = 0, max = len - 1; i < max; i++) {
+      const a = points[i].point
+      const b = points[i + 1].point
+      result += `${a[0].toFixed(3)},${a[1].toFixed(3)} ${average(a[0], b[0]).toFixed(3)},${average(
+        a[1],
+        b[1]
+      ).toFixed(3)} `
+    }
+
+    if (closed) {
+      result += 'Z'
+    }
+
+    return result
   }
 
   /* -------------------------------------------------- */
@@ -1492,3 +1527,7 @@ left past the initial left edge) then swap points on that axis.
 }
 
 export default Utils
+
+function average(a: number, b: number): number {
+  return (a + b) / 2
+}

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1336,9 +1336,8 @@ left past the initial left edge) then swap points on that axis.
   /**
    * Turn an array of points into a path of quadradic curves.
    * @param points - the points returned from perfect-freehand
-   * @param closed - whether to close the stroke
    */
-  static getSvgPathFromStroke(points: number[][], closed = true): string {
+  static getSvgPathFromStroke(points: number[][]): string {
     const len = points.length
 
     if (!len) {
@@ -1357,9 +1356,7 @@ left past the initial left edge) then swap points on that axis.
       ).toFixed(3)} `
     }
 
-    if (closed) {
-      result += 'Z'
-    }
+    result += 'Z'
 
     return result
   }
@@ -1367,9 +1364,8 @@ left past the initial left edge) then swap points on that axis.
   /**
    * Turn an array of stroke points into a path of quadradic curves.
    * @param points - the stroke points returned from perfect-freehand
-   * @param closed - whether to close the stroke
    */
-  static getSvgPathFromStrokePoints(points: StrokePoint[], closed = true): string {
+  static getSvgPathFromStrokePoints(points: StrokePoint[]): string {
     const len = points.length
 
     if (!len) {
@@ -1386,10 +1382,6 @@ left past the initial left edge) then swap points on that axis.
         a[1],
         b[1]
       ).toFixed(3)} `
-    }
-
-    if (closed) {
-      result += 'Z'
     }
 
     return result

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -50,7 +50,7 @@
     "browser-fs-access": "^0.31.0",
     "idb-keyval": "^6.1.0",
     "lz-string": "^1.4.4",
-    "perfect-freehand": "^1.1.0",
+    "perfect-freehand": "^1.2.0",
     "react-error-boundary": "^3.1.4",
     "react-hotkeys-hook": "^3.4.4",
     "react-intl": "^6.0.3",

--- a/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
+++ b/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
@@ -1,6 +1,11 @@
 import { Utils } from '@tldraw/core'
 import Vec from '@tldraw/vec'
-import { StrokeOptions, getStrokeOutlinePoints, getStrokePoints } from 'perfect-freehand'
+import {
+  StrokeOptions,
+  StrokePoint,
+  getStrokeOutlinePoints,
+  getStrokePoints,
+} from 'perfect-freehand'
 import { getShapeStyle } from '~state/shapes/shared'
 import type { DrawShape } from '~types'
 
@@ -59,9 +64,9 @@ export function getSolidStrokePathTDSnapshot(shape: DrawShape) {
   const { points } = shape
   if (points.length < 2) return 'M 0 0 L 0 0'
   const options = getFreehandOptions(shape)
-  const strokePoints = getDrawStrokePoints(shape, options).map((pt) => pt.point.slice(0, 2))
-  const last = points[points.length - 1].slice(0, 2)
-  if (!Vec.isEqual(strokePoints[0], last)) strokePoints.push(last)
-  const path = Utils.getSvgPathFromStroke(strokePoints, false)
+  const strokePoints = getDrawStrokePoints(shape, options)
+  const last = points[points.length - 1]
+  if (!Vec.isEqual(strokePoints[0].point, last)) strokePoints.push({ point: last } as StrokePoint)
+  const path = Utils.getSvgPathFromStrokePoints(strokePoints, false)
   return path
 }

--- a/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
+++ b/packages/tldraw/src/state/shapes/DrawUtil/drawHelpers.ts
@@ -67,6 +67,6 @@ export function getSolidStrokePathTDSnapshot(shape: DrawShape) {
   const strokePoints = getDrawStrokePoints(shape, options)
   const last = points[points.length - 1]
   if (!Vec.isEqual(strokePoints[0].point, last)) strokePoints.push({ point: last } as StrokePoint)
-  const path = Utils.getSvgPathFromStrokePoints(strokePoints, false)
+  const path = Utils.getSvgPathFromStrokePoints(strokePoints)
   return path
 }

--- a/packages/tldraw/src/state/shapes/EllipseUtil/ellipseHelpers.ts
+++ b/packages/tldraw/src/state/shapes/EllipseUtil/ellipseHelpers.ts
@@ -50,5 +50,5 @@ export function getEllipsePath(id: string, radius: number[], style: ShapeStyles)
 }
 
 export function getEllipseIndicatorPath(id: string, radius: number[], style: ShapeStyles) {
-  return Utils.getSvgPathFromStrokePoints(getEllipseStrokePoints(id, radius, style), false)
+  return Utils.getSvgPathFromStrokePoints(getEllipseStrokePoints(id, radius, style))
 }

--- a/packages/tldraw/src/state/shapes/EllipseUtil/ellipseHelpers.ts
+++ b/packages/tldraw/src/state/shapes/EllipseUtil/ellipseHelpers.ts
@@ -50,8 +50,5 @@ export function getEllipsePath(id: string, radius: number[], style: ShapeStyles)
 }
 
 export function getEllipseIndicatorPath(id: string, radius: number[], style: ShapeStyles) {
-  return Utils.getSvgPathFromStroke(
-    getEllipseStrokePoints(id, radius, style).map((pt) => pt.point.slice(0, 2)),
-    false
-  )
+  return Utils.getSvgPathFromStrokePoints(getEllipseStrokePoints(id, radius, style), false)
 }

--- a/packages/tldraw/src/state/shapes/RectangleUtil/rectangleHelpers.ts
+++ b/packages/tldraw/src/state/shapes/RectangleUtil/rectangleHelpers.ts
@@ -90,6 +90,5 @@ export function getRectangleIndicatorPathTDSnapshot(
   size: number[]
 ) {
   const { points, options } = getDrawStrokeInfo(id, style, size)
-  const strokePoints = getStrokePoints(points, options)
-  return Utils.getSvgPathFromStrokePoints(strokePoints, false)
+  return Utils.getSvgPathFromStrokePoints(getStrokePoints(points, options))
 }

--- a/packages/tldraw/src/state/shapes/RectangleUtil/rectangleHelpers.ts
+++ b/packages/tldraw/src/state/shapes/RectangleUtil/rectangleHelpers.ts
@@ -91,8 +91,5 @@ export function getRectangleIndicatorPathTDSnapshot(
 ) {
   const { points, options } = getDrawStrokeInfo(id, style, size)
   const strokePoints = getStrokePoints(points, options)
-  return Utils.getSvgPathFromStroke(
-    strokePoints.map((pt) => pt.point.slice(0, 2)),
-    false
-  )
+  return Utils.getSvgPathFromStrokePoints(strokePoints, false)
 }

--- a/packages/tldraw/src/state/shapes/TriangleUtil/triangleHelpers.ts
+++ b/packages/tldraw/src/state/shapes/TriangleUtil/triangleHelpers.ts
@@ -89,8 +89,5 @@ export function getTrianglePath(id: string, size: number[], style: ShapeStyles) 
 export function getTriangleIndicatorPathTDSnapshot(id: string, size: number[], style: ShapeStyles) {
   const { points, options } = getDrawStrokeInfo(id, size, style)
   const strokePoints = getStrokePoints(points, options)
-  return Utils.getSvgPathFromStroke(
-    strokePoints.map((pt) => pt.point.slice(0, 2)),
-    false
-  )
+  return Utils.getSvgPathFromStrokePoints(strokePoints.map, false)
 }

--- a/packages/tldraw/src/state/shapes/TriangleUtil/triangleHelpers.ts
+++ b/packages/tldraw/src/state/shapes/TriangleUtil/triangleHelpers.ts
@@ -88,6 +88,5 @@ export function getTrianglePath(id: string, size: number[], style: ShapeStyles) 
 
 export function getTriangleIndicatorPathTDSnapshot(id: string, size: number[], style: ShapeStyles) {
   const { points, options } = getDrawStrokeInfo(id, size, style)
-  const strokePoints = getStrokePoints(points, options)
-  return Utils.getSvgPathFromStrokePoints(strokePoints.map, false)
+  return Utils.getSvgPathFromStrokePoints(getStrokePoints(points, options))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7805,6 +7805,11 @@ perfect-freehand@^1.1.0:
   resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.1.0.tgz#65b459f4d6ccceb873e9ac06e07c924761649b32"
   integrity sha512-nVWukMN9qlii1dQsQHVvfaNpeOAWVLgTZP6e/tFcU6cWlLo+6YdvfRGBL2u5pU11APlPbHeB0SpMcGA8ZjPgcQ==
 
+perfect-freehand@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.2.0.tgz#706a0f854544f6175772440c51d3b0563eb3988a"
+  integrity sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"


### PR DESCRIPTION
This PR:
- improves the performance of tldraw by improving the methods we were using to turn freehand points into SVG path data
- bumps perfect-freehand to the latest version