### PR TITLE
fix: arrow binding id

### DIFF
--- a/packages/tldraw/src/state/TLDR.ts
+++ b/packages/tldraw/src/state/TLDR.ts
@@ -637,7 +637,11 @@ export class TLDR {
       const hasDecoration = arrowShape.decorations?.start !== undefined
       const handle = arrowShape.handles.start
       const binding = page.bindings[arrowShape.handles.start.bindingId]
-      if (!binding) throw Error("Could not find a binding to match the start handle's bindingId")
+      if (!binding)
+        throw Error(
+          "Could not find a binding to match the start handle's bindingId: " +
+            arrowShape.handles.start.bindingId
+        )
       const target = page.shapes[binding.toId]
       const util = TLDR.getShapeUtil(target)
       const bounds = util.getBounds(target)

--- a/packages/tldraw/src/state/TldrawApp.spec.ts
+++ b/packages/tldraw/src/state/TldrawApp.spec.ts
@@ -718,6 +718,34 @@ describe('TldrawTestApp', () => {
   })
 })
 
+describe('Arrow binding', () => {
+  it('should delete handles bindingId', () => {
+    const app = new TldrawTestApp()
+
+    app
+      .createShapes(
+        { type: TDShapeType.Rectangle, id: 'target1', point: [0, 0], size: [100, 100] },
+        { type: TDShapeType.Rectangle, id: 'target2', point: [300, 300], size: [100, 100] },
+        { type: TDShapeType.Arrow, id: 'arrow1', point: [200, 200] }
+      )
+      .select('arrow1')
+      .movePointer([200, 200])
+      .startSession(SessionType.Arrow, 'arrow1', 'start')
+      .movePointer([0, 0])
+      .completeSession()
+
+    expect(app.bindings.length).toBe(1)
+
+    app
+      .select('arrow1')
+      .movePointer([200, 200])
+      .startSession(SessionType.Arrow, 'arrow1', 'start')
+      .movePointer([1000, 1000])
+      .completeSession()
+    expect(app.bindings.length).toBe(0)
+  })
+})
+
 describe('When adding an image', () => {
   it.todo('Adds the image to the assets table')
   it.todo('Does not add the image if that image already exists as an asset')

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -383,14 +383,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           Object.keys(page.bindings).forEach((id) => {
             if (!page.bindings[id]) {
               delete page.bindings[id]
-              // Delete the bindingId in arrow handles
-              Object.values(page.shapes).forEach((shape) => {
-                Object.values(shape.handles ?? {}).map((handle) => {
-                  if (handle.bindingId === id) {
-                    shape.handles![handle.id as keyof ArrowShape['handles']].bindingId = undefined
-                  }
-                })
-              })
             }
           })
 

--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -383,6 +383,14 @@ export class TldrawApp extends StateManager<TDSnapshot> {
           Object.keys(page.bindings).forEach((id) => {
             if (!page.bindings[id]) {
               delete page.bindings[id]
+              // Delete the bindingId in arrow handles
+              Object.values(page.shapes).forEach((shape) => {
+                Object.values(shape.handles ?? {}).map((handle) => {
+                  if (handle.bindingId === id) {
+                    shape.handles![handle.id as keyof ArrowShape['handles']].bindingId = undefined
+                  }
+                })
+              })
             }
           })
 
@@ -410,7 +418,6 @@ export class TldrawApp extends StateManager<TDSnapshot> {
             if (visitedShapes.has(fromShape)) {
               return
             }
-
             // We only need to update the binding's "from" shape (an arrow)
             const fromDelta = TLDR.updateArrowBindings(page, fromShape)
             visitedShapes.add(fromShape)


### PR DESCRIPTION
Delete arrow handles bindingId when binding does not exist