### PR TITLE
[minor] Mark tlsync-client internal APIs

### DIFF
--- a/packages/tlsync-client/api-report.md
+++ b/packages/tlsync-client/api-report.md
@@ -37,7 +37,7 @@ export const DEFAULT_DOCUMENT_NAME: any;
 // @internal (undocumented)
 export function getAllIndexDbNames(): string[];
 
-// @public (undocumented)
+// @public
 export function hardReset({ shouldReload }?: {
     shouldReload?: boolean | undefined;
 }): Promise<void>;

--- a/packages/tlsync-client/api-report.md
+++ b/packages/tlsync-client/api-report.md
@@ -14,7 +14,7 @@ import { TLRecord } from '@tldraw/editor';
 import { TLStore } from '@tldraw/editor';
 import { TLStoreSchema } from '@tldraw/editor';
 
-// @public (undocumented)
+// @internal (undocumented)
 export function addDbName(name: string): void;
 
 // @public (undocumented)
@@ -28,13 +28,13 @@ export class BroadcastChannelMock {
     postMessage(_msg: Message): void;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export function clearDb(universalPersistenceKey: string): void;
 
 // @public (undocumented)
 export const DEFAULT_DOCUMENT_NAME: any;
 
-// @public (undocumented)
+// @internal (undocumented)
 export function getAllIndexDbNames(): string[];
 
 // @public (undocumented)
@@ -42,7 +42,7 @@ export function hardReset({ shouldReload }?: {
     shouldReload?: boolean | undefined;
 }): Promise<void>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export function loadDataFromStore(universalPersistenceKey: string, opts?: {
     didCancel?: () => boolean;
 }): Promise<{
@@ -53,12 +53,12 @@ export function loadDataFromStore(universalPersistenceKey: string, opts?: {
 // @public (undocumented)
 export const STORE_PREFIX = "TLDRAW_DOCUMENT_v2";
 
-// @public (undocumented)
+// @internal (undocumented)
 export function storeChangesInIndexedDb(universalPersistenceKey: string, schema: TLStoreSchema, changes: RecordsDiff<any>, opts?: {
     didCancel?: () => boolean;
 }): Promise<void>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export function storeSnapshotInIndexedDb(universalPersistenceKey: string, schema: TLStoreSchema, snapshot: StoreSnapshot<any>, opts?: {
     didCancel?: () => boolean;
 }): Promise<void>;

--- a/packages/tlsync-client/api-report.md
+++ b/packages/tlsync-client/api-report.md
@@ -17,7 +17,7 @@ import { TLStoreSchema } from '@tldraw/editor';
 // @internal (undocumented)
 export function addDbName(name: string): void;
 
-// @public (undocumented)
+// @internal (undocumented)
 export class BroadcastChannelMock {
     constructor(_name: string);
     // (undocumented)
@@ -66,7 +66,7 @@ export function storeSnapshotInIndexedDb(universalPersistenceKey: string, schema
 // @public (undocumented)
 export const TAB_ID: TLInstanceId;
 
-// @public (undocumented)
+// @internal (undocumented)
 export class TLLocalSyncClient {
     constructor(store: TLStore, { universalPersistenceKey, onLoad, onLoadError, }: {
         universalPersistenceKey: string;

--- a/packages/tlsync-client/api-report.md
+++ b/packages/tlsync-client/api-report.md
@@ -4,88 +4,23 @@
 
 ```ts
 
-import { RecordsDiff } from '@tldraw/tlstore';
-import { SerializedSchema } from '@tldraw/tlstore';
-import { StoreSnapshot } from '@tldraw/tlstore';
 import { SyncedStore } from '@tldraw/editor';
 import { TldrawEditorConfig } from '@tldraw/editor';
 import { TLInstanceId } from '@tldraw/editor';
-import { TLRecord } from '@tldraw/editor';
-import { TLStore } from '@tldraw/editor';
-import { TLStoreSchema } from '@tldraw/editor';
-
-// @internal (undocumented)
-export function addDbName(name: string): void;
-
-// @internal (undocumented)
-export class BroadcastChannelMock {
-    constructor(_name: string);
-    // (undocumented)
-    close(): void;
-    // (undocumented)
-    onmessage?: (e: MessageEvent) => void;
-    // (undocumented)
-    postMessage(_msg: Message): void;
-}
-
-// @internal (undocumented)
-export function clearDb(universalPersistenceKey: string): void;
 
 // @public (undocumented)
 export const DEFAULT_DOCUMENT_NAME: any;
-
-// @internal (undocumented)
-export function getAllIndexDbNames(): string[];
 
 // @public
 export function hardReset({ shouldReload }?: {
     shouldReload?: boolean | undefined;
 }): Promise<void>;
 
-// @internal (undocumented)
-export function loadDataFromStore(universalPersistenceKey: string, opts?: {
-    didCancel?: () => boolean;
-}): Promise<{
-    records: TLRecord[];
-    schema?: SerializedSchema;
-} | undefined>;
-
 // @public (undocumented)
 export const STORE_PREFIX = "TLDRAW_DOCUMENT_v2";
 
-// @internal (undocumented)
-export function storeChangesInIndexedDb(universalPersistenceKey: string, schema: TLStoreSchema, changes: RecordsDiff<any>, opts?: {
-    didCancel?: () => boolean;
-}): Promise<void>;
-
-// @internal (undocumented)
-export function storeSnapshotInIndexedDb(universalPersistenceKey: string, schema: TLStoreSchema, snapshot: StoreSnapshot<any>, opts?: {
-    didCancel?: () => boolean;
-}): Promise<void>;
-
 // @public (undocumented)
 export const TAB_ID: TLInstanceId;
-
-// @internal (undocumented)
-export class TLLocalSyncClient {
-    constructor(store: TLStore, { universalPersistenceKey, onLoad, onLoadError, }: {
-        universalPersistenceKey: string;
-        onLoad: (self: TLLocalSyncClient) => void;
-        onLoadError: (error: Error) => void;
-    }, channel?: BroadcastChannel | BroadcastChannelMock);
-    // (undocumented)
-    readonly channel: BroadcastChannel | BroadcastChannelMock;
-    // (undocumented)
-    close(): void;
-    // (undocumented)
-    initTime: number;
-    // (undocumented)
-    readonly serializedSchema: SerializedSchema;
-    // (undocumented)
-    readonly store: TLStore;
-    // (undocumented)
-    readonly universalPersistenceKey: string;
-}
 
 // @public
 export function useLocalSyncClient({ universalPersistenceKey, instanceId, config, }: {

--- a/packages/tlsync-client/src/index.ts
+++ b/packages/tlsync-client/src/index.ts
@@ -1,16 +1,3 @@
-export { BroadcastChannelMock, TLLocalSyncClient } from './lib/TLLocalSyncClient'
 export { hardReset } from './lib/hardReset'
 export { useLocalSyncClient } from './lib/hooks/useLocalSyncClient'
-export {
-	clearDb,
-	loadDataFromStore,
-	storeChangesInIndexedDb,
-	storeSnapshotInIndexedDb,
-} from './lib/indexedDb'
-export {
-	DEFAULT_DOCUMENT_NAME,
-	STORE_PREFIX,
-	TAB_ID,
-	addDbName,
-	getAllIndexDbNames,
-} from './lib/persistence-constants'
+export { DEFAULT_DOCUMENT_NAME, STORE_PREFIX, TAB_ID } from './lib/persistence-constants'

--- a/packages/tlsync-client/src/lib/TLLocalSyncClient.ts
+++ b/packages/tlsync-client/src/lib/TLLocalSyncClient.ts
@@ -36,7 +36,7 @@ type Message = SyncMessage | AnnounceMessage
 
 const msg = (msg: Message) => msg
 
-/** @public */
+/** @internal */
 export class BroadcastChannelMock {
 	onmessage?: (e: MessageEvent) => void
 	constructor(_name: string) {
@@ -52,7 +52,7 @@ export class BroadcastChannelMock {
 
 const BC = typeof BroadcastChannel === 'undefined' ? BroadcastChannelMock : BroadcastChannel
 
-/** @public */
+/** @internal */
 export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
 	private diffQueue: RecordsDiff<any>[] = []

--- a/packages/tlsync-client/src/lib/alerts.ts
+++ b/packages/tlsync-client/src/lib/alerts.ts
@@ -1,4 +1,4 @@
-/** @public */
+/** @internal */
 export function showCantWriteToIndexDbAlert() {
 	window.alert(
 		`Oops! We could not save changes to your browser's storage. We now need to reload the page and try again.
@@ -9,7 +9,7 @@ Keep seeing this message?
 	)
 }
 
-/** @public */
+/** @internal */
 export function showCantReadFromIndexDbAlert() {
 	window.alert(
 		`Oops! We could not access to your browser's storage—and the app won't work correctly without that. We now need to reload the page and try again.

--- a/packages/tlsync-client/src/lib/hardReset.ts
+++ b/packages/tlsync-client/src/lib/hardReset.ts
@@ -1,7 +1,10 @@
 import { deleteDB } from 'idb'
 import { getAllIndexDbNames } from './persistence-constants'
 
-/** @public */
+/**
+ * Clear the database of all data associated with tldraw.
+ *
+ * @public */
 export async function hardReset({ shouldReload = true } = {}) {
 	sessionStorage.clear()
 

--- a/packages/tlsync-client/src/lib/hooks/useLocalSyncClient.ts
+++ b/packages/tlsync-client/src/lib/hooks/useLocalSyncClient.ts
@@ -4,8 +4,7 @@ import '../hardReset'
 import { TLLocalSyncClient } from '../TLLocalSyncClient'
 
 /**
- * This is a temporary solution that will be replaced with the remote sync client once it has the db
- * integrated
+ * Use a client that persists to indexedDB and syncs to other stores with the same instance id, e.g. other tabs running the same instance of tldraw.
  *
  * @public
  */

--- a/packages/tlsync-client/src/lib/indexedDb.ts
+++ b/packages/tlsync-client/src/lib/indexedDb.ts
@@ -20,7 +20,7 @@ async function withDb<T>(storeId: string, cb: (db: IDBPDatabase<unknown>) => Pro
 	}
 }
 
-/** @public */
+/** @internal */
 export async function loadDataFromStore(
 	universalPersistenceKey: string,
 	opts?: {
@@ -41,7 +41,7 @@ export async function loadDataFromStore(
 	})
 }
 
-/** @public */
+/** @internal */
 export async function storeChangesInIndexedDb(
 	universalPersistenceKey: string,
 	schema: TLStoreSchema,
@@ -76,7 +76,7 @@ export async function storeChangesInIndexedDb(
 	})
 }
 
-/** @public */
+/** @internal */
 export async function storeSnapshotInIndexedDb(
 	universalPersistenceKey: string,
 	schema: TLStoreSchema,
@@ -105,7 +105,7 @@ export async function storeSnapshotInIndexedDb(
 	})
 }
 
-/** @public */
+/** @internal */
 export function clearDb(universalPersistenceKey: string) {
 	const dbId = STORE_PREFIX + universalPersistenceKey
 	indexedDB.deleteDatabase(dbId)

--- a/packages/tlsync-client/src/lib/persistence-constants.ts
+++ b/packages/tlsync-client/src/lib/persistence-constants.ts
@@ -27,6 +27,7 @@ function iOS() {
 // the id of the document that will be loaded if the URL doesn't contain a document id
 // again, stored in localStorage
 const defaultDocumentKey = 'TLDRAW_DEFAULT_DOCUMENT_NAME_v2'
+
 /** @public */
 export const DEFAULT_DOCUMENT_NAME =
 	(window?.localStorage.getItem(defaultDocumentKey) as any) ?? uniqueId()
@@ -59,7 +60,7 @@ window?.addEventListener('beforeunload', () => {
 
 const dbNameIndexKey = 'TLDRAW_DB_NAME_INDEX_v2'
 
-/** @public */
+/** @internal */
 export function getAllIndexDbNames(): string[] {
 	const result = JSON.parse(window?.localStorage.getItem(dbNameIndexKey) || '[]') ?? []
 	if (!Array.isArray(result)) {
@@ -68,7 +69,7 @@ export function getAllIndexDbNames(): string[] {
 	return result
 }
 
-/** @public */
+/** @internal */
 export function addDbName(name: string) {
 	const all = new Set(getAllIndexDbNames())
 	all.add(name)


### PR DESCRIPTION
This PR marks internal APIs as internal in `tlsync-client`.

### Change Type

- [x] `major` — Breaking Change

### Release Notes

- Removes internal APIs from `@tldraw/tlsync-client`