### PR TITLE
[fix] restore bg option, fix calculations

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1736,6 +1736,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     getOutlineSegments(shape: Shape): Vec2d[][];
     hideResizeHandles: TLShapeUtilFlag<Shape>;
     hideRotateHandle: TLShapeUtilFlag<Shape>;
+    hideSelectionBoundsBg: TLShapeUtilFlag<Shape>;
     hideSelectionBoundsFg: TLShapeUtilFlag<Shape>;
     abstract indicator(shape: Shape): any;
     isAspectRatioLocked: TLShapeUtilFlag<Shape>;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -150,6 +150,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	hideRotateHandle: TLShapeUtilFlag<Shape> = () => false
 
 	/**
+	 * Whether the shape should hide its selection bounds background when selected.
+	 *
+	 * @public
+	 */
+	hideSelectionBoundsBg: TLShapeUtilFlag<Shape> = () => false
+
+	/**
 	 * Whether the shape should hide its selection bounds foreground when selected.
 	 *
 	 * @public

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -99,13 +99,10 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 				onlyShape &&
 				editor.isShapeOfType<TLTextShape>(onlyShape, 'text'))
 
-		if (
-			onlyShape &&
-			editor.isShapeOfType<TLEmbedShape>(onlyShape, 'embed') &&
-			shouldDisplayBox &&
-			IS_FIREFOX
-		) {
-			shouldDisplayBox = false
+		if (onlyShape && shouldDisplayBox) {
+			if (IS_FIREFOX && editor.isShapeOfType<TLEmbedShape>(onlyShape, 'embed')) {
+				shouldDisplayBox = false
+			}
 		}
 
 		const showCropHandles =

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -64,6 +64,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	override canSnap = () => true
 	override hideResizeHandles: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideRotateHandle: TLShapeUtilFlag<TLArrowShape> = () => true
+	override hideSelectionBoundsBg: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideSelectionBoundsFg: TLShapeUtilFlag<TLArrowShape> = () => true
 
 	override getDefaultProps(): TLArrowShape['props'] {

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -69,7 +69,11 @@ export function selectOnCanvasPointerUp(editor: Editor) {
 		} else {
 			// Otherwise, we clear the selction because the user selected
 			// nothing instead of their current selection.
-			editor.selectNone()
+
+			if (selectedShapeIds.length > 0) {
+				editor.mark('selecting none')
+				editor.selectNone()
+			}
 
 			// If the click was inside of the current focused group, then
 			// we keep that focused group; otherwise we clear the focused

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -195,6 +195,74 @@ describe('when shape is hollow', () => {
 		editor.pointerUp()
 		expect(editor.selectedShapeIds).toEqual([])
 	})
+
+	it('drags draw shape child', () => {
+		editor
+			.selectAll()
+			.deleteShapes(editor.selectedShapeIds)
+			.setCurrentTool('draw')
+			.pointerMove(500, 500)
+			.pointerDown()
+			.pointerMove(501, 501)
+			.pointerMove(550, 550)
+			.pointerMove(599, 599)
+			.pointerMove(600, 600)
+			.pointerUp()
+			.selectAll()
+			.setCurrentTool('select')
+
+		expect(editor.selectedShapeIds.length).toBe(1)
+
+		// Not inside of the shape but inside of the selection bounds
+		editor.pointerMove(510, 590)
+		expect(editor.hoveredShapeId).toBe(null)
+
+		// Draw shapes have `hideSelectionBoundsBg` set to false
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_selection')
+		editor.pointerUp()
+
+		editor.selectAll()
+		editor.rotateSelection(Math.PI)
+		editor.setCurrentTool('select')
+		editor.pointerMove(590, 510)
+
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_selection')
+		editor.pointerUp()
+	})
+
+	it('does not drag arrow shape', () => {
+		editor
+			.selectAll()
+			.deleteShapes(editor.selectedShapeIds)
+			.setCurrentTool('arrow')
+			.pointerMove(500, 500)
+			.pointerDown()
+			.pointerMove(600, 600)
+			.pointerUp()
+			.selectAll()
+			.setCurrentTool('select')
+
+		expect(editor.selectedShapeIds.length).toBe(1)
+
+		// Not inside of the shape but inside of the selection bounds
+		editor.pointerMove(510, 590)
+		expect(editor.hoveredShapeId).toBe(null)
+
+		// Arrow shapes have `hideSelectionBoundsBg` set to true
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_canvas')
+
+		editor.selectAll()
+		editor.rotateSelection(Math.PI)
+		editor.setCurrentTool('select')
+		editor.pointerMove(590, 510)
+
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_canvas')
+		editor.pointerUp()
+	})
 })
 
 describe('when shape is a frame', () => {


### PR DESCRIPTION
This PR fixes a bug introduced with #1751 where pointing the bounds of rotated selections would not correctly hit the bounds background.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a rotated selection.
2. Point into the bounds background

- [x] Unit Tests
