### PR TITLE
Fix image export bug on tldraw with storage bucket attached

### DIFF
--- a/packages/tldraw/src/state/TLDR.ts
+++ b/packages/tldraw/src/state/TLDR.ts
@@ -1141,6 +1141,7 @@ export class TLDR {
 
     const width = +svg.getAttribute('width')!
     const height = +svg.getAttribute('height')!
+    const svgSrc = svg.lastElementChild!.getAttribute('xlink:href')!
 
     if (!svgString) return
 
@@ -1171,7 +1172,7 @@ export class TLDR {
         console.warn('Could not convert that SVG to an image.')
       }
 
-      image.src = dataUrl
+      image.src = svgSrc.includes('data:') ? dataUrl : svgSrc
     })
 
     const blob = await new Promise<Blob>((resolve) =>


### PR DESCRIPTION
Fixed bug: [file exported as image in multiplayer mode contains placeholders instead of image](https://github.com/tldraw/tldraw/issues/1072)

This bug was due to different image `src` format between tldraw with no storage bucket attached & tldraw with storage bucket attached (currently attached in [tldraw.com](https://www.tldraw.com/)'s multiplayer mode).

Basic tldraw's image `src` is base64 format data (ex: `data:image/png;base64`), but tldraw with storage bucket attached has image `src` of storage bucket's file url (ex: `https://s3...`)

This caused `getImageForSvg()` on `TLDR.ts` processed different format of image src, which made canvas not able to draw image properly.

This PR properly sets image's `src` based on the format of src (`data:image `or `http://...`.

P.S: Unlike other storage bucket/CDNs, AWS S3 is not passing `Access-Control-Allow-Origin` on image. This makes canvas not able to load cached image, due to CORS error.

To solve this problem, we need to set AWS S3 to pass `Access-Control-Allow-Origin` header on response, or use AWS CloudFront to add `Access-Control-Allow-Origin` header.

For more details on this issue, check here: https://stackoverflow.com/questions/49503171/the-image-tag-with-crossorigin-anonymous-cant-load-success-from-s3
