### PR TITLE
[fix] Don't make arrows shapes to arrows

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -61,7 +61,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 	override canEdit = () => true
 	override canBind = () => false
-	override canSnap = () => true
+	override canSnap = () => false
 	override hideResizeHandles: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideRotateHandle: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideSelectionBoundsBg: TLShapeUtilFlag<TLArrowShape> = () => true


### PR DESCRIPTION
This PR turns off snapping between shapes and arrows.

### Change Type

- [x] `patch` 

### Test Plan

1. Drag a shape while snapping
2. The shape should not snap to the position of arrows
