### PR TITLE
[fix] bug with eventemitter3 default export

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -15,7 +15,7 @@ import { computed } from '@tldraw/state';
 import { ComputedCache } from '@tldraw/store';
 import { EmbedDefinition } from '@tldraw/tlschema';
 import { EMPTY_ARRAY } from '@tldraw/state';
-import EventEmitter from 'eventemitter3';
+import { EventEmitter } from 'eventemitter3';
 import { HistoryEntry } from '@tldraw/store';
 import { HTMLProps } from 'react';
 import { JsonObject } from '@tldraw/utils';

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -52,7 +52,7 @@ import {
 	sortById,
 	structuredClone,
 } from '@tldraw/utils'
-import EventEmitter from 'eventemitter3'
+import { EventEmitter } from 'eventemitter3'
 import { TLUser, createTLUser } from '../config/createTLUser'
 import { checkShapesAndAddCore } from '../config/defaultShapes'
 import {


### PR DESCRIPTION
This PR switches from the default export to a named export in event emitter 3. Should close https://github.com/tldraw/tldraw/issues/1817.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Hard to test ahead of time, but try [this reproduction](https://stackblitz.com/edit/github-6vmn42?file=src%2FEditor.jsx,src%2Fpages%2Findex.astro,package.json&on=stackblitz) with the new version.

### Release Notes

- [@tldraw/editor] updates eventemitter3 import to fix issue with Astro builds.