### PR TITLE
create new ids for new shapes and map old ids to new ids

### DIFF
--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -9,24 +9,65 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
   } = app
 
   const page = app.document.pages[pageId]
-  const newIds = Object.fromEntries(
-    Object.keys(page.shapes).map(id => [id, Utils.uniqueId()])
+
+  // Map shapes and bindings onto new IDs
+  const oldToNewIds: Record<string, string> = Object.fromEntries([
+    [page.id, Utils.uniqueId()],
+    ...Object.keys(page.shapes).map(id => [id, Utils.uniqueId()]),
+    ...Object.keys(page.bindings).map(id => [id, Utils.uniqueId()]),
+  ])
+
+  const shapes = Object.fromEntries(
+    Object.entries(page.shapes).map(([id, shape]) => [
+      oldToNewIds[id],
+      {
+        ...Utils.deepClone(shape),
+        id: oldToNewIds[id],
+        parentId: oldToNewIds[shape.parentId],
+      }
+    ])
   )
+
+  const bindings = Object.fromEntries(
+    Object.entries(page.bindings).map(([id, binding]) => [
+      oldToNewIds[id],
+      {
+        ...Utils.deepClone(binding),
+        id: oldToNewIds[binding.id],
+        fromId: oldToNewIds[binding.fromId],
+        toId: oldToNewIds[binding.toId],
+      }
+    ])
+  )
+
+  // Update the shape's to and from references to the new bindingid
+  Object.values(page.bindings).forEach(binding => {
+    const fromId = oldToNewIds[binding.fromId]
+    const fromHandles = shapes[fromId]!.handles
+    if (fromHandles) {
+      Object.values(fromHandles).forEach((handle) => {
+        if (handle!.bindingId === binding.id) {
+          handle!.bindingId = oldToNewIds[binding.id]
+        }
+      })
+    }
+    const toId = oldToNewIds[binding.toId]
+    const toHandles = shapes[toId]!.handles
+    if (toHandles) {
+      Object.values(toHandles).forEach((handle) => {
+        if (handle!.bindingId === binding.id) {
+          handle!.bindingId = oldToNewIds[binding.id]
+        }
+      })
+    }
+  })
 
   const nextPage = {
     ...page,
-    id: newIds[page.id],
+    id: oldToNewIds[page.id],
     name: page.name + ' Copy',
-    shapes: Object.fromEntries(
-      Object.entries(page.shapes).map(([id, shape]) => [
-        newIds[id],
-        {
-          ...shape,
-          id: newIds[id],
-          parentId: newIds[shape.parentId],
-        },
-      ])
-    ),
+    shapes,
+    bindings,
   }
 
   return {

--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -44,6 +44,7 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
   Object.values(page.bindings).forEach(binding => {
     const fromId = oldToNewIds[binding.fromId]
     const fromHandles = shapes[fromId]!.handles
+    
     if (fromHandles) {
       Object.values(fromHandles).forEach((handle) => {
         if (handle!.bindingId === binding.id) {
@@ -51,8 +52,10 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         }
       })
     }
+    
     const toId = oldToNewIds[binding.toId]
     const toHandles = shapes[toId]!.handles
+    
     if (toHandles) {
       Object.values(toHandles).forEach((handle) => {
         if (handle!.bindingId === binding.id) {
@@ -60,6 +63,7 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         }
       })
     }
+    
   })
 
   const nextPage = {

--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -13,8 +13,8 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
   // Map shapes and bindings onto new IDs
   const oldToNewIds: Record<string, string> = Object.fromEntries([
     [page.id, Utils.uniqueId()],
-    ...Object.keys(page.shapes).map(id => [id, Utils.uniqueId()]),
-    ...Object.keys(page.bindings).map(id => [id, Utils.uniqueId()]),
+    ...Object.keys(page.shapes).map((id) => [id, Utils.uniqueId()]),
+    ...Object.keys(page.bindings).map((id) => [id, Utils.uniqueId()]),
   ])
 
   const shapes = Object.fromEntries(
@@ -24,7 +24,7 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         ...Utils.deepClone(shape),
         id: oldToNewIds[id],
         parentId: oldToNewIds[shape.parentId],
-      }
+      },
     ])
   )
 
@@ -36,15 +36,15 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         id: oldToNewIds[binding.id],
         fromId: oldToNewIds[binding.fromId],
         toId: oldToNewIds[binding.toId],
