### PR TITLE
chore: add markdown wrapping extension and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["stkb.rewrap"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"rewrap.autoWrap.enabled": true
+}


### PR DESCRIPTION
This PR adds a recommended extension to allow wrapping markdown content with the `Option + Q` keybind. And it sets an automatic setting to make it happen automatically when you type beyond a line. This makes it easier for us to deal with long lines in markdown. There'll be fewer formatting changes when collaborating.

### Change type

- [x] `other`

### Test plan

1. Open a markdown file and type beyond the line limit to verify auto-wrapping.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- None - internal tooling