### PR TITLE
Remove on drop override

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -237,9 +237,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 export const BOUND_ARROW_OFFSET = 10;
 
 // @public (undocumented)
-export const Canvas: React_3.MemoExoticComponent<({ onDropOverride, }: {
-    onDropOverride?: ((defaultOnDrop: (e: React_3.DragEvent<Element>) => Promise<void>) => (e: React_3.DragEvent<Element>) => Promise<void>) | undefined;
-}) => JSX.Element>;
+export const Canvas: React_2.MemoExoticComponent<() => JSX.Element>;
 
 // @public (undocumented)
 export const checkFlag: (flag: (() => boolean) | boolean | undefined) => boolean | undefined;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -237,7 +237,9 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 export const BOUND_ARROW_OFFSET = 10;
 
 // @public (undocumented)
-export const Canvas: React_2.MemoExoticComponent<() => JSX.Element>;
+export const Canvas: React_3.MemoExoticComponent<({ onDropOverride, }: {
+    onDropOverride?: ((defaultOnDrop: (e: React_3.DragEvent<Element>) => Promise<void>) => (e: React_3.DragEvent<Element>) => Promise<void>) | undefined;
+}) => JSX.Element>;
 
 // @public (undocumented)
 export const checkFlag: (flag: (() => boolean) | boolean | undefined) => boolean | undefined;

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -1,7 +1,7 @@
 import { Matrix2d, toDomPrecision } from '@tldraw/primitives'
 import { TLHandle, TLShapeId } from '@tldraw/tlschema'
 import { dedupe, modulate } from '@tldraw/utils'
-import * as React from 'react'
+import React from 'react'
 import { react } from 'signia'
 import { track, useValue } from 'signia-react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
@@ -23,13 +23,7 @@ import { Shape } from './Shape'
 import { ShapeIndicator } from './ShapeIndicator'
 
 /** @public */
-export const Canvas = track(function Canvas({
-	onDropOverride,
-}: {
-	onDropOverride?: (
-		defaultOnDrop: (e: React.DragEvent<Element>) => Promise<void>
-	) => (e: React.DragEvent<Element>) => Promise<void>
-}) {
+export const Canvas = track(function Canvas() {
 	const editor = useEditor()
 
 	const { Background, SvgDefs } = useEditorComponents()
@@ -71,9 +65,6 @@ export const Canvas = track(function Canvas({
 	const { context: patternContext, isReady: patternIsReady } = usePattern()
 
 	const events = useCanvasEvents()
-	if (onDropOverride) {
-		events.onDrop = onDropOverride(events.onDrop)
-	}
 
 	React.useEffect(() => {
 		if (patternIsReady && editor.isSafari) {

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -1,7 +1,7 @@
 import { Matrix2d, toDomPrecision } from '@tldraw/primitives'
 import { TLHandle, TLShapeId } from '@tldraw/tlschema'
 import { dedupe, modulate } from '@tldraw/utils'
-import React from 'react'
+import * as React from 'react'
 import { react } from 'signia'
 import { track, useValue } from 'signia-react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
@@ -23,7 +23,13 @@ import { Shape } from './Shape'
 import { ShapeIndicator } from './ShapeIndicator'
 
 /** @public */
-export const Canvas = track(function Canvas() {
+export const Canvas = track(function Canvas({
+	onDropOverride,
+}: {
+	onDropOverride?: (
+		defaultOnDrop: (e: React.DragEvent<Element>) => Promise<void>
+	) => (e: React.DragEvent<Element>) => Promise<void>
+}) {
 	const editor = useEditor()
 
 	const { Background, SvgDefs } = useEditorComponents()
@@ -65,6 +71,9 @@ export const Canvas = track(function Canvas() {
 	const { context: patternContext, isReady: patternIsReady } = usePattern()
 
 	const events = useCanvasEvents()
+	if (onDropOverride) {
+		events.onDrop = onDropOverride(events.onDrop)
+	}
 
 	React.useEffect(() => {
 		if (patternIsReady && editor.isSafari) {


### PR DESCRIPTION
This PR removes the `onDropOverride` prop from the canvas, which was a bit of a hack.

### Change Type

- [x] `major` — Breaking change

### Release Notes

- [editor] Remove `onDropOverride`