### PR TITLE
Select locked shapes on long press

### DIFF
--- a/packages/ui/src/lib/components/ContextMenu.tsx
+++ b/packages/ui/src/lib/components/ContextMenu.tsx
@@ -48,12 +48,10 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 						// if there are no selected shapes
 						!editor.selectedShapes.length ||
 						// OR if none of the shapes at the point include the selected shape
-						!shapesAtPoint.some((s) => selectedShapes.includes(s))
+						!shapesAtPoint.some(selectedShapes.includes)
 					) {
 						// then are there any locked shapes under the current pointer?
-						const lockedShapes = shapesAtPoint.filter((shape) =>
-							editor.isShapeOrAncestorLocked(shape)
-						)
+						const lockedShapes = shapesAtPoint.filter(editor.isShapeOrAncestorLocked)
 
 						if (lockedShapes.length) {
 							// nice, let's select them


### PR DESCRIPTION
Describe what your pull request does. If appropriate, add GIFs or images showing the before and after.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. On a touch device, create a locked shape
2. Long press on the locked shape to select it and open the context menu

### Release Notes
