### PR TITLE
[fix] text export placement

### DIFF
--- a/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
@@ -188,8 +188,6 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
       const fontSize = getFontSize(shape.style.size, shape.style.font) * (shape.style.scale ?? 1)
       const fontFamily = getFontFace(shape.style.font).slice(1, -1)
 
-      console.log(labelSize[0])
-
       const labelElm = getTextSvgElement(
         s['label'],
         fontSize,

--- a/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
@@ -188,6 +188,8 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
       const fontSize = getFontSize(shape.style.size, shape.style.font) * (shape.style.scale ?? 1)
       const fontFamily = getFontFace(shape.style.font).slice(1, -1)
 
+      console.log(labelSize[0])
+
       const labelElm = getTextSvgElement(
         s['label'],
         fontSize,

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -398,7 +398,7 @@ export class TextUtil extends TDShapeUtil<T, E> {
 
     const fontSize = getFontSize(shape.style.size, shape.style.font) * (shape.style.scale ?? 1)
     const fontFamily = getFontFace(shape.style.font).slice(1, -1)
-    const textAlign = shape.style.textAlign ?? AlignStyle.Start
+    const textAlign = shape.style.textAlign ?? AlignStyle.Middle
 
     const textElm = getTextSvgElement(
       shape.text,

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -54,23 +54,24 @@ export function getTextSvgElement(
     return tspan
   })
 
+  console.log(textAlign)
+
   switch (textAlign) {
     case AlignStyle.Middle: {
       textElm.setAttribute('text-align', 'center')
       textElm.setAttribute('text-anchor', 'middle')
-      textLines.forEach((textElm) => textElm.setAttribute('x', 4 + width / 2 + ''))
+      textLines.forEach((textElm) => textElm.setAttribute('x', width / 2 + ''))
       break
     }
     case AlignStyle.End: {
       textElm.setAttribute('text-align', 'right')
       textElm.setAttribute('text-anchor', 'end')
-      textLines.forEach((textElm) => textElm.setAttribute('x', 4 + width + ''))
+      textLines.forEach((textElm) => textElm.setAttribute('x', width + ''))
       break
     }
     default: {
       textElm.setAttribute('text-align', 'left')
       textElm.setAttribute('text-anchor', 'start')
-      textLines.forEach((textElm) => textElm.setAttribute('x', '4'))
     }
   }
 

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -64,12 +64,13 @@ export function getTextSvgElement(
     case AlignStyle.End: {
       textElm.setAttribute('text-align', 'right')
       textElm.setAttribute('text-anchor', 'end')
-      textLines.forEach((textElm) => textElm.setAttribute('x', width + ''))
+      textLines.forEach((textElm) => textElm.setAttribute('x', -4 + width + ''))
       break
     }
     default: {
       textElm.setAttribute('text-align', 'left')
       textElm.setAttribute('text-anchor', 'start')
+      textLines.forEach((textElm) => textElm.setAttribute('x', 4 + ''))
     }
   }
 

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -54,8 +54,6 @@ export function getTextSvgElement(
     return tspan
   })
 
-  console.log(textAlign)
-
   switch (textAlign) {
     case AlignStyle.Middle: {
       textElm.setAttribute('text-align', 'center')


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/1063

Before:
![image](https://user-images.githubusercontent.com/23072548/205443857-6cf237af-f038-4975-9f15-be8646f62ce9.png)

After:
![image](https://user-images.githubusercontent.com/23072548/205443862-0be2a958-f2df-4c0e-b0e8-37639cdeda16.png)

There is still an issue with the y position of exported text.
