### PR TITLE
Fix people menu button border on android

### DIFF
--- a/packages/ui/ui.css
+++ b/packages/ui/ui.css
@@ -1479,8 +1479,6 @@
 	display: block;
 	content: '';
 	position: absolute;
-	top: -4px;
-	left: -4px;
 	height: 40px;
 	width: 40px;
 	border-radius: 100%;


### PR DESCRIPTION
This PR fixes the people menu button's border being misaligned on android.

There is a still a tiny tiny tiny sliver visible through the border, which could be fixed in a future PR.
![image](https://github.com/tldraw/tldraw/assets/15892272/d84cac26-33e4-4089-b0e0-1fa480b57286)


### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Open a shared project on Android.
2. Place a visible *behind* the people menu button, so that you can 'see' the background-coloured border around the button.
3. Make sure the border is centered around the people menu button.

