### PR TITLE
Firefox: Fix coarse pointer issue

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -559,12 +559,14 @@ export class Editor extends EventEmitter<TLEventMap> {
     };
     get instanceState(): TLInstance;
     interrupt(): this;
+    readonly isAndroid: boolean;
     get isChangingStyle(): boolean;
     set isChangingStyle(v: boolean);
     readonly isChromeForIos: boolean;
     get isCoarsePointer(): boolean;
     set isCoarsePointer(v: boolean);
     get isDarkMode(): boolean;
+    readonly isFirefox: boolean;
     get isFocused(): boolean;
     get isFocusMode(): boolean;
     get isGridMode(): boolean;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -253,10 +253,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 			this.isIos = !!navigator.userAgent.match(/iPad/i) || !!navigator.userAgent.match(/iPhone/i)
 			this.isChromeForIos = /crios.*safari/i.test(navigator.userAgent)
+			this.isFirefox = /firefox/i.test(navigator.userAgent)
+			this.isAndroid = /android/i.test(navigator.userAgent)
 		} else {
 			this.isSafari = false
 			this.isIos = false
 			this.isChromeForIos = false
+			this.isFirefox = false
+			this.isAndroid = false
 		}
 
 		this.store.onBeforeDelete = (record) => {
@@ -423,6 +427,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	readonly isChromeForIos: boolean
+
+	/**
+	 * Whether the editor is running on Firefox.
+	 *
+	 * @public
+	 */
+	readonly isFirefox: boolean
+
+	/**
+	 * Whether the editor is running on Android.
+	 *
+	 * @public
+	 */
+	readonly isAndroid: boolean
 
 	/**
 	 * The current HTML element containing the editor.

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -4,6 +4,13 @@ import { useEditor } from './useEditor'
 export function useCoarsePointer() {
 	const editor = useEditor()
 	useEffect(() => {
+		// This is a workaround for a Firefox bug where we don't correctly
+		// detect coarse VS fine pointer. For now, let's assume that you have a fine
+		// pointer if you're on Firefox on desktop.
+		if (editor.isFirefox && !editor.isAndroid && !editor.isIos) {
+			editor.isCoarsePointer = false
+			return
+		}
 		if (window.matchMedia) {
 			const mql = window.matchMedia('(pointer: coarse)')
 			const handler = () => {


### PR DESCRIPTION
This PR fixes the editor sometimes incorrectly assuming that you're using a coarse pointer in firefox. It's not a complete fix — it just avoids some of the bigger issues with it. ie: It disables cursor chat.

To avoid the issue, we just assume that you have a fine pointer if you're using firefox on desktop.

Eventually, we should do a more complete fix for this.

I QA'd this change on:
* Mac Firefox (no touch screen)
* Windows Firefox (touch screen)
* Android Firefox

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Use firefox on desktop with a touch screen.
2. Check that you can still use cursor chat (when in a shared project).

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed firefox not being able to use cursor chat when using a touch screen on desktop.
