### PR TITLE
[fix] collaborator render order

### DIFF
--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -125,7 +125,6 @@ export const Canvas = track(function Canvas({
 					{SvgDefs && <SvgDefs />}
 				</defs>
 				<g ref={rSvgLayer}>
-					<LiveCollaborators />
 					<ScribbleWrapper />
 					<BrushWrapper />
 					<ZoomBrushWrapper />
@@ -133,8 +132,9 @@ export const Canvas = track(function Canvas({
 					<HoveredShapeIndicator />
 					<SelectionFg />
 					<HintedShapeIndicator />
-					<HandlesWrapper />
 					<SnapLinesWrapper />
+					<HandlesWrapper />
+					<LiveCollaborators />
 				</g>
 			</svg>
 		</div>


### PR DESCRIPTION
This PR fixes a bug where collaborator cursors would appear below other overlay content, such as selection boxes.