### PR TITLE
restore styles sets exports

### DIFF
--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -477,7 +477,34 @@ export const sizeValidator: T.Validator<"l" | "m" | "s" | "xl">;
 export const splineValidator: T.Validator<"cubic" | "line">;
 
 // @public (undocumented)
+export const TL_ALIGN_TYPES: Set<"end" | "middle" | "start">;
+
+// @public (undocumented)
+export const TL_ARROWHEAD_TYPES: Set<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+
+// @public
+export const TL_COLOR_TYPES: Set<"accent" | "black" | "laser" | "muted-1" | "selection-fill" | "selection-stroke" | "white">;
+
+// @public (undocumented)
+export const TL_DASH_TYPES: Set<"dashed" | "dotted" | "draw" | "solid">;
+
+// @public (undocumented)
+export const TL_FILL_TYPES: Set<"none" | "pattern" | "semi" | "solid">;
+
+// @public (undocumented)
+export const TL_FONT_TYPES: Set<"draw" | "mono" | "sans" | "serif">;
+
+// @public (undocumented)
 export const TL_GEO_TYPES: Set<"arrow-down" | "arrow-left" | "arrow-right" | "arrow-up" | "check-box" | "diamond" | "ellipse" | "hexagon" | "octagon" | "oval" | "pentagon" | "rectangle" | "rhombus-2" | "rhombus" | "star" | "trapezoid" | "triangle" | "x-box">;
+
+// @public (undocumented)
+export const TL_OPACITY_TYPES: Set<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+
+// @public (undocumented)
+export const TL_SIZE_TYPES: Set<"l" | "m" | "s" | "xl">;
+
+// @public (undocumented)
+export const TL_SPLINE_TYPES: Set<"cubic" | "line">;
 
 // @public (undocumented)
 export const TL_STYLE_TYPES: Set<"align" | "arrowheadEnd" | "arrowheadStart" | "color" | "dash" | "fill" | "font" | "geo" | "icon" | "labelColor" | "opacity" | "size" | "spline" | "verticalAlign">;
@@ -620,7 +647,7 @@ export interface TLCamera extends BaseRecord<'camera', TLCameraId> {
 export type TLCameraId = RecordId<TLCamera>;
 
 // @public
-export type TLColor = SetValue<typeof TL_COLOR_TYPES_2>;
+export type TLColor = SetValue<typeof TL_COLOR_TYPES>;
 
 // @public (undocumented)
 export interface TLColorStyle extends TLBaseStyle {
@@ -631,7 +658,7 @@ export interface TLColorStyle extends TLBaseStyle {
 }
 
 // @public (undocumented)
-export type TLColorType = SetValue<typeof TL_COLOR_TYPES>;
+export type TLColorType = SetValue<typeof TL_COLOR_TYPES_2>;
 
 // @public
 export interface TLCursor {

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -11,7 +11,7 @@ export { type TLVideoAsset } from './assets/TLVideoAsset'
 export { createPresenceStateDerivation } from './createPresenceStateDerivation'
 export { createTLSchema } from './createTLSchema'
 export { CLIENT_FIXUP_SCRIPT, fixupRecord } from './fixup'
-export { colorTypeValidator, type TLColor } from './misc/TLColor'
+export { TL_COLOR_TYPES, colorTypeValidator, type TLColor } from './misc/TLColor'
 export { type TLCursor, type TLCursorType } from './misc/TLCursor'
 export { type TLHandle, type TLHandleType } from './misc/TLHandle'
 export { scribbleValidator, type TLScribble } from './misc/TLScribble'
@@ -87,22 +87,58 @@ export { type TLLineShape } from './shapes/TLLineShape'
 export { type TLNoteShape } from './shapes/TLNoteShape'
 export { type TLTextShape, type TLTextShapeProps } from './shapes/TLTextShape'
 export { type TLVideoShape } from './shapes/TLVideoShape'
-export { alignValidator, type TLAlignStyle, type TLAlignType } from './styles/TLAlignStyle'
 export {
+	TL_ALIGN_TYPES,
+	alignValidator,
+	type TLAlignStyle,
+	type TLAlignType,
+} from './styles/TLAlignStyle'
+export {
+	TL_ARROWHEAD_TYPES,
 	type TLArrowheadEndStyle,
 	type TLArrowheadStartStyle,
 	type TLArrowheadType,
 } from './styles/TLArrowheadStyle'
 export { TL_STYLE_TYPES, type TLStyleType } from './styles/TLBaseStyle'
 export { colorValidator, type TLColorStyle, type TLColorType } from './styles/TLColorStyle'
-export { dashValidator, type TLDashStyle, type TLDashType } from './styles/TLDashStyle'
-export { fillValidator, type TLFillStyle, type TLFillType } from './styles/TLFillStyle'
-export { fontValidator, type TLFontStyle, type TLFontType } from './styles/TLFontStyle'
+export {
+	TL_DASH_TYPES,
+	dashValidator,
+	type TLDashStyle,
+	type TLDashType,
+} from './styles/TLDashStyle'
+export {
+	TL_FILL_TYPES,
+	fillValidator,
+	type TLFillStyle,
+	type TLFillType,
+} from './styles/TLFillStyle'
+export {
+	TL_FONT_TYPES,
+	fontValidator,
+	type TLFontStyle,
+	type TLFontType,
+} from './styles/TLFontStyle'
 export { TL_GEO_TYPES, geoValidator, type TLGeoStyle, type TLGeoType } from './styles/TLGeoStyle'
 export { iconValidator, type TLIconStyle, type TLIconType } from './styles/TLIconStyle'
-export { opacityValidator, type TLOpacityStyle, type TLOpacityType } from './styles/TLOpacityStyle'
-export { sizeValidator, type TLSizeStyle, type TLSizeType } from './styles/TLSizeStyle'
-export { splineValidator, type TLSplineStyle, type TLSplineType } from './styles/TLSplineStyle'
+export {
+	TL_OPACITY_TYPES,
+	opacityValidator,
+	type TLOpacityStyle,
+	type TLOpacityType,
+} from './styles/TLOpacityStyle'
+export {
+	TL_SIZE_TYPES,
+	sizeValidator,
+	type TLSizeStyle,
+	type TLSizeType,
+} from './styles/TLSizeStyle'
+export {
+	TL_SPLINE_TYPES,
+	splineValidator,
+	type TLSplineStyle,
+	type TLSplineType,
+} from './styles/TLSplineStyle'
 export { verticalAlignValidator, type TLVerticalAlignType } from './styles/TLVerticalAlignStyle'
 export { type TLStyleCollections, type TLStyleItem, type TLStyleProps } from './styles/style-types'
 export {


### PR DESCRIPTION
This PR restores the sets into schema exports so that they can be picked up by check translations script. 

### Change Type

- [x] `internal` — Any other changes that don't affect the published package (will not publish a new version)
