### PR TITLE
remove `selectionPageCenter`

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -541,13 +541,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): this;
     animateToShape(shapeId: TLShapeId, opts?: TLAnimationOptions): this;
     animateToUser(userId: string): void;
-    // @internal (undocumented)
-    annotateError(error: unknown, { origin, willCrashApp, tags, extras, }: {
-        origin: string;
-        willCrashApp: boolean;
-        tags?: Record<string, boolean | number | string>;
-        extras?: Record<string, unknown>;
-    }): void;
     get assets(): (TLBookmarkAsset | TLImageAsset | TLVideoAsset)[];
     bail(): this;
     bailToMark(id: string): this;
@@ -578,19 +571,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal
     get crashingError(): unknown;
     createAssets(assets: TLAsset[]): this;
-    // @internal (undocumented)
-    createErrorAnnotations(origin: string, willCrashApp: 'unknown' | boolean): {
-        tags: {
-            origin: string;
-            willCrashApp: 'unknown' | boolean;
-        };
-        extras: {
-            activeStateNode?: string;
-            selectedShapes?: TLUnknownShape[];
-            editingShape?: TLUnknownShape;
-            inputs?: Record<string, unknown>;
-        };
-    };
     createPage(title: string, id?: TLPageId, belowPageIndex?: string): this;
     createShape<T extends TLUnknownShape>(partial: TLShapePartial<T>, select?: boolean): this;
     createShapes<T extends TLUnknownShape>(partials: TLShapePartial<T>[], select?: boolean): this;
@@ -1292,6 +1272,14 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     static type: "group";
 }
+
+// @public (undocumented)
+export function handleEditorError(editor: Editor, error: unknown, { origin, willCrashApp, tags, extras, }: {
+    origin: string;
+    willCrashApp: boolean;
+    tags?: Record<string, boolean | number | string>;
+    extras?: Record<string, unknown>;
+}): void;
 
 // @public
 export function hardReset({ shouldReload }?: {

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -541,6 +541,13 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): this;
     animateToShape(shapeId: TLShapeId, opts?: TLAnimationOptions): this;
     animateToUser(userId: string): void;
+    // @internal (undocumented)
+    annotateError(error: unknown, { origin, willCrashApp, tags, extras, }: {
+        origin: string;
+        willCrashApp: boolean;
+        tags?: Record<string, boolean | number | string>;
+        extras?: Record<string, unknown>;
+    }): void;
     get assets(): (TLBookmarkAsset | TLImageAsset | TLVideoAsset)[];
     bail(): this;
     bailToMark(id: string): this;
@@ -571,6 +578,19 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal
     get crashingError(): unknown;
     createAssets(assets: TLAsset[]): this;
+    // @internal (undocumented)
+    createErrorAnnotations(origin: string, willCrashApp: 'unknown' | boolean): {
+        tags: {
+            origin: string;
+            willCrashApp: 'unknown' | boolean;
+        };
+        extras: {
+            activeStateNode?: string;
+            selectedShapes?: TLUnknownShape[];
+            editingShape?: TLUnknownShape;
+            inputs?: Record<string, unknown>;
+        };
+    };
     createPage(title: string, id?: TLPageId, belowPageIndex?: string): this;
     createShape<T extends TLUnknownShape>(partial: TLShapePartial<T>, select?: boolean): this;
     createShapes<T extends TLUnknownShape>(partials: TLShapePartial<T>[], select?: boolean): this;
@@ -1272,14 +1292,6 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     static type: "group";
 }
