### PR TITLE
Add link to beta repo in issue template, and fix 'feature' issue label 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: tldraw Beta
     url: https://github.com/tldraw/tldraw-beta/issues/new
-    about: Is your issue for the tldraw beta? Report it on the beta repo.
+    about: Is your issue for the tldraw beta? Report it on the beta repo instead.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: tldraw Beta
+    url: https://github.com/tldraw/tldraw-beta/issues/new
+    about: Is your issue for the tldraw beta? Report it on the beta repo.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,6 +2,6 @@
 name: Feature
 about: Begin discussion of a new feature.
 title: '[feature] Feature or improvement'
-labels: feature
+labels: enhancement
 assignees: ''
 ---


### PR DESCRIPTION
This PR adds a link to the beta repo in our issue templates.

It also fixes the 'feature' issue template not applying its correctly because of an incorrect configuration.