### PR TITLE
[fix] Collaborator scribble on tldraw

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -40,6 +40,7 @@ export function Tldraw(
 		components: useMemo(
 			() => ({
 				Scribble: TldrawScribble,
+				CollaboratorScribble: TldrawScribble,
 				SelectionForeground: TldrawSelectionForeground,
 				SelectionBackground: TldrawSelectionBackground,
 				Handles: TldrawHandles,


### PR DESCRIPTION
This PR fixes the collaborator scribble in the laser pointer, etc.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. In a multiplayer room, have a peer use the laser tool or eraser tool.

