### PR TITLE
Call onRightPointCanvas in the canvas onPointerDown handler

### DIFF
--- a/packages/core/src/hooks/useCanvasEvents.tsx
+++ b/packages/core/src/hooks/useCanvasEvents.tsx
@@ -13,6 +13,7 @@ export function useCanvasEvents() {
 
         // On right click
         if (e.button === 2) {
+          callbacks.onRightPointCanvas?.(inputs.pointerDown(e, 'canvas'), e)
           return
         }
 


### PR DESCRIPTION
# Summary

This makes the canvas' `onPointerDown` handler call the `onRightPointCanvas` callback if the user has right-clicked.

# Motivation

Right-points on the canvas were not being propagated.