### PR TITLE
[proof of concept] feat: custom colors mvp

### DIFF
--- a/apps/examples/src/18-custom-colors/CustomColorsExample.tsx
+++ b/apps/examples/src/18-custom-colors/CustomColorsExample.tsx
@@ -1,0 +1,12 @@
+import { Tldraw } from '@tldraw/tldraw'
+import '@tldraw/tldraw/tldraw.css'
+
+const customColors: string[] = ['#4285F4', '#EA4335', '#FBBC05', '#34A853']
+
+export default function CustomColorsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="tldraw_example" customColors={customColors} autoFocus />
+		</div>
+	)
+}

--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -25,6 +25,7 @@ import ExampleScroll from './6-scroll/ScrollExample'
 import ExampleMultiple from './7-multiple/MultipleExample'
 import ErrorBoundaryExample from './8-error-boundary/ErrorBoundaryExample'
 import HideUiExample from './9-hide-ui/HideUiExample'
+import CustomColorsExample from './18-custom-colors/CustomColorsExample'
 import EndToEnd from './end-to-end/end-to-end'
 import YjsExample from './yjs/YjsExample'
 
@@ -117,6 +118,10 @@ export const allExamples: Example[] = [
 	{
 		path: '/shape-meta',
 		element: <ShapeMetaExample />,
+	},
+	{
+		path: '/custom-colors',
+		element: <CustomColorsExample />,
 	},
 ]
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -38,6 +38,8 @@ export type TldrawEditorProps = {
 	children?: any
 	/** An array of shape utils to use in the editor. */
 	shapes?: readonly AnyTLShapeInfo[]
+	/** An array of additional custom colors in hex format to use in the editor. */
+	customColors?: readonly string[]
 	/** An array of tools to use in the editor. */
 	tools?: readonly TLStateNodeConstructor[]
 	/** Urls for where to find fonts and other assets. */
@@ -100,6 +102,7 @@ declare global {
 }
 
 const EMPTY_SHAPES_ARRAY = [] as const
+const EMPTY_CUSTOM_COLORS_ARRAY = [] as const
 const EMPTY_TOOLS_ARRAY = [] as const
 
 /** @public */
@@ -120,6 +123,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const withDefaults = {
 		...rest,
 		shapes: rest.shapes ?? EMPTY_SHAPES_ARRAY,
+		customColors: rest.customColors ?? EMPTY_CUSTOM_COLORS_ARRAY,
 		tools: rest.tools ?? EMPTY_TOOLS_ARRAY,
 	}
 
@@ -153,12 +157,13 @@ export const TldrawEditor = memo(function TldrawEditor({
 })
 
 function TldrawEditorWithOwnStore(
-	props: Required<TldrawEditorProps & { store: undefined; user: TLUser }, 'shapes' | 'tools'>
+	props: Required<TldrawEditorProps & { store: undefined; user: TLUser }, 'shapes' | 'customColors' | 'tools'>
 ) {
-	const { defaultName, initialData, shapes, persistenceKey, sessionId, user } = props
+	const { defaultName, initialData, shapes, customColors, persistenceKey, sessionId, user } = props
 
 	const syncedStore = useLocalStore({
 		shapes,
+		customColors,
 		initialData,
 		persistenceKey,
 		sessionId,

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -7,10 +7,27 @@ import { AnyTLShapeInfo, TLShapeInfo } from './defineShape'
 export type TLStoreOptions = {
 	initialData?: SerializedStore<TLRecord>
 	defaultName?: string
+	customColors?: readonly string[]
 } & ({ shapes: readonly AnyTLShapeInfo[] } | { schema: StoreSchema<TLRecord, TLStoreProps> })
 
 /** @public */
 export type TLStoreEventInfo = HistoryEntry<TLRecord>
+
+// FIXME: copied from packages/tlschema/src/styles/TLColorStyle.ts as idk how code is shared across packages
+const colors = [
+	'black',
+	'grey',
+	'light-violet',
+	'violet',
+	'blue',
+	'light-blue',
+	'yellow',
+	'orange',
+	'green',
+	'light-green',
+	'light-red',
+	'red',
+] as const
 
 /**
  * A helper for creating a TLStore. Custom shapes cannot override default shapes.
@@ -18,11 +35,14 @@ export type TLStoreEventInfo = HistoryEntry<TLRecord>
  * @param opts - Options for creating the store.
  *
  * @public */
-export function createTLStore({ initialData, defaultName = '', ...rest }: TLStoreOptions): TLStore {
+export function createTLStore({ initialData, defaultName = '', customColors, ...rest }: TLStoreOptions): TLStore {
 	const schema =
 		'schema' in rest
 			? rest.schema
-			: createTLSchema({ shapes: shapesArrayToShapeMap(checkShapesAndAddCore(rest.shapes)) })
+			: createTLSchema({
+				shapes: shapesArrayToShapeMap(checkShapesAndAddCore(rest.shapes)),
+				colors: [...colors, ...(customColors || [])]
+			})
 	return new Store({
 		schema,
 		initialData,

--- a/packages/editor/src/lib/editor/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/arrow/ArrowShapeUtil.tsx
@@ -708,7 +708,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 					)}
 					<g
 						fill="none"
-						stroke={theme[shape.props.color].solid}
+						stroke={shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color}
 						strokeWidth={strokeWidth}
 						strokeLinejoin="round"
 						strokeLinecap="round"
@@ -936,7 +936,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const theme = getDefaultColorTheme(this.editor)
 		ctx.addExportDef(getFillDefForExport(shape.props.fill, theme))
 
-		const color = theme[shape.props.color].solid
+		const color = shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color
 
 		const info = this.getArrowInfo(shape)
 
@@ -1136,7 +1136,7 @@ function getArrowheadSvgPath(
 	const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 	path.setAttribute('d', d)
 	path.setAttribute('fill', 'none')
-	path.setAttribute('stroke', theme[color].solid)
+	path.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	path.setAttribute('stroke-width', strokeWidth + '')
 
 	// Get the fill element, if any

--- a/packages/editor/src/lib/editor/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/draw/DrawShapeUtil.tsx
@@ -158,7 +158,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 					<path
 						d={getSvgPathFromStroke(strokeOutlinePoints, true)}
 						strokeLinecap="round"
-						fill={theme[shape.props.color].solid}
+						fill={shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color}
 					/>
 				</SVGContainer>
 			)
@@ -175,7 +175,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 					d={solidStrokePath}
 					strokeLinecap="round"
 					fill="none"
-					stroke={theme[shape.props.color].solid}
+					stroke={shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color}
 					strokeWidth={strokeWidth}
 					strokeDasharray={getDrawShapeStrokeDashArray(shape, strokeWidth)}
 					strokeDashoffset="0"
@@ -241,14 +241,14 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 
 			const p = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 			p.setAttribute('d', getSvgPathFromStroke(strokeOutlinePoints, true))
-			p.setAttribute('fill', theme[color].solid)
+			p.setAttribute('fill', color in theme ? theme[color].solid : color)
 			p.setAttribute('stroke-linecap', 'round')
 
 			foregroundPath = p
 		} else {
 			const p = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 			p.setAttribute('d', solidStrokePath)
-			p.setAttribute('stroke', theme[color].solid)
+			p.setAttribute('stroke', color in theme ? theme[color].solid : color)
 			p.setAttribute('fill', 'none')
 			p.setAttribute('stroke-linecap', 'round')
 			p.setAttribute('stroke-width', strokeWidth.toString())

--- a/packages/editor/src/lib/editor/shapes/geo/components/DashStyleEllipse.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/DashStyleEllipse.tsx
@@ -49,7 +49,7 @@ export const DashStyleEllipse = React.memo(function DashStyleEllipse({
 				width={toDomPrecision(w)}
 				height={toDomPrecision(h)}
 				fill="none"
-				stroke={theme[color].solid}
+				stroke={color in theme ? theme[color].solid : color}
 				strokeDasharray={strokeDasharray}
 				strokeDashoffset={strokeDashoffset}
 				pointerEvents="all"
@@ -96,7 +96,7 @@ export function DashStyleEllipseSvg({
 	strokeElement.setAttribute('width', w.toString())
 	strokeElement.setAttribute('height', h.toString())
 	strokeElement.setAttribute('fill', 'none')
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	strokeElement.setAttribute('stroke-dasharray', strokeDasharray)
 	strokeElement.setAttribute('stroke-dashoffset', strokeDashoffset)
 

--- a/packages/editor/src/lib/editor/shapes/geo/components/DashStyleOval.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/DashStyleOval.tsx
@@ -46,7 +46,7 @@ export const DashStyleOval = React.memo(function DashStyleOval({
 				width={toDomPrecision(w)}
 				height={toDomPrecision(h)}
 				fill="none"
-				stroke={theme[color].solid}
+				stroke={color in theme ? theme[color].solid : color}
 				strokeDasharray={strokeDasharray}
 				strokeDashoffset={strokeDashoffset}
 				pointerEvents="all"
@@ -87,7 +87,7 @@ export function DashStyleOvalSvg({
 	strokeElement.setAttribute('width', w.toString())
 	strokeElement.setAttribute('height', h.toString())
 	strokeElement.setAttribute('fill', 'none')
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	strokeElement.setAttribute('stroke-dasharray', strokeDasharray)
 	strokeElement.setAttribute('stroke-dashoffset', strokeDashoffset)
 

--- a/packages/editor/src/lib/editor/shapes/geo/components/DashStylePolygon.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/DashStylePolygon.tsx
@@ -36,7 +36,7 @@ export const DashStylePolygon = React.memo(function DashStylePolygon({
 						d={`M${l[0].x},${l[0].y}L${l[1].x},${l[1].y}`}
 					/>
 				))}
-			<g strokeWidth={strokeWidth} stroke={theme[color].solid} fill="none" pointerEvents="all">
+			<g strokeWidth={strokeWidth} stroke={color in theme ? theme[color].solid : color} fill="none" pointerEvents="all">
 				{Array.from(Array(outline.length)).map((_, i) => {
 					const A = outline[i]
 					const B = outline[(i + 1) % outline.length]
@@ -76,7 +76,7 @@ export const DashStylePolygon = React.memo(function DashStylePolygon({
 							<path
 								key={`line_fg_${i}`}
 								d={`M${A.x},${A.y}L${B.x},${B.y}`}
-								stroke={theme[color].solid}
+								stroke={color in theme ? theme[color].solid : color}
 								strokeWidth={strokeWidth}
 								fill="none"
 								strokeDasharray={strokeDasharray}
@@ -105,7 +105,7 @@ export function DashStylePolygonSvg({
 }) {
 	const strokeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 	strokeElement.setAttribute('stroke-width', strokeWidth.toString())
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	strokeElement.setAttribute('fill', 'none')
 
 	Array.from(Array(outline.length)).forEach((_, i) => {

--- a/packages/editor/src/lib/editor/shapes/geo/components/DrawStyleEllipse.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/DrawStyleEllipse.tsx
@@ -37,7 +37,7 @@ export const DrawStyleEllipse = React.memo(function DrawStyleEllipse({
 	return (
 		<>
 			<ShapeFill d={innerPath} color={color} fill={fill} />
-			<path d={outerPath} fill={theme[color].solid} strokeWidth={0} pointerEvents="all" />
+			<path d={outerPath} fill={color in theme ? theme[color].solid : color} strokeWidth={0} pointerEvents="all" />
 		</>
 	)
 })
@@ -57,7 +57,7 @@ export function DrawStyleEllipseSvg({
 }) {
 	const strokeElement = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 	strokeElement.setAttribute('d', getEllipsePath(id, w, h, sw))
-	strokeElement.setAttribute('fill', theme[color].solid)
+	strokeElement.setAttribute('fill', color in theme ? theme[color].solid : color)
 
 	// Get the fill element, if any
 	const fillElement = getShapeFillSvg({

--- a/packages/editor/src/lib/editor/shapes/geo/components/DrawStylePolygon.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/DrawStylePolygon.tsx
@@ -37,7 +37,7 @@ export const DrawStylePolygon = React.memo(function DrawStylePolygon({
 	return (
 		<>
 			<ShapeFill d={innerPathData} fill={fill} color={color} />
-			<path d={strokePathData} stroke={theme[color].solid} strokeWidth={strokeWidth} fill="none" />
+			<path d={strokePathData} stroke={color in theme ? theme[color].solid : color} strokeWidth={strokeWidth} fill="none" />
 		</>
 	)
 })
@@ -73,7 +73,7 @@ export function DrawStylePolygonSvg({
 	const strokeElement = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 	strokeElement.setAttribute('d', strokePathData)
 	strokeElement.setAttribute('fill', 'none')
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	strokeElement.setAttribute('stroke-width', strokeWidth.toString())
 
 	// Get the fill element, if any

--- a/packages/editor/src/lib/editor/shapes/geo/components/SolidStyleEllipse.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/SolidStyleEllipse.tsx
@@ -25,7 +25,7 @@ export const SolidStyleEllipse = React.memo(function SolidStyleEllipse({
 	return (
 		<>
 			<ShapeFill d={d} color={color} fill={fill} />
-			<path d={d} stroke={theme[color].solid} strokeWidth={sw} fill="none" />
+			<path d={d} stroke={color in theme ? theme[color].solid : color} strokeWidth={sw} fill="none" />
 		</>
 	)
 })
@@ -54,7 +54,7 @@ export function SolidStyleEllipseSvg({
 	strokeElement.setAttribute('width', w.toString())
 	strokeElement.setAttribute('height', h.toString())
 	strokeElement.setAttribute('fill', 'none')
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 
 	// Get the fill element, if any
 	const fillElement = getShapeFillSvg({

--- a/packages/editor/src/lib/editor/shapes/geo/components/SolidStyleOval.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/SolidStyleOval.tsx
@@ -21,7 +21,7 @@ export const SolidStyleOval = React.memo(function SolidStyleOval({
 	return (
 		<>
 			<ShapeFill d={d} color={color} fill={fill} />
-			<path d={d} stroke={theme[color].solid} strokeWidth={sw} fill="none" />
+			<path d={d} stroke={color in theme ? theme[color].solid : color} strokeWidth={sw} fill="none" />
 		</>
 	)
 })
@@ -44,7 +44,7 @@ export function SolidStyleOvalSvg({
 	strokeElement.setAttribute('width', w.toString())
 	strokeElement.setAttribute('height', h.toString())
 	strokeElement.setAttribute('fill', 'none')
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 
 	// Get the fill element, if any
 	const fillElement = getShapeFillSvg({

--- a/packages/editor/src/lib/editor/shapes/geo/components/SolidStylePolygon.tsx
+++ b/packages/editor/src/lib/editor/shapes/geo/components/SolidStylePolygon.tsx
@@ -31,7 +31,7 @@ export const SolidStylePolygon = React.memo(function SolidStylePolygon({
 	return (
 		<>
 			<ShapeFill d={path} fill={fill} color={color} />
-			<path d={path} stroke={theme[color].solid} strokeWidth={strokeWidth} fill="none" />
+			<path d={path} stroke={color in theme ? theme[color].solid : color} strokeWidth={strokeWidth} fill="none" />
 		</>
 	)
 })
@@ -63,7 +63,7 @@ export function SolidStylePolygonSvg({
 	const strokeElement = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 	strokeElement.setAttribute('d', strokePathData)
 	strokeElement.setAttribute('stroke-width', strokeWidth.toString())
-	strokeElement.setAttribute('stroke', theme[color].solid)
+	strokeElement.setAttribute('stroke', color in theme ? theme[color].solid : color)
 	strokeElement.setAttribute('fill', 'none')
 
 	// Get the fill element, if any

--- a/packages/editor/src/lib/editor/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/highlight/HighlightShapeUtil.tsx
@@ -236,7 +236,7 @@ function HighlightRenderer({
 	const forceSolid = useForceSolid()
 	const { solidStrokePath, sw } = getHighlightSvgPath(shape, strokeWidth, forceSolid)
 	const colorSpace = useColorSpace()
-	const color = theme[shape.props.color].highlight[colorSpace]
+	const color = shape.props.color in theme ? theme[shape.props.color].highlight[colorSpace] : shape.props.color
 
 	return (
 		<SVGContainer id={shape.id} style={{ opacity }}>

--- a/packages/editor/src/lib/editor/shapes/line/LineShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/line/LineShapeUtil.tsx
@@ -193,7 +193,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				return (
 					<SVGContainer id={shape.id}>
 						<ShapeFill d={pathData} fill={'none'} color={color} />
-						<path d={pathData} stroke={theme[color].solid} strokeWidth={strokeWidth} fill="none" />
+						<path d={pathData} stroke={color in theme ? theme[color].solid : color} strokeWidth={strokeWidth} fill="none" />
 					</SVGContainer>
 				)
 			}
@@ -205,7 +205,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				return (
 					<SVGContainer id={shape.id}>
 						<ShapeFill d={pathData} fill={'none'} color={color} />
-						<g stroke={theme[color].solid} strokeWidth={strokeWidth}>
+						<g stroke={color in theme ? theme[color].solid : color} strokeWidth={strokeWidth}>
 							{spline.segments.map((segment, i) => {
 								const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
 									segment.length,
@@ -241,7 +241,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 						<ShapeFill d={innerPathData} fill={'none'} color={color} />
 						<path
 							d={outerPathData}
-							stroke={theme[color].solid}
+							stroke={color in theme ? theme[color].solid : color}
 							strokeWidth={strokeWidth}
 							fill="none"
 						/>
@@ -260,7 +260,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 						<ShapeFill d={splinePath} fill={'none'} color={color} />
 						<path
 							strokeWidth={strokeWidth}
-							stroke={theme[color].solid}
+							stroke={color in theme ? theme[color].solid : color}
 							fill="none"
 							d={splinePath}
 						/>
@@ -272,7 +272,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				return (
 					<SVGContainer id={shape.id}>
 						<ShapeFill d={splinePath} fill={'none'} color={color} />
-						<g stroke={theme[color].solid} strokeWidth={strokeWidth}>
+						<g stroke={color in theme ? theme[color].solid : color} strokeWidth={strokeWidth}>
 							{spline.segments.map((segment, i) => {
 								const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
 									segment.length,
@@ -306,8 +306,8 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 						<path
 							d={getLineDrawPath(shape, spline, strokeWidth)}
 							strokeWidth={1}
-							stroke={theme[color].solid}
-							fill={theme[color].solid}
+							stroke={color in theme ? theme[color].solid : color}
+							fill={color in theme ? theme[color].solid : color}
 						/>
 					</SVGContainer>
 				)
@@ -339,7 +339,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 
 	toSvg(shape: TLLineShape) {
 		const theme = getDefaultColorTheme(this.editor)
-		const color = theme[shape.props.color].solid
+		const color = shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color
 		const spline = getSplineForLineShape(shape)
 		return getLineSvg(shape, spline, color, STROKE_SIZES[shape.props.size])
 	}

--- a/packages/editor/src/lib/editor/shapes/note/NoteShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/note/NoteShapeUtil.tsx
@@ -74,8 +74,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					<div
 						className="tl-note__container tl-hitarea-fill"
 						style={{
-							color: theme[adjustedColor].solid,
-							backgroundColor: theme[adjustedColor].solid,
+							color: adjustedColor in theme ? theme[adjustedColor].solid : adjustedColor,
+							backgroundColor: adjustedColor in theme ? theme[adjustedColor].solid : adjustedColor,
 						}}
 					>
 						<div className="tl-note__scrim" />
@@ -122,8 +122,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		rect1.setAttribute('rx', '10')
 		rect1.setAttribute('width', NOTE_SIZE.toString())
 		rect1.setAttribute('height', bounds.height.toString())
-		rect1.setAttribute('fill', theme[adjustedColor].solid)
-		rect1.setAttribute('stroke', theme[adjustedColor].solid)
+		rect1.setAttribute('fill', adjustedColor in theme ? theme[adjustedColor].solid : adjustedColor)
+		rect1.setAttribute('stroke', adjustedColor in theme ? theme[adjustedColor].solid : adjustedColor)
 		rect1.setAttribute('stroke-width', '1')
 		g.appendChild(rect1)
 

--- a/packages/editor/src/lib/editor/shapes/shared/ShapeFill.tsx
+++ b/packages/editor/src/lib/editor/shapes/shared/ShapeFill.tsx
@@ -27,7 +27,7 @@ export const ShapeFill = React.memo(function ShapeFill({ d, color, fill }: Shape
 			return <path className={'tl-hitarea-stroke'} fill="none" d={d} />
 		}
 		case 'solid': {
-			return <path className={'tl-hitarea-fill-solid'} fill={theme[color].semi} d={d} />
+			return <path className={'tl-hitarea-fill-solid'} fill={color in theme ? theme[color].semi : color} d={d} />
 		}
 		case 'semi': {
 			return <path className={'tl-hitarea-fill-solid'} fill={theme.solid} d={d} />
@@ -49,11 +49,11 @@ const PatternFill = function PatternFill({ d, color }: ShapeFillProps) {
 
 	return (
 		<>
-			<path className={'tl-hitarea-fill-solid'} fill={theme[color].pattern} d={d} />
+			<path className={'tl-hitarea-fill-solid'} fill={color in theme ? theme[color].pattern : color} d={d} />
 			<path
 				fill={
 					teenyTiny
-						? theme[color].semi
+						? color in theme ? theme[color].semi : color
 						: `url(#${HASH_PATTERN_ZOOM_NAMES[intZoom + (isDarkMode ? '_dark' : '_light')]})`
 				}
 				d={d}
@@ -76,7 +76,7 @@ export function getShapeFillSvg({
 		const gEl = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 		const path1El = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 		path1El.setAttribute('d', d)
-		path1El.setAttribute('fill', theme[color].pattern)
+		path1El.setAttribute('fill', color in theme ? theme[color].pattern : color)
 
 		const path2El = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 		path2El.setAttribute('d', d)
@@ -97,7 +97,7 @@ export function getShapeFillSvg({
 		}
 		case 'solid': {
 			{
-				path.setAttribute('fill', theme[color].semi)
+				path.setAttribute('fill', color in theme ? theme[color].semi : color)
 			}
 			break
 		}

--- a/packages/editor/src/lib/editor/shapes/shared/TextLabel.tsx
+++ b/packages/editor/src/lib/editor/shapes/shared/TextLabel.tsx
@@ -80,7 +80,7 @@ export const TextLabel = React.memo(function TextLabel<
 					lineHeight: LABEL_FONT_SIZES[size] * TEXT_PROPS.lineHeight + 'px',
 					minHeight: isEmpty ? LABEL_FONT_SIZES[size] * TEXT_PROPS.lineHeight + 32 : 0,
 					minWidth: isEmpty ? 33 : 0,
-					color: theme[labelColor].solid,
+					color: labelColor in theme ? theme[labelColor].solid : labelColor,
 				}}
 			>
 				<div className="tl-text tl-text-content" dir="ltr">

--- a/packages/editor/src/lib/editor/shapes/text/TextShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/text/TextShapeUtil.tsx
@@ -96,7 +96,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 						transformOrigin: 'top left',
 						width: Math.max(1, width),
 						height: Math.max(FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight, height),
-						color: theme[color].solid,
+						color: color in theme ? theme[color].solid : color,
 					}}
 				>
 					<div className="tl-text tl-text-content" dir="ltr">
@@ -161,7 +161,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 			overflow: 'wrap' as const,
 		}
 
-		const color = theme[shape.props.color].solid
+		const color = shape.props.color in theme ? theme[shape.props.color].solid : shape.props.color
 		const groupEl = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 
 		const textBgEl = createTextSvgElementFromSpans(

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -16,6 +16,7 @@ export function Tldraw(props: TldrawEditorProps & TldrawUiProps) {
 		...rest,
 		shapes: useMemo(() => [...defaultShapes, ...(rest.shapes ?? [])], [rest.shapes]),
 		tools: useMemo(() => [...defaultTools, ...(rest.tools ?? [])], [rest.tools]),
+		customColors: rest.customColors || [],
 	}
 
 	return (

--- a/packages/tlschema/src/createTLSchema.ts
+++ b/packages/tlschema/src/createTLSchema.ts
@@ -30,7 +30,7 @@ export type TLSchema = StoreSchema<TLRecord, TLStoreProps>
  * @param opts - Options
  *
  * @public */
-export function createTLSchema({ shapes }: { shapes: Record<string, SchemaShapeInfo> }): TLSchema {
+export function createTLSchema({ shapes, colors }: { shapes: Record<string, SchemaShapeInfo>, colors: string[] }): TLSchema {
 	const stylesById = new Map<string, StyleProp<unknown>>()
 	for (const shape of objectMapValues(shapes)) {
 		for (const style of getShapePropKeysByStyle(shape.props ?? {}).keys()) {
@@ -39,6 +39,14 @@ export function createTLSchema({ shapes }: { shapes: Record<string, SchemaShapeI
 			}
 			stylesById.set(style.id, style)
 		}
+	}
+
+	const color = stylesById.get('tldraw:color')
+	if (color) {
+		stylesById.set('tldraw:color', StyleProp.defineEnum('tldraw:color', {
+			defaultValue: 'black',
+			values: colors,
+		}))
 	}
 
 	const ShapeRecordType = createShapeRecordType(shapes)

--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -2,7 +2,7 @@ import { Expand } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
 import { StyleProp } from './StyleProp'
 
-const colors = [
+export const colors = [
 	'black',
 	'grey',
 	'light-violet',
@@ -278,9 +278,9 @@ export function getDefaultColorTheme(opts: { isDarkMode: boolean }): TLDefaultCo
 }
 
 /** @public */
-export const DefaultColorStyle = StyleProp.defineEnum('tldraw:color', {
+export const DefaultColorStyle = StyleProp.define('tldraw:color', {
 	defaultValue: 'black',
-	values: colors,
+	type: T.string,
 })
 
 /** @public */

--- a/packages/ui/src/lib/TldrawUi.tsx
+++ b/packages/ui/src/lib/TldrawUi.tsx
@@ -34,6 +34,7 @@ export type TldrawUiProps = {
 	topZone?: ReactNode
 	/** Additional items to add to the debug menu  (will be deprecated)*/
 	renderDebugMenuItems?: () => React.ReactNode
+	customColors?: string[]
 } & TldrawUiContextProviderProps
 
 /**

--- a/packages/ui/src/lib/TldrawUiContextProvider.tsx
+++ b/packages/ui/src/lib/TldrawUiContextProvider.tsx
@@ -15,12 +15,14 @@ import { ToolbarSchemaProvider } from './hooks/useToolbarSchema'
 import { ToolsProvider } from './hooks/useTools'
 import { TranslationProvider } from './hooks/useTranslation/useTranslation'
 import { TLUiOverrides, useMergedOverrides, useMergedTranslationOverrides } from './overrides'
+import { CustomColorsProvider } from './hooks/useCustomColors'
 
 /** @public */
 export interface TldrawUiContextProviderProps {
 	assetUrls?: RecursivePartial<TLUiAssetUrls>
 	overrides?: TLUiOverrides | TLUiOverrides[]
 	onUiEvent?: TLUiEventHandler
+	customColors?: string[]
 	children?: any
 }
 
@@ -29,6 +31,7 @@ export function TldrawUiContextProvider({
 	overrides,
 	assetUrls,
 	onUiEvent,
+	customColors,
 	children,
 }: TldrawUiContextProviderProps) {
 	return (
@@ -38,7 +41,7 @@ export function TldrawUiContextProvider({
 					<ToastsProvider>
 						<DialogsProvider>
 							<BreakPointProvider>
-								<InternalProviders overrides={overrides}>{children}</InternalProviders>
+								<InternalProviders overrides={overrides} customColors={customColors}>{children}</InternalProviders>
 							</BreakPointProvider>
 						</DialogsProvider>
 					</ToastsProvider>
@@ -49,6 +52,7 @@ export function TldrawUiContextProvider({
 }
 function InternalProviders({
 	overrides,
+	customColors,
 	children,
 }: Omit<TldrawUiContextProviderProps, 'assetBaseUrl'>) {
 	const mergedOverrides = useMergedOverrides(overrides)
@@ -61,7 +65,9 @@ function InternalProviders({
 							<TLUiContextMenuSchemaProvider overrides={mergedOverrides.contextMenu}>
 								<HelpMenuSchemaProvider overrides={mergedOverrides.helpMenu}>
 									<TLUiMenuSchemaProvider overrides={mergedOverrides.menu}>
-										{children}
+										<CustomColorsProvider customColors={customColors}>
+											{children}
+										</CustomColorsProvider>
 									</TLUiMenuSchemaProvider>
 								</HelpMenuSchemaProvider>
 							</TLUiContextMenuSchemaProvider>

--- a/packages/ui/src/lib/components/StylePanel/StylePanel.tsx
+++ b/packages/ui/src/lib/components/StylePanel/StylePanel.tsx
@@ -27,6 +27,7 @@ import { Slider } from '../primitives/Slider'
 import { DoubleDropdownPicker } from './DoubleDropdownPicker'
 import { DropdownPicker } from './DropdownPicker'
 import { STYLES } from './styles'
+import { useCustomColors } from '../../hooks/useCustomColors'
 
 interface StylePanelProps {
 	isMobile?: boolean
@@ -103,6 +104,34 @@ function useStyleChangeCallback() {
 
 const tldrawSupportedOpacities = [0.1, 0.25, 0.5, 0.75, 1] as const
 
+function ColorPicker({ styles }: { styles: ReadonlySharedStyleMap }) {
+	const msg = useTranslation()
+
+	const handleValueChange = useStyleChangeCallback()
+
+	const color = styles.get(DefaultColorStyle)
+	const customColors = useCustomColors()
+	const customColorMenuItems = [...customColors].map((customColor) =>
+		({ icon: 'color', value: customColor, title: customColor }))
+
+	if (color === undefined) {
+		return null;
+	}
+
+	return (
+		<>
+			<ButtonPicker
+				title={msg('style-panel.color')}
+				uiType="color"
+				style={DefaultColorStyle}
+				items={[...STYLES.color, ...customColorMenuItems]}
+				value={color}
+				onValueChange={handleValueChange}
+			/>
+		</>
+	);
+}
+
 function CommonStylePickerSet({
 	styles,
 	opacity,
@@ -124,7 +153,6 @@ function CommonStylePickerSet({
 		[editor]
 	)
 
-	const color = styles.get(DefaultColorStyle)
 	const fill = styles.get(DefaultFillStyle)
 	const dash = styles.get(DefaultDashStyle)
 	const size = styles.get(DefaultSizeStyle)
@@ -143,16 +171,7 @@ function CommonStylePickerSet({
 	return (
 		<>
 			<div className="tlui-style-panel__section__common" aria-label="style panel styles">
-				{color === undefined ? null : (
-					<ButtonPicker
-						title={msg('style-panel.color')}
-						uiType="color"
-						style={DefaultColorStyle}
-						items={STYLES.color}
-						value={color}
-						onValueChange={handleValueChange}
-					/>
-				)}
+				<ColorPicker styles={styles} />
 				{opacity === undefined ? null : (
 					<Slider
 						data-testid="style.opacity"

--- a/packages/ui/src/lib/components/StylePanel/styles.tsx
+++ b/packages/ui/src/lib/components/StylePanel/styles.tsx
@@ -1,6 +1,7 @@
 export type StyleValuesForUi<T> = readonly {
 	readonly value: T
 	readonly icon: string
+	readonly title?: string
 }[]
 
 export const STYLES = {

--- a/packages/ui/src/lib/components/primitives/ButtonPicker.tsx
+++ b/packages/ui/src/lib/components/primitives/ButtonPicker.tsx
@@ -109,11 +109,11 @@ function _ButtonPicker<T extends string>(props: ButtonPickerProps<T>) {
 					data-testid={`style.${uiType}.${item.value}`}
 					aria-label={item.value}
 					data-state={value.type === 'shared' && value.value === item.value ? 'hinted' : undefined}
-					title={title + ' — ' + msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)}
+					title={title + ' — ' + item.title !== undefined ? item.title : msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)}
 					className={classNames('tlui-button-grid__button')}
 					style={
 						style === (DefaultColorStyle as StyleProp<unknown>)
-							? { color: theme[item.value as TLDefaultColorStyle].solid }
+							? { color: theme[item.value as TLDefaultColorStyle]?.solid || item.value }
 							: undefined
 					}
 					onPointerEnter={handleButtonPointerEnter}

--- a/packages/ui/src/lib/hooks/useCustomColors.tsx
+++ b/packages/ui/src/lib/hooks/useCustomColors.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+
+/** @public */
+export type TLUiCustomColorsContextType = string[]
+
+/** @internal */
+export const CustomColorsContext = React.createContext([] as TLUiCustomColorsContextType)
+
+/** @public */
+export type TLUiCustomColorsProviderProps = {
+	customColors?: string[]
+	children: any
+}
+
+export function CustomColorsProvider({ customColors = [], children }: TLUiCustomColorsProviderProps) {
+	return <CustomColorsContext.Provider value={customColors}>{children}</CustomColorsContext.Provider>
+}
+
+/** @public */
+export function useCustomColors() {
+	const ctx = React.useContext(CustomColorsContext)
+
+	if (!ctx) {
+		throw new Error('useCustomColors must be used within a CustomColorsProvider')
+	}
+
+	return ctx
+}


### PR DESCRIPTION
(proof of concept, do not merge)

- updated the `tldraw:color` style schema to accept any string, not sure the predefined color names
- added a `customColors` prop to the `<Tldraw />` component & context provider to allow specifying new custom colors
- updated the styles panel to show the custom colors
- updated all shapes to handle raw color strings
- added an example

note:
1. this PR only serves as an MVP for the feature / a proof of concept
2. on top of 1, i'm very likely breaking all sorts of conventions / best practices here
3. on top of 1 and 2, this could potentially be a completely wrong approach (e.g. maybe this should be supported via a custom theme instead), so feel free to do anything to this PR

:)

related issue: #1294

![FireShot Capture 015 - tldraw examples - localhost](https://github.com/tldraw/tldraw/assets/5616556/eefd4bf0-82ee-42cd-88fd-6cca269c5eb3)

### Change Type

- [ ] `patch` — Bug fix
- [x] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. use the `<Tldraw />` component, specifying the `customColors` prop
2. Notice that the custom colors being selectable in the styles panel
3. Notice that text / shapes can be created / edited with the custom colors

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
