### PR TITLE
fix(tooltip): add tooltips for undo/redo buttons

### DIFF
--- a/packages/tldraw/src/components/TopPanel/TopPanel.tsx
+++ b/packages/tldraw/src/components/TopPanel/TopPanel.tsx
@@ -51,7 +51,7 @@ export function _TopPanel({
                 kbd={'#Z'}
                 label={intl.formatMessage({ id: 'undo' })}
                 onClick={app.undo}
-                id="TD-PrimaryTools-Eraser"
+                id="TD-TopPanel-Undo"
               >
                 <UndoIcon />
               </ToolButtonWithTooltip>
@@ -59,7 +59,7 @@ export function _TopPanel({
                 kbd={'#⇧Z'}
                 label={intl.formatMessage({ id: 'redo' })}
                 onClick={app.redo}
-                id="TD-PrimaryTools-Eraser"
+                id="TD-TopPanel-Redo"
               >
                 <UndoIcon flipHorizontal />
               </ToolButtonWithTooltip>

--- a/packages/tldraw/src/components/TopPanel/TopPanel.tsx
+++ b/packages/tldraw/src/components/TopPanel/TopPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
+import { useIntl } from 'react-intl'
 import { Panel } from '~components/Primitives/Panel'
-import { ToolButton } from '~components/Primitives/ToolButton'
+import { ToolButton, ToolButtonWithTooltip } from '~components/Primitives/ToolButton'
 import { UndoIcon } from '~components/Primitives/icons'
 import { useTldrawApp } from '~hooks'
 import { styled } from '~styles'
@@ -28,6 +29,7 @@ export function _TopPanel({
   showMultiplayerMenu,
 }: TopPanelProps) {
   const app = useTldrawApp()
+  const intl = useIntl()
 
   return (
     <StyledTopPanel>
@@ -45,12 +47,22 @@ export function _TopPanel({
             <ReadOnlyLabel>Read Only</ReadOnlyLabel>
           ) : (
             <>
-              <ToolButton>
-                <UndoIcon onClick={app.undo} />
-              </ToolButton>
-              <ToolButton>
-                <UndoIcon onClick={app.redo} flipHorizontal />
-              </ToolButton>
+              <ToolButtonWithTooltip
+                kbd={'#Z'}
+                label={intl.formatMessage({ id: 'undo' })}
+                onClick={app.undo}
+                id="TD-PrimaryTools-Eraser"
+              >
+                <UndoIcon />
+              </ToolButtonWithTooltip>
+              <ToolButtonWithTooltip
+                kbd={'#⇧Z'}
+                label={intl.formatMessage({ id: 'redo' })}
+                onClick={app.redo}
+                id="TD-PrimaryTools-Eraser"
+              >
+                <UndoIcon flipHorizontal />
+              </ToolButtonWithTooltip>
             </>
           )}
           {showZoom && <ZoomMenu />}


### PR DESCRIPTION
#1099 [bug] undo/redo buttons lack a tooltip

![캡처_2023_01_02_14_30_22_300](https://user-images.githubusercontent.com/19148682/210197684-c92e1a6a-8c4e-4fb1-8d8d-baca2a61d605.png)

![캡처_2023_01_02_14_30_24_744](https://user-images.githubusercontent.com/19148682/210197688-fd753b9f-8cee-49b9-9df8-8b33cde36052.png)
