### PR TITLE
move some kbds into actions and tools

### DIFF
--- a/packages/ui/src/lib/hooks/useActions.tsx
+++ b/packages/ui/src/lib/hooks/useActions.tsx
@@ -691,7 +691,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			{
 				id: 'delete',
 				label: 'action.delete',
-				kbd: '⌫',
+				kbd: '⌫,del,backspace',
 				icon: 'trash',
 				readonlyOk: false,
 				onSelect(source) {
@@ -732,7 +732,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			{
 				id: 'zoom-in',
 				label: 'action.zoom-in',
-				kbd: '$=',
+				kbd: '$=,=',
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('zoom-in', { source })
@@ -742,7 +742,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			{
 				id: 'zoom-out',
 				label: 'action.zoom-out',
-				kbd: '$-',
+				kbd: '$-,-',
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('zoom-out', { source })

--- a/packages/ui/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/lib/hooks/useKeyboardShortcuts.ts
@@ -63,29 +63,6 @@ export function useKeyboardShortcuts() {
 			})
 		}
 
-		// Manually add in a few shortcuts that have "extra" kbds
-		// todo: move these into the actions themselves and make the UI only display the first one
-
-		hot('g', () => {
-			if (areShortcutsDisabled() || editor.isReadOnly) return
-			editor.setSelectedTool('geo')
-		})
-
-		hot('del,backspace', () => {
-			if (areShortcutsDisabled()) return
-			actions['delete'].onSelect('kbd')
-		})
-
-		hot('=', () => {
-			if (areShortcutsDisabled()) return
-			actions['zoom-in'].onSelect('kbd')
-		})
-
-		hot('-', () => {
-			if (areShortcutsDisabled()) return
-			actions['zoom-out'].onSelect('kbd')
-		})
-
 		hotkeys.setScope(editor.store.id)
 
 		return () => {
@@ -95,29 +72,46 @@ export function useKeyboardShortcuts() {
 }
 
 function getHotkeysStringFromKbd(kbd: string) {
-	let str = ''
-
-	const chars = kbd.split('')
-
-	if (chars.length === 1) {
-		str = chars[0]
-	} else {
-		if (chars[0] === '!') {
-			str = `shift+${chars[1]}`
-		} else if (chars[0] === '?') {
-			str = `alt+${chars[1]}`
-		} else if (chars[0] === '$') {
-			if (chars[1] === '!') {
-				str = `cmd+shift+${chars[2]},ctrl+shift+${chars[2]}`
-			} else if (chars[1] === '?') {
-				str = `cmd+⌥+${chars[2]},ctrl+alt+${chars[2]}`
+	return getKeys(kbd)
+		.map(kbd => {
+			let str = ''
+			const chars = kbd.split('')
+			if (chars.length === 1) {
+				str = chars[0]
 			} else {
-				str = `cmd+${chars[1]},ctrl+${chars[1]}`
+				if (chars[0] === '!') {
+					str = `shift+${chars[1]}`
+				} else if (chars[0] === '?') {
+					str = `alt+${chars[1]}`
+				} else if (chars[0] === '$') {
+					if (chars[1] === '!') {
+						str = `cmd+shift+${chars[2]},ctrl+shift+${chars[2]}`
+					} else if (chars[1] === '?') {
+						str = `cmd+⌥+${chars[2]},ctrl+alt+${chars[2]}`
+					} else {
+						str = `cmd+${chars[1]},ctrl+${chars[1]}`
+					}
+				} else {
+					str = kbd
+				}
 			}
-		} else {
-			str = kbd
-		}
-	}
+			return str
+		})
+		.join(',')
+}
 
-	return str
+// Logic to split kbd string from hotkeys-js util.
+function getKeys(key) {
+	if (typeof key !== 'string') key = '';
+	key = key.replace(/\s/g, '');
+	const keys = key.split(',');
+	let index = keys.lastIndexOf('');
+  
+	for (; index >= 0;) {
+	  keys[index - 1] += ',';
+	  keys.splice(index, 1);
+	  index = keys.lastIndexOf('');
+	}
+  
+	return keys;
 }

--- a/packages/ui/src/lib/hooks/useTools.tsx
+++ b/packages/ui/src/lib/hooks/useTools.tsx
@@ -94,6 +94,17 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 					trackEvent('select-tool', { source, id: 'draw' })
 				},
 			},
+			{
+				id: 'geo',
+				label: 'tool.geo',
+				readonlyOk: false,
+				icon: 'tool-geo',
+				kbd: 'g',
+				onSelect(source) {
+					editor.setSelectedTool('geo')
+					trackEvent('select-tool', { source, id: `geo` })
+				}
+			},
 			...[...TL_GEO_TYPES].map((id) => ({
 				id,
 				label: `tool.${id}` as TLUiTranslationKey,


### PR DESCRIPTION
This PR tries to move some remaining kbds into actions and tools, which allows them to be overwritten in actions or tools if developer wishes so. It also modifies `getHotkeysStringFromKbd` to support multiple `kbds` per action and parses them into proper hotkeys.

Right now, these kbds cannot be removed without reimplementing `useKeyboardShortcuts` entirely.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

Should not affect existing kbds behavior as it just moves them into actions or tools.