### PR TITLE
chore: neaten up pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,7 @@ Describe what your pull request does. If appropriate, add GIFs or images showing
 - [ ] `patch` — Bug Fix
 - [ ] `minor` — New Feature
 - [ ] `major` — Breaking Change
-
 - [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)
-
 - [ ] `documentation` — Changes to the documentation only (will not publish a new version)
 - [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
 - [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)


### PR DESCRIPTION
This PR neatens up our PR template.

Github struggles to render lists with gaps in. Could we make it neater?

![image](https://github.com/tldraw/tldraw/assets/15892272/8dccecc2-48be-419f-9272-ef1e19bd8915)

### Change type

- [x] `other`

### Test plan

1. Verify the PR template renders correctly in GitHub.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- None