### PR TITLE
[bad idea] Add route for redirecting to substack

### DIFF
--- a/apps/docs/pages/r/[id].tsx
+++ b/apps/docs/pages/r/[id].tsx
@@ -1,0 +1,11 @@
+import { useRouter } from 'next/router'
+
+export default function RedirectToSubstack() {
+	const router = useRouter()
+	const id = router.query.id as string
+
+	if (typeof window !== 'undefined') {
+		window.location.href = `https://tldraw.substack.com/p/${id}`
+	}
+	return <div>Redirecting...</div>
+}


### PR DESCRIPTION
This PR adds a route to tldraw.dev to redirect to our substack.

At best, it might help us get around the twitter algorithm penalty for substack links???
At worst, it might get tldraw.dev penalised by twitter, or could cause some cross-site-scripting issues?!!??

It uses a manual redirect a la `window.location` because I imagine the twitter algo would detect normal redirect responses.

### Change Type

- [x] `documentation` — Changes to the documentation only (will not publish a new version)

### Test Plan

1. Try a route like `tldraw.dev/r/release-notes-may-19th-2023`
2. Check that it takes you to the relevant substack post, eg: `https://tldraw.substack.com/p/release-notes-may-19th-2023`


