### PR TITLE
[feature] Asset props

### DIFF
--- a/apps/examples/src/examples/AssetOptionsExample.tsx
+++ b/apps/examples/src/examples/AssetOptionsExample.tsx
@@ -1,0 +1,20 @@
+import { Tldraw } from '@tldraw/tldraw'
+import '@tldraw/tldraw/tldraw.css'
+
+export default function AssetPropsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				autoFocus
+				// only allow jpegs
+				acceptedImageMimeTypes={['image/jpeg']}
+				// don't allow any images
+				acceptedVideoMimeTypes={[]}
+				// accept images of any dimension
+				maxImageDimension={Infinity}
+				// ...but only accept assets up to 1mb
+				maxAssetSize={1 * 1024 * 1024}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/HostedImagesExample.tsx
+++ b/apps/examples/src/examples/HostedImagesExample.tsx
@@ -1,0 +1,77 @@
+import {
+	AssetRecordType,
+	Editor,
+	MediaHelpers,
+	TLAsset,
+	TLAssetId,
+	Tldraw,
+	getHashForString,
+	uniqueId,
+} from '@tldraw/tldraw'
+import { getIsGifAnimated } from '@tldraw/tldraw/src/lib/utils/assets'
+import '@tldraw/tldraw/tldraw.css'
+import { useCallback } from 'react'
+
+const UPLOAD_URL = '/SOME_ENDPOINT'
+
+export default function AssetPropsExample() {
+	const handleMount = useCallback((editor: Editor) => {
+		// When a user uploads a file, create an asset from it
+		editor.registerExternalAssetHandler('file', async ({ file }: { type: 'file'; file: File }) => {
+			const id = uniqueId()
+
+			const objectName = `${id}-${file.name}`.replaceAll(/[^a-zA-Z0-9.]/g, '-')
+			const url = `${UPLOAD_URL}/${objectName}`
+
+			await fetch(url, {
+				method: 'POST',
+				body: file,
+			})
+
+			const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
+
+			let size: {
+				w: number
+				h: number
+			}
+			let isAnimated: boolean
+			let shapeType: 'image' | 'video'
+
+			if (['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'].includes(file.type)) {
+				shapeType = 'image'
+				size = await MediaHelpers.getImageSizeFromSrc(url)
+				if (file.type === 'image/gif') {
+					isAnimated = await getIsGifAnimated(file)
+				} else {
+					isAnimated = false
+				}
+			} else {
+				shapeType = 'video'
+				isAnimated = true
+				size = await MediaHelpers.getVideoSizeFromSrc(url)
+			}
+
+			const asset: TLAsset = AssetRecordType.create({
+				id: assetId,
+				type: shapeType,
+				typeName: 'asset',
+				props: {
+					name: file.name,
+					src: url,
+					w: size.w,
+					h: size.h,
+					mimeType: file.type,
+					isAnimated,
+				},
+			})
+
+			return asset
+		})
+	}, [])
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw autoFocus onMount={handleMount} />
+		</div>
+	)
+}

--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -14,6 +14,7 @@ import { ListLink } from './components/ListLink'
 
 import BasicExample from './BasicExample'
 import APIExample from './examples/APIExample'
+import AssetPropsExample from './examples/AssetOptionsExample'
 import CanvasEventsExample from './examples/CanvasEventsExample'
 import CustomComponentsExample from './examples/CustomComponentsExample'
 import CustomConfigExample from './examples/CustomConfigExample/CustomConfigExample'
