### PR TITLE
Initial `EditorExtension` API

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+env:
+  CI: 1
+  TLDRAW_RELEASE_CHANNEL: alpha
+
 jobs:
   deploy:
     name: 'Publish Canary Packages'

--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -25,6 +25,7 @@ import ExamplesTldrawLogo from './ExamplesTldrawLogo'
 import { ListLink } from './components/ListLink'
 import EndToEnd from './end-to-end/end-to-end'
 import OnlyEditorExample from './only-editor/OnlyEditor'
+import ExtensionsExample from './wip-extensions/ExtensionsExample'
 import YjsExample from './yjs/YjsExample'
 
 // This example is only used for end to end tests
@@ -141,6 +142,10 @@ export const allExamples: Example[] = [
 	{
 		path: '/end-to-end',
 		element: <EndToEnd />,
+	},
+	{
+		path: '/wip-extensions',
+		element: <ExtensionsExample />,
 	},
 ]
 

--- a/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeExtension.ts
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeExtension.ts
@@ -1,0 +1,13 @@
+import { EditorExtension } from '@tldraw/tldraw'
+import { CardShapeTool } from './CardShapeTool'
+import { CardShapeUtil } from './CardShapeUtil'
+
+export const CardShapeExtension = EditorExtension.create({
+	name: '@my-app/card-shape',
+	addShapes() {
+		return [CardShapeUtil]
+	},
+	addTools() {
+		return [CardShapeTool]
+	},
+})

--- a/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeTool.tsx
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeTool.tsx
@@ -1,0 +1,14 @@
+import { BaseBoxShapeTool, TLClickEvent } from '@tldraw/tldraw'
+
+// A tool used to create our custom card shapes. Extending the base
+// box shape tool gives us a lot of functionality for free.
+export class CardShapeTool extends BaseBoxShapeTool {
+	static override id = 'card'
+	static override initial = 'idle'
+	override shapeType = 'card'
+
+	override onDoubleClick: TLClickEvent = (_info) => {
+		// you can handle events in handlers like this one;
+		// check the BaseBoxShapeTool source as an example
+	}
+}

--- a/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeUtil.tsx
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/CardShapeUtil.tsx
@@ -1,0 +1,89 @@
+import {
+	Box2d,
+	HTMLContainer,
+	ShapeUtil,
+	TLOnResizeHandler,
+	getDefaultColorTheme,
+	resizeBox,
+} from '@tldraw/tldraw'
+import { useState } from 'react'
+import { cardShapeMigrations } from './card-shape-migrations'
+import { cardShapeProps } from './card-shape-props'
+import { ICardShape } from './card-shape-types'
+
+// A utility class for the card shape. This is where you define
+// the shape's behavior, how it renders (its component and
+// indicator), and how it handles different events.
+
+export class CardShapeUtil extends ShapeUtil<ICardShape> {
+	static override type = 'card' as const
+	// A validation schema for the shape's props (optional)
+	static override props = cardShapeProps
+	// Migrations for upgrading shapes (optional)
+	static override migrations = cardShapeMigrations
+
+	// Flags
+	override isAspectRatioLocked = (_shape: ICardShape) => false
+	override canResize = (_shape: ICardShape) => true
+	override canBind = (_shape: ICardShape) => true
+
+	getDefaultProps(): ICardShape['props'] {
+		return {
+			w: 300,
+			h: 300,
+			color: 'black',
+			weight: 'regular',
+		}
+	}
+
+	getBounds(shape: ICardShape) {
+		return new Box2d(0, 0, shape.props.w, shape.props.h)
+	}
+
+	// Render method — the React component that will be rendered for the shape
+	component(shape: ICardShape) {
+		const bounds = this.editor.getBounds(shape)
+		const theme = getDefaultColorTheme({ isDarkMode: this.editor.user.isDarkMode })
+
+		// Unfortunately eslint will think this is a class components
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [count, setCount] = useState(0)
+
+		return (
+			<HTMLContainer
+				id={shape.id}
+				style={{
+					border: '1px solid black',
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					justifyContent: 'center',
+					pointerEvents: 'all',
+					backgroundColor: theme[shape.props.color].semi,
+					fontWeight: shape.props.weight,
+					color: theme[shape.props.color].solid,
+				}}
+			>
+				<h2>Clicks: {count}</h2>
+				<button
+					onClick={() => setCount((count) => count + 1)}
+					// You need to stop the pointer down event on buttons
+					// that should prevent shape selection or click and drag
+					onPointerDown={(e) => e.stopPropagation()}
+				>
+					{bounds.w.toFixed()}x{bounds.h.toFixed()}
+				</button>
+			</HTMLContainer>
+		)
+	}
+
+	// Indicator — used when hovering over a shape or when it's selected; must return only SVG elements here
+	indicator(shape: ICardShape) {
+		return <rect width={shape.props.w} height={shape.props.h} />
+	}
+
+	// Events
+	override onResize: TLOnResizeHandler<ICardShape> = (shape, info) => {
+		return resizeBox(shape, info)
+	}
+}

