### PR TITLE
Feature flags rework

### DIFF
--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -15,4 +15,9 @@ export default defineConfig({
 	optimizeDeps: {
 		exclude: ['@tldraw/assets'],
 	},
+	define: {
+		'import.meta.env.TLDRAW_ENV': JSON.stringify(
+			process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'development'
+		),
+	},
 })

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -16,8 +16,6 @@ export default defineConfig({
 		exclude: ['@tldraw/assets'],
 	},
 	define: {
-		'import.meta.env.TLDRAW_ENV': JSON.stringify(
-			process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'development'
-		),
+		'process.env.TLDRAW_ENV': JSON.stringify(process.env.VERCEL_ENV ?? 'development'),
 	},
 })

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -611,18 +611,89 @@ export function dataTransferItemAsString(item: DataTransferItem): Promise<string
 export function dataUrlToFile(url: string, filename: string, mimeType: string): Promise<File>;
 
 // @internal (undocumented)
+export type DebugFlag<Def extends DebugFlagDefBase<any>> = Def & {
+    value: DefValue<Def>;
+    set: (value: DefValue<Def>) => void;
+};
+
+// @internal (undocumented)
+export interface DebugFlagDefBase<T> {
+    // (undocumented)
+    defaults: Defaults<T>;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    shouldStoreForSession: boolean;
+}
+
+// @internal (undocumented)
 export const debugFlags: {
-    preventDefaultLogging: Atom<boolean, unknown>;
-    pointerCaptureLogging: Atom<boolean, unknown>;
-    pointerCaptureTracking: Atom<boolean, unknown>;
-    pointerCaptureTrackingObject: Atom<Map<Element, number>, unknown>;
-    elementRemovalLogging: Atom<boolean, unknown>;
-    debugSvg: Atom<boolean, unknown>;
-    throwToBlob: Atom<boolean, unknown>;
-    peopleMenu: Atom<boolean, unknown>;
-    logMessages: Atom<never[], unknown>;
-    resetConnectionEveryPing: Atom<boolean, unknown>;
-    debugCursors: Atom<boolean, unknown>;
+    peopleMenu: DebugFlag<{
+        isFeatureFlag: true;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: true;
+    }>;
+    preventDefaultLogging: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    pointerCaptureLogging: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    pointerCaptureTracking: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    pointerCaptureTrackingObject: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<Map<Element, number>>;
+        shouldStoreForSession: boolean;
+    }>;
+    elementRemovalLogging: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    debugSvg: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    throwToBlob: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    logMessages: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<never[]>;
+        shouldStoreForSession: boolean;
+    }>;
+    resetConnectionEveryPing: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
+    debugCursors: DebugFlag<{
+        isFeatureFlag: false;
+        name: string;
+        defaults: Defaults<boolean>;
+        shouldStoreForSession: boolean;
+    }>;
 };
 
 // @internal (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -611,89 +611,20 @@ export function dataTransferItemAsString(item: DataTransferItem): Promise<string
 export function dataUrlToFile(url: string, filename: string, mimeType: string): Promise<File>;
 
 // @internal (undocumented)
-export type DebugFlag<Def extends DebugFlagDefBase<any>> = Def & {
-    value: DefValue<Def>;
-    set: (value: DefValue<Def>) => void;
-};
-
-// @internal (undocumented)
-export interface DebugFlagDefBase<T> {
-    // (undocumented)
-    defaults: Defaults<T>;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    shouldStoreForSession: boolean;
-}
+export type DebugFlag<T> = DebugFlagDef<T> & Atom<T>;
 
 // @internal (undocumented)
 export const debugFlags: {
-    peopleMenu: DebugFlag<{
-        isFeatureFlag: true;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: true;
-    }>;
-    preventDefaultLogging: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    pointerCaptureLogging: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    pointerCaptureTracking: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    pointerCaptureTrackingObject: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<Map<Element, number>>;
-        shouldStoreForSession: boolean;
-    }>;
-    elementRemovalLogging: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    debugSvg: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    throwToBlob: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    logMessages: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<never[]>;
-        shouldStoreForSession: boolean;
-    }>;
-    resetConnectionEveryPing: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
-    debugCursors: DebugFlag<{
-        isFeatureFlag: false;
-        name: string;
-        defaults: Defaults<boolean>;
-        shouldStoreForSession: boolean;
-    }>;
+    preventDefaultLogging: DebugFlag<boolean>;
+    pointerCaptureLogging: DebugFlag<boolean>;
+    pointerCaptureTracking: DebugFlag<boolean>;
+    pointerCaptureTrackingObject: DebugFlag<Map<Element, number>>;
+    elementRemovalLogging: DebugFlag<boolean>;
+    debugSvg: DebugFlag<boolean>;
+    throwToBlob: DebugFlag<boolean>;
+    logMessages: DebugFlag<never[]>;
+    resetConnectionEveryPing: DebugFlag<boolean>;
+    debugCursors: DebugFlag<boolean>;
 };
 
 // @internal (undocumented)
