### PR TITLE
[fix] arrows bind to locked shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -239,10 +239,12 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const point = this.editor.getShapePageTransform(shape.id)!.applyToPoint(handle)
 
 		const target = this.editor.getShapeAtPoint(point, {
-			filter: (shape) => this.editor.getShapeUtil(shape).canBind(shape),
 			hitInside: true,
 			hitFrameInside: true,
 			margin: 0,
+			filter: (targetShpe) => {
+				return !targetShpe.isLocked && this.editor.getShapeUtil(targetShpe).canBind(targetShpe)
+			},
 		})
 
 		if (!target) {

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -11,7 +11,9 @@ export class Pointing extends StateNode {
 		this.didTimeout = false
 
 		const target = this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
-			filter: (shape) => this.editor.getShapeUtil(shape).canBind(shape),
+			filter: (targetShape) => {
+				return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+			},
 			margin: 0,
 			hitInside: true,
 		})


### PR DESCRIPTION
This PR fixes a bug where arrows would bind to locked shapes.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Lock a shape.
2. Confirm that an arrow can neither begin bound to the shape
3. Confirm that an arrow cannot bind to the shape

- [ ] Unit Tests
- [ ] End to end tests

