### PR TITLE
Don't allow `g` keyboard shortcut in readonly mode, show laser tool in the toolbar

### DIFF
--- a/e2e/test/helpers/util.ts
+++ b/e2e/test/helpers/util.ts
@@ -81,6 +81,7 @@ export async function sleep(ms: number) {
 
 export async function clearClipboard() {
 	return await browser.execute(async () => {
+		if (!(navigator && navigator.clipboard)) return
 		if (navigator.clipboard.write) {
 			await navigator.clipboard.write([
 				new ClipboardItem({

--- a/e2e/test/helpers/util.ts
+++ b/e2e/test/helpers/util.ts
@@ -80,8 +80,6 @@ export async function sleep(ms: number) {
 }
 
 export async function clearClipboard() {
-	if (!(navigator && navigator.clipboard)) return
-
 	return await browser.execute(async () => {
 		if (navigator.clipboard.write) {
 			await navigator.clipboard.write([

--- a/e2e/test/helpers/util.ts
+++ b/e2e/test/helpers/util.ts
@@ -80,7 +80,7 @@ export async function sleep(ms: number) {
 }
 
 export async function clearClipboard() {
-	if (!navigator && navigator.clipboard) return
+	if (!(navigator && navigator.clipboard)) return
 
 	return await browser.execute(async () => {
 		if (navigator.clipboard.write) {

--- a/e2e/test/helpers/util.ts
+++ b/e2e/test/helpers/util.ts
@@ -80,6 +80,8 @@ export async function sleep(ms: number) {
 }
 
 export async function clearClipboard() {
+	if (!navigator && navigator.clipboard) return
+
 	return await browser.execute(async () => {
 		if (navigator.clipboard.write) {
 			await navigator.clipboard.write([

--- a/packages/ui/src/lib/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/lib/components/Toolbar/Toolbar.tsx
@@ -28,6 +28,7 @@ export const Toolbar = function Toolbar() {
 
 	const isReadOnly = useReadonly()
 	const toolbarItems = useToolbarSchema()
+	const laserTool = toolbarItems.find((item) => item.toolItem.id === 'laser')
 
 	const activeToolId = useValue('current tool id', () => app.currentToolId, [app])
 
@@ -142,6 +143,14 @@ export const Toolbar = function Toolbar() {
 								/>
 							)
 						})}
+						{isReadOnly && laserTool && (
+							<ToolbarButton
+								key={laserTool.toolItem.id}
+								item={laserTool.toolItem}
+								title={getTitle(laserTool.toolItem)}
+								isSelected={isActiveToolItem(laserTool.toolItem, activeToolId, geoState)}
+							/>
+						)}
 						{showEditingTools && (
 							<>
 								{/* Draw / Eraser */}

--- a/packages/ui/src/lib/hooks/useClipboardEvents.ts
+++ b/packages/ui/src/lib/hooks/useClipboardEvents.ts
@@ -479,7 +479,9 @@ async function handleClipboardThings(app: App, things: ClipboardThing[], point?:
 const handleNativeOrMenuCopy = (app: App) => {
 	const content = app.getContent()
 	if (!content) {
-		window.navigator.clipboard.writeText('')
+		if (navigator && navigator.clipboard) {
+			navigator.clipboard.writeText('')
+		}
 		return
 	}
 

--- a/packages/ui/src/lib/hooks/useCopyAs.ts
+++ b/packages/ui/src/lib/hooks/useCopyAs.ts
@@ -144,5 +144,6 @@ async function getExportedImageBlob(app: App, ids: TLShapeId[], format: 'png' | 
 }
 
 async function fallbackWriteTextAsync(getText: () => Promise<string>) {
+	if (!(navigator && navigator.clipboard)) return
 	navigator.clipboard.writeText(await getText())
 }

--- a/packages/ui/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/lib/hooks/useKeyboardShortcuts.ts
@@ -66,7 +66,7 @@ export function useKeyboardShortcuts() {
 		// todo: move these into the actions themselves and make the UI only display the first one
 
 		hot('g', () => {
-			if (areShortcutsDisabled()) return
+			if (areShortcutsDisabled() || app.isReadOnly) return
 			app.setSelectedTool('geo')
 		})
 

--- a/packages/ui/src/lib/hooks/useTools.tsx
+++ b/packages/ui/src/lib/hooks/useTools.tsx
@@ -180,7 +180,7 @@ export function ToolsProvider({ overrides, children }: ToolsProviderProps) {
 			{
 				id: 'laser',
 				label: 'tool.laser',
-				readonlyOk: false,
+				readonlyOk: true,
 				icon: 'tool-laser',
 				kbd: 'k',
 				onSelect(source) {

--- a/packages/ui/src/lib/hooks/useTools.tsx
+++ b/packages/ui/src/lib/hooks/useTools.tsx
@@ -180,7 +180,7 @@ export function ToolsProvider({ overrides, children }: ToolsProviderProps) {
 			{
 				id: 'laser',
 				label: 'tool.laser',
-				readonlyOk: true,
+				readonlyOk: false,
 				icon: 'tool-laser',
 				kbd: 'k',
 				onSelect(source) {


### PR DESCRIPTION
Disable `g` keyboard shortcut in readonly mode. Show laser tool in toolbar when in readonly mode.

Resolves [#1936](https://github.com/tldraw/brivate/issues/1936)
Resolves [#1935](https://github.com/tldraw/brivate/issues/1935)

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Open a readonly room.
2. Press `g` and make sure it doesn't switch to it.
3. Laser tool should be visible in the toolbar in readonly rooms.


### Release Notes

- Disable geo tool shortcut in readonly mode. Show laser on the toolbar.
