### PR TITLE
[fix] tldraw api report

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { TldrawEditorProps } from '@tldraw/editor';
 import { TldrawUiProps } from '@tldraw/ui';
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { TldrawEditorProps } from '@tldraw/editor';
 import { TldrawUiProps } from '@tldraw/ui';
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference types="react" />
+
 /** @internal */
 import '@tldraw/polyfills'
 


### PR DESCRIPTION
This PR adds a dumb reference that is presence on the bublic branch but not on tldraw repo. Ridiculous.

### Change Type

- [x] `patch` — Bug fix