### PR TITLE
Fix asset urls

### DIFF
--- a/packages/tldraw/src/lib/utils/assetUrls.ts
+++ b/packages/tldraw/src/lib/utils/assetUrls.ts
@@ -1,5 +1,6 @@
 import { RecursivePartial } from '@tldraw/editor'
-import { useMemo, version } from 'react'
+import { useMemo } from 'react'
+import { version } from '../ui/version'
 
 /** @public */
 export type TLEditorAssetUrls = {


### PR DESCRIPTION
<img width="1372" alt="image" src="https://github.com/tldraw/tldraw/assets/7578559/5d5f29fa-a3d7-488b-a4fe-25673d94134e">

This should be tldraw version instead of react version, the typo happened here: https://github.com/tldraw/tldraw/commit/b7d9c8684cb6cf7bd710af5420135ea3516cc3bf#diff-feb0a5bdada68de6bf60ae3fd8b83915d234dc78f56cae91f33e5c209ad3bf0a.


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Fixed asset urls
