### PR TITLE
[fix] update useTransform.ts

### DIFF
--- a/packages/editor/src/lib/hooks/useTransform.ts
+++ b/packages/editor/src/lib/hooks/useTransform.ts
@@ -14,7 +14,7 @@ export function useTransform(
 
 		if (scale !== undefined) {
 			if (rotate !== undefined) {
-				elm.style.transform = `translate(${x}px, ${y}px) scale(${scale}) rotate(${rotate}deg)`
+				elm.style.transform = `translate(${x}px, ${y}px) scale(${scale}) rotate(${rotate}rad)`
 			} else {
 				elm.style.transform = `translate(${x}px, ${y}px) scale(${scale})`
 			}


### PR DESCRIPTION
This PR fixes the way that rotation is handled in `useTransform`.

Before:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/23072548/236692574-7fcf94bd-76e2-4584-9ea0-4ea4aa6c7ffc.png">
After:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/23072548/236692585-f1970c9e-041c-470c-8bdb-af975ef48246.png">

### Test Plan

1. Select a bunch of shapes
2. Rotate the selection
3. The selection box should be correct

