### PR TITLE
[fix] eslint from brivate

### DIFF
--- a/apps/vscode/editor/package.json
+++ b/apps/vscode/editor/package.json
@@ -30,7 +30,7 @@
 		"build": "yarn run -T tsx scripts/build.ts",
 		"dev": "yarn run -T tsx scripts/dev.ts",
 		"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-		"lint": "yarn run -T tsx ../../../scripts/lint.ts"
+		"lint": "yarn run -T eslint --report-unused-disable-directives --ignore-path ../../../.eslintignore"
 	},
 	"devDependencies": {
 		"@tldraw/assets": "workspace:*",

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -126,7 +126,7 @@
 		"build": "cd ../editor && yarn build && cd ../extension && tsx scripts/build.ts",
 		"package": "yarn build && tsx scripts/package.ts",
 		"publish": "vsce publish",
-		"lint": "yarn run -T tsx ../../../scripts/lint.ts",
+		"lint": "yarn run -T eslint --report-unused-disable-directives --ignore-path ../../../.eslintignore",
 		"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf editor && rm -rf temp & yarn"
 	},
 	"devDependencies": {

--- a/scripts/check-scripts.ts
+++ b/scripts/check-scripts.ts
@@ -63,6 +63,14 @@ const perPackageExceptions: Record<string, Record<string, () => string | undefin
 		prepack: () => undefined,
 		postpack: () => undefined,
 	},
+	'tldraw-vscode': {
+		lint: () =>
+			'yarn run -T eslint --report-unused-disable-directives --ignore-path ../../../.eslintignore',
+	},
+	'@tldraw/vscode-editor': {
+		lint: () =>
+			'yarn run -T eslint --report-unused-disable-directives --ignore-path ../../../.eslintignore',
+	},
 }
 
 async function main({ fix }: { fix?: boolean }) {


### PR DESCRIPTION
This PR updates the `lint` scripts for the vs code extension in order to solve a very weird bug with our submodules setup.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package (will not publish a new version)
