### PR TITLE
Fix tabs not getting converted to spaces on shape paste

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1593,6 +1593,35 @@ export const TEXT_PROPS: {
 };
 
 // @public (undocumented)
+export class TextHelpers {
+    // (undocumented)
+    static findLineEnd(value: string, currentEnd: number): number;
+    // (undocumented)
+    static fixNewLines: RegExp;
+    static getSelection(field: HTMLInputElement | HTMLTextAreaElement): string;
+    // (undocumented)
+    static INDENT: string;
+    // (undocumented)
+    static indent(element: HTMLTextAreaElement): void;
+    // (undocumented)
+    static indentCE(element: HTMLElement): void;
+    static insert(field: HTMLInputElement | HTMLTextAreaElement, text: string): void;
+    // (undocumented)
+    static insertTextFirefox(field: HTMLInputElement | HTMLTextAreaElement, text: string): void;
+    // (undocumented)
+    static normalizeText(text: string): string;
+    // (undocumented)
+    static normalizeTextForDom(text: string): string;
+    static replace(field: HTMLInputElement | HTMLTextAreaElement, searchValue: RegExp | string, replacer: ReplacerCallback | string): void;
+    static set(field: HTMLInputElement | HTMLTextAreaElement, text: string): void;
+    // (undocumented)
+    static unindent(element: HTMLTextAreaElement): void;
+    // (undocumented)
+    static unindentCE(element: HTMLElement): void;
+    static wrapSelection(field: HTMLInputElement | HTMLTextAreaElement, wrap: string, wrapEnd?: string): void;
+}
+
+// @public (undocumented)
 export const TLArrowShapeDef: TLShapeDef<TLArrowShape, TLArrowUtil>;
 
 // @public (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1592,7 +1592,7 @@ export const TEXT_PROPS: {
     maxWidth: string;
 };
 
-// @public (undocumented)
+// @internal (undocumented)
 export class TextHelpers {
     // (undocumented)
     static findLineEnd(value: string, currentEnd: number): number;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -62,6 +62,7 @@ export {
 	type TLShapeUtilFlag,
 } from './lib/app/shapeutils/TLShapeUtil'
 export { TLTextShapeDef, TLTextUtil } from './lib/app/shapeutils/TLTextUtil/TLTextUtil'
+export { TextHelpers } from './lib/app/shapeutils/TLTextUtil/TextHelpers'
 export { TLVideoShapeDef, TLVideoUtil } from './lib/app/shapeutils/TLVideoUtil/TLVideoUtil'
 export { StateNode, type StateNodeConstructor } from './lib/app/statechart/StateNode'
 export { TLBoxTool, type TLBoxLike } from './lib/app/statechart/TLBoxTool/TLBoxTool'

--- a/packages/editor/src/lib/app/shapeutils/TLTextUtil/TextHelpers.ts
+++ b/packages/editor/src/lib/app/shapeutils/TLTextUtil/TextHelpers.ts
@@ -6,7 +6,7 @@
 /** @public */
 export type ReplacerCallback = (substring: string, ...args: unknown[]) => string
 
-/** @public */
+/** @internal */
 export class TextHelpers {
 	static insertTextFirefox(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
 		// Found on https://www.everythingfrontend.com/blog/insert-text-into-textarea-at-cursor-position.html 🎈

--- a/packages/editor/src/lib/app/shapeutils/shared/useEditableText.ts
+++ b/packages/editor/src/lib/app/shapeutils/shared/useEditableText.ts
@@ -135,7 +135,7 @@ export function useEditableText<T extends Extract<TLShape, { props: { text: stri
 
 			// ------- Bug fix ------------
 			// Replace tabs with spaces when pasting
-			const untabbedText = text.replace(/\t/g, '  ')
+			const untabbedText = text.replace(/\t/g, TextHelpers.INDENT)
 			if (untabbedText !== text) {
 				const selectionStart = e.currentTarget.selectionStart
 				e.currentTarget.value = untabbedText

--- a/packages/ui/src/lib/hooks/useClipboardEvents.ts
+++ b/packages/ui/src/lib/hooks/useClipboardEvents.ts
@@ -15,6 +15,7 @@ import {
 	isSvgText,
 	isValidHttpURL,
 	TEXT_PROPS,
+	TextHelpers,
 	TLAlignType,
 	TLArrowheadType,
 	TLArrowShapeDef,
@@ -144,16 +145,18 @@ const pastePlainText = async (app: App, text: string, point?: VecLike) => {
 	const p = point ?? (app.inputs.shiftKey ? app.inputs.currentPagePoint : app.viewportPageCenter)
 	const defaultProps = app.getShapeUtilByDef(TLTextShapeDef).defaultProps()
 
+	const cleanText = TextHelpers.normalizeText(stripHtml(text)).replace(/\t/g, TextHelpers.INDENT)
+
 	// Measure the text with default values
 	const { w, h } = app.textMeasure.measureText({
 		...TEXT_PROPS,
-		text: stripHtml(text),
+		text: cleanText,
 		fontFamily: FONT_FAMILIES[defaultProps.font],
 		fontSize: FONT_SIZES[defaultProps.size],
 		width: 'fit-content',
 	})
 
-	app.mark('paste')
+	app.mark('paste') //hi
 	app.createShapes([
 		{
 			id: createShapeId(),
@@ -161,7 +164,7 @@ const pastePlainText = async (app: App, text: string, point?: VecLike) => {
 			x: p.x - w / 2,
 			y: p.y - h / 2,
 			props: {
-				text: stripHtml(text),
+				text: cleanText,
 				autoSize: true,
 			},
 		},

--- a/packages/ui/src/lib/hooks/useClipboardEvents.ts
+++ b/packages/ui/src/lib/hooks/useClipboardEvents.ts
@@ -156,7 +156,7 @@ const pastePlainText = async (app: App, text: string, point?: VecLike) => {
 		width: 'fit-content',
 	})
 
-	app.mark('paste') //hi
+	app.mark('paste')
 	app.createShapes([
 		{
 			id: createShapeId(),


### PR DESCRIPTION
# Context
We usually convert tabs to spaces in text labels.
eg: When you press the tab key.
eg: When you paste a tab character within a text label.

⭐ This is partly because of aesthetic reasons. (Everything's kinda misaligned anyway in a whiteboard).
⭐ And partly because... we need to manually add an indent when you press the tab key anyway.

# This PR
This PR fixes a case where we *don't* convert tabs. It works differently to the other cases.
🐛 It can lead to things looking weirdly different to other text labels!
🐛 It can lead to export errors (though this will be fixed soon with @SomeHats's upcoming export improvements.

# Anything else?
This PR also removes a hard-coded string from one of the other places. It uses `TextHelpers.INDENT` instead.
➡️ This mean that @SomeHats's PR will affect these places too!
➡️ Heads-up! It also means that the `@tldraw/editor` now exports our `TextHelpers` class.

### Change Type

- [x] `patch` — Bug Fix
### Test Plan

1. Copy some text with a tab in it, eg: `hi	hi`
2. With nothing selected, paste it in tldraw.
3. Make sure that the resulting text shape has converted the tab into spaces.

### Release Notes

- Fixed a bug where pasted tabs wouldn't get converted into spaces.
