### PR TITLE
Update codesandbox + example link

### DIFF
--- a/apps/docs/content/docs/introduction.mdx
+++ b/apps/docs/content/docs/introduction.mdx
@@ -14,8 +14,8 @@ tldraw is a React component that you can use to create infinite canvas experienc
 
 These docs relate to tldraw's **alpha version**. This version is not yet open sourced, however it is available on npm and permissively licensed under Apache 2.0.
 
-- Want to dive in? Visit the [examples CodeSandbox](https://codesandbox.io/p/github/tldraw/tldraw-examples/main?file=%2FREADME.md).
-- Found a bug or integration problem? Please create a ticket [here](https://github.com/tldraw/tldraw-examples/issues).
+- Want to dive in? Visit the [examples StackBlitz](https://stackblitz.com/github/tldraw/tldraw/tree/examples?file=src%2F1-basic%2FBasicExample.tsx).
+- Found a bug or integration problem? Please create a ticket [here](https://github.com/tldraw/tldraw/issues).
 - Questions or feedback? Let us know on the [Discord](https://discord.gg/JMbeb96jsh).
 
 And if you are just looking for the regular app, try [tldraw.com](https://www.tldraw.com).
@@ -92,7 +92,7 @@ The `<Tldraw/>` component combines several other pieces:
 
 > **Note:** In the future, this library will also include an engine for using our collaboration services.
 
-If you wanted to have more granular control, you could also use those subcomponents directly. See the ["exploded" example](https://github.com/tldraw/tldraw-examples/tree/main/src/examples/5-exploded) for what that would look like.
+If you wanted to have more granular control, you could also use those subcomponents directly. See the ["exploded" example](https://github.com/tldraw/tldraw/blob/main/apps/examples/src/5-exploded/ExplodedExample.tsx) for what that would look like.
 
 ### Assets
 


### PR DESCRIPTION
This PR updates the docs site.
* It updates an old CodeSandbox link to the new StackBlitz link.
* It updates an old example link.

There's still more we need to update before closing the tldraw-examples repo.
I'll add it to the linear project and carry on next week!

### Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [ ] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [x] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)

### Test Plan


- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

- [docs] Fixed some links to examples. 
