### PR TITLE
[fix] exit penmode

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -941,7 +941,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('exit-pen-mode', { source })
-					editor.instanceState.isPenMode = false
+					editor.updateInstanceState({ isPenMode: false })
 				},
 			},
 			{


### PR DESCRIPTION
This PR fixes the "Exit Pen Mode" button (see first commit).

There are some other "wrap some stuff in editor.batch" changes in the "follow up changes" commit.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Use an ipad / pencil to enter pen mode
2. Click the Exit pen mode button
