### PR TITLE
prefetl → prefers

### DIFF
--- a/packages/editor/src/lib/components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/DefaultErrorFallback.tsx
@@ -68,7 +68,7 @@ export const DefaultErrorFallback: TLErrorFallback = ({ error, app }) => {
 
 		// if we can't find a theme class from the app or from a parent, we have
 		// to fall back on using a media query:
-		setIsDarkMode(window.matchMedia('(prefetl-color-scheme: dark)').matches)
+		setIsDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches)
 	}, [isDarkModeFromApp])
 
 	useEffect(() => {


### PR DESCRIPTION
Fixed a bug/typo where `prefers-color-schema` was written as `prefetl-color-schema`.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

N/A

### Release Notes

- Fix a bug where `prefers-color-schema` was written as `prefetl-color-schema`.