--- a/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-migrations.ts
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-migrations.ts
@@ -1,0 +1,21 @@
+import { defineMigrations } from '@tldraw/tldraw'
+
+// Migrations for the custom card shape (optional but very helpful)
+export const cardShapeMigrations = defineMigrations({
+	currentVersion: 1,
+	migrators: {
+		1: {
+			// for example, removing a property from the shape
+			up(shape) {
+				const migratedUpShape = { ...shape }
+				delete migratedUpShape._somePropertyToRemove
+				return migratedUpShape
+			},
+			down(shape) {
+				const migratedDownShape = { ...shape }
+				migratedDownShape._somePropertyToRemove = 'some value'
+				return migratedDownShape
+			},
+		},
+	},
+})

--- a/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-props.ts
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-props.ts
@@ -1,0 +1,15 @@
+import { DefaultColorStyle, ShapeProps, StyleProp, T } from '@tldraw/tldraw'
+import { ICardShape } from './card-shape-types'
+
+export const WeightStyle = StyleProp.defineEnum('myApp:weight', {
+	defaultValue: 'regular',
+	values: ['regular', 'bold'],
+})
+
+// Validation for our custom card shape's props, using our custom style + one of tldraw's default styles
+export const cardShapeProps: ShapeProps<ICardShape> = {
+	w: T.number,
+	h: T.number,
+	color: DefaultColorStyle,
+	weight: WeightStyle,
+}

--- a/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-types.ts
+++ b/apps/examples/src/wip-extensions/CardShapeExtension/card-shape-types.ts
@@ -1,0 +1,15 @@
+import { TLBaseShape, TLDefaultColorStyle } from '@tldraw/tldraw'
+
+// We'll have a custom style called weight
+export type IWeightStyle = 'regular' | 'bold'
+
+// A type for our custom card shape
+export type ICardShape = TLBaseShape<
+	'card',
+	{
+		w: number
+		h: number
+		color: TLDefaultColorStyle
+		weight: IWeightStyle
+	}
+>

--- a/apps/examples/src/wip-extensions/ExtensionsExample.tsx
+++ b/apps/examples/src/wip-extensions/ExtensionsExample.tsx
@@ -1,0 +1,18 @@
+import { Tldraw } from '@tldraw/tldraw'
+import '@tldraw/tldraw/tldraw.css'
+import { CardShapeExtension } from './CardShapeExtension/CardShapeExtension'
+import { uiOverrides } from './ui-overrides'
+
+export default function ExtensionsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				autoFocus
+				extensions={[CardShapeExtension]}
+				// Pass in any overrides to the user interface
+				// TODO: bundle this in with the extension?
+				overrides={uiOverrides}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/wip-extensions/ui-overrides.ts
+++ b/apps/examples/src/wip-extensions/ui-overrides.ts
@@ -1,0 +1,33 @@
+import { TLUiMenuGroup, TLUiOverrides, menuItem, toolbarItem } from '@tldraw/tldraw'
+
+// In order to see select our custom shape tool, we need to add it to the ui.
+
+export const uiOverrides: TLUiOverrides = {
+	tools(editor, tools) {
+		// Create a tool item in the ui's context.
+		tools.card = {
+			id: 'card',
+			icon: 'color',
+			label: 'Card' as any,
+			kbd: 'c',
+			readonlyOk: false,
+			onSelect: () => {
+				editor.setCurrentTool('card')
+			},
+		}
+		return tools
+	},
+	toolbar(_app, toolbar, { tools }) {
+		// Add the tool item from the context to the toolbar.
+		toolbar.splice(4, 0, toolbarItem(tools.card))
+		return toolbar
+	},
+	keyboardShortcutsMenu(_app, keyboardShortcutsMenu, { tools }) {
+		// Add the tool item from the context to the keyboard shortcuts dialog.
+		const toolsGroup = keyboardShortcutsMenu.find(
+			(group) => group.id === 'shortcuts-dialog.tools'
+		) as TLUiMenuGroup
+		toolsGroup.children.push(menuItem(tools.card))
+		return keyboardShortcutsMenu
+	},
+}

