### PR TITLE
support custom shapes in yjs example

### DIFF
--- a/apps/examples/src/yjs/useYjsStore.ts
+++ b/apps/examples/src/yjs/useYjsStore.ts
@@ -7,6 +7,7 @@ import {
 	TLInstancePresence,
 	TLPageId,
 	TLRecord,
+	TLShapeInfo,
 	TLStoreWithStatus,
 	createPresenceStateDerivation,
 	createTLStore,
@@ -20,8 +21,14 @@ import * as Y from 'yjs'
 export function useYjsStore({
 	roomId = 'example',
 	hostUrl = process.env.NODE_ENV === 'development' ? 'ws://localhost:1234' : 'wss://demos.yjs.dev',
-}: Partial<{ hostUrl: string; roomId: string; version: number }>) {
-	const [store] = useState(() => createTLStore({ shapes: defaultShapes }))
+	shapes = [],
+}: Partial<{
+	hostUrl: string
+	roomId: string
+	version: number
+	shapes?: TLShapeInfo[]
+}>) {
+	const [store] = useState(() => createTLStore({ shapes: [...defaultShapes, ...shapes] }))
 	const [storeWithStatus, setStoreWithStatus] = useState<TLStoreWithStatus>({ status: 'loading' })
 
 	const { doc, room, yRecords } = useMemo(() => {


### PR DESCRIPTION
This PR adds support for custom shapes (`shapes`) to the y.js example. A user should pass the same data to the `useYjsStore` hook as they pass to the `<Tldraw>` component.

### Change Type

- [x] `internal`
