### PR TITLE
[fix] rename `global` in @tldraw/state to avoid collissions

### DIFF
--- a/packages/state/src/lib/core/capture.ts
+++ b/packages/state/src/lib/core/capture.ts
@@ -1,15 +1,15 @@
 import { attach, detach } from './helpers'
 import { Child, Signal } from './types'
 
-const globalKey = Symbol.for('__@tldraw/state__')
-const global = globalThis as { [globalKey]?: true }
+const tldrawStateGlobalKey = Symbol.for('__@tldraw/state__')
+const tldrawStateGlobal = globalThis as { [tldrawStateGlobalKey]?: true }
 
-if (global[globalKey]) {
+if (tldrawStateGlobal[tldrawStateGlobalKey]) {
 	console.error(
 		'Multiple versions of @tldraw/state detected. This will cause unexpected behavior. Please add "resolutions" (yarn/pnpm) or "overrides" (npm) in your package.json to ensure only one version of @tldraw/state is loaded.'
 	)
 } else {
-	global[globalKey] = true
+	tldrawStateGlobal[tldrawStateGlobalKey] = true
 }
 
 class CaptureStackFrame {


### PR DESCRIPTION
We saw an issue on stackblitz where the `global` constant was causing a conflict (possibly because that environment was injecting its own `global`). Either way, perhaps `global` is a bit of a risky name—this PR renames `global` to `tldrawStateGlobal`.

### Change Type

- [x] `patch`
