### PR TITLE
fix pointer location not updated in edit mode

### DIFF
--- a/packages/editor/src/lib/hooks/useShapeEvents.ts
+++ b/packages/editor/src/lib/hooks/useShapeEvents.ts
@@ -13,7 +13,7 @@ const pointerEventHandler = (
 	capturedPointerIdLookup: Set<string>
 ) => {
 	return (e: React.PointerEvent) => {
-		if (app.pageState.editingId === shapeId) (e as any).isKilled = true
+		if (app.pageState.editingId === shapeId && name !== "pointer_move") (e as any).isKilled = true
 		if ((e as any).isKilled) return
 
 		let pointerInfo = getPointerInfo(e, app.getContainer())


### PR DESCRIPTION
Currently `useShapeEvents.pointerEventHandler` sets `killed = true` when pointer events are received over a shape that's in edit mode. However, this also stops `pointer_move events`, and that means that `inputs.currentPagePoint` will be wrong while you move into or in a shape. The fallout, and the main issue for us, is that this breaks the checks for `canScroll` / `bounds?.containsPoint(app.inputs.currentPagePoint)` and `canScroll` isn't honored and we can't scroll content in certain situations.

### Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)

### Test Plan

1. Put shape that has scrollable content into edit mode
1. Use scrollwheel = content scrolls as it should
1. Move the mouse outside the shape and use the scrollwheel (to move the canvas and get a desired bit of the shape into view better, for example)
1. Move the pointer back inside the shape
1. Use scrollwheel - canvas scrolls since the app thinks the current position is outside (right on the border) of the shape where it last updated it 

### Release Notes

- Fix pointer location not updated in edit mode after moving cursor out of shape and back into shape area