@@ -148,6 +149,11 @@ export const allExamples: Example[] = [
 		title: 'Only editor',
 		path: '/only-editor',
 		element: <OnlyEditorExample />,
+	},
+	{
+		title: 'Asset props',
+		path: '/asset-props',
+		element: <AssetPropsExample />,
 	},
 	// not listed
 	{

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -102,9 +102,6 @@ import { Vec2dModel } from '@tldraw/editor';
 import { VecLike } from '@tldraw/editor';
 
 // @public (undocumented)
-export const ACCEPTED_IMG_TYPE: string[];
-
-// @public (undocumented)
 export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBind: () => boolean;
@@ -264,6 +261,12 @@ function Content({ side, align, sideOffset, alignOffset, children, }: {
 export const ContextMenu: ({ children }: {
     children: any;
 }) => JSX.Element;
+
+// @public (undocumented)
+export const DEFAULT_ACCEPTED_IMG_TYPE: string[];
+
+// @public (undocumented)
+export const DEFAULT_ACCEPTED_VID_TYPE: string[];
 
 // @public (undocumented)
 export const defaultShapeTools: (typeof ArrowShapeTool | typeof DrawShapeTool | typeof FrameShapeTool | typeof GeoShapeTool | typeof LineShapeTool | typeof NoteShapeTool | typeof TextShapeTool)[];
@@ -608,11 +611,6 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 export function getEmbedInfo(inputUrl: string): TLEmbedResult;
 
 // @public (undocumented)
-export function getFileMetaData(file: File): Promise<{
-    isAnimated: boolean;
-}>;
-
-// @public (undocumented)
 function Group({ children, size, }: {
     children: any;
     size?: 'medium' | 'small' | 'tiny' | 'wide';
@@ -727,9 +725,6 @@ function Indicator(): JSX.Element;
 
 // @public (undocumented)
 export const Input: React_3.ForwardRefExoticComponent<TLUiInputProps & React_3.RefAttributes<HTMLInputElement>>;
-
-// @public (undocumented)
-export const isImage: (ext: string) => boolean;
 
 // @public (undocumented)
 function Item({ noClose, ...props }: DropdownMenuItemProps): JSX.Element;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1088,7 +1088,7 @@ function Title({ className, children }: {
 }): JSX.Element;
 
 // @public (undocumented)
-export function Tldraw(props: TldrawEditorProps & TldrawUiProps & {
+export function Tldraw(props: TldrawEditorProps & TldrawUiProps & Partial<TLExternalContentProps> & {
     assetUrls?: RecursivePartial<TLEditorAssetUrls>;
 }): JSX.Element;
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -129,7 +129,7 @@ export {
 export { type TLUiIconType } from './lib/ui/icon-types'
 export { useDefaultHelpers, type TLUiOverrides } from './lib/ui/overrides'
 export { setDefaultEditorAssetUrls } from './lib/utils/assetUrls'
-export { ACCEPTED_IMG_TYPE, getFileMetaData, isImage } from './lib/utils/assets'
+export { DEFAULT_ACCEPTED_IMG_TYPE, DEFAULT_ACCEPTED_VID_TYPE } from './lib/utils/assets'
 export { buildFromV1Document, type LegacyTldrawDocument } from './lib/utils/buildFromV1Document'
 export { getEmbedInfo } from './lib/utils/embeds'
 export {

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -102,8 +102,8 @@ export function Tldraw(
 
 // We put these hooks into a component here so that they can run inside of the context provided by TldrawEditor.
 function InsideOfEditorContext({
-	maxImageDimension = Infinity,
-	maxAssetSize = 10 * 1024 * 1024,
+	maxImageDimension = 1000,
+	maxAssetSize = 10 * 1024 * 1024, // 10mb
 	acceptedImageMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
 	acceptedVideoMimeTypes = ['video/mp4', 'video/quicktime'],
 }: Partial<TLExternalContentProps>) {

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -100,6 +100,7 @@ export function Tldraw(
 	)
 }
 
+// We put these hooks into a component here so that they can run inside of the context provided by TldrawEditor.
 function InsideOfEditorContext({
 	maxImageDimension = Infinity,
 	maxAssetSize = 10 * 1024 * 1024,

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -17,7 +17,10 @@ import { defaultShapeUtils } from './defaultShapeUtils'
 import { defaultTools } from './defaultTools'
 import { TldrawUi, TldrawUiProps } from './ui/TldrawUi'
 import { ContextMenu } from './ui/components/ContextMenu'
-import { useRegisterExternalContentHandlers } from './useRegisterExternalContentHandlers'
+import {
+	TLExternalContentProps,
+	useRegisterExternalContentHandlers,
+} from './useRegisterExternalContentHandlers'
 import { useSideEffects } from './useSideEffects'
 import { TLEditorAssetUrls, useDefaultEditorAssetsWithOverrides } from './utils/assetUrls'
 import { usePreloadAssets } from './utils/usePreloadAssets'
@@ -25,14 +28,22 @@ import { usePreloadAssets } from './utils/usePreloadAssets'
 /** @public */
 export function Tldraw(
 	props: TldrawEditorProps &
-		TldrawUiProps & {
+		TldrawUiProps &
+		Partial<TLExternalContentProps> & {
 			/**
 			 * Urls for the editor to find fonts and other assets.
 			 */
 			assetUrls?: RecursivePartial<TLEditorAssetUrls>
 		}
 ) {
-	const { children, ...rest } = props
+	const {
+		children,
+		maxImageDimension,
+		maxAssetSize,
+		acceptedImageMimeTypes,
+		acceptedVideoMimeTypes,
+		...rest
+	} = props
 
 	const withDefaults: TldrawEditorProps = {
 		initialState: 'select',
@@ -78,14 +89,29 @@ export function Tldraw(
 					<Canvas />
 				</ContextMenu>
 				{children}
-				<Hacks />
+				<InsideOfEditorContext
+					maxImageDimension={maxImageDimension}
+					maxAssetSize={maxAssetSize}
+					acceptedImageMimeTypes={acceptedImageMimeTypes}
+					acceptedVideoMimeTypes={acceptedVideoMimeTypes}
+				/>
 			</TldrawUi>
 		</TldrawEditor>
 	)
 }
 
-function Hacks() {
-	useRegisterExternalContentHandlers()
+function InsideOfEditorContext({
+	maxImageDimension = Infinity,
+	maxAssetSize = 10 * 1024 * 1024,
+	acceptedImageMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'],
+	acceptedVideoMimeTypes = ['video/mp4', 'video/quicktime'],
+}: Partial<TLExternalContentProps>) {
+	useRegisterExternalContentHandlers({
+		maxImageDimension,
+		maxAssetSize,
+		acceptedImageMimeTypes,
+		acceptedVideoMimeTypes,
+	})
 	useSideEffects()
 
 	return null

--- a/packages/tldraw/src/lib/utils/assets.ts
+++ b/packages/tldraw/src/lib/utils/assets.ts
@@ -36,23 +36,15 @@ export function containBoxSize(
 }
 
 /** @public */
-export async function getFileMetaData(file: File): Promise<{ isAnimated: boolean }> {
-	if (file.type === 'image/gif') {
-		return await new Promise((resolve, reject) => {
-			const reader = new FileReader()
-			reader.onerror = () => reject(reader.error)
-			reader.onload = () => {
-				resolve({
-					isAnimated: reader.result ? isAnimated(reader.result as ArrayBuffer) : false,
-				})
-			}
-			reader.readAsArrayBuffer(file)
-		})
-	}
-
-	return {
-		isAnimated: isImage(file.type) ? false : true,
-	}
+export async function getIsGifAnimated(file: File): Promise<boolean> {
+	return await new Promise((resolve, reject) => {
+		const reader = new FileReader()
+		reader.onerror = () => reject(reader.error)
+		reader.onload = () => {
+			resolve(reader.result ? isAnimated(reader.result as ArrayBuffer) : false)
+		}
+		reader.readAsArrayBuffer(file)
+	})
 }
 
 /**
@@ -94,9 +86,6 @@ export async function getResizedImageDataUrl(
 }
 
 /** @public */
-export const ACCEPTED_IMG_TYPE = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
+export const DEFAULT_ACCEPTED_IMG_TYPE = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
 /** @public */
-export const ACCEPTED_VID_TYPE = ['video/mp4', 'video/quicktime']
-
-/** @public */
-export const isImage = (ext: string) => ACCEPTED_IMG_TYPE.includes(ext)
+export const DEFAULT_ACCEPTED_VID_TYPE = ['video/mp4', 'video/quicktime']


### PR DESCRIPTION
This PR adds additional props to the <Tldraw> component for setting the maximum asset size, maximum image dimensions, accepted image types, and accepted video types. It adds an example for using these properties and for uploading image assets.

### Change Type

- [x] `minor` — New feature

### Test Plan

1. Try (and fail) to upload image types other than the default types.
2. Try (and fail) to upload images / videos larger than 10mb.
3. Use the example to customize the properties.

### Release Notes

- [@tldraw/tldraw] add asset props