@@ -784,6 +715,11 @@ export interface ErrorSyncedStore {
 
 // @public (undocumented)
 export const EVENT_NAME_MAP: Record<Exclude<TLEventName, TLPinchEventName>, keyof TLEventHandlers>;
+
+// @internal (undocumented)
+export const featureFlags: {
+    peopleMenu: DebugFlag<boolean>;
+};
 
 // @public
 export function fileToBase64(file: Blob): Promise<string>;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -209,7 +209,7 @@ export {
 	snapToGrid,
 	uniqueId,
 } from './lib/utils/data'
-export { debugFlags } from './lib/utils/debug-flags'
+export { debugFlags, type DebugFlag, type DebugFlagDefBase } from './lib/utils/debug-flags'
 export {
 	loopToHtmlElement,
 	preventDefault,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -209,7 +209,7 @@ export {
 	snapToGrid,
 	uniqueId,
 } from './lib/utils/data'
-export { debugFlags, type DebugFlag, type DebugFlagDefBase } from './lib/utils/debug-flags'
+export { debugFlags, featureFlags, type DebugFlag } from './lib/utils/debug-flags'
 export {
 	loopToHtmlElement,
 	preventDefault,

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -429,8 +429,8 @@ const DebugSvgCopy = track(function DupSvg({ id }: { id: TLShapeId }) {
 	)
 })
 
-const UiLogger = () => {
-	const logMessages = useValue(debugFlags.logMessages)
+const UiLogger = track(() => {
+	const logMessages = debugFlags.logMessages.value
 
 	return (
 		<div className="debug__ui-logger">
@@ -445,4 +445,4 @@ const UiLogger = () => {
 			})}
 		</div>
 	)
-}
+})

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -175,7 +175,6 @@ function readEnv(fn: () => string | undefined) {
 
 function getDefaultValue<T>(def: DebugFlagDef<T>): T {
 	const env =
-		readEnv(() => (import.meta as any).env.TLDRAW_ENV) ??
 		readEnv(() => process.env.TLDRAW_ENV) ??
 		readEnv(() => process.env.VERCEL_PUBLIC_TLDRAW_ENV) ??
 		readEnv(() => process.env.NEXT_PUBLIC_TLDRAW_ENV) ??

--- a/packages/ui/src/lib/components/DebugPanel.tsx
+++ b/packages/ui/src/lib/components/DebugPanel.tsx
@@ -1,8 +1,8 @@
 import {
 	App,
 	DebugFlag,
-	DebugFlagDefBase,
 	debugFlags,
+	featureFlags,
 	hardResetApp,
 	TLShapePartial,
 	uniqueId,
@@ -207,11 +207,8 @@ const DebugMenuContent = track(function DebugMenuContent({
 				/>
 			</DropdownMenu.Group>
 			<DropdownMenu.Group>
-				{Object.values(debugFlags).map((flag) => {
-					if (flag.isFeatureFlag) {
-						return <DebugFlagToggle key={flag.name} flag={flag} />
-					}
-					return null
+				{Object.values(featureFlags).map((flag) => {
+					return <DebugFlagToggle key={flag.name} flag={flag} />
 				})}
 			</DropdownMenu.Group>
 			{renderDebugMenuItems?.()}
@@ -239,7 +236,7 @@ const DebugFlagToggle = track(function DebugFlagToggle({
 	flag,
 	onChange,
 }: {
-	flag: DebugFlag<DebugFlagDefBase<boolean>>
+	flag: DebugFlag<boolean>
 	onChange?: (newValue: boolean) => void
 }) {
 	return (

--- a/packages/ui/src/lib/components/DebugPanel.tsx
+++ b/packages/ui/src/lib/components/DebugPanel.tsx
@@ -1,4 +1,13 @@
-import { App, debugFlags, hardResetApp, TLShapePartial, uniqueId, useApp } from '@tldraw/editor'
+import {
+	App,
+	DebugFlag,
+	DebugFlagDefBase,
+	debugFlags,
+	hardResetApp,
+	TLShapePartial,
+	uniqueId,
+	useApp,
+} from '@tldraw/editor'
 import * as React from 'react'
 import { track, useValue } from 'signia-react'
 import { useDialogs } from '../hooks/useDialogsProvider'
@@ -64,7 +73,7 @@ const ShapeCount = function ShapeCount() {
 	return <div>{count} Shapes</div>
 }
 
-function DebugMenuContent({
+const DebugMenuContent = track(function DebugMenuContent({
 	renderDebugMenuItems,
 }: {
 	renderDebugMenuItems: (() => React.ReactNode) | null
@@ -151,36 +160,6 @@ function DebugMenuContent({
 					<span>Count shapes and nodes</span>
 				</DropdownMenu.Item>
 
-				<DropdownMenu.Item
-					onClick={() => {
-						if (!debugFlags.debugCursors.value) {
-							debugFlags.debugCursors.set(true)
-
-							const MAX_COLUMNS = 5
-							const partials = CURSOR_NAMES.map((name, i) => {
-								return {
-									id: app.createShapeId(),
-									type: 'geo',
-									x: (i % MAX_COLUMNS) * 175,
-									y: Math.floor(i / MAX_COLUMNS) * 175,
-									props: {
-										text: name,
-										w: 150,
-										h: 150,
-										fill: 'semi',
-									},
-								}
-							})
-
-							app.createShapes(partials)
-						} else {
-							debugFlags.debugCursors.set(false)
-						}
-					}}
-				>
-					<span>{debugFlags.debugCursors.value ? 'Debug cursors ✓' : 'Debug cursors'}</span>
-				</DropdownMenu.Item>
-
 				{(() => {
 					if (error) throw Error('oh no!')
 				})()}
@@ -200,27 +179,82 @@ function DebugMenuContent({
 				</DropdownMenu.Item>
 			</DropdownMenu.Group>
 			<DropdownMenu.Group>
-				<DropdownMenu.Item
-					onClick={() => {
-						debugFlags.peopleMenu.set(!debugFlags.peopleMenu.value)
-						window.location.reload()
+				<Toggle label="Read-only" value={app.isReadOnly} onChange={(r) => app.setReadOnly(r)} />
+				<DebugFlagToggle flag={debugFlags.debugSvg} />
+				<DebugFlagToggle
+					flag={debugFlags.debugCursors}
+					onChange={(enabled) => {
+						if (enabled) {
+							const MAX_COLUMNS = 5
+							const partials = CURSOR_NAMES.map((name, i) => {
+								return {
+									id: app.createShapeId(),
+									type: 'geo',
+									x: (i % MAX_COLUMNS) * 175,
+									y: Math.floor(i / MAX_COLUMNS) * 175,
+									props: {
+										text: name,
+										w: 150,
+										h: 150,
+										fill: 'semi',
+									},
+								}
+							})
+
+							app.createShapes(partials)
+						}
 					}}
-				>
-					<span>Toggle people menu</span>
-				</DropdownMenu.Item>
-				<DropdownMenu.Item
-					onClick={() => {
-						// We need to do this manually because `updateUserDocumentSettings` does not allow toggling `isReadOnly`)
-						app.setReadOnly(!app.isReadOnly)
-					}}
-				>
-					<span>Toggle read-only</span>
-				</DropdownMenu.Item>
+				/>
+			</DropdownMenu.Group>
+			<DropdownMenu.Group>
+				{Object.values(debugFlags).map((flag) => {
+					if (flag.isFeatureFlag) {
+						return <DebugFlagToggle key={flag.name} flag={flag} />
+					}
+					return null
+				})}
 			</DropdownMenu.Group>
 			{renderDebugMenuItems?.()}
 		</>
 	)
+})
+
+function Toggle({
+	label,
+	value,
+	onChange,
+}: {
+	label: string
+	value: boolean
+	onChange: (newValue: boolean) => void
+}) {
+	return (
+		<DropdownMenu.CheckboxItem title={label} checked={value} onSelect={() => onChange(!value)}>
+			{label}
+		</DropdownMenu.CheckboxItem>
+	)
 }
+
+const DebugFlagToggle = track(function DebugFlagToggle({
+	flag,
+	onChange,
+}: {
+	flag: DebugFlag<DebugFlagDefBase<boolean>>
+	onChange?: (newValue: boolean) => void
+}) {
+	return (
+		<Toggle
+			label={flag.name
+				.replace(/([a-z0-9])([A-Z])/g, (m) => `${m[0]} ${m[1].toLowerCase()}`)
+				.replace(/^[a-z]/, (m) => m.toUpperCase())}
+			value={flag.value}
+			onChange={(newValue) => {
+				flag.set(newValue)
+				onChange?.(newValue)
+			}}
+		/>
+	)
+})
 
 const CURSOR_NAMES = [
 	'none',


### PR DESCRIPTION
This diff tweaks our `debugFlags` framework to support setting different default value for different environments, makes it easier to define feature flags, and makes feature flags show up in the debug menu by default. With this change, feature flags will default to being enabled in dev and preview environments, but disabled in production.

Specify a feature flag like this:
```ts
const featureFlags = {
      myCoolNewFeature: createFeatureFlag('myCoolNewFeature')
}
```

optionally, pass a second value to control its defaults:
```ts
const featureFlags = {
    featureEnabledInProduction: createFeatureFlag('someFeature', { all: true }),
    customEnabled: createFeatureFlag('otherFeature', {development: true, staging: false, production: false}),
}
```

In code, the value can be read using `featureFlags.myFeature.value`. Remember to wrap reading it in a reactive context!

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

-

### Release Notes

[internal only change]
