### PR TITLE
minify tldr files

### DIFF
--- a/packages/tldraw/src/state/data/filesystem.ts
+++ b/packages/tldraw/src/state/data/filesystem.ts
@@ -38,7 +38,8 @@ export async function saveToFileSystem(
   }
 
   // Serialize to JSON
-  const json = JSON.stringify(file, null, 2)
+  const json =
+    process.env.NODE_ENV === 'production' ? JSON.stringify(file) : JSON.stringify(file, null, 2)
 
   // Create blob
   const blob = new Blob([json], {


### PR DESCRIPTION
fix #418 

Tools like https://codebeautify.org/jsonminifier which was mentioned in the issue are just removing white space from a json file - the same does `JSON.stringify(file)` in this pr.

The `jsonminify` lib from #512 won't help is this case:
> the intended usage is to minify development-friendly JSON (with comments) to valid JSON before parsing, such as:
> `JSON.parse(JSON.minify(str))`
> *[jsonminify - npm](https://www.npmjs.com/package/jsonminify)*

### Size comparison for projects with no media

The initial set consists of 8 shapes - one for each tool, except for image. Then this set gets multiplied to form a bigger document.

number of shapes | size with white space (Kb) | without (Kb) | reduced size (%)
-- | -- | -- | --
8 | 37 | 7 | 81.08%
16 | 74 | 14 | 81.08%
32 | 147 | 28 | 80.95%
64 | 293 | 55 | 81.23%
128 | 586 | 110 | 81.23%
256 | 1140 | 219 | 80.79%
512 | 2290 | 439 | 80.83%
1024 | 4570 | 877 | 80.81%

### Size comparison for projects with images

Same set + 600-700 Kb jpeg images

number of shapes + images | size with white space (Kb) | without (Kb) | reduced size (%)
-- | -- | -- | --
8+1 | 828 | 797 | 3.74%
16+2 | 1550 | 1490 | 3.87%
32+4 | 3260 | 3140 | 3.68%
64+8 | 6480 | 6250 | 3.55%

