### PR TITLE
Call onPointerUp on right pointer up

### DIFF
--- a/packages/core/src/hooks/useCanvasEvents.tsx
+++ b/packages/core/src/hooks/useCanvasEvents.tsx
@@ -54,12 +54,13 @@ export function useCanvasEvents() {
         inputs.activePointer = undefined
         if (!inputs.pointerIsValid(e)) return
 
+        const info = inputs.pointerUp(e, 'canvas')
+
         // On right click up
         if (e.button === 2) {
+          callbacks.onPointerUp?.(info, e)
           return
         }
-
-        const info = inputs.pointerUp(e, 'canvas')
 
         const isDoubleClick = inputs.isDoubleClick()
 

--- a/packages/core/src/hooks/useCanvasEvents.tsx
+++ b/packages/core/src/hooks/useCanvasEvents.tsx
@@ -11,13 +11,13 @@ export function useCanvasEvents() {
         else (e as any).dead = true
         if (!inputs.pointerIsValid(e)) return
 
+        e.currentTarget.setPointerCapture(e.pointerId)
+
         // On right click
         if (e.button === 2) {
           callbacks.onRightPointCanvas?.(inputs.pointerDown(e, 'canvas'), e)
           return
         }
-
-        e.currentTarget.setPointerCapture(e.pointerId)
 
         const info = inputs.pointerDown(e, 'canvas')
 


### PR DESCRIPTION
# Summary
This makes the core app call the `onPointerUp` callback when a right click is released on the canvas.

I have a bit of concern that this change may result in unexpected behavioral changes for some people integrating with tldraw. For example, if they have some logic in the `onPointerUp` callback that they are providing and they are actually relying on it _not_ being called when the right mouse button is released.

If that is a valid concern and there's an alternate way to implement this that avoids that problem, let me know.

# Motivation
I'm implementing right-click-drag-to-pan in an app that's using @tldraw/core and realized that we're not getting `onPointerUp` events when the right mouse button is released.