### PR TITLE
Fix setting the grid mode.

### DIFF
--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -1558,7 +1558,7 @@ export class App extends EventEmitter<TLEventMap> {
 	}
 
 	setGridMode(isGridMode: boolean): this {
-		if (isGridMode === this.isGridMode) {
+		if (isGridMode !== this.isGridMode) {
 			this.updateUserDocumentSettings({ isGridMode }, true)
 		}
 		return this


### PR DESCRIPTION
Fix setting the grid mode. The change was never saved due to the wrong condition.

Resolves #1385

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Go to Preferences -> Show grid. 
2. It should allow you to toggle the display of the grid.

- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

- Fix grid mode toggle.
