### PR TITLE
[fix] penmode

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9205,7 +9205,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 							inputs.isPointing = true
 							inputs.isDragging = false
 
-							if (!this.isPenMode) {
+							if (this.isPenMode) {
+								if (!isPen) {
+									return
+								}
+							} else {
 								if (isPen) {
 									this.setPenMode(true)
 								}

--- a/packages/editor/src/lib/test/penmode.test.ts
+++ b/packages/editor/src/lib/test/penmode.test.ts
@@ -1,0 +1,27 @@
+import { Vec2d } from '@tldraw/primitives'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+it('ignores touch events while in pen mode', async () => {
+	editor.setSelectedTool('draw')
+	editor.setPenMode(true)
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_down',
+		isPen: false,
+		pointerId: 1,
+		point: new Vec2d(100, 100),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		button: 1,
+		target: 'canvas',
+	})
+
+	expect(editor.shapesArray.length).toBe(0)
+})


### PR DESCRIPTION
This PR fixes pen mode.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On iPad, use the pencil to enter pen mode
2. Select the draw tool
3. touch the screen

- [x] Unit Tests (sort of)

### Release Notes

- [fix] pen mode