### PR TITLE
Fix cursor shadow getting clipped

### DIFF
--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -35,7 +35,7 @@ function getCursorCss(
 	const dy = 1 * s + 1 * c
 
 	return (
-		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${color};'><defs><filter id='shadow' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
+		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${color};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
 			r + tr
 		} 16 16)${f ? ` scale(-1,-1) translate(0, -32)` : ''}' filter='url(%23shadow)'>` +
 		svg.replaceAll(`"`, `'`) +


### PR DESCRIPTION
This PR fixes cursor shadow getting clipped in some cases.

Kap doesn't record the error so you'll have to take my word on this one!

### Change Type

- [x] `patch` — Bug Fix

### Release Notes

- Fixed a bug where custom cursors could have their shadow clipped.
