### PR TITLE
[docs] Remove embeds page

### DIFF
--- a/docs/community/embeds.mdx
+++ b/docs/community/embeds.mdx
@@ -1,9 +1,0 @@
----
-title: Embeds
-status: published
-author: steveruizok
-date: 3/22/2023
-order: 2
----
-
-Coming soon.


### PR DESCRIPTION
This PR removes the skeleton Embeds page.

While we're here, do we also want to remove the skeleton Persistence page (would it fit somewhere else? or nah?)

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On the docs site...
2. Make sure that there's no 'Embeds' page in the menu.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Documentation: Removed unused Embeds page.
