### PR TITLE
[docs] Add barebones note about translations

### DIFF
--- a/apps/docs/content/community/translations.mdx
+++ b/apps/docs/content/community/translations.mdx
@@ -6,4 +6,6 @@ date: 3/22/2023
 order: 1
 ---
 
-If you want to help with translations, let us know on [Discord](https://discord.gg/sKNgCZyrrf) so that we can add you to the project.
+The tldraw user interface (in [@tldraw/ui](/docs/user-interface)) is currently translated into over thirty different languages, with twenty languages at above 70% completion. Where a key's translation is missing in the user's current language language, the default (English) translation will be used instead.
+
+We manage our translations through [Lokalise](https://www.lokalise.com), a long-time tldraw sponsor. If you would like to help by translating or reviewing translations, please let us know on [Discord](https://discord.gg/sKNgCZyrrf) so that we can add you to the project.

--- a/apps/docs/content/community/translations.mdx
+++ b/apps/docs/content/community/translations.mdx
@@ -6,4 +6,4 @@ date: 3/22/2023
 order: 1
 ---
 
-Coming soon.
+If you want to help with translations, let us know on [Discord](https://discord.gg/sKNgCZyrrf) so that we can add you to the project.


### PR DESCRIPTION
This PR adds a bare-minimum note to the Translations page on the docs site.

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Take a look at the Translations docs page.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- [docs] Added brief info on how to join as a translations contributor.
