### PR TITLE
Add support for custom cursor components

### DIFF
--- a/apps/www/components/MultiplayerEditor.tsx
+++ b/apps/www/components/MultiplayerEditor.tsx
@@ -1,4 +1,4 @@
-import { Tldraw, useFileSystem } from '@tldraw/tldraw'
+import { Tldraw, TldrawProps, useFileSystem } from '@tldraw/tldraw'
 import * as React from 'react'
 import { useMultiplayerAssets } from '~hooks/useMultiplayerAssets'
 import { useMultiplayerState } from '~hooks/useMultiplayerState'

--- a/packages/core/src/TLShapeUtil/TLShapeUtil.tsx
+++ b/packages/core/src/TLShapeUtil/TLShapeUtil.tsx
@@ -19,7 +19,7 @@ export abstract class TLShapeUtil<T extends TLShape, E extends Element = any, M 
   abstract Indicator: (props: {
     shape: T
     meta: M
-    user?: TLUser<T>
+    user?: TLUser
     bounds: TLBounds
     isHovered: boolean
     isSelected: boolean

--- a/packages/core/src/components/Canvas/Canvas.test.tsx
+++ b/packages/core/src/components/Canvas/Canvas.test.tsx
@@ -2,6 +2,10 @@ import * as React from 'react'
 import { mockDocument, renderWithContext } from '~test'
 import { Canvas } from './Canvas'
 
+function TestCustomCursor() {
+  return <div>Custom cursor</div>
+}
+
 describe('page', () => {
   test('mounts component without crashing', () => {
     expect(() =>
@@ -22,6 +26,31 @@ describe('page', () => {
             // noop
           }}
           assets={{}}
+        />
+      )
+    ).not.toThrowError()
+  })
+
+  test('mounts component with custom cursors without crashing', () => {
+    expect(() =>
+      renderWithContext(
+        <Canvas
+          page={mockDocument.page}
+          pageState={mockDocument.pageState}
+          hideBounds={false}
+          hideGrid={false}
+          hideIndicators={false}
+          hideHandles={false}
+          hideBindingHandles={false}
+          hideResizeHandles={false}
+          hideCloneHandles={false}
+          hideRotateHandle={false}
+          showDashedBrush={false}
+          onBoundsChange={() => {
+            // noop
+          }}
+          assets={{}}
+          components={{ Cursor: TestCustomCursor }}
         />
       )
     ).not.toThrowError()

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Brush } from '~components/Brush'
+import { CursorComponent } from '~components/Cursor/Cursor'
 import { EraseLine } from '~components/EraseLine'
 import { Grid } from '~components/Grid'
 import { Overlay } from '~components/Overlay'
@@ -49,6 +50,9 @@ export interface CanvasProps<T extends TLShape, M extends Record<string, unknown
   showDashedBrush: boolean
   externalContainerRef?: React.RefObject<HTMLElement>
   performanceMode?: TLPerformanceMode
+  components?: {
+    Cursor?: CursorComponent
+  }
   meta?: M
   id?: string
   onBoundsChange: (bounds: TLBounds) => void
@@ -64,6 +68,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
   grid,
   users,
   userId,
+  components,
   meta,
   performanceMode,
   externalContainerRef,
@@ -128,7 +133,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
           {pageState.brush && (
             <Brush brush={pageState.brush} dashed={showDashedBrush} zoom={pageState.camera.zoom} />
           )}
-          {users && <Users userId={userId} users={users} />}
+          {users && <Users userId={userId} users={users} Cursor={components?.Cursor} />}
         </div>
         <Overlay camera={pageState.camera}>
           {eraseLine && <EraseLine points={eraseLine} zoom={pageState.camera.zoom} />}

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Brush } from '~components/Brush'
-import { Cursor, CursorComponent } from '~components/Cursor/Cursor'
+import { Cursor, CursorComponent } from '~components/Cursor'
 import { EraseLine } from '~components/EraseLine'
 import { Grid } from '~components/Grid'
 import { Overlay } from '~components/Overlay'

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Brush } from '~components/Brush'
-import { CursorComponent } from '~components/Cursor/Cursor'
+import { Cursor, CursorComponent } from '~components/Cursor/Cursor'
 import { EraseLine } from '~components/EraseLine'
 import { Grid } from '~components/Grid'
 import { Overlay } from '~components/Overlay'
@@ -37,7 +37,7 @@ export interface CanvasProps<T extends TLShape, M extends Record<string, unknown
   snapLines?: TLSnapLine[]
   eraseLine?: number[][]
   grid?: number
-  users?: TLUsers<T>
+  users?: TLUsers
   userId?: string
   hideBounds: boolean
   hideHandles: boolean
@@ -69,7 +69,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
   grid,
   users,
   userId,
-  components,
+  components = {},
   meta,
   performanceMode,
   showDashedBrush,
@@ -135,7 +135,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
             <Brush brush={pageState.brush} dashed={showDashedBrush} zoom={pageState.camera.zoom} />
           )}
           {users && !hideCursors && (
-            <Users userId={userId} users={users} Cursor={components?.Cursor} />
+            <Users userId={userId} users={users} Cursor={components?.Cursor ?? Cursor} />
           )}
         </div>
         <Overlay camera={pageState.camera}>

