### PR TITLE
fix a couple of consistency assumptions

### DIFF
--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -4833,13 +4833,14 @@ export class App extends EventEmitter<TLEventMap> {
 				// and, if the handler returns a new shape, replace the old shape with
 				// the new one. This is used for example when repositioning a text shape
 				// based on its new text content.
-				const result = []
-				for (const shape of Object.values(updates)) {
+				const result = Object.values(updates)
+				for (let i = 0; i < result.length; i++) {
+					const shape = result[i]
 					const current = this.store.get(shape.id)
 					if (!current) continue
-					const next = this.getShapeUtil(shape).onBeforeUpdate?.(this.store.get(shape.id)!, shape)
+					const next = this.getShapeUtil(shape).onBeforeUpdate?.(current, shape)
 					if (next) {
-						result.push(next)
+						result[i] = next
 					}
 				}
 				this.store.put(result)

--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -4829,22 +4829,20 @@ export class App extends EventEmitter<TLEventMap> {
 		},
 		{
 			do: ({ updates }) => {
-				const arr = Object.values(updates)
-
 				// Iterate through array; if any shape has an onUpdate handler, call it
 				// and, if the handler returns a new shape, replace the old shape with
 				// the new one. This is used for example when repositioning a text shape
 				// based on its new text content.
-				let shape: TLShape
-				let next: TLShape | void
-				for (let i = 0, n = arr.length; i < n; i++) {
-					shape = arr[i]
-					next = this.getShapeUtil(shape).onBeforeUpdate?.(this.store.get(shape.id)!, shape)
+				const result = []
+				for (const shape of Object.values(updates)) {
+					const current = this.store.get(shape.id)
+					if (!current) continue
+					const next = this.getShapeUtil(shape).onBeforeUpdate?.(this.store.get(shape.id)!, shape)
 					if (next) {
-						arr[i] = next
+						result.push(next)
 					}
 				}
-				this.store.put(arr)
+				this.store.put(result)
 			},
 			undo: ({ snapshots }) => {
 				this.store.put(Object.values(snapshots))
@@ -5152,6 +5150,15 @@ export class App extends EventEmitter<TLEventMap> {
 		},
 		{
 			do: ({ deletedPage, deletedPageStates }) => {
+				const { pages } = this
+				if (pages.length === 1) return
+
+				if (deletedPage.id === this.currentPageId) {
+					const index = pages.findIndex((page) => page.id === deletedPage.id)
+					const next = pages[index - 1] ?? pages[index + 1]
+					this.setCurrentPageId(next.id)
+				}
+
 				this.store.remove(deletedPageStates.map((s) => s.id)) // remove the page state
 				this.store.remove([deletedPage.id]) // remove the page
 				this.updateCullingBounds()


### PR DESCRIPTION
This cleans up a couple of assumptions about the state of the world that break down in multiplayer contexts:

1. updated shapes still exist while redoing
2. redoing the delete of a page that I am on will also redo switching away from that page


### Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)



### Release Notes

- Fixes a couple of minor consistency bugs affecting shape updating and page deletion in multiplayer contexts.
