### PR TITLE
fix: onDragBoundsHandle event not triggering

### DIFF
--- a/packages/core/src/hooks/useBoundsHandleEvents.tsx
+++ b/packages/core/src/hooks/useBoundsHandleEvents.tsx
@@ -13,6 +13,8 @@ export function useBoundsHandleEvents(
       else (e as any).dead = true
       if (!inputs.pointerIsValid(e)) return
 
+      e.currentTarget?.setPointerCapture(e.pointerId)
+
       const info = inputs.pointerDown(e, id)
 
       if (e.button === 2) {


### PR DESCRIPTION
**Problem:** When including a function in `onDragBoundsHandle` in `<Renderer>` component it doesn't execute when the bound handles are dragged.

**Cause:** The condition to execute that function depends on `e.currentTarget.hasPointerCapture(e.pointerId)` in `onPointerMove` event, but for it to be used first we need to set it with `e.currentTarget?.setPointerCapture(e.pointerId)` when `onPointerDown` is executed.

**How to know it works**: Just console logging in the block that starts in line 81 we can see if the `onDragBoundsHandle` function is called.

I'm still digesting the core library code, but saw that this pattern is used in other event hooks.
This is my first time contributing to open source code, so I will be more than happy to know if there is a better way of doing it :)