### PR TITLE
[improvement] export scribble manager

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1870,6 +1870,43 @@ export const runtime: {
     hardReset: () => void;
 };
 
+// @public (undocumented)
+export class ScribbleManager implements TLScribble {
+    constructor(opts: {
+        onUpdate: (scribble: TLScribble) => void;
+        onComplete: () => void;
+        size?: TLScribble['size'];
+        color?: TLScribble['color'];
+        opacity?: TLScribble['opacity'];
+        delay?: TLScribble['delay'];
+    });
+    addPoint: (x: number, y: number) => void;
+    // (undocumented)
+    color: "accent" | "black" | "laser" | "muted-1" | "selection-fill" | "selection-stroke" | "white";
+    // (undocumented)
+    delay: number;
+    // (undocumented)
+    delayRemaining: number;
+    getScribble(): TLScribble;
+    // (undocumented)
+    opacity: number;
+    // (undocumented)
+    pause: () => void;
+    // (undocumented)
+    points: Vec2dModel[];
+    // (undocumented)
+    resume: () => void;
+    // (undocumented)
+    size: number;
+    // (undocumented)
+    state: "active" | "paused" | "starting" | "stopping";
+    stop: () => void;
+    // (undocumented)
+    tick: TLTickEvent;
+    // (undocumented)
+    timeoutMs: number;
+}
+
 // @internal (undocumented)
 export function setDefaultEditorAssetUrls(assetUrls: TLEditorAssetUrls): void;
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -90,6 +90,7 @@ export {
 	ExternalContentManager as PlopManager,
 	type TLExternalContent,
 } from './lib/editor/managers/ExternalContentManager'
+export { ScribbleManager } from './lib/editor/managers/ScribbleManager'
 export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseBoxShapeUtil'
 export {
 	ShapeUtil,

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -2,6 +2,7 @@ import { Vec2d, VecLike } from '@tldraw/primitives'
 import { TLScribble, Vec2dModel } from '@tldraw/tlschema'
 import { TLTickEvent } from '../types/event-types'
 
+/** @public */
 export class ScribbleManager implements TLScribble {
 	// Scribble properties
 	state


### PR DESCRIPTION
This PR adds the `ScribbleManager` to the exports from `@tldraw/editor`.

### Change Type

- [x] `minor` — New feature


### Release Notes

- [@tldraw/tldraw] Export `ScribbleManager`