### PR TITLE
fix: wheel event handled twice issue

### DIFF
--- a/packages/core/src/hooks/useZoomEvents.ts
+++ b/packages/core/src/hooks/useZoomEvents.ts
@@ -12,6 +12,7 @@ export function useZoomEvents<T extends HTMLElement>(
   const rOriginPoint = React.useRef<number[] | undefined>(undefined)
   const rPinchPoint = React.useRef<number[] | undefined>(undefined)
   const rDelta = React.useRef<number[]>([0, 0])
+  const rWheelLastTimeStamp = React.useRef<number>(0)
 
   const { inputs, bounds, callbacks } = useTLContext()
 
@@ -32,7 +33,9 @@ export function useZoomEvents<T extends HTMLElement>(
   const handleWheel = React.useCallback<Handler<'wheel', WheelEvent>>(
     ({ event: e }) => {
       e.preventDefault()
-      if (inputs.isPinching) return
+      if (inputs.isPinching || e.timeStamp <= rWheelLastTimeStamp.current) return
+
+      rWheelLastTimeStamp.current = e.timeStamp
 
       const [x, y, z] = normalizeWheel(e)
 


### PR DESCRIPTION
When pinching or panning the canvas with a touchpad on Mac + Arc (Chrome), I noticed that the last wheel event is handled twice. You can see the logs of `console.log(x, y, z, e.timeStamp)` for line 40:

<img width="217" alt="image" src="https://user-images.githubusercontent.com/584378/202605824-fe831769-204d-440e-aafc-f689e473d509.png">

In this PR, I added a timestamp check to make sure the event is not being handled twice.

May fix https://github.com/tldraw/tldraw/issues/681?