### PR TITLE
[experiment] Fix docs anchor links

### DIFF
--- a/apps/docs/components/Search.tsx
+++ b/apps/docs/components/Search.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Icon } from './Icon'
 
 export function Search({ activeId }: { activeId: string | null }) {
+	return null
 	const [query, setQuery] = useState('')
 	const [results, setResults] = useState<SearchResult[]>([])
 	const rResultsList = useRef<HTMLOListElement>(null)
@@ -15,10 +16,10 @@ export function Search({ activeId }: { activeId: string | null }) {
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const sendQuery = useCallback(
-		throttle(async (query: string) => {
-			const res = await fetch(`/api/search?q=${query}&s=${activeId}`)
-			const json = await res.json()
-			setResults(json.results)
+		throttle(async (_query: string) => {
+			// const res = await fetch(`/api/search?q=${query}&s=${activeId}`)
+			// const json = await res.json()
+			// setResults(json.results)
 		}, 150),
 		[activeId]
 	)

--- a/apps/docs/components/mdx-components/generic.tsx
+++ b/apps/docs/components/mdx-components/generic.tsx
@@ -16,9 +16,9 @@ export const ListItem = (props: any) => {
 
 /* ------------------- Typography ------------------- */
 
-type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
-const Heading = ({ level, ...props }: { level: HeadingTag; [key: string]: any }) => {
+const Heading = ({ level, ...props }: { level: HeadingLevel; [key: string]: any }) => {
 	const pathname = usePathname()
 	const Element = level
 	if (props.id) {

--- a/apps/docs/components/mdx-components/generic.tsx
+++ b/apps/docs/components/mdx-components/generic.tsx
@@ -1,3 +1,5 @@
+import { usePathname } from 'next/navigation'
+
 /* ---------------------- Lists --------------------- */
 
 export const UnorderedList = (props: any) => {
@@ -17,11 +19,12 @@ export const ListItem = (props: any) => {
 type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
 const Heading = ({ level, ...props }: { level: HeadingTag; [key: string]: any }) => {
+	const pathname = usePathname()
 	const Element = level
 	if (props.id) {
 		return (
 			<Element {...props}>
-				<a href={`#${props.id}`}>{props.children}</a>
+				<a href={`${pathname}#${props.id}`}>{props.children}</a>
 			</Element>
 		)
 	}

--- a/apps/docs/components/mdx-components/generic.tsx
+++ b/apps/docs/components/mdx-components/generic.tsx
@@ -1,7 +1,5 @@
 /* ---------------------- Lists --------------------- */
 
-import React from 'react'
-
 export const UnorderedList = (props: any) => {
 	return <ul {...props} />
 }
@@ -16,10 +14,10 @@ export const ListItem = (props: any) => {
 
 /* ------------------- Typography ------------------- */
 
-type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
-function heading(heading: Heading, props: any) {
-	const Element = ({ ...props }) => React.createElement(heading, props)
+const Heading = ({ level, ...props }: { level: HeadingTag; [key: string]: any }) => {
+	const Element = level
 	if (props.id) {
 		return (
 			<Element {...props}>
@@ -32,27 +30,27 @@ function heading(heading: Heading, props: any) {
 }
 
 export const Heading1 = (props: any) => {
-	return heading('h1', props)
+	return <Heading level="h1" {...props} />
 }
 
 export const Heading2 = (props: any) => {
-	return heading('h2', props)
+	return <Heading level="h2" {...props} />
 }
 
 export const Heading3 = (props: any) => {
-	return heading('h3', props)
+	return <Heading level="h3" {...props} />
 }
 
 export const Heading4 = (props: any) => {
-	return heading('h4', props)
+	return <Heading level="h4" {...props} />
 }
 
 export const Heading5 = (props: any) => {
-	return heading('h5', props)
+	return <Heading level="h5" {...props} />
 }
 
 export const Heading6 = (props: any) => {
-	return heading('h6', props)
+	return <Heading level="h6" {...props} />
 }
 
 export const Paragraph = (props: any) => {

--- a/apps/docs/components/mdx-components/generic.tsx
+++ b/apps/docs/components/mdx-components/generic.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 /* ---------------------- Lists --------------------- */
@@ -24,7 +25,7 @@ const Heading = ({ level, ...props }: { level: HeadingLevel; [key: string]: any 
 	if (props.id) {
 		return (
 			<Element {...props}>
-				<a href={`${pathname}#${props.id}`}>{props.children}</a>
+				<Link href={`${pathname}#${props.id}`}>{props.children}</Link>
 			</Element>
 		)
 	}

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
 	reactStrictMode: true,
 	experimental: {
-		scrollRestoration: true,
+		scrollRestoration: false,
 	},
 	transpilePackages: ['@tldraw/utils'],
 }

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
 	reactStrictMode: true,
 	experimental: {
-		scrollRestoration: false,
+		scrollRestoration: true,
 	},
 	transpilePackages: ['@tldraw/utils'],
 }

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -353,7 +353,7 @@ body {
 }
 
 .article hr {
-	margin: 52px 0px;
+	/* margin: 52px 0px; */
 	padding: 0px 4px;
 	height: 1px;
 	width: calc(100% - 8px);

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -148,8 +148,8 @@ body {
 	padding: 16px 16px 120px 16px;
 	font-weight: 400;
 	max-width: 100%;
-	/* overflow-x: hidden;
-	overflow-y: visible; */
+	overflow-x: hidden;
+	overflow-y: visible;
 }
 
 .article__details {
@@ -159,7 +159,7 @@ body {
 	margin: 40px 0px;
 	gap: 16px;
 	max-width: 100%;
-	/* overflow: hidden; */
+	overflow: hidden;
 }
 
 .article__details__edit {
@@ -200,7 +200,7 @@ body {
 	padding: 10px 16px;
 	border-radius: 4px;
 	white-space: nowrap;
-	/* overflow: hidden; */
+	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
@@ -316,7 +316,7 @@ body {
 	background-color: var(--color-tint-1);
 	border-radius: 8px;
 	font-size: 13px;
-	/* overflow-x: auto; */
+	overflow-x: auto;
 }
 
 .article code {
@@ -364,7 +364,7 @@ body {
 .article table {
 	margin: 32px 0px;
 	border-radius: 4px;
-	/* overflow: hidden; */
+	overflow: hidden;
 	width: 100%;
 	text-align: left;
 	border: 1px solid var(--color-tint-2);
@@ -437,7 +437,7 @@ body {
 	align-self: start;
 	top: 0px;
 	z-index: 1000;
-	/* overflow-y: auto; */
+	overflow-y: auto;
 }
 
 .sidebar .sidebar__list h4 {
@@ -656,7 +656,7 @@ body {
 	border-radius: 8px;
 	box-shadow: var(--shadow-big);
 	max-height: 80vh;
-	/* overflow-y: auto; */
+	overflow-y: auto;
 }
 
 .search__results__list {

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -148,8 +148,8 @@ body {
 	padding: 16px 16px 120px 16px;
 	font-weight: 400;
 	max-width: 100%;
-	overflow-x: hidden;
-	overflow-y: visible;
+	/* overflow-x: hidden;
+	overflow-y: visible; */
 }
 
 .article__details {
@@ -159,7 +159,7 @@ body {
 	margin: 40px 0px;
 	gap: 16px;
 	max-width: 100%;
-	overflow: hidden;
+	/* overflow: hidden; */
 }
 
 .article__details__edit {
@@ -200,7 +200,7 @@ body {
 	padding: 10px 16px;
 	border-radius: 4px;
 	white-space: nowrap;
-	overflow: hidden;
+	/* overflow: hidden; */
 	text-overflow: ellipsis;
 }
 
@@ -316,7 +316,7 @@ body {
 	background-color: var(--color-tint-1);
 	border-radius: 8px;
 	font-size: 13px;
-	overflow-x: auto;
+	/* overflow-x: auto; */
 }
 
 .article code {
@@ -364,7 +364,7 @@ body {
 .article table {
 	margin: 32px 0px;
 	border-radius: 4px;
-	overflow: hidden;
+	/* overflow: hidden; */
 	width: 100%;
 	text-align: left;
 	border: 1px solid var(--color-tint-2);
@@ -437,7 +437,7 @@ body {
 	align-self: start;
 	top: 0px;
 	z-index: 1000;
-	overflow-y: auto;
+	/* overflow-y: auto; */
 }
 
 .sidebar .sidebar__list h4 {
@@ -656,7 +656,7 @@ body {
 	border-radius: 8px;
 	box-shadow: var(--shadow-big);
 	max-height: 80vh;
-	overflow-y: auto;
+	/* overflow-y: auto; */
 }
 
 .search__results__list {


### PR DESCRIPTION
This PR fixes anchor links sometimes scrolling to the wrong place on the docs site.

## How do we fix it?
🚧 under construction 🚧

## Admin

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

Note: The bug doesn't happen in development, only production.

1. Use Chrome.
2. Make a new tab.
3. Enter this link into your address bar (replacing the host name with the preview link): `HOST_NAME_GOES_HERE/gen/editor/Editor-class#Editor-undo-member`
4. Check that your scroll is at the `undo` method, NOT somewhere else.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Docs: Fixed a bug where anchor links could scroll to the wrong place.