### PR TITLE
Fix text shapes not having colour

### DIFF
--- a/packages/editor/src/lib/editor/shapes/text/TextShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/text/TextShapeUtil.tsx
@@ -63,9 +63,10 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		const {
 			id,
 			type,
-			props: { text },
+			props: { text, color },
 		} = shape
 
+		const theme = getDefaultColorTheme(this.editor)
 		const { width, height } = this.getMinDimensions(shape)
 
 		const {
@@ -95,6 +96,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 						transformOrigin: 'top left',
 						width: Math.max(1, width),
 						height: Math.max(FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight, height),
+						color: theme[color].solid,
 					}}
 				>
 					<div className="tl-text tl-text-content" dir="ltr">


### PR DESCRIPTION
This PR fixes text shapes always being black.
It also fixes Note shapes not having the correct text colour.

<img width="759" alt="Screenshot 2023-06-26 at 11 26 45" src="https://github.com/tldraw/tldraw/assets/15892272/a68ae0d1-69ba-43de-9e21-87c483ffd2dc">


### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Make a text shape.
2. Make sure you can change its colour.
3. Make a note shape.
4. Make sure its text label stays black when you change the note's colour.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- None: Fixes an unreleased bug.
