### PR TITLE
[docs] Update links in docs

### DIFF
--- a/apps/docs/content/docs/api.mdx
+++ b/apps/docs/content/docs/api.mdx
@@ -237,4 +237,4 @@ app.setCamera(0, 0, 1)
 
 ---
 
-See the [tldraw-examples repository](https://github.com/tldraw/tldraw-examples) for an example of how to use tldraw's App API to control the editor.
+See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to use tldraw's App API to control the editor.

--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -15,4 +15,4 @@ keywords:
 
 Coming soon.
 
-See the [tldraw-examples repository](https://github.com/tldraw/tldraw-examples) for an example of how to use the `@tldraw/tlsync-client` library to persist and sync between tabs.
+See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to use the `@tldraw/tlsync-client` library to persist and sync between tabs.

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -13,4 +13,4 @@ keywords:
 
 Coming soon.
 
-See the [tldraw-examples repository](https://github.com/tldraw/tldraw-examples) for an example of how to create custom shapes in tldraw.
+See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to create custom shapes in tldraw.

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -12,4 +12,4 @@ keywords:
 
 Coming soon. 
 
-See the [tldraw-examples repository](https://github.com/tldraw/tldraw-examples) for an example of how to create custom tools in tldraw.
+See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to create custom tools in tldraw.

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -17,4 +17,4 @@ keywords:
 
 Coming soon.
 
-See the [tldraw-examples repository](https://github.com/tldraw/tldraw-examples) for an example of how to customize tldraw's user interface.
+See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to customize tldraw's user interface.


### PR DESCRIPTION
This PR updates links in docs to point to the tldraw repository rather than tldraw-examples.

### Change Type

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [x] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)


### Release Notes

- [docs] Update links in docs to point to the tldraw repository rather than tldraw-examples.