### PR TITLE
Update setter names, `setXXShapeId` rather than `setXXId`

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -919,16 +919,16 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     sendToBack(ids: TLShapeId[]): this;
     setCamera(point: VecLike, animation?: TLAnimationOptions): this;
-    setCroppingId(id: null | TLShapeId): this;
+    setCroppingShapeId(id: null | TLShapeId): this;
     setCurrentPage(page: TLPage, opts?: TLViewportOptions): this;
     // (undocumented)
     setCurrentPage(pageId: TLPageId, opts?: TLViewportOptions): this;
     setCurrentTool(id: string, info?: {}): this;
-    setEditingId(id: null | TLShapeId): this;
-    setErasingIds(ids: TLShapeId[]): this;
+    setEditingShapeId(id: null | TLShapeId): this;
+    setErasingShapeIds(ids: TLShapeId[]): this;
     setFocusedGroupId(next: null | TLShapeId): this;
     setHintingIds(ids: TLShapeId[]): this;
-    setHoveredId(id: null | TLShapeId): this;
+    setHoveredShapeId(id: null | TLShapeId): this;
     setOpacity(opacity: number, ephemeral?: boolean, squashing?: boolean): this;
     setSelectedShapeIds(ids: TLShapeId[], squashing?: boolean): this;
     setStyle<T>(style: StyleProp<T>, value: T, ephemeral?: boolean, squashing?: boolean): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1739,7 +1739,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	setEditingId(id: TLShapeId | null): this {
+	setEditingShapeId(id: TLShapeId | null): this {
 		if (!id) {
 			this._setInstancePageState({ editingShapeId: null })
 		} else {
@@ -1773,7 +1773,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	setHoveredId(id: TLShapeId | null): this {
+	setHoveredShapeId(id: TLShapeId | null): this {
 		if (id === this.currentPageState.hoveredShapeId) return this
 		this.updateCurrentPageState({ hoveredShapeId: id }, true)
 		return this
@@ -1828,7 +1828,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	setErasingIds(ids: TLShapeId[]): this {
+	setErasingShapeIds(ids: TLShapeId[]): this {
 		const erasingShapeIds = this.erasingShapeIdsSet
 		if (ids.length === erasingShapeIds.size && ids.every((id) => erasingShapeIds.has(id)))
 			return this
@@ -1861,7 +1861,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	setCroppingId(id: TLShapeId | null): this {
+	setCroppingShapeId(id: TLShapeId | null): this {
 		if (id !== this.croppingShapeId) {
 			if (!id) {
 				this.updateCurrentPageState({ croppingShapeId: null })

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
@@ -15,7 +15,7 @@ export const FrameLabelInput = forwardRef<
 				// and sending us back into edit mode
 				e.stopPropagation()
 				e.currentTarget.blur()
-				editor.setEditingId(null)
+				editor.setEditingShapeId(null)
 			}
 		},
 		[editor]

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -17,7 +17,7 @@ export class Idle extends StateNode {
 			if (shape && this.editor.isShapeOfType<TLGeoShape>(shape, 'geo')) {
 				// todo: ensure that this only works with the most recently created shape, not just any geo shape that happens to be selected at the time
 				this.editor.mark('editing shape')
-				this.editor.setEditingId(shape.id)
+				this.editor.setEditingShapeId(shape.id)
 				this.editor.setCurrentTool('select.editing_shape', {
 					...info,
 					target: 'shape',

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -65,7 +65,7 @@ export class Pointing extends StateNode {
 			if (this.editor.instanceState.isToolLocked) {
 				this.parent.transition('idle', {})
 			} else {
-				this.editor.setEditingId(this.shape.id)
+				this.editor.setEditingShapeId(this.shape.id)
 				this.editor.setCurrentTool('select.editing_shape', {
 					...this.info,
 					target: 'shape',

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -211,8 +211,8 @@ export function useEditableText<T extends Extract<TLShape, { props: { text: stri
 		(e: React.PointerEvent) => {
 			if (isEditableFromHover) {
 				transact(() => {
-					editor.setEditingId(id)
-					editor.setHoveredId(id)
+					editor.setEditingShapeId(id)
+					editor.setHoveredShapeId(id)
 					editor.setSelectedShapeIds([id])
 				})
 			}

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -23,7 +23,7 @@ export class Idle extends StateNode {
 			if (this.editor.isShapeOfType<TLTextShape>(hitShape, 'text')) {
 				requestAnimationFrame(() => {
 					this.editor.setSelectedShapeIds([hitShape.id])
-					this.editor.setEditingId(hitShape.id)
+					this.editor.setEditingShapeId(hitShape.id)
 					this.editor.setCurrentTool('select.editing_shape', {
 						...info,
 						target: 'shape',
@@ -46,7 +46,7 @@ export class Idle extends StateNode {
 			const shape = this.editor.selectedShapes[0]
 			if (shape && this.editor.isShapeOfType<TLGeoShape>(shape, 'geo')) {
 				this.editor.setCurrentTool('select')
-				this.editor.setEditingId(shape.id)
+				this.editor.setEditingShapeId(shape.id)
 				this.editor.root.current.value!.transition('editing_shape', {
 					...info,
 					target: 'shape',

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -87,7 +87,7 @@ export class Pointing extends StateNode {
 			])
 			.select(id)
 
-		this.editor.setEditingId(id)
+		this.editor.setEditingShapeId(id)
 		this.editor.setCurrentTool('select')
 		this.editor.root.current.value?.transition('editing_shape', {})
 	}

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
@@ -128,17 +128,17 @@ export class Erasing extends StateNode {
 		// Remove the hit shapes, except if they're in the list of excluded shapes
 		// (these excluded shapes will be any frames or groups the pointer was inside of
 		// when the user started erasing)
-		this.editor.setErasingIds([...erasing].filter((id) => !excludedShapeIds.has(id)))
+		this.editor.setErasingShapeIds([...erasing].filter((id) => !excludedShapeIds.has(id)))
 	}
 
 	complete() {
 		this.editor.deleteShapes(this.editor.currentPageState.erasingShapeIds)
-		this.editor.setErasingIds([])
+		this.editor.setErasingShapeIds([])
 		this.parent.transition('idle', {})
 	}
 
 	cancel() {
-		this.editor.setErasingIds([])
+		this.editor.setErasingShapeIds([])
 		this.editor.bailToMark(this.markId)
 		this.parent.transition('idle', this.info)
 	}

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
@@ -46,7 +46,7 @@ export class Pointing extends StateNode {
 			}
 		}
 
-		this.editor.setErasingIds([...erasing])
+		this.editor.setErasingShapeIds([...erasing])
 	}
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
@@ -79,12 +79,12 @@ export class Pointing extends StateNode {
 			this.editor.deleteShapes(erasingShapeIds)
 		}
 
-		this.editor.setErasingIds([])
+		this.editor.setErasingShapeIds([])
 		this.parent.transition('idle', {})
 	}
 
 	cancel() {
-		this.editor.setErasingIds([])
+		this.editor.setErasingShapeIds([])
 		this.parent.transition('idle', {})
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -43,7 +43,7 @@ export class SelectTool extends StateNode {
 
 	override onExit = () => {
 		if (this.editor.currentPageState.editingShapeId) {
-			this.editor.setEditingId(null)
+			this.editor.setEditingShapeId(null)
 		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Crop/children/Idle.ts
@@ -17,7 +17,7 @@ export class Idle extends StateNode {
 		this.editor.mark('crop')
 
 		if (onlySelectedShape) {
-			this.editor.setCroppingId(onlySelectedShape.id)
+			this.editor.setCroppingShapeId(onlySelectedShape.id)
 		}
 	}
 
@@ -28,7 +28,7 @@ export class Idle extends StateNode {
 	}
 
 	override onCancel: TLEventHandlers['onCancel'] = () => {
-		this.editor.setCroppingId(null)
+		this.editor.setCroppingShapeId(null)
 		this.editor.setCurrentTool('select.idle', {})
 	}
 
@@ -36,7 +36,7 @@ export class Idle extends StateNode {
 		if (this.editor.isMenuOpen) return
 
 		if (info.ctrlKey) {
-			this.editor.setCroppingId(null)
+			this.editor.setCroppingShapeId(null)
 			this.editor.setCurrentTool('select.brushing', info)
 			return
 		}
@@ -66,7 +66,7 @@ export class Idle extends StateNode {
 					return
 				} else {
 					if (this.editor.getShapeUtil(info.shape)?.canCrop(info.shape)) {
-						this.editor.setCroppingId(info.shape.id)
+						this.editor.setCroppingShapeId(info.shape.id)
 						this.editor.setSelectedShapeIds([info.shape.id])
 						this.editor.setCurrentTool('select.crop.pointing_crop', info)
 					} else {
@@ -145,7 +145,7 @@ export class Idle extends StateNode {
 	override onKeyUp: TLEventHandlers['onKeyUp'] = (info) => {
 		switch (info.code) {
 			case 'Enter': {
-				this.editor.setCroppingId(null)
+				this.editor.setCroppingShapeId(null)
 				this.editor.setCurrentTool('select.idle', {})
 				break
 			}
@@ -153,7 +153,7 @@ export class Idle extends StateNode {
 	}
 
 	private cancel() {
-		this.editor.setCroppingId(null)
+		this.editor.setCroppingShapeId(null)
 		this.editor.setCurrentTool('select.idle', {})
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Cropping.ts
@@ -207,7 +207,7 @@ export class Cropping extends StateNode {
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, this.info)
 		} else {
-			this.editor.setCroppingId(null)
+			this.editor.setCroppingShapeId(null)
 			this.parent.transition('idle', {})
 		}
 	}
@@ -217,7 +217,7 @@ export class Cropping extends StateNode {
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, this.info)
 		} else {
-			this.editor.setCroppingId(null)
+			this.editor.setCroppingShapeId(null)
 			this.parent.transition('idle', {})
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/children/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/EditingShape.ts
@@ -19,7 +19,7 @@ export class EditingShape extends StateNode {
 		if (!editingShapeId) return
 
 		// Clear the editing shape
-		this.editor.setEditingId(null)
+		this.editor.setEditingShapeId(null)
 
 		const shape = this.editor.getShape(editingShapeId)!
 		const util = this.editor.getShapeUtil(shape)

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -438,7 +438,7 @@ export class Idle extends StateNode {
 	private startEditingShape(shape: TLShape, info: TLClickEventInfo | TLKeyboardEventInfo) {
 		if (this.editor.isShapeOrAncestorLocked(shape) && shape.type !== 'embed') return
 		this.editor.mark('editing shape')
-		this.editor.setEditingId(shape.id)
+		this.editor.setEditingShapeId(shape.id)
 		this.parent.transition('editing_shape', info)
 	}
 
@@ -467,7 +467,7 @@ export class Idle extends StateNode {
 		const shape = this.editor.getShape(id)
 		if (!shape) return
 
-		this.editor.setEditingId(id)
+		this.editor.setEditingShapeId(id)
 		this.editor.select(id)
 		this.parent.transition('editing_shape', info)
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/PointingCropHandle.ts
@@ -29,7 +29,7 @@ export class PointingCropHandle extends StateNode {
 		if (!selectedShape) return
 
 		this.updateCursor(selectedShape)
-		this.editor.setCroppingId(selectedShape.id)
+		this.editor.setCroppingShapeId(selectedShape.id)
 	}
 
 	override onExit = () => {
@@ -52,7 +52,7 @@ export class PointingCropHandle extends StateNode {
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, this.info)
 		} else {
-			this.editor.setCroppingId(null)
+			this.editor.setCroppingShapeId(null)
 			this.parent.transition('idle', {})
 		}
 	}
@@ -73,7 +73,7 @@ export class PointingCropHandle extends StateNode {
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, this.info)
 		} else {
-			this.editor.setCroppingId(null)
+			this.editor.setCroppingShapeId(null)
 			this.parent.transition('idle', {})
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Resizing.ts
@@ -105,7 +105,7 @@ export class Resizing extends StateNode {
 		this.handleResizeEnd()
 
 		if (this.editAfterComplete && this.editor.onlySelectedShape) {
-			this.editor.setEditingId(this.editor.onlySelectedShape.id)
+			this.editor.setEditingShapeId(this.editor.onlySelectedShape.id)
 			this.editor.setCurrentTool('select')
 			this.editor.root.current.value!.transition('editing_shape', {})
 			return

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Translating.ts
@@ -148,7 +148,7 @@ export class Translating extends StateNode {
 			if (this.editAfterComplete) {
 				const onlySelected = this.editor.onlySelectedShape
 				if (onlySelected) {
-					this.editor.setEditingId(onlySelected.id)
+					this.editor.setEditingShapeId(onlySelected.id)
 					this.editor.setCurrentTool('select')
 					this.editor.root.current.value!.transition('editing_shape', {})
 				}

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredId.ts
@@ -7,7 +7,7 @@ export function updateHoveredId(editor: Editor) {
 		margin: HIT_TEST_MARGIN / editor.zoomLevel,
 	})
 
-	if (!hitShape) return editor.setHoveredId(null)
+	if (!hitShape) return editor.setHoveredShapeId(null)
 
 	let shapeToHover: TLShape | undefined = undefined
 
@@ -26,5 +26,5 @@ export function updateHoveredId(editor: Editor) {
 		}
 	}
 
-	return editor.setHoveredId(shapeToHover.id)
+	return editor.setHoveredShapeId(shapeToHover.id)
 }

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -68,25 +68,25 @@ describe('shapes that are moved to another page', () => {
 
 	describe("should be excluded from the previous page's editingShapeId", () => {
 		test('[root shape]', () => {
-			editor.setEditingId(ids.box1)
+			editor.setEditingShapeId(ids.box1)
 			expect(editor.editingShapeId).toBe(ids.box1)
 			moveShapesToPage2()
 			expect(editor.editingShapeId).toBe(null)
 		})
 		test('[child of frame]', () => {
-			editor.setEditingId(ids.box2)
+			editor.setEditingShapeId(ids.box2)
 			expect(editor.editingShapeId).toBe(ids.box2)
 			moveShapesToPage2()
 			expect(editor.editingShapeId).toBe(null)
 		})
 		test('[child of group]', () => {
-			editor.setEditingId(ids.box3)
+			editor.setEditingShapeId(ids.box3)
 			expect(editor.editingShapeId).toBe(ids.box3)
 			moveShapesToPage2()
 			expect(editor.editingShapeId).toBe(null)
 		})
 		test('[frame that doesnt move]', () => {
-			editor.setEditingId(ids.frame1)
+			editor.setEditingShapeId(ids.frame1)
 			expect(editor.editingShapeId).toBe(ids.frame1)
 			moveShapesToPage2()
 			expect(editor.editingShapeId).toBe(ids.frame1)
@@ -95,13 +95,13 @@ describe('shapes that are moved to another page', () => {
 
 	describe("should be excluded from the previous page's erasingShapeIds", () => {
 		test('[boxes]', () => {
-			editor.setErasingIds([ids.box1, ids.box2, ids.box3])
+			editor.setErasingShapeIds([ids.box1, ids.box2, ids.box3])
 			expect(editor.erasingShapeIds).toEqual([ids.box1, ids.box2, ids.box3])
 			moveShapesToPage2()
 			expect(editor.erasingShapeIds).toEqual([])
 		})
 		test('[frame that does not move]', () => {
-			editor.setErasingIds([ids.frame1])
+			editor.setErasingShapeIds([ids.frame1])
 			expect(editor.erasingShapeIds).toEqual([ids.frame1])
 			moveShapesToPage2()
 			expect(editor.erasingShapeIds).toEqual([ids.frame1])


### PR DESCRIPTION
This PR is a follower on #1787 that adds some changes to how setters are named.

### Change Type

- [x] `major` — Breaking change
