### PR TITLE
Fix arrows with weird bends crashing

### DIFF
--- a/packages/editor/src/lib/app/shapeutils/ArrowShapeUtil/arrow/curved-arrow.ts
+++ b/packages/editor/src/lib/app/shapeutils/ArrowShapeUtil/arrow/curved-arrow.ts
@@ -48,6 +48,10 @@ export function getCurvedArrowInfo(editor: Editor, shape: TLArrowShape, extraBen
 
 	const handleArc = getArcInfo(a, b, c)
 
+	if (!Number.isFinite(handleArc.length) || !Number.isFinite(handleArc.size)) {
+		return getStraightArrowInfo(editor, shape)
+	}
+
 	const arrowPageTransform = editor.getPageTransform(shape)!
 
 	if (startShapeInfo && !startShapeInfo.isExact) {


### PR DESCRIPTION
This PR prevents a crash when you try to curve an arrow that is pointing a very small distance.

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Draw a line.
2. Draw an arrow from one point on the line to another point on the line.
3. It will look weird (that's ok - we can fix that another time).
4. Now try move the middle handle of the arrow.
5. It should curve the arrow.

1. Open this snapshot link: https://www.tldraw.com/s/v2_c_LtB3kVSYEyWuR-aCCrrUn
2. Copy its contents onto your own tldraw.
3. Click on the frog.
4. Drag the handle that's on the frog's face.
5. It shouldn't crash the app.

- [ ] Unit Tests
- [ ] Webdriver tests

### Release Notes

- Fixed a rare crash that could happen when you try to curve an arrow with zero distance.
