### PR TITLE
Make resizeBox a regular function

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1839,10 +1839,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     // @internal (undocumented)
     expandSelectionOutlinePx(shape: Shape): number;
     protected abstract getBounds(shape: Shape): Box2d;
-    getCenter(shape: Shape): Vec2d;
+    abstract getCenter(shape: Shape): Vec2d;
     getEditingBounds: (shape: Shape) => Box2d;
     protected getHandles?(shape: Shape): TLHandle[];
-    protected getOutline(shape: Shape): Vec2d[];
+    protected abstract getOutline(shape: Shape): Vec2d[];
     protected getOutlineSegments(shape: Shape): Vec2d[][];
     // (undocumented)
     getStyleIfExists<T>(style: StyleProp<T>, shape: Shape | TLShapePartial<Shape>): T | undefined;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1839,10 +1839,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     // @internal (undocumented)
     expandSelectionOutlinePx(shape: Shape): number;
     protected abstract getBounds(shape: Shape): Box2d;
-    abstract getCenter(shape: Shape): Vec2d;
+    getCenter(shape: Shape): Vec2d;
     getEditingBounds: (shape: Shape) => Box2d;
     protected getHandles?(shape: Shape): TLHandle[];
-    protected abstract getOutline(shape: Shape): Vec2d[];
+    protected getOutline(shape: Shape): Vec2d[];
     protected getOutlineSegments(shape: Shape): Vec2d[][];
     // (undocumented)
     getStyleIfExists<T>(style: StyleProp<T>, shape: Shape | TLShapePartial<Shape>): T | undefined;

--- a/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
@@ -11,7 +11,7 @@ export type ResizeBoxOptions = Partial<{
 	maxHeight: number
 }>
 
-export const resizeBox = (
+export function resizeBox(
 	shape: TLBaseBoxShape,
 	info: {
 		newPoint: Vec2dModel
@@ -23,7 +23,7 @@ export const resizeBox = (
 		initialShape: TLBaseBoxShape
 	},
 	opts = {} as ResizeBoxOptions
-) => {
+) {
 	const { newPoint, handle, scaleX, scaleY } = info
 	const { minWidth = 1, maxWidth = Infinity, minHeight = 1, maxHeight = Infinity } = opts
 


### PR DESCRIPTION
This PR changes `resizeBox` to be a regular function rather than an arrow function.

### Change Type

- [x] `minor` — New feature

### Release Notes

- [editor] Change `resizeBox` to be a regular function.