### PR TITLE
offset drop point by editor client rect

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -106,10 +106,12 @@ export function useCanvasEvents() {
 					(file) => !file.name.endsWith('.tldr')
 				)
 
+				const rect = editor.getContainer().getBoundingClientRect()
+
 				await editor.putExternalContent({
 					type: 'files',
 					files,
-					point: editor.screenToPage(e.clientX, e.clientY),
+					point: editor.screenToPage(e.clientX - rect.x, e.clientY - rect.y),
 					ignoreParent: false,
 				})
 			}


### PR DESCRIPTION
In my app, I have a sidebar and noticed that dropped shapes were being created at an offset by the sidebar's width. This is because the current point given to `putExternalContent` does not offset by the editor's client rect.