### PR TITLE
Update introduction and usage page of docs

### DIFF
--- a/docs/docs/editor.mdx
+++ b/docs/docs/editor.mdx
@@ -24,7 +24,7 @@ keywords:
 
 The [`Editor`](/gen/editor/Editor) class is the main way of controlling tldraw's editor. You can use it to manage the editor's internal state, make changes to the document, or respond to changes that have occurred.
 
-By design, the [`Editor`](/gen/editor/Editor)'s surface area is very large. Almost everything is available through it. Need to create some shapes? Use [`editor.createShapes()`](/gen/editor/Editor#createShapes). Need to delete them? Use [`editor.deleteShapes(editor.selectedShapeIds)`](/gen/editor/Editor#deleteShapes). Need a sorted array of every shape on the current page? Use [`editor.sortedShapesOnCurrentPage`](/gen/editor/Editor#sortedShapesOnCurrentPage).
+By design, the [`Editor`](/gen/editor/Editor)'s surface area is very large. Almost everything is available through it. Need to create some shapes? Use [`editor.createShapes()`](/gen/editor/Editor#createShapes). Need to delete them? Use [`editor.deleteShapes(editor.selectedShapeIds)`](/gen/editor/Editor#deleteShapes). Need a sorted array of every shape on the current page? Use [`editor.currentPageShapesSorted`](/gen/editor/Editor#currentPageShapesSorted).
 
 This page gives a broad idea of how the [`Editor`](/gen/editor/Editor) class is organized and some of the architectural concepts involved. The full reference is available in the [Editor API](/gen/editor/Editor).
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -16,7 +16,7 @@ import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
 	return (
-		<div className="tldraw__editor">
+		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw />
 		</div>
 	)

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -16,7 +16,7 @@ import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
 	return (
-		<div style={{ position: 'fixed', inset: 0 }}>
+		<div className="tldraw__editor">
 			<Tldraw />
 		</div>
 	)

--- a/docs/getting-started/usage.mdx
+++ b/docs/getting-started/usage.mdx
@@ -14,7 +14,7 @@ import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
 	return (
-		<div style={{ position: 'fixed', inset: 0 }}>
+		<div style={{ position: 'fixed', inset: 0 }} >
 			<Tldraw />
 		</div>
 	)

--- a/docs/getting-started/usage.mdx
+++ b/docs/getting-started/usage.mdx
@@ -14,7 +14,7 @@ import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
 	return (
-		<div className="tldraw__editor">
+		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw />
 		</div>
 	)

--- a/docs/getting-started/usage.mdx
+++ b/docs/getting-started/usage.mdx
@@ -45,4 +45,4 @@ By the way, the [`<Tldraw>`](/gen/tldraw/Tldraw) component can't be server-rende
 
 ## Going deeper
 
-The [`<Tldraw>`](/gen/tldraw/Tldraw) component combines two lower-level components: [`<TldrawEditor>`](/gen/editor/TldrawEditor) and [`<TldrawUi>`](gen/ui/TldrawUi). If you want to have more granular control, you can use those lower-level components directly. See [this example](https://github.com/tldraw/tldraw/blob/main/apps/examples/src/examples/ExplodedExample.tsx) for reference.
+The [`<Tldraw>`](/gen/tldraw/Tldraw) component combines two lower-level components: [`<TldrawEditor>`](/gen/editor/TldrawEditor) and [`<TldrawUi>`](gen/tldraw/TldrawUi). If you want to have more granular control, you can use those lower-level components directly. See [this example](https://github.com/tldraw/tldraw/blob/main/apps/examples/src/examples/ExplodedExample.tsx) for reference.

--- a/docs/getting-started/usage.mdx
+++ b/docs/getting-started/usage.mdx
@@ -14,7 +14,7 @@ import '@tldraw/tldraw/tldraw.css'
 
 export default function () {
 	return (
-		<div style={{ position: 'fixed', inset: 0 }} >
+		<div className="tldraw__editor">
 			<Tldraw />
 		</div>
 	)


### PR DESCRIPTION
This PR updates some out-of-date links that I found on the introduction and usage page of the docs. I may have missed some though. 

@Taha-Hassan-Git I know you're going to look through the docs, so this might help!