### PR TITLE
[fix] Replace `findLast` for browser compat

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4232,7 +4232,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const { selectedShapeIds } = this
 		return this.currentPageShapesSorted
 			.filter((shape) => shape.type !== 'group' && selectedShapeIds.includes(shape.id))
-			.findLast((shape) => this.isPointInShape(shape, point, { hitInside: true, margin: 0 }))
+			.reverse() // findlast
+			.find((shape) => this.isPointInShape(shape, point, { hitInside: true, margin: 0 }))
 	}
 
 	/**


### PR DESCRIPTION
Previously, we'd used `Array.findLast` in `getSelectedShapeAtPoint`. This PR removes that newish JS call and replaces it with a `replace` and `find` instead. Closes bug mentioned in https://github.com/tldraw/tldraw/issues/1798.

### Change Type

- [x] `patch` — Bug fix
