### PR TITLE
Fix to not ignore the `userId` option for `<Tldraw/>` component in `@tldraw/tldraw`

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -21,15 +21,17 @@ export function Tldraw(
 
 	const userData = getUserData()
 
+	const userId = props.userId ?? userData.id
+
 	const syncedStore = useLocalSyncClient({
 		instanceId,
-		userId: userData.id,
+		userId: userId,
 		universalPersistenceKey: persistenceKey,
 		config: props.config,
 	})
 
 	return (
-		<TldrawEditor {...rest} instanceId={instanceId} userId={userData.id} store={syncedStore}>
+		<TldrawEditor {...rest} instanceId={instanceId} userId={userId} store={syncedStore}>
 			<TldrawUi {...rest}>
 				<ContextMenu>
 					<Canvas />


### PR DESCRIPTION
The `userId` prop in the `<Tldraw/>` component from the `@tldraw/tldraw` was previously ignored. This PR fixes that to make it operational again. 