### PR TITLE
Go back to default cursor when done resizing.

### DIFF
--- a/packages/editor/src/lib/editor/tools/SelectTool/children/Resizing.ts
+++ b/packages/editor/src/lib/editor/tools/SelectTool/children/Resizing.ts
@@ -344,6 +344,7 @@ export class Resizing extends StateNode {
 	}
 
 	onExit = () => {
+		this.editor.setCursor({ type: 'default' })
 		this.editor.snaps.clear()
 	}
 


### PR DESCRIPTION
Once we are done resizing (when inserting text) we now show the default cursor.

Fixes #1699 

### Change Type

- [x] `patch` — Bug fix


### Test Plan

1. Select text tool
2. Insert a text shape by dragging to select it's size.
3. After you are done dragging the cursor should go back to the default cursor.

### Release Notes

- Switch back to the default cursor after you are done inserting a new text shape.