### PR TITLE
Fix indicator transform miscalculation

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -235,8 +235,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 10px;
-	width: 10px;
+	height: 100vh;
+	width: 100vw;
 	overflow: visible;
 	pointer-events: none;
 	transform-origin: top left;
@@ -246,8 +246,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 10px;
-	width: 10px;
+	height: 100vh;
+	width: 100vw;
 	pointer-events: none;
 }
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -235,8 +235,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 100vh;
-	width: 100vw;
+	height: 100px;
+	width: 100px;
 	overflow: visible;
 	pointer-events: none;
 	transform-origin: top left;
@@ -246,8 +246,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 100vh;
-	width: 100vw;
+	height: 100px;
+	width: 100px;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
Before
![image](https://github.com/tldraw/tldraw/assets/1242537/3bd21dda-2dab-4e1b-8c57-f90799b98f53)


After
![image](https://github.com/tldraw/tldraw/assets/1242537/8e55e154-a4dc-4f46-ac5a-4b322926733b)

follow up to https://github.com/tldraw/tldraw/pull/1836 should fix the caveat raised by @leolorenzoluis #1834 

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Fixes indicator transform miscalculation on android and windows
