### PR TITLE
[improvement] Add build to postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --write .",
     "lint": "turbo run lint --parallel",
     "clean": "turbo run clean",
-    "postinstall": "husky install",
+    "postinstall": "husky install & yarn build",
     "pre-commit": "lint-staged",
     "pre-push": "yarn test"
   },


### PR DESCRIPTION
Due to some monorepo complexity, tldraw needs to be built at least once before it can be developed.

This PR adds a postinstall script that runs build automatically when dependencies are installed.