### PR TITLE
[2/3] renderer changes to support "sandwich mode" highlighting

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -410,6 +410,7 @@ export class App extends EventEmitter<TLEventMap> {
     get renderingShapes(): {
         id: TLShapeId;
         index: number;
+        backgroundIndex: number;
         opacity: number;
         isCulled: boolean;
         isInViewport: boolean;
@@ -2057,6 +2058,8 @@ export class TLFrameUtil extends TLBoxUtil<TLFrameShape> {
     // (undocumented)
     onResizeEnd: OnResizeEndHandler<TLFrameShape>;
     // (undocumented)
+    providesBackgroundForChildren(): boolean;
+    // (undocumented)
     render(shape: TLFrameShape): JSX.Element;
     // (undocumented)
     toSvg(shape: TLFrameShape, font: string, colors: TLExportColors): Promise<SVGElement> | SVGElement;
@@ -2236,6 +2239,8 @@ export class TLHighlightUtil extends TLShapeUtil<TLHighlightShape> {
     onResize: OnResizeHandler<TLHighlightShape>;
     // (undocumented)
     render(shape: TLHighlightShape): JSX.Element;
+    // (undocumented)
+    renderBackground(shape: TLHighlightShape): JSX.Element;
     // (undocumented)
     toSvg(shape: TLHighlightShape, _font: string | undefined, colors: TLExportColors): SVGPathElement;
     // (undocumented)
@@ -2542,7 +2547,11 @@ export abstract class TLShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     onTranslateStart?: OnTranslateStartHandler<T>;
     outline(shape: T): Vec2dModel[];
     point(shape: T): Vec2dModel;
+    // @internal
+    providesBackgroundForChildren(shape: T): boolean;
     abstract render(shape: T): any;
+    // @internal
+    renderBackground?(shape: T): any;
     snapPoints(shape: T): Vec2d[];
     toSvg?(shape: T, font: string | undefined, colors: TLExportColors): Promise<SVGElement> | SVGElement;
     transform(shape: T): Matrix2d;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -280,11 +280,11 @@ export class App extends EventEmitter<TLEventMap> {
     getParentTransform(shape: TLShape): Matrix2d;
     getPointInParentSpace(shapeId: TLShapeId, point: VecLike): Vec2d;
     getPointInShapeSpace(shape: TLShape, point: VecLike): Vec2d;
-    getShapeById<T extends TLShape = TLShape>(id: TLParentId): T | undefined;
     // (undocumented)
-    getShapesAndDescendantsInOrder(ids: TLShapeId[]): TLShape[];
+    getShapeAndDescendantIds(ids: TLShapeId[]): Set<TLShapeId>;
+    getShapeById<T extends TLShape = TLShape>(id: TLParentId): T | undefined;
+    getShapeIdsInPage(pageId: TLPageId): Set<TLShapeId>;
     getShapesAtPoint(point: VecLike): TLShape[];
-    getShapesInPage(pageId: TLPageId): TLShape[];
     getShapeUtil<C extends {
         new (...args: any[]): TLShapeUtil<any>;
         type: string;
@@ -414,6 +414,7 @@ export class App extends EventEmitter<TLEventMap> {
         opacity: number;
         isCulled: boolean;
         isInViewport: boolean;
+        maskedPageBounds: Box2d | undefined;
     }[];
     reorderShapes(operation: 'backward' | 'forward' | 'toBack' | 'toFront', ids: TLShapeId[]): this;
     reparentShapesById(ids: TLShapeId[], parentId: TLParentId, insertIndex?: string): this;
@@ -2242,6 +2243,8 @@ export class TLHighlightUtil extends TLShapeUtil<TLHighlightShape> {
     // (undocumented)
     renderBackground(shape: TLHighlightShape): JSX.Element;
     // (undocumented)
+    toBackgroundSvg(shape: TLHighlightShape, font: string | undefined, colors: TLExportColors): SVGPathElement;
+    // (undocumented)
     toSvg(shape: TLHighlightShape, _font: string | undefined, colors: TLExportColors): SVGPathElement;
     // (undocumented)
     static type: string;
@@ -2553,6 +2556,7 @@ export abstract class TLShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     // @internal
     renderBackground?(shape: T): any;
     snapPoints(shape: T): Vec2d[];
+    toBackgroundSvg?(shape: T, font: string | undefined, colors: TLExportColors): null | Promise<SVGElement> | SVGElement;
     toSvg?(shape: T, font: string | undefined, colors: TLExportColors): Promise<SVGElement> | SVGElement;
     transform(shape: T): Matrix2d;
     // (undocumented)

--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -5658,14 +5658,19 @@ export class App extends EventEmitter<TLEventMap> {
 
 		// --- Common bounding box of all shapes
 		let bbox = null
+		console.group('getSvg')
+		console.log('renderingShapes', renderingShapes)
 		for (const { maskedPageBounds } of renderingShapes) {
 			if (!maskedPageBounds) continue
+			console.log('maskedPageBounds', maskedPageBounds)
 			if (bbox) {
 				bbox.union(maskedPageBounds)
 			} else {
 				bbox = maskedPageBounds.clone()
 			}
 		}
+		console.log('bbox', bbox)
+		console.groupEnd()
 
 		// no unmasked shapes to export
 		if (!bbox) return

--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -5658,19 +5658,14 @@ export class App extends EventEmitter<TLEventMap> {
 
 		// --- Common bounding box of all shapes
 		let bbox = null
-		console.group('getSvg')
-		console.log('renderingShapes', renderingShapes)
 		for (const { maskedPageBounds } of renderingShapes) {
 			if (!maskedPageBounds) continue
-			console.log('maskedPageBounds', maskedPageBounds)
 			if (bbox) {
 				bbox.union(maskedPageBounds)
 			} else {
 				bbox = maskedPageBounds.clone()
 			}
 		}
-		console.log('bbox', bbox)
-		console.groupEnd()
 
 		// no unmasked shapes to export
 		if (!bbox) return

--- a/packages/editor/src/lib/app/shapeutils/TLFrameUtil/TLFrameUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/TLFrameUtil/TLFrameUtil.tsx
@@ -148,6 +148,10 @@ export class TLFrameUtil extends TLBoxUtil<TLFrameShape> {
 		)
 	}
 
+	providesBackgroundForChildren(): boolean {
+		return true
+	}
+
 	override canReceiveNewChildrenOfType = (_type: TLShape['type']) => {
 		return true
 	}

--- a/packages/editor/src/lib/app/shapeutils/TLShapeUtil.ts
+++ b/packages/editor/src/lib/app/shapeutils/TLShapeUtil.ts
@@ -346,6 +346,21 @@ export abstract class TLShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
 	): SVGElement | Promise<SVGElement>
 
 	/**
+	 * Get the shape's background layer as an SVG object.
+	 *
+	 * @param shape - The shape.
+	 * @param color - The shape's CSS color (actual).
+	 * @param font - The shape's CSS font (actual).
+	 * @returns An SVG element.
+	 * @public
+	 */
+	toBackgroundSvg?(
+		shape: T,
+		font: string | undefined,
+		colors: TLExportColors
+	): SVGElement | Promise<SVGElement> | null
+
+	/**
 	 * Get whether a point intersects the shape.
 	 *
 	 * @param shape - The shape.

--- a/packages/editor/src/lib/app/shapeutils/TLShapeUtil.ts
+++ b/packages/editor/src/lib/app/shapeutils/TLShapeUtil.ts
@@ -166,6 +166,14 @@ export abstract class TLShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
 	abstract indicator(shape: T): any
 
 	/**
+	 * Get a JSX element for the shape (as an HTML element) to be rendered as part of the canvas background - behind any other shape content.
+	 *
+	 * @param shape - The shape.
+	 * @internal
+	 */
+	renderBackground?(shape: T): any
+
+	/**
 	 * Get an array of handle models for the shape. This is an optional method.
 	 *
 	 * @example
@@ -373,6 +381,19 @@ export abstract class TLShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
 	/** @internal */
 	expandSelectionOutlinePx(shape: T): number {
 		return 0
+	}
+
+	/**
+	 * Does this shape provide a background for its children? If this is true,
+	 * then any children with a `renderBackground` method will have their
+	 * backgrounds rendered _above_ this shape. Otherwise, the children's
+	 * backgrounds will be rendered above either the next ancestor that provides
+	 * a background, or the canvas background.
+	 *
+	 * @internal
+	 */
+	providesBackgroundForChildren(shape: T): boolean {
+		return false
 	}
 
 	//  Events

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -27,11 +27,13 @@ opacity based on its own opacity and that of its parent's.
 export const Shape = track(function Shape({
 	id,
 	index,
+	backgroundIndex,
 	opacity,
 	isCulled,
 }: {
 	id: TLShapeId
 	index: number
+	backgroundIndex: number
 	opacity: number
 	isCulled: boolean
 }) {
@@ -41,65 +43,63 @@ export const Shape = track(function Shape({
 
 	const events = useShapeEvents(id)
 
-	const rContainer = React.useRef<HTMLDivElement>(null)
+	const containerRef = React.useRef<HTMLDivElement>(null)
+	const backgroundContainerRef = React.useRef<HTMLDivElement>(null)
+
+	const setProperty = React.useCallback((property: string, value: string) => {
+		containerRef.current?.style.setProperty(property, value)
+		backgroundContainerRef.current?.style.setProperty(property, value)
+	}, [])
 
 	useQuickReactor(
 		'set shape container transform position',
 		() => {
-			const elm = rContainer.current
-			if (!elm) return
-
 			const shape = app.getShapeById(id)
 			const pageTransform = app.getPageTransformById(id)
 
 			if (!shape || !pageTransform) return null
 
 			const transform = Matrix2d.toCssString(pageTransform)
-			elm.style.setProperty('transform', transform)
+			setProperty('transform', transform)
 		},
-		[app]
+		[app, setProperty]
 	)
 
 	useQuickReactor(
 		'set shape container clip path / color',
 		() => {
-			const elm = rContainer.current
 			const shape = app.getShapeById(id)
-			if (!elm) return
 			if (!shape) return null
 
 			const clipPath = app.getClipPathById(id)
-			elm.style.setProperty('clip-path', clipPath ?? 'none')
+			setProperty('clip-path', clipPath ?? 'none')
 			if ('color' in shape.props) {
-				elm.style.setProperty('color', app.getCssColor(shape.props.color))
+				setProperty('color', app.getCssColor(shape.props.color))
 			}
 		},
-		[app]
+		[app, setProperty]
 	)
 
 	useQuickReactor(
 		'set shape height and width',
 		() => {
-			const elm = rContainer.current
 			const shape = app.getShapeById(id)
-			if (!elm) return
 			if (!shape) return null
 
 			const util = app.getShapeUtil(shape)
 			const bounds = util.bounds(shape)
-			elm.style.setProperty('width', Math.ceil(bounds.width) + 'px')
-			elm.style.setProperty('height', Math.ceil(bounds.height) + 'px')
+			setProperty('width', Math.ceil(bounds.width) + 'px')
+			setProperty('height', Math.ceil(bounds.height) + 'px')
 		},
 		[app]
 	)
 
 	// Set the opacity of the container when the opacity changes
 	React.useLayoutEffect(() => {
-		const elm = rContainer.current
-		if (!elm) return
-		elm.style.setProperty('opacity', opacity + '')
-		elm.style.setProperty('z-index', index + '')
-	}, [opacity, index])
+		setProperty('opacity', opacity + '')
+		containerRef.current?.style.setProperty('z-index', index + '')
+		backgroundContainerRef.current?.style.setProperty('z-index', backgroundIndex + '')
+	}, [opacity, index, backgroundIndex, setProperty])
 
 	const shape = app.getShapeById(id)
 
@@ -108,37 +108,72 @@ export const Shape = track(function Shape({
 	const util = app.getShapeUtil(shape)
 
 	return (
-		<div
-			key={id}
-			ref={rContainer}
-			className="tl-shape"
-			data-shape-type={shape.type}
-			draggable={false}
-			onPointerDown={events.onPointerDown}
-			onPointerMove={events.onPointerMove}
-			onPointerUp={events.onPointerUp}
-			onPointerEnter={events.onPointerEnter}
-			onPointerLeave={events.onPointerLeave}
-		>
-			{isCulled && util.canUnmount(shape) ? (
-				<CulledShape shape={shape} util={util} />
-			) : (
-				<OptionalErrorBoundary
-					fallback={ShapeErrorFallback ? (error) => <ShapeErrorFallback error={error} /> : null}
-					onError={(error) =>
-						app.annotateError(error, { origin: 'react.shape', willCrashApp: false })
-					}
+		<>
+			{util.renderBackground && (
+				<div
+					ref={backgroundContainerRef}
+					className="tl-shape tl-shape-background"
+					data-shape-type={shape.type}
+					draggable={false}
 				>
-					<InnerShape shape={shape} util={util} />
-				</OptionalErrorBoundary>
+					{isCulled ? (
+						<CulledShape shape={shape} util={util} />
+					) : (
+						<OptionalErrorBoundary
+							fallback={ShapeErrorFallback ? (error) => <ShapeErrorFallback error={error} /> : null}
+							onError={(error) =>
+								app.annotateError(error, { origin: 'react.shape', willCrashApp: false })
+							}
+						>
+							<InnerShapeBackground shape={shape} util={util} />
+						</OptionalErrorBoundary>
+					)}
+				</div>
 			)}
-		</div>
+			<div
+				ref={containerRef}
+				className="tl-shape"
+				data-shape-type={shape.type}
+				draggable={false}
+				onPointerDown={events.onPointerDown}
+				onPointerMove={events.onPointerMove}
+				onPointerUp={events.onPointerUp}
+				onPointerEnter={events.onPointerEnter}
+				onPointerLeave={events.onPointerLeave}
+			>
+				{isCulled && util.canUnmount(shape) ? (
+					<CulledShape shape={shape} util={util} />
+				) : (
+					<OptionalErrorBoundary
+						fallback={ShapeErrorFallback ? (error) => <ShapeErrorFallback error={error} /> : null}
+						onError={(error) =>
+							app.annotateError(error, { origin: 'react.shape', willCrashApp: false })
+						}
+					>
+						<InnerShape shape={shape} util={util} />
+					</OptionalErrorBoundary>
+				)}
+			</div>
+		</>
 	)
 })
 
 const InnerShape = React.memo(
 	function InnerShape<T extends TLShape>({ shape, util }: { shape: T; util: TLShapeUtil<T> }) {
 		return useStateTracking('InnerShape:' + util.type, () => util.render(shape))
+	},
+	(prev, next) => prev.shape.props === next.shape.props
+)
+
+const InnerShapeBackground = React.memo(
+	function InnerShapeBackground<T extends TLShape>({
+		shape,
+		util,
+	}: {
+		shape: T
+		util: TLShapeUtil<T>
+	}) {
+		return useStateTracking('InnerShape:' + util.type, () => util.renderBackground?.(shape))
 	},
 	(prev, next) => prev.shape.props === next.shape.props
 )

--- a/packages/editor/src/lib/test/commands/__snapshots__/getSvg.test.ts.snap
+++ b/packages/editor/src/lib/test/commands/__snapshots__/getSvg.test.ts.snap
@@ -1,14 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Matches a snapshot: Basic SVG 1`] = `
-"<svg direction=\\"ltr\\" width=\\"564\\" height=\\"564\\" viewBox=\\"-32 -32 564 564\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"background-color: transparent;\\"><defs><mask id=\\"hash_pattern_mask\\">
-					<rect x=\\"0\\" y=\\"0\\" width=\\"8\\" height=\\"8\\" fill=\\"white\\"></rect>
-					<g strokelinecap=\\"round\\" stroke=\\"black\\">
-						<line x1=\\"0.6666666666666666\\" y1=\\"2\\" x2=\\"2\\" y2=\\"0.6666666666666666\\"></line>
-						<line x1=\\"3.333333333333333\\" y1=\\"4.666666666666666\\" x2=\\"4.666666666666666\\" y2=\\"3.333333333333333\\"></line>
-						<line x1=\\"6\\" y1=\\"7.333333333333333\\" x2=\\"7.333333333333333\\" y2=\\"6\\"></line>
-					</g>
-				</mask><pattern id=\\"hash_pattern\\" width=\\"8\\" height=\\"8\\" patternUnits=\\"userSpaceOnUse\\">
-					<rect x=\\"0\\" y=\\"0\\" width=\\"8\\" height=\\"8\\" fill=\\"\\" mask=\\"url(#hash_pattern_mask)\\"></rect>
-				</pattern><style></style></defs><g transform=\\"matrix(1, 0, 0, 1, 0, 0)\\" opacity=\\"1\\"><path d=\\"M0, 0L100, 0,100, 100,0, 100Z\\" stroke-width=\\"3.5\\" stroke=\\"\\" fill=\\"none\\"></path><g><text font-size=\\"22px\\" font-family=\\"\\" font-style=\\"normal\\" font-weight=\\"normal\\" line-height=\\"29.700000000000003px\\" dominant-baseline=\\"mathematical\\" alignment-baseline=\\"mathematical\\"><tspan alignment-baseline=\\"mathematical\\" x=\\"16px\\" y=\\"-181px\\">Hello&nbsp;world</tspan></text><text font-size=\\"22px\\" font-family=\\"\\" font-style=\\"normal\\" font-weight=\\"normal\\" line-height=\\"29.700000000000003px\\" dominant-baseline=\\"mathematical\\" alignment-baseline=\\"mathematical\\" fill=\\"\\" stroke=\\"none\\"><tspan alignment-baseline=\\"mathematical\\" x=\\"16px\\" y=\\"-181px\\">Hello&nbsp;world</tspan></text></g></g><path d=\\"M0, 0L50, 0,50, 50,0, 50Z\\" stroke-width=\\"3.5\\" stroke=\\"\\" fill=\\"none\\" transform=\\"matrix(1, 0, 0, 1, 100, 100)\\" opacity=\\"1\\"></path><path d=\\"M0, 0L100, 0,100, 100,0, 100Z\\" stroke-width=\\"3.5\\" stroke=\\"\\" fill=\\"none\\" transform=\\"matrix(1, 0, 0, 1, 400, 400)\\" opacity=\\"1\\"></path></svg>"
+<wrapper>
+  <svg
+    direction="ltr"
+    height="564"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    style="background-color: transparent;"
+    viewBox="-32 -32 564 564"
+    width="564"
+  >
+    <defs>
+      <mask
+        id="hash_pattern_mask"
+      >
+        
+					
+        <rect
+          fill="white"
+          height="8"
+          width="8"
+          x="0"
+          y="0"
+        />
+        
+					
+        <g
+          stroke="black"
+          strokelinecap="round"
+        >
+          
+						
+          <line
+            x1="0.6666666666666666"
+            x2="2"
+            y1="2"
+            y2="0.6666666666666666"
+          />
+          
+						
+          <line
+            x1="3.333333333333333"
+            x2="4.666666666666666"
+            y1="4.666666666666666"
+            y2="3.333333333333333"
+          />
+          
+						
+          <line
+            x1="6"
+            x2="7.333333333333333"
+            y1="7.333333333333333"
+            y2="6"
+          />
+          
+					
+        </g>
+        
+				
+      </mask>
+      <pattern
+        height="8"
+        id="hash_pattern"
+        patternUnits="userSpaceOnUse"
+        width="8"
+      >
+        
+					
+        <rect
+          fill=""
+          height="8"
+          mask="url(#hash_pattern_mask)"
+          width="8"
+          x="0"
+          y="0"
+        />
+        
+				
+      </pattern>
+      <style />
+    </defs>
+    <g
+      opacity="1"
+      transform="matrix(1, 0, 0, 1, 0, 0)"
+    >
+      <g>
+        <path
+          d="M0, 0L100, 0,100, 100,0, 100Z"
+          fill="none"
+          stroke=""
+          stroke-width="3.5"
+        />
+        <g>
+          <text
+            alignment-baseline="mathematical"
+            dominant-baseline="mathematical"
+            font-family=""
+            font-size="22px"
+            font-style="normal"
+            font-weight="normal"
+            line-height="29.700000000000003px"
+          >
+            <tspan
+              alignment-baseline="mathematical"
+              x="16px"
+              y="-181px"
+            >
+              Hello world
+            </tspan>
+          </text>
+          <text
+            alignment-baseline="mathematical"
+            dominant-baseline="mathematical"
+            fill=""
+            font-family=""
+            font-size="22px"
+            font-style="normal"
+            font-weight="normal"
+            line-height="29.700000000000003px"
+            stroke="none"
+          >
+            <tspan
+              alignment-baseline="mathematical"
+              x="16px"
+              y="-181px"
+            >
+              Hello world
+            </tspan>
+          </text>
+        </g>
+      </g>
+    </g>
+    <g
+      opacity="1"
+      transform="matrix(1, 0, 0, 1, 100, 100)"
+    >
+      <path
+        d="M0, 0L50, 0,50, 50,0, 50Z"
+        fill="none"
+        stroke=""
+        stroke-width="3.5"
+      />
+    </g>
+    <g
+      opacity="1"
+      transform="matrix(1, 0, 0, 1, 400, 400)"
+    >
+      <path
+        d="M0, 0L100, 0,100, 100,0, 100Z"
+        fill="none"
+        stroke=""
+        stroke-width="3.5"
+      />
+    </g>
+  </svg>
+</wrapper>
 `;

--- a/packages/editor/src/lib/test/commands/getSvg.test.ts
+++ b/packages/editor/src/lib/test/commands/getSvg.test.ts
@@ -85,7 +85,7 @@ it('Matches a snapshot', async () => {
 	const elm = document.createElement('wrapper')
 	elm.appendChild(svg)
 
-	expect(elm.innerHTML).toMatchSnapshot('Basic SVG')
+	expect(elm).toMatchSnapshot('Basic SVG')
 })
 
 it('Accepts a scale option', async () => {

--- a/packages/primitives/src/lib/Box2d.ts
+++ b/packages/primitives/src/lib/Box2d.ts
@@ -315,8 +315,8 @@ export class Box2d {
 	union(box: Box2dModel) {
 		const minX = Math.min(this.minX, box.x)
 		const minY = Math.min(this.minY, box.y)
-		const maxX = Math.max(this.maxX, this.maxX)
-		const maxY = Math.max(this.maxY, this.maxY)
+		const maxX = Math.max(this.maxX, box.w + box.x)
+		const maxY = Math.max(this.maxY, box.h + box.y)
 
 		this.x = minX
 		this.y = minY

--- a/packages/primitives/src/lib/Box2d.ts
+++ b/packages/primitives/src/lib/Box2d.ts
@@ -315,8 +315,8 @@ export class Box2d {
 	union(box: Box2dModel) {
 		const minX = Math.min(this.minX, box.x)
 		const minY = Math.min(this.minY, box.y)
-		const maxX = Math.max(this.maxX, box.x + box.w)
-		const maxY = Math.max(this.maxY, box.y + box.h)
+		const maxX = Math.max(this.maxX, this.maxX)
+		const maxY = Math.max(this.maxY, this.maxY)
 
 		this.x = minX
 		this.y = minY


### PR DESCRIPTION
This diff modifies our canvas/rendering code to support shapes rendering into a "background layer". The background layer isn't a layer in the sense of our own html/svg/indicator layers, but is instead part of the HTML canvas layer and is created by allocating z-indexes to shapes below all others.

For most shapes, the background starts at the canvas. If a shape is in a frame, then the frame is treated as the background.

![Kapture 2023-05-19 at 11 38 12](https://github.com/tldraw/tldraw/assets/1489520/3ab6e0c0-f71e-4bfd-a996-c5411be28a71)

Exports now use the `renderingShapes` algorithm which fixed a small bug with exports where opacity wouldn't get correctly propagated down through child shapes.

### The plan
1. initial highlighter shape/tool #1401 
2. sandwich rendering for highlighter shapes #1418  **>you are here<**
3. shape styling - new colours and sizes, lightweight perfect freehand changes

### Change Type

- [x] `minor` — New Feature


### Test Plan

not yet!

- [x] Unit Tests

### Release Notes

[not yet!]