-      }
+      },
     ])
   )
 
   // Update the shape's to and from references to the new bindingid
-  Object.values(page.bindings).forEach(binding => {
+  Object.values(page.bindings).forEach((binding) => {
     const fromId = oldToNewIds[binding.fromId]
     const fromHandles = shapes[fromId]!.handles
-    
+
     if (fromHandles) {
       Object.values(fromHandles).forEach((handle) => {
         if (handle!.bindingId === binding.id) {
@@ -52,10 +52,10 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         }
       })
     }
-    
+
     const toId = oldToNewIds[binding.toId]
     const toHandles = shapes[toId]!.handles
-    
+
     if (toHandles) {
       Object.values(toHandles).forEach((handle) => {
         if (handle!.bindingId === binding.id) {
@@ -63,7 +63,6 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
         }
       })
     }
-    
   })
 
   const nextPage = {
@@ -82,25 +81,25 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
       },
       document: {
         pages: {
-          [newId]: undefined,
+          [pageId]: undefined,
         },
         pageStates: {
-          [newId]: undefined,
+          [pageId]: undefined,
         },
       },
     },
     after: {
       appState: {
-        currentPageId: newId,
+        currentPageId: pageId,
       },
       document: {
         pages: {
-          [newId]: nextPage,
+          [pageId]: nextPage,
         },
         pageStates: {
-          [newId]: {
+          [pageId]: {
             ...page,
-            id: newId,
+            id: pageId,
             selectedIds: [],
             camera: { ...camera },
             editingId: undefined,

--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -10,9 +10,11 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
 
   const page = app.document.pages[pageId]
 
+  const newId = Utils.uniqueId()
+
   // Map shapes and bindings onto new IDs
   const oldToNewIds: Record<string, string> = Object.fromEntries([
-    [page.id, Utils.uniqueId()],
+    [page.id, newId],
     ...Object.keys(page.shapes).map((id) => [id, Utils.uniqueId()]),
     ...Object.keys(page.bindings).map((id) => [id, Utils.uniqueId()]),
   ])
@@ -81,25 +83,25 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
       },
       document: {
         pages: {
-          [pageId]: undefined,
+          [newId]: undefined,
         },
         pageStates: {
-          [pageId]: undefined,
+          [newId]: undefined,
         },
       },
     },
     after: {
       appState: {
-        currentPageId: pageId,
+        currentPageId: newId,
       },
       document: {
         pages: {
-          [pageId]: nextPage,
+          [newId]: nextPage,
         },
         pageStates: {
-          [pageId]: {
+          [newId]: {
             ...page,
-            id: pageId,
+            id: newId,
             selectedIds: [],
             camera: { ...camera },
             editingId: undefined,

--- a/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
+++ b/packages/tldraw/src/state/commands/duplicatePage/duplicatePage.ts
@@ -9,23 +9,23 @@ export function duplicatePage(app: TldrawApp, pageId: string): TldrawCommand {
   } = app
 
   const page = app.document.pages[pageId]
-
-  const newId = Utils.uniqueId()
+  const newIds = Object.fromEntries(
+    Object.keys(page.shapes).map(id => [id, Utils.uniqueId()])
+  )
 
   const nextPage = {
     ...page,
-    id: newId,
+    id: newIds[page.id],
     name: page.name + ' Copy',
     shapes: Object.fromEntries(
-      Object.entries(page.shapes).map(([id, shape]) => {
-        return [
-          id,
-          {
-            ...shape,
-            parentId: shape.parentId === page.id ? newId : shape.parentId,
-          },
-        ]
-      })
+      Object.entries(page.shapes).map(([id, shape]) => [
+        newIds[id],
+        {
+          ...shape,
+          id: newIds[id],
+          parentId: newIds[shape.parentId],
+        },
+      ])
     ),
   }
 


### PR DESCRIPTION
From [discord](https://discord.com/channels/859816885297741824/859816885801713729/1037543784659042394):

> I think there is an error in the duplicatePage function. As far as I can understand the shapes that are copied into the new page do not have new IDs assigned to them. Therefore if the duplicated page includes assets they are deleted from both pages if they are deleted one on page. This is caused because in the check for deleting an asset, even though it is checked whether there are other shapes referring to the asset, those shapes with the same ID as the shape that is currently being deleted and is associated with the asset, are ignored (makes total sense, there should just not be two shapes with the same ID).
