### PR TITLE
[fix] svg overlays when browser zoom is not 100%

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -235,8 +235,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 1px;
-	width: 1px;
+	height: 10px;
+	width: 10px;
 	overflow: visible;
 	pointer-events: none;
 	transform-origin: top left;
@@ -246,8 +246,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 1px;
-	width: 1px;
+	height: 10px;
+	width: 10px;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
This PR fixes the effect of browser zoom on SVG overlays. I don't know why this works.

Should fix https://github.com/tldraw/tldraw/issues/1834

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Draw a rectangle.
2. Change your browser's zoom level (note: not tldraw's zoom level, just your browser's).
3. Select the rectangle.
