### PR TITLE
[improvement] More nuanced cursor state

### DIFF
--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -16,31 +16,21 @@ export const LiveCollaborators = track(function Collaborators() {
 	return (
 		<>
 			{peerIds.map((id) => (
-				<Collaborator key={id} userId={id} />
+				<CollaboratorGuard key={id} userId={id} />
 			))}
 		</>
 	)
 })
 
-const Collaborator = track(function Collaborator({ userId }: { userId: string }) {
+const CollaboratorGuard = track(function CollaboratorGuard({ userId }: { userId: string }) {
 	const editor = useEditor()
-
-	const {
-		CollaboratorBrush,
-		CollaboratorScribble,
-		CollaboratorCursor,
-		CollaboratorHint,
-		CollaboratorShapeIndicator,
-	} = useEditorComponents()
-
 	const latestPresence = usePresence(userId)
-
 	const collaboratorState = useCollaboratorState(latestPresence)
 
-	if (!latestPresence) return null
-
-	// if the collaborator is on another page, ignore them
-	if (latestPresence.currentPageId !== editor.currentPageId) return null
+	if (!(latestPresence && latestPresence.currentPageId === editor.currentPageId)) {
+		// No need to render if we don't have a presence or if they're on a different page
+		return null
+	}
 
 	switch (collaboratorState) {
 		case 'inactive': {
@@ -65,8 +55,27 @@ const Collaborator = track(function Collaborator({ userId }: { userId: string })
 		}
 	}
 
-	const { chatMessage, brush, scribble, selectedIds, userName, cursor, color } = latestPresence
+	return <Collaborator latestPresence={latestPresence} />
+})
+
+const Collaborator = track(function Collaborator({
+	latestPresence,
+}: {
+	latestPresence: TLInstancePresence
+}) {
+	const editor = useEditor()
+
+	const {
+		CollaboratorBrush,
+		CollaboratorScribble,
+		CollaboratorCursor,
+		CollaboratorHint,
+		CollaboratorShapeIndicator,
+	} = useEditorComponents()
+
 	const { viewportPageBounds, zoomLevel } = editor
+	const { userId, chatMessage, brush, scribble, selectedIds, userName, cursor, color } =
+		latestPresence
 
 	// Add a little padding to the top-left of the viewport
 	// so that the cursor doesn't get cut off

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -16,15 +16,19 @@ export const LiveCollaborators = track(function Collaborators() {
 	return (
 		<>
 			{peerIds.map((id) => (
-				<CollaboratorGuard key={id} userId={id} />
+				<CollaboratorGuard key={id} collaboratorId={id} />
 			))}
 		</>
 	)
 })
 
-const CollaboratorGuard = track(function CollaboratorGuard({ userId }: { userId: string }) {
+const CollaboratorGuard = track(function CollaboratorGuard({
+	collaboratorId,
+}: {
+	collaboratorId: string
+}) {
 	const editor = useEditor()
-	const presence = usePresence(userId)
+	const presence = usePresence(collaboratorId)
 	const collaboratorState = useCollaboratorState(presence)
 
 	if (!(presence && presence.currentPageId === editor.currentPageId)) {
@@ -36,7 +40,7 @@ const CollaboratorGuard = track(function CollaboratorGuard({ userId }: { userId:
 		case 'inactive': {
 			const { followingUserId, highlightedUserIds } = editor.instanceState
 			// If they're inactive and unless we're following them or they're highlighted, hide them
-			if (!(followingUserId === userId || highlightedUserIds.includes(userId))) {
+			if (!(followingUserId === presence.userId || highlightedUserIds.includes(presence.userId))) {
 				return null
 			}
 			break
@@ -46,7 +50,7 @@ const CollaboratorGuard = track(function CollaboratorGuard({ userId }: { userId:
 			// If they're idle and following us and unless they have a chat message or are highlighted, hide them
 			if (
 				presence.followingUserId === editor.user.id &&
-				!(presence.chatMessage || highlightedUserIds.includes(userId))
+				!(presence.chatMessage || highlightedUserIds.includes(presence.userId))
 			) {
 				return null
 			}

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -34,8 +34,11 @@ const CollaboratorGuard = track(function CollaboratorGuard({ userId }: { userId:
 
 	switch (collaboratorState) {
 		case 'inactive': {
-			// we always hide inactive collaborators
-			return null
+			// we hide inactive collaborators unless they're highlighted
+			if (!editor.instanceState.highlightedUserIds.includes(userId)) {
+				return null
+			}
+			break
 		}
 		case 'idle': {
 			if (

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -95,7 +95,10 @@ export const GRID_STEPS = [
 ]
 
 /** @internal */
-export const COLLABORATOR_TIMEOUT = 3000
+export const COLLABORATOR_INACTIVE_TIMEOUT = 3000
+
+/** @internal */
+export const COLLABORATOR_IDLE_TIMEOUT = 3000
 
 /** @internal */
 export const COLLABORATOR_CHECK_INTERVAL = 1200

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -95,7 +95,7 @@ export const GRID_STEPS = [
 ]
 
 /** @internal */
-export const COLLABORATOR_INACTIVE_TIMEOUT = 3000
+export const COLLABORATOR_INACTIVE_TIMEOUT = 60000
 
 /** @internal */
 export const COLLABORATOR_IDLE_TIMEOUT = 3000

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -87,7 +87,7 @@ import {
 	CAMERA_MAX_RENDERING_INTERVAL,
 	CAMERA_MOVING_TIMEOUT,
 	COARSE_DRAG_DISTANCE,
-	COLLABORATOR_TIMEOUT,
+	COLLABORATOR_IDLE_TIMEOUT,
 	DEFAULT_ANIMATION_OPTIONS,
 	DRAG_DISTANCE,
 	FOLLOW_CHASE_PAN_SNAP,
@@ -3150,7 +3150,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				if (index < 0) return
 				highlightedUserIds.splice(index, 1)
 				this.updateInstanceState({ highlightedUserIds })
-			}, COLLABORATOR_TIMEOUT)
+			}, COLLABORATOR_IDLE_TIMEOUT)
 		})
 	}
 


### PR DESCRIPTION
This PR adds some more nuance to collaborator cursors.

Rather than being timed out or not timed out, a collaborator can now be `active`, `idle` or `inactive`. 

We calculate this based on the difference between the time that has elapsed since the user's last activity timestamp.

After 3 seconds of inactivity, they go `idle`.
After sixty seconds of inactivity, they are `inactive`.
After any activity, they become `active` again.

When a user is `active`, we always show their cursor.
When a user is `idle`, we hide their cursor if they're following us, unless they're highlighted
When a user is `inactive`, we hide their cursor unless they're highlighted.

### Change Type

- [x] `minor`

### Test Plan

1. Find a friend and experiment with inactive times
2. Join a room that includes an inactive cursors; they should be hidden on load
3. Have people follow you; do their timeouts feel natural?

### Release Notes

- Improve cursor timeouts and hiding logic.
