### PR TITLE
Add next cache to clean command

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -27,6 +27,7 @@ goodbye .tsbuild
 goodbye .tsbuild-pub
 goodbye .tsbuild-dev
 goodbye .tsbuild-api
+goodbye .next
 
 rm -rf {packages,bublic/packages}/*/api
 rm -rf {packages,apps,bublic/packages,bublic/apps}/*/*.tgz


### PR DESCRIPTION
In our private repo we have a few next apps and they were not previously being cleaned by the `yarn clean` command

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]


### Release Notes

- Internal tooling change