--- a/config/api-extractor.json
+++ b/config/api-extractor.json
@@ -247,7 +247,7 @@
 		 * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
 		 * DEFAULT VALUE: ""
 		 */
-		// "alphaTrimmedFilePath": "0.0.0",
+		"alphaTrimmedFilePath": "<projectFolder>/packages/<unscopedPackageName>/api/alpha.d.ts",
 		/**
 		 * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.
 		 * This file will include only declarations that are marked as "@public" or "@beta".

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -91,7 +91,7 @@ export function generateSharedScripts(bublic: '<rootDir>' | '<rootDir>/bublic') 
 			baseCommand: `tsx ${bublic}/scripts/api-check.ts`,
 			runsAfter: { 'build-api': {} },
 			cache: {
-				inputs: [`${bublic}/packages/*/api/public.d.ts`],
+				inputs: [`${bublic}/packages/*/api/{public,alpha}.d.ts`],
 			},
 		},
 	} satisfies LazyConfig['scripts']

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -73,6 +73,7 @@ export {
 	type TLUserPreferences,
 } from './lib/config/TLUserPreferences'
 export {
+	createTLSchemaFromExtensions,
 	createTLStore,
 	type TLStoreEventInfo,
 	type TLStoreOptions,
@@ -100,6 +101,12 @@ export {
 	ZOOMS,
 } from './lib/constants'
 export { Editor, type TLAnimationOptions, type TLEditorOptions } from './lib/editor/Editor'
+export {
+	EditorExtension,
+	EditorExtensionInstance,
+	type EditorExtensionConfig,
+} from './lib/editor/extensions/EditorExtension'
+export { EditorExtensionManager } from './lib/editor/extensions/ExtensionManager'
 export {
 	SnapManager,
 	type GapsSnapLine,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -17,7 +17,9 @@ import { DefaultErrorFallback } from './components/default-components/DefaultErr
 import { TLUser, createTLUser } from './config/createTLUser'
 import { TLAnyShapeUtilConstructor } from './config/defaultShapes'
 import { Editor } from './editor/Editor'
+import { EditorExtension } from './editor/extensions/EditorExtension'
 import { TLStateNodeConstructor } from './editor/tools/StateNode'
+import { useArrayShallowEquality } from './hooks/useArrayShallowEquality'
 import { ContainerProvider, useContainer } from './hooks/useContainer'
 import { useCursor } from './hooks/useCursor'
 import { useDarkMode } from './hooks/useDarkMode'
@@ -98,6 +100,12 @@ export interface TldrawEditorBaseProps {
 	 * A classname to pass to the editor's container.
 	 */
 	className?: string
