### PR TITLE
[fix]: Fix typo in shapeType declaration

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.ts
@@ -7,5 +7,5 @@ export class ArrowShapeTool extends StateNode {
 	static override initial = 'idle'
 	static override children = () => [Idle, Pointing]
 
-	overrideshapeType = 'arrow'
+	override shapeType = 'arrow'
 }


### PR DESCRIPTION
Fix minor typo error in shapeType declaration

**Change Type**

- [x] `patch`

**Test Plan**

- [x]  Unit Tests
- [ ]  End to end tests

**Release Notes**

Fix typo