### PR TITLE
Filter out unused assets.

### DIFF
--- a/packages/file-format/src/lib/file.ts
+++ b/packages/file-format/src/lib/file.ts
@@ -196,7 +196,7 @@ export async function serializeTldrawJson(store: TLStore): Promise<string> {
 				break
 		}
 	}
-	const recordsToSave = records.concat(assets.filter((r) => usedAssets.has(r.id)))
+	const recordsToSave = records.concat(assets.filter((a) => usedAssets.has(a.id)))
 
 	return JSON.stringify({
 		tldrawFileFormatVersion: LATEST_TLDRAW_FILE_FORMAT_VERSION,


### PR DESCRIPTION
Prunes unused assets when exporting to a file.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Insert an image.
2. Delete the image.
3. Save to file.
4. The saved file should not have the asset record present.
5. The file size should also be quite small (around 2kb for a file with no shapes).

### Release Notes

- Optimize file size of exported files.
