### PR TITLE
[docs] Fix the types in the Shapes example

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# if the folder we're in is called bublic, it means we're a submodule in the brivate repo.
-# We need to grab .envrc to set up yarn correctly.
-current_file="$(readlink -f "$0")"
-if [[ $current_file == */bublic/.husky/pre-commit ]]; then
-	source "$(dirname -- "$0")/../../.envrc"
-fi
-
 npx lazy run build-api
 git add packages/*/api-report.md
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# if the folder we're in is called bublic, it means we're a submodule in the brivate repo.
+# We need to grab .envrc to set up yarn correctly.
+current_file="$(readlink -f "$0")"
+if [[ $current_file == */bublic/.husky/pre-commit ]]; then
+	source "$(dirname -- "$0")/../../.envrc"
+fi
+
 npx lazy run build-api
 git add packages/*/api-report.md
 npx lint-staged

--- a/docs/docs/shapes.mdx
+++ b/docs/docs/shapes.mdx
@@ -41,7 +41,7 @@ While tldraw's shapes themselves are simple JSON objects, we use `ShapeUtil` cla
 Let's create a `ShapeUtil` class for the shape.
 
 ```tsx
-import { ShapeUtil, HTMLContainer } from '@tldraw/tldraw'
+import { ShapeUtil, HTMLContainer, Box2d } from '@tldraw/tldraw'
 
 class CardShapeUtil extends ShapeUtil<CardShape> {
   static type = 'card' as const
@@ -53,17 +53,17 @@ class CardShapeUtil extends ShapeUtil<CardShape> {
 		}
 	}
 
-  getBounds(shape: Shape) {
+  getBounds(shape: CardShape) {
 		return new Box2d(0, 0, shape.props.w, shape.props.h)
 	}
 
-  component(shape: Shape) {
+  component(shape: CardShape) {
     return (
       <HTMLContainer>Hello</HTMLContainer>
     )
   }
 
-  indicator(shape: Shape) {
+  indicator(shape: CardShape) {
     return (
       <rect width={shape.props.w} height={shape.props.h}/>
     )


### PR DESCRIPTION
This PR fixes some incorrect types in the example on the Shapes page of the docs.

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Documentation: Fix some incorrect types on the Shapes page.