+
+	/**
+	 * Extensions to the editor
+	 * @alpha
+	 */
+	extensions?: readonly EditorExtension<any>[]
 }
 
 /**
@@ -141,6 +149,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 		...rest,
 		shapeUtils: rest.shapeUtils ?? EMPTY_SHAPE_UTILS_ARRAY,
 		tools: rest.tools ?? EMPTY_TOOLS_ARRAY,
+		extensions: useArrayShallowEquality(rest.extensions ?? []),
 	}
 
 	return (
@@ -178,12 +187,17 @@ export const TldrawEditor = memo(function TldrawEditor({
 })
 
 function TldrawEditorWithOwnStore(
-	props: Required<TldrawEditorProps & { store: undefined; user: TLUser }, 'shapeUtils' | 'tools'>
+	props: Required<
+		TldrawEditorProps & { store: undefined; user: TLUser },
+		'shapeUtils' | 'tools' | 'extensions'
+	>
 ) {
-	const { defaultName, initialData, shapeUtils, persistenceKey, sessionId, user } = props
+	const { defaultName, initialData, shapeUtils, extensions, persistenceKey, sessionId, user } =
+		props
 
 	const syncedStore = useLocalStore({
 		shapeUtils,
+		extensions,
 		initialData,
 		persistenceKey,
 		sessionId,
@@ -240,6 +254,7 @@ function TldrawEditorWithReadyStore({
 	store,
 	tools,
 	shapeUtils,
+	extensions,
 	autoFocus,
 	user,
 	initialState,
@@ -259,6 +274,7 @@ function TldrawEditorWithReadyStore({
 			store,
 			shapeUtils,
 			tools,
+			extensions,
 			getContainer: () => container,
 			user,
 			initialState,
@@ -270,7 +286,7 @@ function TldrawEditorWithReadyStore({
 		return () => {
 			editor.dispose()
 		}
-	}, [container, shapeUtils, tools, store, user, initialState])
+	}, [container, shapeUtils, tools, store, user, initialState, extensions])
 
 	React.useLayoutEffect(() => {
 		if (editor && autoFocus) {

--- a/packages/editor/src/lib/config/defaultShapes.ts
+++ b/packages/editor/src/lib/config/defaultShapes.ts
@@ -12,7 +12,7 @@ export const coreShapes = [
 
 const coreShapeTypes = new Set<string>(coreShapes.map((s) => s.type))
 
-export function checkShapesAndAddCore(customShapes: readonly TLAnyShapeUtilConstructor[]) {
+export function checkShapesAndAddCore(customShapes: Iterable<TLAnyShapeUtilConstructor>) {
 	const shapes = [...coreShapes] as TLAnyShapeUtilConstructor[]
 
 	const addedCustomShapeTypes = new Set<string>()

--- a/packages/editor/src/lib/editor/extensions/EditorExtension.tsx
+++ b/packages/editor/src/lib/editor/extensions/EditorExtension.tsx
@@ -1,0 +1,92 @@
+import { TLAnyShapeUtilConstructor } from '../../config/defaultShapes'
+import { Editor } from '../Editor'
+import { TLStateNodeConstructor } from '../tools/StateNode'
+
+/** @alpha */
+export interface EditorExtensionConfig<Options> {
+	readonly name: string
+	addOptions?(this: EditorExtensionInstance<never>): Options
+	addShapes?(this: EditorExtensionInstance<Options>): readonly TLAnyShapeUtilConstructor[]
+	addTools?(this: EditorExtensionInstance<Options>): readonly TLStateNodeConstructor[]
+}
+
+/** @alpha */
+export class EditorExtension<Options> {
+	/**
+	 * Create a new extension.
+	 *
+	 * @example
+	 * ```ts
+	 * const myExtension = EditorExtension.create({
+	 *   name: "my-extension",
+	 *   addOptions() {
+	 * 	   return {
+	 *       kind: "banner",
+	 *     }
+	 *   },
+	 * })
+	 *```
+
+	 * @param config - The extension's configuration
+	 *
+	 * @public
+	 */
+	static create<Options = undefined>(
+		config: EditorExtensionConfig<Options>
+	): EditorExtension<Options> {
+		return new EditorExtension(config, null)
+	}
+
+	private constructor(
+		public readonly config: EditorExtensionConfig<Options>,
+		readonly parent: EditorExtensionConfig<Options> | null
+	) {}
+
+	get name() {
+		return this.config.name
+	}
+
+	configure(options: Options | ((defaults: Options) => Options)) {
+		const baseConfig = this.config
+		return new EditorExtension(
+			{
+				...baseConfig,
+				addOptions() {
+					if (typeof options === 'function') {
+						const baseOptions = baseConfig.addOptions?.call(this) as Options
+						return (options as (defaults: Options) => Options)(baseOptions)
+					}
+					return options
+				},
+			},
+			this
+		)
+	}
+}
+
+/** @alpha */
+export class EditorExtensionInstance<Options> {
+	readonly name: string
+	readonly config: EditorExtensionConfig<Options>
+	readonly options: Options
+
+	constructor(editor: Editor | null, readonly extension: EditorExtension<Options>) {
+		this.name = extension.name
+		this.config = extension.config
+		this.options = this.config.addOptions?.call(this as any) ?? (null as Options)
+
+		if (this.config.addShapes) this.addShapes = this.config.addShapes.bind(this)
+		if (this.config.addTools) this.addTools = this.config.addTools.bind(this)
+	}
+
+	private readonly _editor: Editor | null = null
+	get editor() {
+		if (!this._editor) {
+			throw new Error('Extension is not attached to an editor')
+		}
+		return this._editor
+	}
+
+	addShapes?: () => readonly TLAnyShapeUtilConstructor[]
+	addTools?: () => readonly TLStateNodeConstructor[]
+}

