### PR TITLE
fix people menu name editor input size

### DIFF
--- a/packages/ui/ui.css
+++ b/packages/ui/ui.css
@@ -1565,6 +1565,7 @@
 	height: 100%;
 	padding: 0px;
 	margin: 0px;
+	font-size: 12px;
 }
 
 .tlui-people-menu__user__edit {


### PR DESCRIPTION
This PR fixes the people-menu name-input being the wrong font-size on iPhone.

@SomeHats I haven't tested this - any chance you could test locally on iPhone? 

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Try to change your name in the People Menu on iPhone.
2. Make sure the font-size of the name input stays the same as normal.

