### PR TITLE
fix: height and width exchanged in app.viewport

### DIFF
--- a/packages/tldraw/src/state/TldrawApp.ts
+++ b/packages/tldraw/src/state/TldrawApp.ts
@@ -917,8 +917,8 @@ export class TldrawApp extends StateManager<TDSnapshot> {
       minY,
       maxX,
       maxY,
-      height: maxX - minX,
-      width: maxY - minY,
+      width: maxX - minX,
+      height: maxY - minY,
     }
   }
 


### PR DESCRIPTION
I guess it's a simple bug. But it may affect some behaviour of the app, such as judging whether a shape is pasted within the viewport..