--- a/packages/core/src/components/Canvas/Canvas.tsx
+++ b/packages/core/src/components/Canvas/Canvas.tsx
@@ -56,6 +56,7 @@ export interface CanvasProps<T extends TLShape, M extends Record<string, unknown
   meta?: M
   id?: string
   onBoundsChange: (bounds: TLBounds) => void
+  hideCursors?: boolean
 }
 
 function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
@@ -71,7 +72,6 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
   components,
   meta,
   performanceMode,
-  externalContainerRef,
   showDashedBrush,
   hideHandles,
   hideBounds,
@@ -82,6 +82,7 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
   hideRotateHandle,
   hideGrid,
   onBoundsChange,
+  hideCursors,
 }: CanvasProps<T, M>) {
   const rCanvas = React.useRef<HTMLDivElement>(null)
 
@@ -133,7 +134,9 @@ function _Canvas<T extends TLShape, M extends Record<string, unknown>>({
           {pageState.brush && (
             <Brush brush={pageState.brush} dashed={showDashedBrush} zoom={pageState.camera.zoom} />
           )}
-          {users && <Users userId={userId} users={users} Cursor={components?.Cursor} />}
+          {users && !hideCursors && (
+            <Users userId={userId} users={users} Cursor={components?.Cursor} />
+          )}
         </div>
         <Overlay camera={pageState.camera}>
           {eraseLine && <EraseLine points={eraseLine} zoom={pageState.camera.zoom} />}

--- a/packages/core/src/components/Cursor/Cursor.tsx
+++ b/packages/core/src/components/Cursor/Cursor.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 
 interface CursorProps {
-  color?: string
+  id: string
+  color: string
 }
 
-export function DefaultCursor({ color }: CursorProps) {
+export type CursorComponent = (props: CursorProps) => any
+
+export const Cursor: CursorComponent = React.memo(({ color }) => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35 35" fill="none" fillRule="evenodd">
       <g fill="rgba(0,0,0,.2)" transform="translate(1,1)">
@@ -21,6 +24,4 @@ export function DefaultCursor({ color }: CursorProps) {
       </g>
     </svg>
   )
-}
-
-export type CursorComponent = typeof DefaultCursor
+})

--- a/packages/core/src/components/Cursor/Cursor.tsx
+++ b/packages/core/src/components/Cursor/Cursor.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+
+interface CursorProps {
+  color?: string
+}
+
+export function DefaultCursor({ color }: CursorProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35 35" fill="none" fillRule="evenodd">
+      <g fill="rgba(0,0,0,.2)" transform="translate(1,1)">
+        <path d="m12 24.4219v-16.015l11.591 11.619h-6.781l-.411.124z" />
+        <path d="m21.0845 25.0962-3.605 1.535-4.682-11.089 3.686-1.553z" />
+      </g>
+      <g fill="white">
+        <path d="m12 24.4219v-16.015l11.591 11.619h-6.781l-.411.124z" />
+        <path d="m21.0845 25.0962-3.605 1.535-4.682-11.089 3.686-1.553z" />
+      </g>
+      <g fill={color}>
+        <path d="m19.751 24.4155-1.844.774-3.1-7.374 1.841-.775z" />
+        <path d="m13 10.814v11.188l2.969-2.866.428-.139h4.768z" />
+      </g>
+    </svg>
+  )
+}
+
+export type CursorComponent = typeof DefaultCursor

--- a/packages/core/src/components/Cursor/index.ts
+++ b/packages/core/src/components/Cursor/index.ts
@@ -1,0 +1,1 @@
+export * from './Cursor'

--- a/packages/core/src/components/Renderer/Renderer.test.tsx
+++ b/packages/core/src/components/Renderer/Renderer.test.tsx
@@ -7,6 +7,10 @@ import type { TLBounds, TLPage, TLPageState } from '~types'
 import Utils from '~utils'
 import { Renderer } from './Renderer'
 
+function TestCustomCursor() {
+  return <div>Custom cursor</div>
+}
+
 describe('renderer', () => {
   test('mounts component without crashing', () => {
     expect(() =>
@@ -15,6 +19,19 @@ describe('renderer', () => {
           shapeUtils={mockUtils as any}
           page={mockDocument.page}
           pageState={mockDocument.pageState}
+        />
+      )
+    ).not.toThrowError()
+  })
+
+  test('mounts component with custom cursors without crashing', () => {
+    expect(() =>
+      render(
+        <Renderer
+          shapeUtils={mockUtils as any}
+          page={mockDocument.page}
+          pageState={mockDocument.pageState}
+          components={{ Cursor: TestCustomCursor }}
         />
       )
     ).not.toThrowError()

--- a/packages/core/src/components/Renderer/Renderer.tsx
+++ b/packages/core/src/components/Renderer/Renderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Canvas } from '~/components/Canvas'
-import type { TLShapeUtilsMap } from '~TLShapeUtil'
+import { CursorComponent } from '~components/Cursor/Cursor'
 import { TLContext, TLContextType, useTLTheme } from '~hooks'
 import { Inputs } from '~inputs'
 import type {
@@ -46,6 +46,15 @@ export type RendererProps<T extends TLShape, M = any> = Partial<TLCallbacks<T>> 
    * (optional) A ref for the renderer's container element, used for scoping event handlers.
    */
   containerRef?: React.RefObject<HTMLElement>
+  /**
+   * (optional) Custom components to override parts of the default UI.
+   */
+  components?: {
+    /**
+     * The component to render for multiplayer cursors.
+     */
+    Cursor?: CursorComponent
+  }
   /**
    * (optional) An object of custom options that should be passed to rendered shapes.
    */
@@ -147,6 +156,7 @@ function _Renderer<T extends TLShape, M extends Record<string, unknown>>({
   eraseLine,
   grid,
   containerRef,
+  components,
   performanceMode,
   hideHandles = false,
   hideIndicators = false,
@@ -216,6 +226,7 @@ function _Renderer<T extends TLShape, M extends Record<string, unknown>>({
         showDashedBrush={showDashedBrush}
         onBoundsChange={onBoundsChange}
         performanceMode={performanceMode}
+        components={components}
         meta={meta}
       />
     </TLContext.Provider>

--- a/packages/core/src/components/Renderer/Renderer.tsx
+++ b/packages/core/src/components/Renderer/Renderer.tsx
@@ -17,7 +17,7 @@ import type {
   TLUsers,
 } from '~types'
 
-const EMPTY_OBJECT = {} as TLAssets
+const EMPTY_OBJECT = Object.freeze({}) as TLAssets
 
 export type RendererProps<T extends TLShape, M = any> = Partial<TLCallbacks<T>> & {
   /**
@@ -67,7 +67,7 @@ export type RendererProps<T extends TLShape, M = any> = Partial<TLCallbacks<T>> 
   /**
    * (optional) The current users to render.
    */
-  users?: TLUsers<T>
+  users?: TLUsers
   /**
    * (optional) The current snap lines to render.
    */
@@ -161,8 +161,8 @@ function _Renderer<T extends TLShape, M extends Record<string, unknown>>({
   eraseLine,
   grid,
   containerRef,
-  components,
   performanceMode,
+  components,
   hideHandles = false,
   hideIndicators = false,
   hideCloneHandles = false,

--- a/packages/core/src/components/Renderer/Renderer.tsx
+++ b/packages/core/src/components/Renderer/Renderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Canvas } from '~/components/Canvas'
-import { CursorComponent } from '~components/Cursor/Cursor'
+import { CursorComponent } from '~components/Cursor'
 import { TLContext, TLContextType, useTLTheme } from '~hooks'
 import { Inputs } from '~inputs'
 import type {

--- a/packages/core/src/components/Renderer/Renderer.tsx
+++ b/packages/core/src/components/Renderer/Renderer.tsx
@@ -55,6 +55,11 @@ export type RendererProps<T extends TLShape, M = any> = Partial<TLCallbacks<T>> 
      */
     Cursor?: CursorComponent
   }
+
+  /**
+   * (optional) To hide cursors
+   */
+  hideCursors?: boolean
   /**
    * (optional) An object of custom options that should be passed to rendered shapes.
    */
@@ -167,6 +172,7 @@ function _Renderer<T extends TLShape, M extends Record<string, unknown>>({
   hideBounds = false,
   hideGrid = true,
   showDashedBrush = false,
+  hideCursors,
   ...rest
 }: RendererProps<T, M>) {
   useTLTheme(theme, '#' + id)
@@ -228,6 +234,7 @@ function _Renderer<T extends TLShape, M extends Record<string, unknown>>({
         performanceMode={performanceMode}
         components={components}
         meta={meta}
+        hideCursors={hideCursors}
       />
     </TLContext.Provider>
   )

--- a/packages/core/src/components/ShapeIndicator/ShapeIndicator.tsx
+++ b/packages/core/src/components/ShapeIndicator/ShapeIndicator.tsx
@@ -8,7 +8,7 @@ export interface IndicatorProps<T extends TLShape, M = unknown> {
   isSelected?: boolean
   isHovered?: boolean
   isEditing?: boolean
-  user?: TLUser<T>
+  user?: TLUser
 }
 
 function _ShapeIndicator<T extends TLShape, M>({

--- a/packages/core/src/components/User/User.tsx
+++ b/packages/core/src/components/User/User.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import { CursorComponent, DefaultCursor } from '~components/Cursor/Cursor'
-import type { TLShape, TLUser } from '~types'
+import { CursorComponent } from '~components/Cursor'
+import type { TLUser } from '~types'
 
 interface UserProps {
-  user: TLUser<TLShape>
-  Cursor?: CursorComponent
+  user: TLUser
+  Cursor: CursorComponent
 }
 
-export function User({ user, Cursor = DefaultCursor }: UserProps) {
+export function User({ user, Cursor }: UserProps) {
   const rCursor = React.useRef<HTMLDivElement>(null)
 
   React.useLayoutEffect(() => {
@@ -21,7 +21,7 @@ export function User({ user, Cursor = DefaultCursor }: UserProps) {
       ref={rCursor}
       className={`tl-absolute tl-user tl-counter-scaled ${user.session ? '' : 'tl-animated'}`}
     >
-      <Cursor color={user.color} />
+      <Cursor id={user.id} color={user.color} />
     </div>
   )
 }

--- a/packages/core/src/components/User/User.tsx
+++ b/packages/core/src/components/User/User.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react'
+import { CursorComponent, DefaultCursor } from '~components/Cursor/Cursor'
 import type { TLShape, TLUser } from '~types'
 
 interface UserProps {
   user: TLUser<TLShape>
+  Cursor?: CursorComponent
 }
 
-export function User({ user }: UserProps) {
-  const rCursor = React.useRef<SVGSVGElement>(null)
+export function User({ user, Cursor = DefaultCursor }: UserProps) {
+  const rCursor = React.useRef<HTMLDivElement>(null)
 
   React.useLayoutEffect(() => {
     if (rCursor.current) {
@@ -15,26 +17,11 @@ export function User({ user }: UserProps) {
   }, [user.point])
 
   return (
-    <svg
+    <div
       ref={rCursor}
       className={`tl-absolute tl-user tl-counter-scaled ${user.session ? '' : 'tl-animated'}`}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 35 35"
-      fill="none"
-      fillRule="evenodd"
     >
-      <g fill="rgba(0,0,0,.2)" transform="translate(1,1)">
-        <path d="m12 24.4219v-16.015l11.591 11.619h-6.781l-.411.124z" />
-        <path d="m21.0845 25.0962-3.605 1.535-4.682-11.089 3.686-1.553z" />
-      </g>
-      <g fill="white">
-        <path d="m12 24.4219v-16.015l11.591 11.619h-6.781l-.411.124z" />
-        <path d="m21.0845 25.0962-3.605 1.535-4.682-11.089 3.686-1.553z" />
-      </g>
-      <g fill={user.color}>
-        <path d="m19.751 24.4155-1.844.774-3.1-7.374 1.841-.775z" />
-        <path d="m13 10.814v11.188l2.969-2.866.428-.139h4.768z" />
-      </g>
-    </svg>
+      <Cursor color={user.color} />
+    </div>
   )
 }

--- a/packages/core/src/components/Users/Users.tsx
+++ b/packages/core/src/components/Users/Users.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import { CursorComponent } from '~components/Cursor/Cursor'
 import { User } from '~components/User/User'
-import type { TLShape, TLUsers } from '~types'
+import type { TLUsers } from '~types'
 
 export interface UserProps {
   userId?: string
-  users: TLUsers<TLShape>
-  Cursor?: CursorComponent
+  users: TLUsers
+  Cursor: CursorComponent
 }
 
 export function Users({ userId, users, Cursor }: UserProps) {

--- a/packages/core/src/components/Users/Users.tsx
+++ b/packages/core/src/components/Users/Users.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react'
+import { CursorComponent } from '~components/Cursor/Cursor'
 import { User } from '~components/User/User'
 import type { TLShape, TLUsers } from '~types'
 
 export interface UserProps {
   userId?: string
   users: TLUsers<TLShape>
+  Cursor?: CursorComponent
 }
 
-export function Users({ userId, users }: UserProps) {
+export function Users({ userId, users, Cursor }: UserProps) {
   return (
     <>
       {Object.values(users)
         .filter((user) => user && user.id !== userId)
         .map((user) => (
-          <User key={user.id} user={user} />
+          <User key={user.id} user={user} Cursor={Cursor} />
         ))}
     </>
   )

--- a/packages/core/src/components/Users/Users.tsx
+++ b/packages/core/src/components/Users/Users.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CursorComponent } from '~components/Cursor/Cursor'
+import { CursorComponent } from '~components/Cursor'
 import { User } from '~components/User/User'
 import type { TLUsers } from '~types'
 

--- a/packages/core/src/components/UsersIndicators/UsersIndicators.tsx
+++ b/packages/core/src/components/UsersIndicators/UsersIndicators.tsx
@@ -7,7 +7,7 @@ import Utils from '~utils'
 interface UserIndicatorProps<T extends TLShape> {
   page: TLPage<any, any>
   userId: string
-  users: TLUsers<T>
+  users: TLUsers
   meta: any
 }
 

--- a/packages/core/src/components/index.tsx
+++ b/packages/core/src/components/index.tsx
@@ -1,3 +1,4 @@
 export * from './Renderer'
 export * from './SVGContainer'
 export * from './HTMLContainer'
+export * from './Cursor'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,7 +44,7 @@ export interface TLPageState {
   bindingId?: string | null
 }
 
-export interface TLUser<T extends TLShape> {
+export interface TLUser {
   id: string
   color: string
   point: number[]
@@ -52,7 +52,7 @@ export interface TLUser<T extends TLShape> {
   session?: boolean
 }
 
-export type TLUsers<T extends TLShape, U extends TLUser<T> = TLUser<T>> = Record<string, U>
+export type TLUsers = Record<string, TLUser>
 
 export type TLSnapLine = number[][]
 

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -1,5 +1,4 @@
-import { Renderer } from '@tldraw/core'
-import { CursorComponent } from '@tldraw/core/src/components/Cursor/Cursor'
+import { CursorComponent, Renderer } from '@tldraw/core'
 import * as React from 'react'
 import { ErrorBoundary as _Errorboundary } from 'react-error-boundary'
 import { IntlProvider } from 'react-intl'

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -113,6 +113,11 @@ export interface TldrawProps extends TDCallbacks {
      */
     Cursor?: CursorComponent
   }
+
+  /**
+   * (optional) To hide cursors
+   */
+  hideCursors?: boolean
 }
 
 const isSystemDarkMode = window.matchMedia
@@ -155,6 +160,7 @@ export function Tldraw({
   onSessionStart,
   onSessionEnd,
   onExport,
+  hideCursors,
 }: TldrawProps) {
   const [sId, setSId] = React.useState(id)
 
@@ -349,6 +355,7 @@ export function Tldraw({
           showUI={showUI}
           readOnly={readOnly}
           components={components}
+          hideCursors={hideCursors}
         />
       </AlertDialogContext.Provider>
     </TldrawContext.Provider>
@@ -369,6 +376,7 @@ interface InnerTldrawProps {
   components?: {
     Cursor?: CursorComponent
   }
+  hideCursors?: boolean
 }
 
 const InnerTldraw = React.memo(function InnerTldraw({
@@ -383,6 +391,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
   readOnly,
   showUI,
   components,
+  hideCursors,
 }: InnerTldrawProps) {
   const app = useTldrawApp()
   const [dialogContainer, setDialogContainer] = React.useState<any>(null)
@@ -507,6 +516,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
                 theme={theme}
                 meta={meta}
                 components={components}
+                hideCursors={hideCursors}
                 hideBounds={hideBounds}
                 hideHandles={hideHandles}
                 hideResizeHandles={isHideResizeHandlesShape}

--- a/packages/tldraw/src/Tldraw.tsx
+++ b/packages/tldraw/src/Tldraw.tsx
@@ -1,4 +1,5 @@
 import { Renderer } from '@tldraw/core'
+import { CursorComponent } from '@tldraw/core/src/components/Cursor/Cursor'
 import * as React from 'react'
 import { ErrorBoundary as _Errorboundary } from 'react-error-boundary'
 import { IntlProvider } from 'react-intl'
@@ -102,6 +103,16 @@ export interface TldrawProps extends TDCallbacks {
    * bucket based solution will cause massive base64 string to be written to the liveblocks room.
    */
   disableAssets?: boolean
+
+  /**
+   * (optional) Custom components to override parts of the default UI.
+   */
+  components?: {
+    /**
+     * The component to render for multiplayer cursors.
+     */
+    Cursor?: CursorComponent
+  }
 }
 
 const isSystemDarkMode = window.matchMedia
@@ -123,6 +134,7 @@ export function Tldraw({
   readOnly = false,
   disableAssets = false,
   darkMode = isSystemDarkMode,
+  components,
   onMount,
   onChange,
   onChangePresence,
@@ -336,6 +348,7 @@ export function Tldraw({
           showTools={showTools}
           showUI={showUI}
           readOnly={readOnly}
+          components={components}
         />
       </AlertDialogContext.Provider>
     </TldrawContext.Provider>
@@ -353,6 +366,9 @@ interface InnerTldrawProps {
   showStyles: boolean
   showUI: boolean
   showTools: boolean
+  components?: {
+    Cursor?: CursorComponent
+  }
 }
 
 const InnerTldraw = React.memo(function InnerTldraw({
@@ -366,6 +382,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
   showTools,
   readOnly,
   showUI,
+  components,
 }: InnerTldrawProps) {
   const app = useTldrawApp()
   const [dialogContainer, setDialogContainer] = React.useState<any>(null)
@@ -489,6 +506,7 @@ const InnerTldraw = React.memo(function InnerTldraw({
                 userId={room?.userId}
                 theme={theme}
                 meta={meta}
+                components={components}
                 hideBounds={hideBounds}
                 hideHandles={hideHandles}
                 hideResizeHandles={isHideResizeHandlesShape}

--- a/packages/tldraw/src/types.ts
+++ b/packages/tldraw/src/types.ts
@@ -176,7 +176,7 @@ export enum TDUserStatus {
 }
 
 // A TDUser, for multiplayer rooms
-export interface TDUser extends TLUser<TDShape> {
+export interface TDUser extends TLUser {
   activeShapes: TDShape[]
   status: TDUserStatus
   session?: boolean


### PR DESCRIPTION
This introduces a new prop on the `Renderer` component that allows users integrating with @tldraw/core to provide custom components to override parts of the default UI.

At this point, the only thing you can override is the component that's rendered for multiplayer cursors.

The only change to the default behavior here for users who don't provide a custom cursor component is that the default multiplayer cursors are now wrapped in a `<div>`. I don't love adding an extra level of depth to the HTML like that, so I'd love suggestions for other ways to implement this that keep the API simple without introducing breaking changes or extra HTML elements.

Please let me know if there are any code style or general structural issues with this implementation that I can clean up or fix.