### PR TITLE
[fix] pointer location not updating when moving over editing shape

### DIFF
--- a/packages/editor/src/lib/hooks/useShapeEvents.ts
+++ b/packages/editor/src/lib/hooks/useShapeEvents.ts
@@ -13,7 +13,7 @@ const pointerEventHandler = (
 	capturedPointerIdLookup: Set<string>
 ) => {
 	return (e: React.PointerEvent) => {
-		if (app.pageState.editingId === shapeId) (e as any).isKilled = true
+		if (name !== 'pointer_move' && app.pageState.editingId === shapeId) (e as any).isKilled = true
 		if ((e as any).isKilled) return
 
 		let pointerInfo = getPointerInfo(e, app.getContainer())


### PR DESCRIPTION
This PR is entirely unrelated to https://github.com/tldraw/tldraw/pull/1352.

### Change Type

- [x] `minor` — New Feature

### Release Notes

- Fix a bug where the pointer location would not update when moving the pointer over an editing shape.
