### PR TITLE
remove state checks for brush and zoom brush

### DIFF
--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -149,7 +149,7 @@ const BrushWrapper = track(function BrushWrapper() {
 	const { brush } = editor
 	const { Brush } = useEditorComponents()
 
-	if (!(Brush && brush && editor.isIn('select.brushing'))) return null
+	if (!(Brush && brush)) return null
 
 	return <Brush className="tl-user-brush" brush={brush} />
 })
@@ -159,7 +159,7 @@ export const ZoomBrushWrapper = track(function Zoom() {
 	const { zoomBrush } = editor
 	const { ZoomBrush } = useEditorComponents()
 
-	if (!(ZoomBrush && zoomBrush && editor.isIn('zoom'))) return null
+	if (!(ZoomBrush && zoomBrush)) return null
 
 	return <ZoomBrush className="tl-user-brush" brush={zoomBrush} />
 })


### PR DESCRIPTION
This PR removes the strict state checks for the brush and zoom brush. We should consider making the canvas more controlled by what exists (e.g. whether a `brush` exists) rather than depending on particular statechart states.

### Change Type

- [x] `minor`

### Test Plan

1. Create a brush manually in the API.
2. The brush should be visible on the canvas.

### Release Notes

- [editor] remove `editor.isIn` state checks for displaying brush and zoom brush.
