### PR TITLE
fix: Double click canvas fires on every click

### DIFF
--- a/packages/core/src/hooks/useCanvasEvents.tsx
+++ b/packages/core/src/hooks/useCanvasEvents.tsx
@@ -54,6 +54,8 @@ export function useCanvasEvents() {
         inputs.activePointer = undefined
         if (!inputs.pointerIsValid(e)) return
 
+        const isDoubleClick = inputs.isDoubleClick()
+
         const info = inputs.pointerUp(e, 'canvas')
 
         // On right click up
@@ -61,8 +63,6 @@ export function useCanvasEvents() {
           callbacks.onPointerUp?.(info, e)
           return
         }
-
-        const isDoubleClick = inputs.isDoubleClick()
 
         // Release pointer capture, if any
         if (e.currentTarget.hasPointerCapture(e.pointerId)) {


### PR DESCRIPTION
**Problem**: `onDoubleClickCanvas` fires every time the canvas is clicked, with no regards of the time passed between clicks.

**Solution**: 
`isDoubleClick` function calculates if the time between succeeding `onPointerUp` events is less than certain threshold.
It does that storing in `pointerUpTime` field the exact time that a `onPointerUp` occurs. On every pointer up event we calculate the difference between the current time and the one stored in `pointerUpTime`.

The conflict was that in the canvas hook the code order was wrong. Instead of comparing current time with the one stored in `pointerUpTime`, and AFTER that update the field, we were updating it BEFORE, so we were comparing current time with the one we just updated. Because of that the time difference was always less than the threshold.

**How to know if it works**: Just console log inside the block that starts in line 74 of `useCanvasEvents.tsx` to see when double click is triggered.