### PR TITLE
[docs] Fix wrong cursor when hovering buttons

### DIFF
--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -118,6 +118,7 @@ body {
 	border: none;
 	--bg: transparent;
 	color: var(--color-text);
+	cursor: pointer;
 }
 
 .icon-button::after {


### PR DESCRIPTION
This PR fixes your cursor when you hover some buttons in the docs site.

This makes them consistent with all other buttons.

![image](https://github.com/tldraw/tldraw/assets/15892272/d918e12e-2831-49fe-acf7-34c67a9cd976)

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On the docs site, hover your cursor over the light/dark button.
2. Make sure that your cursor is a pointing finger.


### Release Notes

- Documentation: Fixed the wrong cursor showing when hovering some buttons.
