### PR TITLE
[fix] line tool bug with tool locked

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
@@ -209,3 +209,20 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 		expect(handles.length).toBe(3)
 	})
 })
+
+describe('tool lock bug', () => {
+	it('works as expected when tool lock is on but shift is off', () => {
+		expect(editor.currentPageShapes.length).toBe(0)
+		editor
+			.updateInstanceState({ isToolLocked: true })
+			.setCurrentTool('line')
+			.pointerDown(0, 0)
+			.pointerMove(10, 10)
+			.pointerUp(10, 10)
+			.pointerDown(100, 100)
+			.pointerMove(110, 110)
+			.pointerUp(100, 100)
+			.pointerUp(120, 110)
+		expect(editor.currentPageShapes.length).toBe(2)
+	})
+})

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -29,60 +29,58 @@ export class Pointing extends StateNode {
 
 		const shape = info.shapeId && this.editor.getShape<TLLineShape>(info.shapeId)
 
-		if (shape) {
+		if (shape && inputs.shiftKey) {
 			this.markId = `creating:${shape.id}`
 			this.editor.mark(this.markId)
 			this.shape = shape
 
-			if (inputs.shiftKey) {
-				const handles = this.editor.getShapeHandles(this.shape)
-				if (!handles) return
+			const handles = this.editor.getShapeHandles(this.shape)
+			if (!handles) return
 
-				const vertexHandles = handles.filter((h) => h.type === 'vertex').sort(sortByIndex)
-				const endHandle = vertexHandles[vertexHandles.length - 1]
+			const vertexHandles = handles.filter((h) => h.type === 'vertex').sort(sortByIndex)
+			const endHandle = vertexHandles[vertexHandles.length - 1]
 
-				const shapePagePoint = Matrix2d.applyToPoint(
-					this.editor.getShapeParentTransform(this.shape)!,
-					new Vec2d(this.shape.x, this.shape.y)
-				)
+			const shapePagePoint = Matrix2d.applyToPoint(
+				this.editor.getShapeParentTransform(this.shape)!,
+				new Vec2d(this.shape.x, this.shape.y)
+			)
 
-				let nextEndHandleIndex: string, nextEndHandleId: string, nextEndHandle: TLHandle
+			let nextEndHandleIndex: string, nextEndHandleId: string, nextEndHandle: TLHandle
 
-				if (vertexHandles.length === 2 && vertexHandles[1].x === 1 && vertexHandles[1].y === 1) {
-					nextEndHandleIndex = vertexHandles[1].index
-					nextEndHandleId = vertexHandles[1].id
-					nextEndHandle = {
-						...vertexHandles[1],
-						x: currentPagePoint.x - shapePagePoint.x,
-						y: currentPagePoint.y - shapePagePoint.y,
-					}
-				} else {
-					nextEndHandleIndex = getIndexAbove(endHandle.index)
-					nextEndHandleId = 'handle:' + nextEndHandleIndex
-					nextEndHandle = {
-						x: currentPagePoint.x - shapePagePoint.x,
-						y: currentPagePoint.y - shapePagePoint.y,
-						index: nextEndHandleIndex,
-						canBind: false,
-						type: 'vertex',
-						id: nextEndHandleId,
-					}
+			if (vertexHandles.length === 2 && vertexHandles[1].x === 1 && vertexHandles[1].y === 1) {
+				nextEndHandleIndex = vertexHandles[1].index
+				nextEndHandleId = vertexHandles[1].id
+				nextEndHandle = {
+					...vertexHandles[1],
+					x: currentPagePoint.x - shapePagePoint.x,
+					y: currentPagePoint.y - shapePagePoint.y,
 				}
-
-				const nextHandles = structuredClone(this.shape.props.handles)
-
-				nextHandles[nextEndHandle.id] = nextEndHandle
-
-				this.editor.updateShapes([
-					{
-						id: this.shape.id,
-						type: this.shape.type,
-						props: {
-							handles: nextHandles,
-						},
-					},
-				])
+			} else {
+				nextEndHandleIndex = getIndexAbove(endHandle.index)
+				nextEndHandleId = 'handle:' + nextEndHandleIndex
+				nextEndHandle = {
+					x: currentPagePoint.x - shapePagePoint.x,
+					y: currentPagePoint.y - shapePagePoint.y,
+					index: nextEndHandleIndex,
+					canBind: false,
+					type: 'vertex',
+					id: nextEndHandleId,
+				}
 			}
+
+			const nextHandles = structuredClone(this.shape.props.handles)
+
+			nextHandles[nextEndHandle.id] = nextEndHandle
+
+			this.editor.updateShapes([
+				{
+					id: this.shape.id,
+					type: this.shape.type,
+					props: {
+						handles: nextHandles,
+					},
+				},
+			])
 		} else {
 			const id = createShapeId()
 


### PR DESCRIPTION
This PR fixes a bug where tool lock would cause the line tool to not work properly.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Turn on tool lock.
2. Draw two line shapes

- [x] Unit Tests

