### PR TITLE
[fix] page item submenu

### DIFF
--- a/packages/ui/src/lib/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/ui/src/lib/components/PageMenu/PageItemSubmenu.tsx
@@ -44,7 +44,7 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	}, [app, item])
 
 	return (
-		<M.Root id="page item submenu">
+		<M.Root id={`page item submenu ${index}`}>
 			<M.Trigger>
 				<Button title={msg('page-menu.submenu.title')} icon="dots-vertical" />
 			</M.Trigger>


### PR DESCRIPTION
This PR fixes a bug that would effect the page item submenu. With the `useMenuIsOpen` hook, it's important that multiple menus have unique ids. In this case each page was using `page sub menu` and so each open menu would be closed by the not-open menu effects.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Create two pages
2. Open the submenus on each page
