### PR TITLE
Disable nightly/on-demand webdriver scripts

### DIFF
--- a/.github/workflows/webdriver-nightly.yml
+++ b/.github/workflows/webdriver-nightly.yml
@@ -1,62 +1,64 @@
-name: Webdriver nightly (browserstack)
+# name: Webdriver nightly (browserstack)
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
+# on:
+#   workflow_dispatch:
+#   schedule:
+#     - cron: '0 2 * * *' # run at 2 AM UTC
 
-jobs:
-  test:
-    name: 'nightly'
-    runs-on: ${{ matrix.os }}
+# jobs:
+#   test:
+#     name: 'nightly'
+#     runs-on: ${{ matrix.os }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest-16-cores-open]
-        node-version: [16]
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: [ubuntu-latest-16-cores-open]
+#         node-version: [16]
 
-    container:
-      image: node:${{ matrix.node-version }}
-      options: --network-alias testhost
-      volumes:
-        - /home/runner/work/_temp/e2e:/home/runner/work/_temp/e2e
+#     container:
+#       image: node:${{ matrix.node-version }}
+#       options: --network-alias testhost
+#       volumes:
+#         - /home/runner/work/_temp/e2e:/home/runner/work/_temp/e2e
 
-    steps:
-      # start browserstack
-      - name: 'BrowserStack Env Setup' # Invokes the setup-env action
-        uses: browserstack/github-actions/setup-env@master
-        with:
-          username: jamieblair_YXsTBS
-          access-key: BUcyZn9PF4iwKgayXinm
-      - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: start
-          local-identifier: random
+#     steps:
+#       # start browserstack
+#       - name: 'BrowserStack Env Setup' # Invokes the setup-env action
+#         uses: browserstack/github-actions/setup-env@master
+#         with:
+#           username: jamieblair_YXsTBS
+#           access-key: BUcyZn9PF4iwKgayXinm
+#       - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
+#         uses: browserstack/github-actions/setup-local@master
+#         with:
+#           local-testing: start
+#           local-identifier: random
 
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: true
+#       - name: Check out code
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0
+#           submodules: true
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: 'public-yarn.lock'
+#       - name: Setup Node.js environment
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: 18
+#           cache: 'yarn'
+#           cache-dependency-path: 'public-yarn.lock'
 
-      - name: Enable corepack
-        run: corepack enable
+#       - name: Enable corepack
+#         run: corepack enable
 
-      - name: Install dependencies
-        run: yarn
+#       - name: Install dependencies
+#         run: yarn
 
-      - run: yarn e2e test:ci nightly
-        env:
-          CI: true
-          DOWNLOADS_DIR: '/home/runner/work/_temp/e2e/'
-          TEST_URL: 'https://testhost:5421'
-          WB_BUILD_NAME: 'nightly'
+#       - run: yarn e2e test:ci nightly
+#         env:
+#           CI: true
+#           DOWNLOADS_DIR: '/home/runner/work/_temp/e2e/'
+#           TEST_URL: 'https://testhost:5421'
+#           WB_BUILD_NAME: 'nightly'
+#           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+#           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.github/workflows/webdriver-nightly.yml
+++ b/.github/workflows/webdriver-nightly.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Run server
-        run: yarn dev-webdriver &
-
       - run: yarn e2e test:ci nightly
         env:
           CI: true

--- a/.github/workflows/webdriver-on-demand.yml
+++ b/.github/workflows/webdriver-on-demand.yml
@@ -1,117 +1,117 @@
-name: Webdriver on demand (browserstack)
+# name: Webdriver on demand (browserstack)
 
-on:
-  workflow_dispatch:
-    inputs:
-      WD_BROWSER_CHROME:
-        description: 'Chrome'
-        required: false
-        default: true
-        type: boolean
-      WD_BROWSER_FIREFOX:
-        description: 'Firefox'
-        required: false
-        default: true
-        type: boolean
-      WD_BROWSER_EDGE:
-        description: 'Edge'
-        required: false
-        default: true
-        type: boolean
-      WD_BROWSER_SAFARI:
-        description: 'Safari'
-        required: false
-        default: true
-        type: boolean
-      WD_BROWSER_SAMSUNG:
-        description: 'Samsung'
-        required: false
-        default: true
-        type: boolean
-      WD_OS_WINDOWS:
-        description: 'Windows'
-        required: false
-        default: true
-        type: boolean
-      WD_OS_MACOS:
-        description: 'MacOS'
-        required: false
-        default: true
-        type: boolean
-      WD_OS_ANDROID:
-        description: 'Android'
-        required: false
-        default: true
-        type: boolean
-      WD_OS_IOS:
-        description: 'iOS'
-        required: false
-        default: true
-        type: boolean
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       WD_BROWSER_CHROME:
+#         description: 'Chrome'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_BROWSER_FIREFOX:
+#         description: 'Firefox'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_BROWSER_EDGE:
+#         description: 'Edge'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_BROWSER_SAFARI:
+#         description: 'Safari'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_BROWSER_SAMSUNG:
+#         description: 'Samsung'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_OS_WINDOWS:
+#         description: 'Windows'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_OS_MACOS:
+#         description: 'MacOS'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_OS_ANDROID:
+#         description: 'Android'
+#         required: false
+#         default: true
+#         type: boolean
+#       WD_OS_IOS:
+#         description: 'iOS'
+#         required: false
+#         default: true
+#         type: boolean
 
