### PR TITLE
[fix] example routes on vercel

### DIFF
--- a/apps/examples/vercel.json
+++ b/apps/examples/vercel.json
@@ -9,5 +9,11 @@
 				}
 			]
 		}
+	],
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/index.html"
+		}
 	]
 }


### PR DESCRIPTION
This PR updates our example app's vercel config so that routes (e.g. bublic.tldraw.com/scroll) will work.