### PR TITLE
Improve zooming performance on Safari

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -831,6 +831,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         speedThreshold?: number | undefined;
     }): this;
     readonly snaps: SnapManager;
+    get stableZoomLevel(): number;
     stackShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical', gap: number): this;
     startFollowingUser(userId: string): this;
     stopCameraAnimation(): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2039,6 +2039,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.camera.z
 	}
 
+	private _stableZoomLevel = atom('stable zoom level', 1)
+
+	/**
+	 * The stable camera zoom level.
+	 *
+	 * @public
+	 */
+	@computed get stableZoomLevel() {
+		return this._stableZoomLevel.value
+	}
+
 	/** @internal */
 	private _setCamera(point: VecLike): this {
 		const currentCamera = this.camera
@@ -3198,6 +3209,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		} else {
 			this._renderingBoundsExpanded.set(viewportPageBounds)
 		}
+
+		// update stable zoom level, too
+		this._stableZoomLevel.set(this.camera.z)
 		return this
 	}
 

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -2,6 +2,7 @@ import type { AnyHandlerEventTypes, EventTypes, GestureKey, Handler } from '@use
 import { createUseGesture, pinchAction, wheelAction } from '@use-gesture/react'
 import throttle from 'lodash.throttle'
 import * as React from 'react'
+import { MAX_ZOOM, MIN_ZOOM } from '../constants'
 import { TLWheelEventInfo } from '../editor/types/event-types'
 import { Vec2d } from '../primitives/Vec2d'
 import { preventDefault } from '../utils/dom'
@@ -242,8 +243,24 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 		pinch: {
 			from: () => [editor.zoomLevel, 0], // Return the camera z to use when pinch starts
 			scaleBounds: () => {
-				return { from: editor.zoomLevel, max: 8, min: 0.05 }
+				return { from: editor.zoomLevel, max: MAX_ZOOM, min: MIN_ZOOM }
 			},
+			pinchOnWheel: false,
+			preventDefault: true,
 		},
 	})
+
+	React.useEffect(() => {
+		const elm = ref.current
+		if (!elm) return
+		const handler = (e: Event) => e.preventDefault()
+		elm.addEventListener('gesturestart', handler)
+		elm.addEventListener('gesturechange', handler)
+		elm.addEventListener('gestureend', handler)
+		return () => {
+			elm.removeEventListener('gesturestart', handler)
+			elm.addEventListener('gesturechange', handler)
+			elm.removeEventListener('gestureend', handler)
+		}
+	}, [ref])
 }

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -67,7 +67,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 						) : (
 							<div className="tl-bookmark__placeholder" />
 						)}
-						<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.zoomLevel} />
+						<HyperlinkButton url={shape.props.url} />
 					</div>
 					<div className="tl-bookmark__copy_container">
 						{asset?.props.title && (

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -531,9 +531,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					labelColor={labelColor}
 					wrap
 				/>
-				{shape.props.url && (
-					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.zoomLevel} />
-				)}
+				{shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -152,9 +152,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 						)}
 					</div>
 				</HTMLContainer>
-				{'url' in shape.props && shape.props.url && (
-					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.zoomLevel} />
-				)}
+				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -93,9 +93,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						/>
 					</div>
 				</div>
-				{'url' in shape.props && shape.props.url && (
-					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.zoomLevel} />
-				)}
+				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
@@ -1,14 +1,16 @@
-import { stopEventPropagation } from '@tldraw/editor'
+import { stopEventPropagation, useEditor } from '@tldraw/editor'
 import classNames from 'classnames'
 
 const LINK_ICON =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' fill='none'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 5H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6M19 5h6m0 0v6m0-6L13 17'/%3E%3C/svg%3E"
 