--- a/packages/editor/src/lib/editor/extensions/ExtensionManager.tsx
+++ b/packages/editor/src/lib/editor/extensions/ExtensionManager.tsx
@@ -1,0 +1,59 @@
+import { assertExists } from '@tldraw/utils'
+import { TLAnyShapeUtilConstructor } from '../../config/defaultShapes'
+import { KeyedSet, ReadonlyKeyedSet } from '../../utils/KeyedSet'
+import { Editor } from '../Editor'
+import { TLStateNodeConstructor } from '../tools/StateNode'
+import { EditorExtension, EditorExtensionInstance } from './EditorExtension'
+
+/** @alpha */
+export class EditorExtensionManager {
+	private readonly extensionInstances: ReadonlyMap<string, EditorExtensionInstance<any>>
+	private readonly extensions: ReadonlyKeyedSet<'name', EditorExtension<any>>
+
+	readonly shapes: ReadonlyKeyedSet<'name', TLAnyShapeUtilConstructor>
+	readonly tools: ReadonlyKeyedSet<'name', TLStateNodeConstructor>
+
+	constructor(editor: Editor | null, extensions: readonly EditorExtension<any>[]) {
+		const extensionInstancesByName = new Map<string, EditorExtensionInstance<any>>()
+
+		this.extensions = new KeyedSet('name', 'EditorExtension', extensions)
+
+		const shapes = new KeyedSet<'name', TLAnyShapeUtilConstructor>('name', 'ShapeUtil')
+		const tools = new KeyedSet<'name', TLStateNodeConstructor>('name', 'Tool')
+
+		for (const extension of this.extensions) {
+			const instance = new EditorExtensionInstance(editor, extension)
+			extensionInstancesByName.set(instance.name, instance)
+
+			if (instance.addShapes) shapes.addAll(instance.addShapes())
+			if (instance.addTools) tools.addAll(instance.addTools())
+		}
+
+		this.extensionInstances = extensionInstancesByName
+		this.shapes = shapes
+		this.tools = tools
+	}
+
+	/**
+	 * Get an extension instance
+	 *
+	 * @example
+	 * ```ts
+	 * editor.get(ChartExtension)
+	 * ```
+	 *
+	 * @returns The extension with the given name.
+	 * @public
+	 */
+	get<Options>(ext: EditorExtension<Options>): EditorExtensionInstance<Options> {
+		const instance = assertExists(
+			this.extensionInstances.get(ext.config.name),
+			`Extension "${ext.config.name}" not found`
+		)
+		return instance as any
+	}
+
+	[Symbol.iterator]() {
+		return this.extensionInstances.values()
+	}
+}

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -138,7 +138,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	 *
 	 * @public
 	 */
