### PR TITLE
fix scrolling menus

### DIFF
--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -84,7 +84,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
 
   rZoomRef.current = pageState.camera.zoom
 
-  useZoomEvents(rZoomRef, externalContainerRef || rCanvas)
+  useZoomEvents(rZoomRef, rCanvas)
 
   useResizeObserver(rCanvas, onBoundsChange)
 

--- a/packages/tldraw/src/components/Primitives/DropdownMenu/DMContent.tsx
+++ b/packages/tldraw/src/components/Primitives/DropdownMenu/DMContent.tsx
@@ -29,7 +29,7 @@ export function DMContent({
   const container = useContainer()
 
   return (
-    <DropdownMenu.Portal container={overflow ? undefined : container.current} dir="ltr">
+    <DropdownMenu.Portal container={container.current} dir="ltr">
       <DropdownMenu.Content
         align={align}
         alignOffset={alignOffset}

--- a/packages/tldraw/src/components/ToolsPanel/KeyboardShortcutDialog.tsx
+++ b/packages/tldraw/src/components/ToolsPanel/KeyboardShortcutDialog.tsx
@@ -6,6 +6,7 @@ import { IconButton } from '~components/Primitives/IconButton'
 import { Kbd } from '~components/Primitives/Kbd'
 import { RowButton } from '~components/Primitives/RowButton'
 import { breakpoints } from '~components/breakpoints'
+import { useContainer } from '~hooks'
 import { styled } from '~styles'
 
 export function KeyboardShortcutDialog({
@@ -14,6 +15,7 @@ export function KeyboardShortcutDialog({
   onOpenChange?: (open: boolean) => void
 }) {
   const intl = useIntl()
+  const container = useContainer()
 
   const shortcuts = {
     Tools: [
@@ -89,7 +91,7 @@ export function KeyboardShortcutDialog({
           <FormattedMessage id="keyboard.shortcuts" />
         </RowButton>
       </Dialog.Trigger>
-      <Dialog.Portal>
+      <Dialog.Portal container={container.current}>
         <DialogOverlay />
         <DialogContent>
           <DialogTitle>


### PR DESCRIPTION
fix #969

Changes tracking zoom & scroll on the `div#canvas`. This results in:

- when hovering any UI element (toolbars, menus):
  - canvas doesn't scroll - ok
  - browser's zooming kicks in and scales both ui and canvas - ~~is it ok?~~
- ~~I have some bugs with menus not always opening in the dev env, but on the deployed version for this pr it works fine~~