### PR TITLE
[tweak] migrate store snapshot arguments

### DIFF
--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -181,10 +181,10 @@ export class TLLocalSyncClient {
 				const documentSnapshot = Object.fromEntries(data.records.map((r) => [r.id, r]))
 				const sessionStateSnapshot =
 					data.sessionStateSnapshot ?? extractSessionStateFromLegacySnapshot(documentSnapshot)
-				const migrationResult = this.store.schema.migrateStoreSnapshot(
-					documentSnapshot,
-					data.schema ?? this.store.schema.serializeEarliestVersion()
-				)
+				const migrationResult = this.store.schema.migrateStoreSnapshot({
+					store: documentSnapshot,
+					schema: data.schema ?? this.store.schema.serializeEarliestVersion(),
+				})
 
 				if (migrationResult.type === 'error') {
 					console.error('failed to migrate store', migrationResult)

--- a/packages/file-format/src/lib/file.ts
+++ b/packages/file-format/src/lib/file.ts
@@ -122,7 +122,7 @@ export function parseTldrawJsonFile({
 	let migrationResult: MigrationResult<SerializedStore<TLRecord>>
 	try {
 		const storeSnapshot = Object.fromEntries(data.records.map((r) => [r.id, r as TLRecord]))
-		migrationResult = schema.migrateStoreSnapshot(storeSnapshot, data.schema)
+		migrationResult = schema.migrateStoreSnapshot({ store: storeSnapshot, schema: data.schema })
 	} catch (e) {
 		// junk data in the migration
 		return Result.err({ type: 'invalidRecords', cause: e })

--- a/packages/store/api-report.md
+++ b/packages/store/api-report.md
@@ -304,7 +304,7 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
     // (undocumented)
     migratePersistedRecord(record: R, persistedSchema: SerializedSchema, direction?: 'down' | 'up'): MigrationResult<R>;
     // (undocumented)
-    migrateStoreSnapshot(storeSnapshot: SerializedStore<R>, persistedSchema: SerializedSchema): MigrationResult<SerializedStore<R>>;
+    migrateStoreSnapshot(snapshot: StoreSnapshot<R>): MigrationResult<SerializedStore<R>>;
     // (undocumented)
     serialize(): SerializedSchema;
     // (undocumented)

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -551,7 +551,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * @public
 	 */
 	loadSnapshot(snapshot: StoreSnapshot<R>): void {
-		const migrationResult = this.schema.migrateStoreSnapshot(snapshot.store, snapshot.schema)
+		const migrationResult = this.schema.migrateStoreSnapshot(snapshot)
 
 		if (migrationResult.type === 'error') {
 			throw new Error(`Failed to migrate snapshot: ${migrationResult.reason}`)

--- a/packages/store/src/lib/test/migrate.test.ts
+++ b/packages/store/src/lib/test/migrate.test.ts
@@ -305,7 +305,7 @@ test('subtype versions in the future fail', () => {
 })
 
 test('migrating a whole store snapshot works', () => {
-	const snapshot: SerializedStore<any> = {
+	const serializedStore: SerializedStore<any> = {
 		'user-1': {
 			id: 'user-1',
 			typeName: 'user',
@@ -329,7 +329,10 @@ test('migrating a whole store snapshot works', () => {
 		},
 	}
 
-	const result = testSchemaV1.migrateStoreSnapshot(snapshot, serializedV0Schenma)
+	const result = testSchemaV1.migrateStoreSnapshot({
+		store: serializedStore,
+		schema: serializedV0Schenma,
+	})
 
 	if (result.type !== 'success') {
 		console.error(result)


### PR DESCRIPTION
This PR updates the `migrateStoreSnapshot` method in @tldraw/store

### Change Type

- [x] `major` — Breaking change

### Test Plan

- [x] Unit Tests
