### PR TITLE
[tiny] rename show menu paste

### DIFF
--- a/packages/ui/src/lib/hooks/menuHelpers.ts
+++ b/packages/ui/src/lib/hooks/menuHelpers.ts
@@ -194,7 +194,7 @@ function _findMenuItem(menu: MenuSchema | MenuChild[], path: string[]): MenuChil
 	}
 }
 
-export const showUiPaste =
+export const showMenuPaste =
 	typeof window !== 'undefined' &&
 	'navigator' in window &&
 	Boolean(navigator.clipboard) &&

--- a/packages/ui/src/lib/hooks/useContextMenuSchema.tsx
+++ b/packages/ui/src/lib/hooks/useContextMenuSchema.tsx
@@ -8,7 +8,7 @@ import {
 	menuItem,
 	MenuSchema,
 	menuSubmenu,
-	showUiPaste,
+	showMenuPaste,
 	useAllowGroup,
 	useAllowUngroup,
 	useThreeStackableItems,
@@ -163,7 +163,7 @@ export const ContextMenuSchemaProvider = track(function ContextMenuSchemaProvide
 				'clipboard-group',
 				oneSelected && menuItem(actions['cut']),
 				oneSelected && menuItem(actions['copy']),
-				showUiPaste && menuCustom('MENU_PASTE', { readonlyOk: false })
+				showMenuPaste && menuCustom('MENU_PASTE', { readonlyOk: false })
 			),
 			atLeastOneShapeOnPage &&
 				menuGroup(

--- a/packages/ui/src/lib/hooks/useMenuSchema.tsx
+++ b/packages/ui/src/lib/hooks/useMenuSchema.tsx
@@ -8,7 +8,7 @@ import {
 	menuGroup,
 	menuItem,
 	menuSubmenu,
-	showUiPaste,
+	showMenuPaste,
 	useAllowGroup,
 	useAllowUngroup,
 } from './menuHelpers'
@@ -100,7 +100,7 @@ export function MenuSchemaProvider({ overrides, children }: MenuSchemaProviderPr
 						{
 							id: 'MENU_PASTE',
 							type: 'custom',
-							disabled: !showUiPaste,
+							disabled: !showMenuPaste,
 							readonlyOk: false,
 						}
 					),


### PR DESCRIPTION
This PR renames `showUiPaste` to `showMenuPaste`, since we use `MENU_PASTE` elsewhere.
