### PR TITLE
remove `ShapeUtil.transform`

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1903,7 +1903,6 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
     snapPoints(shape: T): Vec2d[];
     toBackgroundSvg?(shape: T, font: string | undefined, colors: TLExportColors): null | Promise<SVGElement> | SVGElement;
     toSvg?(shape: T, font: string | undefined, colors: TLExportColors): Promise<SVGElement> | SVGElement;
-    transform(shape: T): Matrix2d;
     // (undocumented)
     readonly type: T['type'];
     static type: string;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1998,8 +1998,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	getTransform(shape: TLShape) {
-		const util = this.getShapeUtil(shape)
-		return util.transform(shape)
+		return Matrix2d.Compose(Matrix2d.Translate(shape.x, shape.y), Matrix2d.Rotate(shape.rotation))
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Box2d, linesIntersect, Matrix2d, VecLike } from '@tldraw/primitives'
+import { Box2d, linesIntersect, VecLike } from '@tldraw/primitives'
 import { ComputedCache } from '@tldraw/store'
 import { TLHandle, TLShape, TLShapePartial, TLUnknownShape, Vec2dModel } from '@tldraw/tlschema'
 import { computed, EMPTY_ARRAY } from 'signia'
@@ -9,7 +9,6 @@ import { TLResizeHandle } from '../types/selection-types'
 import { TLExportColors } from './shared/TLExportColors'
 
 const points = new WeakMapCache<TLShape, Vec2dModel>()
-const transforms = new WeakMapCache<TLShape, Matrix2d>()
 
 /** @public */
 export interface TLShapeUtilConstructor<
@@ -220,18 +219,6 @@ export abstract class ShapeUtil<T extends TLUnknownShape = TLUnknownShape> {
 			return new Box2d(result.x, result.y, Math.max(result.width, 1), Math.max(result.height, 1))
 		}
 		return result
-	}
-
-	/**
-	 * Get the cached transform. Do not override this method!
-	 *
-	 * @param shape - The shape.
-	 * @public
-	 */
-	transform(shape: T): Matrix2d {
-		return transforms.get<T>(shape, (shape) =>
-			Matrix2d.Compose(Matrix2d.Translate(shape.x, shape.y), Matrix2d.Rotate(shape.rotation))
-		)
 	}
 
 	/**


### PR DESCRIPTION
Removes the cached (but not really needed) local transform for shapes. We almost never get the local transform except when getting the page transform.

### Change Type

- [x] `major` — Breaking change


### Release Notes

- [editor] Remove `ShapeUtil.transform`