### PR TITLE
feat: run yarn build after running yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --write .",
     "lint": "turbo run lint --parallel",
     "clean": "turbo run clean",
-    "postinstall": "husky install",
+    "postinstall": "husky install && yarn build",
     "pre-commit": "lint-staged",
     "pre-push": "yarn test"
   },


### PR DESCRIPTION
before running tldraw we need to build first, so I added a post install script to run yarn build after installing package (yarn)