### PR TITLE
export `UiEventsProvider`

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -176,6 +176,15 @@ interface DropdownMenuItemProps extends TLUiButtonProps {
 }
 
 // @public (undocumented)
+export function EventsProvider({ onEvent, children }: EventsProviderProps): JSX.Element;
+
+// @public (undocumented)
+export type EventsProviderProps = {
+    onEvent?: TLUiEventHandler;
+    children: any;
+};
+
+// @public (undocumented)
 export function findMenuItem(menu: TLUiMenuSchema, path: string[]): TLUiMenuChild;
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -176,9 +176,6 @@ interface DropdownMenuItemProps extends TLUiButtonProps {
 }
 
 // @public (undocumented)
-export function EventsProvider({ onEvent, children }: EventsProviderProps): JSX.Element;
-
-// @public (undocumented)
 export type EventsProviderProps = {
     onEvent?: TLUiEventHandler;
     children: any;
@@ -731,6 +728,9 @@ function Trigger({ children, 'data-testid': testId, }: {
 export const truncateStringWithEllipsis: (str: string, maxLength: number) => string;
 
 // @public (undocumented)
+export function UiEventsProvider({ onEvent, children }: EventsProviderProps): JSX.Element;
+
+// @public (undocumented)
 export function useActions(): TLUiActionsContextType;
 
 // @public (undocumented)
@@ -773,9 +773,6 @@ export function useDefaultHelpers(): {
 
 // @public (undocumented)
 export function useDialogs(): TLUiDialogsContextType;
-
-// @public (undocumented)
-export function useEvents(): TLUiEventContextType;
 
 // @public (undocumented)
 export function useExportAs(): (ids?: TLShapeId[], format?: TLExportType) => Promise<void>;
@@ -822,6 +819,9 @@ export function useTools(): TLUiToolsContextType;
 
 // @public
 export function useTranslation(): (id: TLUiTranslationKey) => string;
+
+// @public (undocumented)
+export function useUiEvents(): TLUiEventContextType;
 
 
 export * from "@tldraw/editor";

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -59,8 +59,8 @@ export {
 	type TLUiDialogsContextType,
 } from './lib/ui/hooks/useDialogsProvider'
 export {
-	UiEventsProvider as EventsProvider,
-	useUiEvents as useEvents,
+	UiEventsProvider,
+	useUiEvents,
 	type EventsProviderProps,
 	type TLUiEventContextType,
 	type TLUiEventHandler,

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -59,7 +59,9 @@ export {
 	type TLUiDialogsContextType,
 } from './lib/ui/hooks/useDialogsProvider'
 export {
+	EventsProvider,
 	useEvents,
+	type EventsProviderProps,
 	type TLUiEventContextType,
 	type TLUiEventHandler,
 	type TLUiEventSource,

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -59,8 +59,8 @@ export {
 	type TLUiDialogsContextType,
 } from './lib/ui/hooks/useDialogsProvider'
 export {
-	EventsProvider,
-	useEvents,
+	UiEventsProvider as EventsProvider,
+	useUiEvents as useEvents,
 	type EventsProviderProps,
 	type TLUiEventContextType,
 	type TLUiEventHandler,

--- a/packages/tldraw/src/lib/ui/TldrawUiContextProvider.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUiContextProvider.tsx
@@ -6,7 +6,7 @@ import { AssetUrlsProvider } from './hooks/useAssetUrls'
 import { BreakPointProvider } from './hooks/useBreakpoint'
 import { TLUiContextMenuSchemaProvider } from './hooks/useContextMenuSchema'
 import { DialogsProvider } from './hooks/useDialogsProvider'
-import { EventsProvider, TLUiEventHandler } from './hooks/useEventsProvider'
+import { TLUiEventHandler, UiEventsProvider } from './hooks/useEventsProvider'
 import { HelpMenuSchemaProvider } from './hooks/useHelpMenuSchema'
 import { KeyboardShortcutsSchemaProvider } from './hooks/useKeyboardShortcutsSchema'
 import { TLUiMenuSchemaProvider } from './hooks/useMenuSchema'
@@ -53,7 +53,7 @@ export function TldrawUiContextProvider({
 	return (
 		<AssetUrlsProvider assetUrls={useDefaultUiAssetUrlsWithOverrides(assetUrls)}>
 			<TranslationProvider overrides={useMergedTranslationOverrides(overrides)}>
-				<EventsProvider onEvent={onUiEvent}>
+				<UiEventsProvider onEvent={onUiEvent}>
 					<ToastsProvider>
 						<DialogsProvider>
 							<BreakPointProvider>
@@ -61,7 +61,7 @@ export function TldrawUiContextProvider({
 							</BreakPointProvider>
 						</DialogsProvider>
 					</ToastsProvider>
-				</EventsProvider>
+				</UiEventsProvider>
 			</TranslationProvider>
 		</AssetUrlsProvider>
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -24,7 +24,7 @@ import { TLUiIconType } from '../icon-types'
 import { useMenuClipboardEvents } from './useClipboardEvents'
 import { useCopyAs } from './useCopyAs'
 import { useDialogs } from './useDialogsProvider'
-import { TLUiEventSource, useEvents } from './useEventsProvider'
+import { TLUiEventSource, useUiEvents } from './useEventsProvider'
 import { useExportAs } from './useExportAs'
 import { useInsertMedia } from './useInsertMedia'
 import { usePrint } from './usePrint'
@@ -79,7 +79,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 	const copyAs = useCopyAs()
 	const exportAs = useExportAs()
 
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -18,7 +18,7 @@ import { pasteExcalidrawContent } from './clipboard/pasteExcalidrawContent'
 import { pasteFiles } from './clipboard/pasteFiles'
 import { pasteTldrawContent } from './clipboard/pasteTldrawContent'
 import { pasteUrl } from './clipboard/pasteUrl'
-import { TLUiEventSource, useEvents } from './useEventsProvider'
+import { TLUiEventSource, useUiEvents } from './useEventsProvider'
 
 /** @public */
 export const isValidHttpURL = (url: string) => {
@@ -583,7 +583,7 @@ const handleNativeOrMenuCopy = (editor: Editor) => {
 /** @public */
 export function useMenuClipboardEvents() {
 	const editor = useEditor()
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	const copy = useCallback(
 		function onCopy(source: TLUiEventSource) {
@@ -640,7 +640,7 @@ export function useMenuClipboardEvents() {
 /** @public */
 export function useNativeClipboardEvents() {
 	const editor = useEditor()
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	const appIsFocused = useValue('editor.isFocused', () => editor.instanceState.isFocused, [editor])
 

--- a/packages/tldraw/src/lib/ui/hooks/useDialogsProvider.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useDialogsProvider.tsx
@@ -1,6 +1,6 @@
 import { Editor, uniqueId, useEditor } from '@tldraw/editor'
 import { createContext, useCallback, useContext, useState } from 'react'
-import { useEvents } from './useEventsProvider'
+import { useUiEvents } from './useEventsProvider'
 
 /** @public */
 export interface TLUiDialogProps {
@@ -35,7 +35,7 @@ export type DialogsProviderProps = {
 /** @internal */
 export function DialogsProvider({ children }: DialogsProviderProps) {
 	const editor = useEditor()
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	const [dialogs, setDialogs] = useState<TLUiDialog[]>([])
 

--- a/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
@@ -111,7 +111,7 @@ export type EventsProviderProps = {
 }
 
 /** @public */
-export function EventsProvider({ onEvent, children }: EventsProviderProps) {
+export function UiEventsProvider({ onEvent, children }: EventsProviderProps) {
 	return (
 		<EventsContext.Provider value={onEvent ?? defaultEventHandler}>
 			{children}
@@ -120,7 +120,7 @@ export function EventsProvider({ onEvent, children }: EventsProviderProps) {
 }
 
 /** @public */
-export function useEvents() {
+export function useUiEvents() {
 	const eventHandler = React.useContext(EventsContext)
 	return eventHandler ?? defaultEventHandler
 }

--- a/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
@@ -104,13 +104,13 @@ export type TLUiEventContextType = TLUiEventHandler<keyof TLUiEventMap>
 /** @internal */
 export const EventsContext = React.createContext<TLUiEventContextType>({} as TLUiEventContextType)
 
-/** @internal */
+/** @public */
 export type EventsProviderProps = {
 	onEvent?: TLUiEventHandler
 	children: any
 }
 
-/** @internal */
+/** @public */
 export function EventsProvider({ onEvent, children }: EventsProviderProps) {
 	return (
 		<EventsContext.Provider value={onEvent ?? defaultEventHandler}>

--- a/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useEventsProvider.tsx
@@ -121,5 +121,6 @@ export function EventsProvider({ onEvent, children }: EventsProviderProps) {
 
 /** @public */
 export function useEvents() {
-	return React.useContext(EventsContext)
+	const eventHandler = React.useContext(EventsContext)
+	return eventHandler ?? defaultEventHandler
 }

--- a/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
@@ -1,12 +1,12 @@
 import { useEditor, useValue } from '@tldraw/editor'
 import { useCallback, useEffect, useRef } from 'react'
-import { useEvents } from './useEventsProvider'
+import { useUiEvents } from './useEventsProvider'
 
 /** @public */
 export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void) {
 	const editor = useEditor()
 	const rIsOpen = useRef(false)
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	const onOpenChange = useCallback(
 		(isOpen: boolean) => {

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { EmbedDialog } from '../components/EmbedDialog'
 import { TLUiIconType } from '../icon-types'
 import { useDialogs } from './useDialogsProvider'
-import { TLUiEventSource, useEvents } from './useEventsProvider'
+import { TLUiEventSource, useUiEvents } from './useEventsProvider'
 import { useInsertMedia } from './useInsertMedia'
 import { TLUiTranslationKey } from './useTranslation/TLUiTranslationKey'
 
@@ -40,7 +40,7 @@ export type TLUiToolsProviderProps = {
 /** @internal */
 export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 	const editor = useEditor()
-	const trackEvent = useEvents()
+	const trackEvent = useUiEvents()
 
 	const { addDialog } = useDialogs()
 	const insertMedia = useInsertMedia()


### PR DESCRIPTION
This PR exports the `UiEventsProvider` component (and renames `useEvents` to `useUiEvents`). It also changes the `useUiEvents` hook to work outside of the context. When used outside of the context, the hook will no longer throw an error—though it will also have no effect.

### Change Type

- [x] `minor`

### Release Notes

- [@tldraw/tldraw] export ui events, so that UI hooks can work without context