### PR TITLE
[fix] control click on mac

### DIFF
--- a/packages/editor/src/lib/app/Editor.ts
+++ b/packages/editor/src/lib/app/Editor.ts
@@ -3593,7 +3593,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			shiftKey: this.inputs.shiftKey,
 			ctrlKey: this.inputs.ctrlKey,
 			altKey: this.inputs.altKey,
-			code: 'CtrlLeft',
+			code: 'ControlLeft',
 		})
 	}
 
@@ -3980,6 +3980,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 					break
 				}
 				case 'keyboard': {
+					// please, please
+					if (info.code === 'ControlRight') info.code = 'ControlLeft'
+
 					switch (info.name) {
 						case 'key_down': {
 							// Add the key from the keys set

--- a/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/getPath.ts
+++ b/packages/editor/src/lib/app/shapeutils/DrawShapeUtil/getPath.ts
@@ -43,7 +43,7 @@ export function getHighlightFreehandSettings(
 	return {
 		size: 1 + strokeWidth,
 		thinning: 0.1,
-		streamline: 0.1, // 0.62 + ((1 + strokeWidth) / 8) * 0.06,
+		streamline: 0.5, // 0.62 + ((1 + strokeWidth) / 8) * 0.06,
 		smoothing: 0.5,
 		simulatePressure: true,
 		easing: EASINGS.easeOutSine,

--- a/packages/editor/src/lib/app/tools/SelectTool/children/Idle.ts
+++ b/packages/editor/src/lib/app/tools/SelectTool/children/Idle.ts
@@ -12,6 +12,8 @@ import { StateNode } from '../../StateNode'
 export class Idle extends StateNode {
 	static override id = 'idle'
 
+	isDarwin = window.navigator.userAgent.toLowerCase().indexOf('mac') > -1
+
 	onPointerEnter: TLEventHandlers['onPointerEnter'] = (info) => {
 		switch (info.target) {
 			case 'canvas': {
@@ -62,10 +64,7 @@ export class Idle extends StateNode {
 
 		if (info.ctrlKey && !shouldEnterCropMode) {
 			// On Mac, you can right click using the Control keys + Click.
-			if (
-				info.target === 'shape' &&
-				(this.editor.inputs.keys.has('ControlLeft') || this.editor.inputs.keys.has('ControlRight'))
-			) {
+			if (info.target === 'shape' && this.isDarwin && this.editor.inputs.keys.has('ControlLeft')) {
 				if (!this.editor.isShapeOrAncestorLocked(info.shape)) {
 					this.parent.transition('pointing_shape', info)
 					return

--- a/packages/editor/src/lib/app/tools/SelectTool/children/Idle.ts
+++ b/packages/editor/src/lib/app/tools/SelectTool/children/Idle.ts
@@ -61,9 +61,20 @@ export class Idle extends StateNode {
 		const shouldEnterCropMode = this.shouldEnterCropMode(info, true)
 
 		if (info.ctrlKey && !shouldEnterCropMode) {
+			// On Mac, you can right click using the Control keys + Click.
+			if (
+				info.target === 'shape' &&
+				(this.editor.inputs.keys.has('ControlLeft') || this.editor.inputs.keys.has('ControlRight'))
+			) {
+				if (!this.editor.isShapeOrAncestorLocked(info.shape)) {
+					this.parent.transition('pointing_shape', info)
+					return
+				}
+			}
 			this.parent.transition('brushing', info)
 			return
 		}
+
 		switch (info.target) {
 			case 'canvas': {
 				this.parent.transition('pointing_canvas', info)


### PR DESCRIPTION
This PR fixes control click for right click on Mac.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. On a PC, ensure that control clicking does not select the thing under your cursor
2. On a mac, ensure that control clicking does select the thing under your cursor before the context menu opens

### Release Notes

- Fix control click to open menu on Mac