### PR TITLE
highlighter fixes

### DIFF
--- a/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/getPath.ts
+++ b/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/getPath.ts
@@ -36,17 +36,22 @@ const solidSettings = (strokeWidth: number): StrokeOptions => {
 	}
 }
 
-export function getHighlightFreehandSettings(
-	strokeWidth: number,
+export function getHighlightFreehandSettings({
+	strokeWidth,
+	showAsComplete,
+	isPen,
+}: {
+	strokeWidth: number
 	showAsComplete: boolean
-): StrokeOptions {
+	isPen: boolean
+}): StrokeOptions {
 	return {
 		size: 1 + strokeWidth,
 		thinning: 0.1,
-		streamline: 0.1, // 0.62 + ((1 + strokeWidth) / 8) * 0.06,
+		streamline: 0.5,
 		smoothing: 0.5,
-		simulatePressure: true,
-		easing: EASINGS.easeOutSine,
+		simulatePressure: !isPen,
+		easing: isPen ? PEN_EASING : EASINGS.easeOutSine,
 		last: showAsComplete,
 	}
 }

--- a/packages/ui/src/lib/components/StylePanel/StylePanel.tsx
+++ b/packages/ui/src/lib/components/StylePanel/StylePanel.tsx
@@ -82,6 +82,8 @@ function CommonStylePickerSet({ props }: { props: TLNullableShapeProps }) {
 
 	const { color, fill, dash, size, opacity } = props
 
+	console.log({ size })
+
 	if (
 		color === undefined &&
 		fill === undefined &&
@@ -92,7 +94,7 @@ function CommonStylePickerSet({ props }: { props: TLNullableShapeProps }) {
 		return null
 	}
 
-	const showPickers = fill || dash || size
+	const showPickers = fill !== undefined || dash !== undefined || size !== undefined
 
 	const opacityIndex = styles.opacity.findIndex((s) => s.id === opacity)
 


### PR DESCRIPTION
Fixes the following issues with highlighter:
* Exported highlighter has much larger stroke width than in-app highlighter
* Selecting two highlighter shapes with different sizes would hide the size option from the styles panel
* Highlighter lines drawn on ipad look noise-y

### Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change
- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)
- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)

### Test Plan

-

### Release Notes

[aq bug fixes]
