### PR TITLE
chore: use npx to run auto in canary publish script

### DIFF
--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -18,7 +18,11 @@ async function main() {
 	}
 
 	// module was called directly
-	const bumpType = (await exec('auto', ['version'])).trim() as 'major' | 'minor' | 'patch' | ''
+	const bumpType = (await exec('npx', ['auto', 'version'])).trim() as
+		| 'major'
+		| 'minor'
+		| 'patch'
+		| ''
 
 	nicelog('bumpType', bumpType)
 	if (bumpType === '') {


### PR DESCRIPTION
The canary release failed due to not finding auto: https://github.com/tldraw/tldraw/actions/runs/5178225013/jobs/9329393446

No idea why, but I'm going to try running it with npx here.

### Change type

- [x] `other`

### Test plan

1. Run the canary release action.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal: Updated canary release script to use npx for auto.