### PR TITLE
Small translation change (ja)

### DIFF
--- a/packages/tldraw/src/translations/ja.json
+++ b/packages/tldraw/src/translations/ja.json
@@ -2,7 +2,7 @@
   "style.menu.color": "色",
   "style.menu.fill": "塗りつぶし",
   "style.menu.dash": "線",
-  "style.menu.size": "大きさ",
+  "style.menu.size": "太さ/サイズ",
   "style.menu.keep.open": "常に表示",
   "style.menu.font": "フォント",
   "style.menu.align": "配置",


### PR DESCRIPTION
The English "size" could mean both thickness and dimension. In Japanese however, there is not really corresponding word to it. 

The current Japanese translation of "size", which is "大きさ", tells only about the dimension, never meaning the thickness. Thus I think it's less confusing to translate it to "太さ/サイズ" which means "thickness/size".  

Alternatively, simply "サイズ" is also acceptable. 