### PR TITLE
Add optional generic to `updateShapes` / `createShapes`

### DIFF
--- a/apps/examples/src/2-api/APIExample.tsx
+++ b/apps/examples/src/2-api/APIExample.tsx
@@ -24,38 +24,38 @@ export default function APIExample() {
 
 		editor.focus()
 
-		const geoShapePartial: TLShapePartial<TLGeoShape> = {
-			id,
-			type: 'geo',
-			x: 128 + Math.random() * 500,
-			y: 128 + Math.random() * 500,
-			props: {
-				geo: 'rectangle',
-				w: 100,
-				h: 100,
-				dash: 'draw',
-				color: 'blue',
-				size: 'm',
-			},
-		}
-
 		// Create a shape
-		editor.createShapes([geoShapePartial])
+		editor.createShapes<TLGeoShape>([
+			{
+				id,
+				type: 'geo',
+				x: 128 + Math.random() * 500,
+				y: 128 + Math.random() * 500,
+				props: {
+					geo: 'rectangle',
+					w: 100,
+					h: 100,
+					dash: 'draw',
+					color: 'blue',
+					size: 'm',
+				},
+			},
+		])
 
 		// Get the created shape
 		const shape = editor.getShapeById<TLGeoShape>(id)!
 
-		// Update the shape
-		editor.updateShapes([
-			{
-				id,
-				type: 'geo',
-				props: {
-					h: shape.props.h * 3,
-					text: 'hello world!',
-				},
+		const shapeUpdate: TLShapePartial<TLGeoShape> = {
+			id,
+			type: 'geo',
+			props: {
+				h: shape.props.h * 3,
+				text: 'hello world!',
 			},
-		])
+		}
+
+		// Update the shape
+		editor.updateShapes([shapeUpdate])
 
 		// Select the shape
 		editor.select(id)

--- a/apps/examples/src/2-api/APIExample.tsx
+++ b/apps/examples/src/2-api/APIExample.tsx
@@ -1,4 +1,11 @@
-import { createShapeId, Editor, Tldraw, TLGeoShape, useEditor } from '@tldraw/tldraw'
+import {
+	createShapeId,
+	Editor,
+	Tldraw,
+	TLGeoShape,
+	TLShapePartial,
+	useEditor,
+} from '@tldraw/tldraw'
 import '@tldraw/tldraw/editor.css'
 import '@tldraw/tldraw/ui.css'
 import { useEffect } from 'react'
@@ -17,23 +24,23 @@ export default function APIExample() {
 
 		editor.focus()
 
-		// Create a shape
-		editor.createShapes([
-			{
-				id,
-				type: 'geo',
-				x: 128 + Math.random() * 500,
-				y: 128 + Math.random() * 500,
-				props: {
-					geo: 'rectangle',
-					w: 100,
-					h: 100,
-					dash: 'draw',
-					color: 'blue',
-					size: 'm',
-				},
+		const geoShapePartial: TLShapePartial<TLGeoShape> = {
+			id,
+			type: 'geo',
+			x: 128 + Math.random() * 500,
+			y: 128 + Math.random() * 500,
+			props: {
+				geo: 'rectangle',
+				w: 100,
+				h: 100,
+				dash: 'draw',
+				color: 'blue',
+				size: 'm',
 			},
-		])
+		}
+
+		// Create a shape
+		editor.createShapes([geoShapePartial])
 
 		// Get the created shape
 		const shape = editor.getShapeById<TLGeoShape>(id)!

--- a/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
+++ b/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
@@ -1,4 +1,4 @@
-import { createShapeId, Tldraw } from '@tldraw/tldraw'
+import { createShapeId, Tldraw, TLShapePartial } from '@tldraw/tldraw'
 import '@tldraw/tldraw/editor.css'
 import '@tldraw/tldraw/ui.css'
 import { ErrorShape } from './ErrorShape'
@@ -16,16 +16,16 @@ export default function ErrorBoundaryExample() {
 					ShapeErrorFallback: ({ error }) => <div>Shape error! {String(error)}</div>, // use a custom error fallback for shapes
 				}}
 				onMount={(editor) => {
+					const errorShapePartial: TLShapePartial<ErrorShape> = {
+						type: 'error',
+						id: createShapeId(),
+						x: 0,
+						y: 0,
+						props: { message: 'Something has gone wrong' },
+					}
+
 					// When the app starts, create our error shape so we can see.
-					editor.createShapes([
-						{
-							type: 'error',
-							id: createShapeId(),
-							x: 0,
-							y: 0,
-							props: { message: 'Something has gone wrong' },
-						},
-					])
+					editor.createShapes([errorShapePartial])
 
 					// Center the camera on the error shape
 					editor.zoomToFit()

--- a/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
+++ b/apps/examples/src/8-error-boundary/ErrorBoundaryExample.tsx
@@ -25,7 +25,7 @@ export default function ErrorBoundaryExample() {
 					}
 
 					// When the app starts, create our error shape so we can see.
-					editor.createShapes([errorShapePartial])
+					editor.createShapes<ErrorShape>([errorShapePartial])
 
 					// Center the camera on the error shape
 					editor.zoomToFit()

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -424,7 +424,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         };
     };
     createPage(title: string, id?: TLPageId, belowPageIndex?: string): this;
-    createShapes(partials: TLShapePartial[], select?: boolean): this;
+    createShapes<T extends TLUnknownShape>(partials: TLShapePartial<T>[], select?: boolean): this;
     get croppingId(): null | TLShapeId;
     get cullingBounds(): Box2d;
     // @internal (undocumented)
@@ -760,7 +760,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     updateDocumentSettings(settings: Partial<TLDocument>): void;
     updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, ephemeral?: boolean, squashing?: boolean): this;
     updatePage(partial: RequiredKeys<TLPage, 'id'>, squashing?: boolean): this;
-    updateShapes(partials: (null | TLShapePartial | undefined)[], squashing?: boolean): this;
+    updateShapes<T extends TLUnknownShape>(partials: (null | TLShapePartial<T> | undefined)[], squashing?: boolean): this;
     updateViewportScreenBounds(center?: boolean): this;
     // (undocumented)
     readonly user: UserPreferencesManager;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1348,7 +1348,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 
 		if (finalIndex !== reparentedArrow.index) {
-			this.updateShapes([{ id: arrowId, type: 'arrow', index: finalIndex }])
+			this.updateShapes<TLArrowShape>([{ id: arrowId, type: 'arrow', index: finalIndex }])
 		}
 	}
 
@@ -4636,14 +4636,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @example
 	 *
 	 * ```ts
-	 * editor.createShapes([{ id: 'box1', type: 'box' }])
+	 * editor.createShapes([{ id: 'box1', type: 'text', props: { text: "ok" } }])
 	 * ```
 	 *
 	 * @param partials - The shape partials to create.
 	 * @param select - Whether to select the created shapes. Defaults to false.
 	 * @public
 	 */
-	createShapes(partials: TLShapePartial[], select = false) {
+	createShapes<T extends TLUnknownShape>(partials: TLShapePartial<T>[], select = false) {
 		this._createShapes(partials, select)
 		return this
 	}
@@ -4934,14 +4934,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @example
 	 *
 	 * ```ts
-	 * editor.updateShapes([{ id: 'box1', type: 'box', x: 100, y: 100 }])
+	 * editor.updateShapes([{ id: 'box1', type: 'geo', props: { w: 100, h: 100 } }])
 	 * ```
 	 *
 	 * @param partials - The shape partials to update.
 	 * @param squashing - Whether the change is ephemeral.
 	 * @public
 	 */
-	updateShapes(partials: (TLShapePartial | null | undefined)[], squashing = false) {
+	updateShapes<T extends TLUnknownShape>(
+		partials: (TLShapePartial<T> | null | undefined)[],
+		squashing = false
+	) {
 		let compactedPartials = compact(partials)
 		if (this.animatingShapes.size > 0) {
 			compactedPartials.forEach((p) => this.animatingShapes.delete(p.id))
@@ -8985,17 +8988,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const highestIndex = shapesWithRootParent[shapesWithRootParent.length - 1]?.index
 
 		this.batch(() => {
-			const groupShapePartial: TLShapePartial<TLGroupShape> = {
-				id: groupId,
-				type: 'group',
-				parentId,
-				index: highestIndex,
-				x,
-				y,
-				opacity: 1,
-				props: {},
-			}
-			this.createShapes([groupShapePartial])
+			this.createShapes<TLGroupShape>([
+				{
+					id: groupId,
+					type: 'group',
+					parentId,
+					index: highestIndex,
+					x,
+					y,
+					opacity: 1,
+					props: {},
+				},
+			])
 			this.reparentShapesById(sortedShapeIds, groupId)
 			this.select(groupId)
 		})

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8985,18 +8985,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const highestIndex = shapesWithRootParent[shapesWithRootParent.length - 1]?.index
 
 		this.batch(() => {
-			this.createShapes([
-				{
-					id: groupId,
-					type: 'group',
-					parentId,
-					index: highestIndex,
-					x,
-					y,
-					opacity: 1,
-					props: {},
-				},
-			])
+			const groupShapePartial: TLShapePartial<TLGroupShape> = {
+				id: groupId,
+				type: 'group',
+				parentId,
+				index: highestIndex,
+				x,
+				y,
+				opacity: 1,
+				props: {},
+			}
+			this.createShapes([groupShapePartial])
 			this.reparentShapesById(sortedShapeIds, groupId)
 			this.select(groupId)
 		})

--- a/packages/editor/src/lib/editor/derivations/arrowBindingsIndex.test.tsx
+++ b/packages/editor/src/lib/editor/derivations/arrowBindingsIndex.test.tsx
@@ -1,4 +1,4 @@
-import { TLShapeId } from '@tldraw/tlschema'
+import { TLArrowShape, TLShapeId } from '@tldraw/tlschema'
 import { TestEditor } from '../../test/TestEditor'
 import { TL } from '../../test/jsx'
 
@@ -212,7 +212,7 @@ describe('arrowBindingsIndex', () => {
 			)
 
 			// move arrowA from box2 to box3
-			editor.updateShapes([
+			editor.updateShapes<TLArrowShape>([
 				{
 					id: arrowAId,
 					type: 'arrow',

--- a/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
+++ b/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
@@ -298,21 +298,21 @@ export class ExternalContentManager {
 			p.y = editor.viewportPageBounds.minY + 40 + h / 2
 		}
 
-		const textShapePartial: TLShapePartial<TLTextShape> = {
-			id: createShapeId(),
-			type: 'text',
-			x: p.x - w / 2,
-			y: p.y - h / 2,
-			props: {
-				text: textToPaste,
-				// if the text has more than one line, align it to the left
-				align,
-				autoSize,
-				w,
+		editor.createShapes<TLTextShape>([
+			{
+				id: createShapeId(),
+				type: 'text',
+				x: p.x - w / 2,
+				y: p.y - h / 2,
+				props: {
+					text: textToPaste,
+					// if the text has more than one line, align it to the left
+					align,
+					autoSize,
+					w,
+				},
 			},
-		}
-
-		editor.createShapes([textShapePartial])
+		])
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
+++ b/packages/editor/src/lib/editor/managers/ExternalContentManager.ts
@@ -5,6 +5,8 @@ import {
 	TLAsset,
 	TLAssetId,
 	TLShapePartial,
+	TLTextShape,
+	TLTextShapeProps,
 	createShapeId,
 } from '@tldraw/tlschema'
 import { compact, getHashForString } from '@tldraw/utils'
@@ -251,7 +253,7 @@ export class ExternalContentManager {
 		let w: number
 		let h: number
 		let autoSize: boolean
-		let align = 'middle'
+		let align = 'middle' as TLTextShapeProps['align']
 
 		const isMultiLine = textToPaste.split('\n').length > 1
 
@@ -296,21 +298,21 @@ export class ExternalContentManager {
 			p.y = editor.viewportPageBounds.minY + 40 + h / 2
 		}
 
-		editor.createShapes([
-			{
-				id: createShapeId(),
-				type: 'text',
-				x: p.x - w / 2,
-				y: p.y - h / 2,
-				props: {
-					text: textToPaste,
-					// if the text has more than one line, align it to the left
-					align,
-					autoSize,
-					w,
-				},
+		const textShapePartial: TLShapePartial<TLTextShape> = {
+			id: createShapeId(),
+			type: 'text',
+			x: p.x - w / 2,
+			y: p.y - h / 2,
+			props: {
+				text: textToPaste,
+				// if the text has more than one line, align it to the left
+				align,
+				autoSize,
+				w,
 			},
-		])
+		}
+
+		editor.createShapes([textShapePartial])
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/arrow/ArrowShapeUtil.tsx
@@ -907,7 +907,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		} = shape
 
 		if (text.trimEnd() !== shape.props.text) {
-			this.editor.updateShapes([
+			this.editor.updateShapes<TLArrowShape>([
 				{
 					id,
 					type,

--- a/packages/editor/src/lib/editor/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/arrow/toolStates/Pointing.ts
@@ -1,4 +1,4 @@
-import { createShapeId, TLArrowShape, TLShapePartial } from '@tldraw/tlschema'
+import { createShapeId, TLArrowShape } from '@tldraw/tlschema'
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
@@ -34,14 +34,14 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		const shapePartial: TLShapePartial<TLArrowShape> = {
-			id,
-			type: 'arrow',
-			x: currentPagePoint.x,
-			y: currentPagePoint.y,
-		}
-
-		this.editor.createShapes([shapePartial])
+		this.editor.createShapes<TLArrowShape>([
+			{
+				id,
+				type: 'arrow',
+				x: currentPagePoint.x,
+				y: currentPagePoint.y,
+			},
+		])
 
 		const util = this.editor.getShapeUtil(ArrowShapeUtil)
 		const shape = this.editor.getShapeById<TLArrowShape>(id)

--- a/packages/editor/src/lib/editor/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/arrow/toolStates/Pointing.ts
@@ -1,8 +1,7 @@
-import { createShapeId, TLArrowShape } from '@tldraw/tlschema'
+import { createShapeId, TLArrowShape, TLShapePartial } from '@tldraw/tlschema'
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
-import { ArrowShapeTool } from '../ArrowShapeTool'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -31,20 +30,18 @@ export class Pointing extends StateNode {
 
 		this.didTimeout = false
 
-		const shapeType = (this.parent as ArrowShapeTool).shapeType
-
 		this.editor.mark('creating')
 
 		const id = createShapeId()
 
-		this.editor.createShapes([
-			{
-				id,
-				type: shapeType,
-				x: currentPagePoint.x,
-				y: currentPagePoint.y,
-			},
-		])
+		const shapePartial: TLShapePartial<TLArrowShape> = {
+			id,
+			type: 'arrow',
+			x: currentPagePoint.x,
+			y: currentPagePoint.y,
+		}
+
+		this.editor.createShapes([shapePartial])
 
 		const util = this.editor.getShapeUtil(ArrowShapeUtil)
 		const shape = this.editor.getShapeById<TLArrowShape>(id)

--- a/packages/editor/src/lib/editor/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -139,7 +139,7 @@ function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) 
 	if (editor.getAssetById(assetId)) {
 		// Existing asset for this URL?
 		if (shape.props.assetId !== assetId) {
-			editor.updateShapes([
+			editor.updateShapes<TLBookmarkShape>([
 				{
 					id: shape.id,
 					type: shape.type,
@@ -151,7 +151,7 @@ function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) 
 		// No asset for this URL?
 
 		// First, clear out the existing asset reference
-		editor.updateShapes([
+		editor.updateShapes<TLBookmarkShape>([
 			{
 				id: shape.id,
 				type: shape.type,
@@ -181,7 +181,7 @@ const createBookmarkAssetOnUrlChange = debounce(async (editor: Editor, shape: TL
 		editor.createAssets([asset])
 
 		// And update the shape
-		editor.updateShapes([
+		editor.updateShapes<TLBookmarkShape>([
 			{
 				id: shape.id,
 				type: shape.type,

--- a/packages/editor/src/lib/editor/shapes/draw/toolStates/Drawing.ts
+++ b/packages/editor/src/lib/editor/shapes/draw/toolStates/Drawing.ts
@@ -4,6 +4,7 @@ import {
 	TLDrawShape,
 	TLDrawShapeSegment,
 	TLHighlightShape,
+	TLShapePartial,
 	TLSizeType,
 	Vec2dModel,
 } from '@tldraw/tlschema'
@@ -238,30 +239,30 @@ export class Drawing extends StateNode {
 
 		this.pagePointWhereCurrentSegmentChanged = originPagePoint.clone()
 		const id = createShapeId()
-		this.editor.createShapes([
-			{
-				id,
-				type: this.shapeType,
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-				props: {
-					isPen: this.isPen,
-					segments: [
-						{
-							type: this.segmentMode,
-							points: [
-								{
-									x: 0,
-									y: 0,
-									z: +pressure.toFixed(2),
-								},
-							],
-						},
-					],
-				},
-			},
-		])
 
+		const shapePartial: TLShapePartial<DrawableShape> = {
+			id,
+			type: this.shapeType,
+			x: originPagePoint.x,
+			y: originPagePoint.y,
+			props: {
+				isPen: this.isPen,
+				segments: [
+					{
+						type: this.segmentMode,
+						points: [
+							{
+								x: 0,
+								y: 0,
+								z: +pressure.toFixed(2),
+							},
+						],
+					},
+				],
+			},
+		}
+
+		this.editor.createShapes([shapePartial])
 		this.currentLineLength = 0
 		this.initialShape = this.editor.getShapeById<DrawableShape>(id)
 	}
@@ -603,23 +604,23 @@ export class Drawing extends StateNode {
 
 					const newShapeId = createShapeId()
 
-					this.editor.createShapes([
-						{
-							id: newShapeId,
-							type: this.shapeType,
-							x: toFixed(currentPagePoint.x),
-							y: toFixed(currentPagePoint.y),
-							props: {
-								isPen: this.isPen,
-								segments: [
-									{
-										type: 'free',
-										points: [{ x: 0, y: 0, z: this.isPen ? +(z! * 1.25).toFixed() : 0.5 }],
-									},
-								],
-							},
+					const shapePartial: TLShapePartial<DrawableShape> = {
+						id: newShapeId,
+						type: this.shapeType,
+						x: toFixed(currentPagePoint.x),
+						y: toFixed(currentPagePoint.y),
+						props: {
+							isPen: this.isPen,
+							segments: [
+								{
+									type: 'free',
+									points: [{ x: 0, y: 0, z: this.isPen ? +(z! * 1.25).toFixed() : 0.5 }],
+								},
+							],
 						},
-					])
+					}
+
+					this.editor.createShapes([shapePartial])
 
 					this.initialShape = structuredClone(this.editor.getShapeById<DrawableShape>(newShapeId)!)
 					this.mergeNextPoint = false

--- a/packages/editor/src/lib/editor/shapes/draw/toolStates/Drawing.ts
+++ b/packages/editor/src/lib/editor/shapes/draw/toolStates/Drawing.ts
@@ -4,6 +4,7 @@ import {
 	TLDrawShape,
 	TLDrawShapeSegment,
 	TLHighlightShape,
+	TLShapePartial,
 	TLSizeType,
 	Vec2dModel,
 } from '@tldraw/tlschema'
@@ -219,30 +220,22 @@ export class Drawing extends StateNode {
 
 				this.currentLineLength = this.getLineLength(segments)
 
-				if (this.shapeType === 'highlight') {
-					this.editor.updateShapes<TLHighlightShape>([
-						{
-							id: shape.id,
-							type: 'highlight',
-							props: {
-								segments,
-							},
-						},
-					])
-				} else {
-					this.editor.updateShapes<TLDrawShape>([
-						{
-							id: shape.id,
-							type: 'draw',
-							props: {
-								segments,
-								isClosed: this.canClose()
-									? this.getIsClosed(segments, shape.props.size)
-									: undefined,
-							},
-						},
-					])
+				const shapePartial: TLShapePartial<DrawableShape> = {
+					id: shape.id,
+					type: this.shapeType,
+					props: {
+						segments,
+					},
 				}
+
+				if (this.canClose()) {
+					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+						segments,
+						shape.props.size
+					)
+				}
+
+				this.editor.updateShapes<TLDrawShape | TLHighlightShape>([shapePartial])
 
 				return
 			}
@@ -357,19 +350,22 @@ export class Drawing extends StateNode {
 						}
 					}
 
-					this.editor.updateShapes(
-						[
-							{
-								id,
-								type: this.shapeType,
-								props: {
-									segments: [...segments, newSegment],
-									isClosed: this.canClose() ? this.getIsClosed(segments, size) : undefined,
-								},
-							},
-						],
-						true
-					)
+					const shapePartial: TLShapePartial<DrawableShape> = {
+						id,
+						type: this.shapeType,
+						props: {
+							segments: [...segments, newSegment],
+						},
+					}
+
+					if (this.canClose()) {
+						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+							segments,
+							size
+						)
+					}
+
+					this.editor.updateShapes<TLDrawShape | TLHighlightShape>([shapePartial], true)
 				}
 				break
 			}
@@ -414,19 +410,22 @@ export class Drawing extends StateNode {
 					const finalSegments = [...newSegments, newFreeSegment]
 					this.currentLineLength = this.getLineLength(finalSegments)
 
-					this.editor.updateShapes(
-						[
-							{
-								id,
-								type: this.shapeType,
-								props: {
-									segments: finalSegments,
-									isClosed: this.canClose() ? this.getIsClosed(finalSegments, size) : undefined,
-								},
-							},
-						],
-						true
-					)
+					const shapePartial: TLShapePartial<DrawableShape> = {
+						id,
+						type: this.shapeType,
+						props: {
+							segments: finalSegments,
+						},
+					}
+
+					if (this.canClose()) {
+						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+							finalSegments,
+							size
+						)
+					}
+
+					this.editor.updateShapes([shapePartial], true)
 				}
 
 				break
@@ -553,19 +552,22 @@ export class Drawing extends StateNode {
 					points: [newSegment.points[0], newPoint],
 				}
 
-				this.editor.updateShapes(
-					[
-						{
-							id,
-							type: this.shapeType,
-							props: {
-								segments: newSegments,
-								isClosed: this.canClose() ? this.getIsClosed(segments, size) : undefined,
-							},
-						},
-					],
-					true
-				)
+				const shapePartial: TLShapePartial<DrawableShape> = {
+					id,
+					type: this.shapeType,
+					props: {
+						segments: newSegments,
+					},
+				}
+
+				if (this.canClose()) {
+					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+						segments,
+						size
+					)
+				}
+
+				this.editor.updateShapes([shapePartial], true)
 
 				break
 			}
@@ -595,19 +597,22 @@ export class Drawing extends StateNode {
 
 				this.currentLineLength = this.getLineLength(newSegments)
 
-				this.editor.updateShapes(
-					[
-						{
-							id,
-							type: this.shapeType,
-							props: {
-								segments: newSegments,
-								isClosed: this.canClose() ? this.getIsClosed(segments, size) : undefined,
-							},
-						},
-					],
-					true
-				)
+				const shapePartial: TLShapePartial<DrawableShape> = {
+					id,
+					type: this.shapeType,
+					props: {
+						segments: newSegments,
+					},
+				}
+
+				if (this.canClose()) {
+					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+						newSegments,
+						size
+					)
+				}
+
+				this.editor.updateShapes([shapePartial], true)
 
 				// Set a maximum length for the lines array; after 200 points, complete the line.
 				if (newPoints.length > 500) {

--- a/packages/editor/src/lib/editor/shapes/geo/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/geo/toolStates/Pointing.ts
@@ -1,5 +1,5 @@
 import { Box2d, getStarBounds } from '@tldraw/primitives'
-import { TLGeoShape, TLShapePartial, createShapeId } from '@tldraw/tlschema'
+import { TLGeoShape, createShapeId } from '@tldraw/tlschema'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
 
@@ -14,19 +14,19 @@ export class Pointing extends StateNode {
 
 			this.editor.mark('creating')
 
-			const shapePartial: TLShapePartial<TLGeoShape> = {
-				id,
-				type: 'geo',
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-				props: {
-					w: 1,
-					h: 1,
-					geo: this.editor.instanceState.propsForNextShape.geo,
+			this.editor.createShapes<TLGeoShape>([
+				{
+					id,
+					type: 'geo',
+					x: originPagePoint.x,
+					y: originPagePoint.y,
+					props: {
+						w: 1,
+						h: 1,
+						geo: this.editor.instanceState.propsForNextShape.geo,
+					},
 				},
-			}
-
-			this.editor.createShapes([shapePartial])
+			])
 
 			this.editor.select(id)
 			this.editor.setSelectedTool('select.resizing', {
@@ -63,19 +63,19 @@ export class Pointing extends StateNode {
 
 		this.editor.mark('creating')
 
-		const geoShapePartial: TLShapePartial<TLGeoShape> = {
-			id,
-			type: 'geo',
-			x: originPagePoint.x,
-			y: originPagePoint.y,
-			props: {
-				geo: this.editor.instanceState.propsForNextShape.geo,
-				w: 1,
-				h: 1,
+		this.editor.createShapes<TLGeoShape>([
+			{
+				id,
+				type: 'geo',
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+				props: {
+					geo: this.editor.instanceState.propsForNextShape.geo,
+					w: 1,
+					h: 1,
+				},
 			},
-		}
-
-		this.editor.createShapes([geoShapePartial])
+		])
 
 		const shape = this.editor.getShapeById<TLGeoShape>(id)!
 		if (!shape) return
@@ -85,7 +85,7 @@ export class Pointing extends StateNode {
 		const delta = this.editor.getDeltaInParentSpace(shape, bounds.center)
 
 		this.editor.select(id)
-		this.editor.updateShapes([
+		this.editor.updateShapes<TLGeoShape>([
 			{
 				id: shape.id,
 				type: 'geo',

--- a/packages/editor/src/lib/editor/shapes/geo/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/geo/toolStates/Pointing.ts
@@ -1,5 +1,5 @@
 import { Box2d, getStarBounds } from '@tldraw/primitives'
-import { TLGeoShape, createShapeId } from '@tldraw/tlschema'
+import { TLGeoShape, TLShapePartial, createShapeId } from '@tldraw/tlschema'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
 
@@ -14,19 +14,19 @@ export class Pointing extends StateNode {
 
 			this.editor.mark('creating')
 
-			this.editor.createShapes([
-				{
-					id,
-					type: 'geo',
-					x: originPagePoint.x,
-					y: originPagePoint.y,
-					props: {
-						w: 1,
-						h: 1,
-						geo: this.editor.instanceState.propsForNextShape.geo,
-					},
+			const shapePartial: TLShapePartial<TLGeoShape> = {
+				id,
+				type: 'geo',
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+				props: {
+					w: 1,
+					h: 1,
+					geo: this.editor.instanceState.propsForNextShape.geo,
 				},
-			])
+			}
+
+			this.editor.createShapes([shapePartial])
 
 			this.editor.select(id)
 			this.editor.setSelectedTool('select.resizing', {
@@ -63,19 +63,19 @@ export class Pointing extends StateNode {
 
 		this.editor.mark('creating')
 
-		this.editor.createShapes([
-			{
-				id,
-				type: 'geo',
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-				props: {
-					geo: this.editor.instanceState.propsForNextShape.geo,
-					w: 1,
-					h: 1,
-				},
+		const geoShapePartial: TLShapePartial<TLGeoShape> = {
+			id,
+			type: 'geo',
+			x: originPagePoint.x,
+			y: originPagePoint.y,
+			props: {
+				geo: this.editor.instanceState.propsForNextShape.geo,
+				w: 1,
+				h: 1,
 			},
-		])
+		}
+
+		this.editor.createShapes([geoShapePartial])
 
 		const shape = this.editor.getShapeById<TLGeoShape>(id)!
 		if (!shape) return

--- a/packages/editor/src/lib/editor/shapes/line/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/line/toolStates/Pointing.ts
@@ -1,6 +1,6 @@
 import { getIndexAbove, sortByIndex } from '@tldraw/indices'
 import { Matrix2d, Vec2d } from '@tldraw/primitives'
-import { TLHandle, TLLineShape, TLShapeId, TLShapePartial, createShapeId } from '@tldraw/tlschema'
+import { TLHandle, TLLineShape, TLShapeId, createShapeId } from '@tldraw/tlschema'
 import { last, structuredClone } from '@tldraw/utils'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers, TLInterruptEvent } from '../../../types/event-types'
@@ -78,14 +78,14 @@ export class Pointing extends StateNode {
 		} else {
 			const id = createShapeId()
 
-			const shapePartial: TLShapePartial<TLLineShape> = {
-				id,
-				type: 'line',
-				x: currentPagePoint.x,
-				y: currentPagePoint.y,
-			}
-
-			this.editor.createShapes([shapePartial])
+			this.editor.createShapes<TLLineShape>([
+				{
+					id,
+					type: 'line',
+					x: currentPagePoint.x,
+					y: currentPagePoint.y,
+				},
+			])
 
 			this.editor.select(id)
 			this.shape = this.editor.getShapeById(id)!

--- a/packages/editor/src/lib/editor/shapes/line/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/line/toolStates/Pointing.ts
@@ -1,10 +1,9 @@
 import { getIndexAbove, sortByIndex } from '@tldraw/indices'
 import { Matrix2d, Vec2d } from '@tldraw/primitives'
-import { TLHandle, TLLineShape, TLShapeId, createShapeId } from '@tldraw/tlschema'
+import { TLHandle, TLLineShape, TLShapeId, TLShapePartial, createShapeId } from '@tldraw/tlschema'
 import { last, structuredClone } from '@tldraw/utils'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers, TLInterruptEvent } from '../../../types/event-types'
-import { LineShapeTool } from '../LineShapeTool'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -79,14 +78,14 @@ export class Pointing extends StateNode {
 		} else {
 			const id = createShapeId()
 
-			this.editor.createShapes([
-				{
-					id,
-					type: (this.parent as LineShapeTool).shapeType,
-					x: currentPagePoint.x,
-					y: currentPagePoint.y,
-				},
-			])
+			const shapePartial: TLShapePartial<TLLineShape> = {
+				id,
+				type: 'line',
+				x: currentPagePoint.x,
+				y: currentPagePoint.y,
+			}
+
+			this.editor.createShapes([shapePartial])
 
 			this.editor.select(id)
 			this.shape = this.editor.getShapeById(id)!

--- a/packages/editor/src/lib/editor/shapes/shared/useEditableText.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/useEditableText.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-inner-declarations */
-import { TLShape } from '@tldraw/tlschema'
+import { TLShape, TLUnknownShape } from '@tldraw/tlschema'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { useValue } from 'signia-react'
 import { useEditor } from '../../../hooks/useEditor'
@@ -145,7 +145,9 @@ export function useEditableText<T extends Extract<TLShape, { props: { text: stri
 			}
 			// ----------------------------
 
-			editor.updateShapes([{ id, type, props: { text } }])
+			editor.updateShapes<TLUnknownShape & { props: { text: string } }>([
+				{ id, type, props: { text } },
+			])
 		},
 		[editor, id, type]
 	)

--- a/packages/editor/src/lib/editor/shapes/text/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/text/toolStates/Pointing.ts
@@ -1,4 +1,4 @@
-import { createShapeId, TLTextShape } from '@tldraw/tlschema'
+import { createShapeId, TLShapePartial, TLTextShape } from '@tldraw/tlschema'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
 
@@ -21,19 +21,19 @@ export class Pointing extends StateNode {
 
 			this.editor.mark('creating')
 
-			this.editor.createShapes([
-				{
-					id,
-					type: 'text',
-					x: originPagePoint.x,
-					y: originPagePoint.y,
-					props: {
-						text: '',
-						autoSize: false,
-						w: 20,
-					},
+			const textShapePartial: TLShapePartial<TLTextShape> = {
+				id,
+				type: 'text',
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+				props: {
+					text: '',
+					autoSize: false,
+					w: 20,
 				},
-			])
+			}
+
+			this.editor.createShapes([textShapePartial])
 
 			this.editor.select(id)
 

--- a/packages/editor/src/lib/editor/shapes/text/toolStates/Pointing.ts
+++ b/packages/editor/src/lib/editor/shapes/text/toolStates/Pointing.ts
@@ -1,4 +1,4 @@
-import { createShapeId, TLShapePartial, TLTextShape } from '@tldraw/tlschema'
+import { createShapeId, TLTextShape } from '@tldraw/tlschema'
 import { StateNode } from '../../../tools/StateNode'
 import { TLEventHandlers } from '../../../types/event-types'
 
@@ -21,19 +21,19 @@ export class Pointing extends StateNode {
 
 			this.editor.mark('creating')
 
-			const textShapePartial: TLShapePartial<TLTextShape> = {
-				id,
-				type: 'text',
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-				props: {
-					text: '',
-					autoSize: false,
-					w: 20,
+			this.editor.createShapes<TLTextShape>([
+				{
+					id,
+					type: 'text',
+					x: originPagePoint.x,
+					y: originPagePoint.y,
+					props: {
+						text: '',
+						autoSize: false,
+						w: 20,
+					},
 				},
-			}
-
-			this.editor.createShapes([textShapePartial])
+			])
 
 			this.editor.select(id)
 

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -1,5 +1,5 @@
 import { Vec2d } from '@tldraw/primitives'
-import { createShapeId } from '@tldraw/tlschema'
+import { TLShapePartial, createShapeId } from '@tldraw/tlschema'
 import { TLBaseBoxShape } from '../../../shapes/BaseBoxShapeUtil'
 import { TLEventHandlers } from '../../../types/event-types'
 import { StateNode } from '../../StateNode'
@@ -27,20 +27,18 @@ export class Pointing extends StateNode {
 
 			this.editor.mark(this.markId)
 
-			this.editor.createShapes([
-				{
-					id,
-					type: shapeType,
-					x: originPagePoint.x,
-					y: originPagePoint.y,
-					props: {
-						w: 1,
-						h: 1,
-					},
+			const shapePartial: TLShapePartial<TLBaseBoxShape> = {
+				id,
+				type: shapeType,
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+				props: {
+					w: 1,
+					h: 1,
 				},
-			])
+			}
 
-			this.editor.setSelectedIds([id])
+			this.editor.createShapes([shapePartial], true)
 			this.editor.setSelectedTool('select.resizing', {
 				...info,
 				target: 'selection',
@@ -83,14 +81,14 @@ export class Pointing extends StateNode {
 
 		this.editor.mark(this.markId)
 
-		this.editor.createShapes([
-			{
-				id,
-				type: shapeType,
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-			},
-		])
+		const shapePartial: TLShapePartial<TLBaseBoxShape> = {
+			id,
+			type: shapeType,
+			x: originPagePoint.x,
+			y: originPagePoint.y,
+		}
+
+		this.editor.createShapes([shapePartial])
 
 		const shape = this.editor.getShapeById<TLBaseBoxShape>(id)!
 		const { w, h } = this.editor.getShapeUtil(shape).defaultProps() as TLBaseBoxShape['props']

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -1,5 +1,5 @@
 import { Vec2d } from '@tldraw/primitives'
-import { TLShapePartial, createShapeId } from '@tldraw/tlschema'
+import { createShapeId } from '@tldraw/tlschema'
 import { TLBaseBoxShape } from '../../../shapes/BaseBoxShapeUtil'
 import { TLEventHandlers } from '../../../types/event-types'
 import { StateNode } from '../../StateNode'
@@ -27,18 +27,21 @@ export class Pointing extends StateNode {
 
 			this.editor.mark(this.markId)
 
-			const shapePartial: TLShapePartial<TLBaseBoxShape> = {
-				id,
-				type: shapeType,
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-				props: {
-					w: 1,
-					h: 1,
-				},
-			}
-
-			this.editor.createShapes([shapePartial], true)
+			this.editor.createShapes<TLBaseBoxShape>(
+				[
+					{
+						id,
+						type: shapeType,
+						x: originPagePoint.x,
+						y: originPagePoint.y,
+						props: {
+							w: 1,
+							h: 1,
+						},
+					},
+				],
+				true
+			)
 			this.editor.setSelectedTool('select.resizing', {
 				...info,
 				target: 'selection',
@@ -81,20 +84,20 @@ export class Pointing extends StateNode {
 
 		this.editor.mark(this.markId)
 
-		const shapePartial: TLShapePartial<TLBaseBoxShape> = {
-			id,
-			type: shapeType,
-			x: originPagePoint.x,
-			y: originPagePoint.y,
-		}
-
-		this.editor.createShapes([shapePartial])
+		this.editor.createShapes<TLBaseBoxShape>([
+			{
+				id,
+				type: shapeType,
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+			},
+		])
 
 		const shape = this.editor.getShapeById<TLBaseBoxShape>(id)!
 		const { w, h } = this.editor.getShapeUtil(shape).defaultProps() as TLBaseBoxShape['props']
 		const delta = this.editor.getDeltaInParentSpace(shape, new Vec2d(w / 2, h / 2))
 
-		this.editor.updateShapes([
+		this.editor.updateShapes<TLBaseBoxShape>([
 			{
 				id,
 				type: shapeType,

--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Crop/children/Idle.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Crop/children/Idle.ts
@@ -185,7 +185,7 @@ export class Idle extends StateNode {
 				this.editor.mark('translate crop')
 			}
 
-			this.editor.updateShapes([partial])
+			this.editor.updateShapes<ShapeWithCrop>([partial])
 		}
 	}
 }

--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Idle.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Idle.ts
@@ -1,5 +1,5 @@
 import { Vec2d } from '@tldraw/primitives'
-import { TLGeoShape, TLShape, TLShapePartial, TLTextShape, createShapeId } from '@tldraw/tlschema'
+import { TLGeoShape, TLShape, TLTextShape, createShapeId } from '@tldraw/tlschema'
 import { debugFlags } from '../../../../utils/debug-flags'
 import {
 	TLClickEventInfo,
@@ -382,18 +382,18 @@ export class Idle extends StateNode {
 
 		const { x, y } = this.editor.inputs.currentPagePoint
 
-		const textShapePartial: TLShapePartial<TLTextShape> = {
-			id,
-			type: 'text',
-			x,
-			y,
-			props: {
-				text: '',
-				autoSize: true,
+		this.editor.createShapes<TLTextShape>([
+			{
+				id,
+				type: 'text',
+				x,
+				y,
+				props: {
+					text: '',
+					autoSize: true,
+				},
 			},
-		}
-
-		this.editor.createShapes([textShapePartial])
+		])
 
 		const shape = this.editor.getShapeById(id)
 		if (!shape) return

--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Idle.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Idle.ts
@@ -1,5 +1,5 @@
 import { Vec2d } from '@tldraw/primitives'
-import { TLGeoShape, TLShape, createShapeId } from '@tldraw/tlschema'
+import { TLGeoShape, TLShape, TLShapePartial, TLTextShape, createShapeId } from '@tldraw/tlschema'
 import { debugFlags } from '../../../../utils/debug-flags'
 import {
 	TLClickEventInfo,
@@ -382,18 +382,18 @@ export class Idle extends StateNode {
 
 		const { x, y } = this.editor.inputs.currentPagePoint
 
-		this.editor.createShapes([
-			{
-				id,
-				type: 'text',
-				x,
-				y,
-				props: {
-					text: '',
-					autoSize: true,
-				},
+		const textShapePartial: TLShapePartial<TLTextShape> = {
+			id,
+			type: 'text',
+			x,
+			y,
+			props: {
+				text: '',
+				autoSize: true,
 			},
-		])
+		}
+
+		this.editor.createShapes([textShapePartial])
 
 		const shape = this.editor.getShapeById(id)
 		if (!shape) return

--- a/packages/editor/src/lib/test/commands/createShapes.test.ts
+++ b/packages/editor/src/lib/test/commands/createShapes.test.ts
@@ -1,4 +1,4 @@
-import { TLGeoShape, createShapeId } from '@tldraw/tlschema'
+import { TLArrowShape, TLGeoShape, createShapeId } from '@tldraw/tlschema'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -14,6 +14,71 @@ const ids = {
 
 beforeEach(() => {
 	editor = new TestEditor()
+})
+
+it('Uses typescript generics', () => {
+	// No error here because no generic, the editor doesn't know what this guy is
+	editor.createShapes([
+		{
+			id: ids.box1,
+			type: 'geo',
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// Yep error here because we are giving the wrong props to the shape
+	editor.createShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+			//@ts-expect-error
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// Yep error here because we are giving the wrong generic
+	editor.createShapes<TLArrowShape>([
+		{
+			id: ids.box1,
+			//@ts-expect-error
+			type: 'geo',
+			//@ts-expect-error
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// All good, correct match of generic and shape type
+	editor.createShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+			props: { w: 100 },
+		},
+	])
+
+	editor.createShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+		},
+		{
+			id: ids.box1,
+			// @ts-expect-error - wrong type
+			type: 'arrow',
+		},
+	])
+
+	// Unions are supported just fine
+	editor.createShapes<TLGeoShape | TLArrowShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+		},
+		{
+			id: ids.box1,
+			type: 'arrow',
+		},
+	])
 })
 
 it('Parents shapes to the current page if the parent is not found', () => {

--- a/packages/editor/src/lib/test/commands/createShapes.test.ts
+++ b/packages/editor/src/lib/test/commands/createShapes.test.ts
@@ -17,68 +17,69 @@ beforeEach(() => {
 })
 
 it('Uses typescript generics', () => {
-	// No error here because no generic, the editor doesn't know what this guy is
-	editor.createShapes([
-		{
-			id: ids.box1,
-			type: 'geo',
-			props: { w: 'OH NO' },
-		},
-	])
+	expect(() => {
+		// No error here because no generic, the editor doesn't know what this guy is
+		editor.createShapes([
+			{
+				id: ids.box1,
+				type: 'geo',
+				props: { w: 'OH NO' },
+			},
+		])
+		// Yep error here because we are giving the wrong props to the shape
+		editor.createShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+				//@ts-expect-error
+				props: { w: 'OH NO' },
+			},
+		])
 
-	// Yep error here because we are giving the wrong props to the shape
-	editor.createShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-			//@ts-expect-error
-			props: { w: 'OH NO' },
-		},
-	])
+		// Yep error here because we are giving the wrong generic
+		editor.createShapes<TLArrowShape>([
+			{
+				id: ids.box1,
+				//@ts-expect-error
+				type: 'geo',
+				//@ts-expect-error
+				props: { w: 'OH NO' },
+			},
+		])
 
-	// Yep error here because we are giving the wrong generic
-	editor.createShapes<TLArrowShape>([
-		{
-			id: ids.box1,
-			//@ts-expect-error
-			type: 'geo',
-			//@ts-expect-error
-			props: { w: 'OH NO' },
-		},
-	])
+		// All good, correct match of generic and shape type
+		editor.createShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+				props: { w: 100 },
+			},
+		])
 
-	// All good, correct match of generic and shape type
-	editor.createShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-			props: { w: 100 },
-		},
-	])
+		editor.createShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+			},
+			{
+				id: ids.box1,
+				// @ts-expect-error - wrong type
+				type: 'arrow',
+			},
+		])
 
-	editor.createShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-		},
-		{
-			id: ids.box1,
-			// @ts-expect-error - wrong type
-			type: 'arrow',
-		},
-	])
-
-	// Unions are supported just fine
-	editor.createShapes<TLGeoShape | TLArrowShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-		},
-		{
-			id: ids.box1,
-			type: 'arrow',
-		},
-	])
+		// Unions are supported just fine
+		editor.createShapes<TLGeoShape | TLArrowShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+			},
+			{
+				id: ids.box1,
+				type: 'arrow',
+			},
+		])
+	}).toThrowError()
 })
 
 it('Parents shapes to the current page if the parent is not found', () => {

--- a/packages/editor/src/lib/test/commands/updateShapes.test.ts
+++ b/packages/editor/src/lib/test/commands/updateShapes.test.ts
@@ -14,68 +14,70 @@ beforeEach(() => {
 })
 
 it('Uses typescript generics', () => {
-	// No error here because no generic, the editor doesn't know what this guy is
-	editor.updateShapes([
-		{
-			id: ids.box1,
-			type: 'geo',
-			props: { w: 'OH NO' },
-		},
-	])
+	expect(() => {
+		// No error here because no generic, the editor doesn't know what this guy is
+		editor.updateShapes([
+			{
+				id: ids.box1,
+				type: 'geo',
+				props: { w: 'OH NO' },
+			},
+		])
 
-	// Yep error here because we are giving the wrong props to the shape
-	editor.updateShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-			//@ts-expect-error
-			props: { w: 'OH NO' },
-		},
-	])
+		// Yep error here because we are giving the wrong props to the shape
+		editor.updateShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+				//@ts-expect-error
+				props: { w: 'OH NO' },
+			},
+		])
 
-	// Yep error here because we are giving the wrong generic
-	editor.updateShapes<TLArrowShape>([
-		{
-			id: ids.box1,
-			//@ts-expect-error
-			type: 'geo',
-			//@ts-expect-error
-			props: { w: 'OH NO' },
-		},
-	])
+		// Yep error here because we are giving the wrong generic
+		editor.updateShapes<TLArrowShape>([
+			{
+				id: ids.box1,
+				//@ts-expect-error
+				type: 'geo',
+				//@ts-expect-error
+				props: { w: 'OH NO' },
+			},
+		])
 
-	// All good, correct match of generic and shape type
-	editor.updateShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-			props: { w: 100 },
-		},
-	])
+		// All good, correct match of generic and shape type
+		editor.updateShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+				props: { w: 100 },
+			},
+		])
 
-	editor.updateShapes<TLGeoShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-		},
-		{
-			id: ids.box1,
-			// @ts-expect-error - wrong type
-			type: 'arrow',
-		},
-	])
+		editor.updateShapes<TLGeoShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+			},
+			{
+				id: ids.box1,
+				// @ts-expect-error - wrong type
+				type: 'arrow',
+			},
+		])
 
-	// Unions are supported just fine
-	editor.updateShapes<TLGeoShape | TLArrowShape>([
-		{
-			id: ids.box1,
-			type: 'geo',
-		},
-		{
-			id: ids.box1,
-			type: 'arrow',
-		},
-	])
+		// Unions are supported just fine
+		editor.updateShapes<TLGeoShape | TLArrowShape>([
+			{
+				id: ids.box1,
+				type: 'geo',
+			},
+			{
+				id: ids.box1,
+				type: 'arrow',
+			},
+		])
+	}).toThrowError()
 })
 
 it('updates shapes', () => {

--- a/packages/editor/src/lib/test/commands/updateShapes.test.ts
+++ b/packages/editor/src/lib/test/commands/updateShapes.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId } from '@tldraw/tlschema'
+import { createShapeId, TLArrowShape, TLGeoShape } from '@tldraw/tlschema'
 import { createDefaultShapes, TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -11,6 +11,71 @@ const ids = {
 beforeEach(() => {
 	editor = new TestEditor()
 	editor.createShapes(createDefaultShapes())
+})
+
+it('Uses typescript generics', () => {
+	// No error here because no generic, the editor doesn't know what this guy is
+	editor.updateShapes([
+		{
+			id: ids.box1,
+			type: 'geo',
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// Yep error here because we are giving the wrong props to the shape
+	editor.updateShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+			//@ts-expect-error
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// Yep error here because we are giving the wrong generic
+	editor.updateShapes<TLArrowShape>([
+		{
+			id: ids.box1,
+			//@ts-expect-error
+			type: 'geo',
+			//@ts-expect-error
+			props: { w: 'OH NO' },
+		},
+	])
+
+	// All good, correct match of generic and shape type
+	editor.updateShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+			props: { w: 100 },
+		},
+	])
+
+	editor.updateShapes<TLGeoShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+		},
+		{
+			id: ids.box1,
+			// @ts-expect-error - wrong type
+			type: 'arrow',
+		},
+	])
+
+	// Unions are supported just fine
+	editor.updateShapes<TLGeoShape | TLArrowShape>([
+		{
+			id: ids.box1,
+			type: 'geo',
+		},
+		{
+			id: ids.box1,
+			type: 'arrow',
+		},
+	])
 })
 
 it('updates shapes', () => {

--- a/packages/file-format/src/lib/buildFromV1Document.ts
+++ b/packages/file-format/src/lib/buildFromV1Document.ts
@@ -19,7 +19,6 @@ import {
 	TLNoteShape,
 	TLPageId,
 	TLShapeId,
-	TLShapePartial,
 	TLSizeType,
 	TLTextShape,
 	TLVideoShape,
@@ -182,41 +181,41 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 
 					switch (v1Shape.type) {
 						case TDShapeType.Sticky: {
-							const partial: TLShapePartial<TLNoteShape> = {
-								...inCommon,
-								type: 'note',
-								props: {
-									text: v1Shape.text ?? '',
-									color: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									align: getV2Align(v1Shape.style.textAlign),
+							editor.createShapes<TLNoteShape>([
+								{
+									...inCommon,
+									type: 'note',
+									props: {
+										text: v1Shape.text ?? '',
+										color: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										align: getV2Align(v1Shape.style.textAlign),
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 							break
 						}
 						case TDShapeType.Rectangle: {
-							const partial: TLShapePartial<TLGeoShape> = {
-								...inCommon,
-								type: 'geo',
-								props: {
-									geo: 'rectangle',
-									w: coerceDimension(v1Shape.size[0]),
-									h: coerceDimension(v1Shape.size[1]),
-									text: v1Shape.label ?? '',
-									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-									labelColor: getV2Color(v1Shape.style.color),
-									color: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									dash: getV2Dash(v1Shape.style.dash),
-									align: 'middle',
+							editor.createShapes<TLGeoShape>([
+								{
+									...inCommon,
+									type: 'geo',
+									props: {
+										geo: 'rectangle',
+										w: coerceDimension(v1Shape.size[0]),
+										h: coerceDimension(v1Shape.size[1]),
+										text: v1Shape.label ?? '',
+										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+										labelColor: getV2Color(v1Shape.style.color),
+										color: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										dash: getV2Dash(v1Shape.style.dash),
+										align: 'middle',
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 
 							const pageBoundsBeforeLabel = editor.getPageBoundsById(inCommon.id)!
 
@@ -254,24 +253,24 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 							break
 						}
 						case TDShapeType.Triangle: {
-							const partial: TLShapePartial<TLGeoShape> = {
-								...inCommon,
-								type: 'geo',
-								props: {
-									geo: 'triangle',
-									w: coerceDimension(v1Shape.size[0]),
-									h: coerceDimension(v1Shape.size[1]),
-									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-									labelColor: getV2Color(v1Shape.style.color),
-									color: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									dash: getV2Dash(v1Shape.style.dash),
-									align: 'middle',
+							editor.createShapes<TLGeoShape>([
+								{
+									...inCommon,
+									type: 'geo',
+									props: {
+										geo: 'triangle',
+										w: coerceDimension(v1Shape.size[0]),
+										h: coerceDimension(v1Shape.size[1]),
+										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+										labelColor: getV2Color(v1Shape.style.color),
+										color: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										dash: getV2Dash(v1Shape.style.dash),
+										align: 'middle',
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 
 							const pageBoundsBeforeLabel = editor.getPageBoundsById(inCommon.id)!
 
@@ -309,24 +308,24 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 							break
 						}
 						case TDShapeType.Ellipse: {
-							const partial: TLShapePartial<TLGeoShape> = {
-								...inCommon,
-								type: 'geo',
-								props: {
-									geo: 'ellipse',
-									w: coerceDimension(v1Shape.radius[0]) * 2,
-									h: coerceDimension(v1Shape.radius[1]) * 2,
-									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-									labelColor: getV2Color(v1Shape.style.color),
-									color: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									dash: getV2Dash(v1Shape.style.dash),
-									align: 'middle',
+							editor.createShapes<TLGeoShape>([
+								{
+									...inCommon,
+									type: 'geo',
+									props: {
+										geo: 'ellipse',
+										w: coerceDimension(v1Shape.radius[0]) * 2,
+										h: coerceDimension(v1Shape.radius[1]) * 2,
+										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+										labelColor: getV2Color(v1Shape.style.color),
+										color: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										dash: getV2Dash(v1Shape.style.dash),
+										align: 'middle',
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 
 							const pageBoundsBeforeLabel = editor.getPageBoundsById(inCommon.id)!
 
@@ -370,21 +369,21 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 								break
 							}
 
-							const partial: TLShapePartial<TLDrawShape> = {
-								...inCommon,
-								type: 'draw',
-								props: {
-									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-									color: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									dash: getV2Dash(v1Shape.style.dash),
-									isPen: false,
-									isComplete: v1Shape.isComplete,
-									segments: [{ type: 'free', points: v1Shape.points.map(getV2Point) }],
+							editor.createShapes<TLDrawShape>([
+								{
+									...inCommon,
+									type: 'draw',
+									props: {
+										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+										color: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										dash: getV2Dash(v1Shape.style.dash),
+										isPen: false,
+										isComplete: v1Shape.isComplete,
+										segments: [{ type: 'free', points: v1Shape.points.map(getV2Point) }],
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 							break
 						}
 						case TDShapeType.Arrow: {
@@ -395,51 +394,51 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 							const v2Bend = (dist * -v1Bend) / 2
 
 							// Could also be a line... but we'll use it as an arrow anyway
-							const partial: TLShapePartial<TLArrowShape> = {
-								...inCommon,
-								type: 'arrow',
-								props: {
-									text: v1Shape.label ?? '',
-									color: getV2Color(v1Shape.style.color),
-									labelColor: getV2Color(v1Shape.style.color),
-									size: getV2Size(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									dash: getV2Dash(v1Shape.style.dash),
-									arrowheadStart: getV2Arrowhead(v1Shape.decorations?.start),
-									arrowheadEnd: getV2Arrowhead(v1Shape.decorations?.end),
-									start: {
-										type: 'point',
-										x: coerceNumber(v1Shape.handles.start.point[0]),
-										y: coerceNumber(v1Shape.handles.start.point[1]),
+							editor.createShapes<TLArrowShape>([
+								{
+									...inCommon,
+									type: 'arrow',
+									props: {
+										text: v1Shape.label ?? '',
+										color: getV2Color(v1Shape.style.color),
+										labelColor: getV2Color(v1Shape.style.color),
+										size: getV2Size(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										dash: getV2Dash(v1Shape.style.dash),
+										arrowheadStart: getV2Arrowhead(v1Shape.decorations?.start),
+										arrowheadEnd: getV2Arrowhead(v1Shape.decorations?.end),
+										start: {
+											type: 'point',
+											x: coerceNumber(v1Shape.handles.start.point[0]),
+											y: coerceNumber(v1Shape.handles.start.point[1]),
+										},
+										end: {
+											type: 'point',
+											x: coerceNumber(v1Shape.handles.end.point[0]),
+											y: coerceNumber(v1Shape.handles.end.point[1]),
+										},
+										bend: v2Bend,
 									},
-									end: {
-										type: 'point',
-										x: coerceNumber(v1Shape.handles.end.point[0]),
-										y: coerceNumber(v1Shape.handles.end.point[1]),
-									},
-									bend: v2Bend,
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 
 							break
 						}
 						case TDShapeType.Text: {
-							const partial: TLShapePartial<TLTextShape> = {
-								...inCommon,
-								type: 'text',
-								props: {
-									text: v1Shape.text ?? ' ',
-									color: getV2Color(v1Shape.style.color),
-									size: getV2TextSize(v1Shape.style.size),
-									font: getV2Font(v1Shape.style.font),
-									align: getV2Align(v1Shape.style.textAlign),
-									scale: v1Shape.style.scale ?? 1,
+							editor.createShapes<TLTextShape>([
+								{
+									...inCommon,
+									type: 'text',
+									props: {
+										text: v1Shape.text ?? ' ',
+										color: getV2Color(v1Shape.style.color),
+										size: getV2TextSize(v1Shape.style.size),
+										font: getV2Font(v1Shape.style.font),
+										align: getV2Align(v1Shape.style.textAlign),
+										scale: v1Shape.style.scale ?? 1,
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 							break
 						}
 						case TDShapeType.Image: {
@@ -450,17 +449,17 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 								return
 							}
 
-							const partial: TLShapePartial<TLImageShape> = {
-								...inCommon,
-								type: 'image',
-								props: {
-									w: coerceDimension(v1Shape.size[0]),
-									h: coerceDimension(v1Shape.size[1]),
-									assetId,
+							editor.createShapes<TLImageShape>([
+								{
+									...inCommon,
+									type: 'image',
+									props: {
+										w: coerceDimension(v1Shape.size[0]),
+										h: coerceDimension(v1Shape.size[1]),
+										assetId,
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 							break
 						}
 						case TDShapeType.Video: {
@@ -471,17 +470,17 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 								return
 							}
 
-							const partial: TLShapePartial<TLVideoShape> = {
-								...inCommon,
-								type: 'video',
-								props: {
-									w: coerceDimension(v1Shape.size[0]),
-									h: coerceDimension(v1Shape.size[1]),
-									assetId,
+							editor.createShapes<TLVideoShape>([
+								{
+									...inCommon,
+									type: 'video',
+									props: {
+										w: coerceDimension(v1Shape.size[0]),
+										h: coerceDimension(v1Shape.size[1]),
+										assetId,
+									},
 								},
-							}
-
-							editor.createShapes([partial])
+							])
 							break
 						}
 					}


### PR DESCRIPTION
This PR adds a generic that we can use with `updateShapes` and `createShapes` in order to type the partials being passed into those methods. By default, the partials are typed as `TLUnknownShape`, which accepts any props.

### Change Type

- [x] `minor` — New feature

### Test Plan

- [x] Unit Tests

### Release Notes

- [editor] adds an optional shape generic to `updateShapes` and `createShapes`