-jobs:
-  test:
-    name: 'on-demand'
-    runs-on: ${{ matrix.os }}
+# jobs:
+#   test:
+#     name: 'on-demand'
+#     runs-on: ${{ matrix.os }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest-16-cores-open]
-        node-version: [16]
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: [ubuntu-latest-16-cores-open]
+#         node-version: [16]
 
-    container:
-      image: node:${{ matrix.node-version }}
-      options: --network-alias testhost
-      volumes:
-        - /home/runner/work/_temp/e2e:/home/runner/work/_temp/e2e
+#     container:
+#       image: node:${{ matrix.node-version }}
+#       options: --network-alias testhost
+#       volumes:
+#         - /home/runner/work/_temp/e2e:/home/runner/work/_temp/e2e
 
-    steps:
-      # start browserstack
-      - name: 'BrowserStack Env Setup' # Invokes the setup-env action
-        uses: browserstack/github-actions/setup-env@master
-        with:
-          username: jamieblair_YXsTBS
-          access-key: BUcyZn9PF4iwKgayXinm
-      - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: start
-          local-identifier: random
+#     steps:
+#       # start browserstack
+#       - name: 'BrowserStack Env Setup' # Invokes the setup-env action
+#         uses: browserstack/github-actions/setup-env@master
+#         with:
+#           username: jamieblair_YXsTBS
+#           access-key: BUcyZn9PF4iwKgayXinm
+#       - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
+#         uses: browserstack/github-actions/setup-local@master
+#         with:
+#           local-testing: start
+#           local-identifier: random
 
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: true
+#       - name: Check out code
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0
+#           submodules: true
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: 'public-yarn.lock'
+#       - name: Setup Node.js environment
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: 18
+#           cache: 'yarn'
+#           cache-dependency-path: 'public-yarn.lock'
 
-      - name: Enable corepack
-        run: corepack enable
+#       - name: Enable corepack
+#         run: corepack enable
 
-      - name: Install dependencies
-        run: yarn
+#       - name: Install dependencies
+#         run: yarn
 
-      - run: yarn e2e test:ci nightly
-        env:
-          CI: true
-          DOWNLOADS_DIR: '/home/runner/work/_temp/e2e/'
-          TEST_URL: 'https://testhost:5421'
-          WD_BROWSER_CHROME: ${{ inputs.WD_BROWSER_CHROME }}
-          WD_BROWSER_FIREFOX: ${{ inputs.WD_BROWSER_FIREFOX }}
-          WD_BROWSER_EDGE: ${{ inputs.WD_BROWSER_EDGE }}
-          WD_BROWSER_SAFARI: ${{ inputs.WD_BROWSER_SAFARI }}
-          WD_BROWSER_SAMSUNG: ${{ inputs.WD_BROWSER_SAMSUNG }}
-          WD_OS_WINDOWS: ${{ inputs.WD_OS_WINDOWS }}
-          WD_OS_MACOS: ${{ inputs.WD_OS_MACOS }}
-          WD_OS_ANDROID: ${{ inputs.WD_OS_ANDROID }}
-          WD_OS_IOS: ${{ inputs.WD_OS_IOS }}
-          WB_BUILD_NAME: 'ondemand'
-          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
-          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+#       - run: yarn e2e test:ci nightly
+#         env:
+#           CI: true
+#           DOWNLOADS_DIR: '/home/runner/work/_temp/e2e/'
+#           TEST_URL: 'https://testhost:5421'
+#           WD_BROWSER_CHROME: ${{ inputs.WD_BROWSER_CHROME }}
+#           WD_BROWSER_FIREFOX: ${{ inputs.WD_BROWSER_FIREFOX }}
+#           WD_BROWSER_EDGE: ${{ inputs.WD_BROWSER_EDGE }}
+#           WD_BROWSER_SAFARI: ${{ inputs.WD_BROWSER_SAFARI }}
+#           WD_BROWSER_SAMSUNG: ${{ inputs.WD_BROWSER_SAMSUNG }}
+#           WD_OS_WINDOWS: ${{ inputs.WD_OS_WINDOWS }}
+#           WD_OS_MACOS: ${{ inputs.WD_OS_MACOS }}
+#           WD_OS_ANDROID: ${{ inputs.WD_OS_ANDROID }}
+#           WD_OS_IOS: ${{ inputs.WD_OS_IOS }}
+#           WB_BUILD_NAME: 'ondemand'
+#           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+#           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.github/workflows/webdriver-on-demand.yml
+++ b/.github/workflows/webdriver-on-demand.yml
@@ -113,3 +113,5 @@ jobs:
           WD_OS_ANDROID: ${{ inputs.WD_OS_ANDROID }}
           WD_OS_IOS: ${{ inputs.WD_OS_IOS }}
           WB_BUILD_NAME: 'ondemand'
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.github/workflows/webdriver-on-demand.yml
+++ b/.github/workflows/webdriver-on-demand.yml
@@ -98,9 +98,6 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Run server
-        run: yarn dev-webdriver &
-
       - run: yarn e2e test:ci nightly
         env:
           CI: true


### PR DESCRIPTION
Disable nightly/on-demand webdriver gh-actions. I currently can't get them running correctly.

### Change Type

- [x] `tests` — Changes to any testing-related code only (will not publish a new version)

### Test Plan
None

### Release Notes
None
