### PR TITLE
[fix] make follow icon visible on iPad

### DIFF
--- a/packages/ui/ui.css
+++ b/packages/ui/ui.css
@@ -1486,6 +1486,7 @@
 	border-radius: 100%;
 	border: 4px solid var(--color-background);
 	z-index: -1;
+	pointer-events: none;
 }
 
 .tlui-people-menu__button:not([data-state='selected'], :disabled):active::after {
@@ -1610,10 +1611,6 @@
 	min-width: 44px;
 }
 
-.tlui-people-menu__item__follow .tlui-icon {
-	opacity: 0;
-}
-
 .tlui-people-menu__item__follow[data-active='true'] .tlui-icon {
 	opacity: 1;
 }
@@ -1623,6 +1620,10 @@
 }
 
 @media (hover: hover) {
+	.tlui-people-menu__item__follow .tlui-icon {
+		opacity: 0;
+	}
+
 	.tlui-people-menu__item__follow:hover .tlui-icon {
 		opacity: 1;
 	}


### PR DESCRIPTION
This PR makes the "follow" button visible on iPad where hover is not available.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. View the people menu on iPad
2. See that the follow person button is visible
