### PR TITLE
[fix] embeds

### DIFF
--- a/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
+++ b/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
@@ -4,6 +4,7 @@ import {
 	EmbedDefinition,
 	TLAsset,
 	TLAssetId,
+	TLEmbedShape,
 	TLShapePartial,
 	createShapeId,
 } from '@tldraw/tlschema'
@@ -150,25 +151,21 @@ export class ExternalContentManager {
 		const position =
 			point ?? (editor.inputs.shiftKey ? editor.inputs.currentPagePoint : editor.viewportPageCenter)
 
-		const { width, height, doesResize } = embed
+		const { width, height } = embed
 
-		editor.createShapes(
-			[
-				{
-					id: createShapeId(),
-					type: 'embed',
-					x: position.x - (width || 450) / 2,
-					y: position.y - (height || 450) / 2,
-					props: {
-						w: width,
-						h: height,
-						doesResize: doesResize,
-						url,
-					},
-				},
-			],
-			true
-		)
+		const shapePartial: TLShapePartial<TLEmbedShape> = {
+			id: createShapeId(),
+			type: 'embed',
+			x: position.x - (width || 450) / 2,
+			y: position.y - (height || 450) / 2,
+			props: {
+				w: width,
+				h: height,
+				url,
+			},
+		}
+
+		editor.createShapes([shapePartial], true)
 	}
 
 	/**

--- a/packages/ui/src/lib/hooks/useActions.tsx
+++ b/packages/ui/src/lib/hooks/useActions.tsx
@@ -5,6 +5,7 @@ import {
 	DEFAULT_BOOKMARK_WIDTH,
 	Editor,
 	EmbedShapeUtil,
+	TLEmbedShape,
 	TLShapeId,
 	TLShapePartial,
 	TLTextShape,
@@ -314,14 +315,14 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						if (!embedInfo) continue
 						if (!embedInfo.definition) continue
 
-						const { width, height, doesResize } = embedInfo.definition
+						const { width, height } = embedInfo.definition
 
 						const newPos = new Vec2d(shape.x, shape.y)
 						newPos.rot(-shape.rotation)
 						newPos.add(new Vec2d(shape.props.w / 2 - width / 2, shape.props.h / 2 - height / 2))
 						newPos.rot(shape.rotation)
 
-						createList.push({
+						const shapeToCreate: TLShapePartial<TLEmbedShape> = {
 							id: createShapeId(),
 							type: 'embed',
 							x: newPos.x,
@@ -331,9 +332,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 								url: url,
 								w: width,
 								h: height,
-								doesResize,
 							},
-						})
+						}
+
+						createList.push(shapeToCreate)
 						deleteList.push(shape.id)
 					}
 


### PR DESCRIPTION
This PR fixes embeds to remove the `doesResize` prop when creating embeds / converting between bookmarks and embeds.

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Create an embed
2. Convert between bookmark and embed

