### PR TITLE
fix(tldraw): resolve copy as png dimensions and null attribute error

### DIFF
--- a/packages/tldraw/src/state/TLDR.ts
+++ b/packages/tldraw/src/state/TLDR.ts
@@ -1139,10 +1139,6 @@ export class TLDR {
 
     const svgString = TLDR.getSvgString(svg, scale)
 
-    const width = +svg.getAttribute('width')!
-    const height = +svg.getAttribute('height')!
-    const svgSrc = svg.lastElementChild!.getAttribute('xlink:href')!
-
     if (!svgString) return
 
     const canvas = await new Promise<HTMLCanvasElement>((resolve) => {
@@ -1158,10 +1154,12 @@ export class TLDR {
         const canvas = document.createElement('canvas') as HTMLCanvasElement
         const context = canvas.getContext('2d')!
 
-        canvas.width = width
-        canvas.height = height
+        const imageWidth = image.width
+        const imageHeight = image.height
 
-        context.drawImage(image, 0, 0, width, height)
+        canvas.width = imageWidth
+        canvas.height = imageHeight
+        context.drawImage(image, 0, 0, imageWidth, imageHeight)
 
         URL.revokeObjectURL(dataUrl)
 
@@ -1172,7 +1170,7 @@ export class TLDR {
         console.warn('Could not convert that SVG to an image.')
       }
 
-      image.src = svgSrc.includes('data:') ? dataUrl : svgSrc
+      image.src = dataUrl
     })
 
     const blob = await new Promise<Blob>((resolve) =>


### PR DESCRIPTION
Removed `svgSrc` from `getImageForSvg` function which had a value of `null` in the reported bug. Reproduction of bug caused the same error - the issue was caused by using non-null assertion operator on the `getAttribute` method of last child element, which is usually (or always) of value `null`. Assigned `dataUrl` to source of new clipboard image. Subsequent manual tests showed that dimensions of clipboard image were twice as big as the original image, so I assigned the size of copied image to context and canvas of clipboard image. 

Tested changes on Chrome 109.0.5414.120, Opera GX 94.0.4606.96 and Firefox 109.0.1.

Resolves tldraw/tldraw-v1#37 

### Change type

- [x] `bugfix` 

### Test plan

1. Copy an object as PNG and paste it into another application.
2. Verify the dimensions match the original selection.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where copying as PNG could fail or result in incorrect image dimensions.