### PR TITLE
[improvement] delete shapes

### DIFF
--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -227,10 +227,10 @@ export class App extends EventEmitter<TLEventMap> {
 					break
 				}
 			}
+		}
 
-			if (deletedShapes !== undefined) {
-				this._shapesWillBeDeleted(deletedShapes)
-			}
+		if (deletedShapes !== undefined) {
+			this._shapesWillBeDeleted(deletedShapes)
 		}
 
 		this.store.onAfterChange = (prev, next) => {


### PR DESCRIPTION
This PR makes a small performance improvement to deleting shapes. Previously, we would call the expensive `_deleteShape` for each shape being deleted. We now call `_deleteShapes`, which combines some of that expensive work.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. In a bigger project, delete some shapes.

### Release Notes

- [editor] Improve performance when deleting many shapes at a time in a project with many shapes.