### PR TITLE
Fix issue template label not getting applied

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: File a feature request
 title: '[Feature]: '
-labels: ['feature', 'triage']
+labels: ['enhancement']
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
This PR *should* fix our issue templates not working correctly.

Before: No label was getting assigned to feature requests.
After: We add the 'enhancement' label to them.

### Change Type

- [x] `patch` — Bug Fix
