### PR TITLE
Move shape schema (prop validators & migrations) onto shape utils

### DIFF
--- a/apps/examples/src/3-custom-config/CustomConfigExample.tsx
+++ b/apps/examples/src/3-custom-config/CustomConfigExample.tsx
@@ -4,7 +4,7 @@ import '@tldraw/tldraw/ui.css'
 import { CardShapeTool } from './CardShapeTool'
 import { CardShapeUtil } from './CardShapeUtil'
 
-const shapes = { card: { util: CardShapeUtil } }
+const shapes = { card: CardShapeUtil }
 const tools = [CardShapeTool]
 
 export default function CustomConfigExample() {

--- a/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
+++ b/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
@@ -4,9 +4,7 @@ import '@tldraw/tldraw/ui.css'
 import { ErrorShapeUtil } from './ErrorShapeUtil'
 
 const shapes = {
-	error: {
-		util: ErrorShapeUtil, // a custom shape that will always error
-	},
+	error: ErrorShapeUtil, // a custom shape that will always error
 }
 
 export default function ErrorBoundaryExample() {

--- a/apps/examples/src/8-error-boundary/ErrorShapeUtil.ts
+++ b/apps/examples/src/8-error-boundary/ErrorShapeUtil.ts
@@ -2,7 +2,7 @@ import { BaseBoxShapeUtil } from '@tldraw/tldraw'
 import { ErrorShape } from './ErrorShape'
 
 export class ErrorShapeUtil extends BaseBoxShapeUtil<ErrorShape> {
-	static override type = 'error'
+	static override type = 'error' as const
 	override type = 'error' as const
 
 	defaultProps() {

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -6,12 +6,14 @@
 
 /// <reference types="react" />
 
+import { ArrayOfValidator } from '@tldraw/validate/.tsbuild/lib/validation';
 import { Atom } from 'signia';
 import { Box2d } from '@tldraw/primitives';
 import { Box2dModel } from '@tldraw/tlschema';
 import { Computed } from 'signia';
 import { ComputedCache } from '@tldraw/store';
 import { CubicSpline2d } from '@tldraw/primitives';
+import { DictValidator } from '@tldraw/validate/.tsbuild/lib/validation';
 import { EASINGS } from '@tldraw/primitives';
 import { EmbedDefinition } from '@tldraw/tlschema';
 import { EventEmitter } from 'eventemitter3';
@@ -32,9 +34,11 @@ import { SerializedSchema } from '@tldraw/store';
 import { Signal } from 'signia';
 import { StoreSnapshot } from '@tldraw/store';
 import { StrokePoint } from '@tldraw/primitives';
+import { T } from '@tldraw/validate';
 import { TLAlignType } from '@tldraw/tlschema';
 import { TLArrowheadType } from '@tldraw/tlschema';
 import { TLArrowShape } from '@tldraw/tlschema';
+import { TLArrowTerminal } from '@tldraw/tlschema';
 import { TLAsset } from '@tldraw/tlschema';
 import { TLAssetId } from '@tldraw/tlschema';
 import { TLAssetPartial } from '@tldraw/tlschema';
@@ -47,6 +51,7 @@ import { TLColorType } from '@tldraw/tlschema';
 import { TLCursor } from '@tldraw/tlschema';
 import { TLDocument } from '@tldraw/tlschema';
 import { TLDrawShape } from '@tldraw/tlschema';
+import { TLDrawShapeSegment } from '@tldraw/tlschema';
 import { TLEmbedShape } from '@tldraw/tlschema';
 import { TLFontType } from '@tldraw/tlschema';
 import { TLFrameShape } from '@tldraw/tlschema';
@@ -85,6 +90,7 @@ import { TLUnknownShape } from '@tldraw/tlschema';
 import { TLUserDocument } from '@tldraw/tlschema';
 import { TLVideoAsset } from '@tldraw/tlschema';
 import { TLVideoShape } from '@tldraw/tlschema';
+import { Validator } from '@tldraw/validate/.tsbuild/lib/validation';
 import { Vec2d } from '@tldraw/primitives';
 import { Vec2dModel } from '@tldraw/tlschema';
 import { VecLike } from '@tldraw/primitives';
@@ -150,6 +156,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     get labelBoundsCache(): ComputedCache<Box2d | null, TLArrowShape>;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onDoubleClickHandle: (shape: TLArrowShape, handle: TLHandle) => TLShapePartial<TLArrowShape> | void;
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLArrowShape>;
@@ -159,6 +167,22 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     onResize: TLOnResizeHandler<TLArrowShape>;
     // (undocumented)
     onTranslateStart: TLOnTranslateStartHandler<TLArrowShape>;
+    // (undocumented)
+    props: {
+        labelColor: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        fill: Validator<"none" | "pattern" | "semi" | "solid">;
+        dash: Validator<"dashed" | "dotted" | "draw" | "solid">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        arrowheadStart: Validator<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+        arrowheadEnd: Validator<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+        font: Validator<"draw" | "mono" | "sans" | "serif">;
+        start: Validator<TLArrowTerminal>;
+        end: Validator<TLArrowTerminal>;
+        bend: Validator<number>;
+        text: Validator<string>;
+    };
     // (undocumented)
     render(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -217,9 +241,19 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
     indicator(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onBeforeCreate?: TLOnBeforeCreateHandler<TLBookmarkShape>;
     // (undocumented)
     onBeforeUpdate?: TLOnBeforeUpdateHandler<TLBookmarkShape>;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        h: Validator<number>;
+        assetId: Validator<null | TLAssetId>;
+        url: Validator<string>;
+    };
     // (undocumented)
     render(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -313,7 +347,15 @@ export function defaultEmptyAs(str: string, dflt: string): string;
 export const DefaultErrorFallback: TLErrorFallbackComponent;
 
 // @public (undocumented)
-export const defaultShapes: Record<string, TLShapeInfo>;
+export const defaultShapes: {
+    draw: typeof DrawShapeUtil;
+    geo: typeof GeoShapeUtil;
+    line: typeof LineShapeUtil;
+    note: typeof NoteShapeUtil;
+    frame: typeof FrameShapeUtil;
+    arrow: typeof ArrowShapeUtil;
+    highlight: typeof HighlightShapeUtil;
+};
 
 // @public (undocumented)
 export const defaultTools: TLStateNodeConstructor[];
@@ -356,7 +398,21 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
     // (undocumented)
     isClosed: (shape: TLDrawShape) => boolean;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLDrawShape>;
+    // (undocumented)
+    props: {
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        fill: Validator<"none" | "pattern" | "semi" | "solid">;
+        dash: Validator<"dashed" | "dotted" | "draw" | "solid">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        segments: ArrayOfValidator<TLDrawShapeSegment>;
+        isComplete: Validator<boolean>;
+        isClosed: Validator<boolean>;
+        isPen: Validator<boolean>;
+    };
     // (undocumented)
     render(shape: TLDrawShape): JSX.Element;
     // (undocumented)
@@ -807,7 +863,19 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
     isAspectRatioLocked: TLShapeUtilFlag<TLEmbedShape>;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLEmbedShape>;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        h: Validator<number>;
+        url: Validator<string>;
+        tmpOldUrl: Validator<string | undefined>;
+        doesResize: Validator<boolean>;
+        overridePermissions: Validator<Record<"allow-downloads-without-user-activation" | "allow-downloads" | "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups-to-escape-sandbox" | "allow-popups" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation-by-user-activation" | "allow-top-navigation", boolean | undefined> | undefined>;
+    };
     // (undocumented)
     render(shape: TLEmbedShape): JSX.Element;
     // (undocumented)
@@ -869,6 +937,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     indicator(shape: TLFrameShape): JSX.Element;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onDragShapesOut: (_shape: TLFrameShape, shapes: TLShape[]) => void;
     // (undocumented)
     onDragShapesOver: (frame: TLFrameShape, shapes: TLShape[]) => {
@@ -876,6 +946,13 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     };
     // (undocumented)
     onResizeEnd: TLOnResizeEndHandler<TLFrameShape>;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        h: Validator<number>;
+        name: Validator<string>;
+    };
     // (undocumented)
     providesBackgroundForChildren(): boolean;
     // (undocumented)
@@ -904,6 +981,8 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     hitTestPoint(shape: TLGeoShape, point: VecLike): boolean;
     // (undocumented)
     indicator(shape: TLGeoShape): JSX.Element;
+    // (undocumented)
+    migrations: Migrations;
     // (undocumented)
     onBeforeCreate: (shape: TLGeoShape) => {
         props: {
@@ -994,6 +1073,24 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     onEditEnd: TLOnEditEndHandler<TLGeoShape>;
     // (undocumented)
     onResize: TLOnResizeHandler<TLGeoShape>;
+    // (undocumented)
+    props: {
+        geo: Validator<"arrow-down" | "arrow-left" | "arrow-right" | "arrow-up" | "check-box" | "diamond" | "ellipse" | "hexagon" | "octagon" | "oval" | "pentagon" | "rectangle" | "rhombus-2" | "rhombus" | "star" | "trapezoid" | "triangle" | "x-box">;
+        labelColor: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        fill: Validator<"none" | "pattern" | "semi" | "solid">;
+        dash: Validator<"dashed" | "dotted" | "draw" | "solid">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        font: Validator<"draw" | "mono" | "sans" | "serif">;
+        align: Validator<"end" | "middle" | "start">;
+        verticalAlign: Validator<"end" | "middle" | "start">;
+        url: Validator<string>;
+        w: Validator<number>;
+        h: Validator<number>;
+        growY: Validator<number>;
+        text: Validator<string>;
+    };
     // (undocumented)
     render(shape: TLGeoShape): JSX.Element;
     // (undocumented)
@@ -1114,7 +1211,13 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     indicator(shape: TLGroupShape): JSX.Element;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onChildrenChange: TLOnChildrenChangeHandler<TLGroupShape>;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    };
     // (undocumented)
     render(shape: TLGroupShape): JSX.Element | null;
     // (undocumented)
@@ -1164,7 +1267,18 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
     // (undocumented)
     indicator(shape: TLHighlightShape): JSX.Element;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLHighlightShape>;
+    // (undocumented)
+    props: {
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        segments: ArrayOfValidator<TLDrawShapeSegment>;
+        isComplete: Validator<boolean>;
+        isPen: Validator<boolean>;
+    };
     // (undocumented)
     render(shape: TLHighlightShape): JSX.Element;
     // (undocumented)
@@ -1197,9 +1311,32 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     isAspectRatioLocked: () => boolean;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onDoubleClick: (shape: TLImageShape) => void;
     // (undocumented)
     onDoubleClickEdge: TLOnDoubleClickHandler<TLImageShape>;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        h: Validator<number>;
+        playing: Validator<boolean>;
+        url: Validator<string>;
+        assetId: Validator<TLAssetId | null>;
+        crop: Validator<    {
+        topLeft: {
+        x: number;
+        y: number;
+        z: number | undefined;
+        };
+        bottomRight: {
+        x: number;
+        y: number;
+        z: number | undefined;
+        };
+        } | null>;
+    };
     // (undocumented)
     render(shape: TLImageShape): JSX.Element;
     // (undocumented)
@@ -1267,9 +1404,20 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     isClosed: () => boolean;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onHandleChange: TLOnHandleChangeHandler<TLLineShape>;
     // (undocumented)
     onResize: TLOnResizeHandler<TLLineShape>;
+    // (undocumented)
+    props: {
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        dash: Validator<"dashed" | "dotted" | "draw" | "solid">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        spline: Validator<"cubic" | "line">;
+        handles: DictValidator<string, TLHandle>;
+    };
     // (undocumented)
     render(shape: TLLineShape): JSX.Element | undefined;
     // (undocumented)
@@ -1690,6 +1838,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onBeforeCreate: (next: TLNoteShape) => {
         props: {
             growY: number;
@@ -1735,6 +1885,17 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     } | undefined;
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
+    // (undocumented)
+    props: {
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        font: Validator<"draw" | "mono" | "sans" | "serif">;
+        align: Validator<"end" | "middle" | "start">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        growY: Validator<number>;
+        url: Validator<string>;
+        text: Validator<string>;
+    };
     // (undocumented)
     render(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -1811,7 +1972,7 @@ export function setUserPreferences(user: TLUserPreferences): void;
 
 // @public (undocumented)
 export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
-    constructor(editor: Editor, type: T['type']);
+    constructor(_editor: Editor | null, type: T['type']);
     bounds(shape: T): Box2d;
     canBind: <K>(_shape: T, _otherShape?: K | undefined) => boolean;
     canCrop: TLShapeUtilFlag<T>;
@@ -1824,7 +1985,7 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     center(shape: T): Vec2dModel;
     abstract defaultProps(): T['props'];
     // (undocumented)
-    editor: Editor;
+    get editor(): Editor;
     // @internal (undocumented)
     expandSelectionOutlinePx(shape: T): number;
     protected abstract getBounds(shape: T): Box2d;
@@ -1843,6 +2004,8 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     is(shape: TLBaseShape<string, object>): shape is T;
     isAspectRatioLocked: TLShapeUtilFlag<T>;
     isClosed: TLShapeUtilFlag<T>;
+    // (undocumented)
+    migrations?: Migrations;
     onBeforeCreate?: TLOnBeforeCreateHandler<T>;
     onBeforeUpdate?: TLOnBeforeUpdateHandler<T>;
     // @internal
@@ -1870,6 +2033,10 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     onTranslateStart?: TLOnTranslateStartHandler<T>;
     outline(shape: T): Vec2dModel[];
     point(shape: T): Vec2dModel;
+    // (undocumented)
+    props?: {
+        [Prop in keyof T['props']]: T.Validator<T['props'][Prop]>;
+    };
     // @internal
     providesBackgroundForChildren(shape: T): boolean;
     abstract render(shape: T): any;
@@ -2012,6 +2179,8 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     isAspectRatioLocked: TLShapeUtilFlag<TLTextShape>;
     // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
     onBeforeCreate: (shape: TLTextShape) => {
         x: number;
         y: number;
@@ -2067,6 +2236,18 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     onEditEnd: TLOnEditEndHandler<TLTextShape>;
     // (undocumented)
     onResize: TLOnResizeHandler<TLTextShape>;
+    // (undocumented)
+    props: {
+        color: Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+        size: Validator<"l" | "m" | "s" | "xl">;
+        font: Validator<"draw" | "mono" | "sans" | "serif">;
+        align: Validator<"end" | "middle" | "start">;
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        text: Validator<string>;
+        scale: Validator<number>;
+        autoSize: Validator<boolean>;
+    };
     // (undocumented)
     render(shape: TLTextShape): JSX.Element;
     // (undocumented)
@@ -2171,7 +2352,7 @@ export const TldrawEditor: React_2.NamedExoticComponent<TldrawEditorProps>;
 // @public (undocumented)
 export type TldrawEditorProps = {
     children?: any;
-    shapes?: Record<string, TLShapeInfo>;
+    shapes?: Record<string, AnyTLShapeUtilConstructor>;
     tools?: TLStateNodeConstructor[];
     assetUrls?: TLEditorAssetUrls;
     autoFocus?: boolean;
@@ -2246,7 +2427,7 @@ export interface TLEditorComponents {
 // @public (undocumented)
 export interface TLEditorOptions {
     getContainer: () => HTMLElement;
-    shapes?: Record<string, TLShapeInfo>;
+    shapes?: Record<string, AnyTLShapeUtilConstructor>;
     store: TLStore;
     tools?: TLStateNodeConstructor[];
     user?: TLUser;
@@ -2530,7 +2711,7 @@ export type TLSelectionHandle = RotateCorner | SelectionCorner | SelectionEdge;
 // @public (undocumented)
 export interface TLShapeUtilConstructor<T extends TLUnknownShape, U extends ShapeUtil<T> = ShapeUtil<T>> {
     // (undocumented)
-    new (editor: Editor, type: T['type']): U;
+    new (editor: Editor | null, type: T['type']): U;
     // (undocumented)
     type: T['type'];
 }
@@ -2659,6 +2840,18 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)
     isAspectRatioLocked: () => boolean;
+    // (undocumented)
+    migrations: Migrations;
+    // (undocumented)
+    props: {
+        opacity: Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+        w: Validator<number>;
+        h: Validator<number>;
+        time: Validator<number>;
+        playing: Validator<boolean>;
+        url: Validator<string>;
+        assetId: Validator<TLAssetId | null>;
+    };
     // (undocumented)
     render(shape: TLVideoShape): JSX.Element;
     // (undocumented)

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -3,11 +3,11 @@ import { TLAsset, TLInstanceId, TLRecord, TLStore } from '@tldraw/tlschema'
 import { annotateError } from '@tldraw/utils'
 import React, { memo, useCallback, useLayoutEffect, useState, useSyncExternalStore } from 'react'
 import { Editor } from './app/Editor'
+import { AnyTLShapeUtilConstructor } from './app/shapeutils/ShapeUtil'
 import { TLStateNodeConstructor } from './app/tools/StateNode'
 import { TLEditorAssetUrls, defaultEditorAssetUrls } from './assetUrls'
 import { DefaultErrorFallback } from './components/DefaultErrorFallback'
 import { OptionalErrorBoundary } from './components/ErrorBoundary'
-import { TLShapeInfo } from './config/createTLStore'
 import { ContainerProvider, useContainer } from './hooks/useContainer'
 import { useCursor } from './hooks/useCursor'
 import { useDarkMode } from './hooks/useDarkMode'
@@ -32,7 +32,7 @@ export type TldrawEditorProps = {
 	/**
 	 * An array of shape utils to use in the editor.
 	 */
-	shapes?: Record<string, TLShapeInfo>
+	shapes?: Record<string, AnyTLShapeUtilConstructor>
 	/**
 	 * An array of tools to use in the editor.
 	 */

--- a/packages/editor/src/lib/app/Editor.ts
+++ b/packages/editor/src/lib/app/Editor.ts
@@ -70,6 +70,7 @@ import {
 	compact,
 	dedupe,
 	deepCopy,
+	mapObjectMap,
 	partition,
 	sortById,
 	structuredClone,
@@ -77,7 +78,6 @@ import {
 import { EventEmitter } from 'eventemitter3'
 import { nanoid } from 'nanoid'
 import { EMPTY_ARRAY, atom, computed, transact } from 'signia'
-import { TLShapeInfo } from '../config/createTLStore'
 import { TLUser, createTLUser } from '../config/createTLUser'
 import { coreShapes, defaultShapes } from '../config/defaultShapes'
 import { defaultTools } from '../config/defaultTools'
@@ -131,7 +131,7 @@ import {
 import { getStraightArrowInfo } from './shapeutils/ArrowShapeUtil/arrow/straight-arrow'
 import { FrameShapeUtil } from './shapeutils/FrameShapeUtil/FrameShapeUtil'
 import { GroupShapeUtil } from './shapeutils/GroupShapeUtil/GroupShapeUtil'
-import { ShapeUtil, TLResizeMode } from './shapeutils/ShapeUtil'
+import { AnyTLShapeUtilConstructor, ShapeUtil, TLResizeMode } from './shapeutils/ShapeUtil'
 import { TextShapeUtil } from './shapeutils/TextShapeUtil/TextShapeUtil'
 import { TLExportColors } from './shapeutils/shared/TLExportColors'
 import { RootState } from './tools/RootState'
@@ -164,7 +164,7 @@ export interface TLEditorOptions {
 	/**
 	 * An array of shapes to use in the editor. These will be used to create and manage shapes in the editor.
 	 */
-	shapes?: Record<string, TLShapeInfo>
+	shapes?: Record<string, AnyTLShapeUtilConstructor>
 	/**
 	 * An array of tools to use in the editor. These will be used to handle events and manage user interactions in the editor.
 	 */
@@ -203,11 +203,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// Shapes.
 		// Accept shapes from constructor parameters which may not conflict with the root note's core tools.
-		const shapeUtils = Object.fromEntries(
-			Object.values(coreShapes).map(({ util: Util }) => [Util.type, new Util(this, Util.type)])
+		const shapeUtils: Record<string, ShapeUtil> = mapObjectMap(
+			coreShapes,
+			(_, Util: AnyTLShapeUtilConstructor) => new Util(this, Util.type)
 		)
 
-		for (const [type, { util: Util }] of Object.entries(shapes)) {
+		for (const [type, Util] of Object.entries(shapes)) {
 			if (shapeUtils[type]) {
 				throw Error(`May not overwrite core shape of type "${type}".`)
 			}

--- a/packages/editor/src/lib/app/shapeutils/ArrowShapeUtil/ArrowShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/ArrowShapeUtil/ArrowShapeUtil.tsx
@@ -12,6 +12,8 @@ import {
 } from '@tldraw/primitives'
 import { ComputedCache } from '@tldraw/store'
 import {
+	arrowShapeMigrations,
+	arrowShapePropsValidators,
 	TLArrowheadType,
 	TLArrowShape,
 	TLColorType,
@@ -58,6 +60,8 @@ let globalRenderIndex = 0
 /** @public */
 export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	static override type = 'arrow'
+	override props = arrowShapePropsValidators
+	override migrations = arrowShapeMigrations
 
 	override canEdit = () => true
 	override canBind = () => false

--- a/packages/editor/src/lib/app/shapeutils/BookmarkShapeUtil/BookmarkShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/BookmarkShapeUtil/BookmarkShapeUtil.tsx
@@ -1,5 +1,12 @@
 import { toDomPrecision } from '@tldraw/primitives'
-import { AssetRecordType, TLAssetId, TLBookmarkAsset, TLBookmarkShape } from '@tldraw/tlschema'
+import {
+	AssetRecordType,
+	TLAssetId,
+	TLBookmarkAsset,
+	TLBookmarkShape,
+	bookmarkShapePropsValidators,
+} from '@tldraw/tlschema'
+import { bookmarkAssetMigrations } from '@tldraw/tlschema/src/assets/TLBookmarkAsset'
 import { debounce, getHashForString } from '@tldraw/utils'
 import { HTMLContainer } from '../../../components/HTMLContainer'
 import {
@@ -19,6 +26,8 @@ import { HyperlinkButton } from '../shared/HyperlinkButton'
 /** @public */
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 	static override type = 'bookmark'
+	override props = bookmarkShapePropsValidators
+	override migrations = bookmarkAssetMigrations
 
 	override canResize = () => false
 

--- a/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/DrawShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/DrawShapeUtil.tsx
@@ -9,7 +9,12 @@ import {
 	Vec2d,
 	VecLike,
 } from '@tldraw/primitives'
-import { TLDrawShape, TLDrawShapeSegment } from '@tldraw/tlschema'
+import {
+	drawShapeMigrations,
+	drawShapePropsValidators,
+	TLDrawShape,
+	TLDrawShapeSegment,
+} from '@tldraw/tlschema'
 import { last, rng } from '@tldraw/utils'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { getSvgPathFromStroke, getSvgPathFromStrokePoints } from '../../../utils/svg'
@@ -22,6 +27,8 @@ import { getDrawShapeStrokeDashArray, getFreehandOptions, getPointsFromSegments 
 /** @public */
 export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 	static override type = 'draw'
+	override props = drawShapePropsValidators
+	override migrations = drawShapeMigrations
 
 	hideResizeHandles = (shape: TLDrawShape) => getIsDot(shape)
 	hideRotateHandle = (shape: TLDrawShape) => getIsDot(shape)

--- a/packages/editor/src/lib/app/shapeutils/EmbedShapeUtil/EmbedShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/EmbedShapeUtil/EmbedShapeUtil.tsx
@@ -3,7 +3,9 @@ import { toDomPrecision } from '@tldraw/primitives'
 import {
 	TLEmbedShape,
 	TLEmbedShapePermissions,
+	embedShapeMigrations,
 	embedShapePermissionDefaults,
+	embedShapePropsValidators,
 } from '@tldraw/tlschema'
 import * as React from 'react'
 import { useMemo } from 'react'
@@ -28,6 +30,8 @@ const getSandboxPermissions = (permissions: TLEmbedShapePermissions) => {
 /** @public */
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	static override type = 'embed'
+	override props = embedShapePropsValidators
+	override migrations = embedShapeMigrations
 
 	override canUnmount: TLShapeUtilFlag<TLEmbedShape> = () => false
 	override canResize = (shape: TLEmbedShape) => {

--- a/packages/editor/src/lib/app/shapeutils/FrameShapeUtil/FrameShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/FrameShapeUtil/FrameShapeUtil.tsx
@@ -1,5 +1,11 @@
 import { canolicalizeRotation, SelectionEdge, toDomPrecision } from '@tldraw/primitives'
-import { TLFrameShape, TLShape, TLShapeId } from '@tldraw/tlschema'
+import {
+	frameShapeMigrations,
+	frameShapePropsValidators,
+	TLFrameShape,
+	TLShape,
+	TLShapeId,
+} from '@tldraw/tlschema'
 import { last } from '@tldraw/utils'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { defaultEmptyAs } from '../../../utils/string'
@@ -12,6 +18,8 @@ import { FrameHeading } from './components/FrameHeading'
 /** @public */
 export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	static override type = 'frame'
+	override props = frameShapePropsValidators
+	override migrations = frameShapeMigrations
 
 	override canBind = () => true
 

--- a/packages/editor/src/lib/app/shapeutils/GeoShapeUtil/GeoShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/GeoShapeUtil/GeoShapeUtil.tsx
@@ -12,7 +12,12 @@ import {
 	Vec2d,
 	VecLike,
 } from '@tldraw/primitives'
-import { TLDashType, TLGeoShape } from '@tldraw/tlschema'
+import {
+	geoShapeMigrations,
+	geoShapePropsValidators,
+	TLDashType,
+	TLGeoShape,
+} from '@tldraw/tlschema'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../../../constants'
 import { getLegacyOffsetX } from '../../../utils/legacy'
@@ -43,6 +48,8 @@ const MIN_SIZE_WITH_LABEL = 17 * 3
 /** @public */
 export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	static override type = 'geo'
+	override props = geoShapePropsValidators
+	override migrations = geoShapeMigrations
 
 	canEdit = () => true
 

--- a/packages/editor/src/lib/app/shapeutils/GroupShapeUtil/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/GroupShapeUtil/GroupShapeUtil.tsx
@@ -1,5 +1,10 @@
 import { Box2d, Matrix2d } from '@tldraw/primitives'
-import { TLGroupShape, Vec2dModel } from '@tldraw/tlschema'
+import {
+	TLGroupShape,
+	Vec2dModel,
+	groupShapeMigrations,
+	groupShapePropsValidators,
+} from '@tldraw/tlschema'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { ShapeUtil, TLOnChildrenChangeHandler } from '../ShapeUtil'
 import { DashedOutlineBox } from '../shared/DashedOutlineBox'
@@ -7,6 +12,8 @@ import { DashedOutlineBox } from '../shared/DashedOutlineBox'
 /** @public */
 export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	static override type = 'group'
+	override props = groupShapePropsValidators
+	override migrations = groupShapeMigrations
 
 	type = 'group' as const
 

--- a/packages/editor/src/lib/app/shapeutils/HighlightShapeUtil/HighlightShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/HighlightShapeUtil/HighlightShapeUtil.tsx
@@ -8,7 +8,12 @@ import {
 	Vec2d,
 	VecLike,
 } from '@tldraw/primitives'
-import { TLDrawShapeSegment, TLHighlightShape } from '@tldraw/tlschema'
+import {
+	highlightShapeMigrations,
+	highlightShapePropsValidators,
+	TLDrawShapeSegment,
+	TLHighlightShape,
+} from '@tldraw/tlschema'
 import { last, rng } from '@tldraw/utils'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { FONT_SIZES } from '../../../constants'
@@ -25,6 +30,8 @@ const UNDERLAY_OPACITY = 0.82
 /** @public */
 export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	static type = 'highlight'
+	override props = highlightShapePropsValidators
+	override migrations = highlightShapeMigrations
 
 	hideResizeHandles = (shape: TLHighlightShape) => getIsDot(shape)
 	hideRotateHandle = (shape: TLHighlightShape) => getIsDot(shape)

--- a/packages/editor/src/lib/app/shapeutils/ImageShapeUtil/ImageShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/ImageShapeUtil/ImageShapeUtil.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Vec2d, toDomPrecision } from '@tldraw/primitives'
-import { TLImageShape, TLShapePartial } from '@tldraw/tlschema'
+import {
+	TLImageShape,
+	TLShapePartial,
+	imageShapeMigrations,
+	imageShapePropsValidators,
+} from '@tldraw/tlschema'
 import { deepCopy } from '@tldraw/utils'
 import { useEffect, useState } from 'react'
 import { useValue } from 'signia-react'
@@ -50,6 +55,8 @@ async function getDataURIFromURL(url: string): Promise<string> {
 /** @public */
 export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	static override type = 'image'
+	override props = imageShapePropsValidators
+	override migrations = imageShapeMigrations
 
 	override isAspectRatioLocked = () => true
 	override canCrop = () => true

--- a/packages/editor/src/lib/app/shapeutils/LineShapeUtil/LineShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/LineShapeUtil/LineShapeUtil.tsx
@@ -9,7 +9,12 @@ import {
 	intersectLineSegmentPolyline,
 	pointNearToPolyline,
 } from '@tldraw/primitives'
-import { TLHandle, TLLineShape } from '@tldraw/tlschema'
+import {
+	TLHandle,
+	TLLineShape,
+	lineShapeMigrations,
+	lineShapePropsValidators,
+} from '@tldraw/tlschema'
 import { deepCopy } from '@tldraw/utils'
 import { SVGContainer } from '../../../components/SVGContainer'
 import { WeakMapCache } from '../../../utils/WeakMapCache'
@@ -27,6 +32,8 @@ const handlesCache = new WeakMapCache<TLLineShape['props'], TLHandle[]>()
 /** @public */
 export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	static override type = 'line'
+	override props = lineShapePropsValidators
+	override migrations = lineShapeMigrations
 
 	override hideResizeHandles = () => true
 	override hideRotateHandle = () => true

--- a/packages/editor/src/lib/app/shapeutils/NoteShapeUtil/NoteShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/NoteShapeUtil/NoteShapeUtil.tsx
@@ -1,5 +1,5 @@
 import { Box2d, toDomPrecision, Vec2d } from '@tldraw/primitives'
-import { TLNoteShape } from '@tldraw/tlschema'
+import { noteShapeMigrations, noteShapePropsValidators, TLNoteShape } from '@tldraw/tlschema'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../../../constants'
 import { getLegacyOffsetX } from '../../../utils/legacy'
 import { Editor } from '../../Editor'
@@ -14,6 +14,8 @@ const NOTE_SIZE = 200
 /** @public */
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	static override type = 'note'
+	override props = noteShapePropsValidators
+	override migrations = noteShapeMigrations
 
 	canEdit = () => true
 	hideResizeHandles = () => true

--- a/packages/editor/src/lib/app/shapeutils/ShapeUtil.ts
+++ b/packages/editor/src/lib/app/shapeutils/ShapeUtil.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Box2d, linesIntersect, Matrix2d, VecLike } from '@tldraw/primitives'
-import { ComputedCache } from '@tldraw/store'
+import { ComputedCache, Migrations } from '@tldraw/store'
 import {
 	TLBaseShape,
 	TLHandle,
@@ -9,6 +9,8 @@ import {
 	TLUnknownShape,
 	Vec2dModel,
 } from '@tldraw/tlschema'
+import { assert } from '@tldraw/utils'
+import { T } from '@tldraw/validate'
 import { computed, EMPTY_ARRAY } from 'signia'
 import { WeakMapCache } from '../../utils/WeakMapCache'
 import type { Editor } from '../Editor'
@@ -23,18 +25,30 @@ export interface TLShapeUtilConstructor<
 	T extends TLUnknownShape,
 	U extends ShapeUtil<T> = ShapeUtil<T>
 > {
-	new (editor: Editor, type: T['type']): U
+	new (editor: Editor | null, type: T['type']): U
 	type: T['type']
 }
+
+export type AnyTLShapeUtilConstructor = TLShapeUtilConstructor<TLBaseShape<any, any>>
 
 /** @public */
 export type TLShapeUtilFlag<T> = (shape: T) => boolean
 
 /** @public */
 export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
-	constructor(public editor: Editor, public readonly type: T['type']) {}
+	constructor(private _editor: Editor | null, public readonly type: T['type']) {}
+
+	get editor() {
+		assert(
+			this._editor,
+			'ShapeUtil constructed without an editor. Only basic functionality (e.g. props, migrations, is) work in this mode.'
+		)
+		return this._editor
+	}
 
 	static type: string
+	props?: { [Prop in keyof T['props']]: T.Validator<T['props'][Prop]> }
+	migrations?: Migrations
 
 	/**
 	 * Check if a shape is of this type.
@@ -214,6 +228,7 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
 	 */
 	protected abstract getBounds(shape: T): Box2d
 
+	/** @internal */
 	@computed
 	private get boundsCache(): ComputedCache<Box2d, TLShape> {
 		return this.editor.store.createComputedCache('bounds:' + this.type, (shape) => {

--- a/packages/editor/src/lib/app/shapeutils/TextShapeUtil/TextShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/TextShapeUtil/TextShapeUtil.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Box2d, toDomPrecision, Vec2d } from '@tldraw/primitives'
-import { TLTextShape } from '@tldraw/tlschema'
+import { textShapeMigrations, textShapePropsValidators, TLTextShape } from '@tldraw/tlschema'
 import { HTMLContainer } from '../../../components/HTMLContainer'
 import { FONT_FAMILIES, FONT_SIZES, TEXT_PROPS } from '../../../constants'
 import { stopEventPropagation } from '../../../utils/dom'
@@ -19,6 +19,8 @@ const sizeCache = new WeakMapCache<TLTextShape['props'], { height: number; width
 /** @public */
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	static override type = 'text'
+	override props = textShapePropsValidators
+	override migrations = textShapeMigrations
 
 	canEdit = () => true
 

--- a/packages/editor/src/lib/app/shapeutils/VideoShapeUtil/VideoShapeUtil.tsx
+++ b/packages/editor/src/lib/app/shapeutils/VideoShapeUtil/VideoShapeUtil.tsx
@@ -1,5 +1,5 @@
 import { toDomPrecision } from '@tldraw/primitives'
-import { TLVideoShape } from '@tldraw/tlschema'
+import { TLVideoShape, videoShapeMigrations, videoShapePropsValidators } from '@tldraw/tlschema'
 import * as React from 'react'
 import { track } from 'signia-react'
 import { DefaultSpinner } from '../../../components/DefaultSpinner'
@@ -12,6 +12,8 @@ import { HyperlinkButton } from '../shared/HyperlinkButton'
 /** @public */
 export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	static override type = 'video'
+	override props = videoShapePropsValidators
+	override migrations = videoShapeMigrations
 
 	override canEdit = () => true
 	override isAspectRatioLocked = () => true

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -1,24 +1,19 @@
-import { Migrations, Store, StoreSnapshot } from '@tldraw/store'
+import { Store, StoreSnapshot } from '@tldraw/store'
 import {
 	InstanceRecordType,
 	TLDOCUMENT_ID,
 	TLInstanceId,
 	TLRecord,
 	TLStore,
+	TLUnknownShape,
 	createTLSchema,
 } from '@tldraw/tlschema'
+import { mapObjectMap } from '@tldraw/utils'
 import { TLShapeUtilConstructor } from '../app/shapeutils/ShapeUtil'
 
 /** @public */
-export type TLShapeInfo = {
-	util: TLShapeUtilConstructor<any>
-	migrations?: Migrations
-	validator?: { validate: (record: any) => any }
-}
-
-/** @public */
 export type TLStoreOptions = {
-	customShapes?: Record<string, TLShapeInfo>
+	customShapes?: Record<string, TLShapeUtilConstructor<TLUnknownShape>>
 	instanceId?: TLInstanceId
 	initialData?: StoreSnapshot<TLRecord>
 	defaultName?: string
@@ -39,7 +34,9 @@ export function createTLStore(opts = {} as TLStoreOptions): TLStore {
 	} = opts
 
 	return new Store({
-		schema: createTLSchema({ customShapes }),
+		schema: createTLSchema({
+			customShapes: mapObjectMap(customShapes, (_, Util) => new Util(null, Util.type)),
+		}),
 		initialData,
 		props: {
 			instanceId,

--- a/packages/editor/src/lib/config/defaultShapes.ts
+++ b/packages/editor/src/lib/config/defaultShapes.ts
@@ -11,57 +11,30 @@ import { LineShapeUtil } from '../app/shapeutils/LineShapeUtil/LineShapeUtil'
 import { NoteShapeUtil } from '../app/shapeutils/NoteShapeUtil/NoteShapeUtil'
 import { TextShapeUtil } from '../app/shapeutils/TextShapeUtil/TextShapeUtil'
 import { VideoShapeUtil } from '../app/shapeutils/VideoShapeUtil/VideoShapeUtil'
-import { TLShapeInfo } from './createTLStore'
 
 /** @public */
-export const coreShapes: Record<string, TLShapeInfo> = {
+export const coreShapes = {
 	// created by grouping interactions, probably the corest core shape that we have
-	group: {
-		util: GroupShapeUtil,
-	},
+	group: GroupShapeUtil,
 	// created by embed menu / url drop
-	embed: {
-		util: EmbedShapeUtil,
-	},
+	embed: EmbedShapeUtil,
 	// created by copy and paste / url drop
-	bookmark: {
-		util: BookmarkShapeUtil,
-	},
+	bookmark: BookmarkShapeUtil,
 	// created by copy and paste / file drop
-	image: {
-		util: ImageShapeUtil,
-	},
+	image: ImageShapeUtil,
 	// created by copy and paste / file drop
-	video: {
-		util: VideoShapeUtil,
-	},
+	video: VideoShapeUtil,
 	// created by copy and paste
-	text: {
-		util: TextShapeUtil,
-	},
+	text: TextShapeUtil,
 }
 
 /** @public */
-export const defaultShapes: Record<string, TLShapeInfo> = {
-	draw: {
-		util: DrawShapeUtil,
-	},
-	geo: {
-		util: GeoShapeUtil,
-	},
-	line: {
-		util: LineShapeUtil,
-	},
-	note: {
-		util: NoteShapeUtil,
-	},
-	frame: {
-		util: FrameShapeUtil,
-	},
-	arrow: {
-		util: ArrowShapeUtil,
-	},
-	highlight: {
-		util: HighlightShapeUtil,
-	},
+export const defaultShapes = {
+	draw: DrawShapeUtil,
+	geo: GeoShapeUtil,
+	line: LineShapeUtil,
+	note: NoteShapeUtil,
+	frame: FrameShapeUtil,
+	arrow: ArrowShapeUtil,
+	highlight: HighlightShapeUtil,
 }

--- a/packages/editor/src/lib/test/TldrawEditor.test.tsx
+++ b/packages/editor/src/lib/test/TldrawEditor.test.tsx
@@ -220,7 +220,7 @@ describe('Custom shapes', () => {
 	}
 
 	const tools = [CardTool]
-	const shapes = { card: { util: CardUtil } }
+	const shapes = { card: CardUtil }
 
 	it('Uses custom shapes', async () => {
 		let editor = {} as Editor

--- a/packages/editor/src/lib/test/tools/translating.test.ts
+++ b/packages/editor/src/lib/test/tools/translating.test.ts
@@ -755,9 +755,7 @@ describe('custom snapping points', () => {
 		editor = new TestEditor({
 			shapes: {
 				...defaultShapes,
-				__test_top_left_snap_only: {
-					util: __TopLeftSnapOnlyShapeUtil,
-				},
+				__test_top_left_snap_only: __TopLeftSnapOnlyShapeUtil,
 			},
 			// x───────┐
 			// │ T     │

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -18,6 +18,26 @@ import { UnknownRecord } from '@tldraw/store';
 // @internal (undocumented)
 export const alignValidator: T.Validator<"end" | "middle" | "start">;
 
+// @internal (undocumented)
+export const arrowShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const arrowShapePropsValidators: {
+    labelColor: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    fill: T.Validator<"none" | "pattern" | "semi" | "solid">;
+    dash: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    arrowheadStart: T.Validator<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+    arrowheadEnd: T.Validator<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+    font: T.Validator<"draw" | "mono" | "sans" | "serif">;
+    start: T.Validator<TLArrowTerminal>;
+    end: T.Validator<TLArrowTerminal>;
+    bend: T.Validator<number>;
+    text: T.Validator<string>;
+};
+
 // @public
 export const assetIdValidator: T.Validator<TLAssetId>;
 
@@ -29,6 +49,18 @@ export const AssetRecordType: RecordType<TLAsset, "props" | "type">;
 
 // @internal (undocumented)
 export const assetValidator: T.Validator<TLAsset>;
+
+// @internal (undocumented)
+export const bookmarkShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const bookmarkShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    assetId: T.Validator<null | TLAssetId>;
+    url: T.Validator<string>;
+};
 
 // @public
 export interface Box2dModel {
@@ -96,6 +128,22 @@ export const dashValidator: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
 
 // @public (undocumented)
 export const DocumentRecordType: RecordType<TLDocument, never>;
+
+// @internal (undocumented)
+export const drawShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const drawShapePropsValidators: {
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    fill: T.Validator<"none" | "pattern" | "semi" | "solid">;
+    dash: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    segments: T.ArrayOfValidator<TLDrawShapeSegment>;
+    isComplete: T.Validator<boolean>;
+    isClosed: T.Validator<boolean>;
+    isPen: T.Validator<boolean>;
+};
 
 // @public (undocumented)
 export const EMBED_DEFINITIONS: readonly [{
@@ -284,6 +332,9 @@ export type EmbedDefinition = {
     readonly fromEmbedUrl: (url: string) => string | undefined;
 };
 
+// @internal (undocumented)
+export const embedShapeMigrations: Migrations;
+
 // @public
 export const embedShapePermissionDefaults: {
     readonly 'allow-downloads-without-user-activation': false;
@@ -303,6 +354,17 @@ export const embedShapePermissionDefaults: {
 };
 
 // @internal (undocumented)
+export const embedShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    url: T.Validator<string>;
+    tmpOldUrl: T.Validator<string | undefined>;
+    doesResize: T.Validator<boolean>;
+    overridePermissions: T.Validator<Record<"allow-downloads-without-user-activation" | "allow-downloads" | "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups-to-escape-sandbox" | "allow-popups" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation-by-user-activation" | "allow-top-navigation", boolean | undefined> | undefined>;
+};
+
+// @internal (undocumented)
 export const fillValidator: T.Validator<"none" | "pattern" | "semi" | "solid">;
 
 // @internal (undocumented)
@@ -315,16 +377,108 @@ export function fixupRecord(oldRecord: TLRecord): {
 export const fontValidator: T.Validator<"draw" | "mono" | "sans" | "serif">;
 
 // @internal (undocumented)
+export const frameShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const frameShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    name: T.Validator<string>;
+};
+
+// @internal (undocumented)
+export const geoShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const geoShapePropsValidators: {
+    geo: T.Validator<"arrow-down" | "arrow-left" | "arrow-right" | "arrow-up" | "check-box" | "diamond" | "ellipse" | "hexagon" | "octagon" | "oval" | "pentagon" | "rectangle" | "rhombus-2" | "rhombus" | "star" | "trapezoid" | "triangle" | "x-box">;
+    labelColor: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    fill: T.Validator<"none" | "pattern" | "semi" | "solid">;
+    dash: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    font: T.Validator<"draw" | "mono" | "sans" | "serif">;
+    align: T.Validator<"end" | "middle" | "start">;
+    verticalAlign: T.Validator<"end" | "middle" | "start">;
+    url: T.Validator<string>;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    growY: T.Validator<number>;
+    text: T.Validator<string>;
+};
+
+// @internal (undocumented)
 export const geoValidator: T.Validator<"arrow-down" | "arrow-left" | "arrow-right" | "arrow-up" | "check-box" | "diamond" | "ellipse" | "hexagon" | "octagon" | "oval" | "pentagon" | "rectangle" | "rhombus-2" | "rhombus" | "star" | "trapezoid" | "triangle" | "x-box">;
 
 // @public (undocumented)
 export function getDefaultTranslationLocale(): TLLanguage['locale'];
 
 // @internal (undocumented)
+export const groupShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const groupShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+};
+
+// @internal (undocumented)
+export const highlightShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const highlightShapePropsValidators: {
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    segments: T.ArrayOfValidator<TLDrawShapeSegment>;
+    isComplete: T.Validator<boolean>;
+    isPen: T.Validator<boolean>;
+};
+
+// @internal (undocumented)
+export const iconShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const iconShapePropsValidators: {
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    icon: T.Validator<"activity" | "airplay" | "alert-circle" | "alert-octagon" | "alert-triangle" | "align-center" | "align-justify" | "align-left" | "align-right" | "anchor" | "aperture" | "archive" | "arrow-down-circle" | "arrow-down-left" | "arrow-down-right" | "arrow-down" | "arrow-left-circle" | "arrow-left" | "arrow-right-circle" | "arrow-right" | "arrow-up-circle" | "arrow-up-left" | "arrow-up-right" | "arrow-up" | "at-sign" | "award" | "bar-chart-2" | "bar-chart" | "battery-charging" | "battery" | "bell-off" | "bell" | "bluetooth" | "bold" | "book-open" | "book" | "bookmark" | "briefcase" | "calendar" | "camera-off" | "camera" | "cast" | "check-circle" | "check-square" | "check" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up" | "chevrons-down" | "chevrons-left" | "chevrons-right" | "chevrons-up" | "chrome" | "circle" | "clipboard" | "clock" | "cloud-drizzle" | "cloud-lightning" | "cloud-off" | "cloud-rain" | "cloud-snow" | "cloud" | "codepen" | "codesandbox" | "coffee" | "columns" | "command" | "compass" | "copy" | "corner-down-left" | "corner-down-right" | "corner-left-down" | "corner-left-up" | "corner-right-down" | "corner-right-up" | "corner-up-left" | "corner-up-right" | "cpu" | "credit-card" | "crop" | "crosshair" | "database" | "delete" | "disc" | "divide-circle" | "divide-square" | "divide" | "dollar-sign" | "download-cloud" | "download" | "dribbble" | "droplet" | "edit-2" | "edit-3" | "edit" | "external-link" | "eye-off" | "eye" | "facebook" | "fast-forward" | "feather" | "figma" | "file-minus" | "file-plus" | "file-text" | "file" | "film" | "filter" | "flag" | "folder-minus" | "folder-plus" | "folder" | "framer" | "frown" | "geo" | "gift" | "git-branch" | "git-commit" | "git-merge" | "git-pull-request" | "github" | "gitlab" | "globe" | "grid" | "hard-drive" | "hash" | "headphones" | "heart" | "help-circle" | "hexagon" | "home" | "image" | "inbox" | "info" | "instagram" | "italic" | "key" | "layers" | "layout" | "life-buoy" | "link-2" | "link" | "linkedin" | "list" | "loader" | "lock" | "log-in" | "log-out" | "mail" | "map-pin" | "map" | "maximize-2" | "maximize" | "meh" | "menu" | "message-circle" | "message-square" | "mic-off" | "mic" | "minimize-2" | "minimize" | "minus-circle" | "minus-square" | "minus" | "monitor" | "moon" | "more-horizontal" | "more-vertical" | "mouse-pointer" | "move" | "music" | "navigation-2" | "navigation" | "octagon" | "package" | "paperclip" | "pause-circle" | "pause" | "pen-tool" | "percent" | "phone-call" | "phone-forwarded" | "phone-incoming" | "phone-missed" | "phone-off" | "phone-outgoing" | "phone" | "pie-chart" | "play-circle" | "play" | "plus-circle" | "plus-square" | "plus" | "pocket" | "power" | "printer" | "radio" | "refresh-ccw" | "refresh-cw" | "repeat" | "rewind" | "rotate-ccw" | "rotate-cw" | "rss" | "save" | "scissors" | "search" | "send" | "server" | "settings" | "share-2" | "share" | "shield-off" | "shield" | "shopping-bag" | "shopping-cart" | "shuffle" | "sidebar" | "skip-back" | "skip-forward" | "slack" | "slash" | "sliders" | "smartphone" | "smile" | "speaker" | "square" | "star" | "stop-circle" | "sun" | "sunrise" | "sunset" | "table" | "tablet" | "tag" | "target" | "terminal" | "thermometer" | "thumbs-down" | "thumbs-up" | "toggle-left" | "toggle-right" | "tool" | "trash-2" | "trash" | "trello" | "trending-down" | "trending-up" | "triangle" | "truck" | "tv" | "twitch" | "twitter" | "type" | "umbrella" | "underline" | "unlock" | "upload-cloud" | "upload" | "user-check" | "user-minus" | "user-plus" | "user-x" | "user" | "users" | "video-off" | "video" | "voicemail" | "volume-1" | "volume-2" | "volume-x" | "volume" | "watch" | "wifi-off" | "wifi" | "wind" | "x-circle" | "x-octagon" | "x-square" | "x" | "youtube" | "zap-off" | "zap" | "zoom-in" | "zoom-out">;
+    dash: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    scale: T.Validator<number>;
+};
+
+// @internal (undocumented)
 export const iconValidator: T.Validator<"activity" | "airplay" | "alert-circle" | "alert-octagon" | "alert-triangle" | "align-center" | "align-justify" | "align-left" | "align-right" | "anchor" | "aperture" | "archive" | "arrow-down-circle" | "arrow-down-left" | "arrow-down-right" | "arrow-down" | "arrow-left-circle" | "arrow-left" | "arrow-right-circle" | "arrow-right" | "arrow-up-circle" | "arrow-up-left" | "arrow-up-right" | "arrow-up" | "at-sign" | "award" | "bar-chart-2" | "bar-chart" | "battery-charging" | "battery" | "bell-off" | "bell" | "bluetooth" | "bold" | "book-open" | "book" | "bookmark" | "briefcase" | "calendar" | "camera-off" | "camera" | "cast" | "check-circle" | "check-square" | "check" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up" | "chevrons-down" | "chevrons-left" | "chevrons-right" | "chevrons-up" | "chrome" | "circle" | "clipboard" | "clock" | "cloud-drizzle" | "cloud-lightning" | "cloud-off" | "cloud-rain" | "cloud-snow" | "cloud" | "codepen" | "codesandbox" | "coffee" | "columns" | "command" | "compass" | "copy" | "corner-down-left" | "corner-down-right" | "corner-left-down" | "corner-left-up" | "corner-right-down" | "corner-right-up" | "corner-up-left" | "corner-up-right" | "cpu" | "credit-card" | "crop" | "crosshair" | "database" | "delete" | "disc" | "divide-circle" | "divide-square" | "divide" | "dollar-sign" | "download-cloud" | "download" | "dribbble" | "droplet" | "edit-2" | "edit-3" | "edit" | "external-link" | "eye-off" | "eye" | "facebook" | "fast-forward" | "feather" | "figma" | "file-minus" | "file-plus" | "file-text" | "file" | "film" | "filter" | "flag" | "folder-minus" | "folder-plus" | "folder" | "framer" | "frown" | "geo" | "gift" | "git-branch" | "git-commit" | "git-merge" | "git-pull-request" | "github" | "gitlab" | "globe" | "grid" | "hard-drive" | "hash" | "headphones" | "heart" | "help-circle" | "hexagon" | "home" | "image" | "inbox" | "info" | "instagram" | "italic" | "key" | "layers" | "layout" | "life-buoy" | "link-2" | "link" | "linkedin" | "list" | "loader" | "lock" | "log-in" | "log-out" | "mail" | "map-pin" | "map" | "maximize-2" | "maximize" | "meh" | "menu" | "message-circle" | "message-square" | "mic-off" | "mic" | "minimize-2" | "minimize" | "minus-circle" | "minus-square" | "minus" | "monitor" | "moon" | "more-horizontal" | "more-vertical" | "mouse-pointer" | "move" | "music" | "navigation-2" | "navigation" | "octagon" | "package" | "paperclip" | "pause-circle" | "pause" | "pen-tool" | "percent" | "phone-call" | "phone-forwarded" | "phone-incoming" | "phone-missed" | "phone-off" | "phone-outgoing" | "phone" | "pie-chart" | "play-circle" | "play" | "plus-circle" | "plus-square" | "plus" | "pocket" | "power" | "printer" | "radio" | "refresh-ccw" | "refresh-cw" | "repeat" | "rewind" | "rotate-ccw" | "rotate-cw" | "rss" | "save" | "scissors" | "search" | "send" | "server" | "settings" | "share-2" | "share" | "shield-off" | "shield" | "shopping-bag" | "shopping-cart" | "shuffle" | "sidebar" | "skip-back" | "skip-forward" | "slack" | "slash" | "sliders" | "smartphone" | "smile" | "speaker" | "square" | "star" | "stop-circle" | "sun" | "sunrise" | "sunset" | "table" | "tablet" | "tag" | "target" | "terminal" | "thermometer" | "thumbs-down" | "thumbs-up" | "toggle-left" | "toggle-right" | "tool" | "trash-2" | "trash" | "trello" | "trending-down" | "trending-up" | "triangle" | "truck" | "tv" | "twitch" | "twitter" | "type" | "umbrella" | "underline" | "unlock" | "upload-cloud" | "upload" | "user-check" | "user-minus" | "user-plus" | "user-x" | "user" | "users" | "video-off" | "video" | "voicemail" | "volume-1" | "volume-2" | "volume-x" | "volume" | "watch" | "wifi-off" | "wifi" | "wind" | "x-circle" | "x-octagon" | "x-square" | "x" | "youtube" | "zap-off" | "zap" | "zoom-in" | "zoom-out">;
 
 // @internal (undocumented)
 export function idValidator<Id extends RecordId<UnknownRecord>>(prefix: Id['__type__']['typeName']): T.Validator<Id>;
+
+// @internal (undocumented)
+export const imageShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const imageShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    playing: T.Validator<boolean>;
+    url: T.Validator<string>;
+    assetId: T.Validator<null | TLAssetId>;
+    crop: T.Validator<{
+        topLeft: {
+            x: number;
+            y: number;
+            z: number | undefined;
+        };
+        bottomRight: {
+            x: number;
+            y: number;
+            z: number | undefined;
+        };
+    } | null>;
+};
 
 // @public (undocumented)
 export const InstancePageStateRecordType: RecordType<TLInstancePageState, "cameraId" | "instanceId" | "pageId">;
@@ -450,6 +604,34 @@ export const LANGUAGES: readonly [{
 }];
 
 // @internal (undocumented)
+export const lineShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const lineShapePropsValidators: {
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    dash: T.Validator<"dashed" | "dotted" | "draw" | "solid">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    spline: T.Validator<"cubic" | "line">;
+    handles: T.DictValidator<string, TLHandle>;
+};
+
+// @internal (undocumented)
+export const noteShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const noteShapePropsValidators: {
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    font: T.Validator<"draw" | "mono" | "sans" | "serif">;
+    align: T.Validator<"end" | "middle" | "start">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    growY: T.Validator<number>;
+    url: T.Validator<string>;
+    text: T.Validator<string>;
+};
+
+// @internal (undocumented)
 export const opacityValidator: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
 
 // @public (undocumented)
@@ -475,6 +657,22 @@ export const sizeValidator: T.Validator<"l" | "m" | "s" | "xl">;
 
 // @internal (undocumented)
 export const splineValidator: T.Validator<"cubic" | "line">;
+
+// @internal (undocumented)
+export const textShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const textShapePropsValidators: {
+    color: T.Validator<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
+    size: T.Validator<"l" | "m" | "s" | "xl">;
+    font: T.Validator<"draw" | "mono" | "sans" | "serif">;
+    align: T.Validator<"end" | "middle" | "start">;
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    text: T.Validator<string>;
+    scale: T.Validator<number>;
+    autoSize: T.Validator<boolean>;
+};
 
 // @public (undocumented)
 export const TL_ALIGN_TYPES: Set<"end" | "middle" | "start">;
@@ -1134,6 +1332,20 @@ export interface Vec2dModel {
 
 // @internal (undocumented)
 export const verticalAlignValidator: T.Validator<"end" | "middle" | "start">;
+
+// @internal (undocumented)
+export const videoShapeMigrations: Migrations;
+
+// @internal (undocumented)
+export const videoShapePropsValidators: {
+    opacity: T.Validator<"0.1" | "0.25" | "0.5" | "0.75" | "1">;
+    w: T.Validator<number>;
+    h: T.Validator<number>;
+    time: T.Validator<number>;
+    playing: T.Validator<boolean>;
+    url: T.Validator<string>;
+    assetId: T.Validator<null | TLAssetId>;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -57,6 +57,8 @@ export {
 } from './records/TLShape'
 export { UserDocumentRecordType, type TLUserDocument } from './records/TLUserDocument'
 export {
+	arrowShapeMigrations,
+	arrowShapePropsValidators,
 	type TLArrowShape,
 	type TLArrowShapeProps,
 	type TLArrowTerminal,
@@ -68,25 +70,75 @@ export {
 	shapeIdValidator,
 	type TLBaseShape,
 } from './shapes/TLBaseShape'
-export { type TLBookmarkShape } from './shapes/TLBookmarkShape'
-export { type TLDrawShape, type TLDrawShapeSegment } from './shapes/TLDrawShape'
+export {
+	bookmarkShapeMigrations,
+	bookmarkShapePropsValidators,
+	type TLBookmarkShape,
+} from './shapes/TLBookmarkShape'
+export {
+	drawShapeMigrations,
+	drawShapePropsValidators,
+	type TLDrawShape,
+	type TLDrawShapeSegment,
+} from './shapes/TLDrawShape'
 export {
 	EMBED_DEFINITIONS,
+	embedShapeMigrations,
 	embedShapePermissionDefaults,
+	embedShapePropsValidators,
 	type EmbedDefinition,
 	type TLEmbedShape,
 	type TLEmbedShapePermissions,
 } from './shapes/TLEmbedShape'
-export { type TLFrameShape } from './shapes/TLFrameShape'
-export { type TLGeoShape } from './shapes/TLGeoShape'
-export { type TLGroupShape } from './shapes/TLGroupShape'
-export { type TLHighlightShape } from './shapes/TLHighlightShape'
-export { type TLIconShape } from './shapes/TLIconShape'
-export { type TLImageCrop, type TLImageShape, type TLImageShapeProps } from './shapes/TLImageShape'
-export { type TLLineShape } from './shapes/TLLineShape'
-export { type TLNoteShape } from './shapes/TLNoteShape'
-export { type TLTextShape, type TLTextShapeProps } from './shapes/TLTextShape'
-export { type TLVideoShape } from './shapes/TLVideoShape'
+export {
+	frameShapeMigrations,
+	frameShapePropsValidators,
+	type TLFrameShape,
+} from './shapes/TLFrameShape'
+export { geoShapeMigrations, geoShapePropsValidators, type TLGeoShape } from './shapes/TLGeoShape'
+export {
+	groupShapeMigrations,
+	groupShapePropsValidators,
+	type TLGroupShape,
+} from './shapes/TLGroupShape'
+export {
+	highlightShapeMigrations,
+	highlightShapePropsValidators,
+	type TLHighlightShape,
+} from './shapes/TLHighlightShape'
+export {
+	iconShapeMigrations,
+	iconShapePropsValidators,
+	type TLIconShape,
+} from './shapes/TLIconShape'
+export {
+	imageShapeMigrations,
+	imageShapePropsValidators,
+	type TLImageCrop,
+	type TLImageShape,
+	type TLImageShapeProps,
+} from './shapes/TLImageShape'
+export {
+	lineShapeMigrations,
+	lineShapePropsValidators,
+	type TLLineShape,
+} from './shapes/TLLineShape'
+export {
+	noteShapeMigrations,
+	noteShapePropsValidators,
+	type TLNoteShape,
+} from './shapes/TLNoteShape'
+export {
+	textShapeMigrations,
+	textShapePropsValidators,
+	type TLTextShape,
+	type TLTextShapeProps,
+} from './shapes/TLTextShape'
+export {
+	videoShapeMigrations,
+	videoShapePropsValidators,
+	type TLVideoShape,
+} from './shapes/TLVideoShape'
 export {
 	TL_ALIGN_TYPES,
 	alignValidator,

--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -64,23 +64,26 @@ export const arrowTerminalValidator: T.Validator<TLArrowTerminal> = T.union('typ
 })
 
 /** @internal */
+export const arrowShapePropsValidators = {
+	labelColor: colorValidator,
+	color: colorValidator,
+	fill: fillValidator,
+	dash: dashValidator,
+	size: sizeValidator,
+	opacity: opacityValidator,
+	arrowheadStart: arrowheadValidator,
+	arrowheadEnd: arrowheadValidator,
+	font: fontValidator,
+	start: arrowTerminalValidator,
+	end: arrowTerminalValidator,
+	bend: T.number,
+	text: T.string,
+}
+
+/** @internal */
 export const arrowShapeValidator: T.Validator<TLArrowShape> = createShapeValidator(
 	'arrow',
-	T.object({
-		labelColor: colorValidator,
-		color: colorValidator,
-		fill: fillValidator,
-		dash: dashValidator,
-		size: sizeValidator,
-		opacity: opacityValidator,
-		arrowheadStart: arrowheadValidator,
-		arrowheadEnd: arrowheadValidator,
-		font: fontValidator,
-		start: arrowTerminalValidator,
-		end: arrowTerminalValidator,
-		bend: T.number,
-		text: T.string,
-	})
+	T.object(arrowShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLBookmarkShape.ts
+++ b/packages/tlschema/src/shapes/TLBookmarkShape.ts
@@ -18,15 +18,18 @@ export type TLBookmarkShapeProps = {
 export type TLBookmarkShape = TLBaseShape<'bookmark', TLBookmarkShapeProps>
 
 /** @internal */
+export const bookmarkShapePropsValidators = {
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	assetId: assetIdValidator.nullable(),
+	url: T.string,
+}
+
+/** @internal */
 export const bookmarkShapeValidator: T.Validator<TLBookmarkShape> = createShapeValidator(
 	'bookmark',
-	T.object({
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		assetId: assetIdValidator.nullable(),
-		url: T.string,
-	})
+	T.object(bookmarkShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLDrawShape.ts
+++ b/packages/tlschema/src/shapes/TLDrawShape.ts
@@ -41,19 +41,22 @@ export type TLDrawShapeProps = {
 export type TLDrawShape = TLBaseShape<'draw', TLDrawShapeProps>
 
 /** @internal */
+export const drawShapePropsValidators = {
+	color: colorValidator,
+	fill: fillValidator,
+	dash: dashValidator,
+	size: sizeValidator,
+	opacity: opacityValidator,
+	segments: T.arrayOf(drawShapeSegmentValidator),
+	isComplete: T.boolean,
+	isClosed: T.boolean,
+	isPen: T.boolean,
+}
+
+/** @internal */
 export const drawShapeValidator: T.Validator<TLDrawShape> = createShapeValidator(
 	'draw',
-	T.object({
-		color: colorValidator,
-		fill: fillValidator,
-		dash: dashValidator,
-		size: sizeValidator,
-		opacity: opacityValidator,
-		segments: T.arrayOf(drawShapeSegmentValidator),
-		isComplete: T.boolean,
-		isClosed: T.boolean,
-		isPen: T.boolean,
-	})
+	T.object(drawShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLEmbedShape.ts
+++ b/packages/tlschema/src/shapes/TLEmbedShape.ts
@@ -563,22 +563,25 @@ export type TLEmbedShapeProps = {
 export type TLEmbedShape = TLBaseShape<'embed', TLEmbedShapeProps>
 
 /** @internal */
+export const embedShapePropsValidators = {
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	url: T.string,
+	tmpOldUrl: T.string.optional(),
+	doesResize: T.boolean,
+	overridePermissions: T.dict(
+		T.setEnum(
+			new Set(Object.keys(embedShapePermissionDefaults) as (keyof TLEmbedShapePermissions)[])
+		),
+		T.boolean.optional()
+	).optional(),
+}
+
+/** @internal */
 export const embedShapeTypeValidator: T.Validator<TLEmbedShape> = createShapeValidator(
 	'embed',
-	T.object({
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		url: T.string,
-		tmpOldUrl: T.string.optional(),
-		doesResize: T.boolean,
-		overridePermissions: T.dict(
-			T.setEnum(
-				new Set(Object.keys(embedShapePermissionDefaults) as (keyof TLEmbedShapePermissions)[])
-			),
-			T.boolean.optional()
-		).optional(),
-	})
+	T.object(embedShapePropsValidators)
 )
 
 /** @public */

--- a/packages/tlschema/src/shapes/TLFrameShape.ts
+++ b/packages/tlschema/src/shapes/TLFrameShape.ts
@@ -14,14 +14,17 @@ type TLFrameShapeProps = {
 export type TLFrameShape = TLBaseShape<'frame', TLFrameShapeProps>
 
 /** @internal */
+export const frameShapePropsValidators = {
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	name: T.string,
+}
+
+/** @internal */
 export const frameShapeValidator: T.Validator<TLFrameShape> = createShapeValidator(
 	'frame',
-	T.object({
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		name: T.string,
-	})
+	T.object(frameShapePropsValidators)
 )
 
 /** @internal */

--- a/packages/tlschema/src/shapes/TLGeoShape.ts
+++ b/packages/tlschema/src/shapes/TLGeoShape.ts
@@ -34,25 +34,28 @@ export type TLGeoShapeProps = {
 export type TLGeoShape = TLBaseShape<'geo', TLGeoShapeProps>
 
 /** @internal */
+export const geoShapePropsValidators = {
+	geo: geoValidator,
+	labelColor: colorValidator,
+	color: colorValidator,
+	fill: fillValidator,
+	dash: dashValidator,
+	size: sizeValidator,
+	opacity: opacityValidator,
+	font: fontValidator,
+	align: alignValidator,
+	verticalAlign: verticalAlignValidator,
+	url: T.string,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	growY: T.positiveNumber,
+	text: T.string,
+}
+
+/** @internal */
 export const geoShapeValidator: T.Validator<TLGeoShape> = createShapeValidator(
 	'geo',
-	T.object({
-		geo: geoValidator,
-		labelColor: colorValidator,
-		color: colorValidator,
-		fill: fillValidator,
-		dash: dashValidator,
-		size: sizeValidator,
-		opacity: opacityValidator,
-		font: fontValidator,
-		align: alignValidator,
-		verticalAlign: verticalAlignValidator,
-		url: T.string,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		growY: T.positiveNumber,
-		text: T.string,
-	})
+	T.object(geoShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLGroupShape.ts
+++ b/packages/tlschema/src/shapes/TLGroupShape.ts
@@ -8,15 +8,18 @@ export type TLGroupShapeProps = {
 	opacity: TLOpacityType
 }
 
+/** @internal */
+export const groupShapePropsValidators = {
+	opacity: opacityValidator,
+}
+
 /** @public */
 export type TLGroupShape = TLBaseShape<'group', TLGroupShapeProps>
 
 /** @internal */
 export const groupShapeValidator: T.Validator<TLGroupShape> = createShapeValidator(
 	'group',
-	T.object({
-		opacity: opacityValidator,
-	})
+	T.object(groupShapePropsValidators)
 )
 
 /** @internal */

--- a/packages/tlschema/src/shapes/TLHighlightShape.ts
+++ b/packages/tlschema/src/shapes/TLHighlightShape.ts
@@ -20,16 +20,19 @@ export type TLHighlightShapeProps = {
 export type TLHighlightShape = TLBaseShape<'highlight', TLHighlightShapeProps>
 
 /** @internal */
+export const highlightShapePropsValidators = {
+	color: colorValidator,
+	size: sizeValidator,
+	opacity: opacityValidator,
+	segments: T.arrayOf(drawShapeSegmentValidator),
+	isComplete: T.boolean,
+	isPen: T.boolean,
+}
+
+/** @internal */
 export const highlightShapeValidator: T.Validator<TLHighlightShape> = createShapeValidator(
 	'highlight',
-	T.object({
-		color: colorValidator,
-		size: sizeValidator,
-		opacity: opacityValidator,
-		segments: T.arrayOf(drawShapeSegmentValidator),
-		isComplete: T.boolean,
-		isPen: T.boolean,
-	})
+	T.object(highlightShapePropsValidators)
 )
 
 /** @internal */

--- a/packages/tlschema/src/shapes/TLIconShape.ts
+++ b/packages/tlschema/src/shapes/TLIconShape.ts
@@ -21,16 +21,19 @@ export type TLIconShapeProps = {
 export type TLIconShape = TLBaseShape<'icon', TLIconShapeProps>
 
 /** @internal */
+export const iconShapePropsValidators = {
+	size: sizeValidator,
+	icon: iconValidator,
+	dash: dashValidator,
+	color: colorValidator,
+	opacity: opacityValidator,
+	scale: T.number,
+}
+
+/** @internal */
 export const iconShapeValidator: T.Validator<TLIconShape> = createShapeValidator(
 	'icon',
-	T.object({
-		size: sizeValidator,
-		icon: iconValidator,
-		dash: dashValidator,
-		color: colorValidator,
-		opacity: opacityValidator,
-		scale: T.number,
-	})
+	T.object(iconShapePropsValidators)
 )
 
 /** @internal */

--- a/packages/tlschema/src/shapes/TLImageShape.ts
+++ b/packages/tlschema/src/shapes/TLImageShape.ts
@@ -32,17 +32,20 @@ export const cropValidator = T.object({
 })
 
 /** @internal */
+export const imageShapePropsValidators = {
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	playing: T.boolean,
+	url: T.string,
+	assetId: assetIdValidator.nullable(),
+	crop: cropValidator.nullable(),
+}
+
+/** @internal */
 export const imageShapeValidator: T.Validator<TLImageShape> = createShapeValidator(
 	'image',
-	T.object({
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		playing: T.boolean,
-		url: T.string,
-		assetId: assetIdValidator.nullable(),
-		crop: cropValidator.nullable(),
-	})
+	T.object(imageShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLLineShape.ts
+++ b/packages/tlschema/src/shapes/TLLineShape.ts
@@ -24,16 +24,19 @@ export type TLLineShapeProps = {
 export type TLLineShape = TLBaseShape<'line', TLLineShapeProps>
 
 /** @internal */
+export const lineShapePropsValidators = {
+	color: colorValidator,
+	dash: dashValidator,
+	size: sizeValidator,
+	opacity: opacityValidator,
+	spline: splineValidator,
+	handles: T.dict(T.string, handleValidator),
+}
+
+/** @internal */
 export const lineShapeValidator: T.Validator<TLLineShape> = createShapeValidator(
 	'line',
-	T.object({
-		color: colorValidator,
-		dash: dashValidator,
-		size: sizeValidator,
-		opacity: opacityValidator,
-		spline: splineValidator,
-		handles: T.dict(T.string, handleValidator),
-	})
+	T.object(lineShapePropsValidators)
 )
 
 /** @internal */

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -23,18 +23,21 @@ export type TLNoteShapeProps = {
 export type TLNoteShape = TLBaseShape<'note', TLNoteShapeProps>
 
 /** @internal */
+export const noteShapePropsValidators = {
+	color: colorValidator,
+	size: sizeValidator,
+	font: fontValidator,
+	align: alignValidator,
+	opacity: opacityValidator,
+	growY: T.positiveNumber,
+	url: T.string,
+	text: T.string,
+}
+
+/** @internal */
 export const noteShapeValidator: T.Validator<TLNoteShape> = createShapeValidator(
 	'note',
-	T.object({
-		color: colorValidator,
-		size: sizeValidator,
-		font: fontValidator,
-		align: alignValidator,
-		opacity: opacityValidator,
-		growY: T.positiveNumber,
-		url: T.string,
-		text: T.string,
-	})
+	T.object(noteShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLTextShape.ts
+++ b/packages/tlschema/src/shapes/TLTextShape.ts
@@ -24,19 +24,22 @@ export type TLTextShapeProps = {
 export type TLTextShape = TLBaseShape<'text', TLTextShapeProps>
 
 /** @internal */
+export const textShapePropsValidators = {
+	color: colorValidator,
+	size: sizeValidator,
+	font: fontValidator,
+	align: alignValidator,
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	text: T.string,
+	scale: T.nonZeroNumber,
+	autoSize: T.boolean,
+}
+
+/** @internal */
 export const textShapeValidator: T.Validator<TLTextShape> = createShapeValidator(
 	'text',
-	T.object({
-		color: colorValidator,
-		size: sizeValidator,
-		font: fontValidator,
-		align: alignValidator,
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		text: T.string,
-		scale: T.nonZeroNumber,
-		autoSize: T.boolean,
-	})
+	T.object(textShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/tlschema/src/shapes/TLVideoShape.ts
+++ b/packages/tlschema/src/shapes/TLVideoShape.ts
@@ -20,17 +20,20 @@ export type TLVideoShapeProps = {
 export type TLVideoShape = TLBaseShape<'video', TLVideoShapeProps>
 
 /** @internal */
+export const videoShapePropsValidators = {
+	opacity: opacityValidator,
+	w: T.nonZeroNumber,
+	h: T.nonZeroNumber,
+	time: T.number,
+	playing: T.boolean,
+	url: T.string,
+	assetId: assetIdValidator.nullable(),
+}
+
+/** @internal */
 export const videoShapeValidator: T.Validator<TLVideoShape> = createShapeValidator(
 	'video',
-	T.object({
-		opacity: opacityValidator,
-		w: T.nonZeroNumber,
-		h: T.nonZeroNumber,
-		time: T.number,
-		playing: T.boolean,
-		url: T.string,
-		assetId: assetIdValidator.nullable(),
-	})
+	T.object(videoShapePropsValidators)
 )
 
 const Versions = {

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -83,6 +83,13 @@ export function lerp(a: number, b: number, t: number): number;
 // @public (undocumented)
 export function lns(str: string): string;
 
+// @internal
+export function mapObjectMap<Key extends string, Value, NewValue>(object: {
+    [K in Key]: Value;
+}, fn: (key: Key, value: Value) => NewValue): {
+    [K in Key]: NewValue;
+};
+
 // @internal (undocumented)
 export function minBy<T>(arr: readonly T[], fn: (item: T) => number): T | undefined;
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,6 +19,7 @@ export {
 	filterEntries,
 	getOwnProperty,
 	hasOwnProperty,
+	mapObjectMap,
 	objectMapEntries,
 	objectMapFromEntries,
 	objectMapKeys,

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -101,6 +101,23 @@ export function objectMapFromEntries<Key extends string, Value>(
 }
 
 /**
+ * Map over an object's entries and return a new object with the same keys but different values.
+ *
+ * @internal
+ */
+export function mapObjectMap<Key extends string, Value, NewValue>(
+	object: { [K in Key]: Value },
+	fn: (key: Key, value: Value) => NewValue
+): { [K in Key]: NewValue } {
+	const result: { [K in Key]?: NewValue } = {}
+	for (const [key, value] of objectMapEntries(object)) {
+		const newValue = fn(key, value)
+		result[key] = newValue
+	}
+	return result as { [K in Key]: NewValue }
+}
+
+/**
  * Filters an object using a predicate function.
  * @returns a new object with only the entries that pass the predicate
  * @internal


### PR DESCRIPTION
In preparation for the upcoming styles API, this diff moves the place that you define the validations & migrations for a shape onto the shape util.

Before:
```ts
class MyCustomShapeUtil extends ShapeUtil {
    // ...
}

const shapes = {
    myCustom: {
        util: MyCustomShapeUtil,
        validation: createShapeValidator('myCustom', T.object({
            w: T.number,
            h: T.number,
        })),
        migrations: { ... },
    }
}
```

After:
```ts
class MyCustomShapeUtil extends ShapeUtil {
    props = {
        w: T.number,
        h: T.number,
    }
    migrations: {...}
}

const shapes = {
    myCustom: MyCustomShapeUtil,
}
```

Caveat here that right now we have quite a lot of duplication that comes from the fact we can't depend on the editor on the worker. That means we have to duplicate these declarations for server-side use. If we relaxed that (i think we could!) we could get rid of most of `tlschema` or even just inline it in `editor`

### Change Type

- [x] `major` — Breaking Change

### Test Plan

1. Tested locally

- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

[internal only for now]
