### PR TITLE
feat: export menu accessibility

### DIFF
--- a/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/tldraw/src/components/ContextMenu/ContextMenu.tsx
@@ -280,6 +280,29 @@ const InnerMenu = React.memo(function InnerMenu() {
           <CMRowButton onClick={handleRedo} kbd="#⇧Z" id="TD-ContextMenu-Redo">
             <FormattedMessage id="redo" />
           </CMRowButton>
+          <ContextMenuSubMenu
+            label={`${intl.formatMessage({ id: 'export.as' })}...`}
+            size="small"
+            id="TD-ContextMenu-Export"
+          >
+            <CMRowButton onClick={handleExportSVG} id="TD-ContextMenu-Export-SVG">
+              SVG
+            </CMRowButton>
+            <CMRowButton onClick={handleExportPNG} id="TD-ContextMenu-Export-PNG">
+              PNG
+            </CMRowButton>
+            <CMRowButton onClick={handleExportJPG} id="TD-ContextMenu-Export-JPG">
+              JPG
+            </CMRowButton>
+            <CMRowButton onClick={handleExportWEBP} id="TD-ContextMenu-Export-WEBP">
+              WEBP
+            </CMRowButton>
+            {isDebugMode && (
+              <CMRowButton onClick={handleExportJSON} id="TD-ContextMenu-Export-JSON">
+                JSON
+              </CMRowButton>
+            )}
+          </ContextMenuSubMenu>
         </>
       )}
     </>

--- a/packages/tldraw/src/components/TopPanel/Menu/Menu.tsx
+++ b/packages/tldraw/src/components/TopPanel/Menu/Menu.tsx
@@ -161,6 +161,27 @@ export const Menu = React.memo(function Menu({ readOnly }: MenuProps) {
                   ...
                 </DMItem>
               )}
+              <DMSubMenu
+                label={`${intl.formatMessage({ id: 'export.as' })}...`}
+                size="small"
+                id="TD-MenuItem-Export"
+              >
+                <DMItem onClick={handleExportSVG} id="TD-MenuItem-Export-SVG">
+                  SVG
+                </DMItem>
+                <DMItem onClick={handleExportPNG} id="TD-MenuItem-Export-PNG">
+                  PNG
+                </DMItem>
+                <DMItem onClick={handleExportJPG} id="TD-MenuItem-Export-JPG">
+                  JPG
+                </DMItem>
+                <DMItem onClick={handleExportWEBP} id="TD-MenuItem-Export-WEBP">
+                  WEBP
+                </DMItem>
+                <DMItem onClick={handleExportJSON} id="TD-MenuItem-Export-JSON">
+                  JSON
+                </DMItem>
+              </DMSubMenu>
               {!disableAssets && (
                 <>
                   <Divider />
@@ -230,27 +251,6 @@ export const Menu = React.memo(function Menu({ readOnly }: MenuProps) {
                 PNG
               </DMItem>
               <DMItem onClick={handleCopyJSON} id="TD-MenuItem-Copy_as_JSON">
-                JSON
-              </DMItem>
-            </DMSubMenu>
-            <DMSubMenu
-              label={`${intl.formatMessage({ id: 'export.as' })}...`}
-              size="small"
-              id="TD-MenuItem-Export"
-            >
-              <DMItem onClick={handleExportSVG} id="TD-MenuItem-Export-SVG">
-                SVG
-              </DMItem>
-              <DMItem onClick={handleExportPNG} id="TD-MenuItem-Export-PNG">
-                PNG
-              </DMItem>
-              <DMItem onClick={handleExportJPG} id="TD-MenuItem-Export-JPG">
-                JPG
-              </DMItem>
-              <DMItem onClick={handleExportWEBP} id="TD-MenuItem-Export-WEBP">
-                WEBP
-              </DMItem>
-              <DMItem onClick={handleExportJSON} id="TD-MenuItem-Export-JSON">
                 JSON
               </DMItem>
             </DMSubMenu>

--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useFileSystemHandlers, useTldrawApp } from '~hooks'
-import { AlignStyle, TDShapeType } from '~types'
+import { AlignStyle, TDExportType, TDShapeType } from '~types'
 
 export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
   const app = useTldrawApp()
@@ -227,6 +227,58 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
     undefined,
     [app]
   )
+
+  useHotkeys(
+    'ctrl+alt+1,⌘+alt+1',
+    (e) => {
+      if (!canHandleEvent()) return
+
+      app.exportImage(TDExportType.SVG, { scale: 2, quality: 1 })
+    },
+    undefined,
+    [app]
+  )
+  useHotkeys(
+    'ctrl+alt+2,⌘+alt+2',
+    (e) => {
+      if (!canHandleEvent()) return
+
+      app.exportImage(TDExportType.PNG, { scale: 2, quality: 1 })
+    },
+    undefined,
+    [app]
+  )
+  useHotkeys(
+    'ctrl+alt+3,⌘+alt+3',
+    (e) => {
+      if (!canHandleEvent()) return
+
+      app.exportImage(TDExportType.JPG, { scale: 2, quality: 1 })
+    },
+    undefined,
+    [app]
+  )
+  useHotkeys(
+    'ctrl+alt+4,⌘+alt+4',
+    (e) => {
+      if (!canHandleEvent()) return
+
+      app.exportImage(TDExportType.WEBP, { scale: 2, quality: 1 })
+    },
+    undefined,
+    [app]
+  )
+  useHotkeys(
+    'ctrl+alt+5,⌘+alt+5',
+    (e) => {
+      if (!canHandleEvent()) return
+
+      app.exportJson()
+    },
+    undefined,
+    [app]
+  )
+
   useHotkeys(
     'ctrl+o,⌘+o',
     (e) => {


### PR DESCRIPTION
resolve #912
I made three changes.
1. Shorcuts to export
The export menu is not often used, so I thought it was unnecessary to make all five export buttons clickable at once, like undo/redo. So I bound export to Ctrl+Alt+1~5.

2. Change the path of the export submenu
Fixed what gordielachance mentioned in the comments for that issue.

3. Add export menu to context menu with no selection.
There is export in the context menu when hasSelection. The menu make the selected object to be exported. 
So I thought the context menu should have a menu that exports the entire canvas when nothing is selected.