-	_currentToolIdMask = atom('curent tool id mask', undefined as string | undefined)
+	_currentToolIdMask = atom('current tool id mask', undefined as string | undefined)
 
 	@computed get currentToolIdMask() {
 		return this._currentToolIdMask.value

--- a/packages/editor/src/lib/hooks/useArrayShallowEquality.ts
+++ b/packages/editor/src/lib/hooks/useArrayShallowEquality.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export function useArrayShallowEquality<T>(array: ReadonlyArray<T>): ReadonlyArray<T> {
+	const [current, setCurrent] = useState(array)
+	if (current === array) {
+		return current
+	}
+	if (current.length !== array.length) {
+		setCurrent(array)
+		return array
+	}
+	for (let i = 0; i < current.length; i++) {
+		if (!Object.is(current[i], array[i])) {
+			setCurrent(array)
+			return array
+		}
+	}
+	return current
+}

--- a/packages/editor/src/lib/test/ExtensionManager.test.ts
+++ b/packages/editor/src/lib/test/ExtensionManager.test.ts
@@ -1,0 +1,125 @@
+import { expectType, noop } from '@tldraw/utils'
+import { createTLStore } from '../config/createTLStore'
+import { Editor, TLEditorOptions } from '../editor/Editor'
+import { EditorExtension, EditorExtensionInstance } from '../editor/extensions/EditorExtension'
+
+function makeEditor(opts: Partial<TLEditorOptions>) {
+	return new Editor({
+		...opts,
+		getContainer: () => ({ addEventListener: noop } as any),
+		store: opts.store ?? createTLStore({ shapeUtils: [], extensions: [] }),
+		shapeUtils: opts.shapeUtils ?? [],
+		tools: opts.tools ?? [],
+	})
+}
+
+describe('ExtensionManager', () => {
+	it('throws if two extensions have the same name', () => {
+		const extension1 = EditorExtension.create({ name: 'test' })
+		const extension2 = EditorExtension.create({ name: 'test' })
+
+		expect(() =>
+			makeEditor({ extensions: [extension1, extension2] })
+		).toThrowErrorMatchingInlineSnapshot(
+			`"Cannot have two EditorExtensions with the name \\"test\\""`
+		)
+	})
+
+	it('allows the same extension to be specified twice', () => {
+		const extension = EditorExtension.create({ name: 'test' })
+
+		const editor = makeEditor({ extensions: [extension, extension] })
+		expect(Array.from(editor.extensions, (ext) => ext.name)).toStrictEqual(['__core__', 'test'])
+	})
+
+	it('only initializes duplicated extensions once', () => {
+		const extension = EditorExtension.create({
+			name: 'test',
+			addOptions: jest.fn(() => null),
+		})
+
+		makeEditor({ extensions: [extension, extension] })
+		expect(extension.config.addOptions).toHaveBeenCalledTimes(1)
+	})
+
+	it('allows retrieving extensions', () => {
+		const extension = EditorExtension.create({ name: 'test' })
+
+		const editor = makeEditor({ extensions: [extension] })
+		const instance = editor.extensions.get(extension)
+		expect(instance).toBeInstanceOf(EditorExtensionInstance)
+		expect(instance.name).toBe('test')
+		expectType<EditorExtensionInstance<undefined>>(instance)
+	})
+
+	it('throws when trying to retrieve an extension that doesnt exist', () => {
+		const extension = EditorExtension.create({ name: 'test' })
+		const editor = makeEditor({ extensions: [] })
+		expect(() => editor.extensions.get(extension)).toThrowErrorMatchingInlineSnapshot(
+			`"Extension \\"test\\" not found"`
+		)
+	})
+
+	it('initializes options on the extension', () => {
+		const extension = EditorExtension.create({
+			name: 'test',
+			addOptions() {
+				expect(this).toBeInstanceOf(EditorExtensionInstance)
+				expectType<EditorExtensionInstance<never>>(this)
+				expect(this.options).toEqual(undefined)
+				return 'here are my options' as const
+			},
+		})
+
+		const editor = makeEditor({ extensions: [extension] })
+		const instance = editor.extensions.get(extension)
+		expect(instance.options).toEqual('here are my options')
+		expectType<EditorExtensionInstance<'here are my options'>>(instance)
+	})
+
+	it('allows overriding options with `configure`', () => {
+		const addOptions = jest.fn(() => ({
+			a: 1,
+			b: 2,
+		}))
+		const extension = EditorExtension.create({
+			name: 'test',
+			addOptions,
+		})
+
+		const editor1 = makeEditor({ extensions: [extension] })
+		const instance1 = editor1.extensions.get(extension)
+		expect(instance1.options).toEqual({ a: 1, b: 2 })
+		expect(addOptions).toHaveBeenCalledTimes(1)
+		expect((addOptions as any).mock.contexts[0]).toBe(instance1)
+
+		const editor2 = makeEditor({ extensions: [extension.configure({ a: 2, b: 3 })] })
+		const instance2 = editor2.extensions.get(extension)
+		expect(instance2.options).toEqual({ a: 2, b: 3 })
+		expect(addOptions).toHaveBeenCalledTimes(1)
+
+		const editor3 = makeEditor({
+			extensions: [extension.configure((opts) => ({ ...opts, a: 1000 }))],
+		})
+		const instance3 = editor3.extensions.get(extension)
+		expect(instance3.options).toEqual({ a: 1000, b: 2 })
+		expect(addOptions).toHaveBeenCalledTimes(2)
+		expect((addOptions as any).mock.contexts[1]).toBe(instance3)
+	})
+
+	it('gets a configured extension either by the configured version or by the original', () => {
+		const extension1 = EditorExtension.create({
+			name: 'test',
+			addOptions: () => 1,
+		})
+		const extension2 = extension1.configure(() => 2)
+		const extension3 = extension2.configure(() => 3)
+
+		const editor = makeEditor({ extensions: [extension3] })
+		const instance = editor.extensions.get(extension3)
+		expect(instance.options).toEqual(3)
+
+		expect(editor.extensions.get(extension2)).toStrictEqual(instance)
+		expect(editor.extensions.get(extension1)).toStrictEqual(instance)
+	})
+})

--- a/packages/editor/src/lib/test/currentToolIdMask.test.ts
+++ b/packages/editor/src/lib/test/currentToolIdMask.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 		initialState: 'A',
 		shapeUtils: [],
 		tools: [A, B, C],
-		store: createTLStore({ shapeUtils: [] }),
+		store: createTLStore({ shapeUtils: [], extensions: [] }),
 		getContainer: () => document.body,
 	})
 })

