### PR TITLE
[fix] SVG export for arrows with labels but no arrowheads

### DIFF
--- a/packages/editor/src/lib/app/shapeutils/TLArrowUtil/TLArrowUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/TLArrowUtil/TLArrowUtil.tsx
@@ -918,7 +918,7 @@ export class TLArrowUtil extends TLShapeUtil<TLArrowShape> {
 		const maskId = (shape.id + '_clip').replace(':', '_')
 
 		// If we have any arrowheads, then mask the arrowheads
-		if (as || ae) {
+		if (as || ae || labelSize) {
 			// Create mask for arrowheads
 
 			// Create defs


### PR DESCRIPTION
This PR fixes a bug where arrow shapes without arrowheads would not mask their labels when exporting images.