### PR TITLE
[chore] remove yarnrc-private.yml

### DIFF
--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -4,9 +4,6 @@ name: Publish new version of public packages
 # Package publishing is manually triggered on github actions dashboard
 on: workflow_dispatch
 
-env:
-  YARN_RC_FILENAME: .yarnrc-private.yml
-
 jobs:
   deploy:
     name: 'Publish new version of public packages'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# if the folder we're in is called "bublic", set YARN_RC_FILENAME:
-if [ "$(basename "$(pwd)")" = "bublic" ]; then
-  export YARN_RC_FILENAME=.yarnrc-private.yml
-fi
-
 npx lazy run build-api
 git add packages/*/api-report.md
 npx lint-staged


### PR DESCRIPTION
This is a legacy of the chicken run.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package (will not publish a new version)

