### PR TITLE
Restore some editor shape+type inference

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -499,10 +499,11 @@ export class Editor extends EventEmitter<TLEventMap> {
     getShapesAtPoint(point: VecLike): TLShape[];
     // (undocumented)
     getShapeStyleIfExists<T>(shape: TLShape, style: StyleProp<T>): T | undefined;
+    getShapeUtil<Def extends TLAnyShapeUtilConstructor>(definition: Def): InstanceType<Def>;
     getShapeUtil<S extends TLUnknownShape>(shape: S | TLShapePartial<S>): ShapeUtil<S>;
-    // (undocumented)
+    // @internal (undocumented)
     getShapeUtil<S extends TLUnknownShape>(type: S['type']): ShapeUtil<S>;
-    // (undocumented)
+    // @internal (undocumented)
     getShapeUtil<T extends ShapeUtil>(type: T extends ShapeUtil<infer R> ? R['type'] : string): T;
     getSortedChildIds(parentId: TLParentId): TLShapeId[];
     getStateDescendant(path: string): StateNode | undefined;
@@ -556,6 +557,11 @@ export class Editor extends EventEmitter<TLEventMap> {
     isPointInShape(point: VecLike, shape: TLShape): boolean;
     readonly isSafari: boolean;
     isShapeInPage(shape: TLShape, pageId?: TLPageId): boolean;
+    isShapeOfType<T extends TLBaseShape<any, any>>(shape: TLUnknownShape, util: {
+        new (...args: any[]): ShapeUtil<T>;
+        type: string;
+    }): shape is T;
+    // @internal (undocumented)
     isShapeOfType<T extends TLUnknownShape>(shape: TLUnknownShape, type: T['type']): shape is T;
     isShapeOrAncestorLocked(shape?: TLShape): boolean;
     mark(markId?: string, onUndo?: boolean, onRedo?: boolean): string;
@@ -1306,12 +1312,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onTranslateEnd?: TLOnTranslateEndHandler<Shape>;
     onTranslateStart?: TLOnTranslateStartHandler<Shape>;
     // (undocumented)
-    static props?: ShapeProps<TLUnknownShape>;
+    static props?: ShapeProps<TLBaseShape<any, any>>;
     // @internal
     providesBackgroundForChildren(shape: Shape): boolean;
     snapPoints(shape: Shape): Vec2d[];
     toBackgroundSvg?(shape: Shape, ctx: SvgExportContext): null | Promise<SVGElement> | SVGElement;
     toSvg?(shape: Shape, ctx: SvgExportContext): Promise<SVGElement> | SVGElement;
+    // (undocumented)
     static type: string;
 }
 
@@ -1684,7 +1691,7 @@ export interface TLEditorOptions {
     getContainer: () => HTMLElement;
     // (undocumented)
     initialState?: string;
-    shapeUtils: readonly TLShapeUtilConstructor<TLUnknownShape>[];
+    shapeUtils: readonly TLAnyShapeUtilConstructor[];
     store: TLStore;
     tools: readonly TLStateNodeConstructor[];
     user?: TLUser;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Migrations } from '@tldraw/store'
-import { ShapeProps, TLHandle, TLShape, TLShapePartial, TLUnknownShape } from '@tldraw/tlschema'
+import {
+	ShapeProps,
+	TLBaseShape,
+	TLHandle,
+	TLShape,
+	TLShapePartial,
+	TLUnknownShape,
+} from '@tldraw/tlschema'
 import { Box2d } from '../../primitives/Box2d'
 import { Vec2d, VecLike } from '../../primitives/Vec2d'
 import { linesIntersect } from '../../primitives/intersect'
@@ -31,15 +38,9 @@ export interface TLShapeUtilCanvasSvgDef {
 /** @public */
 export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	constructor(public editor: Editor) {}
-	static props?: ShapeProps<TLUnknownShape>
-	static migrations?: Migrations
-
-	/**
-	 * The type of the shape util, which should match the shape's type.
-	 *
-	 * @public
-	 */
 	static type: string
+	static props?: ShapeProps<TLBaseShape<any, any>>
+	static migrations?: Migrations
 
 	/**
 	 * Get the default props for a shape.

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -1,8 +1,6 @@
 import {
 	RotateCorner,
-	TLEmbedShape,
 	TLSelectionForegroundComponent,
-	TLTextShape,
 	getCursor,
 	toDomPrecision,
 	track,
@@ -12,6 +10,8 @@ import {
 } from '@tldraw/editor'
 import classNames from 'classnames'
 import { useRef } from 'react'
+import { EmbedShapeUtil } from '../shapes/embed/EmbedShapeUtil'
+import { TextShapeUtil } from '../shapes/text/TextShapeUtil'
 import { useReadOnly } from '../ui/hooks/useReadOnly'
 import { CropHandles } from './CropHandles'
 
@@ -100,11 +100,11 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 			(showSelectionBounds &&
 				editor.isIn('select.resizing') &&
 				onlyShape &&
-				editor.isShapeOfType<TLTextShape>(onlyShape, 'text'))
+				editor.isShapeOfType(onlyShape, TextShapeUtil))
 
 		if (
 			onlyShape &&
-			editor.isShapeOfType<TLEmbedShape>(onlyShape, 'embed') &&
+			editor.isShapeOfType(onlyShape, EmbedShapeUtil) &&
 			shouldDisplayBox &&
 			IS_FIREFOX
 		) {
@@ -193,7 +193,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 			shouldDisplayControls &&
 			isCoarsePointer &&
 			onlyShape &&
-			editor.isShapeOfType<TLTextShape>(onlyShape, 'text') &&
+			editor.isShapeOfType(onlyShape, TextShapeUtil) &&
 			textHandleHeight * zoom >= 4
 
 		return (

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -7,6 +7,7 @@ import {
 	TLShapeId,
 } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
+import { ArrowShapeUtil } from './ArrowShapeUtil'
 
 let editor: TestEditor
 
@@ -303,7 +304,7 @@ describe('Other cases when arrow are moved', () => {
 
 		editor.setCurrentTool('arrow').pointerDown(1000, 1000).pointerMove(50, 350).pointerUp(50, 350)
 		let arrow = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLArrowShape>(arrow, 'arrow'))
+		assert(editor.isShapeOfType(arrow, ArrowShapeUtil))
 		assert(arrow.props.end.type === 'binding')
 		expect(arrow.props.end.boundShapeId).toBe(ids.box3)
 
@@ -312,7 +313,7 @@ describe('Other cases when arrow are moved', () => {
 
 		// arrow should still be bound to box3
 		arrow = editor.getShapeById(arrow.id)!
-		assert(editor.isShapeOfType<TLArrowShape>(arrow, 'arrow'))
+		assert(editor.isShapeOfType(arrow, ArrowShapeUtil))
 		assert(arrow.props.end.type === 'binding')
 		expect(arrow.props.end.boundShapeId).toBe(ids.box3)
 	})

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -1,4 +1,5 @@
 import { StateNode, TLArrowShape, TLEventHandlers, createShapeId } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../ArrowShapeUtil'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -40,7 +41,7 @@ export class Pointing extends StateNode {
 			},
 		])
 
-		const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
+		const util = this.editor.getShapeUtil(ArrowShapeUtil)
 		const shape = this.editor.getShapeById<TLArrowShape>(id)
 		if (!shape) return
 
@@ -87,7 +88,7 @@ export class Pointing extends StateNode {
 			}
 
 			if (!this.didTimeout) {
-				const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
+				const util = this.editor.getShapeUtil(ArrowShapeUtil)
 				const shape = this.editor.getShapeById<TLArrowShape>(this.shape.id)
 
 				if (!shape) return

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -88,7 +88,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 				if (editingId && hoveredId !== editingId) {
 					const editingShape = this.editor.getShapeById(editingId)
-					if (editingShape && this.editor.isShapeOfType<TLEmbedShape>(editingShape, 'embed')) {
+					if (editingShape && this.editor.isShapeOfType(editingShape, EmbedShapeUtil)) {
 						return true
 					}
 				}

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -1,9 +1,9 @@
 import {
 	BaseBoxShapeUtil,
+	GroupShapeUtil,
 	SVGContainer,
 	SelectionEdge,
 	TLFrameShape,
-	TLGroupShape,
 	TLOnResizeEndHandler,
 	TLShape,
 	TLShapeId,
@@ -190,7 +190,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 
 	override onDragShapesOut = (_shape: TLFrameShape, shapes: TLShape[]): void => {
 		const parent = this.editor.getShapeById(_shape.parentId)
-		const isInGroup = parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')
+		const isInGroup = parent && this.editor.isShapeOfType(parent, GroupShapeUtil)
 
 		// If frame is in a group, keep the shape
 		// moved out in that group

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -1,4 +1,5 @@
-import { StateNode, TLEventHandlers, TLGeoShape } from '@tldraw/editor'
+import { StateNode, TLEventHandlers } from '@tldraw/editor'
+import { GeoShapeUtil } from '../GeoShapeUtil'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -14,7 +15,7 @@ export class Idle extends StateNode {
 	override onKeyUp: TLEventHandlers['onKeyUp'] = (info) => {
 		if (info.key === 'Enter') {
 			const shape = this.editor.onlySelectedShape
-			if (shape && this.editor.isShapeOfType<TLGeoShape>(shape, 'geo')) {
+			if (shape && this.editor.isShapeOfType(shape, GeoShapeUtil)) {
 				// todo: ensure that this only works with the most recently created shape, not just any geo shape that happens to be selected at the time
 				this.editor.mark('editing shape')
 				this.editor.setEditingId(shape.id)

--- a/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
@@ -1,5 +1,6 @@
-import { TLLineShape, assert } from '@tldraw/editor'
+import { assert } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
+import { LineShapeUtil } from './LineShapeUtil'
 
 let editor: TestEditor
 
@@ -127,7 +128,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 			.pointerUp(20, 10)
 
 		const line = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
+		assert(editor.isShapeOfType(line, LineShapeUtil))
 		const handles = Object.values(line.props.handles)
 		expect(handles.length).toBe(3)
 	})
@@ -144,7 +145,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 			.pointerUp(30, 10)
 
 		const line = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
+		assert(editor.isShapeOfType(line, LineShapeUtil))
 		const handles = Object.values(line.props.handles)
 		expect(handles.length).toBe(3)
 	})
@@ -162,7 +163,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 			.pointerUp(30, 10)
 
 		const line = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
+		assert(editor.isShapeOfType(line, LineShapeUtil))
 		const handles = Object.values(line.props.handles)
 		expect(handles.length).toBe(3)
 	})
@@ -182,7 +183,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 			.pointerUp(30, 10)
 
 		const line = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
+		assert(editor.isShapeOfType(line, LineShapeUtil))
 		const handles = Object.values(line.props.handles)
 		expect(handles.length).toBe(3)
 	})
@@ -204,7 +205,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 			.pointerUp(40, 10)
 
 		const line = editor.shapesArray[editor.shapesArray.length - 1]
-		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
+		assert(editor.isShapeOfType(line, LineShapeUtil))
 		const handles = Object.values(line.props.handles)
 		expect(handles.length).toBe(3)
 	})

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -1,4 +1,6 @@
-import { StateNode, TLEventHandlers, TLGeoShape, TLTextShape } from '@tldraw/editor'
+import { StateNode, TLEventHandlers } from '@tldraw/editor'
+import { GeoShapeUtil } from '../../geo/GeoShapeUtil'
+import { TextShapeUtil } from '../TextShapeUtil'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -16,7 +18,7 @@ export class Idle extends StateNode {
 					(parent) => !selectedIds.includes(parent.id)
 				)
 				if (hoveringShape.id !== focusLayerId) {
-					if (this.editor.isShapeOfType<TLTextShape>(hoveringShape, 'text')) {
+					if (this.editor.isShapeOfType(hoveringShape, TextShapeUtil)) {
 						this.editor.hoveredId = hoveringShape.id
 					}
 				}
@@ -38,7 +40,7 @@ export class Idle extends StateNode {
 		const { hoveredId } = this.editor
 		if (hoveredId) {
 			const shape = this.editor.getShapeById(hoveredId)!
-			if (this.editor.isShapeOfType<TLTextShape>(shape, 'text')) {
+			if (this.editor.isShapeOfType(shape, TextShapeUtil)) {
 				requestAnimationFrame(() => {
 					this.editor.setSelectedIds([shape.id])
 					this.editor.setEditingId(shape.id)
@@ -62,7 +64,7 @@ export class Idle extends StateNode {
 	override onKeyDown: TLEventHandlers['onKeyDown'] = (info) => {
 		if (info.key === 'Enter') {
 			const shape = this.editor.selectedShapes[0]
-			if (shape && this.editor.isShapeOfType<TLGeoShape>(shape, 'geo')) {
+			if (shape && this.editor.isShapeOfType(shape, GeoShapeUtil)) {
 				this.editor.setCurrentTool('select')
 				this.editor.setEditingId(shape.id)
 				this.editor.root.current.value!.transition('editing_shape', {

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
@@ -1,13 +1,13 @@
 import {
+	GroupShapeUtil,
 	StateNode,
 	TLEventHandlers,
-	TLFrameShape,
-	TLGroupShape,
 	TLPointerEventInfo,
 	TLScribble,
 	TLShapeId,
 	pointInPolygon,
 } from '@tldraw/editor'
+import { FrameShapeUtil } from '../../../shapes/frame/FrameShapeUtil'
 import { ScribbleManager } from '../../../shapes/shared/ScribbleManager'
 
 export class Erasing extends StateNode {
@@ -28,8 +28,8 @@ export class Erasing extends StateNode {
 				.filter(
 					(shape) =>
 						this.editor.isShapeOrAncestorLocked(shape) ||
-						((this.editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
-							this.editor.isShapeOfType<TLFrameShape>(shape, 'frame')) &&
+						((this.editor.isShapeOfType(shape, GroupShapeUtil) ||
+							this.editor.isShapeOfType(shape, FrameShapeUtil)) &&
 							this.editor.isPointInShape(originPagePoint, shape))
 				)
 				.map((shape) => shape.id)
@@ -102,7 +102,7 @@ export class Erasing extends StateNode {
 		const erasing = new Set<TLShapeId>(erasingIdsSet)
 
 		for (const shape of shapesArray) {
-			if (this.editor.isShapeOfType<TLGroupShape>(shape, 'group')) continue
+			if (this.editor.isShapeOfType(shape, GroupShapeUtil)) continue
 
 			// Avoid testing masked shapes, unless the pointer is inside the mask
 			const pageMask = this.editor.getPageMaskById(shape.id)

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
@@ -1,4 +1,5 @@
-import { StateNode, TLEventHandlers, TLFrameShape, TLGroupShape, TLShapeId } from '@tldraw/editor'
+import { GroupShapeUtil, StateNode, TLEventHandlers, TLShapeId } from '@tldraw/editor'
+import { FrameShapeUtil } from '../../../shapes/frame/FrameShapeUtil'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -13,16 +14,12 @@ export class Pointing extends StateNode {
 		for (const shape of [...this.editor.sortedShapesArray].reverse()) {
 			if (this.editor.isPointInShape(inputs.currentPagePoint, shape)) {
 				// Skip groups
-				if (this.editor.isShapeOfType<TLGroupShape>(shape, 'group')) continue
+				if (this.editor.isShapeOfType(shape, GroupShapeUtil)) continue
 
 				const hitShape = this.editor.getOutermostSelectableShape(shape)
 
 				// If we've hit a frame after hitting any other shape, stop here
-				if (
-					this.editor.isShapeOfType<TLFrameShape>(hitShape, 'frame') &&
-					erasing.size > initialSize
-				)
-					break
+				if (this.editor.isShapeOfType(hitShape, FrameShapeUtil) && erasing.size > initialSize) break
 
 				erasing.add(hitShape.id)
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Brushing.ts
@@ -1,12 +1,11 @@
 import {
 	Box2d,
+	GroupShapeUtil,
 	Matrix2d,
 	ShapeUtil,
 	StateNode,
 	TLCancelEvent,
 	TLEventHandlers,
-	TLFrameShape,
-	TLGroupShape,
 	TLInterruptEvent,
 	TLKeyboardEvent,
 	TLPageId,
@@ -18,6 +17,7 @@ import {
 	pointInPolygon,
 	polygonsIntersect,
 } from '@tldraw/editor'
+import { FrameShapeUtil } from '../../../shapes/frame/FrameShapeUtil'
 
 export class Brushing extends StateNode {
 	static override id = 'brushing'
@@ -43,7 +43,7 @@ export class Brushing extends StateNode {
 			this.editor.shapesArray
 				.filter(
 					(shape) =>
-						this.editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
+						this.editor.isShapeOfType(shape, GroupShapeUtil) ||
 						this.editor.isShapeOrAncestorLocked(shape)
 				)
 				.map((shape) => shape.id)
@@ -136,7 +136,7 @@ export class Brushing extends StateNode {
 			// Should we even test for a single segment intersections? Only if
 			// we're not holding the ctrl key for alternate selection mode
 			// (only wraps count!), or if the shape is a frame.
-			if (ctrlKey || this.editor.isShapeOfType<TLFrameShape>(shape, 'frame')) {
+			if (ctrlKey || this.editor.isShapeOfType(shape, FrameShapeUtil)) {
 				continue testAllShapes
 			}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Cropping.ts
@@ -11,6 +11,7 @@ import {
 	Vec2d,
 	deepCopy,
 } from '@tldraw/editor'
+import { ImageShapeUtil } from '../../../shapes/image/ImageShapeUtil'
 import { MIN_CROP_SIZE } from './Crop/crop-constants'
 import { CursorTypeMap } from './PointingResizeHandle'
 
@@ -80,7 +81,7 @@ export class Cropping extends StateNode {
 		const { shape, cursorHandleOffset } = this.snapshot
 
 		if (!shape) return
-		const util = this.editor.getShapeUtil<TLImageShape>('image')
+		const util = this.editor.getShapeUtil(ImageShapeUtil)
 		if (!util) return
 
 		const props = shape.props

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -1,9 +1,9 @@
 import {
+	GroupShapeUtil,
 	StateNode,
 	TLClickEventInfo,
 	TLEventHandlers,
 	TLGeoShape,
-	TLGroupShape,
 	TLKeyboardEventInfo,
 	TLPointerEventInfo,
 	TLShape,
@@ -326,9 +326,7 @@ export class Idle extends StateNode {
 				case 'Enter': {
 					const { selectedShapes } = this.editor
 
-					if (
-						selectedShapes.every((shape) => this.editor.isShapeOfType<TLGroupShape>(shape, 'group'))
-					) {
+					if (selectedShapes.every((shape) => this.editor.isShapeOfType(shape, GroupShapeUtil))) {
 						this.editor.setSelectedIds(
 							selectedShapes.flatMap((shape) => this.editor.getSortedChildIds(shape.id))
 						)

--- a/packages/tldraw/src/lib/tools/SelectTool/children/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/PointingShape.ts
@@ -1,7 +1,7 @@
 import {
+	GroupShapeUtil,
 	StateNode,
 	TLEventHandlers,
-	TLGroupShape,
 	TLPointerEventInfo,
 	TLShape,
 } from '@tldraw/editor'
@@ -43,7 +43,7 @@ export class PointingShape extends StateNode {
 
 			const parent = this.editor.getParentShape(info.shape)
 
-			if (parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')) {
+			if (parent && this.editor.isShapeOfType(parent, GroupShapeUtil)) {
 				this.editor.cancelDoubleClick()
 			}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
@@ -8,7 +8,6 @@ import {
 	TAU,
 	TLEnterEventHandler,
 	TLEventHandlers,
-	TLFrameShape,
 	TLPointerEventInfo,
 	TLShape,
 	TLShapeId,
@@ -17,6 +16,7 @@ import {
 	VecLike,
 	areAnglesCompatible,
 } from '@tldraw/editor'
+import { FrameShapeUtil } from '../../../shapes/frame/FrameShapeUtil'
 
 type ResizingInfo = TLPointerEventInfo & {
 	target: 'selection'
@@ -375,13 +375,12 @@ export class Resizing extends StateNode {
 			const shape = this.editor.getShapeById(id)
 			if (shape) {
 				shapeSnapshots.set(shape.id, this._createShapeSnapshot(shape))
-				if (this.editor.isShapeOfType<TLFrameShape>(shape, 'frame') && selectedIds.length === 1)
-					return
+				if (this.editor.isShapeOfType(shape, FrameShapeUtil) && selectedIds.length === 1) return
 				this.editor.visitDescendants(shape.id, (descendantId) => {
 					const descendent = this.editor.getShapeById(descendantId)
 					if (descendent) {
 						shapeSnapshots.set(descendent.id, this._createShapeSnapshot(descendent))
-						if (this.editor.isShapeOfType<TLFrameShape>(descendent, 'frame')) {
+						if (this.editor.isShapeOfType(descendent, FrameShapeUtil)) {
 							return false
 						}
 					}

--- a/packages/tldraw/src/lib/tools/SelectTool/children/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/ScribbleBrushing.ts
@@ -1,15 +1,15 @@
 import {
+	GroupShapeUtil,
 	ShapeUtil,
 	StateNode,
 	TLEventHandlers,
-	TLFrameShape,
-	TLGroupShape,
 	TLScribble,
 	TLShape,
 	TLShapeId,
 	intersectLineSegmentPolyline,
 	pointInPolygon,
 } from '@tldraw/editor'
+import { FrameShapeUtil } from '../../../shapes/frame/FrameShapeUtil'
 import { ScribbleManager } from '../../../shapes/shared/ScribbleManager'
 
 export class ScribbleBrushing extends StateNode {
@@ -111,9 +111,9 @@ export class ScribbleBrushing extends StateNode {
 			util = this.editor.getShapeUtil(shape)
 
 			if (
-				this.editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
+				this.editor.isShapeOfType(shape, GroupShapeUtil) ||
 				this.newlySelectedIds.has(shape.id) ||
-				(this.editor.isShapeOfType<TLFrameShape>(shape, 'frame') &&
+				(this.editor.isShapeOfType(shape, FrameShapeUtil) &&
 					util.hitTestPoint(shape, this.editor.getPointInShapeSpace(shape, originPagePoint))) ||
 				this.editor.isShapeOrAncestorLocked(shape)
 			) {

--- a/packages/tldraw/src/lib/ui/hooks/menuHelpers.ts
+++ b/packages/tldraw/src/lib/ui/hooks/menuHelpers.ts
@@ -1,11 +1,5 @@
-import {
-	Editor,
-	TLArrowShape,
-	assert,
-	exhaustiveSwitchError,
-	useEditor,
-	useValue,
-} from '@tldraw/editor'
+import { Editor, assert, exhaustiveSwitchError, useEditor, useValue } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../../shapes/arrow/ArrowShapeUtil'
 import { TLUiActionItem } from './useActions'
 import { TLUiToolItem } from './useTools'
 import { TLUiTranslationKey } from './useTranslation/TLUiTranslationKey'
@@ -144,13 +138,10 @@ function shapesWithUnboundArrows(editor: Editor) {
 
 	return selectedShapes.filter((shape) => {
 		if (!shape) return false
-		if (
-			editor.isShapeOfType<TLArrowShape>(shape, 'arrow') &&
-			shape.props.start.type === 'binding'
-		) {
+		if (editor.isShapeOfType(shape, ArrowShapeUtil) && shape.props.start.type === 'binding') {
 			return false
 		}
-		if (editor.isShapeOfType<TLArrowShape>(shape, 'arrow') && shape.props.end.type === 'binding') {
+		if (editor.isShapeOfType(shape, ArrowShapeUtil) && shape.props.end.type === 'binding') {
 			return false
 		}
 		return true

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -2,10 +2,9 @@ import {
 	ANIMATION_MEDIUM_MS,
 	Box2d,
 	Editor,
+	GroupShapeUtil,
 	TAU,
-	TLBookmarkShape,
 	TLEmbedShape,
-	TLGroupShape,
 	TLShapeId,
 	TLShapePartial,
 	TLTextShape,
@@ -17,6 +16,9 @@ import {
 	useEditor,
 } from '@tldraw/editor'
 import * as React from 'react'
+import { BookmarkShapeUtil } from '../../shapes/bookmark/BookmarkShapeUtil'
+import { EmbedShapeUtil } from '../../shapes/embed/EmbedShapeUtil'
+import { TextShapeUtil } from '../../shapes/text/TextShapeUtil'
 import { getEmbedInfo } from '../../utils/embeds'
 import { EditLinkDialog } from '../components/EditLinkDialog'
 import { EmbedDialog } from '../components/EmbedDialog'
@@ -215,7 +217,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						editor.selectedShapes
 							.filter(
 								(shape): shape is TLTextShape =>
-									editor.isShapeOfType<TLTextShape>(shape, 'text') && shape.props.autoSize === false
+									editor.isShapeOfType(shape, TextShapeUtil) && shape.props.autoSize === false
 							)
 							.map((shape) => {
 								return {
@@ -244,7 +246,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						return
 					}
 					const shape = editor.getShapeById(ids[0])
-					if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed')) {
+					if (!shape || !editor.isShapeOfType(shape, EmbedShapeUtil)) {
 						console.error(warnMsg)
 						return
 					}
@@ -279,8 +281,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const createList: TLShapePartial[] = []
 					const deleteList: TLShapeId[] = []
 					for (const shape of shapes) {
-						if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed') || !shape.props.url)
-							continue
+						if (!shape || !editor.isShapeOfType(shape, EmbedShapeUtil) || !shape.props.url) continue
 
 						const newPos = new Vec2d(shape.x, shape.y)
 						newPos.rot(-shape.rotation)
@@ -318,7 +319,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const createList: TLShapePartial[] = []
 					const deleteList: TLShapeId[] = []
 					for (const shape of shapes) {
-						if (!editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark')) continue
+						if (!editor.isShapeOfType(shape, BookmarkShapeUtil)) continue
 
 						const { url } = shape.props
 
@@ -401,7 +402,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect(source) {
 					trackEvent('group-shapes', { source })
 					const { onlySelectedShape } = editor
-					if (onlySelectedShape && editor.isShapeOfType<TLGroupShape>(onlySelectedShape, 'group')) {
+					if (onlySelectedShape && editor.isShapeOfType(onlySelectedShape, GroupShapeUtil)) {
 						editor.mark('ungroup')
 						editor.ungroupShapes(editor.selectedIds)
 					} else {

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -1,19 +1,11 @@
-import {
-	Editor,
-	TLArrowShape,
-	TLBookmarkShape,
-	TLContent,
-	TLEmbedShape,
-	TLGeoShape,
-	TLTextShape,
-	VecLike,
-	isNonNull,
-	uniq,
-	useEditor,
-	useValue,
-} from '@tldraw/editor'
+import { Editor, TLContent, VecLike, isNonNull, uniq, useEditor, useValue } from '@tldraw/editor'
 import { compressToBase64, decompressFromBase64 } from 'lz-string'
 import { useCallback, useEffect } from 'react'
+import { ArrowShapeUtil } from '../../shapes/arrow/ArrowShapeUtil'
+import { BookmarkShapeUtil } from '../../shapes/bookmark/BookmarkShapeUtil'
+import { EmbedShapeUtil } from '../../shapes/embed/EmbedShapeUtil'
+import { GeoShapeUtil } from '../../shapes/geo/GeoShapeUtil'
+import { TextShapeUtil } from '../../shapes/text/TextShapeUtil'
 import { pasteExcalidrawContent } from './clipboard/pasteExcalidrawContent'
 import { pasteFiles } from './clipboard/pasteFiles'
 import { pasteTldrawContent } from './clipboard/pasteTldrawContent'
@@ -537,15 +529,15 @@ const handleNativeOrMenuCopy = (editor: Editor) => {
 		const textItems = content.shapes
 			.map((shape) => {
 				if (
-					editor.isShapeOfType<TLTextShape>(shape, 'text') ||
-					editor.isShapeOfType<TLGeoShape>(shape, 'geo') ||
-					editor.isShapeOfType<TLArrowShape>(shape, 'arrow')
+					editor.isShapeOfType(shape, TextShapeUtil) ||
+					editor.isShapeOfType(shape, GeoShapeUtil) ||
+					editor.isShapeOfType(shape, ArrowShapeUtil)
 				) {
 					return shape.props.text
 				}
 				if (
-					editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark') ||
-					editor.isShapeOfType<TLEmbedShape>(shape, 'embed')
+					editor.isShapeOfType(shape, BookmarkShapeUtil) ||
+					editor.isShapeOfType(shape, EmbedShapeUtil)
 				) {
 					return shape.props.url
 				}

--- a/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
@@ -65,7 +65,7 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 	// 		if (editor.selectedIds.length !== 1) return false
 	// 		return editor.selectedIds.some((selectedId) => {
 	// 			const shape = editor.getShapeById(selectedId)
-	// 			return shape && editor.isShapeOfType<TLEmbedShape>(shape, 'embed') && shape.props.url
+	// 			return shape && editor.isShapeOfType(shape, EmbedShapeUtil) && shape.props.url
 	// 		})
 	// 	},
 	// 	[]
@@ -79,7 +79,7 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 	// 			const shape = editor.getShapeById(selectedId)
 	// 			return (
 	// 				shape &&
-	// 				editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark') &&
+	// 				editor.isShapeOfType(shape, BookmarkShapeUtil) &&
 	// 				shape.props.url &&
 	// 				getEmbedInfo(shape.props.url)
 	// 			)

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -1,5 +1,6 @@
-import { TLFrameShape, TLShapeId, useEditor } from '@tldraw/editor'
+import { TLShapeId, useEditor } from '@tldraw/editor'
 import { useCallback } from 'react'
+import { FrameShapeUtil } from '../../shapes/frame/FrameShapeUtil'
 import {
 	TLExportType,
 	downloadDataURLAsFile,
@@ -36,7 +37,7 @@ export function useExportAs() {
 
 			if (ids.length === 1) {
 				const first = editor.getShapeById(ids[0])!
-				if (editor.isShapeOfType<TLFrameShape>(first, 'frame')) {
+				if (editor.isShapeOfType(first, FrameShapeUtil)) {
 					name = first.props.name ?? 'frame'
 				} else {
 					name = first.id.replace(/:/, '_')

--- a/packages/tldraw/src/lib/ui/hooks/useOnlyFlippableShape.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useOnlyFlippableShape.ts
@@ -1,11 +1,7 @@
-import {
-	TLArrowShape,
-	TLDrawShape,
-	TLGroupShape,
-	TLLineShape,
-	useEditor,
-	useValue,
-} from '@tldraw/editor'
+import { GroupShapeUtil, useEditor, useValue } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../../shapes/arrow/ArrowShapeUtil'
+import { DrawShapeUtil } from '../../shapes/draw/DrawShapeUtil'
+import { LineShapeUtil } from '../../shapes/line/LineShapeUtil'
 
 export function useOnlyFlippableShape() {
 	const editor = useEditor()
@@ -17,10 +13,10 @@ export function useOnlyFlippableShape() {
 				selectedShapes.length === 1 &&
 				selectedShapes.every(
 					(shape) =>
-						editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
-						editor.isShapeOfType<TLArrowShape>(shape, 'arrow') ||
-						editor.isShapeOfType<TLLineShape>(shape, 'line') ||
-						editor.isShapeOfType<TLDrawShape>(shape, 'draw')
+						editor.isShapeOfType(shape, GroupShapeUtil) ||
+						editor.isShapeOfType(shape, ArrowShapeUtil) ||
+						editor.isShapeOfType(shape, LineShapeUtil) ||
+						editor.isShapeOfType(shape, DrawShapeUtil)
 				)
 			)
 		},

--- a/packages/tldraw/src/lib/ui/hooks/useShowAutoSizeToggle.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useShowAutoSizeToggle.ts
@@ -1,4 +1,5 @@
-import { TLTextShape, useEditor, useValue } from '@tldraw/editor'
+import { useEditor, useValue } from '@tldraw/editor'
+import { TextShapeUtil } from '../../shapes/text/TextShapeUtil'
 
 export function useShowAutoSizeToggle() {
 	const editor = useEditor()
@@ -8,7 +9,7 @@ export function useShowAutoSizeToggle() {
 			const { selectedShapes } = editor
 			return (
 				selectedShapes.length === 1 &&
-				editor.isShapeOfType<TLTextShape>(selectedShapes[0], 'text') &&
+				editor.isShapeOfType(selectedShapes[0], TextShapeUtil) &&
 				selectedShapes[0].props.autoSize === false
 			)
 		},

--- a/packages/tldraw/src/lib/useRegisterExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/useRegisterExternalContentHandlers.ts
@@ -16,6 +16,7 @@ import {
 } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { FONT_FAMILIES, FONT_SIZES, TEXT_PROPS } from './shapes/shared/default-shape-constants'
+import { TextShapeUtil } from './shapes/text/TextShapeUtil'
 import {
 	ACCEPTED_IMG_TYPE,
 	ACCEPTED_VID_TYPE,
@@ -225,7 +226,7 @@ export function useRegisterExternalContentHandlers() {
 				point ??
 				(editor.inputs.shiftKey ? editor.inputs.currentPagePoint : editor.viewportPageCenter)
 
-			const defaultProps = editor.getShapeUtil<TLTextShape>('text').getDefaultProps()
+			const defaultProps = editor.getShapeUtil(TextShapeUtil).getDefaultProps()
 
 			const textToPaste = cleanupText(text)
 

--- a/packages/tldraw/src/lib/utils/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/buildFromV1Document.ts
@@ -26,6 +26,7 @@ import {
 	clamp,
 	createShapeId,
 } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../shapes/arrow/ArrowShapeUtil'
 
 const TLDRAW_V1_VERSION = 15.5
 
@@ -518,7 +519,7 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 					}
 
 					const v2ShapeId = v1ShapeIdsToV2ShapeIds.get(v1Shape.id)!
-					const util = editor.getShapeUtil<TLArrowShape>('arrow')
+					const util = editor.getShapeUtil(ArrowShapeUtil)
 
 					// dumb but necessary
 					editor.inputs.ctrlKey = false

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -275,8 +275,6 @@ describe('Custom shapes', () => {
 	>
 
 	class CardUtil extends BaseBoxShapeUtil<CardShape> {
-		static override type = 'card' as const
-
 		override isAspectRatioLocked = (_shape: CardShape) => false
 		override canResize = (_shape: CardShape) => true
 		override canBind = (_shape: CardShape) => true

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -275,6 +275,7 @@ describe('Custom shapes', () => {
 	>
 
 	class CardUtil extends BaseBoxShapeUtil<CardShape> {
+		static override type = 'card' as const
 		override isAspectRatioLocked = (_shape: CardShape) => false
 		override canResize = (_shape: CardShape) => true
 		override canBind = (_shape: CardShape) => true

--- a/packages/tldraw/src/test/arrowBindingsIndex.test.tsx
+++ b/packages/tldraw/src/test/arrowBindingsIndex.test.tsx
@@ -1,4 +1,5 @@
-import { TLArrowShape, TLGeoShape, TLShapeId } from '@tldraw/editor'
+import { TLArrowShape, TLShapeId } from '@tldraw/editor'
+import { GeoShapeUtil } from '../lib/shapes/geo/GeoShapeUtil'
 import { TestEditor } from './TestEditor'
 import { TL } from './test-jsx'
 
@@ -184,7 +185,7 @@ describe('arrowBindingsIndex', () => {
 			editor.duplicateShapes()
 
 			const [box1Clone, box2Clone] = editor.selectedShapes
-				.filter((shape) => editor.isShapeOfType<TLGeoShape>(shape, 'geo'))
+				.filter((shape) => editor.isShapeOfType(shape, GeoShapeUtil))
 				.sort((a, b) => a.x - b.x)
 
 			expect(editor.getArrowsBoundTo(box2Clone.id)).toHaveLength(3)

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -1,4 +1,5 @@
 import { createShapeId, TLArrowShape, TLShapePartial } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../lib/shapes/arrow/ArrowShapeUtil'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -188,7 +189,7 @@ describe('When duplicating shapes that include arrows', () => {
 			.createShapes(shapes)
 			.select(
 				...editor.shapesArray
-					.filter((s) => editor.isShapeOfType<TLArrowShape>(s, 'arrow'))
+					.filter((s) => editor.isShapeOfType(s, ArrowShapeUtil))
 					.map((s) => s.id)
 			)
 

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1,4 +1,5 @@
-import { DefaultFillStyle, TLArrowShape, TLFrameShape, createShapeId } from '@tldraw/editor'
+import { DefaultFillStyle, TLArrowShape, createShapeId } from '@tldraw/editor'
+import { FrameShapeUtil } from '../lib/shapes/frame/FrameShapeUtil'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -32,7 +33,7 @@ describe('creating frames', () => {
 		editor.setCurrentTool('frame')
 		editor.pointerDown(100, 100).pointerUp(100, 100)
 		expect(editor.onlySelectedShape?.type).toBe('frame')
-		const { w, h } = editor.getShapeUtil<TLFrameShape>('frame').getDefaultProps()
+		const { w, h } = editor.getShapeUtil(FrameShapeUtil).getDefaultProps()
 		expect(editor.getPageBounds(editor.onlySelectedShape!)).toMatchObject({
 			x: 100 - w / 2,
 			y: 100 - h / 2,

--- a/packages/tldraw/src/test/groups.test.ts
+++ b/packages/tldraw/src/test/groups.test.ts
@@ -1,5 +1,6 @@
 import {
 	Box2d,
+	GroupShapeUtil,
 	TLArrowShape,
 	TLGroupShape,
 	TLLineShape,
@@ -1895,7 +1896,7 @@ describe('Group opacity', () => {
 		editor.setOpacity(0.5)
 		editor.groupShapes()
 		const group = editor.getShapeById(onlySelectedId())!
-		assert(editor.isShapeOfType<TLGroupShape>(group, 'group'))
+		assert(editor.isShapeOfType(group, GroupShapeUtil))
 		expect(group.opacity).toBe(1)
 	})
 })

--- a/packages/tldraw/src/test/groups.test.ts
+++ b/packages/tldraw/src/test/groups.test.ts
@@ -1,6 +1,5 @@
 import {
 	Box2d,
-	GroupShapeUtil,
 	TLArrowShape,
 	TLGroupShape,
 	TLLineShape,
@@ -117,7 +116,7 @@ describe('creating groups', () => {
 		expect(editor.getShapeById(ids.boxB)).toBeTruthy()
 
 		const group = onlySelectedShape()
-		expect(group.type).toBe(GroupShapeUtil.type)
+		expect(group.type).toBe('group')
 		expect(editor.getPageBoundsById(group.id)!).toCloselyMatchObject({ x: 0, y: 0, w: 30, h: 10 })
 		expect(children(group).has(editor.getShapeById(ids.boxA)!)).toBe(true)
 		expect(children(group).has(editor.getShapeById(ids.boxB)!)).toBe(true)
@@ -214,7 +213,7 @@ describe('creating groups', () => {
 		editor.groupShapes()
 
 		const uberGroup = onlySelectedShape()
-		expect(uberGroup.type).toBe(GroupShapeUtil.type)
+		expect(uberGroup.type).toBe('group')
 		expect(editor.getPageBoundsById(uberGroup.id)!).toCloselyMatchObject({
 			x: 0,
 			y: 0,
@@ -496,7 +495,7 @@ describe('ungrouping shapes', () => {
 
 		editor.ungroupShapes()
 		expect(editor.selectedIds.length).toBe(1)
-		expect(onlySelectedShape().type).toBe(GroupShapeUtil.type)
+		expect(onlySelectedShape().type).toBe('group')
 	})
 	it('keeps order correct simple', () => {
 		// 0   10  20  30  40  50  60  70

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -1,4 +1,6 @@
-import { createShapeId, TLFrameShape, TLGeoShape } from '@tldraw/editor'
+import { createShapeId } from '@tldraw/editor'
+import { FrameShapeUtil } from '../lib/shapes/frame/FrameShapeUtil'
+import { GeoShapeUtil } from '../lib/shapes/geo/GeoShapeUtil'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -54,7 +56,7 @@ beforeEach(() => {
 describe('When interacting with a shape...', () => {
 	it('fires rotate events', () => {
 		// Set start / change / end events on only the geo shape
-		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const util = editor.getShapeUtil(FrameShapeUtil)
 
 		const fnStart = jest.fn()
 		util.onRotateStart = fnStart
@@ -87,12 +89,12 @@ describe('When interacting with a shape...', () => {
 	})
 
 	it('cleans up events', () => {
-		const util = editor.getShapeUtil<TLGeoShape>('geo')
+		const util = editor.getShapeUtil(GeoShapeUtil)
 		expect(util.onRotateStart).toBeUndefined()
 	})
 
 	it('fires double click handler event', () => {
-		const util = editor.getShapeUtil<TLGeoShape>('geo')
+		const util = editor.getShapeUtil(GeoShapeUtil)
 
 		const fnStart = jest.fn()
 		util.onDoubleClick = fnStart
@@ -103,7 +105,7 @@ describe('When interacting with a shape...', () => {
 	})
 
 	it('Fires resisizing events', () => {
-		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const util = editor.getShapeUtil(FrameShapeUtil)
 
 		const fnStart = jest.fn()
 		util.onResizeStart = fnStart
@@ -140,7 +142,7 @@ describe('When interacting with a shape...', () => {
 	})
 
 	it('Fires translating events', () => {
-		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const util = editor.getShapeUtil(FrameShapeUtil)
 
 		const fnStart = jest.fn()
 		util.onTranslateStart = fnStart
@@ -168,7 +170,7 @@ describe('When interacting with a shape...', () => {
 	})
 
 	it('Uses the shape utils onClick handler', () => {
-		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const util = editor.getShapeUtil(FrameShapeUtil)
 
 		const fnClick = jest.fn()
 		util.onClick = fnClick
@@ -182,7 +184,7 @@ describe('When interacting with a shape...', () => {
 	})
 
 	it('Uses the shape utils onClick handler', () => {
-		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const util = editor.getShapeUtil(FrameShapeUtil)
 
 		const fnClick = jest.fn((shape: any) => {
 			return {

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2,12 +2,12 @@ import {
 	GapsSnapLine,
 	PointsSnapLine,
 	SnapLine,
-	TLArrowShape,
 	TLShapeId,
 	TLShapePartial,
 	Vec2d,
 	createShapeId,
 } from '@tldraw/editor'
+import { ArrowShapeUtil } from '../lib/shapes/arrow/ArrowShapeUtil'
 import { TestEditor } from './TestEditor'
 import { getSnapLines } from './getSnapLines'
 
@@ -1649,7 +1649,7 @@ describe('translating a shape with a bound shape', () => {
 		})
 
 		const newArrow = editor.shapesArray.find(
-			(s) => editor.isShapeOfType<TLArrowShape>(s, 'arrow') && s.id !== arrow1
+			(s) => editor.isShapeOfType(s, ArrowShapeUtil) && s.id !== arrow1
 		)
 		expect(newArrow).toMatchObject({
 			props: { start: { type: 'binding' }, end: { type: 'point' } },


### PR DESCRIPTION
This is a follow up to the shape extraction work started in #1693 & #1710. In those changes, we removed the type-inference versions of `getShapeUtil` and `isShapeOfType` because we needed to remove dependency on shape utils from the editor. Instead, we made users pass both a type and a value instead of only needing to pass a single value.

In this diff:

1. `getShapeUtil` and `isShapeOfType` get updated versions of their type-inference signatures restored. In my opinion, these APIs don't have any extra overhead for plain JS users (`getShapeUtil('arrow')` vs `getShapeUtil(ArrowShape)`) but are better for TS users because:
     - we don't force them to repeat themselves - e.g. `getShapeUtil(ArrowShapeUtil)` vs `getShapeUtil<TLArrowShape>('arrow')`
     - we return more accurate types - `ArrowShapeUtil` instead of `ShapeUtil<TLArrowShape>`. This is important as devs might define shape-specific helpers on utils.
     - we do the right thing first time. devs aren't likely to think to pass a generic at first, which means TS users will have to first encounter an error and then go back to fix it. we can avoid the friction with an API that doesn't need an explicit generic.
2. to reduce confusion, the string-typed versions of those APIs are marked as internal. We need to keep the string versions for internal use, but i find they muddle the public API a bit.

### Change Type


- [x] `major` — Breaking change


### Test Plan

- [x] Unit Tests
- [ ] End to end tests

### Release Notes

///
