### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -2,7 +2,7 @@ name: Publish Canary Packages
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'alex/better-publish-debugging']
 
 jobs:
   deploy:
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
+      - name: tldraw-repo-sync token
+        id: tldraw-repo-sync
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.HUPPY_APP_ID }}
+          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -33,5 +40,5 @@ jobs:
       - name: Publish Canary Packages
         run: yarn tsx ./scripts/publish-canary.ts
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -2,7 +2,7 @@ name: Publish Canary Packages
 
 on:
   push:
-    branches: [main, 'alex/better-publish-debugging']
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
+      - name: tldraw-repo-sync token
+        id: tldraw-repo-sync
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.HUPPY_APP_ID }}
+          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -32,5 +39,5 @@ jobs:
       - name: Publish
         run: yarn tsx ./scripts/publish-manual.ts
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -15,10 +15,17 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
+      - name: tldraw-repo-sync token
+        id: tldraw-repo-sync
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.HUPPY_APP_ID }}
+          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Prepare repository
         # Fetch full git history and tags for auto
@@ -40,5 +47,5 @@ jobs:
       - name: Publish
         run: yarn tsx ./scripts/publish-new.ts
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -2,7 +2,7 @@ import { exec } from './lib/exec'
 import { getLatestVersion, publish, setAllVersions } from './lib/publishing'
 
 async function main() {
-	const sha = (await exec('git', ['rev-parse', '--short', 'HEAD'])).trim()
+	const sha = (await exec('git', ['rev-parse', 'HEAD'])).trim().slice(0, 12)
 
 	async function setCanaryVersions(bump: 'major' | 'minor' | 'patch') {
 		const latestVersion = getLatestVersion()

--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -1,24 +1,23 @@
-import { execSync } from 'child_process'
-import { pathToFileURL } from 'url'
+import { exec } from './lib/exec'
 import { getLatestVersion, publish, setAllVersions } from './lib/publishing'
 
-const sha = execSync('git rev-parse --short HEAD').toString().trim()
+async function main() {
+	const sha = (await exec('git', ['rev-parse', '--short', 'HEAD'])).trim()
 
-async function setCanaryVersions(bump: 'major' | 'minor' | 'patch') {
-	const latestVersion = getLatestVersion()
+	async function setCanaryVersions(bump: 'major' | 'minor' | 'patch') {
+		const latestVersion = getLatestVersion()
 
-	const nextVersion = latestVersion.prerelease.length
-		? // if the package is in prerelease mode, we want to release a canary for the current version rather than bumping
-		  latestVersion
-		: latestVersion?.inc(bump)
-	const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-canary.${sha}`
+		const nextVersion = latestVersion.prerelease.length
+			? // if the package is in prerelease mode, we want to release a canary for the current version rather than bumping
+			  latestVersion
+			: latestVersion?.inc(bump)
+		const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-canary.${sha}`
 
-	setAllVersions(versionString)
-}
+		setAllVersions(versionString)
+	}
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 	// module was called directly
-	const bumpType = execSync('auto version').toString().trim() as 'major' | 'minor' | 'patch' | ''
+	const bumpType = (await exec('auto', ['version'])).trim() as 'major' | 'minor' | 'patch' | ''
 
 	console.log('bumpType', bumpType)
 	if (bumpType === '') {
@@ -31,3 +30,5 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 		throw new Error('Invalid bump type provided')
 	}
 }
+
+main()

--- a/scripts/publish-manual.ts
+++ b/scripts/publish-manual.ts
@@ -1,11 +1,8 @@
-import { pathToFileURL } from 'url'
 import { publish } from './lib/publishing'
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-	// This expects the package.json files to be in the correct state.
-	// You might want to run this locally after a failed publish attempt on CI.
-	// Or if you need to hotfix a package it might be desirable to run this.
+// This expects the package.json files to be in the correct state.
+// You might want to run this locally after a failed publish attempt on CI.
+// Or if you need to hotfix a package it might be desirable to run this.
 
-	// Generate a npm automation token and run this with the NPM_TOKEN env var set.
-	publish()
-}
+// Generate a npm automation token and run this with the NPM_TOKEN env var set.
+publish()

--- a/scripts/publish-new.ts
+++ b/scripts/publish-new.ts
@@ -1,69 +1,66 @@
 import { Auto } from '@auto-it/core'
-import { execSync } from 'child_process'
 import { parse } from 'semver'
-import { pathToFileURL } from 'url'
+import { exec } from './lib/exec'
 import { getLatestVersion, publish, setAllVersions } from './lib/publishing'
 
-const auto = new Auto({
-	plugins: ['npm'],
-	baseBranch: 'main',
-	owner: 'tldraw',
-	repo: 'tldraw-lite',
-	verbose: true,
-})
+async function main() {
+	const auto = new Auto({
+		plugins: ['npm'],
+		baseBranch: 'main',
+		owner: 'tldraw',
+		repo: 'tldraw-lite',
+		verbose: true,
+	})
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 	// module was called directly
-	const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+	const currentBranch = (await exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).toString().trim()
 	if (currentBranch !== 'main') {
 		throw new Error('Must be on main branch to publish')
 	}
 
-	;(async () => {
-		await auto.loadConfig()
-		const bump = await auto.getVersion()
-		if (!bump) {
-			console.log('nothing to do')
-			return
-		}
+	await auto.loadConfig()
+	const bump = await auto.getVersion()
+	if (!bump) {
+		console.log('nothing to do')
+		return
+	}
 
-		const latestVersion = parse(getLatestVersion())!
+	const latestVersion = parse(getLatestVersion())!
 
-		console.log('latestVersion', latestVersion)
+	console.log('latestVersion', latestVersion)
 
-		const [prereleaseTag, prereleaseNumber] = latestVersion.prerelease
-		if (prereleaseTag && typeof prereleaseNumber !== 'number') {
-			throw new Error(
-				`Invalid prerelease format in version ${latestVersion}, expected e.g. -alpha.1`
-			)
-		}
+	const [prereleaseTag, prereleaseNumber] = latestVersion.prerelease
+	if (prereleaseTag && typeof prereleaseNumber !== 'number') {
+		throw new Error(`Invalid prerelease format in version ${latestVersion}, expected e.g. -alpha.1`)
+	}
 
-		// if we're in prerelease mode, don't bump the version, only the prerelease number
-		const nextVersion = prereleaseTag
-			? `${latestVersion.major}.${latestVersion.minor}.${latestVersion.patch}-${prereleaseTag}.${
-					Number(prereleaseNumber) + 1
-			  }`
-			: latestVersion.inc(bump).format()
+	// if we're in prerelease mode, don't bump the version, only the prerelease number
+	const nextVersion = prereleaseTag
+		? `${latestVersion.major}.${latestVersion.minor}.${latestVersion.patch}-${prereleaseTag}.${
+				Number(prereleaseNumber) + 1
+		  }`
+		: latestVersion.inc(bump).format()
 
-		setAllVersions(nextVersion)
+	setAllVersions(nextVersion)
 
-		// stage the changes
-		execSync('git add lerna.json bublic/packages/*/package.json', { stdio: 'inherit' })
+	// stage the changes
+	await exec('git', ['add', 'lerna.json', 'bublic/packages/*/package.json'])
 
-		// this creates a new commit
-		await auto.changelog({
-			useVersion: nextVersion,
-			title: `v${nextVersion}`,
-		})
+	// this creates a new commit
+	await auto.changelog({
+		useVersion: nextVersion,
+		title: `v${nextVersion}`,
+	})
 
-		// create and push a new tag
-		execSync(`git tag -f v${nextVersion}`, { stdio: 'inherit' })
-		execSync('git push --follow-tags', { stdio: 'inherit' })
+	// create and push a new tag
+	await exec('git', ['tag', '-f', `v${nextVersion}`])
+	await exec('git', ['push', '--follow-tags'])
 
-		// create a release on github
-		await auto.runRelease({ useVersion: nextVersion })
+	// create a release on github
+	await auto.runRelease({ useVersion: nextVersion })
 
-		// finally, publish the packages [IF THIS STEP FAILS, RUN THE `publish-manual.ts` script locally]
-		await publish()
-	})()
+	// finally, publish the packages [IF THIS STEP FAILS, RUN THE `publish-manual.ts` script locally]
+	await publish()
 }
+
+main()


### PR DESCRIPTION
Automated package publish had gotten broken because we lost all our git tags/releases. We fixed that, but also:
* made releases come from huppy instead of david
* swtiched from node's `execSync` to our `exec` for more debuggable output
* cleaned up some of the scripts a little

this diff has a lot of whitespace changes so you're best off reviewing it with whitespace changes hidden: https://github.com/tldraw/tldraw/pull/1338/files?diff=split&w=1