### PR TITLE
Change app to editor in docs

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -20,11 +20,11 @@ Rather than document everything, this page is intended to give a broad idea of h
 
 ## State
 
-The app holds the raw state of the document in its `store` property. Data is kept here as a table of JSON serializable records. 
+The editor holds the raw state of the document in its `store` property. Data is kept here as a table of JSON serializable records. 
 
 For example, the store contains a `page` record for each page in the current document, as well as an `instancePageState` record for each page that stores information about the editor's state for that page, and a single `instanceState` for each editor instance which stores the id of the user's current page.
 
-The app also exposes many _computed_ values which are derived from other records in the store. For example, `editor.selectedIds` is a computed property that will return the editor's current selected shape ids for its current page.
+The editor also exposes many _computed_ values which are derived from other records in the store. For example, `editor.selectedIds` is a computed property that will return the editor's current selected shape ids for its current page.
 
 You can use these properties directly or you can use them in [signia](https://github.com/tldraw/signia) signals.
 
@@ -55,7 +55,7 @@ Each change to the state happens within a transaction. You can batch changes int
 
 ### Listening for changes
 
-You can subscribe to changes using `editor.store.listen`. Each time a transaction completes, the app will call the callback with a history entry. This entry contains information about the records that were added, changed, or deleted, as well as whether the change was caused by the user or from a remote change.
+You can subscribe to changes using `editor.store.listen`. Each time a transaction completes, the editor will call the callback with a history entry. This entry contains information about the records that were added, changed, or deleted, as well as whether the change was caused by the user or from a remote change.
 
 ```ts
 editor.store.listen(entry => {
@@ -75,7 +75,7 @@ The history stack in tldraw contains two types of data: "marks" and "commands". 
 
 You can call `editor.mark(id)` to add a mark to the history stack with the given `id`. 
 
-When you call `editor.undo()`, the app will undo each command until it finds either a mark or the start of the stack. When you call `editor.redo()`, the app will redo each command until it finds either a mark or the end of the stack. 
+When you call `editor.undo()`, the editor will undo each command until it finds either a mark or the start of the stack. When you call `editor.redo()`, the editor will redo each command until it finds either a mark or the end of the stack. 
 
 ```ts
 // A
@@ -117,23 +117,23 @@ editor.bailToMark("first") // will to A
 
 ## Events and Tools
 
-The `Editor` class receives events from the user interface via its `dispatch` method. When the `Editor` receives an event, it is first handled internally to update `editor.inputs` and other state before, and then sent into to the app's state chart.
+The `Editor` class receives events from the user interface via its `dispatch` method. When the `Editor` receives an event, it is first handled internally to update `editor.inputs` and other state before, and then sent into to the editor's state chart.
 
 You shouldn't need to use the `dispatch` method directly, however you may write code in the state chart that responds to these events.
 
 ### State Chart
 
-The `Editor` class has a "state chart", or a tree of `StateNode` instances, that contain the logic for the app's tools such as the select tool or the draw tool. User interactions such as moving the cursor will produce different changes to the state depending on which nodes are active.
+The `Editor` class has a "state chart", or a tree of `StateNode` instances, that contain the logic for the editor's tools such as the select tool or the draw tool. User interactions such as moving the cursor will produce different changes to the state depending on which nodes are active.
 
 Each node be active or inactive. Each state node may also have zero or more children. When a state is active, and if the state has children, one (and only one) of its children must also be active. When a state node receives an event from its parent, it has the opportunity to handle the event before passing the event to its active child. The node can handle an event in any way: it can ignore the event, update records in the store, or run a _transition_ that changes which states nodes are active.
 
-When a user interaction is sent to the app via its `dispatch` method, this event is sent to the app's root state node (`editor.root`) and passed then down through the chart's active states until either it reaches a leaf node or until one of those nodes produces a transaction.
+When a user interaction is sent to the editor via its `dispatch` method, this event is sent to the editor's root state node (`editor.root`) and passed then down through the chart's active states until either it reaches a leaf node or until one of those nodes produces a transaction.
 
-<Image title="Events" src="/images/api/events.png" alt="A diagram showing an event being sent to the app and handled in the state chart." title="The app passes an event into the state start where it is handled by each active state in order."/>
+<Image title="Events" src="/images/api/events.png" alt="A diagram showing an event being sent to the editor and handled in the state chart." title="The editor passes an event into the state start where it is handled by each active state in order."/>
 
 ### Path
 
-You can get the app's current "path" of active states via `editor.root.path`. In the above example, the value would be `"root.select.idle"`.
+You can get the editor's current "path" of active states via `editor.root.path`. In the above example, the value would be `"root.select.idle"`.
 
 You can check whether a path is active via `editor.isIn`, or else check whether multiple paths are active via `editor.isInAny`. 
 
@@ -148,7 +148,7 @@ editor.isInAny('editor.select.idle', 'editor.select.pointing_shape') // true
 
 Note that the paths you pass to `isIn` or `isInAny` can be the full path or a partial of the start of the path. For example, if the full path is `root.select.idle`, then `isIn` would return true for the paths `root`, `root.select`, or `root.select.idle`.
 
-> If all you're interested in is the state below `root`, there is a convenience property, `editor.currentToolId`, that can help with the app's currently selected tool.
+> If all you're interested in is the state below `root`, there is a convenience property, `editor.currentToolId`, that can help with the editor's currently selected tool.
 
 ```tsx
 import { track } from "@tldraw/signia"
@@ -169,13 +169,13 @@ export const CreatingBubbleToolUi = track(() => {
 
 ## Inputs
 
-The app's `inputs` object holds information about the user's current input state, including their cursor position (in page space _and_ screen space), which keys are pressed, what their multi-click state is, and whether they are dragging, pointing, pinching, and so on.
+The editor's `inputs` object holds information about the user's current input state, including their cursor position (in page space _and_ screen space), which keys are pressed, what their multi-click state is, and whether they are dragging, pointing, pinching, and so on.
 
 Note that the modifier keys include a short delay after being released in order to prevent certain errors when modeling interactions. For example, when a user releases the "Shift" key, `editor.inputs.shiftKey` will remain `true` for another 100 milliseconds or so.
 
 This property is stored as regular data. It is not reactive. 
 
-## Common things to do with the app
+## Common things to do with the editor
 
 ### Create shapes
 


### PR DESCRIPTION
This PR changes App to Editor in the docs.
It goes alongside some changes that I accidentally commited to main... so feel free to review those here as well!
([this one](https://github.com/tldraw/tldraw/commit/be1ec9699c4c25f7192518b14c7678c8c4cfc2d2)) and ([this one](https://github.com/tldraw/tldraw/commit/5a9f3a17261a68f44ab03df788f33bd27539ed1b))

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Check that there's an Editor page in the docs sidebar.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- [docs] Updated 'App' to 'Editor'.
