### PR TITLE
enable eslint for test files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,6 @@
 **/*.css.map
 **/*.js.map
 **/*.d.ts
-**/*.test.ts
 **/api/*
 !**/pages/api/*
 **/*.json

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
 			{ fixMixedExportsWithInlineTypeSpecifier: true },
 		],
 		'local/no-export-star': 'error',
+		'no-only-tests/no-only-tests': 'error',
 	},
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -55,7 +56,7 @@ module.exports = {
 			rules: {
 				'@typescript-eslint/explicit-module-boundary-types': [0],
 				'no-console': ['error', { allow: ['warn', 'error'] }],
-				'no-only-tests/no-only-tests': ['error', { fix: true }],
+				// 'no-only-tests/no-only-tests': ['error', { fix: true }],
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,6 @@ module.exports = {
 			rules: {
 				'@typescript-eslint/explicit-module-boundary-types': [0],
 				'no-console': ['error', { allow: ['warn', 'error'] }],
-				// 'no-only-tests/no-only-tests': ['error', { fix: true }],
 			},
 		},
 		{

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -31,6 +31,11 @@ export function generateSharedScripts(bublic: '<rootDir>' | '<rootDir>/bublic') 
 		lint: {
 			execution: 'independent',
 			runsAfter: { 'build-types': {} },
+			cache: {
+				inputs: {
+					exclude: ['**/*.tsbuildinfo'],
+				},
+			},
 		},
 		'build-package': {
 			runsAfter: { 'build-api': {}, prebuild: {} },

--- a/packages/editor/src/lib/test/App.test.ts
+++ b/packages/editor/src/lib/test/App.test.ts
@@ -332,8 +332,8 @@ describe('isFocused', () => {
 	})
 
 	it('calls .focus() and .blur() on the container div when you call .focus() and .blur() on the editor', () => {
-		const focusMock = jest.spyOn(app.elm, 'focus').mockImplementation(() => {})
-		const blurMock = jest.spyOn(app.elm, 'blur').mockImplementation(() => {})
+		const focusMock = jest.spyOn(app.elm, 'focus').mockImplementation()
+		const blurMock = jest.spyOn(app.elm, 'blur').mockImplementation()
 
 		expect(focusMock).not.toHaveBeenCalled()
 		expect(blurMock).not.toHaveBeenCalled()


### PR DESCRIPTION
We've had a few issues where .only in tests wasn't getting caught by our lint rules. Turns out it's because we were excluding tests from eslint completely

### Change Type
- [x] `internal` — Any other changes that don't affect the published package (will not publish a new version)

### Release Notes

internal-only change
