### PR TITLE
(2/2) [docs] Fix links to API.

### DIFF
--- a/docs/docs/editor.mdx
+++ b/docs/docs/editor.mdx
@@ -24,9 +24,9 @@ keywords:
 
 The `Editor` class is the main way of controlling tldraw's editor. You can use it to manage the editor's internal state, make changes to the document, or respond to changes that have occurred.
 
-By design, the `Editor`'s surface area is [very large](/gen/editor/Editor-class). Almost everything is available through it. Need to create some shapes? Use `editor.createShapes()`. Need to delete them? Use `editor.deleteShapes()`. Need a sorted array of every shape on the current page? Use `editor.sortedShapesArray`.
+By design, the `Editor`'s surface area is [very large](/gen/editor/Editor). Almost everything is available through it. Need to create some shapes? Use `editor.createShapes()`. Need to delete them? Use `editor.deleteShapes()`. Need a sorted array of every shape on the current page? Use `editor.sortedShapesArray`.
 
-This page gives a broad idea of how the `Editor` class is organized and some of the architectural concepts involved. The full reference is available in the [Editor API](/gen/editor/Editor-class).
+This page gives a broad idea of how the `Editor` class is organized and some of the architectural concepts involved. The full reference is available in the [Editor API](/gen/editor/Editor).
 
 ## State
 

--- a/scripts/lib/docs/docs-utils.ts
+++ b/scripts/lib/docs/docs-utils.ts
@@ -52,7 +52,7 @@ function sanitizeReference(reference: string) {
 }
 
 export function getSlug(item: ApiItem): string {
-	return sanitizeReference(item.canonicalReference.toString().replace(/^@tldraw\/[^!]+!/, ''))
+	return sanitizeReference(item.displayName.toString().replace(/^@tldraw\/[^!]+!/, ''))
 }
 
 export function getPath(item: ApiItem): string {
@@ -61,7 +61,7 @@ export function getPath(item: ApiItem): string {
 		const childSlug = getSlug(item)
 		return `${parentPath}#${childSlug}`
 	}
-	return sanitizeReference(item.canonicalReference.toString().replace(/^@tldraw\/([^!]+)/, '$1/'))
+	return sanitizeReference(item.displayName.toString().replace(/^@tldraw\/([^!]+)/, '$1/'))
 }
 
 const prettierConfigPromise = prettier.resolveConfig(__dirname)

--- a/scripts/lib/docs/docs-utils.ts
+++ b/scripts/lib/docs/docs-utils.ts
@@ -52,7 +52,7 @@ function sanitizeReference(reference: string) {
 }
 
 export function getSlug(item: ApiItem): string {
-	return sanitizeReference(item.displayName.toString().replace(/^@tldraw\/[^!]+!/, ''))
+	return sanitizeReference(item.canonicalReference.toString().replace(/^@tldraw\/[^!]+!/, ''))
 }
 
 export function getPath(item: ApiItem): string {
@@ -61,7 +61,7 @@ export function getPath(item: ApiItem): string {
 		const childSlug = getSlug(item)
 		return `${parentPath}#${childSlug}`
 	}
-	return sanitizeReference(item.displayName.toString().replace(/^@tldraw\/([^!]+)/, '$1/'))
+	return sanitizeReference(item.canonicalReference.toString().replace(/^@tldraw\/([^!]+)/, '$1/'))
 }
 
 const prettierConfigPromise = prettier.resolveConfig(__dirname)


### PR DESCRIPTION
This PR fixes some links to the API in the docs.
It's part 2 of two PRs related to simplifying the paths of our API reference.
This first one is https://github.com/tldraw/brivate/pull/2128

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On the docs site...
2. Go to the Editor page...
3. Click on the links to the Editor API reference.
4. Make sure they take you to the right place.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Documentation: Simplified links to the API reference.
