### PR TITLE
[fix] Remove group shape export backgrounds

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6088,6 +6088,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 					if (id === singleFrameShapeId) return []
 
 					const shape = this.getShapeById(id)!
+
+					if (this.isShapeOfType(shape, GroupShapeUtil)) return []
+
 					const util = this.getShapeUtil(shape)
 
 					let font: string | undefined
@@ -6113,6 +6116,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						outerElement.appendChild(shapeSvgElement)
 						shapeSvgElement = outerElement
 					}
+
 					if (backgroundSvgElement) {
 						const outerElement = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 						outerElement.appendChild(backgroundSvgElement)


### PR DESCRIPTION
This PR removes the default SVG export for groups.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a group
2. Export it to SVG

### Release Notes

- Fix image exports for groups