### PR TITLE
[improvement] add box sizing border box

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -183,6 +183,7 @@
 	scrollbar-highlight-color: transparent;
 	-webkit-user-select: none;
 	user-select: none;
+	box-sizing: border-box;
 	outline: none;
 }
 


### PR DESCRIPTION
This PR adds `box-sizing: border-box` to the editor and its children.

### Change Type

- [x] `patch`

### Release Notes

- [@tldraw/editor] Add `box-sizing: border-box` to `tl-container`