### PR TITLE
Move the loading of assets to the TldrawEditorWithReadyStore so that all code paths load the assets.

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -193,13 +193,8 @@ function TldrawEditorWithOwnStore(props: TldrawEditorProps & { store: undefined 
 
 const TldrawEditorWithLoadingStore = memo(function TldrawEditorBeforeLoading({
 	store,
-	assetUrls,
 	...rest
 }: TldrawEditorProps & { store: TLStoreWithStatus }) {
-	const { done: preloadingComplete, error: preloadingError } = usePreloadAssets(
-		assetUrls ?? defaultEditorAssetUrls
-	)
-
 	switch (store.status) {
 		case 'error': {
 			// for error handling, we fall back to the default error boundary.
@@ -221,14 +216,6 @@ const TldrawEditorWithLoadingStore = memo(function TldrawEditorBeforeLoading({
 		}
 	}
 
-	if (preloadingError) {
-		return <ErrorScreen>Could not load assets. Please refresh the page.</ErrorScreen>
-	}
-
-	if (!preloadingComplete) {
-		return <LoadingScreen>Loading assets...</LoadingScreen>
-	}
-
 	return <TldrawEditorWithReadyStore {...rest} store={store.store} />
 })
 
@@ -241,6 +228,7 @@ function TldrawEditorWithReadyStore({
 	tools,
 	shapes,
 	autoFocus,
+	assetUrls,
 }: TldrawEditorProps & {
 	store: TLStore
 }) {
@@ -305,6 +293,18 @@ function TldrawEditorWithReadyStore({
 		),
 		() => editor?.crashingError ?? null
 	)
+
+	const { done: preloadingComplete, error: preloadingError } = usePreloadAssets(
+		assetUrls ?? defaultEditorAssetUrls
+	)
+
+	if (preloadingError) {
+		return <ErrorScreen>Could not load assets. Please refresh the page.</ErrorScreen>
+	}
+
+	if (!preloadingComplete) {
+		return <LoadingScreen>Loading assets...</LoadingScreen>
+	}
 
 	if (!editor) {
 		return null


### PR DESCRIPTION
Move the preloading of assets to `TldrawEditorWithReadyStore` which makes it sure that all codepaths preload assets. Before that didn't happen for cases where we passed in an existing store - snapshots.


### Change Type

- [x] `patch` — Bug Fix

### Release notes
- Fix a problem where assets were not loading in some cases (snapshots).