-
-// @public (undocumented)
-export function handleEditorError(editor: Editor, error: unknown, { origin, willCrashApp, tags, extras, }: {
-    origin: string;
-    willCrashApp: boolean;
-    tags?: Record<string, boolean | number | string>;
-    extras?: Record<string, unknown>;
-}): void;
 
 // @public
 export function hardReset({ shouldReload }?: {

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -913,7 +913,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     get selectedShapes(): TLShape[];
     get selectionBounds(): Box2d | undefined;
     get selectionPageBounds(): Box2d | null;
-    get selectionPageCenter(): null | Vec2d;
     get selectionRotation(): number;
     selectNone(): this;
     sendBackward(shapes: TLShape[]): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1657,18 +1657,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return box
 	}
 
-	/**
-	 * The center of the selection bounding box.
-	 *
-	 * @readonly
-	 * @public
-	 */
-	@computed get selectionPageCenter() {
-		const { selectionBounds, selectionRotation } = this
-		if (!selectionBounds) return null
-		return Vec2d.RotWith(selectionBounds.center, selectionBounds.point, selectionRotation)
-	}
-
 	// Focus Layer Id
 
 	/**

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -9,7 +9,7 @@ import { Vec2d } from '../primitives/Vec2d'
 export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationSnapshot | null {
 	const {
 		selectionRotation,
-		selectionPageCenter,
+		selectionBounds,
 		inputs: { originPagePoint },
 		selectedShapes,
 	} = editor
@@ -19,9 +19,13 @@ export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationS
 	// will produce the wrong results
 
 	// Return null if there are no selected shapes
-	if (!selectionPageCenter) {
+	if (!selectionBounds) {
 		return null
 	}
+
+	const selectionPageCenter = selectionBounds.center
+		.clone()
+		.rotWith(selectionBounds.point, selectionRotation)
 
 	return {
 		selectionPageCenter: selectionPageCenter,

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Rotating.ts
@@ -139,13 +139,19 @@ export class Rotating extends StateNode {
 
 	_getRotationFromPointerPosition({ snapToNearestDegree }: { snapToNearestDegree: boolean }) {
 		const {
-			selectionPageCenter,
+			selectionBounds,
+			selectionRotation,
 			inputs: { shiftKey, currentPagePoint },
 		} = this.editor
 		const { initialCursorAngle, initialSelectionRotation } = this.snapshot
 
+		if (!selectionBounds) return initialSelectionRotation
+
+		const selectionPageCenter = selectionBounds.center
+			.clone()
+			.rotWith(selectionBounds.point, selectionRotation)
+
 		// The delta is the difference between the current angle and the initial angle
-		if (!selectionPageCenter) return initialSelectionRotation
 		const preSnapRotationDelta = selectionPageCenter.angle(currentPagePoint) - initialCursorAngle
 		let newSelectionRotation = initialSelectionRotation + preSnapRotationDelta
 

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -493,6 +493,18 @@ export class TestEditor extends Editor {
 		return this
 	}
 
+	/**
+	 * The center of the selection bounding box.
+	 *
+	 * @readonly
+	 * @public
+	 */
+	get selectionPageCenter() {
+		const { selectionBounds, selectionRotation } = this
+		if (!selectionBounds) return null
+		return Vec2d.RotWith(selectionBounds.center, selectionBounds.point, selectionRotation)
+	}
+
 	translateSelection(dx: number, dy: number, options?: Partial<TLPointerEventInfo>) {
 		if (this.selectedShapeIds.length === 0) {
 			throw new Error('No selection')

--- a/packages/tldraw/src/test/commands/rotateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/rotateShapes.test.ts
@@ -77,6 +77,6 @@ describe('editor.rotateShapes', () => {
 			.expectShapeToMatch({ id: ids.box2, rotation: Math.PI })
 
 		// Are the centers the same?
-		expect(selectionPageCenter).toMatchObject(editor.selectionPageCenter!)
+		expect(selectionPageCenter).toCloselyMatchObject(editor.selectionPageCenter!)
 	})
 })


### PR DESCRIPTION
This PR removes `Editor.selectionPageCenter` and moves its implementation inline where used (in two places).

### Change Type

- [x] `major` — Breaking change

### Release Notes

- [dev] Removes `Editor.selectionPageCenter`