### PR TITLE
Add link to original tldraw within issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Original tldraw
+    url: https://github.com/tldraw/tldraw-v1/issues/new
+    about: Is your issue for the original tldraw? Report it on the original tldraw repo instead.


### PR DESCRIPTION
This PR adds a link to the original tldraw repo within our issue templates.

It will look similar to this (with different wording):
![image](https://user-images.githubusercontent.com/15892272/236198339-9dd12831-fec0-49f4-b279-9c991dfaaafc.png)
