### PR TITLE
A better translation of "zoom to" in Japanese

### DIFF
--- a/packages/tldraw/src/translations/ja.json
+++ b/packages/tldraw/src/translations/ja.json
@@ -19,7 +19,7 @@
   "become.a.sponsor": "支援する",
   "zoom.to.selection": "選択したアイテムに合わせて拡大",
   "zoom.to.fit": "拡大してすべてを表示",
-  "zoom.to": "にズーム",
+  "zoom.to": "拡大率",
   "preferences.dark.mode": "ダークモード",
   "preferences.focus.mode": "フォーカスモード",
   "preferences.debug.mode": "デバッグモード",


### PR DESCRIPTION
Although there is no perfect translation, "拡大率" (zoom ratio) would make more sense for "zoom to".