### PR TITLE
Add laser keyboard shortcut.

### DIFF
--- a/packages/ui/src/lib/hooks/useKeyboardShortcutsSchema.tsx
+++ b/packages/ui/src/lib/hooks/useKeyboardShortcutsSchema.tsx
@@ -48,7 +48,8 @@ export const KeyboardShortcutsSchemaProvider = track(function KeyboardShortcutsS
 				menuItem(tools['line']),
 				menuItem(tools['text']),
 				menuItem(tools['frame']),
-				menuItem(tools['note'])
+				menuItem(tools['note']),
+				menuItem(tools['laser'])
 			),
 			menuGroup(
 				'shortcuts-dialog.file',


### PR DESCRIPTION
Adds laser keyboard shortcut to the keyboard shortcuts dialog. Fixes [#1465](https://github.com/tldraw/tldraw/issues/1465)
### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Open the keyboard shortcuts dialog from the help menu.
2. Laser tool should be listed.
