### PR TITLE
Bump version.

### DIFF
--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
Bump vs code version. I build the extension from the `release-2023-05-16` branch, but didn't push the changes there as we never pull them back to main. So I'm making this change here.

### Change Type

- [x] `patch` — Bug Fix


