### PR TITLE
Stricter ID types

### DIFF
--- a/apps/vscode/extension/src/WebViewMessageHandler.ts
+++ b/apps/vscode/extension/src/WebViewMessageHandler.ts
@@ -1,4 +1,4 @@
-import { BaseRecord } from '@tldraw/tlstore'
+import { UnknownRecord } from '@tldraw/tlstore'
 import { isEqual } from 'lodash'
 import fetch from 'node-fetch'
 import * as vscode from 'vscode'
@@ -173,7 +173,7 @@ export class WebViewMessageHandler {
 		}
 	}
 
-	private omit = (records: BaseRecord<any>[], keys: RegExp) => {
+	private omit = (records: UnknownRecord[], keys: RegExp) => {
 		return records.filter((record) => {
 			return !record.id.match(keys)
 		})

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -7,7 +7,6 @@
 /// <reference types="react" />
 
 import { Atom } from 'signia';
-import { BaseRecord } from '@tldraw/tlstore';
 import { Box2d } from '@tldraw/primitives';
 import { Box2dModel } from '@tldraw/tlschema';
 import { Computed } from 'signia';
@@ -25,7 +24,6 @@ import { getIndicesAbove } from '@tldraw/indices';
 import { getIndicesBelow } from '@tldraw/indices';
 import { getIndicesBetween } from '@tldraw/indices';
 import { HistoryEntry } from '@tldraw/tlstore';
-import { ID } from '@tldraw/tlstore';
 import { MatLike } from '@tldraw/primitives';
 import { Matrix2d } from '@tldraw/primitives';
 import { Matrix2dModel } from '@tldraw/primitives';
@@ -103,6 +101,7 @@ import { TLUserId } from '@tldraw/tlschema';
 import { TLUserPresence } from '@tldraw/tlschema';
 import { TLVideoAsset } from '@tldraw/tlschema';
 import { TLVideoShape } from '@tldraw/tlschema';
+import { UnknownRecord } from '@tldraw/tlstore';
 import { ValidatorsForShapes } from '@tldraw/tlschema';
 import { Vec2d } from '@tldraw/primitives';
 import { Vec2dModel } from '@tldraw/tlschema';
@@ -1729,7 +1728,7 @@ export type TLCancelEventInfo = {
 };
 
 // @public (undocumented)
-export type TLChange<T extends BaseRecord<any> = any> = HistoryEntry<T>;
+export type TLChange<T extends UnknownRecord = any> = HistoryEntry<T>;
 
 // @public (undocumented)
 export type TLClickEvent = (info: TLClickEventInfo) => void;
@@ -2109,7 +2108,7 @@ export class TLGeoUtil extends TLBoxUtil<TLGeoShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLGeoShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2138,7 +2137,7 @@ export class TLGeoUtil extends TLBoxUtil<TLGeoShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLGeoShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2153,7 +2152,7 @@ export class TLGeoUtil extends TLBoxUtil<TLGeoShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLGeoShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | {
         props: {
@@ -2166,7 +2165,7 @@ export class TLGeoUtil extends TLBoxUtil<TLGeoShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLGeoShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2344,7 +2343,7 @@ export class TLNoteUtil extends TLShapeUtil<TLNoteShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLNoteShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2366,7 +2365,7 @@ export class TLNoteUtil extends TLShapeUtil<TLNoteShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLNoteShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2557,7 +2556,7 @@ export class TLTextUtil extends TLShapeUtil<TLTextShape> {
         parentId: TLParentId;
         isLocked: boolean;
         props: TLTextShapeProps;
-        id: ID<TLTextShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
@@ -2580,19 +2579,19 @@ export class TLTextUtil extends TLShapeUtil<TLTextShape> {
         index: string;
         parentId: TLParentId;
         isLocked: boolean;
-        id: ID<TLTextShape>;
+        id: TLShapeId;
         typeName: "shape";
     } | undefined;
     // (undocumented)
     onDoubleClickEdge: (shape: TLTextShape) => {
-        id: ID<TLTextShape>;
+        id: TLShapeId;
         type: "text";
         props: {
             autoSize: boolean;
             scale?: undefined;
         };
     } | {
-        id: ID<TLTextShape>;
+        id: TLShapeId;
         type: "text";
         props: {
             scale: number;

--- a/packages/editor/src/lib/app/App.ts
+++ b/packages/editor/src/lib/app/App.ts
@@ -63,7 +63,7 @@ import {
 	isShape,
 	isShapeId,
 } from '@tldraw/tlschema'
-import { BaseRecord, ComputedCache, HistoryEntry } from '@tldraw/tlstore'
+import { ComputedCache, HistoryEntry, UnknownRecord } from '@tldraw/tlstore'
 import {
 	annotateError,
 	compact,
@@ -138,7 +138,7 @@ import { RequiredKeys } from './types/misc-types'
 import { TLResizeHandle } from './types/selection-types'
 
 /** @public */
-export type TLChange<T extends BaseRecord<any> = any> = HistoryEntry<T>
+export type TLChange<T extends UnknownRecord = any> = HistoryEntry<T>
 
 /** @public */
 export type AnimationOptions = Partial<{

--- a/packages/file-format/api-report.md
+++ b/packages/file-format/api-report.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { App } from '@tldraw/editor';
-import { BaseRecord } from '@tldraw/tlstore';
 import { MigrationFailureReason } from '@tldraw/tlstore';
 import { Result } from '@tldraw/utils';
 import { SerializedSchema } from '@tldraw/tlstore';
@@ -15,6 +14,7 @@ import { TLStore } from '@tldraw/editor';
 import { TLTranslationKey } from '@tldraw/ui';
 import { TLUserId } from '@tldraw/editor';
 import { ToastsContextType } from '@tldraw/ui';
+import { UnknownRecord } from '@tldraw/tlstore';
 
 // @public (undocumented)
 export function isV1File(data: any): boolean;
@@ -45,7 +45,7 @@ export const TLDRAW_FILE_MIMETYPE: "application/vnd.tldraw+json";
 // @public (undocumented)
 export interface TldrawFile {
     // (undocumented)
-    records: BaseRecord[];
+    records: UnknownRecord[];
     // (undocumented)
     schema: SerializedSchema;
     // (undocumented)

--- a/packages/file-format/src/lib/file.ts
+++ b/packages/file-format/src/lib/file.ts
@@ -10,12 +10,12 @@ import {
 	TLUserId,
 } from '@tldraw/editor'
 import {
-	BaseRecord,
 	ID,
 	MigrationFailureReason,
 	MigrationResult,
 	SerializedSchema,
 	StoreSnapshot,
+	UnknownRecord,
 } from '@tldraw/tlstore'
 import { T } from '@tldraw/tlvalidate'
 import { TLTranslationKey, ToastsContextType } from '@tldraw/ui'
@@ -35,7 +35,7 @@ const LATEST_TLDRAW_FILE_FORMAT_VERSION = 1
 export interface TldrawFile {
 	tldrawFileFormatVersion: number
 	schema: SerializedSchema
-	records: BaseRecord[]
+	records: UnknownRecord[]
 }
 
 const tldrawFileValidator: T.Validator<TldrawFile> = T.object({

--- a/packages/file-format/src/test/file.test.ts
+++ b/packages/file-format/src/test/file.test.ts
@@ -1,5 +1,5 @@
 import { createCustomShapeId, TldrawEditorConfig, TLInstance, TLUser } from '@tldraw/editor'
-import { BaseRecord, MigrationFailureReason } from '@tldraw/tlstore'
+import { MigrationFailureReason, UnknownRecord } from '@tldraw/tlstore'
 import { assert } from '@tldraw/utils'
 import { parseTldrawJsonFile as _parseTldrawJsonFile, TldrawFile } from '../lib/file'
 
@@ -100,7 +100,7 @@ describe('parseTldrawJsonFile', () => {
 						id: createCustomShapeId('shape'),
 						type: 'geo',
 						props: {},
-					} as BaseRecord,
+					} as UnknownRecord,
 				],
 			})
 		)

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -14,6 +14,7 @@ import { StoreSchema } from '@tldraw/tlstore';
 import { StoreSchemaOptions } from '@tldraw/tlstore';
 import { StoreSnapshot } from '@tldraw/tlstore';
 import { T } from '@tldraw/tlvalidate';
+import { UnknownRecord } from '@tldraw/tlstore';
 
 // @internal (undocumented)
 export const alignValidator: T.Validator<"end" | "middle" | "start">;
@@ -370,7 +371,7 @@ export const iconShapeTypeValidator: T.Validator<TLIconShape>;
 export const iconValidator: T.Validator<"activity" | "airplay" | "alert-circle" | "alert-octagon" | "alert-triangle" | "align-center" | "align-justify" | "align-left" | "align-right" | "anchor" | "aperture" | "archive" | "arrow-down-circle" | "arrow-down-left" | "arrow-down-right" | "arrow-down" | "arrow-left-circle" | "arrow-left" | "arrow-right-circle" | "arrow-right" | "arrow-up-circle" | "arrow-up-left" | "arrow-up-right" | "arrow-up" | "at-sign" | "award" | "bar-chart-2" | "bar-chart" | "battery-charging" | "battery" | "bell-off" | "bell" | "bluetooth" | "bold" | "book-open" | "book" | "bookmark" | "briefcase" | "calendar" | "camera-off" | "camera" | "cast" | "check-circle" | "check-square" | "check" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up" | "chevrons-down" | "chevrons-left" | "chevrons-right" | "chevrons-up" | "chrome" | "circle" | "clipboard" | "clock" | "cloud-drizzle" | "cloud-lightning" | "cloud-off" | "cloud-rain" | "cloud-snow" | "cloud" | "codepen" | "codesandbox" | "coffee" | "columns" | "command" | "compass" | "copy" | "corner-down-left" | "corner-down-right" | "corner-left-down" | "corner-left-up" | "corner-right-down" | "corner-right-up" | "corner-up-left" | "corner-up-right" | "cpu" | "credit-card" | "crop" | "crosshair" | "database" | "delete" | "disc" | "divide-circle" | "divide-square" | "divide" | "dollar-sign" | "download-cloud" | "download" | "dribbble" | "droplet" | "edit-2" | "edit-3" | "edit" | "external-link" | "eye-off" | "eye" | "facebook" | "fast-forward" | "feather" | "figma" | "file-minus" | "file-plus" | "file-text" | "file" | "film" | "filter" | "flag" | "folder-minus" | "folder-plus" | "folder" | "framer" | "frown" | "geo" | "gift" | "git-branch" | "git-commit" | "git-merge" | "git-pull-request" | "github" | "gitlab" | "globe" | "grid" | "hard-drive" | "hash" | "headphones" | "heart" | "help-circle" | "hexagon" | "home" | "image" | "inbox" | "info" | "instagram" | "italic" | "key" | "layers" | "layout" | "life-buoy" | "link-2" | "link" | "linkedin" | "list" | "loader" | "lock" | "log-in" | "log-out" | "mail" | "map-pin" | "map" | "maximize-2" | "maximize" | "meh" | "menu" | "message-circle" | "message-square" | "mic-off" | "mic" | "minimize-2" | "minimize" | "minus-circle" | "minus-square" | "minus" | "monitor" | "moon" | "more-horizontal" | "more-vertical" | "mouse-pointer" | "move" | "music" | "navigation-2" | "navigation" | "octagon" | "package" | "paperclip" | "pause-circle" | "pause" | "pen-tool" | "percent" | "phone-call" | "phone-forwarded" | "phone-incoming" | "phone-missed" | "phone-off" | "phone-outgoing" | "phone" | "pie-chart" | "play-circle" | "play" | "plus-circle" | "plus-square" | "plus" | "pocket" | "power" | "printer" | "radio" | "refresh-ccw" | "refresh-cw" | "repeat" | "rewind" | "rotate-ccw" | "rotate-cw" | "rss" | "save" | "scissors" | "search" | "send" | "server" | "settings" | "share-2" | "share" | "shield-off" | "shield" | "shopping-bag" | "shopping-cart" | "shuffle" | "sidebar" | "skip-back" | "skip-forward" | "slack" | "slash" | "sliders" | "smartphone" | "smile" | "speaker" | "square" | "star" | "stop-circle" | "sun" | "sunrise" | "sunset" | "table" | "tablet" | "tag" | "target" | "terminal" | "thermometer" | "thumbs-down" | "thumbs-up" | "toggle-left" | "toggle-right" | "tool" | "trash-2" | "trash" | "trello" | "trending-down" | "trending-up" | "triangle" | "truck" | "tv" | "twitch" | "twitter" | "type" | "umbrella" | "underline" | "unlock" | "upload-cloud" | "upload" | "user-check" | "user-minus" | "user-plus" | "user-x" | "user" | "users" | "video-off" | "video" | "voicemail" | "volume-1" | "volume-2" | "volume-x" | "volume" | "watch" | "wifi-off" | "wifi" | "wind" | "x-circle" | "x-octagon" | "x-square" | "x" | "youtube" | "zap-off" | "zap" | "zoom-in" | "zoom-out">;
 
 // @internal (undocumented)
-export function idValidator<Id extends ID<BaseRecord<any>>>(prefix: Id['__type__']['typeName']): T.Validator<Id>;
+export function idValidator<Id extends ID<UnknownRecord>>(prefix: Id['__type__']['typeName']): T.Validator<Id>;
 
 // @public (undocumented)
 export const imageAssetMigrations: Migrations;
@@ -400,7 +401,7 @@ export const instanceTypeMigrations: Migrations;
 export const instanceTypeValidator: T.Validator<TLInstance>;
 
 // @public (undocumented)
-export function isShape(record?: BaseRecord<string>): record is TLShape;
+export function isShape(record?: UnknownRecord): record is TLShape;
 
 // @public (undocumented)
 export function isShapeId(id?: string): id is TLShapeId;
@@ -626,7 +627,7 @@ export type TLAssetShape = Extract<TLShape, {
 }>;
 
 // @public (undocumented)
-export interface TLBaseAsset<Type extends string, Props> extends BaseRecord<'asset'> {
+export interface TLBaseAsset<Type extends string, Props> extends BaseRecord<'asset', TLAssetId> {
     // (undocumented)
     props: Props;
     // (undocumented)
@@ -634,7 +635,7 @@ export interface TLBaseAsset<Type extends string, Props> extends BaseRecord<'ass
 }
 
 // @public (undocumented)
-export interface TLBaseShape<Type extends string, Props extends object> extends BaseRecord<'shape'> {
+export interface TLBaseShape<Type extends string, Props extends object> extends BaseRecord<'shape', TLShapeId> {
     // (undocumented)
     index: string;
     // (undocumented)
@@ -682,7 +683,7 @@ export type TLBookmarkShapeProps = {
 };
 
 // @public
-export interface TLCamera extends BaseRecord<'camera'> {
+export interface TLCamera extends BaseRecord<'camera', TLCameraId> {
     // (undocumented)
     x: number;
     // (undocumented)
@@ -733,7 +734,7 @@ export interface TLDashStyle extends TLBaseStyle {
 export type TLDashType = SetValue<typeof TL_DASH_TYPES>;
 
 // @public
-export interface TLDocument extends BaseRecord<'document'> {
+export interface TLDocument extends BaseRecord<'document', ID<TLDocument>> {
     // (undocumented)
     gridSize: number;
 }
@@ -960,7 +961,7 @@ export type TLImageShapeProps = {
 };
 
 // @public
-export interface TLInstance extends BaseRecord<'instance'> {
+export interface TLInstance extends BaseRecord<'instance', TLInstanceId> {
     // (undocumented)
     brush: Box2dModel | null;
     // (undocumented)
@@ -996,7 +997,7 @@ export const TLInstance: RecordType<TLInstance, "currentPageId" | "userId">;
 export type TLInstanceId = ID<TLInstance>;
 
 // @public
-export interface TLInstancePageState extends BaseRecord<'instance_page_state'> {
+export interface TLInstancePageState extends BaseRecord<'instance_page_state', TLInstancePageStateId> {
     // (undocumented)
     cameraId: ID<TLCamera>;
     // (undocumented)
@@ -1026,7 +1027,7 @@ export const TLInstancePageState: RecordType<TLInstancePageState, "cameraId" | "
 export type TLInstancePageStateId = ID<TLInstancePageState>;
 
 // @public (undocumented)
-export interface TLInstancePresence extends BaseRecord<'instance_presence'> {
+export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceID> {
     // (undocumented)
     brush: Box2dModel | null;
     // (undocumented)
@@ -1117,7 +1118,7 @@ export interface TLOpacityStyle extends TLBaseStyle {
 export type TLOpacityType = SetValue<typeof TL_OPACITY_TYPES>;
 
 // @public
-export interface TLPage extends BaseRecord<'page'> {
+export interface TLPage extends BaseRecord<'page', TLPageId> {
     // (undocumented)
     index: string;
     // (undocumented)
@@ -1150,7 +1151,7 @@ export type TLScribble = {
 export type TLShape = TLArrowShape | TLBookmarkShape | TLDrawShape | TLEmbedShape | TLFrameShape | TLGeoShape | TLGroupShape | TLIconShape | TLImageShape | TLLineShape | TLNoteShape | TLTextShape | TLUnknownShape | TLVideoShape;
 
 // @public (undocumented)
-export type TLShapeId = ID<TLBaseShape<any, any>>;
+export type TLShapeId = ID<TLUnknownShape>;
 
 // @public (undocumented)
 export type TLShapePartial<T extends TLShape = TLShape> = T extends T ? {
@@ -1266,7 +1267,7 @@ export type TLUiColorType = SetValue<typeof TL_UI_COLOR_TYPES>;
 export type TLUnknownShape = TLBaseShape<string, object>;
 
 // @public
-export interface TLUser extends BaseRecord<'user'> {
+export interface TLUser extends BaseRecord<'user', TLUserId> {
     // (undocumented)
     locale: string;
     // (undocumented)
@@ -1277,7 +1278,7 @@ export interface TLUser extends BaseRecord<'user'> {
 export const TLUser: RecordType<TLUser, never>;
 
 // @public
-export interface TLUserDocument extends BaseRecord<'user_document'> {
+export interface TLUserDocument extends BaseRecord<'user_document', TLUserDocumentId> {
     // (undocumented)
     isDarkMode: boolean;
     // (undocumented)
@@ -1306,7 +1307,7 @@ export type TLUserDocumentId = ID<TLUserDocument>;
 export type TLUserId = ID<TLUser>;
 
 // @public (undocumented)
-export interface TLUserPresence extends BaseRecord<'user_presence'> {
+export interface TLUserPresence extends BaseRecord<'user_presence', TLUserPresenceId> {
     // (undocumented)
     color: string;
     // (undocumented)

--- a/packages/tlschema/src/assets/asset-validation.ts
+++ b/packages/tlschema/src/assets/asset-validation.ts
@@ -4,7 +4,7 @@ import { TLAssetId } from '../records/TLAsset'
 import { assetIdValidator } from '../validation'
 
 /** @public */
-export interface TLBaseAsset<Type extends string, Props> extends BaseRecord<'asset'> {
+export interface TLBaseAsset<Type extends string, Props> extends BaseRecord<'asset', TLAssetId> {
 	type: Type
 	props: Props
 }

--- a/packages/tlschema/src/records/TLCamera.ts
+++ b/packages/tlschema/src/records/TLCamera.ts
@@ -7,7 +7,7 @@ import { idValidator } from '../validation'
  *
  * @public
  */
-export interface TLCamera extends BaseRecord<'camera'> {
+export interface TLCamera extends BaseRecord<'camera', TLCameraId> {
 	x: number
 	y: number
 	z: number

--- a/packages/tlschema/src/records/TLDocument.ts
+++ b/packages/tlschema/src/records/TLDocument.ts
@@ -6,7 +6,7 @@ import { T } from '@tldraw/tlvalidate'
  *
  * @public
  */
-export interface TLDocument extends BaseRecord<'document'> {
+export interface TLDocument extends BaseRecord<'document', ID<TLDocument>> {
 	gridSize: number
 }
 

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -34,7 +34,7 @@ export type TLInstancePropsForNextShape = Pick<TLShapeProps, TLStyleType>
  *
  * @public
  */
-export interface TLInstance extends BaseRecord<'instance'> {
+export interface TLInstance extends BaseRecord<'instance', TLInstanceId> {
 	userId: TLUserId
 	currentPageId: TLPageId
 	followingUserId: TLUserId | null

--- a/packages/tlschema/src/records/TLInstancePageState.ts
+++ b/packages/tlschema/src/records/TLInstancePageState.ts
@@ -13,7 +13,8 @@ import { TLShapeId } from './TLShape'
  *
  * @public
  */
-export interface TLInstancePageState extends BaseRecord<'instance_page_state'> {
+export interface TLInstancePageState
+	extends BaseRecord<'instance_page_state', TLInstancePageStateId> {
 	instanceId: ID<TLInstance>
 	pageId: ID<TLPage>
 	cameraId: ID<TLCamera>

--- a/packages/tlschema/src/records/TLInstancePresence.ts
+++ b/packages/tlschema/src/records/TLInstancePresence.ts
@@ -9,7 +9,7 @@ import { TLShapeId } from './TLShape'
 import { TLUserId } from './TLUser'
 
 /** @public */
-export interface TLInstancePresence extends BaseRecord<'instance_presence'> {
+export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceID> {
 	instanceId: TLInstanceId
 	userId: TLUserId
 	userName: string

--- a/packages/tlschema/src/records/TLPage.ts
+++ b/packages/tlschema/src/records/TLPage.ts
@@ -7,7 +7,7 @@ import { pageIdValidator } from '../validation'
  *
  * @public
  */
-export interface TLPage extends BaseRecord<'page'> {
+export interface TLPage extends BaseRecord<'page', TLPageId> {
 	name: string
 	index: string
 }

--- a/packages/tlschema/src/records/TLShape.ts
+++ b/packages/tlschema/src/records/TLShape.ts
@@ -1,4 +1,4 @@
-import { BaseRecord, defineMigrations, ID } from '@tldraw/tlstore'
+import { defineMigrations, ID, UnknownRecord } from '@tldraw/tlstore'
 import { nanoid } from 'nanoid'
 import { TLBaseShape } from '../shapes/shape-validation'
 import { TLArrowShape } from '../shapes/TLArrowShape'
@@ -54,7 +54,7 @@ export type TLShapePartial<T extends TLShape = TLShape> = T extends T
 	: never
 
 /** @public */
-export type TLShapeId = ID<TLBaseShape<any, any>>
+export type TLShapeId = ID<TLUnknownShape>
 
 /** @public */
 export type TLShapeProps = SmooshedUnionObject<TLShape['props']>
@@ -94,7 +94,7 @@ export const rootShapeTypeMigrations = defineMigrations({
 })
 
 /** @public */
-export function isShape(record?: BaseRecord<string>): record is TLShape {
+export function isShape(record?: UnknownRecord): record is TLShape {
 	if (!record) return false
 	return record.typeName === 'shape'
 }

--- a/packages/tlschema/src/records/TLUser.ts
+++ b/packages/tlschema/src/records/TLUser.ts
@@ -8,7 +8,7 @@ import { userIdValidator } from '../validation'
  *
  * @public
  */
-export interface TLUser extends BaseRecord<'user'> {
+export interface TLUser extends BaseRecord<'user', TLUserId> {
 	name: string
 	locale: string
 }

--- a/packages/tlschema/src/records/TLUserDocument.ts
+++ b/packages/tlschema/src/records/TLUserDocument.ts
@@ -12,7 +12,7 @@ import { TLUserId } from './TLUser'
  *
  * @public
  */
-export interface TLUserDocument extends BaseRecord<'user_document'> {
+export interface TLUserDocument extends BaseRecord<'user_document', TLUserDocumentId> {
 	userId: TLUserId
 	isPenMode: boolean
 	isGridMode: boolean

--- a/packages/tlschema/src/records/TLUserPresence.ts
+++ b/packages/tlschema/src/records/TLUserPresence.ts
@@ -6,7 +6,7 @@ import { TLInstanceId } from './TLInstance'
 import { TLUserId } from './TLUser'
 
 /** @public */
-export interface TLUserPresence extends BaseRecord<'user_presence'> {
+export interface TLUserPresence extends BaseRecord<'user_presence', TLUserPresenceId> {
 	userId: TLUserId
 	lastUsedInstanceId: TLInstanceId | null
 	lastActivityTimestamp: number

--- a/packages/tlschema/src/shapes/shape-validation.ts
+++ b/packages/tlschema/src/shapes/shape-validation.ts
@@ -1,11 +1,11 @@
 import { BaseRecord } from '@tldraw/tlstore'
 import { T } from '@tldraw/tlvalidate'
-import { TLParentId } from '../records/TLShape'
+import { TLParentId, TLShapeId } from '../records/TLShape'
 import { parentIdValidator, shapeIdValidator } from '../validation'
 
 /** @public */
 export interface TLBaseShape<Type extends string, Props extends object>
-	extends BaseRecord<'shape'> {
+	extends BaseRecord<'shape', TLShapeId> {
 	type: Type
 	x: number
 	y: number

--- a/packages/tlschema/src/validation.ts
+++ b/packages/tlschema/src/validation.ts
@@ -1,5 +1,4 @@
-import type { ID } from '@tldraw/tlstore'
-import { BaseRecord } from '@tldraw/tlstore'
+import type { ID, UnknownRecord } from '@tldraw/tlstore'
 import { T } from '@tldraw/tlvalidate'
 import type { TLAssetId } from './records/TLAsset'
 import type { TLInstanceId } from './records/TLInstance'
@@ -22,7 +21,7 @@ import {
 } from './style-types'
 
 /** @internal */
-export function idValidator<Id extends ID<BaseRecord<any>>>(
+export function idValidator<Id extends ID<UnknownRecord>>(
 	prefix: Id['__type__']['typeName']
 ): T.Validator<Id> {
 	return T.string.refine((id) => {

--- a/packages/tlstore/api-report.md
+++ b/packages/tlstore/api-report.md
@@ -11,13 +11,17 @@ import { Signal } from 'signia';
 // @public
 export type AllRecords<T extends Store<any>> = ExtractR<ExtractRecordType<T>>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "assertIdType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export function assertIdType<R extends BaseRecord>(id: string | undefined, type: RecordType<R, any>): asserts id is ID<R>;
+export function assertIdType<R extends UnknownRecord>(id: string | undefined, type: RecordType<R, any>): asserts id is ID<R>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "BaseRecord" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export interface BaseRecord<TypeName extends string = string> {
+export interface BaseRecord<TypeName extends string, Id extends ID<UnknownRecord>> {
     // (undocumented)
-    readonly id: ID<this>;
+    readonly id: Id;
     // (undocumented)
     readonly typeName: TypeName;
 }
@@ -34,13 +38,17 @@ export function compareRecordVersions(a: RecordVersion, b: RecordVersion): -1 | 
 // @public (undocumented)
 export const compareSchemas: (a: SerializedSchema, b: SerializedSchema) => -1 | 0 | 1;
 
+// Warning: (ae-incompatible-release-tags) The symbol "ComputedCache" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export type ComputedCache<Data, R extends BaseRecord> = {
-    get(id: ID<R>): Data | undefined;
+export type ComputedCache<Data, R extends UnknownRecord> = {
+    get(id: IdOf<R>): Data | undefined;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "createRecordType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export function createRecordType<R extends BaseRecord>(typeName: R['typeName'], config: {
+export function createRecordType<R extends UnknownRecord>(typeName: R['typeName'], config: {
     migrations?: Migrations;
     validator?: StoreValidator<R>;
     scope: Scope;
@@ -64,19 +72,28 @@ export function defineMigrations<FirstVersion extends EMPTY_SYMBOL | number = EM
 // @public
 export function devFreeze<T>(object: T): T;
 
+// Warning: (ae-incompatible-release-tags) The symbol "getRecordVersion" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export function getRecordVersion(record: BaseRecord, serializedSchema: SerializedSchema): RecordVersion;
+export function getRecordVersion(record: UnknownRecord, serializedSchema: SerializedSchema): RecordVersion;
 
+// Warning: (ae-incompatible-release-tags) The symbol "HistoryEntry" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export type HistoryEntry<R extends BaseRecord = BaseRecord> = {
+export type HistoryEntry<R extends UnknownRecord = UnknownRecord> = {
     changes: RecordsDiff<R>;
     source: 'remote' | 'user';
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "ID" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export type ID<R extends BaseRecord = BaseRecord> = string & {
+export type ID<R extends UnknownRecord> = string & {
     __type__: R;
 };
+
+// @internal (undocumented)
+export type IdOf<R extends UnknownRecord> = R['id'];
 
 // @internal
 export class IncrementalSetConstructor<T> {
@@ -101,8 +118,10 @@ export function migrate<T>({ value, migrations, fromVersion, toVersion, }: {
     toVersion: number;
 }): MigrationResult<T>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "migrateRecord" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export function migrateRecord<R extends BaseRecord>({ record, migrations, fromVersion, toVersion, }: {
+export function migrateRecord<R extends UnknownRecord>({ record, migrations, fromVersion, toVersion, }: {
     record: unknown;
     migrations: Migrations;
     fromVersion: number;
@@ -148,15 +167,19 @@ export interface Migrations extends BaseMigrationsInfo {
     subTypeMigrations?: Record<string, BaseMigrationsInfo>;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "RecordsDiff" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export type RecordsDiff<R extends BaseRecord> = {
-    added: Record<string, R>;
-    updated: Record<string, [from: R, to: R]>;
-    removed: Record<string, R>;
+export type RecordsDiff<R extends UnknownRecord> = {
+    added: Record<IdOf<R>, R>;
+    updated: Record<IdOf<R>, [from: R, to: R]>;
+    removed: Record<IdOf<R>, R>;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "RecordType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export class RecordType<R extends BaseRecord, RequiredProperties extends keyof Omit<R, 'id' | 'typeName'>> {
+export class RecordType<R extends UnknownRecord, RequiredProperties extends keyof Omit<R, 'id' | 'typeName'>> {
     constructor(
     typeName: R['typeName'], config: {
         readonly createDefaultProperties: () => Exclude<OmitMeta<R>, RequiredProperties>;
@@ -173,7 +196,7 @@ export class RecordType<R extends BaseRecord, RequiredProperties extends keyof O
     readonly createDefaultProperties: () => Exclude<OmitMeta<R>, RequiredProperties>;
     createId(): ID<R>;
     isId(id?: string): id is ID<R>;
-    isInstance: (record?: BaseRecord) => record is R;
+    isInstance: (record?: UnknownRecord) => record is R;
     // (undocumented)
     readonly migrations: Migrations;
     parseId(id: string): ID<R>;
@@ -210,11 +233,15 @@ export interface SerializedSchema {
     storeVersion: number;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "squashRecordDiffs" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export function squashRecordDiffs<T extends BaseRecord>(diffs: RecordsDiff<T>[]): RecordsDiff<T>;
+export function squashRecordDiffs<T extends UnknownRecord>(diffs: RecordsDiff<T>[]): RecordsDiff<T>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Store" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export class Store<R extends BaseRecord = BaseRecord, Props = unknown> {
+export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
     constructor(config: {
         initialData?: StoreSnapshot<R>;
         schema: StoreSchema<R, Props>;
@@ -233,8 +260,10 @@ export class Store<R extends BaseRecord = BaseRecord, Props = unknown> {
     extractingChanges(fn: () => void): RecordsDiff<R>;
     // (undocumented)
     _flushHistory(): void;
-    get: <K extends ID<R>>(id: K) => RecFromId<K> | undefined;
-    has: <K extends ID<R>>(id: K) => boolean;
+    // Warning: (ae-incompatible-release-tags) The symbol "get" is marked as @public, but its signature references "IdOf" which is marked as @internal
+    get: <K extends IdOf<R>>(id: K) => RecFromId<K> | undefined;
+    // Warning: (ae-incompatible-release-tags) The symbol "has" is marked as @public, but its signature references "IdOf" which is marked as @internal
+    has: <K extends IdOf<R>>(id: K) => boolean;
     readonly history: Atom<number, RecordsDiff<R>>;
     // @internal (undocumented)
     isPossiblyCorrupted(): boolean;
@@ -250,13 +279,16 @@ export class Store<R extends BaseRecord = BaseRecord, Props = unknown> {
     readonly props: Props;
     put: (records: R[], phaseOverride?: 'initialize') => void;
     readonly query: StoreQueries<R>;
-    remove: (ids: ID<R>[]) => void;
+    // Warning: (ae-incompatible-release-tags) The symbol "remove" is marked as @public, but its signature references "IdOf" which is marked as @internal
+    remove: (ids: IdOf<R>[]) => void;
     // (undocumented)
     readonly schema: StoreSchema<R, Props>;
     serialize: (filter?: ((record: R) => boolean) | undefined) => StoreSnapshot<R>;
     serializeDocumentState: () => StoreSnapshot<R>;
-    unsafeGetWithoutCapture: <K extends ID<R>>(id: K) => RecFromId<K> | undefined;
-    update: <K extends ID<R>>(id: K, updater: (record: RecFromId<K>) => RecFromId<K>) => void;
+    // Warning: (ae-incompatible-release-tags) The symbol "unsafeGetWithoutCapture" is marked as @public, but its signature references "IdOf" which is marked as @internal
+    unsafeGetWithoutCapture: <K extends IdOf<R>>(id: K) => RecFromId<K> | undefined;
+    // Warning: (ae-incompatible-release-tags) The symbol "update" is marked as @public, but its signature references "IdOf" which is marked as @internal
+    update: <K extends IdOf<R>>(id: K, updater: (record: RecFromId<K>) => RecFromId<K>) => void;
     // (undocumented)
     validate(phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord'): void;
 }
@@ -270,13 +302,17 @@ export type StoreError = {
     isExistingValidationIssue: boolean;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreListener" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public
-export type StoreListener<R extends BaseRecord> = (entry: HistoryEntry<R>) => void;
+export type StoreListener<R extends UnknownRecord> = (entry: HistoryEntry<R>) => void;
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreSchema" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export class StoreSchema<R extends BaseRecord, P = unknown> {
+export class StoreSchema<R extends UnknownRecord, P = unknown> {
     // (undocumented)
-    static create<R extends BaseRecord, P = unknown>(types: {
+    static create<R extends UnknownRecord, P = unknown>(types: {
         [TypeName in R['typeName']]: {
             createId: any;
         };
@@ -303,8 +339,10 @@ export class StoreSchema<R extends BaseRecord, P = unknown> {
     validateRecord(store: Store<R>, record: R, phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord', recordBefore: null | R): R;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreSchemaOptions" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export type StoreSchemaOptions<R extends BaseRecord, P> = {
+export type StoreSchemaOptions<R extends UnknownRecord, P> = {
     snapshotMigrations?: Migrations;
     onValidationFailure?: (data: {
         error: unknown;
@@ -317,20 +355,37 @@ export type StoreSchemaOptions<R extends BaseRecord, P> = {
     derivePresenceState?: (store: Store<R, P>) => Signal<null | R>;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreSnapshot" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+// Warning: (ae-incompatible-release-tags) The symbol "StoreSnapshot" is marked as @public, but its signature references "IdOf" which is marked as @internal
+//
 // @public
-export type StoreSnapshot<R extends BaseRecord> = Record<string, R>;
+export type StoreSnapshot<R extends UnknownRecord> = Record<IdOf<R>, R>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreValidator" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export type StoreValidator<R extends BaseRecord> = {
+export type StoreValidator<R extends UnknownRecord> = {
     validate: (record: unknown) => R;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "StoreValidators" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
+//
 // @public (undocumented)
-export type StoreValidators<R extends BaseRecord> = {
+export type StoreValidators<R extends UnknownRecord> = {
     [K in R['typeName']]: StoreValidator<Extract<R, {
         typeName: K;
     }>>;
 };
+
+// @internal (undocumented)
+export type UnknownRecord = BaseRecord<string, ID<UnknownRecord>>;
+
+// Warnings were encountered during analysis:
+//
+// src/lib/Store.ts:24:2 - (ae-incompatible-release-tags) The symbol "added" is marked as @public, but its signature references "IdOf" which is marked as @internal
+// src/lib/Store.ts:25:2 - (ae-incompatible-release-tags) The symbol "updated" is marked as @public, but its signature references "IdOf" which is marked as @internal
+// src/lib/Store.ts:26:2 - (ae-incompatible-release-tags) The symbol "removed" is marked as @public, but its signature references "IdOf" which is marked as @internal
+// src/lib/Store.ts:59:2 - (ae-incompatible-release-tags) The symbol "get" is marked as @public, but its signature references "IdOf" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/tlstore/api-report.md
+++ b/packages/tlstore/api-report.md
@@ -11,13 +11,9 @@ import { Signal } from 'signia';
 // @public
 export type AllRecords<T extends Store<any>> = ExtractR<ExtractRecordType<T>>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "assertIdType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export function assertIdType<R extends UnknownRecord>(id: string | undefined, type: RecordType<R, any>): asserts id is ID<R>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "BaseRecord" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export interface BaseRecord<TypeName extends string, Id extends ID<UnknownRecord>> {
     // (undocumented)
@@ -38,15 +34,11 @@ export function compareRecordVersions(a: RecordVersion, b: RecordVersion): -1 | 
 // @public (undocumented)
 export const compareSchemas: (a: SerializedSchema, b: SerializedSchema) => -1 | 0 | 1;
 
-// Warning: (ae-incompatible-release-tags) The symbol "ComputedCache" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export type ComputedCache<Data, R extends UnknownRecord> = {
     get(id: IdOf<R>): Data | undefined;
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "createRecordType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export function createRecordType<R extends UnknownRecord>(typeName: R['typeName'], config: {
     migrations?: Migrations;
@@ -72,27 +64,21 @@ export function defineMigrations<FirstVersion extends EMPTY_SYMBOL | number = EM
 // @public
 export function devFreeze<T>(object: T): T;
 
-// Warning: (ae-incompatible-release-tags) The symbol "getRecordVersion" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export function getRecordVersion(record: UnknownRecord, serializedSchema: SerializedSchema): RecordVersion;
 
-// Warning: (ae-incompatible-release-tags) The symbol "HistoryEntry" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export type HistoryEntry<R extends UnknownRecord = UnknownRecord> = {
     changes: RecordsDiff<R>;
     source: 'remote' | 'user';
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "ID" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export type ID<R extends UnknownRecord> = string & {
     __type__: R;
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type IdOf<R extends UnknownRecord> = R['id'];
 
 // @internal
@@ -118,8 +104,6 @@ export function migrate<T>({ value, migrations, fromVersion, toVersion, }: {
     toVersion: number;
 }): MigrationResult<T>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "migrateRecord" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export function migrateRecord<R extends UnknownRecord>({ record, migrations, fromVersion, toVersion, }: {
     record: unknown;
@@ -167,8 +151,6 @@ export interface Migrations extends BaseMigrationsInfo {
     subTypeMigrations?: Record<string, BaseMigrationsInfo>;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "RecordsDiff" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export type RecordsDiff<R extends UnknownRecord> = {
     added: Record<IdOf<R>, R>;
@@ -176,8 +158,6 @@ export type RecordsDiff<R extends UnknownRecord> = {
     removed: Record<IdOf<R>, R>;
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "RecordType" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export class RecordType<R extends UnknownRecord, RequiredProperties extends keyof Omit<R, 'id' | 'typeName'>> {
     constructor(
@@ -233,13 +213,9 @@ export interface SerializedSchema {
     storeVersion: number;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "squashRecordDiffs" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export function squashRecordDiffs<T extends UnknownRecord>(diffs: RecordsDiff<T>[]): RecordsDiff<T>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "Store" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
     constructor(config: {
@@ -260,9 +236,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
     extractingChanges(fn: () => void): RecordsDiff<R>;
     // (undocumented)
     _flushHistory(): void;
-    // Warning: (ae-incompatible-release-tags) The symbol "get" is marked as @public, but its signature references "IdOf" which is marked as @internal
     get: <K extends IdOf<R>>(id: K) => RecFromId<K> | undefined;
-    // Warning: (ae-incompatible-release-tags) The symbol "has" is marked as @public, but its signature references "IdOf" which is marked as @internal
     has: <K extends IdOf<R>>(id: K) => boolean;
     readonly history: Atom<number, RecordsDiff<R>>;
     // @internal (undocumented)
@@ -279,15 +253,12 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
     readonly props: Props;
     put: (records: R[], phaseOverride?: 'initialize') => void;
     readonly query: StoreQueries<R>;
-    // Warning: (ae-incompatible-release-tags) The symbol "remove" is marked as @public, but its signature references "IdOf" which is marked as @internal
     remove: (ids: IdOf<R>[]) => void;
     // (undocumented)
     readonly schema: StoreSchema<R, Props>;
     serialize: (filter?: ((record: R) => boolean) | undefined) => StoreSnapshot<R>;
     serializeDocumentState: () => StoreSnapshot<R>;
-    // Warning: (ae-incompatible-release-tags) The symbol "unsafeGetWithoutCapture" is marked as @public, but its signature references "IdOf" which is marked as @internal
     unsafeGetWithoutCapture: <K extends IdOf<R>>(id: K) => RecFromId<K> | undefined;
-    // Warning: (ae-incompatible-release-tags) The symbol "update" is marked as @public, but its signature references "IdOf" which is marked as @internal
     update: <K extends IdOf<R>>(id: K, updater: (record: RecFromId<K>) => RecFromId<K>) => void;
     // (undocumented)
     validate(phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord'): void;
@@ -302,13 +273,9 @@ export type StoreError = {
     isExistingValidationIssue: boolean;
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreListener" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public
 export type StoreListener<R extends UnknownRecord> = (entry: HistoryEntry<R>) => void;
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreSchema" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export class StoreSchema<R extends UnknownRecord, P = unknown> {
     // (undocumented)
@@ -339,8 +306,6 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
     validateRecord(store: Store<R>, record: R, phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord', recordBefore: null | R): R;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreSchemaOptions" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export type StoreSchemaOptions<R extends UnknownRecord, P> = {
     snapshotMigrations?: Migrations;
@@ -355,21 +320,14 @@ export type StoreSchemaOptions<R extends UnknownRecord, P> = {
     derivePresenceState?: (store: Store<R, P>) => Signal<null | R>;
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreSnapshot" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-// Warning: (ae-incompatible-release-tags) The symbol "StoreSnapshot" is marked as @public, but its signature references "IdOf" which is marked as @internal
-//
 // @public
 export type StoreSnapshot<R extends UnknownRecord> = Record<IdOf<R>, R>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreValidator" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export type StoreValidator<R extends UnknownRecord> = {
     validate: (record: unknown) => R;
 };
 
-// Warning: (ae-incompatible-release-tags) The symbol "StoreValidators" is marked as @public, but its signature references "UnknownRecord" which is marked as @internal
-//
 // @public (undocumented)
 export type StoreValidators<R extends UnknownRecord> = {
     [K in R['typeName']]: StoreValidator<Extract<R, {
@@ -377,15 +335,8 @@ export type StoreValidators<R extends UnknownRecord> = {
     }>>;
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type UnknownRecord = BaseRecord<string, ID<UnknownRecord>>;
-
-// Warnings were encountered during analysis:
-//
-// src/lib/Store.ts:24:2 - (ae-incompatible-release-tags) The symbol "added" is marked as @public, but its signature references "IdOf" which is marked as @internal
-// src/lib/Store.ts:25:2 - (ae-incompatible-release-tags) The symbol "updated" is marked as @public, but its signature references "IdOf" which is marked as @internal
-// src/lib/Store.ts:26:2 - (ae-incompatible-release-tags) The symbol "removed" is marked as @public, but its signature references "IdOf" which is marked as @internal
-// src/lib/Store.ts:59:2 - (ae-incompatible-release-tags) The symbol "get" is marked as @public, but its signature references "IdOf" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/tlstore/src/index.ts
+++ b/packages/tlstore/src/index.ts
@@ -1,4 +1,4 @@
-export type { BaseRecord, ID } from './lib/BaseRecord'
+export type { BaseRecord, ID, IdOf, UnknownRecord } from './lib/BaseRecord'
 export { IncrementalSetConstructor } from './lib/IncrementalSetConstructor'
 export { RecordType, assertIdType, createRecordType } from './lib/RecordType'
 export { Store, reverseRecordsDiff, squashRecordDiffs } from './lib/Store'

--- a/packages/tlstore/src/lib/BaseRecord.ts
+++ b/packages/tlstore/src/lib/BaseRecord.ts
@@ -1,18 +1,24 @@
 /** @public */
-export type ID<R extends BaseRecord = BaseRecord> = string & { __type__: R }
+export type ID<R extends UnknownRecord> = string & { __type__: R }
+
+/** @internal */
+export type IdOf<R extends UnknownRecord> = R['id']
 
 /**
  * The base record that all records must extend.
  *
  * @public
  */
-export interface BaseRecord<TypeName extends string = string> {
-	readonly id: ID<this>
+export interface BaseRecord<TypeName extends string, Id extends ID<UnknownRecord>> {
+	readonly id: Id
 	readonly typeName: TypeName
 }
 
-export type OmitMeta<R extends BaseRecord> = R extends R ? Omit<R, 'id' | 'typeName'> : R
+/** @internal */
+export type UnknownRecord = BaseRecord<string, ID<UnknownRecord>>
 
-export function isRecord(record: unknown): record is BaseRecord {
+export type OmitMeta<R extends UnknownRecord> = R extends R ? Omit<R, 'id' | 'typeName'> : R
+
+export function isRecord(record: unknown): record is UnknownRecord {
 	return typeof record === 'object' && record !== null && 'id' in record && 'typeName' in record
 }

--- a/packages/tlstore/src/lib/BaseRecord.ts
+++ b/packages/tlstore/src/lib/BaseRecord.ts
@@ -1,7 +1,7 @@
 /** @public */
 export type ID<R extends UnknownRecord> = string & { __type__: R }
 
-/** @internal */
+/** @public */
 export type IdOf<R extends UnknownRecord> = R['id']
 
 /**
@@ -14,7 +14,7 @@ export interface BaseRecord<TypeName extends string, Id extends ID<UnknownRecord
 	readonly typeName: TypeName
 }
 
-/** @internal */
+/** @public */
 export type UnknownRecord = BaseRecord<string, ID<UnknownRecord>>
 
 export type OmitMeta<R extends UnknownRecord> = R extends R ? Omit<R, 'id' | 'typeName'> : R

--- a/packages/tlstore/src/lib/RecordType.ts
+++ b/packages/tlstore/src/lib/RecordType.ts
@@ -1,6 +1,6 @@
 import { structuredClone } from '@tldraw/utils'
 import { nanoid } from 'nanoid'
-import { BaseRecord, ID, OmitMeta } from './BaseRecord'
+import { ID, OmitMeta, UnknownRecord } from './BaseRecord'
 import { StoreValidator } from './Store'
 import { Migrations } from './migrate'
 
@@ -24,7 +24,7 @@ export type Scope = 'instance' | 'document' | 'presence'
  * @public
  */
 export class RecordType<
-	R extends BaseRecord,
+	R extends UnknownRecord,
 	RequiredProperties extends keyof Omit<R, 'id' | 'typeName'>
 > {
 	readonly createDefaultProperties: () => Exclude<OmitMeta<R>, RequiredProperties>
@@ -143,7 +143,7 @@ export class RecordType<
 	 * @param record - The record to check.
 	 * @returns Whether the record is an instance of this record type.
 	 */
-	isInstance = (record?: BaseRecord): record is R => {
+	isInstance = (record?: UnknownRecord): record is R => {
 		return record?.typeName === this.typeName
 	}
 
@@ -214,7 +214,7 @@ export class RecordType<
  * @param typeName - The name of the type to create.
  * @public
  */
-export function createRecordType<R extends BaseRecord>(
+export function createRecordType<R extends UnknownRecord>(
 	typeName: R['typeName'],
 	config: {
 		migrations?: Migrations
@@ -243,7 +243,7 @@ export function createRecordType<R extends BaseRecord>(
  * @param type - The type of the record.
  * @public
  */
-export function assertIdType<R extends BaseRecord>(
+export function assertIdType<R extends UnknownRecord>(
 	id: string | undefined,
 	type: RecordType<R, any>
 ): asserts id is ID<R> {

--- a/packages/tlstore/src/lib/StoreSchema.ts
+++ b/packages/tlstore/src/lib/StoreSchema.ts
@@ -1,6 +1,6 @@
 import { getOwnProperty, objectMapValues } from '@tldraw/utils'
 import { Signal } from 'signia'
-import { BaseRecord } from './BaseRecord'
+import { IdOf, UnknownRecord } from './BaseRecord'
 import { RecordType } from './RecordType'
 import { Store, StoreSnapshot } from './Store'
 import {
@@ -36,7 +36,7 @@ export interface SerializedSchema {
 }
 
 /** @public */
-export type StoreSchemaOptions<R extends BaseRecord, P> = {
+export type StoreSchemaOptions<R extends UnknownRecord, P> = {
 	/** @public */
 	snapshotMigrations?: Migrations
 	/** @public */
@@ -54,8 +54,8 @@ export type StoreSchemaOptions<R extends BaseRecord, P> = {
 }
 
 /** @public */
-export class StoreSchema<R extends BaseRecord, P = unknown> {
-	static create<R extends BaseRecord, P = unknown>(
+export class StoreSchema<R extends UnknownRecord, P = unknown> {
+	static create<R extends UnknownRecord, P = unknown>(
 		// HACK: making this param work with RecordType is an enormous pain
 		// let's just settle for making sure each typeName has a corresponding RecordType
 		// and accept that this function won't be able to infer the record type from it's arguments
@@ -222,7 +222,7 @@ export class StoreSchema<R extends BaseRecord, P = unknown> {
 		}
 
 		const updated: R[] = []
-		for (const r of Object.values(storeSnapshot)) {
+		for (const r of objectMapValues(storeSnapshot)) {
 			const result = this.migratePersistedRecord(r, persistedSchema)
 			if (result.type === 'error') {
 				return result
@@ -233,7 +233,7 @@ export class StoreSchema<R extends BaseRecord, P = unknown> {
 		if (updated.length) {
 			storeSnapshot = { ...storeSnapshot }
 			for (const r of updated) {
-				storeSnapshot[r.id] = r
+				storeSnapshot[r.id as IdOf<R>] = r
 			}
 		}
 		return { type: 'success', value: storeSnapshot }

--- a/packages/tlstore/src/lib/executeQuery.ts
+++ b/packages/tlstore/src/lib/executeQuery.ts
@@ -1,4 +1,4 @@
-import { BaseRecord, ID } from './BaseRecord'
+import { IdOf, UnknownRecord } from './BaseRecord'
 import { intersectSets } from './setUtils'
 import { StoreQueries } from './StoreQueries'
 
@@ -24,11 +24,11 @@ export function objectMatchesQuery<T extends object>(query: QueryExpression<T>, 
 	return true
 }
 
-export function executeQuery<R extends BaseRecord, TypeName extends R['typeName']>(
+export function executeQuery<R extends UnknownRecord, TypeName extends R['typeName']>(
 	store: StoreQueries<R>,
 	typeName: TypeName,
 	query: QueryExpression<Extract<R, { typeName: TypeName }>>
-): Set<ID<Extract<R, { typeName: TypeName }>>> {
+): Set<IdOf<Extract<R, { typeName: TypeName }>>> {
 	const matchIds = Object.fromEntries(Object.keys(query).map((key) => [key, new Set()]))
 
 	for (const [k, matcher] of Object.entries(query)) {
@@ -61,5 +61,5 @@ export function executeQuery<R extends BaseRecord, TypeName extends R['typeName'
 		}
 	}
 
-	return intersectSets(Object.values(matchIds)) as Set<ID<Extract<R, { typeName: TypeName }>>>
+	return intersectSets(Object.values(matchIds)) as Set<IdOf<Extract<R, { typeName: TypeName }>>>
 }

--- a/packages/tlstore/src/lib/migrate.ts
+++ b/packages/tlstore/src/lib/migrate.ts
@@ -1,4 +1,4 @@
-import { BaseRecord, isRecord } from './BaseRecord'
+import { UnknownRecord, isRecord } from './BaseRecord'
 import { SerializedSchema } from './StoreSchema'
 
 type EMPTY_SYMBOL = symbol
@@ -77,7 +77,7 @@ export enum MigrationFailureReason {
 export type RecordVersion = { rootVersion: number; subTypeVersion?: number }
 /** @public */
 export function getRecordVersion(
-	record: BaseRecord,
+	record: UnknownRecord,
 	serializedSchema: SerializedSchema
 ): RecordVersion {
 	const persistedType = serializedSchema.recordVersions[record.typeName]
@@ -112,7 +112,7 @@ export function compareRecordVersions(a: RecordVersion, b: RecordVersion) {
 }
 
 /** @public */
-export function migrateRecord<R extends BaseRecord>({
+export function migrateRecord<R extends UnknownRecord>({
 	record,
 	migrations,
 	fromVersion,

--- a/packages/tlstore/src/lib/test/recordStore.test.ts
+++ b/packages/tlstore/src/lib/test/recordStore.test.ts
@@ -4,7 +4,7 @@ import { createRecordType } from '../RecordType'
 import { CollectionDiff, RecordsDiff, Store } from '../Store'
 import { StoreSchema } from '../StoreSchema'
 
-interface Book extends BaseRecord<'book'> {
+interface Book extends BaseRecord<'book', ID<Book>> {
 	title: string
 	author: ID<Author>
 	numPages: number
@@ -15,7 +15,7 @@ const Book = createRecordType<Book>('book', {
 	scope: 'document',
 })
 
-interface Author extends BaseRecord<'author'> {
+interface Author extends BaseRecord<'author', ID<Author>> {
 	name: string
 	isPseudonym: boolean
 }

--- a/packages/tlstore/src/lib/test/recordStoreQueries.test.ts
+++ b/packages/tlstore/src/lib/test/recordStoreQueries.test.ts
@@ -4,7 +4,7 @@ import { createRecordType } from '../RecordType'
 import { Store } from '../Store'
 import { StoreSchema } from '../StoreSchema'
 
-interface Author extends BaseRecord<'author'> {
+interface Author extends BaseRecord<'author', ID<Author>> {
 	name: string
 	age: number
 }
@@ -22,7 +22,7 @@ const Author = createRecordType<Author>('author', {
 	scope: 'document',
 }).withDefaultProperties(() => ({ age: 23 }))
 
-interface Book extends BaseRecord<'book'> {
+interface Book extends BaseRecord<'book', ID<Book>> {
 	title: string
 	authorId: ID<Author>
 }

--- a/packages/tlstore/src/lib/test/testSchema.v0.ts
+++ b/packages/tlstore/src/lib/test/testSchema.v0.ts
@@ -1,11 +1,11 @@
 import { assert } from '@tldraw/utils'
-import { BaseRecord } from '../BaseRecord'
+import { BaseRecord, ID } from '../BaseRecord'
 import { createRecordType } from '../RecordType'
 import { StoreSchema } from '../StoreSchema'
 import { defineMigrations } from '../migrate'
 
 /** A user of tldraw */
-interface User extends BaseRecord<'user'> {
+interface User extends BaseRecord<'user', ID<User>> {
 	name: string
 }
 
@@ -24,7 +24,7 @@ const User = createRecordType<User>('user', {
 	scope: 'document',
 })
 
-interface Shape<Props> extends BaseRecord<'shape'> {
+interface Shape<Props> extends BaseRecord<'shape', ID<Shape<object>>> {
 	type: string
 	x: number
 	y: number
@@ -72,7 +72,7 @@ const Shape = createRecordType<Shape<RectangleProps | OvalProps>>('shape', {
 })
 
 // this interface only exists to be removed
-interface Org extends BaseRecord<'org'> {
+interface Org extends BaseRecord<'org', ID<Org>> {
 	name: string
 }
 

--- a/packages/tlstore/src/lib/test/testSchema.v1.ts
+++ b/packages/tlstore/src/lib/test/testSchema.v1.ts
@@ -11,7 +11,7 @@ const UserVersion = {
 } as const
 
 /** A user of tldraw */
-interface User extends BaseRecord<'user'> {
+interface User extends BaseRecord<'user', ID<User>> {
 	name: string
 	locale: string
 	phoneNumber: string | null
@@ -79,12 +79,14 @@ const OvalVersion = {
 	AddBorderStyle: 1,
 } as const
 
-interface Shape<Props> extends BaseRecord<'shape'> {
+type ShapeId = ID<Shape<object>>
+
+interface Shape<Props> extends BaseRecord<'shape', ShapeId> {
 	type: string
 	x: number
 	y: number
 	rotation: number
-	parentId: ID<Shape<Props>> | null
+	parentId: ShapeId | null
 	props: Props
 }
 

--- a/packages/tlstore/src/lib/test/validate.test.ts
+++ b/packages/tlstore/src/lib/test/validate.test.ts
@@ -1,11 +1,11 @@
-import { BaseRecord, ID } from '../BaseRecord'
+import { BaseRecord, ID, IdOf } from '../BaseRecord'
 import { createRecordType } from '../RecordType'
 import { Store, StoreSnapshot } from '../Store'
 import { StoreSchema } from '../StoreSchema'
 
-interface Book extends BaseRecord<'book'> {
+interface Book extends BaseRecord<'book', ID<Book>> {
 	title: string
-	author: ID<Author>
+	author: IdOf<Author>
 	numPages: number
 }
 
@@ -24,7 +24,7 @@ const Book = createRecordType<Book>('book', {
 	scope: 'document',
 })
 
-interface Author extends BaseRecord<'author'> {
+interface Author extends BaseRecord<'author', ID<Author>> {
 	name: string
 	isPseudonym: boolean
 }

--- a/packages/ui/src/lib/hooks/useActions.tsx
+++ b/packages/ui/src/lib/hooks/useActions.tsx
@@ -211,21 +211,22 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					trackEvent('toggle-auto-size', { source })
 					app.mark()
 					app.updateShapes(
-						(
-							app.selectedShapes.filter(
-								(shape) => app.isShapeOfType(shape, TLTextUtil) && shape.props.autoSize === false
-							) as TLTextShape[]
-						).map((shape) => {
-							return {
-								id: shape.id,
-								type: shape.type,
-								props: {
-									...shape.props,
-									w: 8,
-									autoSize: true,
-								},
-							}
-						})
+						app.selectedShapes
+							.filter(
+								(shape): shape is TLTextShape =>
+									app.isShapeOfType(shape, TLTextUtil) && shape.props.autoSize === false
+							)
+							.map((shape) => {
+								return {
+									id: shape.id,
+									type: shape.type,
+									props: {
+										...shape.props,
+										w: 8,
+										autoSize: true,
+									},
+								}
+							})
 					)
 				},
 			},

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -95,6 +95,11 @@ export function objectMapEntries<Key extends string, Value>(object: {
 }): Array<[Key, Value]>;
 
 // @internal
+export function objectMapFromEntries<Key extends string, Value>(entries: ReadonlyArray<readonly [Key, Value]>): {
+    [K in Key]: Value;
+};
+
+// @internal
 export function objectMapKeys<Key extends string>(object: {
     readonly [K in Key]: unknown;
 }): Array<Key>;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,6 +20,7 @@ export {
 	getOwnProperty,
 	hasOwnProperty,
 	objectMapEntries,
+	objectMapFromEntries,
 	objectMapKeys,
 	objectMapValues,
 } from './lib/object'

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -89,6 +89,18 @@ export function objectMapEntries<Key extends string, Value>(object: {
 }
 
 /**
+ * An alias for `Object.fromEntries` that treats the object as a map and so preserves the type of the
+ * keys.
+ *
+ * @internal
+ */
+export function objectMapFromEntries<Key extends string, Value>(
+	entries: ReadonlyArray<readonly [Key, Value]>
+): { [K in Key]: Value } {
+	return Object.fromEntries(entries) as { [K in Key]: Value }
+}
+
+/**
  * Filters an object using a predicate function.
  * @returns a new object with only the entries that pass the predicate
  * @internal


### PR DESCRIPTION
We noticed that when inferring the type of a shape from its ID, it was getting inferred as `any` which was hiding some issues. This diff switches `BaseRecord`'s automatic ID to an explicit one, which lets us pass in our correct `TLShapeId` definition and still have it play nicely with other places.

### Change Type

- [x] `patch` — Bug Fix

### Release Notes

[internal only, covered by #1432 changelog]
