### PR TITLE
Use dark title bar color on PWA when dark scheme is preferred

### DIFF
--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -23,7 +23,8 @@ function MyApp({ Component, pageProps }: any) {
         <meta name="description" content={APP_DESCRIPTION} />
         <meta name="format-detection" content="telephone=no" />
         <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="theme-color" content="#fafafa" />
+        <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafafa" />
+        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#212529" />
 
         <meta name="twitter:url" content={APP_URL} />
         <meta name="twitter:title" content={APP_NAME} />


### PR DESCRIPTION
Before changes on dark mode:
<img width="521" alt="image" src="https://user-images.githubusercontent.com/7587323/229260467-ccfc433e-ca6f-43bc-9307-dd9a76dd3885.png">


After changes on dark mode:
<img width="585" alt="image" src="https://user-images.githubusercontent.com/7587323/229260483-9eac1e16-78dd-4f71-bf9e-f3e48c94b706.png">
