### PR TITLE
[fix] Blur inputs during multiplayer

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -2856,6 +2856,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
         // We're currently creating a shape. Override the command's
         // before state so that when we undo the command, we remove
         // the shape we just created.
+
         result.before = {
           appState: {
             ...result.before.appState,

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -206,8 +206,11 @@ export class TextUtil extends TDShapeUtil<T, E> {
         [isEditing]
       )
 
+      const rWasEditing = React.useRef(isEditing)
+
       React.useEffect(() => {
         if (isEditing) {
+          rWasEditing.current = true
           this.texts.set(shape.id, text)
           requestAnimationFrame(() => {
             rIsMounted.current = true
@@ -217,7 +220,8 @@ export class TextUtil extends TDShapeUtil<T, E> {
               elm.select()
             }
           })
-        } else {
+        } else if (rWasEditing.current) {
+          rWasEditing.current = false
           onShapeBlur?.()
         }
       }, [isEditing])

--- a/packages/tldraw/src/state/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/state/shapes/shared/TextLabel.tsx
@@ -112,8 +112,11 @@ export const TextLabel = React.memo(function TextLabel({
     [isEditing]
   )
 
+  const rWasEditing = React.useRef(isEditing)
+
   React.useEffect(() => {
     if (isEditing) {
+      rWasEditing.current = true
       requestAnimationFrame(() => {
         rIsMounted.current = true
         const elm = rInput.current
@@ -122,8 +125,9 @@ export const TextLabel = React.memo(function TextLabel({
           elm.select()
         }
       })
-    } else {
+    } else if (rWasEditing.current) {
       onBlur?.()
+      rWasEditing.current = false
     }
   }, [isEditing, onBlur])
 


### PR DESCRIPTION
This PR fixes a bug where a user's editingId would be cleared when a new user creates a text or shape with a label. Closes #1033.