### PR TITLE
Use functional updates for core-example

### DIFF
--- a/examples/core-example/src/App.tsx
+++ b/examples/core-example/src/App.tsx
@@ -35,25 +35,25 @@ export default function App() {
     },
   })
   const onHoverShape: TLPointerEventHandler = (e) => {
-    setPageState({
-      ...pageState,
+    setPageState((prevState) => ({
+      ...prevState,
       hoveredId: e.target,
-    })
+    }))
   }
 
   const onUnhoverShape: TLPointerEventHandler = () => {
-    setPageState({
-      ...pageState,
+    setPageState((prevState) => ({
+      ...prevState,
       hoveredId: null,
-    })
+    }))
   }
 
   const onPointShape: TLPointerEventHandler = (info) => {
-    setPageState({ ...pageState, selectedIds: [info.target] })
+    setPageState((prevState) => ({ ...prevState, selectedIds: [info.target] }))
   }
 
   const onPointCanvas: TLPointerEventHandler = () => {
-    setPageState({ ...pageState, selectedIds: [] })
+    setPageState((prevState) => ({ ...prevState, selectedIds: [] }))
   }
 
   const onDragShape: TLPointerEventHandler = (e) => {
@@ -75,11 +75,11 @@ export default function App() {
 
   const onPointerMove: TLPointerEventHandler = (info) => {
     if (info.shiftKey) {
-      setPageState((prev) => ({
-        ...pageState,
+      setPageState((prevState) => ({
+        ...prevState,
         camera: {
-          ...prev.camera,
-          point: Vec.add(prev.camera.point, info.delta),
+          ...prevState.camera,
+          point: Vec.add(prevState.camera.point, info.delta),
         },
       }))
     }


### PR DESCRIPTION
Noticed an issue with the `core-example` that would cause the square to be deselected whenever the hover / unhover events were triggered. Related to https://github.com/tldraw/tldraw/issues/639.

This PR changes calls to `setPageState({ ...pageState, ... })` to `setPageState(prevState => {...prevState, ...})`.

Would probably be a good idea to add documentation either in this example or elsewhere to illustrate why it's important to update state in this way.
