### PR TITLE
Update examples links to point to examples folder.

### DIFF
--- a/apps/docs/content/docs/api.mdx
+++ b/apps/docs/content/docs/api.mdx
@@ -237,4 +237,4 @@ editor.setCamera(0, 0, 1)
 
 ---
 
-See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to use tldraw's App API to control the editor.
+See the [tldraw repository](https://github.com/tldraw/tldraw/tree/main/apps/examples) for an example of how to use tldraw's App API to control the editor.

--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -15,4 +15,4 @@ keywords:
 
 Coming soon.
 
-See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to use persistence with the `@tldraw/tldraw` or `@tldraw/editor` libraries.
+See the [tldraw repository](https://github.com/tldraw/tldraw/tree/main/apps/examples) for an example of how to use persistence with the `@tldraw/tldraw` or `@tldraw/editor` libraries.

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -13,4 +13,4 @@ keywords:
 
 Coming soon.
 
-See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to create custom shapes in tldraw.
+See the [tldraw repository](https://github.com/tldraw/tldraw/tree/main/apps/examples) for an example of how to create custom shapes in tldraw.

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -12,4 +12,4 @@ keywords:
 
 Coming soon. 
 
-See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to create custom tools in tldraw.
+See the [tldraw repository](https://github.com/tldraw/tldraw/tree/main/apps/examples) for an example of how to create custom tools in tldraw.

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -35,4 +35,4 @@ The `onUiEvent` callback is called with the name of the event as a string and an
 
 Note that `onUiEvent` is only called when interacting with the user interface. It is not called when running commands manually against the app, e.g. `editor.alignShapes()` will not call `onUiEvent`.
 
-See the [tldraw repository](https://github.com/tldraw/tldraw) for an example of how to customize tldraw's user interface.
+See the [tldraw repository](https://github.com/tldraw/tldraw/tree/main/apps/examples) for an example of how to customize tldraw's user interface.


### PR DESCRIPTION
This PR updates the docs examples links to point to the examples folder.

### Change Type

- [x] `documentation` — Changes to the documentation only (will not publish a new version)

