### PR TITLE
[fix] editing video shapes

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -554,16 +554,14 @@ input,
 	background-size: cover;
 	width: 100%;
 	height: 100%;
+	pointer-events: all;
 }
 
 .tl-image-container,
-.tl-video-container,
 .tl-embed-container {
 	width: 100%;
 	height: 100%;
 	pointer-events: all;
-	/* background-color: var(--color-background); */
-
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -161,6 +161,12 @@ const TLVideoUtilComponent = track(function TLVideoUtilComponent(props: {
 		if (isLoaded && !isEditing && time !== video.currentTime) {
 			video.currentTime = time
 		}
+
+		if (isEditing) {
+			if (document.activeElement !== video) {
+				video.focus()
+			}
+		}
 	}, [isEditing, isLoaded, time])
 
 	React.useEffect(() => {


### PR DESCRIPTION
This PR fixes editing video shapes. The controls are now interactive again.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a video shape.
2. Double click to edit the shape.
3. Use the controls to pause, change time, etc.

### Release Notes

- Fix bug with editing video shapes.