### PR TITLE
[docs] Add missing params docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+
+# if the folder we're in is called "bublic", set YARN_RC_FILENAME:
+if [ "$(basename "$(pwd)")" = "bublic" ]; then
+  export YARN_RC_FILENAME=.yarnrc-private.yml
+fi
+
 yarn lazy run build-api
 git add packages/*/api-report.md
 yarn lint-staged

--- a/apps/docs/scripts/getApiMarkdown.ts
+++ b/apps/docs/scripts/getApiMarkdown.ts
@@ -244,6 +244,23 @@ async function addDocComment(result: Result, member: ApiItem) {
 		member instanceof ApiEnum ||
 		member instanceof ApiNamespace
 	) {
+		const params = member.tsdocComment?.params
+		if (params && params.count > 0) {
+			result.markdown += `##### Parameters\n\n\n`
+			result.markdown += '<ParametersTable>\n\n'
+			for (const block of params.blocks) {
+				result.markdown += '<ParametersTableRow>\n'
+				result.markdown += '<ParametersTableName>\n\n'
+				result.markdown += `\`${block.parameterName}\`\n\n`
+				result.markdown += `</ParametersTableName>\n`
+				result.markdown += `<ParametersTableDescription>\n\n`
+				result.markdown += await MarkdownWriter.docNodeToMarkdown(block.content)
+				result.markdown += `\n\n</ParametersTableDescription>\n`
+				result.markdown += `</ParametersTableRow>\n`
+			}
+			result.markdown += '</ParametersTable>\n\n'
+		}
+
 		// no specific docs for these types
 		result.markdown += `##### Signature\n\n\n`
 		result.markdown += await typeExcerptToMarkdown(member.excerpt, { kind: member.kind })


### PR DESCRIPTION
This PR makes the docs site show documentation for parameters, even when api-extractor thinks that there aren't any.

eg: Properties like `onBeforeUpdate`
eg: Types

![image](https://user-images.githubusercontent.com/15892272/236172263-155005cf-5a94-40ca-8faa-995e7d670e96.png)
![image](https://user-images.githubusercontent.com/15892272/236172299-8d1ff9dd-580d-48e8-bec9-903a9568a177.png)
