### PR TITLE
[fix] reorder handles in front of selection

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -407,54 +407,54 @@ input,
 }
 
 .tl-collaborator__brush {
-	z-index: 11;
+	z-index: 20;
 }
 
 .tl-collaborator__shape-indicator {
-	z-index: 12;
-}
-
-.tl-user-handles {
-	z-index: 50;
+	z-index: 30;
 }
 
 .tl-user-scribble {
-	z-index: 52;
+	z-index: 40;
 }
 
 .tl-user-brush {
-	z-index: 51;
+	z-index: 50;
 }
 
 .tl-user-indicator__selected {
-	z-index: 51;
+	z-index: 60;
 }
 
 .tl-user-indicator__hovered {
-	z-index: 52;
+	z-index: 70;
+}
+
+.tl-user-handles {
+	z-index: 80;
 }
 
 .tl-user-snapline {
-	z-index: 53;
+	z-index: 90;
 }
 
 .tl-selection__fg {
 	pointer-events: none;
-	z-index: 54;
+	z-index: 100;
 }
 
 .tl-user-indicator__hint {
-	z-index: 55;
+	z-index: 110;
 	stroke-width: calc(2.5px * var(--tl-scale));
 }
 
 /* behind collaborator cursor */
 .tl-collaborator__cursor-hint {
-	z-index: 56;
+	z-index: 120;
 }
 
 .tl-collaborator__cursor {
-	z-index: 57;
+	z-index: 130;
 }
 
 .tl-cursor {


### PR DESCRIPTION
This PR places handles in front of selection.

<img width="742" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/22640acf-54dc-4c69-a041-4187088005b5">

### Change Type

- [x] `patch` — Bug Fix

### Release Notes

- Fix a bug where handles would appear behind selection indicators.