### PR TITLE
Fix crash when rotating a deleted shape

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5628,11 +5628,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/**
 	 * Rotate shapes by a delta in radians.
+	 * Note: Currently, this assumes that the shapes are your currently selected shapes.
 	 *
 	 * @example
 	 * ```ts
-	 * editor.rotateShapesBy(['box1', 'box2'], Math.PI)
-	 * editor.rotateShapesBy(['box1', 'box2'], Math.PI / 2)
+	 * editor.rotateShapesBy(editor.selectedIds, Math.PI)
+	 * editor.rotateShapesBy(editor.selectedIds, Math.PI / 2)
 	 * ```
 	 *
 	 * @param ids - The ids of the shapes to move.
@@ -5642,6 +5643,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (ids.length <= 0) return this
 
 		const snapshot = getRotationSnapshot({ editor: this })
+		if (!snapshot) return this
 		applyRotationToSnapshotShapes({ delta, snapshot, editor: this, stage: 'one-off' })
 
 		return this

--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Rotating.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Rotating.ts
@@ -25,7 +25,9 @@ export class Rotating extends StateNode {
 
 		this.markId = this.editor.mark('rotate start')
 
-		this.snapshot = getRotationSnapshot({ editor: this.editor })
+		const snapshot = getRotationSnapshot({ editor: this.editor })
+		if (!snapshot) return this.parent.transition('idle', this.info)
+		this.snapshot = snapshot
 
 		// Trigger a pointer move
 		this.handleStart()

--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Rotating.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Rotating.ts
@@ -132,7 +132,8 @@ export class Rotating extends StateNode {
 		const { initialCursorAngle, initialSelectionRotation } = this.snapshot
 
 		// The delta is the difference between the current angle and the initial angle
-		const preSnapRotationDelta = selectionPageCenter!.angle(currentPagePoint) - initialCursorAngle
+		if (!selectionPageCenter) return initialSelectionRotation
+		const preSnapRotationDelta = selectionPageCenter.angle(currentPagePoint) - initialCursorAngle
 		let newSelectionRotation = initialSelectionRotation + preSnapRotationDelta
 
 		if (shiftKey) {

--- a/packages/editor/src/lib/test/tools/rotating.test.ts
+++ b/packages/editor/src/lib/test/tools/rotating.test.ts
@@ -273,6 +273,34 @@ describe('When rotating...', () => {
 
 		expect(centerBefore.toFixed().toJson()).toMatchObject(centerAfter.toFixed().toJson())
 	})
+
+	it("doesn't crash when rotating a deleted shape", () => {
+		editor.select(ids.box1)
+
+		editor.deleteShapes([ids.box1])
+
+		editor
+			.pointerDown(0, 0, {
+				target: 'selection',
+				handle: 'top_left_rotate',
+			})
+			.pointerMove(50, 100)
+			.pointerUp()
+
+		expect(editor.getShapeById(ids.box1)).toBeUndefined()
+	})
+
+	// todo
+	it.skip("rotates shapes that aren't the currently selected ones", () => {
+		editor.select(ids.box1)
+
+		editor.rotateShapesBy([ids.box2], Math.PI * 0.5)
+
+		editor.expectShapeToMatch(
+			{ id: ids.box1, rotation: 0 },
+			{ id: ids.box2, rotation: Math.PI * 0.5 }
+		)
+	})
 })
 
 describe('Rotation math', () => {

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -1,10 +1,10 @@
 import { canolicalizeRotation, Matrix2d, Vec2d } from '@tldraw/primitives'
-import { isShapeId, TLShapePartial } from '@tldraw/tlschema'
+import { isShapeId, TLShape, TLShapePartial } from '@tldraw/tlschema'
 import { structuredClone } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 
 /** @internal */
-export function getRotationSnapshot({ editor }: { editor: Editor }) {
+export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationSnapshot | null {
 	const {
 		selectionRotation,
 		selectionPageCenter,
@@ -14,12 +14,16 @@ export function getRotationSnapshot({ editor }: { editor: Editor }) {
 
 	// todo: this assumes we're rotating the selected shapes
 	// if we try to rotate shapes that aren't selected, this
-	// will produce the wrong results if there are other shapes
-	// selected or else break if there are none.
+	// will produce the wrong results
+
+	// Return null if there are no selected shapes
+	if (!selectionPageCenter) {
+		return null
+	}
 
 	return {
-		selectionPageCenter: selectionPageCenter!,
-		initialCursorAngle: selectionPageCenter!.angle(originPagePoint),
+		selectionPageCenter: selectionPageCenter,
+		initialCursorAngle: selectionPageCenter.angle(originPagePoint),
 		initialSelectionRotation: selectionRotation,
 		shapeSnapshots: selectedShapes.map((shape) => ({
 			shape: structuredClone(shape),
@@ -29,7 +33,15 @@ export function getRotationSnapshot({ editor }: { editor: Editor }) {
 }
 
 /** @internal */
-export type TLRotationSnapshot = ReturnType<typeof getRotationSnapshot>
+export type TLRotationSnapshot = {
+	selectionPageCenter: Vec2d
+	initialCursorAngle: number
+	initialSelectionRotation: number
+	shapeSnapshots: {
+		shape: TLShape
+		initialPagePoint: Vec2d
+	}[]
+}
 
 /** @internal */
 export function applyRotationToSnapshotShapes({

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -32,7 +32,16 @@ export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationS
 	}
 }
 
-/** @internal */
+/**
+ * Info about a rotation that can be applied to the editor's selected shapes.
+ *
+ * @param selectionPageCenter - The center of the selection in page coordinates
+ * @param initialCursorAngle - The angle of the cursor relative to the selection center when the rotation started
+ * @param initialSelectionRotation - The rotation of the selection when the rotation started
+ * @param shapeSnapshots - Info about each shape that is being rotated
+ *
+ * @public
+ **/
 export type TLRotationSnapshot = {
 	selectionPageCenter: Vec2d
 	initialCursorAngle: number


### PR DESCRIPTION
This PR fixes a crash when rotating a deleted shapes, and adds a unit test for it.

It also updates the docs of an editor method to communicate a current limitation that we left a 'todo' for. See code comments for more info.

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Get two devices out for this! (or write a little console script to do it for you)
2. Rotate a shape on one device.
3. While rotating it, delete it on the other device.
4. Make sure the page doesn't crash!

- [x] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed a crash when trying to rotate a deleted shape.
