### PR TITLE
[fix] shape indicator showing when locked shapes are hovered

### DIFF
--- a/packages/editor/src/lib/components/ShapeIndicator.tsx
+++ b/packages/editor/src/lib/components/ShapeIndicator.tsx
@@ -28,7 +28,8 @@ export const InnerIndicator = ({ editor, id }: { editor: Editor; id: TLShapeId }
 
 	const { ShapeIndicatorErrorFallback } = useEditorComponents()
 
-	if (!shape.shape) return null
+	if (!shape.shape || shape.shape.isLocked) return null
+
 	return (
 		<OptionalErrorBoundary
 			fallback={ShapeIndicatorErrorFallback}


### PR DESCRIPTION
This PR makes it so that locked shapes do not show an indicator when hovered.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Hover a locked shape
2. Hover a shape, then lock it

### Release Notes

- locked shapes do not show an indicator when hovered