### PR TITLE
Fix outlines on text shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -93,7 +93,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 					data-font={shape.props.font}
 					data-align={shape.props.align}
 					data-hastext={!isEmpty}
-					data-isediting={isEditing || isEditableFromHover}
+					data-isediting={isEditing}
 					data-textwrap={true}
 					style={{
 						fontSize: FONT_SIZES[shape.props.size],


### PR DESCRIPTION
This PR fixes the extra outlines on text shapes when not editing those shapes.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create two text shapes
2. Edit one of them
3. The outline on the second shape should not be shown
