### PR TITLE
[fix] Lock shortcut

### DIFF
--- a/apps/examples/e2e/tests/test-kbds.spec.ts
+++ b/apps/examples/e2e/tests/test-kbds.spec.ts
@@ -299,6 +299,12 @@ test.describe('Keyboard Shortcuts', () => {
 
 			/* ---------------------- Misc ---------------------- */
 
+			// toggle lock
+			await page.keyboard.press('Shift+l')
+			expect(await page.evaluate(() => __tldraw_ui_event)).toMatchObject({
+				name: 'toggle-lock',
+			})
+
 			// await page.keyboard.press('Control+i')
 			// expect(await page.evaluate(() => __tldraw_ui_event)).toMatchObject({
 			// 	name: 'open-menu',

--- a/packages/ui/src/lib/hooks/useActions.tsx
+++ b/packages/ui/src/lib/hooks/useActions.tsx
@@ -930,7 +930,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				id: 'toggle-lock',
 				label: 'action.toggle-lock',
 				readonlyOk: false,
-				kbd: '!$l',
+				kbd: '!l',
 				onSelect(source) {
 					trackEvent('toggle-lock', { source })
 					editor.toggleLock()


### PR DESCRIPTION
This PR fixes the shortcut for lock shapes, which may be blocked by browser defaults. We now use Shift+L instead of Cmd+Shift+L. Closes https://github.com/tldraw/tldraw/issues/1676.

### Change Type

- [x] `patch` 

### Test Plan

1. Try the lock tool shortcuts.

- [x] End to end tests

### Release Notes

- [@tldraw/editor] Fix lock tool shortcut