### PR TITLE
Fix tsdocs for TldrawUi component

### DIFF
--- a/packages/ui/api-report.md
+++ b/packages/ui/api-report.md
@@ -222,7 +222,7 @@ export const TldrawUi: React_2.NamedExoticComponent<{
 // @public (undocumented)
 export function TldrawUiContextProvider({ overrides, assetUrls, onUiEvent, children, }: TldrawUiContextProviderProps): JSX.Element;
 
-// @public (undocumented)
+// @public
 export interface TldrawUiContextProviderProps {
     // (undocumented)
     assetUrls?: RecursivePartial<TLUiAssetUrls>;
@@ -234,7 +234,7 @@ export interface TldrawUiContextProviderProps {
     overrides?: TLUiOverrides | TLUiOverrides[];
 }
 
-// @public (undocumented)
+// @public
 export type TldrawUiProps = {
     children?: ReactNode;
     hideUi?: boolean;

--- a/packages/ui/src/lib/TldrawUi.tsx
+++ b/packages/ui/src/lib/TldrawUi.tsx
@@ -24,15 +24,22 @@ import { useEditorEvents } from './hooks/useEditorEvents'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useTranslation } from './hooks/useTranslation/useTranslation'
 
-/** @public */
+/**
+ * Attributes for the {@link @tldraw/tldraw#Tldraw} and {@link TldrawUi} components.
+ *
+ * @param children - The component's children.
+ * @param hideUi - Whether to hide the interface and only display the canvas.
+ * @param shareZone - A component to use for the share zone (will be deprecated)
+ * @param topZone - A component to use for the top zone (will be deprecated)
+ * @param renderDebugMenuItems - Additional items to add to the debug menu (will be deprecated)
+ *
+ * @public
+ */
 export type TldrawUiProps = {
 	children?: ReactNode
-	/** Whether to hide the interface and only display the canvas. */
 	hideUi?: boolean
-	/** A component to use for the share zone (will be deprecated) */
 	shareZone?: ReactNode
 	topZone?: ReactNode
-	/** Additional items to add to the debug menu  (will be deprecated)*/
 	renderDebugMenuItems?: () => React.ReactNode
 } & TldrawUiContextProviderProps
 

--- a/packages/ui/src/lib/TldrawUiContextProvider.tsx
+++ b/packages/ui/src/lib/TldrawUiContextProvider.tsx
@@ -16,7 +16,16 @@ import { ToolsProvider } from './hooks/useTools'
 import { TranslationProvider } from './hooks/useTranslation/useTranslation'
 import { TLUiOverrides, useMergedOverrides, useMergedTranslationOverrides } from './overrides'
 
-/** @public */
+/**
+ * Attributes for the {@link @tldraw/tldraw#Tldraw} and {@link TldrawUi} components.
+ *
+ * @param assetUrls - Urls for where to find fonts and other assets for the UI.
+ * @param overrides - Overrides for the UI.
+ * @param onUiEvent - Callback for when UI events occur.
+ * @param children - The component's children.
+ *
+ * @public
+ **/
 export interface TldrawUiContextProviderProps {
 	assetUrls?: RecursivePartial<TLUiAssetUrls>
 	overrides?: TLUiOverrides | TLUiOverrides[]


### PR DESCRIPTION
This PR fixes the tsdocs formatting on the TldrawUi component so that they appear on the docs site. Very similar to https://github.com/tldraw/tldraw/pull/1706

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Go to `/gen/ui/TldrawUiProps`
2. Make sure that there are descriptions for all parameters.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Docs: Show some docs missing from TldrawUi component.
