### PR TITLE
[infra] use huppy token for publish-new

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -12,13 +12,6 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
-      - name: tldraw-repo-sync token
-        id: tldraw-repo-sync
-        uses: getsentry/action-github-app-token@v2
-        with:
-          app_id: ${{ secrets.HUPPY_APP_ID }}
-          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
-
       - name: Check out code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -13,14 +13,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
-      - name: tldraw-repo-sync token
-        id: tldraw-repo-sync
-        uses: getsentry/action-github-app-token@v2
-        with:
-          app_id: ${{ secrets.HUPPY_APP_ID }}
-          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
-
-      - name: Check out code
+     - name: Check out code
         uses: actions/checkout@v3
 
       - name: Setup Node.js environment

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -42,7 +42,10 @@ jobs:
         run: yarn
 
       - name: Publish
-        run: yarn tsx ./scripts/publish-new.ts
+        run: |
+          git config --global user.name 'huppy-bot[bot]'
+          git config --global user.email '128400622+huppy-bot[bot]@users.noreply.github.com'
+          yarn tsx ./scripts/publish-new.ts
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
 
     steps:
-      - name: tldraw-repo-sync token
-        id: tldraw-repo-sync
-        uses: getsentry/action-github-app-token@v2
+      - name: Generate GH token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
           app_id: ${{ secrets.HUPPY_APP_ID }}
           private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
@@ -22,7 +22,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.STEVES_PUBLISH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Prepare repository
         # Fetch full git history and tags for auto
@@ -44,6 +44,6 @@ jobs:
       - name: Publish
         run: yarn tsx ./scripts/publish-new.ts
         env:
-          GH_TOKEN: ${{ secrets.STEVES_PUBLISH_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUPPY_TOKEN: ${{ secrets.HUPPY_TOKEN }}


### PR DESCRIPTION
This PR sets up our publish-new script to use Huppy's GH token. At the same time I added huppy to a list of actors who are allowed to override the branch protection rules for `main` so hopefully next time we run the release script the push will succeed and the release will therefore also succeed. I will create a test repo to see if that works and if it does I'll merge this.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


