### PR TITLE
fix: Zoom to 100% translated into Japanese should be 100%にズーム #1058

### DIFF
--- a/packages/tldraw/src/translations/ja.json
+++ b/packages/tldraw/src/translations/ja.json
@@ -19,7 +19,7 @@
   "become.a.sponsor": "支援する",
   "zoom.to.selection": "選択したアイテムに合わせて拡大",
   "zoom.to.fit": "拡大してすべてを表示",
-  "zoom.to": " ",
+  "zoom.to": "にズーム",
   "preferences.dark.mode": "ダークモード",
   "preferences.focus.mode": "フォーカスモード",
   "preferences.debug.mode": "デバッグモード",


### PR DESCRIPTION
translated "Zoom to 100% " into Japanese text "100%にズーム"
