### PR TITLE
[refactor] just validators

### DIFF
--- a/packages/editor/src/lib/config/TldrawEditorConfig.tsx
+++ b/packages/editor/src/lib/config/TldrawEditorConfig.tsx
@@ -10,6 +10,7 @@ import {
 	TLStore,
 	TLStoreProps,
 	createTLSchema,
+	defaultTldrawEditorValidator,
 } from '@tldraw/tlschema'
 import { Migrations, RecordType, Store, StoreSchema, StoreSnapshot } from '@tldraw/tlstore'
 import { Signal, computed } from 'signia'
@@ -56,7 +57,6 @@ export type TldrawEditorConfigOptions = {
 		string,
 		{
 			util: TLShapeUtilConstructor<any>
-			validator?: { validate: <T>(record: T) => T }
 			migrations?: Migrations
 		}
 	>
@@ -64,6 +64,7 @@ export type TldrawEditorConfigOptions = {
 	derivePresenceState?: (store: TLStore) => Signal<TLInstancePresence | null>
 	userPreferences?: Signal<TLUserPreferences>
 	setUserPreferences?: (userPreferences: TLUserPreferences) => void
+	validator?: { validate: (r: any) => any }
 }
 
 /** @public */
@@ -84,7 +85,12 @@ export class TldrawEditorConfig {
 	readonly setUserPreferences: (userPreferences: TLUserPreferences) => void
 
 	constructor(opts = {} as TldrawEditorConfigOptions) {
-		const { shapes = {}, tools = [], derivePresenceState } = opts
+		const {
+			validator = defaultTldrawEditorValidator,
+			shapes = {},
+			tools = [],
+			derivePresenceState,
+		} = opts
 
 		this.tools = tools
 		this.derivePresenceState = derivePresenceState ?? (() => computed('presence', () => null))
@@ -99,6 +105,7 @@ export class TldrawEditorConfig {
 
 		this.storeSchema = createTLSchema({
 			customShapes: shapes,
+			validator,
 		})
 
 		this.TLShape = this.storeSchema.types.shape as RecordType<

--- a/packages/editor/src/lib/test/tools/translating.test.ts
+++ b/packages/editor/src/lib/test/tools/translating.test.ts
@@ -46,6 +46,7 @@ const configWithCustomShape = new TldrawEditorConfig({
 			util: __TopLeftSnapOnlyShapeUtil,
 		},
 	},
+	validator: { validate: (r) => r }, // basically turn of all validation
 })
 
 let app: TestApp

--- a/packages/file-format/src/test/file.test.ts
+++ b/packages/file-format/src/test/file.test.ts
@@ -106,7 +106,7 @@ describe('parseTldrawJsonFile', () => {
 		assert(!result.ok)
 		assert(result.error.type === 'invalidRecords')
 		expect(result.error.cause).toMatchInlineSnapshot(
-			`[ValidationError: At shape(id = shape:shape, type = geo).rotation: Expected number, got undefined]`
+			`[ValidationError: At (typeName = shape).shape(id = shape:shape, type = geo).rotation: Expected number, got undefined]`
 		)
 	})
 

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -434,6 +434,12 @@ export const instancePageStateTypeValidator: T.Validator<TLInstancePageState>;
 export const InstancePresenceRecordType: RecordType<TLInstancePresence, "currentPageId" | "instanceId" | "userId" | "userName">;
 
 // @public (undocumented)
+export const instancePresenceTypeMigrations: Migrations;
+
+// @public (undocumented)
+export const instancePresenceTypeValidator: T.Validator<TLInstancePresence>;
+
+// @public (undocumented)
 export const InstanceRecordType: RecordType<TLInstance, "currentPageId">;
 
 // @public (undocumented)
@@ -471,6 +477,9 @@ export const pageIdValidator: T.Validator<TLPageId>;
 
 // @public (undocumented)
 export const PageRecordType: RecordType<TLPage, "index" | "name">;
+
+// @public (undocumented)
+export const pageTypeMigrations: Migrations;
 
 // @public (undocumented)
 export const pageTypeValidator: T.Validator<TLPage>;
@@ -1061,7 +1070,7 @@ export interface TLInstancePageState extends BaseRecord<'instance_page_state', T
 export type TLInstancePageStateId = ID<TLInstancePageState>;
 
 // @public (undocumented)
-export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceID> {
+export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceId> {
     // (undocumented)
     brush: Box2dModel | null;
     // (undocumented)
@@ -1098,6 +1107,9 @@ export interface TLInstancePresence extends BaseRecord<'instance_presence', TLIn
     // (undocumented)
     userName: string;
 }
+
+// @public (undocumented)
+export type TLInstancePresenceId = ID<TLInstancePresence>;
 
 // @public (undocumented)
 export type TLInstancePropsForNextShape = Pick<TLShapeProps, TLStyleType>;

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -112,8 +112,13 @@ export function createShapeValidator<Type extends string, Props extends object>(
 }>;
 
 // @public
-export function createTLSchema<T extends TLUnknownShape>(opts?: {
-    customShapes?: { [K in T["type"]]: CustomShapeInfo<T>; } | undefined;
+export function createTLSchema(opts?: {
+    customShapes?: {
+        [key: string]: CustomShapeInfo;
+    } | undefined;
+    validator?: {
+        validate: (r: any) => any;
+    } | undefined;
 }): StoreSchema<TLRecord, TLStoreProps>;
 
 // @public (undocumented)
@@ -124,6 +129,20 @@ export const cursorValidator: T.Validator<TLCursor>;
 
 // @internal (undocumented)
 export const dashValidator: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+
+// @public (undocumented)
+export const defaultTldrawEditorValidator: T.UnionValidator<"typeName", {
+    pointer: T.Validator<TLPointer>;
+    asset: T.Validator<TLAsset>;
+    camera: T.Validator<TLCamera>;
+    document: T.Validator<TLDocument>;
+    instance: T.Validator<TLInstance>;
+    instance_page_state: T.Validator<TLInstancePageState>;
+    page: T.Validator<TLPage>;
+    shape: T.Validator<TLShape>;
+    user_document: T.Validator<TLUserDocument>;
+    instance_presence: T.Validator<TLInstancePresence>;
+}, never>;
 
 // @public (undocumented)
 export const documentTypeValidator: T.Validator<TLDocument>;

--- a/packages/tlschema/src/defaultTldrawEditorValidator.ts
+++ b/packages/tlschema/src/defaultTldrawEditorValidator.ts
@@ -1,0 +1,25 @@
+import { T } from '@tldraw/tlvalidate'
+import { assetTypeValidator } from './records/TLAsset'
+import { cameraTypeValidator } from './records/TLCamera'
+import { documentTypeValidator } from './records/TLDocument'
+import { instanceTypeValidator } from './records/TLInstance'
+import { instancePageStateTypeValidator } from './records/TLInstancePageState'
+import { instancePresenceTypeValidator } from './records/TLInstancePresence'
+import { pageTypeValidator } from './records/TLPage'
+import { pointerTypeValidator } from './records/TLPointer'
+import { shapeTypeValidator } from './records/TLShape'
+import { userDocumentTypeValidator } from './records/TLUserDocument'
+
+/** @public */
+export const defaultTldrawEditorValidator = T.union('typeName', {
+	pointer: pointerTypeValidator,
+	asset: assetTypeValidator,
+	camera: cameraTypeValidator,
+	document: documentTypeValidator,
+	instance: instanceTypeValidator,
+	instance_page_state: instancePageStateTypeValidator,
+	page: pageTypeValidator,
+	shape: shapeTypeValidator,
+	user_document: userDocumentTypeValidator,
+	instance_presence: instancePresenceTypeValidator,
+})

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -64,8 +64,20 @@ export {
 	type TLInstancePageState,
 	type TLInstancePageStateId,
 } from './records/TLInstancePageState'
-export { InstancePresenceRecordType, type TLInstancePresence } from './records/TLInstancePresence'
-export { PageRecordType, pageTypeValidator, type TLPage, type TLPageId } from './records/TLPage'
+export {
+	InstancePresenceRecordType,
+	instancePresenceTypeMigrations,
+	instancePresenceTypeValidator,
+	type TLInstancePresence,
+	type TLInstancePresenceId,
+} from './records/TLInstancePresence'
+export {
+	PageRecordType,
+	pageTypeMigrations,
+	pageTypeValidator,
+	type TLPage,
+	type TLPageId,
+} from './records/TLPage'
 export {
 	PointerRecordType,
 	TLPOINTER_ID,

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -25,6 +25,7 @@ export {
 export { createAssetValidator, type TLBaseAsset } from './assets/asset-validation'
 export { createPresenceStateDerivation } from './createPresenceStateDerivation'
 export { createTLSchema } from './createTLSchema'
+export { defaultTldrawEditorValidator } from './defaultTldrawEditorValidator'
 export { CLIENT_FIXUP_SCRIPT, fixupRecord } from './fixup'
 export { type Box2dModel, type Vec2dModel } from './geometry-types'
 export {

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -6,7 +6,7 @@ import { videoAssetMigrations } from './assets/TLVideoAsset'
 import { instanceTypeMigrations, instanceTypeVersions } from './records/TLInstance'
 import { instancePageStateMigrations } from './records/TLInstancePageState'
 import { instancePresenceTypeMigrations } from './records/TLInstancePresence'
-import { rootShapeTypeMigrations, TLShape } from './records/TLShape'
+import { rootShapeTypeMigrations } from './records/TLShape'
 import { userDocumentTypeMigrations, userDocumentVersions } from './records/TLUserDocument'
 import { storeMigrations, storeVersions } from './schema'
 import { arrowShapeTypeMigrations } from './shapes/TLArrowShape'
@@ -173,7 +173,6 @@ describe('TLImageAsset AddIsAnimated', () => {
 })
 
 const ShapeRecord = createRecordType('shape', {
-	validator: { validate: (record) => record as TLShape },
 	scope: 'document',
 })
 

--- a/packages/tlschema/src/records/TLAsset.ts
+++ b/packages/tlschema/src/records/TLAsset.ts
@@ -46,7 +46,6 @@ export type TLAssetPartial<T extends TLAsset = TLAsset> = T extends T
 /** @public */
 export const TLAsset = createRecordType<TLAsset>('asset', {
 	migrations: assetTypeMigrations,
-	validator: assetTypeValidator,
 	scope: 'document',
 })
 

--- a/packages/tlschema/src/records/TLCamera.ts
+++ b/packages/tlschema/src/records/TLCamera.ts
@@ -30,7 +30,6 @@ export const cameraTypeValidator: T.Validator<TLCamera> = T.model(
 
 /** @public */
 export const TLCamera = createRecordType<TLCamera>('camera', {
-	validator: cameraTypeValidator,
 	scope: 'instance',
 }).withDefaultProperties(
 	(): Omit<TLCamera, 'id' | 'typeName'> => ({

--- a/packages/tlschema/src/records/TLDocument.ts
+++ b/packages/tlschema/src/records/TLDocument.ts
@@ -22,7 +22,6 @@ export const documentTypeValidator: T.Validator<TLDocument> = T.model(
 
 /** @public */
 export const TLDocument = createRecordType<TLDocument>('document', {
-	validator: documentTypeValidator,
 	scope: 'document',
 }).withDefaultProperties(
 	(): Omit<TLDocument, 'id' | 'typeName'> => ({

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -248,7 +248,6 @@ export const instanceTypeMigrations = defineMigrations({
 /** @public */
 export const TLInstance = createRecordType<TLInstance>('instance', {
 	migrations: instanceTypeMigrations,
-	validator: instanceTypeValidator,
 	scope: 'instance',
 }).withDefaultProperties(
 	(): Omit<TLInstance, 'typeName' | 'id' | 'currentPageId'> => ({

--- a/packages/tlschema/src/records/TLInstancePageState.ts
+++ b/packages/tlschema/src/records/TLInstancePageState.ts
@@ -68,7 +68,6 @@ export const instancePageStateMigrations = defineMigrations({
 /** @public */
 export const TLInstancePageState = createRecordType<TLInstancePageState>('instance_page_state', {
 	migrations: instancePageStateMigrations,
-	validator: instancePageStateTypeValidator,
 	scope: 'instance',
 }).withDefaultProperties(
 	(): Omit<

--- a/packages/tlschema/src/records/TLInstancePresence.ts
+++ b/packages/tlschema/src/records/TLInstancePresence.ts
@@ -92,7 +92,6 @@ export const instancePresenceTypeMigrations = defineMigrations({
 /** @public */
 export const TLInstancePresence = createRecordType<TLInstancePresence>('instance_presence', {
 	migrations: instancePresenceTypeMigrations,
-	validator: instancePresenceTypeValidator,
 	scope: 'presence',
 }).withDefaultProperties(() => ({
 	lastActivityTimestamp: 0,

--- a/packages/tlschema/src/records/TLInstancePresence.ts
+++ b/packages/tlschema/src/records/TLInstancePresence.ts
@@ -8,7 +8,7 @@ import { TLPageId } from './TLPage'
 import { TLShapeId } from './TLShape'
 
 /** @public */
-export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceID> {
+export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceId> {
 	instanceId: TLInstanceId
 	userId: string
 	userName: string
@@ -30,7 +30,7 @@ export interface TLInstancePresence extends BaseRecord<'instance_presence', TLIn
 }
 
 /** @public */
-export type TLInstancePresenceID = ID<TLInstancePresence>
+export type TLInstancePresenceId = ID<TLInstancePresence>
 
 // --- VALIDATION ---
 /** @public */
@@ -39,7 +39,7 @@ export const instancePresenceTypeValidator: T.Validator<TLInstancePresence> = T.
 	T.object({
 		instanceId: idValidator<TLInstanceId>('instance'),
 		typeName: T.literal('instance_presence'),
-		id: idValidator<TLInstancePresenceID>('instance_presence'),
+		id: idValidator<TLInstancePresenceId>('instance_presence'),
 		userId: T.string,
 		userName: T.string,
 		lastActivityTimestamp: T.number,
@@ -68,6 +68,7 @@ const Versions = {
 	AddScribbleDelay: 1,
 } as const
 
+/** @public */
 export const instancePresenceTypeMigrations = defineMigrations({
 	currentVersion: Versions.AddScribbleDelay,
 	migrators: {

--- a/packages/tlschema/src/records/TLPage.ts
+++ b/packages/tlschema/src/records/TLPage.ts
@@ -28,7 +28,6 @@ export const pageTypeValidator: T.Validator<TLPage> = T.model(
 
 /** @public */
 export const TLPage = createRecordType<TLPage>('page', {
-	validator: pageTypeValidator,
 	scope: 'document',
 })
 

--- a/packages/tlschema/src/records/TLPointer.ts
+++ b/packages/tlschema/src/records/TLPointer.ts
@@ -30,7 +30,6 @@ export const pointerTypeValidator: T.Validator<TLPointer> = T.model(
 
 /** @public */
 export const TLPointer = createRecordType<TLPointer>('pointer', {
-	validator: pointerTypeValidator,
 	scope: 'instance',
 }).withDefaultProperties(
 	(): Omit<TLPointer, 'id' | 'typeName'> => ({

--- a/packages/tlschema/src/records/TLShape.ts
+++ b/packages/tlschema/src/records/TLShape.ts
@@ -1,19 +1,20 @@
 import { defineMigrations, ID, UnknownRecord } from '@tldraw/tlstore'
+import { T } from '@tldraw/tlvalidate'
 import { nanoid } from 'nanoid'
 import { TLBaseShape } from '../shapes/shape-validation'
-import { TLArrowShape } from '../shapes/TLArrowShape'
-import { TLBookmarkShape } from '../shapes/TLBookmarkShape'
-import { TLDrawShape } from '../shapes/TLDrawShape'
-import { TLEmbedShape } from '../shapes/TLEmbedShape'
-import { TLFrameShape } from '../shapes/TLFrameShape'
-import { TLGeoShape } from '../shapes/TLGeoShape'
-import { TLGroupShape } from '../shapes/TLGroupShape'
-import { TLIconShape } from '../shapes/TLIconShape'
-import { TLImageShape } from '../shapes/TLImageShape'
-import { TLLineShape } from '../shapes/TLLineShape'
-import { TLNoteShape } from '../shapes/TLNoteShape'
-import { TLTextShape } from '../shapes/TLTextShape'
-import { TLVideoShape } from '../shapes/TLVideoShape'
+import { arrowShapeTypeValidator, TLArrowShape } from '../shapes/TLArrowShape'
+import { bookmarkShapeTypeValidator, TLBookmarkShape } from '../shapes/TLBookmarkShape'
+import { drawShapeTypeValidator, TLDrawShape } from '../shapes/TLDrawShape'
+import { embedShapeTypeValidator, TLEmbedShape } from '../shapes/TLEmbedShape'
+import { frameShapeTypeValidator, TLFrameShape } from '../shapes/TLFrameShape'
+import { geoShapeTypeValidator, TLGeoShape } from '../shapes/TLGeoShape'
+import { groupShapeTypeValidator, TLGroupShape } from '../shapes/TLGroupShape'
+import { iconShapeTypeValidator, TLIconShape } from '../shapes/TLIconShape'
+import { imageShapeTypeValidator, TLImageShape } from '../shapes/TLImageShape'
+import { lineShapeTypeValidator, TLLineShape } from '../shapes/TLLineShape'
+import { noteShapeTypeValidator, TLNoteShape } from '../shapes/TLNoteShape'
+import { textShapeTypeValidator, TLTextShape } from '../shapes/TLTextShape'
+import { TLVideoShape, videoShapeTypeValidator } from '../shapes/TLVideoShape'
 import { SmooshedUnionObject } from '../util-types'
 import { TLPageId } from './TLPage'
 
@@ -120,3 +121,23 @@ export function createShapeId(): TLShapeId {
 export function createCustomShapeId(id: string): TLShapeId {
 	return `shape:${id}` as TLShapeId
 }
+
+/** @public */
+export const shapeTypeValidator: T.Validator<TLShape> = T.model(
+	'shape',
+	T.union('type', {
+		arrow: arrowShapeTypeValidator,
+		bookmark: bookmarkShapeTypeValidator,
+		draw: drawShapeTypeValidator,
+		embed: embedShapeTypeValidator,
+		frame: frameShapeTypeValidator,
+		geo: geoShapeTypeValidator,
+		group: groupShapeTypeValidator,
+		image: imageShapeTypeValidator,
+		line: lineShapeTypeValidator,
+		note: noteShapeTypeValidator,
+		text: textShapeTypeValidator,
+		video: videoShapeTypeValidator,
+		icon: iconShapeTypeValidator,
+	})
+)

--- a/packages/tlschema/src/records/TLUserDocument.ts
+++ b/packages/tlschema/src/records/TLUserDocument.ts
@@ -95,7 +95,6 @@ export const userDocumentTypeMigrations = defineMigrations({
 /** @public */
 export const TLUserDocument = createRecordType<TLUserDocument>('user_document', {
 	migrations: userDocumentTypeMigrations,
-	validator: userDocumentTypeValidator,
 	scope: 'instance',
 }).withDefaultProperties(
 	(): Omit<TLUserDocument, 'id' | 'typeName' | 'userId'> => ({

--- a/packages/tlstore/api-report.md
+++ b/packages/tlstore/api-report.md
@@ -41,7 +41,6 @@ export type ComputedCache<Data, R extends UnknownRecord> = {
 // @public
 export function createRecordType<R extends UnknownRecord>(typeName: R['typeName'], config: {
     migrations?: Migrations;
-    validator?: StoreValidator<R>;
     scope: Scope;
 }): RecordType<R, keyof Omit<R, 'id' | 'typeName'>>;
 
@@ -301,6 +300,10 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
     };
     // (undocumented)
     validateRecord(store: Store<R>, record: R, phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord', recordBefore: null | R): R;
+    // (undocumented)
+    validator: {
+        validate: (record: any) => R;
+    };
 }
 
 // @public (undocumented)
@@ -313,6 +316,9 @@ export type StoreSchemaOptions<R extends UnknownRecord, P> = {
         phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord';
         recordBefore: null | R;
     }) => R;
+    validator?: {
+        validate: (record: any) => R;
+    };
     createIntegrityChecker?: (store: Store<R, P>) => void;
 };
 

--- a/packages/tlstore/src/lib/RecordType.ts
+++ b/packages/tlstore/src/lib/RecordType.ts
@@ -218,14 +218,12 @@ export function createRecordType<R extends UnknownRecord>(
 	typeName: R['typeName'],
 	config: {
 		migrations?: Migrations
-		validator?: StoreValidator<R>
 		scope: Scope
 	}
 ): RecordType<R, keyof Omit<R, 'id' | 'typeName'>> {
 	return new RecordType<R, keyof Omit<R, 'id' | 'typeName'>>(typeName, {
 		createDefaultProperties: () => ({} as any),
 		migrations: config.migrations ?? { currentVersion: 0, firstVersion: 0, migrators: {} },
-		validator: config.validator,
 		scope: config.scope,
 	})
 }

--- a/packages/tlstore/src/lib/test/recordStore.test.ts
+++ b/packages/tlstore/src/lib/test/recordStore.test.ts
@@ -11,7 +11,6 @@ interface Book extends BaseRecord<'book', ID<Book>> {
 }
 
 const Book = createRecordType<Book>('book', {
-	validator: { validate: (book) => book as Book },
 	scope: 'document',
 })
 
@@ -21,7 +20,6 @@ interface Author extends BaseRecord<'author', ID<Author>> {
 }
 
 const Author = createRecordType<Author>('author', {
-	validator: { validate: (author) => author as Author },
 	scope: 'document',
 }).withDefaultProperties(() => ({
 	isPseudonym: false,

--- a/packages/tlstore/src/lib/test/recordStoreFuzzing.test.ts
+++ b/packages/tlstore/src/lib/test/recordStoreFuzzing.test.ts
@@ -11,16 +11,6 @@ interface Author extends BaseRecord<'author', ID<Author>> {
 	age: number
 }
 const Author = createRecordType<Author>('author', {
-	validator: {
-		validate(value) {
-			const author = value as Author
-			if (author.typeName !== 'author') throw Error()
-			if (!author.id.startsWith('author:')) throw Error()
-			if (!Number.isFinite(author.age)) throw Error()
-			if (author.age < 0) throw Error()
-			return author
-		},
-	},
 	scope: 'document',
 }).withDefaultProperties(() => ({ age: 23 }))
 
@@ -29,16 +19,6 @@ interface Book extends BaseRecord<'book', ID<Book>> {
 	authorId: ID<Author>
 }
 const Book = createRecordType<Book>('book', {
-	validator: {
-		validate(value) {
-			const book = value as Book
-			if (!book.id.startsWith('book:')) throw Error()
-			if (book.typeName !== 'book') throw Error()
-			if (typeof book.title !== 'string') throw Error()
-			if (!book.authorId.startsWith('author')) throw Error()
-			return book
-		},
-	},
 	scope: 'document',
 })
 
@@ -51,12 +31,12 @@ function rng(seed: number) {
 	}
 }
 
-type Record = Author | Book
+type StoreRecord = Author | Book
 
 type Op =
-	| { readonly type: 'add'; readonly record: Record }
-	| { readonly type: 'delete'; readonly id: IdOf<Record> }
-	| { readonly type: 'update'; readonly record: Record }
+	| { readonly type: 'add'; readonly record: StoreRecord }
+	| { readonly type: 'delete'; readonly id: IdOf<StoreRecord> }
+	| { readonly type: 'update'; readonly record: StoreRecord }
 	| { readonly type: 'set_book_name_query_param'; readonly bookName: BookName }
 	| { readonly type: 'set_author_id_query_param'; readonly authorId: IdOf<Author> }
 
@@ -325,6 +305,29 @@ function reacreateSetFromDiffs<T>(diffs: CollectionDiff<T>[]) {
 
 const NUM_OPS = 200
 
+const validator = {
+	validate: (record: StoreRecord): StoreRecord => {
+		switch (record.typeName) {
+			case 'book': {
+				const book = record as Book
+				if (!book.id.startsWith('book:')) throw Error()
+				if (book.typeName !== 'book') throw Error()
+				if (typeof book.title !== 'string') throw Error()
+				if (!book.authorId.startsWith('author')) throw Error()
+				return book
+			}
+			case 'author': {
+				const author = record as Author
+				if (author.typeName !== 'author') throw Error()
+				if (!author.id.startsWith('author:')) throw Error()
+				if (!Number.isFinite(author.age)) throw Error()
+				if (author.age < 0) throw Error()
+				return author
+			}
+		}
+	},
+}
+
 function runTest(seed: number) {
 	const store = new Store({
 		props: {},
@@ -339,6 +342,7 @@ function runTest(seed: number) {
 					firstVersion: 0,
 					migrators: {},
 				},
+				validator,
 			}
 		),
 	})

--- a/packages/tlstore/src/lib/test/recordStoreQueries.test.ts
+++ b/packages/tlstore/src/lib/test/recordStoreQueries.test.ts
@@ -9,16 +9,6 @@ interface Author extends BaseRecord<'author', ID<Author>> {
 	age: number
 }
 const Author = createRecordType<Author>('author', {
-	validator: {
-		validate(value) {
-			const author = value as Author
-			if (author.typeName !== 'author') throw Error()
-			if (!author.id.startsWith('author:')) throw Error()
-			if (!Number.isFinite(author.age)) throw Error()
-			if (author.age < 0) throw Error()
-			return author
-		},
-	},
 	scope: 'document',
 }).withDefaultProperties(() => ({ age: 23 }))
 
@@ -27,16 +17,6 @@ interface Book extends BaseRecord<'book', ID<Book>> {
 	authorId: ID<Author>
 }
 const Book = createRecordType<Book>('book', {
-	validator: {
-		validate(value) {
-			const book = value as Book
-			if (!book.id.startsWith('book:')) throw Error()
-			if (book.typeName !== 'book') throw Error()
-			if (typeof book.title !== 'string') throw Error()
-			if (!book.authorId.startsWith('author')) throw Error()
-			return book
-		},
-	},
 	scope: 'document',
 })
 const authors = {
@@ -56,12 +36,37 @@ const books = {
 	farenheit: Book.create({ title: 'Farenheit 451', authorId: authors.bradbury.id }),
 }
 
-let store: Store<Author | Book>
+type StoreRecord = Author | Book
+
+let store: Store<StoreRecord>
+
+const validator = {
+	validate: (record: StoreRecord): StoreRecord => {
+		switch (record.typeName) {
+			case 'book': {
+				const book = record
+				if (!book.id.startsWith('book:')) throw Error()
+				if (book.typeName !== 'book') throw Error()
+				if (typeof book.title !== 'string') throw Error()
+				if (!book.authorId.startsWith('author')) throw Error()
+				return book
+			}
+			case 'author': {
+				const author = record
+				if (author.typeName !== 'author') throw Error()
+				if (!author.id.startsWith('author:')) throw Error()
+				if (!Number.isFinite(author.age)) throw Error()
+				if (author.age < 0) throw Error()
+				return author
+			}
+		}
+	},
+}
 
 beforeEach(() => {
 	store = new Store({
 		props: {},
-		schema: StoreSchema.create<Author | Book>(
+		schema: StoreSchema.create<StoreRecord>(
 			{
 				author: Author,
 				book: Book,
@@ -72,6 +77,7 @@ beforeEach(() => {
 					firstVersion: 0,
 					migrators: {},
 				},
+				validator,
 			}
 		),
 	})

--- a/packages/tlstore/src/lib/test/testSchema.v0.ts
+++ b/packages/tlstore/src/lib/test/testSchema.v0.ts
@@ -13,14 +13,6 @@ const userMigrations = defineMigrations({})
 
 const User = createRecordType<User>('user', {
 	migrations: userMigrations,
-	validator: {
-		validate: (record) => {
-			assert(
-				record && typeof record === 'object' && 'name' in record && typeof record.name === 'string'
-			)
-			return record as User
-		},
-	},
 	scope: 'document',
 })
 
@@ -51,23 +43,6 @@ const shapeTypeMigrations = defineMigrations({
 
 const Shape = createRecordType<Shape<RectangleProps | OvalProps>>('shape', {
 	migrations: shapeTypeMigrations,
-	validator: {
-		validate: (record) => {
-			assert(
-				record &&
-					typeof record === 'object' &&
-					'type' in record &&
-					typeof record.type === 'string' &&
-					'x' in record &&
-					typeof record.x === 'number' &&
-					'y' in record &&
-					typeof record.y === 'number' &&
-					'props' in record &&
-					typeof record.props === 'object'
-			)
-			return record as Shape<RectangleProps | OvalProps>
-		},
-	},
 	scope: 'document',
 })
 
@@ -78,16 +53,50 @@ interface Org extends BaseRecord<'org', ID<Org>> {
 
 const Org = createRecordType<Org>('org', {
 	migrations: defineMigrations({}),
-	validator: {
-		validate: (record) => {
-			assert(
-				record && typeof record === 'object' && 'name' in record && typeof record.name === 'string'
-			)
-			return record as Org
-		},
-	},
 	scope: 'document',
 })
+
+type StoreRecord = Org | User | Shape<RectangleProps | OvalProps>
+
+const validator = {
+	validate: (record: StoreRecord): StoreRecord => {
+		switch (record.typeName) {
+			case 'org': {
+				assert(
+					record &&
+						typeof record === 'object' &&
+						'name' in record &&
+						typeof record.name === 'string'
+				)
+				return record
+			}
+			case 'user': {
+				assert(
+					record &&
+						typeof record === 'object' &&
+						'type' in record &&
+						typeof record.type === 'string' &&
+						'x' in record &&
+						typeof record.x === 'number' &&
+						'y' in record &&
+						typeof record.y === 'number' &&
+						'props' in record &&
+						typeof record.props === 'object'
+				)
+				return record
+			}
+			case 'shape': {
+				assert(
+					record &&
+						typeof record === 'object' &&
+						'name' in record &&
+						typeof record.name === 'string'
+				)
+				return record
+			}
+		}
+	},
+}
 
 export const testSchemaV0 = StoreSchema.create(
 	{
@@ -97,5 +106,6 @@ export const testSchemaV0 = StoreSchema.create(
 	},
 	{
 		snapshotMigrations: defineMigrations({}),
+		validator,
 	}
 )

--- a/packages/tlstore/src/lib/test/testSchema.v1.ts
+++ b/packages/tlstore/src/lib/test/testSchema.v1.ts
@@ -47,19 +47,6 @@ const userMigrations = defineMigrations({
 
 const User = createRecordType<User>('user', {
 	migrations: userMigrations,
-	validator: {
-		validate: (record) => {
-			assert(record && typeof record === 'object')
-			assert('id' in record && typeof record.id === 'string')
-			assert('name' in record && typeof record.name === 'string')
-			assert('locale' in record && typeof record.locale === 'string')
-			assert(
-				'phoneNumber' in record &&
-					(record.phoneNumber === null || typeof record.phoneNumber === 'string')
-			)
-			return record as User
-		},
-	},
 	scope: 'document',
 }).withDefaultProperties(() => ({
 	/* STEP 6: Add any new default values for properties here */
@@ -176,17 +163,6 @@ const shapeTypeMigrations = defineMigrations({
 
 const Shape = createRecordType<Shape<RectangleProps | OvalProps>>('shape', {
 	migrations: shapeTypeMigrations,
-	validator: {
-		validate: (record) => {
-			assert(record && typeof record === 'object')
-			assert('id' in record && typeof record.id === 'string')
-			assert('type' in record && typeof record.type === 'string')
-			assert('x' in record && typeof record.x === 'number')
-			assert('y' in record && typeof record.y === 'number')
-			assert('rotation' in record && typeof record.rotation === 'number')
-			return record as Shape<RectangleProps | OvalProps>
-		},
-	},
 	scope: 'document',
 }).withDefaultProperties(() => ({
 	x: 0,
@@ -214,6 +190,35 @@ const snapshotMigrations = defineMigrations({
 	},
 })
 
+type StoreRecord = User | Shape<any>
+
+const validator = {
+	validate: (record: StoreRecord) => {
+		switch (record.typeName) {
+			case 'shape': {
+				assert(record && typeof record === 'object')
+				assert('id' in record && typeof record.id === 'string')
+				assert('type' in record && typeof record.type === 'string')
+				assert('x' in record && typeof record.x === 'number')
+				assert('y' in record && typeof record.y === 'number')
+				assert('rotation' in record && typeof record.rotation === 'number')
+				return record as Shape<RectangleProps | OvalProps>
+			}
+			case 'user': {
+				assert(record && typeof record === 'object')
+				assert('id' in record && typeof record.id === 'string')
+				assert('name' in record && typeof record.name === 'string')
+				assert('locale' in record && typeof record.locale === 'string')
+				assert(
+					'phoneNumber' in record &&
+						(record.phoneNumber === null || typeof record.phoneNumber === 'string')
+				)
+				return record as User
+			}
+		}
+	},
+}
+
 export const testSchemaV1 = StoreSchema.create<User | Shape<any>>(
 	{
 		user: User,
@@ -221,5 +226,6 @@ export const testSchemaV1 = StoreSchema.create<User | Shape<any>>(
 	},
 	{
 		snapshotMigrations,
+		validator,
 	}
 )

--- a/packages/tlstore/src/lib/test/validate.test.ts
+++ b/packages/tlstore/src/lib/test/validate.test.ts
@@ -10,17 +10,6 @@ interface Book extends BaseRecord<'book', ID<Book>> {
 }
 
 const Book = createRecordType<Book>('book', {
-	validator: {
-		validate(value) {
-			const book = value as Book
-			if (!book.id.startsWith('book:')) throw Error()
-			if (book.typeName !== 'book') throw Error()
-			if (typeof book.title !== 'string') throw Error()
-			if (!Number.isFinite(book.numPages)) throw Error()
-			if (book.numPages < 0) throw Error()
-			return book
-		},
-	},
 	scope: 'document',
 })
 
@@ -30,20 +19,36 @@ interface Author extends BaseRecord<'author', ID<Author>> {
 }
 
 const Author = createRecordType<Author>('author', {
-	validator: {
-		validate(value) {
-			const author = value as Author
-			if (author.typeName !== 'author') throw Error()
-			if (!author.id.startsWith('author:')) throw Error()
-			if (typeof author.name !== 'string') throw Error()
-			if (typeof author.isPseudonym !== 'boolean') throw Error()
-			return author
-		},
-	},
 	scope: 'document',
 }).withDefaultProperties(() => ({
 	isPseudonym: false,
 }))
+
+type StoreRecord = Book | Author
+
+const validator = {
+	validate: (record: StoreRecord): StoreRecord => {
+		switch (record.typeName) {
+			case 'book': {
+				const book = record
+				if (!book.id.startsWith('book:')) throw Error()
+				if (book.typeName !== 'book') throw Error()
+				if (typeof book.title !== 'string') throw Error()
+				if (!Number.isFinite(book.numPages)) throw Error()
+				if (book.numPages < 0) throw Error()
+				return book
+			}
+			case 'author': {
+				const author = record
+				if (author.typeName !== 'author') throw Error()
+				if (!author.id.startsWith('author:')) throw Error()
+				if (typeof author.name !== 'string') throw Error()
+				if (typeof author.isPseudonym !== 'boolean') throw Error()
+				return author
+			}
+		}
+	},
+}
 
 const schema = StoreSchema.create<Book | Author>(
 	{
@@ -56,6 +61,7 @@ const schema = StoreSchema.create<Book | Author>(
 			firstVersion: 0,
 			migrators: {},
 		},
+		validator,
 	}
 )
 


### PR DESCRIPTION
This PR extracts the fundamental validator API changes from #1450.

The general idea is to make the Tldraw editor work a bit better by separating validators from record types.

We:
- make our RecordTypes more flexible by moving validators (and, in another PR, migrators) out of the RecordType itself, allowing for variation without modifying the RecordType

### Change Type

- [x] `major` — Breaking Change

### Test Plan

- [x] Unit Tests

### Release Notes

- Removes validator from `RecordType`
- Creates the `defaultTldrawValidator` object