### PR TITLE
Fix being able to undo following

### DIFF
--- a/packages/editor/src/lib/app/Editor.ts
+++ b/packages/editor/src/lib/app/Editor.ts
@@ -8575,9 +8575,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		transact(() => {
 			this.stopFollowingUser()
 
-			this.updateInstanceState({
-				followingUserId: userId,
-			})
+			this.updateInstanceState({ followingUserId: userId }, true)
 		})
 
 		const cancel = () => {
@@ -8680,12 +8678,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	stopFollowingUser = () => {
-		this.updateInstanceState({
-			followingUserId: null,
-		})
-
+		this.updateInstanceState({ followingUserId: null }, true)
 		this.emit('stop-following')
-
 		return this
 	}
 


### PR DESCRIPTION
This PR fixes a bug where you could undo following/unfollowing.

Fixes #1532

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. In two browser sessions...
2. In a shared project...
3. Follow the other tab's user.
4. Draw something.
5. Unfollow them.
6. Close the people menu!
7. Undo as far as you can go.
8. Check that you don't start following them again at any point.

- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

- Fixed a bug where you could undo viewport-following and viewport-unfollowing.
