### PR TITLE
[enhancement] Export function in file menu + current page name when exporting.

### DIFF
--- a/packages/ui/src/lib/hooks/useExportAs.ts
+++ b/packages/ui/src/lib/hooks/useExportAs.ts
@@ -34,14 +34,12 @@ export function useExportAs() {
 
 			if (!svg) throw new Error('Could not construct SVG.')
 
-			let name = 'shapes'
+			let name = app.currentPage.name
 
 			if (ids.length === 1) {
 				const first = app.getShapeById(ids[0])!
 				if (first.type === 'frame') {
 					name = (first as TLFrameShape).props.name ?? 'frame'
-				} else {
-					name = first.id.replace(/:/, '_')
 				}
 			}
 

--- a/packages/ui/src/lib/hooks/useMenuSchema.tsx
+++ b/packages/ui/src/lib/hooks/useMenuSchema.tsx
@@ -83,7 +83,24 @@ export function MenuSchemaProvider({ overrides, children }: MenuSchemaProviderPr
 				menuSubmenu(
 					'file',
 					'menu.file',
-					menuGroup('print', menuItem(actions['print'], { disabled: emptyPage }))
+					menuGroup('print', menuItem(actions['print'], { disabled: emptyPage })),
+					menuGroup(
+						'export',
+						menuSubmenu(
+							'export-as',
+							'menu.export-as',
+							menuGroup(
+								'export-as-group',
+								menuItem(actions['export-as-svg'], { disabled: emptyPage }),
+								menuItem(actions['export-as-png'], { disabled: emptyPage }),
+								menuItem(actions['export-as-json'], { disabled: emptyPage })
+							),
+							menuGroup(
+								'export-bg',
+								menuItem(actions['toggle-transparent'], { checked: !exportBackground })
+							)
+						)
+					)
 				),
 				menuSubmenu(
 					'edit',
@@ -114,20 +131,6 @@ export function MenuSchemaProvider({ overrides, children }: MenuSchemaProviderPr
 								menuItem(actions['copy-as-svg'], { disabled: emptyPage }),
 								menuItem(actions['copy-as-png'], { disabled: emptyPage || !hasClipboardWrite }),
 								menuItem(actions['copy-as-json'], { disabled: emptyPage })
-							),
-							menuGroup(
-								'export-bg',
-								menuItem(actions['toggle-transparent'], { checked: !exportBackground })
-							)
-						),
-						menuSubmenu(
-							'export-as',
-							'menu.export-as',
-							menuGroup(
-								'export-as-group',
-								menuItem(actions['export-as-svg'], { disabled: emptyPage }),
-								menuItem(actions['export-as-png'], { disabled: emptyPage }),
-								menuItem(actions['export-as-json'], { disabled: emptyPage })
 							),
 							menuGroup(
 								'export-bg',

--- a/packages/ui/src/lib/hooks/useMenuSchema.tsx
+++ b/packages/ui/src/lib/hooks/useMenuSchema.tsx
@@ -83,24 +83,7 @@ export function MenuSchemaProvider({ overrides, children }: MenuSchemaProviderPr
 				menuSubmenu(
 					'file',
 					'menu.file',
-					menuGroup('print', menuItem(actions['print'], { disabled: emptyPage })),
-					menuGroup(
-						'export',
-						menuSubmenu(
-							'export-as',
-							'menu.export-as',
-							menuGroup(
-								'export-as-group',
-								menuItem(actions['export-as-svg'], { disabled: emptyPage }),
-								menuItem(actions['export-as-png'], { disabled: emptyPage }),
-								menuItem(actions['export-as-json'], { disabled: emptyPage })
-							),
-							menuGroup(
-								'export-bg',
-								menuItem(actions['toggle-transparent'], { checked: !exportBackground })
-							)
-						)
-					)
+					menuGroup('print', menuItem(actions['print'], { disabled: emptyPage }))
 				),
 				menuSubmenu(
 					'edit',
@@ -163,6 +146,20 @@ export function MenuSchemaProvider({ overrides, children }: MenuSchemaProviderPr
 						menuItem(actions['zoom-to-100'], { disabled: isZoomedTo100 }),
 						menuItem(actions['zoom-to-fit'], { disabled: emptyPage }),
 						menuItem(actions['zoom-to-selection'], { disabled: emptyPage || !oneSelected })
+					)
+				),
+				menuSubmenu(
+					'export-as',
+					'menu.export-as',
+					menuGroup(
+						'export-as-group',
+						menuItem(actions['export-as-svg'], { disabled: emptyPage }),
+						menuItem(actions['export-as-png'], { disabled: emptyPage }),
+						menuItem(actions['export-as-json'], { disabled: emptyPage })
+					),
+					menuGroup(
+						'export-bg',
+						menuItem(actions['toggle-transparent'], { checked: !exportBackground })
 					)
 				)
 			),


### PR DESCRIPTION
Hi,

This PR moves the export-as function submenu to the file menu and changes the export name to the `app.currentPage.name` instead of `shapes` or the shape ID.

resolves #1258 

### Test Plan

1. Add shape
2. File > export as 
