### PR TITLE
feat(ui): hide style panel when nothing is selected with the select tool

### DIFF
--- a/packages/ui/src/lib/TldrawUi.tsx
+++ b/packages/ui/src/lib/TldrawUi.tsx
@@ -96,6 +96,11 @@ const TldrawUiContent = React.memo(function TldrawUI({
 	const isReadonlyMode = useValue('isReadOnlyMode', () => editor.isReadOnly, [editor])
 	const isFocusMode = useValue('focus', () => editor.instanceState.isFocusMode, [editor])
 	const isDebugMode = useValue('debug', () => editor.instanceState.isDebugMode, [editor])
+	const isSelectToolWithNoSelections = useValue(
+		'isSelectToolWithNoSelections',
+		() => editor.currentToolId === 'select' && editor.selectedIds.length === 0,
+		[editor]
+	)
 
 	useKeyboardShortcuts()
 	useNativeClipboardEvents()
@@ -133,7 +138,7 @@ const TldrawUiContent = React.memo(function TldrawUI({
 							<div className="tlui-layout__top__center">{topZone}</div>
 							<div className="tlui-layout__top__right">
 								{shareZone}
-								{breakpoint >= 5 && !isReadonlyMode && (
+								{breakpoint >= 5 && !isReadonlyMode && !isSelectToolWithNoSelections && (
 									<div className="tlui-style-panel__wrapper">
 										<StylePanel />
 									</div>


### PR DESCRIPTION
When the select tool is active and nothing is selected (the starting point of the application), the style panel appears, occupying space while not providing any functionality, potentially confusing users.
This PR hides the panel when nothing is selected while the select tool is active.

Before:
![before](https://github.com/tldraw/tldraw/assets/5616556/0f737bcc-fd4e-4482-aa7e-14816e8ba598)
After:
![after](https://github.com/tldraw/tldraw/assets/5616556/da08cddb-8797-4cf9-8f88-a2d4e3f77014)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Run the application
2. Notice that the style panel is not displayed initially
3. Switch to the draw tool, notice that the style panel is now shown
4. Start drawing
5. Switch to the select tool, notice that the style panel is now gone
6. Select elements drawn, notice that the style panel is now shown
7. Deselect the elements, notice that the style panel is now gone
8. Test that apart from the above scenario, the visibility behaviour of the panel should be same as before

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Hide style panel when nothing is selected with the select tool