-export function HyperlinkButton({ url, zoomLevel }: { url: string; zoomLevel: number }) {
+export function HyperlinkButton({ url }: { url: string }) {
+	const editor = useEditor()
+
 	return (
 		<a
 			className={classNames('tl-hyperlink-button', {
-				'tl-hyperlink-button__hidden': zoomLevel < 0.32,
+				'tl-hyperlink-button__hidden': editor.stableZoomLevel < 0.32,
 			})}
 			href={url}
 			target="_blank"

--- a/packages/tldraw/src/lib/shapes/shared/ShapeFill.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/ShapeFill.tsx
@@ -4,11 +4,10 @@ import {
 	TLDefaultColorTheme,
 	TLDefaultFillStyle,
 	getDefaultColorTheme,
-	useEditor,
 	useIsDarkMode,
-	useValue,
 } from '@tldraw/editor'
 import React from 'react'
+import { useStableZoomLevel } from './useStableZoomLevel'
 
 export interface ShapeFillProps {
 	d: string
@@ -39,11 +38,9 @@ export const ShapeFill = React.memo(function ShapeFill({ theme, d, color, fill }
 })
 
 const PatternFill = function PatternFill({ d, color, theme }: ShapeFillProps) {
-	const editor = useEditor()
-	const zoomLevel = useValue('zoomLevel', () => editor.zoomLevel, [editor])
-
+	const zoomLevel = useStableZoomLevel()
 	const intZoom = Math.ceil(zoomLevel)
-	const teenyTiny = editor.zoomLevel <= 0.18
+	const teenyTiny = zoomLevel <= 0.18
 
 	return (
 		<>

--- a/packages/tldraw/src/lib/shapes/shared/useForceSolid.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useForceSolid.ts
@@ -2,5 +2,5 @@ import { useEditor, useValue } from '@tldraw/editor'
 
 export function useForceSolid() {
 	const editor = useEditor()
-	return useValue('zoom', () => editor.zoomLevel < 0.35, [editor])
+	return useValue('zoom', () => editor.stableZoomLevel < 0.35, [editor])
 }

--- a/packages/tldraw/src/lib/shapes/shared/useStableZoomLevel.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useStableZoomLevel.ts
@@ -1,0 +1,6 @@
+import { useEditor, useValue } from '@tldraw/editor'
+
+export function useStableZoomLevel() {
+	const editor = useEditor()
+	return useValue('stable zoom level', () => editor.stableZoomLevel, [editor])
+}

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -71,7 +71,7 @@ const TLVideoUtilComponent = track(function TLVideoUtilComponent(props: {
 }) {
 	const { shape, videoUtil } = props
 	const showControls =
-		videoUtil.editor.getShapeGeometry(shape).bounds.w * videoUtil.editor.zoomLevel >= 110
+		videoUtil.editor.getShapeGeometry(shape).bounds.w * videoUtil.editor.stableZoomLevel >= 110
 	const asset = shape.props.assetId ? videoUtil.editor.getAsset(shape.props.assetId) : null
 	const { time, playing } = shape.props
 	const isEditing = useIsEditing(shape.id)
@@ -200,9 +200,7 @@ const TLVideoUtilComponent = track(function TLVideoUtilComponent(props: {
 					) : null}
 				</div>
 			</HTMLContainer>
-			{'url' in shape.props && shape.props.url && (
-				<HyperlinkButton url={shape.props.url} zoomLevel={videoUtil.editor.zoomLevel} />
-			)}
+			{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 		</>
 	)
 })

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
@@ -98,7 +98,7 @@ export class Erasing extends StateNode {
 
 	update() {
 		const {
-			zoomLevel,
+			stableZoomLevel,
 			currentPageShapes: currentPageShapes,
 			erasingShapeIds,
 			inputs: { currentPagePoint, previousPagePoint },
@@ -124,7 +124,7 @@ export class Erasing extends StateNode {
 			const A = this.editor.getPointInShapeSpace(shape, previousPagePoint)
 			const B = this.editor.getPointInShapeSpace(shape, currentPagePoint)
 
-			if (geometry.hitTestLineSegment(A, B, HIT_TEST_MARGIN / zoomLevel)) {
+			if (geometry.hitTestLineSegment(A, B, HIT_TEST_MARGIN / stableZoomLevel)) {
 				erasing.add(this.editor.getOutermostSelectableShape(shape).id)
 			}
 		}

--- a/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
@@ -14,7 +14,7 @@ export class Pointing extends StateNode {
 		const {
 			inputs: { currentPagePoint },
 			currentPageShapesSorted: sortedShapesOnCurrentPage,
-			zoomLevel,
+			stableZoomLevel,
 		} = this.editor
 
 		const erasing = new Set<TLShapeId>()
@@ -30,7 +30,7 @@ export class Pointing extends StateNode {
 			if (
 				this.editor.isPointInShape(shape, currentPagePoint, {
 					hitInside: false,
-					margin: HIT_TEST_MARGIN / zoomLevel,
+					margin: HIT_TEST_MARGIN / stableZoomLevel,
 				})
 			) {
 				const hitShape = this.editor.getOutermostSelectableShape(shape)

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -23,7 +23,7 @@
 	pointer-events: none;
 	user-select: none;
 	z-index: var(--layer-panels);
-	-webkit-transform: translate3d(0, 0, 0);
+	/* -webkit-transform: translate3d(0, 0, 0); */
 	--sab: env(safe-area-inset-bottom);
 }
 

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
@@ -1,22 +1,23 @@
-import { ANIMATION_MEDIUM_MS, track, useEditor } from '@tldraw/editor'
-import * as React from 'react'
+import { ANIMATION_MEDIUM_MS, useEditor, useValue } from '@tldraw/editor'
+import { memo, useCallback } from 'react'
 import { useActions } from '../../hooks/useActions'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { Button } from '../primitives/Button'
 import * as M from '../primitives/DropdownMenu'
 
-export const ZoomMenu = track(function ZoomMenu() {
+export const ZoomMenu = memo(() => {
 	const editor = useEditor()
 	const msg = useTranslation()
 	const breakpoint = useBreakpoint()
 
-	const zoom = editor.zoomLevel
-	const hasShapes = editor.currentPageShapeIds.size > 0
-	const hasSelected = editor.selectedShapeIds.length > 0
-	const isZoomedTo100 = editor.zoomLevel === 1
+	const zoomLevel = useValue('zoom level', () => editor.zoomLevel, [editor])
+	const hasShapes = useValue('hasShapes', () => editor.currentPageShapeIds.size > 0, [editor])
+	const hasSelected = useValue('hasSelected', () => editor.selectedShapeIds.length > 0, [editor])
 
-	const handleDoubleClick = React.useCallback(() => {
+	const isZoomedTo100 = zoomLevel === 1
+
+	const handleDoubleClick = useCallback(() => {
 		editor.resetZoom(editor.viewportScreenCenter, { duration: ANIMATION_MEDIUM_MS })
 	}, [editor])
 
@@ -31,7 +32,7 @@ export const ZoomMenu = track(function ZoomMenu() {
 					icon={breakpoint < 4 ? 'zoom-in' : undefined}
 				>
 					{breakpoint < 4 ? null : (
-						<span style={{ flexGrow: 0, textAlign: 'center' }}>{Math.floor(zoom * 100)}%</span>
+						<span style={{ flexGrow: 0, textAlign: 'center' }}>{Math.floor(zoomLevel * 100)}%</span>
 					)}
 				</Button>
 			</M.Trigger>


### PR DESCRIPTION
This PR is an attempt to improve zoom performance in the app. 

On Chrome, etc, this gesture goes through out control key + mouse wheel route.

On Safari, pinch zooming goes through our pinch gesture route. There are performance problems here. If you instead hold control key and scroll, those performance problems go away.

But why? 

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Open the editor in Safari on Mac.
2. Create 100 shapes
3. Zoom in and out
