### PR TITLE
rename selection page bounds

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -909,10 +909,10 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     select(...shapes: TLShape[]): this;
     selectAll(): this;
-    get selectedPageBounds(): Box2d | null;
     get selectedShapeIds(): TLShapeId[];
     get selectedShapes(): TLShape[];
     get selectionBounds(): Box2d | undefined;
+    get selectionPageBounds(): Box2d | null;
     get selectionPageCenter(): null | Vec2d;
     get selectionRotation(): number;
     selectNone(): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1583,7 +1583,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	@computed get selectedPageBounds(): Box2d | null {
+	@computed get selectionPageBounds(): Box2d | null {
 		const {
 			currentPageState: { selectedShapeIds },
 		} = this
@@ -1631,7 +1631,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const { selectionRotation } = this
 		if (selectionRotation === 0) {
-			return this.selectedPageBounds!
+			return this.selectionPageBounds!
 		}
 
 		if (selectedShapeIds.length === 1) {
@@ -2064,7 +2064,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	zoomToContent() {
-		const bounds = this.selectedPageBounds ?? this.commonBoundsOfAllShapesOnCurrentPage
+		const bounds = this.selectionPageBounds ?? this.commonBoundsOfAllShapesOnCurrentPage
 
 		if (bounds) {
 			this.zoomToBounds(
@@ -5262,9 +5262,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// If we've offset the duplicated shapes, check to see whether their new bounds is entirely
 				// contained in the current viewport. If not, then animate the camera to be centered on the
 				// new shapes.
-				const { viewportPageBounds, selectedPageBounds } = this
-				if (selectedPageBounds && !viewportPageBounds.contains(selectedPageBounds)) {
-					this.centerOnPoint(selectedPageBounds.center.x, selectedPageBounds.center.y, {
+				const { viewportPageBounds, selectionPageBounds: selectionPageBounds } = this
+				if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {
+					this.centerOnPoint(selectionPageBounds.center.x, selectionPageBounds.center.y, {
 						duration: ANIMATION_MEDIUM_MS,
 					})
 				}

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -143,7 +143,7 @@ describe('When translating the arrow', () => {
 
 	it('retains all handles if either bound shape is also translating', () => {
 		editor.select(ids.arrow1, ids.box2)
-		expect(editor.selectedPageBounds).toMatchObject({
+		expect(editor.selectionPageBounds).toMatchObject({
 			x: 200,
 			y: 200,
 			w: 200,

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
@@ -410,7 +410,7 @@ export class Resizing extends StateNode {
 			selectionRotation,
 			selectedShapeIds,
 			canShapesDeform,
-			initialSelectionPageBounds: this.editor.selectedPageBounds!,
+			initialSelectionPageBounds: this.editor.selectionPageBounds!,
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Translating.ts
@@ -309,12 +309,12 @@ function getTranslatingSnapshot(editor: Editor) {
 		averagePagePoint: Vec2d.Average(pagePoints),
 		movingShapes,
 		shapeSnapshots,
-		initialPageBounds: editor.selectedPageBounds!,
+		initialPageBounds: editor.selectionPageBounds!,
 		initialSnapPoints:
 			editor.selectedShapeIds.length === 1
 				? editor.snaps.snapPointsCache.get(editor.selectedShapeIds[0])!
-				: editor.selectedPageBounds
-				? editor.selectedPageBounds.snapPoints.map((p, i) => ({
+				: editor.selectionPageBounds
+				? editor.selectionPageBounds.snapPoints.map((p, i) => ({
 						id: 'selection:' + i,
 						x: p.x,
 						y: p.y,

--- a/packages/tldraw/src/lib/useRegisterExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/useRegisterExternalContentHandlers.ts
@@ -409,10 +409,10 @@ export async function createShapesForAssets(editor: Editor, assets: TLAsset[], p
 
 		// Re-position shapes so that the center of the group is at the provided point
 		const { viewportPageBounds } = editor
-		let { selectedPageBounds } = editor
+		let { selectionPageBounds } = editor
 
-		if (selectedPageBounds) {
-			const offset = selectedPageBounds!.center.sub(position)
+		if (selectionPageBounds) {
+			const offset = selectionPageBounds!.center.sub(position)
 
 			editor.updateShapes(
 				paritals.map((partial) => {
@@ -427,8 +427,8 @@ export async function createShapesForAssets(editor: Editor, assets: TLAsset[], p
 		}
 
 		// Zoom out to fit the shapes, if necessary
-		selectedPageBounds = editor.selectedPageBounds
-		if (selectedPageBounds && !viewportPageBounds.contains(selectedPageBounds)) {
+		selectionPageBounds = editor.selectionPageBounds
+		if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {
 			editor.zoomToSelection()
 		}
 	})

--- a/packages/tldraw/src/test/commands/moveShapesToPage.test.ts
+++ b/packages/tldraw/src/test/commands/moveShapesToPage.test.ts
@@ -241,7 +241,7 @@ describe('arrows', () => {
 		editor.setCurrentTool('arrow').pointerDown(250, 250).pointerMove(450, 450).pointerUp(450, 450)
 
 		editor.moveShapesToPage([ids.box1, ids.box2], ids.page2)
-		const { selectedPageBounds } = editor
-		expect(editor.viewportPageCenter).toMatchObject(selectedPageBounds!.center)
+		const { selectionPageBounds } = editor
+		expect(editor.viewportPageCenter).toMatchObject(selectionPageBounds!.center)
 	})
 })

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -73,14 +73,14 @@ describe('When a shape is selected...', () => {
 		editor.setSelectedShapeIds([ids.boxA])
 
 		editor.keyDown('ArrowUp')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 9 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 9 })
 		editor.keyUp('ArrowUp')
 
 		editor.undo()
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 10 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 10 })
 
 		editor.redo()
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 9 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 9 })
 	})
 
 	it('nudges and holds', () => {
@@ -93,34 +93,34 @@ describe('When a shape is selected...', () => {
 		editor.keyRepeat('ArrowUp')
 		editor.keyUp('ArrowUp')
 
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 5 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 5 })
 
 		// Undoing should go back to the keydown state, all those
 		// repeats should be ephemeral and squashed down
 		editor.undo()
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 10 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 10 })
 
 		editor.redo()
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 5 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 5 })
 	})
 
 	it('nudges a shape correctly', () => {
 		editor.setSelectedShapeIds([ids.boxA])
 
 		editor.keyDown('ArrowUp')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 9 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 9 })
 		editor.keyUp('ArrowUp')
 
 		editor.keyDown('ArrowRight')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 11, y: 9 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 11, y: 9 })
 		editor.keyUp('ArrowRight')
 
 		editor.keyDown('ArrowDown')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 11, y: 10 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 11, y: 10 })
 		editor.keyUp('ArrowDown')
 
 		editor.keyDown('ArrowLeft')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 10 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 10 })
 		editor.keyUp('ArrowLeft')
 	})
 })
@@ -141,13 +141,13 @@ describe('When a shape is rotated...', () => {
 
 		// Here's the selection page bounds and shape before we nudge it
 		editor.setSelectedShapeIds([ids.boxA])
-		expect(editor.selectedPageBounds).toCloselyMatchObject({ x: 10, y: 10, w: 100, h: 100 })
+		expect(editor.selectionPageBounds).toCloselyMatchObject({ x: 10, y: 10, w: 100, h: 100 })
 		expect(editor.getShape(ids.boxA)).toCloselyMatchObject({ x: 10, y: -10 })
 
 		// Select box A and move it up. The page bounds should move up, but the
 		// shape should move left (since its parent is rotated 90 degrees)
 		editor.keyDown('ArrowUp')
-		expect(editor.selectedPageBounds).toMatchObject({ x: 10, y: 9, w: 100, h: 100 })
+		expect(editor.selectionPageBounds).toMatchObject({ x: 10, y: 9, w: 100, h: 100 })
 		expect(editor.getShape(ids.boxA)).toMatchObject({ x: 9, y: -10 })
 		editor.keyUp('ArrowUp')
 	})

--- a/packages/tldraw/src/test/flipShapes.test.ts
+++ b/packages/tldraw/src/test/flipShapes.test.ts
@@ -104,11 +104,11 @@ describe('When flipping horizontally', () => {
 	it('Flips rotated shapes', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
-		const a = editor.selectedPageBounds
+		const a = editor.selectionPageBounds
 		editor.mark('flipped')
 		editor.flipShapes(editor.selectedShapeIds, 'horizontal')
 
-		const b = editor.selectedPageBounds
+		const b = editor.selectionPageBounds
 		expect(a!).toCloselyMatchObject(b!)
 
 		editor.expectShapeToMatch(
@@ -129,11 +129,11 @@ describe('When flipping horizontally', () => {
 		editor.reparentShapes([ids.boxB], ids.boxA)
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
-		const a = editor.selectedPageBounds
+		const a = editor.selectionPageBounds
 		editor.mark('flipped')
 		editor.flipShapes(editor.selectedShapeIds, 'horizontal')
 
-		const b = editor.selectedPageBounds
+		const b = editor.selectionPageBounds
 		expect(a).toCloselyMatchObject(b!)
 	})
 })
@@ -184,11 +184,11 @@ describe('When flipping vertically', () => {
 	it('Flips rotated shapes', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
-		const a = editor.selectedPageBounds
+		const a = editor.selectionPageBounds
 		editor.mark('flipped')
 		editor.flipShapes(editor.selectedShapeIds, 'vertical')
 
-		const b = editor.selectedPageBounds
+		const b = editor.selectionPageBounds
 		expect(a).toCloselyMatchObject(b!)
 		editor.expectShapeToMatch(
 			{
@@ -208,27 +208,27 @@ describe('When flipping vertically', () => {
 		editor.reparentShapes([ids.boxB], ids.boxA)
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
-		const a = editor.selectedPageBounds
+		const a = editor.selectionPageBounds
 		editor.mark('flipped')
 		editor.flipShapes(editor.selectedShapeIds, 'vertical')
 
-		const b = editor.selectedPageBounds
+		const b = editor.selectionPageBounds
 		expect(a).toCloselyMatchObject(b!)
 	})
 })
 
 it('Preserves the selection bounds.', () => {
 	editor.selectAll()
-	const a = editor.selectedPageBounds
+	const a = editor.selectionPageBounds
 	editor.mark('flipped')
 	editor.flipShapes(editor.selectedShapeIds, 'horizontal')
 
-	const b = editor.selectedPageBounds
+	const b = editor.selectionPageBounds
 	expect(a).toMatchObject(b!)
 	editor.mark('flipped')
 	editor.flipShapes(editor.selectedShapeIds, 'vertical')
 
-	const c = editor.selectedPageBounds
+	const c = editor.selectionPageBounds
 	expect(a).toMatchObject(c!)
 })
 

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -243,9 +243,9 @@ describe('When resizing a rotated shape...', () => {
 		const initialPagePoint = editor.getPageTransform(ids.boxA)!.point()
 
 		const pt0 = Vec2d.From(initialPagePoint)
-		const pt1 = Vec2d.RotWith(initialPagePoint, editor.selectedPageBounds!.center, rotation)
+		const pt1 = Vec2d.RotWith(initialPagePoint, editor.selectionPageBounds!.center, rotation)
 		const pt2 = Vec2d.Sub(initialPagePoint, offset).rotWith(
-			editor.selectedPageBounds!.center!,
+			editor.selectionPageBounds!.center!,
 			rotation
 		)
 
@@ -345,7 +345,7 @@ describe('When resizing mulitple shapes...', () => {
 
 			// Now drag to resize the selection bounds
 
-			const initialBounds = editor.selectedPageBounds!
+			const initialBounds = editor.selectionPageBounds!
 
 			// oddly rotated shapes maintain aspect ratio when being resized (for now)
 			const aspectRatio = initialBounds.width / initialBounds.height
@@ -368,9 +368,9 @@ describe('When resizing mulitple shapes...', () => {
 				.pointerMove(resizeEnd.x, resizeEnd.y)
 				.pointerUp()
 
-			expect(editor.selectedPageBounds!.point).toCloselyMatchObject(resizeEnd)
+			expect(editor.selectionPageBounds!.point).toCloselyMatchObject(resizeEnd)
 			expect(new Vec2d(initialBounds.maxX, initialBounds.maxY)).toCloselyMatchObject(
-				new Vec2d(editor.selectedPageBounds!.maxX, editor.selectedPageBounds!.maxY)
+				new Vec2d(editor.selectionPageBounds!.maxX, editor.selectionPageBounds!.maxY)
 			)
 		}
 	)
@@ -418,7 +418,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		editor.pointerDown(30, 30, { target: 'selection', handle: 'bottom_right' })
 		editor.pointerMove(15, 15)
 
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 10, y: 10, w: 5, h: 5 })
 
@@ -442,7 +442,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//  └──────────────────────────────────────────────────────────────────O
 
 		editor.pointerMove(60, 30)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 60, h: 30 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 60, h: 30 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 20, h: 10 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 40, y: 20, w: 20, h: 10 })
 		// stretch vertically
@@ -477,7 +477,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		// 60    │                    └──────────┘ │
 		//       └─────────────────────────────────O
 		editor.pointerMove(30, 60)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 30, h: 60 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 30, h: 60 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 10, h: 20 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 20, y: 40, w: 10, h: 20 })
 
@@ -494,7 +494,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//   │         └───┘ │
 		//   └───────────────┘
 		editor.pointerMove(-15, -15)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: -5, y: -5, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: -15, y: -15, w: 5, h: 5 })
 
@@ -518,7 +518,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//     └───────────────────────────────────O
 		editor.pointerMove(45, 45, { altKey: true })
 
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({
 			w: 60,
 			h: 60,
 			x: -15,
@@ -543,7 +543,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		editor.pointerMove(15, 8, { altKey: false, shiftKey: true })
 		jest.advanceTimersByTime(200)
 
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 10, y: 10, w: 5, h: 5 })
 
@@ -566,7 +566,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//     │                      └──────────┘ │
 		//     └───────────────────────────────────O
 		editor.pointerMove(45, 16, { altKey: true, shiftKey: true })
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({
 			w: 60,
 			h: 60,
 			x: -15,
@@ -617,7 +617,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 10, y: 10, w: 5, h: 5 })
 
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 
 		// strech horizontally
 
@@ -639,7 +639,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//  └──────────────────────────────────────────────────────────────────O
 
 		editor.pointerMove(60, 30)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 60, h: 30 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 60, h: 30 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 20, h: 10 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 40, y: 20, w: 20, h: 10 })
 		// stretch vertically
@@ -674,7 +674,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		// 60    │                    └──────────┘ │
 		//       └─────────────────────────────────O
 		editor.pointerMove(30, 60)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 30, h: 60 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 30, h: 60 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 10, h: 20 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 20, y: 40, w: 10, h: 20 })
 
@@ -691,7 +691,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//   │         └───┘ │
 		//   └───────────────┘
 		editor.pointerMove(-15, -15)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: -5, y: -5, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: -15, y: -15, w: 5, h: 5 })
 
@@ -714,7 +714,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//     │                      └──────────┘ │
 		//     └───────────────────────────────────O
 		editor.pointerMove(45, 45, { altKey: true })
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({
 			w: 60,
 			h: 60,
 			x: -15,
@@ -739,7 +739,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		editor.pointerMove(15, 8, { altKey: false, shiftKey: true })
 		jest.advanceTimersByTime(200)
 
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 15, h: 15 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
 		expect(roundedPageBounds(ids.boxB)).toMatchObject({ x: 10, y: 10, w: 5, h: 5 })
 
@@ -762,7 +762,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		//     │                      └──────────┘ │
 		//     └───────────────────────────────────O
 		editor.pointerMove(45, 16, { altKey: true, shiftKey: true })
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({
 			w: 60,
 			h: 60,
 			x: -15,
@@ -798,7 +798,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		editor.select(ids.boxA, ids.boxB)
 		editor.pointerDown(30, 30, { target: 'selection', handle: 'bottom_right' })
 		editor.pointerMove(60, 30)
-		expect(roundedBox(editor.selectedPageBounds!)).toMatchObject({ w: 60, h: 30 })
+		expect(roundedBox(editor.selectionPageBounds!)).toMatchObject({ w: 60, h: 30 })
 		// A should stretch
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 20, h: 10 })
 		// B should not

--- a/packages/tldraw/src/test/rotating.test.ts
+++ b/packages/tldraw/src/test/rotating.test.ts
@@ -119,7 +119,7 @@ describe('When rotating...', () => {
 		editor.select(ids.box1)
 
 		const shapeA = editor.getShape(ids.box1)!
-		const box = editor.selectedPageBounds!
+		const box = editor.selectionPageBounds!
 		const center = box.center.clone().toFixed()
 
 		expect(Vec2d.ToFixed(editor.getPageCenter(shapeA)!)).toMatchObject(center)
@@ -159,7 +159,7 @@ describe('When rotating...', () => {
 
 		editor.select(ids.box1, ids.box2)
 
-		const box = editor.selectedPageBounds!
+		const box = editor.selectionPageBounds!
 		const center = box.center.clone()
 
 		editor.pointerDown(box.midX, box.minY, {
@@ -219,7 +219,7 @@ describe('When rotating...', () => {
 	it('restores initial points / rotation when cancelled', () => {
 		editor.select(ids.box1, ids.box2)
 
-		const box = editor.selectedPageBounds!
+		const box = editor.selectionPageBounds!
 		const center = box.center.clone()
 
 		const shapeA = editor.getShape(ids.box1)!
@@ -246,7 +246,7 @@ describe('When rotating...', () => {
 	it('uses the same selection box center when rotating multiple times', () => {
 		editor.select(ids.box1, ids.box2)
 
-		const centerBefore = editor.selectedPageBounds!.center.clone()
+		const centerBefore = editor.selectionPageBounds!.center.clone()
 
 		editor
 			.pointerDown(0, 0, {
@@ -256,7 +256,7 @@ describe('When rotating...', () => {
 			.pointerMove(50, 100)
 			.pointerUp()
 
-		const centerBetween = editor.selectedPageBounds!.center.clone()
+		const centerBetween = editor.selectionPageBounds!.center.clone()
 
 		expect(centerBefore.toFixed().toJson()).toMatchObject(centerBetween.toFixed().toJson())
 
@@ -268,7 +268,7 @@ describe('When rotating...', () => {
 			.pointerMove(0, 0)
 			.pointerUp()
 
-		const centerAfter = editor.selectedPageBounds!.center.clone()
+		const centerAfter = editor.selectionPageBounds!.center.clone()
 
 		expect(centerBefore.toFixed().toJson()).toMatchObject(centerAfter.toFixed().toJson())
 	})


### PR DESCRIPTION
This PR renames `selectedPageBounds` to `selectionPageBounds`.

### Change Type

- [x] `major` — Breaking change


### Release Notes

- [editor] rename `selectedPageBounds` to `selectionPageBounds`