### PR TITLE
fix: change property name `code` to `locale` inside translation.md example

### DIFF
--- a/guides/translation.md
+++ b/guides/translation.md
@@ -34,10 +34,10 @@ import eo from './eo.json'
 
 export const TRANSLATIONS: TDTranslations = [
   // Default language:
-  { code: 'en', label: 'English', messages: en },
+  { locale: 'en', label: 'English', messages: en },
   // Translations:
-  { code: 'ar', label: 'عربي', messages: ar },
-  { code: 'eo', label: 'Esperanto', messages: eo }, // <-- add an entry here
+  { locale: 'ar', label: 'عربي', messages: ar },
+  { locale: 'eo', label: 'Esperanto', messages: eo }, // <-- add an entry here
 ]
 ```
 


### PR DESCRIPTION
## Improving Guidelines

Inside translation.md (`guides/translation.md`) file the example that was given to add a language is not the same like the translation.ts (`packages/tldraw/src/translations/translations.ts` ) that is used to add languages

```
{ code: 'eo', label: 'Esperanto', messages: eo } -> { locale: 'eo', label: 'Esperanto', messages: eo }
```