### PR TITLE
[fix] Clipboard steals focus

### DIFF
--- a/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/tldraw/src/hooks/useKeyboardShortcuts.tsx
@@ -10,7 +10,6 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
     (ignoreMenus = false) => {
       const elm = ref.current
       if (ignoreMenus && (app.isMenuOpen || app.settings.keepStyleMenuOpen)) return true
-      elm?.focus()
       return elm && (document.activeElement === elm || elm.contains(document.activeElement))
     },
     [ref]


### PR DESCRIPTION
This PR fixes https://github.com/tldraw/tldraw/issues/1032. Not sure why / when we started forcing the canvas to focus but the feature seems to work fine without that line.