--- a/packages/editor/src/lib/test/user.test.ts
+++ b/packages/editor/src/lib/test/user.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
 	editor = new Editor({
 		shapeUtils: [],
 		tools: [],
-		store: createTLStore({ shapeUtils: [] }),
+		store: createTLStore({ shapeUtils: [], extensions: [] }),
 		getContainer: () => document.body,
 	})
 })

--- a/packages/editor/src/lib/utils/KeyedSet.tsx
+++ b/packages/editor/src/lib/utils/KeyedSet.tsx
@@ -1,0 +1,58 @@
+export class KeyedSet<Key extends string, Value extends { readonly [K in Key]: string }> {
+	protected readonly map = new Map<string, Value>()
+
+	constructor(
+		protected readonly key: Key,
+		protected readonly valueTypeForErrorMessages: string,
+		values?: Iterable<Value>
+	) {
+		if (values) this.addAll(values)
+	}
+
+	add(value: Value) {
+		const key = value[this.key]
+		if (this.map.has(key)) {
+			if (this.map.get(key) !== value) {
+				throw Error(
+					`Cannot have two ${this.valueTypeForErrorMessages}s with the ${this.key} "${key}"`
+				)
+			}
+			return
+		}
+		this.map.set(key, value)
+	}
+
+	addAll(values: Iterable<Value>) {
+		for (const value of values) this.add(value)
+	}
+
+	getByKey(key: string) {
+		return this.map.get(key)
+	}
+
+	getByValue(value: Value) {
+		return this.map.get(value[this.key])
+	}
+
+	asObject(): Record<string, Value> {
+		return Object.fromEntries(this.map.entries())
+	}
+
+	assertHas(value: Value) {
+		if (!this.map.has(value[this.key])) {
+			throw Error(`${this.valueTypeForErrorMessages} "${value[this.key]}" not found`)
+		}
+		if (this.map.get(value[this.key]) !== value) {
+			throw Error(`${this.valueTypeForErrorMessages} "${value[this.key]}" not found`)
+		}
+	}
+
+	[Symbol.iterator]() {
+		return this.map.values()
+	}
+}
+
+export type ReadonlyKeyedSet<
+	Key extends string,
+	Value extends { readonly [K in Key]: string }
+> = Omit<KeyedSet<Key, Value>, 'add' | 'addAll'>

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -24,7 +24,7 @@ class BroadcastChannelMock {
 }
 
 function testClient(channel = new BroadcastChannelMock('test')) {
-	const store = createTLStore({ shapeUtils: [] })
+	const store = createTLStore({ shapeUtils: [], extensions: [] })
 	const onLoad = jest.fn(() => {
 		return
 	})

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -61,7 +61,10 @@ export class TestEditor extends Editor {
 			...options,
 			shapeUtils: [...shapeUtilsWithDefaults],
 			tools: [...defaultTools, ...defaultShapeTools, ...(options.tools ?? [])],
-			store: createTLStore({ shapeUtils: [...shapeUtilsWithDefaults] }),
+			store: createTLStore({
+				shapeUtils: [...shapeUtilsWithDefaults],
+				extensions: options.extensions ?? [],
+			}),
 			getContainer: () => elm,
 			initialState: 'select',
 		})

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -87,7 +87,7 @@ describe('<TldrawEditor />', () => {
 	})
 
 	it('Renders with an external store', async () => {
-		const store = createTLStore({ shapeUtils: [] })
+		const store = createTLStore({ shapeUtils: [], extensions: [] })
 		render(
 			<TldrawEditor
 				store={store}
@@ -146,7 +146,7 @@ describe('<TldrawEditor />', () => {
 	})
 
 	it('Accepts fresh versions of store and calls `onMount` for each one', async () => {
-		const initialStore = createTLStore({ shapeUtils: [] })
+		const initialStore = createTLStore({ shapeUtils: [], extensions: [] })
 		const onMount = jest.fn()
 		const rendered = render(
 			<TldrawEditor
@@ -179,7 +179,7 @@ describe('<TldrawEditor />', () => {
 		// not called again:
 		expect(onMount).toHaveBeenCalledTimes(1)
 		// re-render with a new store:
-		const newStore = createTLStore({ shapeUtils: [] })
+		const newStore = createTLStore({ shapeUtils: [], extensions: [] })
 		rendered.rerender(
 			<TldrawEditor
 				tools={defaultTools}

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -42,6 +42,9 @@ export type Expand<T> = T extends infer O ? {
     [K in keyof O]: O[K];
 } : never;
 
+// @internal (undocumented)
+export function expectType<T>(value: T): T;
+
 // @public
 export class FileHelpers {
     // @internal (undocumented)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -31,6 +31,6 @@ export {
 export { PngHelpers } from './lib/png'
 export { rafThrottle, throttledRaf } from './lib/raf'
 export { sortById } from './lib/sort'
-export type { Expand, RecursivePartial, Required } from './lib/types'
+export { expectType, type Expand, type RecursivePartial, type Required } from './lib/types'
 export { isValidUrl } from './lib/url'
 export { isDefined, isNonNull, isNonNullish, structuredClone } from './lib/value'

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -10,3 +10,8 @@ type _Required<T> = { [K in keyof T]-?: T[K] }
 
 /** @internal */
 export type Required<T, K extends keyof T> = Expand<Omit<T, K> & _Required<Pick<T, K>>>
+
+/** @internal */
+export function expectType<T>(value: T) {
+	return value
+}


### PR DESCRIPTION
This diff adds a very minimal version of the `EditorExtension` API from our tldraw micro spike. It currently only supports adding shapes and tools, and is only available in canary releases.

My plan here is that we can expand & refine this API over time with:
- event handlers
- a reworked `EditorTool` API that doesn't require tools to be our state charts
- the storage API
- UI overrides
- canvas layers
- etc

Some of this we can do soon, and other bits might take a bit longer, but none of it should be super hard.

As part of this, I've set up the `@alpha` tag. This tag works similarly to `@internal` and `@public` but where `@internal` strips the types entirely, things marked as `@alpha` will only be stripped from the main builds - they're still available in canaries. This is really necessary right now whilst we're in alpha, but once we leave alpha I want us to have a way to iterate on APIs and get feedback from the community before we commit to them.

### Change Type

- [x] `minor` — New feature


### Test Plan

- [x] Unit Tests
- [ ] End to end tests

### Release Notes
Currently un-released/undocumented API changes
