### PR TITLE
[Docs] Change some internal methods to public

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -723,7 +723,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal (undocumented)
     setProjectName(name: string): void;
     setProp(key: TLShapeProp, value: any, ephemeral?: boolean, squashing?: boolean): this;
-    // @internal (undocumented)
+    // (undocumented)
     setReadOnly(isReadOnly: boolean): this;
     setScribble(scribble?: null | TLScribble): this;
     setSelectedIds(ids: TLShapeId[], squashing?: boolean): this;
@@ -763,13 +763,13 @@ export class Editor extends EventEmitter<TLEventMap> {
     updateAssets(assets: TLAssetPartial[]): this;
     // @internal
     updateCullingBounds(): this;
-    // @internal (undocumented)
+    // (undocumented)
     updateDocumentSettings(settings: Partial<TLDocument>): void;
     updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, ephemeral?: boolean, squashing?: boolean): this;
     updatePage(partial: RequiredKeys<TLPage, 'id'>, squashing?: boolean): this;
     updateShapes(partials: (null | TLShapePartial | undefined)[], squashing?: boolean): this;
     updateViewportScreenBounds(center?: boolean): this;
-    // @internal (undocumented)
+    // (undocumented)
     readonly user: UserPreferencesManager;
     get viewportPageBounds(): Box2d;
     get viewportPageCenter(): Vec2d;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -377,7 +377,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	readonly snaps = new SnapManager(this)
 
 	/**
-	 * @internal
+	 * @public
 	 */
 	readonly user: UserPreferencesManager
 
@@ -1513,7 +1513,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.store.get(TLDOCUMENT_ID)!
 	}
 
-	/** @internal */
+	/** @public */
 	updateDocumentSettings(settings: Partial<TLDocument>) {
 		this.store.put([{ ...this.documentSettings, ...settings }])
 	}
@@ -1600,7 +1600,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	private _isReadOnly = atom<boolean>('isReadOnly', false as any)
 
-	/** @internal */
+	/** @public */
 	setReadOnly(isReadOnly: boolean): this {
 		this._isReadOnly.set(isReadOnly)
 		if (isReadOnly) {


### PR DESCRIPTION
This PR changes some Editor methods from internal to public, so that they appear on the docs site.

Closes #1545 

### Change Type

- [x] `documentation` — Changes to the documentation only (will not publish a new version)

### Release Notes

- [docs] Changed some Editor methods from internal to public.
