### PR TITLE
[fix] tldraw file drop

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -102,9 +102,7 @@ export function useCanvasEvents() {
 				preventDefault(e)
 				if (!e.dataTransfer?.files?.length) return
 
-				const files = Array.from(e.dataTransfer.files).filter(
-					(file) => !file.name.endsWith('.tldr')
-				)
+				const files = Array.from(e.dataTransfer.files)
 
 				const rect = editor.getContainer().getBoundingClientRect()
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { TldrawEditorProps } from '@tldraw/editor';
 import { TldrawUiProps } from '@tldraw/ui';
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { TldrawEditorProps } from '@tldraw/editor';
 import { TldrawUiProps } from '@tldraw/ui';
 


### PR DESCRIPTION
This PR removes a line of code that was filtering out .tldraw files when dropping files onto the canvas.

### Change Type

- [x] `patch` — Bug fix
