### PR TITLE
[docs] Tighten up Introduction page

### DIFF
--- a/apps/docs/content/docs/introduction.mdx
+++ b/apps/docs/content/docs/introduction.mdx
@@ -19,7 +19,7 @@ export default function () {
 }
 ```
 
-You can use the `<Tldraw>` React component to build on top of the default tldraw experience. It's easy to use, and easy to extend with your own [custom shapes](/docs/shapes), [custom tools](/docs/tools), and [user interface](/docs/user-interface) overrides. 
+You can use the `<Tldraw>` React component to build on top of the default tldraw experience. It's easy to use and easy to extend with your own [custom shapes](/docs/shapes), [custom tools](/docs/tools), and [user interface](/docs/user-interface) overrides. 
 
 If you want to go even deeper, you can use the `<TldrawEditor>` component as a more minimal engine without the default tldraw shapes or user interface.
 

--- a/apps/docs/content/docs/introduction.mdx
+++ b/apps/docs/content/docs/introduction.mdx
@@ -8,26 +8,22 @@ order: 0
 
 Welcome to the tldraw developer docs.
 
-Here at tldraw, we make two things: a very good multiplayer whiteboard (at [tldraw.com](https://www.tldraw.com)) and the [open source](https://github.com/tldraw/tldraw) libraries used to create that product. This page is meant to provide documentation and reference for those open source libraries.
+Here at tldraw, we make two things: a very good multiplayer whiteboard (at [tldraw.com](https://tldraw.com)), and the [open source library](https://github.com/tldraw/tldraw) that powers it. This page provides documentation and reference for that open source library.
 
 ```tsx 
 import { Tldraw } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
-	return (
-		<div style={{ position: 'fixed', inset: 0 }}>
-			<Tldraw />
-		</div>
-	)
+	return <Tldraw />
 }
 ```
 
-You can use the `<Tldraw>` React component to build on top of the default tldraw experience. It's easy to use and easy to extend with your own [custom shapes](/docs/shapes), [custom tools](/docs/tools), and [user interface](/docs/user-interface) overrides. 
+You can use the `<Tldraw>` React component to build on top of the default tldraw experience. It's easy to use, and easy to extend with your own [custom shapes](/docs/shapes), [custom tools](/docs/tools), and [user interface](/docs/user-interface) overrides. 
 
 If you want to go even deeper, you can use the `<TldrawEditor>` component as a more minimal engine without the default tldraw shapes or user interface.
 
-And in either case, you can use the [Editor API](/docs/editor) to drive the experience programatically in order to create or delete shapes, control the camera, or do just about anything you can imagine.
+In either case, you can use the [Editor API](/docs/editor) to drive the experience programatically in order to create or delete shapes, control the camera, or do just about anything you can imagine.
 
 Best of all, you can easily plug tldraw into the [collaboration backend](/docs/collaboration) of your choice.
 
@@ -38,9 +34,9 @@ Otherwise, continue on to the [installation](/docs/installation) and [usage](/do
 
 ## Community
 
-Found a bug or want to request a feature? Create a issue [here](https://github.com/tldraw/tldraw/issues). To connect with the team and other users, join us on our [Discord](https://discord.gg/JMbeb96jsh).
+Found a bug or want to request a feature? Create an issue [here](https://github.com/tldraw/tldraw/issues). To connect with the team and other users, join us on our [Discord](https://discord.gg/JMbeb96jsh).
 
-If you spot an issue with these docs, please use the links at the bottom of each page to create a. If you would like to contribute, the docs are part of the [tldraw repo](https://github.com/tldraw/tldraw).
+If you spot an issue with these docs, please use the links at the bottom of each page to suggest a change.
 
 ## License
 

--- a/apps/docs/content/docs/introduction.mdx
+++ b/apps/docs/content/docs/introduction.mdx
@@ -21,9 +21,10 @@ export default function () {
 
 You can use the `<Tldraw>` React component to build on top of the default tldraw experience. It's easy to use and easy to extend with your own [custom shapes](/docs/shapes), [custom tools](/docs/tools), and [user interface](/docs/user-interface) overrides. 
 
+You can also use the [Editor API](/docs/editor) to create, update, and delete shapes, control the camera, or do just about anything else.
+
 If you want to go even deeper, you can use the `<TldrawEditor>` component as a more minimal engine without the default tldraw shapes or user interface.
 
-In either case, you can use the [Editor API](/docs/editor) to drive the experience programatically in order to create or delete shapes, control the camera, or do just about anything you can imagine.
 
 Best of all, you can easily plug tldraw into the [collaboration backend](/docs/collaboration) of your choice.
 

--- a/apps/docs/content/docs/introduction.mdx
+++ b/apps/docs/content/docs/introduction.mdx
@@ -15,7 +15,11 @@ import { Tldraw } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
-	return <Tldraw />
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw />
+		</div>
+	)
 }
 ```
 


### PR DESCRIPTION
This PR contains some feedback for the Introduction page of the docs.
I've written comments explaining my feedback, and the changes are some potential changes (but they're just examples).

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Documentation: Simplified the Introduction page.
