### PR TITLE
[improvement] Embed shape cleanup

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1032,6 +1032,9 @@ export function getPointerInfo(e: PointerEvent | React.PointerEvent, container: 
 export function getResizedImageDataUrl(dataURLForImage: string, width: number, height: number): Promise<string>;
 
 // @public (undocumented)
+export function getRotatedBoxShadow(rotation: number): string;
+
+// @public (undocumented)
 export function getSplineForLineShape(shape: TLLineShape): NonNullable<CubicSpline2d | Polyline2d>;
 
 // @public (undocumented)
@@ -1289,6 +1292,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 520;
         readonly height: 400;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1300,6 +1304,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1309,6 +1314,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1319,6 +1325,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1328,6 +1335,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1337,6 +1345,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1348,6 +1357,7 @@ export function matchEmbedUrl(url: string): {
         readonly minWidth: 460;
         readonly minHeight: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly instructionLink: "https://support.google.com/calendar/answer/41207?hl=en";
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1358,6 +1368,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1369,6 +1380,7 @@ export function matchEmbedUrl(url: string): {
         readonly minWidth: 460;
         readonly minHeight: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1378,6 +1390,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: false;
         readonly backgroundColor: "#fff";
         readonly toEmbedUrl: (url: string) => string | undefined;
@@ -1389,6 +1402,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1398,6 +1412,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 520;
         readonly height: 400;
         readonly doesResize: false;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1409,6 +1424,7 @@ export function matchEmbedUrl(url: string): {
         readonly minHeight: 500;
         readonly overrideOutlineRadius: 12;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1420,6 +1436,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1429,6 +1446,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 640;
         readonly height: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1439,6 +1457,7 @@ export function matchEmbedUrl(url: string): {
         readonly width: 800;
         readonly height: 450;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly overridePermissions: {
             readonly 'allow-presentation': true;
         };
@@ -1461,6 +1480,7 @@ export function matchUrl(url: string): {
         readonly width: 520;
         readonly height: 400;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1472,6 +1492,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1481,6 +1502,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1491,6 +1513,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1500,6 +1523,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1509,6 +1533,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1520,6 +1545,7 @@ export function matchUrl(url: string): {
         readonly minWidth: 460;
         readonly minHeight: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly instructionLink: "https://support.google.com/calendar/answer/41207?hl=en";
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1530,6 +1556,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1541,6 +1568,7 @@ export function matchUrl(url: string): {
         readonly minWidth: 460;
         readonly minHeight: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1550,6 +1578,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: false;
         readonly backgroundColor: "#fff";
         readonly toEmbedUrl: (url: string) => string | undefined;
@@ -1561,6 +1590,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1570,6 +1600,7 @@ export function matchUrl(url: string): {
         readonly width: 520;
         readonly height: 400;
         readonly doesResize: false;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1581,6 +1612,7 @@ export function matchUrl(url: string): {
         readonly minHeight: 500;
         readonly overrideOutlineRadius: 12;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1592,6 +1624,7 @@ export function matchUrl(url: string): {
         readonly width: 720;
         readonly height: 500;
         readonly doesResize: true;
+        readonly canUnmount: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
     } | {
@@ -1601,6 +1634,7 @@ export function matchUrl(url: string): {
         readonly width: 640;
         readonly height: 360;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly isAspectRatioLocked: true;
         readonly toEmbedUrl: (url: string) => string | undefined;
         readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -1611,6 +1645,7 @@ export function matchUrl(url: string): {
         readonly width: 800;
         readonly height: 450;
         readonly doesResize: true;
+        readonly canUnmount: false;
         readonly overridePermissions: {
             readonly 'allow-presentation': true;
         };
@@ -1787,24 +1822,6 @@ export type RequiredKeys<T, K extends keyof T> = Pick<T, K> & Partial<T>;
 
 // @internal (undocumented)
 export const RICH_TYPES: Record<string, boolean>;
-
-// @public (undocumented)
-export function rotateBoxShadow(rotation: number, shadows: {
-    offsetX: number;
-    offsetY: number;
-    blur: number;
-    spread: number;
-    color: string;
-}[]): string;
-
-// @public (undocumented)
-export const ROTATING_SHADOWS: {
-    offsetX: number;
-    offsetY: number;
-    blur: number;
-    spread: number;
-    color: string;
-}[];
 
 // @public (undocumented)
 export const runtime: {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -78,7 +78,6 @@ export {
 	MULTI_CLICK_DURATION,
 	REMOVE_SYMBOL,
 	RICH_TYPES,
-	ROTATING_SHADOWS,
 	STYLES,
 	SVG_PADDING,
 	TEXT_PROPS,
@@ -215,10 +214,10 @@ export {
 } from './lib/utils/data'
 export { debugFlags, featureFlags, type DebugFlag } from './lib/utils/debug-flags'
 export {
+	getRotatedBoxShadow,
 	loopToHtmlElement,
 	preventDefault,
 	releasePointerCapture,
-	rotateBoxShadow,
 	setPointerCapture,
 	truncateStringWithEllipsis,
 	usePrefersReducedMotion,

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -101,24 +101,6 @@ export const DEFAULT_BOOKMARK_WIDTH = 300
 export const DEFAULT_BOOKMARK_HEIGHT = 320
 
 /** @public */
-export const ROTATING_SHADOWS = [
-	{
-		offsetX: 0,
-		offsetY: 2,
-		blur: 4,
-		spread: 0,
-		color: '#00000029',
-	},
-	{
-		offsetX: 0,
-		offsetY: 3,
-		blur: 6,
-		spread: 0,
-		color: '#0000001f',
-	},
-]
-
-/** @public */
 export const GRID_STEPS = [
 	{ min: -1, mid: 0.15, step: 100 },
 	{ min: 0.05, mid: 0.375, step: 25 },

--- a/packages/editor/src/lib/editor/shapeutils/BookmarkShapeUtil/BookmarkShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapeutils/BookmarkShapeUtil/BookmarkShapeUtil.tsx
@@ -2,13 +2,9 @@ import { toDomPrecision } from '@tldraw/primitives'
 import { AssetRecordType, TLAssetId, TLBookmarkAsset, TLBookmarkShape } from '@tldraw/tlschema'
 import { debounce, getHashForString } from '@tldraw/utils'
 import { HTMLContainer } from '../../../components/HTMLContainer'
+import { DEFAULT_BOOKMARK_HEIGHT, DEFAULT_BOOKMARK_WIDTH } from '../../../constants'
 import {
-	DEFAULT_BOOKMARK_HEIGHT,
-	DEFAULT_BOOKMARK_WIDTH,
-	ROTATING_SHADOWS,
-} from '../../../constants'
-import {
-	rotateBoxShadow,
+	getRotatedBoxShadow,
 	stopEventPropagation,
 	truncateStringWithEllipsis,
 } from '../../../utils/dom'
@@ -48,7 +44,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 				<div
 					className="tl-bookmark__container tl-hitarea-stroke"
 					style={{
-						boxShadow: rotateBoxShadow(pageRotation, ROTATING_SHADOWS),
+						boxShadow: getRotatedBoxShadow(pageRotation),
 					}}
 				>
 					<div className="tl-bookmark__image_container">

--- a/packages/editor/src/lib/editor/tools/SelectTool/SelectTool.test.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/SelectTool.test.ts
@@ -406,7 +406,7 @@ describe('When in readonly mode', () => {
 				x: 100,
 				y: 100,
 				opacity: 1,
-				props: { w: 100, h: 100, url: '', doesResize: false },
+				props: { w: 100, h: 100, url: '' },
 			},
 		])
 		editor.setReadOnly(true)

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -83,12 +83,26 @@ export function releasePointerCapture(
 	}
 }
 
+export const ROTATING_BOX_SHADOWS = [
+	{
+		offsetX: 0,
+		offsetY: 2,
+		blur: 4,
+		spread: 0,
+		color: '#00000029',
+	},
+	{
+		offsetX: 0,
+		offsetY: 3,
+		blur: 6,
+		spread: 0,
+		color: '#0000001f',
+	},
+]
+
 /** @public */
-export function rotateBoxShadow(
-	rotation: number,
-	shadows: { offsetX: number; offsetY: number; blur: number; spread: number; color: string }[]
-) {
-	const cssStrings = shadows.map((shadow) => {
+export function getRotatedBoxShadow(rotation: number) {
+	const cssStrings = ROTATING_BOX_SHADOWS.map((shadow) => {
 		const { offsetX, offsetY, blur, spread, color } = shadow
 		const vec = new Vec2d(offsetX, offsetY)
 		const { x, y } = vec.rot(-rotation)

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -108,6 +108,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: true;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -119,6 +120,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -130,6 +132,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 520;
     readonly height: 400;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -139,6 +142,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 520;
     readonly height: 400;
     readonly doesResize: false;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -148,6 +152,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 800;
     readonly height: 450;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly overridePermissions: {
         readonly 'allow-presentation': true;
     };
@@ -161,6 +166,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: true;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -170,6 +176,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -181,6 +188,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly minWidth: 460;
     readonly minHeight: 360;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly instructionLink: "https://support.google.com/calendar/answer/41207?hl=en";
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -193,6 +201,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly minWidth: 460;
     readonly minHeight: 360;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -202,6 +211,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: true;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -211,6 +221,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -220,6 +231,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -231,6 +243,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly minHeight: 500;
     readonly overrideOutlineRadius: 12;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
 }, {
@@ -240,6 +253,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 640;
     readonly height: 360;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly isAspectRatioLocked: true;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -250,6 +264,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly isAspectRatioLocked: true;
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly fromEmbedUrl: (url: string) => string | undefined;
@@ -260,6 +275,7 @@ export const EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
     readonly height: 500;
     readonly doesResize: true;
+    readonly canUnmount: false;
     readonly isAspectRatioLocked: false;
     readonly backgroundColor: "#fff";
     readonly toEmbedUrl: (url: string) => string | undefined;
@@ -276,6 +292,7 @@ export type EmbedDefinition = {
     readonly width: number;
     readonly height: number;
     readonly doesResize: boolean;
+    readonly canUnmount: boolean;
     readonly isAspectRatioLocked?: boolean;
     readonly overridePermissions?: TLEmbedShapePermissions;
     readonly instructionLink?: string;

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -1110,6 +1110,51 @@ describe('hoist opacity', () => {
 	})
 })
 
+describe('Removes does resize from embed', () => {
+	const { up, down } = embedShapeMigrations.migrators[2]
+	test('up works as expected', () => {
+		expect(up({ props: { url: 'https://tldraw.com', doesResize: true } })).toEqual({
+			props: { url: 'https://tldraw.com' },
+		})
+	})
+	test('down works as expected', () => {
+		expect(down({ props: { url: 'https://tldraw.com' } })).toEqual({
+			props: { url: 'https://tldraw.com', doesResize: true },
+		})
+	})
+})
+
+describe('Removes tmpOldUrl from embed', () => {
+	const { up, down } = embedShapeMigrations.migrators[3]
+	test('up works as expected', () => {
+		expect(up({ props: { url: 'https://tldraw.com', tmpOldUrl: 'https://tldraw.com' } })).toEqual({
+			props: { url: 'https://tldraw.com' },
+		})
+	})
+	test('down works as expected', () => {
+		expect(down({ props: { url: 'https://tldraw.com' } })).toEqual({
+			props: { url: 'https://tldraw.com' },
+		})
+	})
+})
+
+describe('Removes overridePermissions from embed', () => {
+	const { up, down } = embedShapeMigrations.migrators[4]
+
+	test('up works as expected', () => {
+		expect(
+			up({ props: { url: 'https://tldraw.com', overridePermissions: { display: 'maybe' } } })
+		).toEqual({
+			props: { url: 'https://tldraw.com' },
+		})
+	})
+	test('down works as expected', () => {
+		expect(down({ props: { url: 'https://tldraw.com' } })).toEqual({
+			props: { url: 'https://tldraw.com' },
+		})
+	})
+})
+
 /* ---  PUT YOUR MIGRATIONS TESTS ABOVE HERE --- */
 
 for (const migrator of allMigrators) {

--- a/packages/tlschema/src/shapes/TLEmbedShape.ts
+++ b/packages/tlschema/src/shapes/TLEmbedShape.ts
@@ -24,6 +24,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(TLDRAW_APP_RE)) {
@@ -48,6 +49,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			const matches = urlObj && urlObj.pathname.match(/\/s\/([^/]+)\/?/)
@@ -74,6 +76,7 @@ export const EMBED_DEFINITIONS = [
 		width: 520,
 		height: 400,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const CODEPEN_URL_REGEXP = /https:\/\/codepen.io\/([^/]+)\/pen\/([^/]+)/
 			const matches = url.match(CODEPEN_URL_REGEXP)
@@ -100,6 +103,7 @@ export const EMBED_DEFINITIONS = [
 		width: 520,
 		height: 400,
 		doesResize: false,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const SCRATCH_URL_REGEXP = /https?:\/\/scratch.mit.edu\/projects\/([^/]+)/
 			const matches = url.match(SCRATCH_URL_REGEXP)
@@ -126,6 +130,7 @@ export const EMBED_DEFINITIONS = [
 		width: 800,
 		height: 450,
 		doesResize: true,
+		canUnmount: false,
 		overridePermissions: {
 			'allow-presentation': true,
 		},
@@ -168,6 +173,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: true,
 		toEmbedUrl: (url) => {
 			if (
 				!!url.match(
@@ -198,6 +204,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			if (url.includes('/maps/')) {
 				const match = url.match(/@(.*),(.*),(.*)z/)
@@ -236,6 +243,7 @@ export const EMBED_DEFINITIONS = [
 		minWidth: 460,
 		minHeight: 360,
 		doesResize: true,
+		canUnmount: false,
 		instructionLink: 'https://support.google.com/calendar/answer/41207?hl=en',
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
@@ -278,6 +286,7 @@ export const EMBED_DEFINITIONS = [
 		minWidth: 460,
 		minHeight: 360,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 
@@ -312,9 +321,11 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([^/]+)/)) {
+				if (!url.split('/').pop()) return
 				return url
 			}
 			return
@@ -322,6 +333,7 @@ export const EMBED_DEFINITIONS = [
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([^/]+)/)) {
+				if (!url.split('/').pop()) return
 				return url
 			}
 			return
@@ -334,6 +346,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/\/@([^/]+)\/([^/]+)/)) {
@@ -361,6 +374,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/^\/map\//)) {
@@ -386,6 +400,7 @@ export const EMBED_DEFINITIONS = [
 		minHeight: 500,
 		overrideOutlineRadius: 12,
 		doesResize: true,
+		canUnmount: false,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/^\/(artist|album)\//)) {
@@ -408,6 +423,7 @@ export const EMBED_DEFINITIONS = [
 		width: 640,
 		height: 360,
 		doesResize: true,
+		canUnmount: false,
 		isAspectRatioLocked: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
@@ -438,6 +454,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		isAspectRatioLocked: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
@@ -461,6 +478,7 @@ export const EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		canUnmount: false,
 		isAspectRatioLocked: false,
 		backgroundColor: '#fff',
 		toEmbedUrl: (url) => {
@@ -553,7 +571,6 @@ export type TLEmbedShapeProps = {
 	url: string
 	// TODO: This is to store during migration in case anything goes wrong so we can revert.
 	tmpOldUrl?: string
-	doesResize: boolean
 	overridePermissions?: TLEmbedShapePermissions
 }
 
@@ -568,7 +585,6 @@ export const embedShapeTypeValidator: T.Validator<TLEmbedShape> = createShapeVal
 		h: T.nonZeroNumber,
 		url: T.string,
 		tmpOldUrl: T.string.optional(),
-		doesResize: T.boolean,
 		overridePermissions: T.dict(
 			T.setEnum(
 				new Set(Object.keys(embedShapePermissionDefaults) as (keyof TLEmbedShapePermissions)[])
@@ -588,6 +604,7 @@ export type EmbedDefinition = {
 	readonly width: number
 	readonly height: number
 	readonly doesResize: boolean
+	readonly canUnmount: boolean
 	readonly isAspectRatioLocked?: boolean
 	readonly overridePermissions?: TLEmbedShapePermissions
 	readonly instructionLink?: string
@@ -600,11 +617,12 @@ export type EmbedDefinition = {
 
 const Versions = {
 	GenOriginalUrlInEmbed: 1,
+	RemoveDoesResize: 2,
 } as const
 
 /** @internal */
 export const embedShapeMigrations = defineMigrations({
-	currentVersion: Versions.GenOriginalUrlInEmbed,
+	currentVersion: Versions.RemoveDoesResize,
 	migrators: {
 		[Versions.GenOriginalUrlInEmbed]: {
 			// add tmpOldUrl property
@@ -656,6 +674,26 @@ export const embedShapeMigrations = defineMigrations({
 					props: {
 						...props,
 						url: newUrl ?? '',
+					},
+				}
+			},
+		},
+		[Versions.RemoveDoesResize]: {
+			up: (shape) => {
+				const { doesResize: _, ...props } = shape.props
+				return {
+					...shape,
+					props: {
+						...props,
+					},
+				}
+			},
+			down: (shape) => {
+				return {
+					...shape,
+					props: {
+						...shape.props,
+						doesResize: true,
 					},
 				}
 			},


### PR DESCRIPTION
This PR does some cleanup around our Embed Shape.

It:
- removes used `doesResize` and `overridePermissions` props
- removes the no-longer-needed `tmpOldUrl` prop
- adds a `canUnmount` property to embed definitions, so that some embeds can unmount when desired

### Change Type

- [x] `patch` — Bug Fix

### Test Plan

1. Create embed shapes
2. Migrate old data that includes embed shapes?

- [x] Unit Tests

### Release Notes

- [editor] Remove unused props for `TLEditorShape`
- [editor] Adds `canUnmount` property to embed definitions