### PR TITLE
Misc sync fixes

### DIFF
--- a/packages/editor/src/lib/test/commands/setCurrentPage.test.ts
+++ b/packages/editor/src/lib/test/commands/setCurrentPage.test.ts
@@ -32,20 +32,11 @@ describe('setCurrentPage', () => {
 		expect(editor.currentPage).toEqual(editor.pages[0])
 	})
 
-	it('adds tab state for the page if it doesnt already exist', () => {
-		editor.setCamera(1, 2, 4)
-		expect(editor.camera).toMatchObject({ x: 1, y: 2, z: 4 })
-
+	it("adding a page to the store by any means adds tab state for the page if it doesn't already exist", () => {
 		const page = PageRecordType.create({ name: 'test', index: 'a4' })
-		editor.store.put([page])
-
 		expect(editor.getPageStateByPageId(page.id)).toBeUndefined()
-
-		editor.setCurrentPageId(page.id)
-
+		editor.store.put([page])
 		expect(editor.getPageStateByPageId(page.id)).not.toBeUndefined()
-
-		expect(editor.camera).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
 
 	it('squashes', () => {


### PR DESCRIPTION
I've been doing some fuzz testing for the socket robustness work. This PR pulls in the bublic fixes. It also fixes #1511 

### Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change
- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)
- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)

### Test Plan

1. Create a frame in a multiplayer room
2. create two boxes inside the frame
3. draw an arrow connecting the two boxes
4. delete the frame
5. hit undo
6. the frame and boxes and arrows should reappear as they were before

### Release Notes

- Fixes a handful of state management bugs that manifest in multiplayer rooms