### PR TITLE
Bump vs code version.

### DIFF
--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.11
+- Added cloud shape.
+
 ## 2.0.10
 - Removed the lock option from the highlighter tool.
 - Disabled the styles button for the laser tool on small screens.

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.10",
+	"version": "2.0.11",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
Bumps the VS Code version.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
