### PR TITLE
Fix tooltip z-index

### DIFF
--- a/packages/tldraw/src/components/Primitives/Tooltip/Tooltip.tsx
+++ b/packages/tldraw/src/components/Primitives/Tooltip/Tooltip.tsx
@@ -45,6 +45,7 @@ const StyledContent = styled(RadixTooltip.Content, {
   alignItems: 'center',
   fontFamily: '$ui',
   userSelect: 'none',
+  zIndex: "9999"
 })
 
 const StyledArrow = styled(RadixTooltip.Arrow, {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71993095/196173443-cadab978-3617-4e0c-820d-f5330bd72f48.png)


I noticed when hovering the tooltip gets hidden, changing the z-index fixes this