### PR TITLE
[hot take] remove `tool` from shape definition

### DIFF
--- a/apps/examples/src/16-custom-styles/CardShape.tsx
+++ b/apps/examples/src/16-custom-styles/CardShape.tsx
@@ -92,7 +92,6 @@ export class CardShapeTool extends BaseBoxShapeTool {
 
 export const CardShape = defineShape('card', {
 	util: CardShapeUtil,
-	tool: CardShapeTool,
 	// to use a style prop, you need to describe all the props in your shape.
 	props: {
 		w: T.number,

--- a/apps/examples/src/16-custom-styles/CustomStylesExample.tsx
+++ b/apps/examples/src/16-custom-styles/CustomStylesExample.tsx
@@ -1,6 +1,6 @@
 import { Tldraw } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
-import { CardShape } from './CardShape'
+import { CardShape, CardShapeTool } from './CardShape'
 import { FilterStyleUi } from './FilterStyleUi'
 import { uiOverrides } from './ui-overrides'
 
@@ -13,6 +13,7 @@ export default function CustomStylesExample() {
 				autoFocus
 				persistenceKey="custom-styles-example"
 				shapes={shapes}
+				tools={[CardShapeTool]}
 				overrides={uiOverrides}
 			>
 				<FilterStyleUi />

--- a/apps/examples/src/3-custom-config/CardShape/CardShape.ts
+++ b/apps/examples/src/3-custom-config/CardShape/CardShape.ts
@@ -1,5 +1,4 @@
 import { defineShape } from '@tldraw/tldraw'
-import { CardShapeTool } from './CardShapeTool'
 import { CardShapeUtil } from './CardShapeUtil'
 import { cardShapeMigrations } from './card-shape-migrations'
 import { cardShapeProps } from './card-shape-props'
@@ -9,7 +8,6 @@ export const CardShape = defineShape('card', {
 	// A utility class
 	util: CardShapeUtil,
 	// A tool that is used to create and edit the shape (optional)
-	tool: CardShapeTool,
 	// A validation schema for the shape's props (optional)
 	props: cardShapeProps,
 	// Migrations for upgrading shapes (optional)

--- a/apps/examples/src/3-custom-config/CustomConfigExample.tsx
+++ b/apps/examples/src/3-custom-config/CustomConfigExample.tsx
@@ -1,5 +1,6 @@
 import { Tldraw } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
+import { CardShapeTool } from './CardShape/CardShapeTool'
 import { customShapes } from './custom-shapes'
 import { uiOverrides } from './ui-overrides'
 
@@ -10,6 +11,8 @@ export default function CustomConfigExample() {
 				autoFocus
 				// Pass in the array of custom shape definitions
 				shapes={customShapes}
+				// Pass in the array of custom tools
+				tools={[CardShapeTool]}
 				// Pass in any overrides to the user interface
 				overrides={uiOverrides}
 			/>

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2661,7 +2661,6 @@ export type TLShapeInfo<T extends TLUnknownShape = TLUnknownShape> = {
     util: TLShapeUtilConstructor<T>;
     props?: ShapeProps<T>;
     migrations?: Migrations;
-    tool?: TLStateNodeConstructor;
 };
 
 // @public (undocumented)

--- a/packages/editor/src/lib/config/defaultTools.ts
+++ b/packages/editor/src/lib/config/defaultTools.ts
@@ -1,7 +1,32 @@
+import { ArrowShapeTool } from '../editor/shapes/arrow/ArrowShapeTool'
+import { DrawShapeTool } from '../editor/shapes/draw/DrawShapeTool'
+import { FrameShapeTool } from '../editor/shapes/frame/FrameShapeTool'
+import { GeoShapeTool } from '../editor/shapes/geo/GeoShapeTool'
+import { HighlightShapeTool } from '../editor/shapes/highlight/HighlightShapeTool'
+import { LineShapeTool } from '../editor/shapes/line/LineShapeTool'
+import { NoteShapeTool } from '../editor/shapes/note/NoteShapeTool'
+import { TextShapeTool } from '../editor/shapes/text/TextShapeTool'
 import { EraserTool } from '../editor/tools/EraserTool/EraserTool'
 import { HandTool } from '../editor/tools/HandTool/HandTool'
 import { LaserTool } from '../editor/tools/LaserTool/LaserTool'
 import { TLStateNodeConstructor } from '../editor/tools/StateNode'
 
 /** @public */
-export const defaultTools: TLStateNodeConstructor[] = [HandTool, EraserTool, LaserTool]
+export const coreTools = [
+	// created by copy and paste
+	TextShapeTool,
+]
+
+/** @public */
+export const defaultTools: TLStateNodeConstructor[] = [
+	HandTool,
+	EraserTool,
+	LaserTool,
+	DrawShapeTool,
+	GeoShapeTool,
+	LineShapeTool,
+	NoteShapeTool,
+	FrameShapeTool,
+	ArrowShapeTool,
+	HighlightShapeTool,
+]

--- a/packages/editor/src/lib/config/defineShape.ts
+++ b/packages/editor/src/lib/config/defineShape.ts
@@ -2,7 +2,6 @@ import { Migrations } from '@tldraw/store'
 import { ShapeProps, TLBaseShape, TLUnknownShape } from '@tldraw/tlschema'
 import { assert } from '@tldraw/utils'
 import { TLShapeUtilConstructor } from '../editor/shapes/ShapeUtil'
-import { TLStateNodeConstructor } from '../editor/tools/StateNode'
 
 /** @public */
 export type TLShapeInfo<T extends TLUnknownShape = TLUnknownShape> = {
@@ -10,7 +9,6 @@ export type TLShapeInfo<T extends TLUnknownShape = TLUnknownShape> = {
 	util: TLShapeUtilConstructor<T>
 	props?: ShapeProps<T>
 	migrations?: Migrations
-	tool?: TLStateNodeConstructor
 }
 
 export type AnyTLShapeInfo = TLShapeInfo<TLBaseShape<any, any>>

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -80,6 +80,7 @@ import { EventEmitter } from 'eventemitter3'
 import { nanoid } from 'nanoid'
 import { TLUser, createTLUser } from '../config/createTLUser'
 import { checkShapesAndAddCore } from '../config/defaultShapes'
+import { coreTools } from '../config/defaultTools'
 import { AnyTLShapeInfo } from '../config/defineShape'
 import {
 	ANIMATION_MEDIUM_MS,
@@ -190,6 +191,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.root = new RootState(this)
 
+		const allTools = [...coreTools, ...tools]
 		const allShapes = checkShapesAndAddCore(shapes)
 
 		const shapeTypesInSchema = new Set(
@@ -233,15 +235,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// Tools.
 		// Accept tools from constructor parameters which may not conflict with the root note's default or
 		// "baked in" tools, select and zoom.
-		for (const { tool: Tool } of allShapes) {
-			if (Tool) {
-				if (hasOwnProperty(this.root.children!, Tool.id)) {
-					throw Error(`Can't override tool with id "${Tool.id}"`)
-				}
-				this.root.children![Tool.id] = new Tool(this)
-			}
-		}
-		for (const Tool of tools) {
+		for (const Tool of allTools) {
 			if (hasOwnProperty(this.root.children!, Tool.id)) {
 				throw Error(`Can't override tool with id "${Tool.id}"`)
 			}

--- a/packages/editor/src/lib/editor/shapes/arrow/ArrowShape.ts
+++ b/packages/editor/src/lib/editor/shapes/arrow/ArrowShape.ts
@@ -1,6 +1,5 @@
 import { arrowShapeMigrations, arrowShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { ArrowShapeTool } from './ArrowShapeTool'
 import { ArrowShapeUtil } from './ArrowShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const ArrowShape = defineShape('arrow', {
 	util: ArrowShapeUtil,
 	props: arrowShapeProps,
 	migrations: arrowShapeMigrations,
-	tool: ArrowShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/draw/DrawShape.ts
+++ b/packages/editor/src/lib/editor/shapes/draw/DrawShape.ts
@@ -1,6 +1,5 @@
 import { drawShapeMigrations, drawShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { DrawShapeTool } from './DrawShapeTool'
 import { DrawShapeUtil } from './DrawShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const DrawShape = defineShape('draw', {
 	util: DrawShapeUtil,
 	props: drawShapeProps,
 	migrations: drawShapeMigrations,
-	tool: DrawShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/frame/FrameShape.ts
+++ b/packages/editor/src/lib/editor/shapes/frame/FrameShape.ts
@@ -1,6 +1,5 @@
 import { frameShapeMigrations, frameShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { FrameShapeTool } from './FrameShapeTool'
 import { FrameShapeUtil } from './FrameShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const FrameShape = defineShape('frame', {
 	util: FrameShapeUtil,
 	props: frameShapeProps,
 	migrations: frameShapeMigrations,
-	tool: FrameShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/geo/GeoShape.ts
+++ b/packages/editor/src/lib/editor/shapes/geo/GeoShape.ts
@@ -1,6 +1,5 @@
 import { geoShapeMigrations, geoShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { GeoShapeTool } from './GeoShapeTool'
 import { GeoShapeUtil } from './GeoShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const GeoShape = defineShape('geo', {
 	util: GeoShapeUtil,
 	props: geoShapeProps,
 	migrations: geoShapeMigrations,
-	tool: GeoShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/highlight/HighlightShape.ts
+++ b/packages/editor/src/lib/editor/shapes/highlight/HighlightShape.ts
@@ -1,6 +1,5 @@
 import { highlightShapeMigrations, highlightShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { HighlightShapeTool } from './HighlightShapeTool'
 import { HighlightShapeUtil } from './HighlightShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const HighlightShape = defineShape('highlight', {
 	util: HighlightShapeUtil,
 	props: highlightShapeProps,
 	migrations: highlightShapeMigrations,
-	tool: HighlightShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/line/LineShape.ts
+++ b/packages/editor/src/lib/editor/shapes/line/LineShape.ts
@@ -1,6 +1,5 @@
 import { lineShapeMigrations, lineShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { LineShapeTool } from './LineShapeTool'
 import { LineShapeUtil } from './LineShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const LineShape = defineShape('line', {
 	util: LineShapeUtil,
 	props: lineShapeProps,
 	migrations: lineShapeMigrations,
-	tool: LineShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/note/NoteShape.ts
+++ b/packages/editor/src/lib/editor/shapes/note/NoteShape.ts
@@ -1,6 +1,5 @@
 import { noteShapeMigrations, noteShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { NoteShapeTool } from './NoteShapeTool'
 import { NoteShapeUtil } from './NoteShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const NoteShape = defineShape('note', {
 	util: NoteShapeUtil,
 	props: noteShapeProps,
 	migrations: noteShapeMigrations,
-	tool: NoteShapeTool,
 })

--- a/packages/editor/src/lib/editor/shapes/text/TextShape.ts
+++ b/packages/editor/src/lib/editor/shapes/text/TextShape.ts
@@ -1,6 +1,5 @@
 import { textShapeMigrations, textShapeProps } from '@tldraw/tlschema'
 import { defineShape } from '../../../config/defineShape'
-import { TextShapeTool } from './TextShapeTool'
 import { TextShapeUtil } from './TextShapeUtil'
 
 /** @public */
@@ -8,5 +7,4 @@ export const TextShape = defineShape('text', {
 	util: TextShapeUtil,
 	props: textShapeProps,
 	migrations: textShapeMigrations,
-	tool: TextShapeTool,
 })


### PR DESCRIPTION
This PR removes the `tool` parameter from the `defineShape` function. It's an opinionated change that I think we should at the very least consider.

## What's the context?

Currently, you can add **tools** (aka state nodes) to your state chart in two different ways:

1. Passing them to the `<Tldraw>` component with the `tools` attribute.
2. As part of a shape definition's `tool` property, which you then pass to the `<Tldraw>` component with the `shapes` attribute.

This is what (1) looks like:

```jsx
import { MyTool } from "./MyTool"

function Example() {
  return <Tldraw tools={[MyTool]} />
}
```

This is what (2) looks like:

```jsx
import { MyTool } from "./MyTool"
import { MyShapeUtil, myShapeProps } from "./MyShape"

const MyShapeDefinition = defineShape("my-shape", {
  util: MyShapeUtil,
  props: myShapeProps,
  tool: MyTool,
})

function Example() {
  return <Tldraw shapes={[MyShapeDefinition]} />
}
```

Clearly, (1) is better for when you want to add *just a tool*, that doesn't have an associated shape.
And (2) is better for when you want to add *both* a tool and an associated shape. 

## Why change it?

I think we should remove method (2). Because I think that it adds a few complications.


#### Does it help?

I don't think that it helps to streamline the process of coupling shapes and tools. You still need to remember to add your tool.

Seeing as `tool` is optional on the shape definition (rightly so), it doesn't prompt you to do it.

#### What's easier to explain?

I think it's easier to just have to explain _one method_. It would take longer to explain two methods, and it complicates the concepts involved.

Seeing as there's not a big benefit to one method over the other, the added explanation wouldn't be a good trade-off.

#### What happens if I use both?

It's unclear to the user what would happen if they use both methods. Do we know what the intended behaviour of this would be? I think this will happen often.

```jsx
import { MyTool } from "./MyTool"
import { MyShapeUtil, myShapeProps } from "./MyShape"

const MyShapeDefinition = defineShape("my-shape", {
  util: MyShapeUtil,
  props: myShapeProps,
  tool: MyTool,
})

function Example() {
  return <Tldraw tools={[MyTool]} shapes={[MyShapeDefinition]} />
}
```

#### Does it fit my shape/tool?

Many shapes are coupled closely with one tool. But some shapes would involve multiple tools. And some tools would involve multiple shapes.

For example, you might first add a tool and a shape that go nicely together, so you use method (2). But two months later, you decide that you want another tool to be able to make this shape too. Now you've inserted your related tools in two different places, unless you refactor.

Alternatively, you might want to add some more functionality to your tool, so that it can make multiple types of shapes. Instead of refactoring the existing shape, you want to create an entirely new shape, to keep your new code separate. Should you add the `tool` property to the new shape as well? What would happen if you did/didn't? What happens if you later disable the original shape? Would you need to move the `tool` property from there to the newer shape?

It would be a lot simpler to just have the tool in your list of tools, instead of having them tangled up with shapes.

#### Plugins?

We've been considering moving towards some sort of 'plugins' system in the future, that could collect together shapes, tools, and other stuff.

I think that a more complete concept of a 'plugin' would be the best place to collect together shapes, and tools — not on the shape itself.

### Change Type

- [x] `major` — Breaking change

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Try using all of the app's tools, making sure they still work.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- [dev] Removed the `tool` property from `defineShape`
