### PR TITLE
Disable styles panel button on mobile when using the laser tool.

### DIFF
--- a/packages/ui/src/lib/components/MobileStylePanel.tsx
+++ b/packages/ui/src/lib/components/MobileStylePanel.tsx
@@ -25,7 +25,7 @@ export function MobileStylePanel() {
 
 	const disableStylePanel = useValue(
 		'isHandOrEraserToolActive',
-		() => editor.isInAny('hand', 'zoom', 'eraser'),
+		() => editor.isInAny('hand', 'zoom', 'eraser', 'laser'),
 		[editor]
 	)
 


### PR DESCRIPTION
Disable the style panel button on mobile layouts when using the laser tool.

Fixes #1702 
### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Use a mobile layout.
2. Select laser tool
3. Make sure you cannot click the style panel button - it should be disabled.

### Release Notes

- Disable the styles panel button for laser tool on mobile.
