### PR TITLE
Add contributor license agreement.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,6 @@ To create a pull request:
 5. Run `yarn build` and then run tests with `yarn test`.
 6. Push your branch and open a PR. 🚀
 
-Before your code is merged, you will need to sign our [contributor license agreement](https://tldraw.dev/cla), which is handled via GitHub comments. Your PR will be reviewed and merged in within a day or two if everything looks good.
+Before your code is merged, you will need to sign our [contributor license agreement](https://tldraw.notion.site/Contributor-License-Agreement-4d529dd5e4b3438b90cdf2a2f9d7e7e6?pvs=25), which is handled via GitHub comments. Your PR will be reviewed and merged in within a day or two if everything looks good.
 
 Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,6 @@ To create a pull request:
 5. Run `yarn build` and then run tests with `yarn test`.
 6. Push your branch and open a PR. 🚀
 
-Your PR will be reviewed and merged in within a day or two if everything looks good.
+Before your code is merged, you will need to sign our [contributor license agreement](/cla), which is handled via GitHub comments. Your PR will be reviewed and merged in within a day or two if everything looks good.
+
+Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,6 @@ To create a pull request:
 5. Run `yarn build` and then run tests with `yarn test`.
 6. Push your branch and open a PR. 🚀
 
-Before your code is merged, you will need to sign our [contributor license agreement](/cla), which is handled via GitHub comments. Your PR will be reviewed and merged in within a day or two if everything looks good.
+Before your code is merged, you will need to sign our [contributor license agreement](https://tldraw.dev/cla), which is handled via GitHub comments. Your PR will be reviewed and merged in within a day or two if everything looks good.
 
 Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.

--- a/apps/docs/content/community/contributing.mdx
+++ b/apps/docs/content/community/contributing.mdx
@@ -8,6 +8,8 @@ order: 0
 
 Interested in contributing to the open source project? 
 
-You can find tldraw on GitHub at [github.com/tldraw/tldraw](https://github.com/tldraw/tldraw). You can [create an issue](https://github.com/tldraw/tldraw/issues/new/choose) and submit pull requests for our review. Before your code is merged, you will need to sign our [contributor license agreement](/cla), which is handled via GitHub comments.
+You can find tldraw on GitHub at [github.com/tldraw/tldraw](https://github.com/tldraw/tldraw). You can [create an issue](https://github.com/tldraw/tldraw/issues/new/choose) and submit pull requests for our review.
+
+Please see our [Contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md) for more information.
 
 Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.

--- a/apps/docs/content/community/contributing.mdx
+++ b/apps/docs/content/community/contributing.mdx
@@ -6,4 +6,8 @@ date: 3/22/2023
 order: 0
 ---
 
-Coming soon.
+Interested in contributing to the open source project? 
+
+You can find tldraw on GitHub at [github.com/tldraw/tldraw](https://github.com/tldraw/tldraw). You can [create an issue](https://github.com/tldraw/tldraw/issues/new/choose) and submit pull requests for our review. Before your code is merged, you will need to sign our [contributor license agreement](/cla), which is handled via GitHub comments.
+
+Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.

--- a/apps/docs/pages/cla.tsx
+++ b/apps/docs/pages/cla.tsx
@@ -28,6 +28,7 @@ export default function CLA({ sidebar }: Props) {
 					}}
 				/>
 				<h2>Contributor License Agreement</h2>
+				<h4>Version 1.0 — June 8th 2023</h4>
 				<p>
 					In order to clarify the intellectual property license granted with Contributions from any
 					person, tldraw, Inc. (“tldraw”) must have a Contributor License Agreement on file that has

--- a/apps/docs/pages/cla.tsx
+++ b/apps/docs/pages/cla.tsx
@@ -1,0 +1,137 @@
+import { Sidebar } from '@/components/Sidebar'
+import { Article, ArticleLinks, SidebarContentList } from '@/types/content-types'
+import { getArticle, getArticleSource, getLinks } from '@/utils/content'
+import { getSidebarContentList } from '@/utils/getSidebarContentList'
+import { GetStaticProps } from 'next'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { useTheme } from 'next-themes'
+
+interface Props {
+	article: Article
+	links: ArticleLinks
+	sidebar: SidebarContentList
+	mdxSource: MDXRemoteSerializeResult
+}
+
+export default function CLA({ sidebar }: Props) {
+	const theme = useTheme()
+
+	return (
+		<div className="layout">
+			<Sidebar {...sidebar} />
+			<main className={`article ${theme.theme ?? 'light'}`}>
+				<div
+					className="lockup"
+					style={{
+						mask: `url(/lockup.svg) center 100% / 100% no-repeat`,
+						WebkitMask: `url(/lockup.svg) center 100% / 100% no-repeat`,
+					}}
+				/>
+				<h2>Contributor License Agreement</h2>
+				<p>
+					In order to clarify the intellectual property license granted with Contributions from any
+					person, tldraw, Inc. (“tldraw”) must have a Contributor License Agreement on file that has
+					been signed by each contributor, indicating agreement to the license terms below. This
+					license is for Your protection as a contributor as well as the protection of tldraw; it
+					does not change your rights to use Your own contributions for any other purpose.
+				</p>
+				<p>
+					You accept and agree to the following terms and conditions for Your Contributions (present
+					and future) that you submit to tldraw. Except for the license granted herein to tldraw,
+					You reserve all right, title, and interest in and to Your Contributions.{' '}
+				</p>
+				<p>1. Definitions. </p>
+				<p>"You" (or "Your") means the individual identified above. </p>
+				<p>
+					"Contribution" means any original work of authorship, including any modifications or
+					additions to an existing work, that is intentionally submitted by You to tldraw for
+					inclusion in, or documentation of, any of the products owned or managed by tldraw (each, a
+					"Work"). For the purposes of this definition, "submitted" means any form of electronic,
+					verbal, or written communication sent to tldraw or its representatives, including but not
+					limited to communication on electronic mailing lists, source code control systems, and
+					issue tracking systems that are managed by, or on behalf of, tldraw for the purpose of
+					discussing and improving the Works, but excluding communication that is conspicuously
+					marked or otherwise designated in writing by You as "Not a Contribution."{' '}
+				</p>
+				<p>
+					2. Grant of Copyright License. You hereby grant to tldraw a perpetual, worldwide,
+					non-exclusive, sublicensable (through multiple tiers), no-charge, royalty-free,
+					irrevocable copyright license to reproduce, prepare derivative works of, publicly display,
+					publicly perform, distribute, and otherwise exploit Your Contributions and such derivative
+					works.{' '}
+				</p>
+				<p>
+					3. Grant of Patent License. You hereby grant to tldraw a perpetual, worldwide,
+					non-exclusive, sublicensable (through multiple tiers), no-charge, royalty-free,
+					irrevocable patent license to make, have made, use, offer to sell, sell, import, and
+					otherwise transfer and exploit the Works, where such license applies only to those patent
+					claims licensable by You that are necessarily infringed by Your Contribution(s) alone or
+					by combination of Your Contribution(s) with the Works to which such Contribution(s) was
+					submitted.{' '}
+				</p>
+				<p>
+					4. You represent that you are legally entitled to grant the above license. If your
+					employer(s) has rights to intellectual property that you create that includes your
+					Contributions, you represent that you have received permission to make Contributions on
+					behalf of that employer, that your employer has waived in writing any rights it may have
+					in Your Contributions to tldraw, or that your employer has executed a separate Corporate
+					CLA with tldraw.{' '}
+				</p>
+				<p>
+					5. You represent that each of Your Contributions is Your original creation and does not
+					incorporate any material created by others. You represent that Your Contribution
+					submissions include complete details of any patents or copyrights which are associated
+					with any part of Your Contributions.{' '}
+				</p>
+				<p>
+					6. You are not expected to provide support for Your Contributions, except to the extent
+					You desire to provide support. You may provide support for free, for a fee, or not at all.
+					Unless required by applicable law or agreed to in writing, You provide Your Contributions
+					on an "as is" basis, without warranties or conditions of any kind, either express or
+					implied, including, without limitation, any warranties or conditions of title,
+					non-infringement, merchantability, or fitness for a particular purpose.{' '}
+				</p>
+				<p>
+					7. You agree to notify tldraw of any facts or circumstances of which you become aware (now
+					or in the future) that would make Your representations in this Agreement inaccurate in any
+					respect.
+				</p>
+				<p>
+					8. You acknowledge that tldraw owns all right, title, and interest in and to the Works.
+					Notwithstanding the foregoing, tldraw’s subsidiary, tldraw GB limited (the “Subsidiary”),
+					is the beneficial owner of the Works, and tldraw will sublicense its rights in your
+					Contributions under this Agreement to the Subsidiary in furtherance of the Subsidiary’s
+					status as beneficial owner of the Works.
+				</p>
+				<p>
+					9. This Agreement is governed by the laws of Delaware, and the parties consent to
+					exclusive jurisdiction in the courts sitting in Delaware. The parties waive all defenses
+					of lack of personal jurisdiction and forum non-conveniens.
+				</p>
+				<p>
+					10. Entire Agreement/Assignment. This Agreement is the entire agreement between the
+					parties, and supersedes any and all prior agreements, understandings or communications,
+					written or oral, between the parties relating to the subject matter hereof. This Agreement
+					may be assigned by tldraw without Your prior consent.{' '}
+				</p>
+				<hr />
+				<p>
+					Questions or concerns? Email <a href="mailto://hello@tldraw.com">hello@tldraw.com.</a>
+				</p>
+			</main>
+		</div>
+	)
+}
+
+const sectionId = 'docs'
+const categoryId = 'ucg'
+const articleId = 'introduction'
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+	const sidebar = await getSidebarContentList({ sectionId, categoryId, articleId })
+	const article = await getArticle(articleId)
+	const links = await getLinks(articleId)
+	const mdxSource = await getArticleSource(articleId)
+
+	return { props: { article, sidebar, links, mdxSource } }
+}


### PR DESCRIPTION
This PR adds a contributor license agreement (CLA) to the project. Contributors will need to sign the CLA before we merge their PRs. This will be handled automatically via a bot here on GitHub.

## Context

Did you know tldraw is a [venture backed](https://tldraw.substack.com/p/tiny-little-seed-round) company? Our CLA is designed to protect our options for any future re-licensing of the project's code or transferring ownership, which can become complicated when taking public contributions community, but which can become necessary by fate and/or go to market strategies.

A CLA adds a bit of friction and hassle for contributors, however I'd prefer to be upfront about our relationship rather than doing what many open source projects have done in the past, which is relicensing code contributed without such prior agreement.

If you have any questions, feel free to post them below.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package (will not publish a new version)
