### PR TITLE
Group multi-draw into a single grouped shape

### DIFF
--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -8752,14 +8752,6 @@ export class App extends EventEmitter<TLEventMap> {
 
 		const parentId = this.findCommonAncestor(shapes) ?? this.currentPageId
 
-		// Only group when the select tool is active
-		if (this.currentToolId !== 'select') return this
-
-		// If not already in idle, cancel the current interaction (get back to idle)
-		if (!this.isIn('select.idle')) {
-			this.cancel()
-		}
-
 		// Find all the shapes that have the same parentId, and use the highest index.
 		const shapesWithRootParent = shapes
 			.filter((shape) => shape.parentId === parentId)

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -293,3 +293,6 @@ export const BLACKLISTED_PROPS = new Set([
 	'url',
 	'growY',
 ])
+
+/** @public */
+export const MAX_DRAW_POINTS = 500


### PR DESCRIPTION
When drawing with the _draw tool_, if your line goes over `500` points then we currently break the line and start a new line. This changes that functionality to group all the paths into a single group

Before (note capped at `100` rather than `500`)

https://github.com/tldraw/tldraw/assets/235915/6f82fb73-68f7-475f-871f-b9c0eda918e6

After (note capped at `100` rather than `500`)

https://github.com/tldraw/tldraw/assets/235915/56a100e2-1ba6-4f84-8387-fb884f446bbc

This also removes the state transitions from `App#groupShapes(...)` as I don't think, this API shouldn't be state bound.

### Change Type

- [x] `major` — Breaking Change
   - This changes the behaviour of `groupShapes()`  


### Test Plan

1. Draw for a while so it passes over 500 points
2. Check that the shape is a grouped set of draw shapes

- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

- Group multi-draw into a single grouped shape
- `App#groupShapes(...)` is no longer bound to UI state 
