### PR TITLE
[firefox] Fix the pointer getting stuck down when you press the control key

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -156,6 +156,8 @@ export class App extends EventEmitter<TLEventMap> {
     set canMoveCamera(canMove: boolean);
     get canRedo(): boolean;
     get canUndo(): boolean;
+    // @internal (undocumented)
+    capturedPointerId: null | number;
     centerOnPoint(x: number, y: number, opts?: AnimationOptions): this;
     // @internal
     protected _clickManager: ClickManager;

--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -3526,6 +3526,9 @@ export class App extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _selectedIdsAtPointerDown: TLShapeId[] = []
 
+	/** @internal */
+	capturedPointerId: number | null = null
+
 	/**
 	 * Dispatch an event to the app.
 	 *
@@ -3741,6 +3744,12 @@ export class App extends EventEmitter<TLEventMap> {
 						case 'pointer_down': {
 							this._selectedIdsAtPointerDown = this.selectedIds.slice()
 
+							// Firefox bug fix...
+							// If it's a left-mouse-click, we store the pointer id for later user
+							if (info.button === 0) {
+								this.capturedPointerId = info.pointerId
+							}
+
 							// Add the button from the buttons set
 							inputs.buttons.add(info.button)
 
@@ -3830,6 +3839,14 @@ export class App extends EventEmitter<TLEventMap> {
 
 							if (!isPen && this.isPenMode) {
 								return
+							}
+
+							// Firefox bug fix...
+							// If it's the same pointer that we stored earlier...
+							// ... then it's probably still a left-mouse-click!
+							if (this.capturedPointerId === info.pointerId) {
+								this.capturedPointerId = null
+								info.button = 0
 							}
 
 							if (inputs.isPanning) {

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -43,7 +43,7 @@ export function useCanvasEvents() {
 
 			function onPointerUp(e: React.PointerEvent) {
 				if ((e as any).isKilled) return
-				if (e.button !== 0 && e.button !== 1 && e.button !== 5) return
+				if (e.button !== 0 && e.button !== 1 && e.button !== 2 && e.button !== 5) return
 				lastX = e.clientX
 				lastY = e.clientY
 


### PR DESCRIPTION
This PR fixes a bug in firefox where the pointer can get stuck down while pressing the control key.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Use firefox.
2. On the canvas... pointer down (to start a selection box).
3. Control key down.
4. Pointer up.
5. Make sure that that the selection box is gone.

^ Repeat the above for:
Pointer down on a shape.
Pointer down on a handle.

### Release Notes

- [Firefox] Fixed a bug where the pointer could get stuck down when the control key is held down.
