### PR TITLE
Add snapshot prop, examples

### DIFF
--- a/apps/examples/e2e/tests/test-routes.spec.ts
+++ b/apps/examples/e2e/tests/test-routes.spec.ts
@@ -70,4 +70,9 @@ test.describe('Routes', () => {
 		await page.goto('http://localhost:5420/persistence')
 		await page.waitForSelector('.tl-canvas')
 	})
+
+	test('snapshots', async ({ page }) => {
+		await page.goto('http://localhost:5420/snapshots')
+		await page.waitForSelector('.tl-canvas')
+	})
 })

--- a/apps/examples/src/examples/SnapshotExample/SnapshotExample.tsx
+++ b/apps/examples/src/examples/SnapshotExample/SnapshotExample.tsx
@@ -1,0 +1,39 @@
+import { Tldraw } from '@tldraw/tldraw'
+import '@tldraw/tldraw/tldraw.css'
+import jsonSnapshot from './snapshot.json'
+// ^^^
+// This snapshot was previously created with `editor.store.getSnapshot()`
+// We'll now load this into the editor with `editor.store.loadSnapshot()`.
+// Loading it also migrates the snapshot, so even though the snapshot was
+// created in the past (potentially a few versions ago) it should load
+// successfully.
+
+const LOAD_SNAPSHOT_WITH_INITIAL_DATA = true
+
+export default function SnapshotExample() {
+	if (LOAD_SNAPSHOT_WITH_INITIAL_DATA) {
+		// If you want to use the snapshot as the store's initial data, you can do so like this:
+		return (
+			<div className="tldraw__editor">
+				<Tldraw snapshot={jsonSnapshot} />
+			</div>
+		)
+	}
+
+	// You can also load the snapshot an existing editor instance afterwards. Note that this
+	// does not create a new editor, and doesn't change the editor's state or the editor's undo
+	// history, so you should only ever use this on mount.
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				autoFocus
+				onMount={(editor) => {
+					editor.store.loadSnapshot(jsonSnapshot)
+				}}
+			/>
+		</div>
+	)
+}
+
+// Tips:
+// Want to migrate a snapshot but not load it? Use `editor.store.migrateSnapshot()`

--- a/apps/examples/src/examples/SnapshotExample/snapshot.json
+++ b/apps/examples/src/examples/SnapshotExample/snapshot.json
@@ -1,0 +1,38229 @@
+{
+	"store": {
+		"document:document": {
+			"gridSize": 10,
+			"name": "",
+			"meta": {},
+			"id": "document:document",
+			"typeName": "document"
+		},
+		"page:3qj9EtNgqSCW_6knX2K9_": {
+			"meta": {},
+			"id": "page:3qj9EtNgqSCW_6knX2K9_",
+			"name": "Page 1",
+			"index": "a1",
+			"typeName": "page"
+		},
+		"page:page2": {
+			"meta": {},
+			"id": "page:page2",
+			"name": "Page",
+			"index": "a3",
+			"typeName": "page"
+		},
+		"asset:imageAssetA": {
+			"type": "image",
+			"props": {
+				"w": 1200,
+				"h": 800,
+				"name": "",
+				"isAnimated": false,
+				"mimeType": "png",
+				"src": ""
+			},
+			"meta": {},
+			"id": "asset:imageAssetA",
+			"typeName": "asset"
+		},
+		"shape:EHeAIsYe4xu1-kGxK-Tl_": {
+			"x": 165.796875,
+			"y": 262.39453125,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.13,
+								"y": 0.13,
+								"z": 0.5
+							},
+							{
+								"x": -0.05,
+								"y": 0.27,
+								"z": 0.5
+							},
+							{
+								"x": 0.89,
+								"y": 0.27,
+								"z": 0.5
+							},
+							{
+								"x": 6.72,
+								"y": 0.27,
+								"z": 0.5
+							},
+							{
+								"x": 19.89,
+								"y": -2,
+								"z": 0.5
+							},
+							{
+								"x": 33.39,
+								"y": -6.93,
+								"z": 0.5
+							},
+							{
+								"x": 45.85,
+								"y": -14.57,
+								"z": 0.5
+							},
+							{
+								"x": 59.59,
+								"y": -25.83,
+								"z": 0.5
+							},
+							{
+								"x": 69.66,
+								"y": -38.32,
+								"z": 0.5
+							},
+							{
+								"x": 74.64,
+								"y": -50.34,
+								"z": 0.5
+							},
+							{
+								"x": 76.25,
+								"y": -61.21,
+								"z": 0.5
+							},
+							{
+								"x": 76.23,
+								"y": -71.55,
+								"z": 0.5
+							},
+							{
+								"x": 74.98,
+								"y": -79.2,
+								"z": 0.5
+							},
+							{
+								"x": 70.04,
+								"y": -84.48,
+								"z": 0.5
+							},
+							{
+								"x": 64,
+								"y": -88.11,
+								"z": 0.5
+							},
+							{
+								"x": 58.74,
+								"y": -89.03,
+								"z": 0.5
+							},
+							{
+								"x": 52.9,
+								"y": -88.88,
+								"z": 0.5
+							},
+							{
+								"x": 47.43,
+								"y": -86.1,
+								"z": 0.5
+							},
+							{
+								"x": 42.63,
+								"y": -80,
+								"z": 0.5
+							},
+							{
+								"x": 38.77,
+								"y": -69.36,
+								"z": 0.5
+							},
+							{
+								"x": 36.81,
+								"y": -51.13,
+								"z": 0.5
+							},
+							{
+								"x": 36.43,
+								"y": -26.77,
+								"z": 0.5
+							},
+							{
+								"x": 40.13,
+								"y": 3.13,
+								"z": 0.5
+							},
+							{
+								"x": 48.43,
+								"y": 38.37,
+								"z": 0.5
+							},
+							{
+								"x": 55.57,
+								"y": 69.78,
+								"z": 0.5
+							},
+							{
+								"x": 60.53,
+								"y": 100.75,
+								"z": 0.5
+							},
+							{
+								"x": 63.42,
+								"y": 133.8,
+								"z": 0.5
+							},
+							{
+								"x": 63.1,
+								"y": 160.92,
+								"z": 0.5
+							},
+							{
+								"x": 58.09,
+								"y": 180.57,
+								"z": 0.5
+							},
+							{
+								"x": 47.5,
+								"y": 192.21,
+								"z": 0.5
+							},
+							{
+								"x": 33.36,
+								"y": 197.42,
+								"z": 0.5
+							},
+							{
+								"x": 18.86,
+								"y": 198.58,
+								"z": 0.5
+							},
+							{
+								"x": 6.95,
+								"y": 197.67,
+								"z": 0.5
+							},
+							{
+								"x": -1.21,
+								"y": 194.8,
+								"z": 0.5
+							},
+							{
+								"x": -5.55,
+								"y": 190.55,
+								"z": 0.5
+							},
+							{
+								"x": -6.84,
+								"y": 184.29,
+								"z": 0.5
+							},
+							{
+								"x": -0.86,
+								"y": 173.8,
+								"z": 0.5
+							},
+							{
+								"x": 17.39,
+								"y": 158.11,
+								"z": 0.5
+							},
+							{
+								"x": 45.72,
+								"y": 137.57,
+								"z": 0.5
+							},
+							{
+								"x": 76.32,
+								"y": 113.69,
+								"z": 0.5
+							},
+							{
+								"x": 102.73,
+								"y": 87.41,
+								"z": 0.5
+							},
+							{
+								"x": 120.88,
+								"y": 63.27,
+								"z": 0.5
+							},
+							{
+								"x": 131.73,
+								"y": 39.67,
+								"z": 0.5
+							},
+							{
+								"x": 137.52,
+								"y": 15.89,
+								"z": 0.5
+							},
+							{
+								"x": 138.82,
+								"y": -0.14,
+								"z": 0.5
+							},
+							{
+								"x": 137.79,
+								"y": -10.26,
+								"z": 0.5
+							},
+							{
+								"x": 134.94,
+								"y": -17.39,
+								"z": 0.5
+							},
+							{
+								"x": 131.56,
+								"y": -21.15,
+								"z": 0.5
+							},
+							{
+								"x": 128.66,
+								"y": -22.95,
+								"z": 0.5
+							},
+							{
+								"x": 126.65,
+								"y": -23.48,
+								"z": 0.5
+							},
+							{
+								"x": 125.56,
+								"y": -23.35,
+								"z": 0.5
+							},
+							{
+								"x": 124.66,
+								"y": -20.86,
+								"z": 0.5
+							},
+							{
+								"x": 123.36,
+								"y": -9.53,
+								"z": 0.5
+							},
+							{
+								"x": 120.79,
+								"y": 12.29,
+								"z": 0.5
+							},
+							{
+								"x": 116.39,
+								"y": 41.36,
+								"z": 0.5
+							},
+							{
+								"x": 112.64,
+								"y": 69.82,
+								"z": 0.5
+							},
+							{
+								"x": 111.43,
+								"y": 96.55,
+								"z": 0.5
+							},
+							{
+								"x": 111.3,
+								"y": 122.02,
+								"z": 0.5
+							},
+							{
+								"x": 113.43,
+								"y": 138.52,
+								"z": 0.5
+							},
+							{
+								"x": 119.61,
+								"y": 149.46,
+								"z": 0.5
+							},
+							{
+								"x": 126.6,
+								"y": 156.13,
+								"z": 0.5
+							},
+							{
+								"x": 134.3,
+								"y": 157.33,
+								"z": 0.5
+							},
+							{
+								"x": 144.39,
+								"y": 154.1,
+								"z": 0.5
+							},
+							{
+								"x": 155.78,
+								"y": 144.19,
+								"z": 0.5
+							},
+							{
+								"x": 166.99,
+								"y": 129.98,
+								"z": 0.5
+							},
+							{
+								"x": 176.18,
+								"y": 113.52,
+								"z": 0.5
+							},
+							{
+								"x": 182.1,
+								"y": 96.91,
+								"z": 0.5
+							},
+							{
+								"x": 184.19,
+								"y": 84.67,
+								"z": 0.5
+							},
+							{
+								"x": 184.39,
+								"y": 75.84,
+								"z": 0.5
+							},
+							{
+								"x": 183.51,
+								"y": 69.13,
+								"z": 0.5
+							},
+							{
+								"x": 181.32,
+								"y": 65.31,
+								"z": 0.5
+							},
+							{
+								"x": 178.81,
+								"y": 63.84,
+								"z": 0.5
+							},
+							{
+								"x": 175.82,
+								"y": 63.95,
+								"z": 0.5
+							},
+							{
+								"x": 172.76,
+								"y": 68.43,
+								"z": 0.5
+							},
+							{
+								"x": 170.66,
+								"y": 80.02,
+								"z": 0.5
+							},
+							{
+								"x": 169.83,
+								"y": 96.5,
+								"z": 0.5
+							},
+							{
+								"x": 171.36,
+								"y": 115.16,
+								"z": 0.5
+							},
+							{
+								"x": 175.26,
+								"y": 128.82,
+								"z": 0.5
+							},
+							{
+								"x": 180.67,
+								"y": 136.26,
+								"z": 0.5
+							},
+							{
+								"x": 187.09,
+								"y": 140.58,
+								"z": 0.5
+							},
+							{
+								"x": 193.12,
+								"y": 140.88,
+								"z": 0.5
+							},
+							{
+								"x": 199.64,
+								"y": 134.48,
+								"z": 0.5
+							},
+							{
+								"x": 207.02,
+								"y": 120.32,
+								"z": 0.5
+							},
+							{
+								"x": 213.03,
+								"y": 103.6,
+								"z": 0.5
+							},
+							{
+								"x": 216.17,
+								"y": 90.35,
+								"z": 0.5
+							},
+							{
+								"x": 217.28,
+								"y": 81.68,
+								"z": 0.5
+							},
+							{
+								"x": 217.74,
+								"y": 76.23,
+								"z": 0.5
+							},
+							{
+								"x": 217.66,
+								"y": 74.24,
+								"z": 0.5
+							},
+							{
+								"x": 217.05,
+								"y": 74.53,
+								"z": 0.5
+							},
+							{
+								"x": 215.91,
+								"y": 79.41,
+								"z": 0.5
+							},
+							{
+								"x": 215.21,
+								"y": 90.56,
+								"z": 0.5
+							},
+							{
+								"x": 215.13,
+								"y": 104.09,
+								"z": 0.5
+							},
+							{
+								"x": 215.88,
+								"y": 113.92,
+								"z": 0.5
+							},
+							{
+								"x": 218.83,
+								"y": 120,
+								"z": 0.5
+							},
+							{
+								"x": 223.3,
+								"y": 124.19,
+								"z": 0.5
+							},
+							{
+								"x": 227.71,
+								"y": 125.39,
+								"z": 0.5
+							},
+							{
+								"x": 232.17,
+								"y": 123.21,
+								"z": 0.5
+							},
+							{
+								"x": 236.51,
+								"y": 115.61,
+								"z": 0.5
+							},
+							{
+								"x": 240.17,
+								"y": 103.63,
+								"z": 0.5
+							},
+							{
+								"x": 242.44,
+								"y": 92.33,
+								"z": 0.5
+							},
+							{
+								"x": 243.3,
+								"y": 83.07,
+								"z": 0.5
+							},
+							{
+								"x": 243.52,
+								"y": 76.01,
+								"z": 0.5
+							},
+							{
+								"x": 243.52,
+								"y": 72.19,
+								"z": 0.5
+							},
+							{
+								"x": 243.35,
+								"y": 70.46,
+								"z": 0.5
+							},
+							{
+								"x": 243.19,
+								"y": 70.11,
+								"z": 0.5
+							},
+							{
+								"x": 243.9,
+								"y": 71.26,
+								"z": 0.5
+							},
+							{
+								"x": 249,
+								"y": 75.84,
+								"z": 0.5
+							},
+							{
+								"x": 260.58,
+								"y": 85.07,
+								"z": 0.5
+							},
+							{
+								"x": 276.09,
+								"y": 98.02,
+								"z": 0.5
+							},
+							{
+								"x": 291.7,
+								"y": 113.78,
+								"z": 0.5
+							},
+							{
+								"x": 302.66,
+								"y": 132.02,
+								"z": 0.5
+							},
+							{
+								"x": 307.07,
+								"y": 155.19,
+								"z": 0.5
+							},
+							{
+								"x": 301.63,
+								"y": 180.46,
+								"z": 0.5
+							},
+							{
+								"x": 279.7,
+								"y": 204.16,
+								"z": 0.5
+							},
+							{
+								"x": 251.84,
+								"y": 221.13,
+								"z": 0.5
+							},
+							{
+								"x": 227.02,
+								"y": 228.63,
+								"z": 0.5
+							},
+							{
+								"x": 207.41,
+								"y": 230.88,
+								"z": 0.5
+							},
+							{
+								"x": 195.65,
+								"y": 227.65,
+								"z": 0.5
+							},
+							{
+								"x": 190.99,
+								"y": 216.82,
+								"z": 0.5
+							},
+							{
+								"x": 200.69,
+								"y": 197.52,
+								"z": 0.5
+							},
+							{
+								"x": 229.42,
+								"y": 170.67,
+								"z": 0.5
+							},
+							{
+								"x": 272.13,
+								"y": 137.71,
+								"z": 0.5
+							},
+							{
+								"x": 318.65,
+								"y": 101.51,
+								"z": 0.5
+							},
+							{
+								"x": 352.09,
+								"y": 71.88,
+								"z": 0.5
+							},
+							{
+								"x": 368.29,
+								"y": 50.72,
+								"z": 0.5
+							},
+							{
+								"x": 374.72,
+								"y": 33.76,
+								"z": 0.5
+							},
+							{
+								"x": 370.11,
+								"y": 22.56,
+								"z": 0.5
+							},
+							{
+								"x": 352.23,
+								"y": 17.24,
+								"z": 0.5
+							},
+							{
+								"x": 328.26,
+								"y": 16.93,
+								"z": 0.5
+							},
+							{
+								"x": 308.98,
+								"y": 20.41,
+								"z": 0.5
+							},
+							{
+								"x": 295.36,
+								"y": 25.56,
+								"z": 0.5
+							},
+							{
+								"x": 287.54,
+								"y": 29.66,
+								"z": 0.5
+							},
+							{
+								"x": 285.12,
+								"y": 33.56,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a1",
+			"id": "shape:EHeAIsYe4xu1-kGxK-Tl_",
+			"typeName": "shape"
+		},
+		"shape:rw3t_OBpBeheLvZIrp4Mx": {
+			"x": 511.83984375,
+			"y": 354.4296875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "text",
+			"props": {
+				"color": "black",
+				"size": "m",
+				"w": 133.484375,
+				"text": "It worked!",
+				"font": "draw",
+				"align": "middle",
+				"autoSize": true,
+				"scale": 1
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a2",
+			"id": "shape:rw3t_OBpBeheLvZIrp4Mx",
+			"typeName": "shape"
+		},
+		"shape:0S9cS5N4-B_1723oeZtzj": {
+			"x": 544.390625,
+			"y": 399.0234375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a3",
+			"id": "shape:0S9cS5N4-B_1723oeZtzj",
+			"typeName": "shape"
+		},
+		"shape:NHvyJ2i5f3g27J9B3O5Zy": {
+			"x": 586.1015625,
+			"y": 399.0234375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.3,
+								"y": 0,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a4",
+			"id": "shape:NHvyJ2i5f3g27J9B3O5Zy",
+			"typeName": "shape"
+		},
+		"shape:oJrNFeQHqg7REKEVCUwYv": {
+			"x": 557.6875,
+			"y": 405.50390625,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.27,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.53,
+								"y": 0.21,
+								"z": 0.5
+							},
+							{
+								"x": -0.64,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -1.63,
+								"y": 1.37,
+								"z": 0.5
+							},
+							{
+								"x": -3.02,
+								"y": 2.95,
+								"z": 0.5
+							},
+							{
+								"x": -4.45,
+								"y": 4.56,
+								"z": 0.5
+							},
+							{
+								"x": -5.67,
+								"y": 5.6,
+								"z": 0.5
+							},
+							{
+								"x": -6.29,
+								"y": 6.38,
+								"z": 0.5
+							},
+							{
+								"x": -6.71,
+								"y": 6.99,
+								"z": 0.5
+							},
+							{
+								"x": -6.83,
+								"y": 7.24,
+								"z": 0.5
+							},
+							{
+								"x": -6.66,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -6.21,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -5.64,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -5.07,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -4.51,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -3.95,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -3.42,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -2.86,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -2.35,
+								"y": 7.36,
+								"z": 0.5
+							},
+							{
+								"x": -2.07,
+								"y": 7.36,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a5",
+			"id": "shape:oJrNFeQHqg7REKEVCUwYv",
+			"typeName": "shape"
+		},
+		"shape:DrggNaYz6Rk_ieKWskDsU": {
+			"x": 533.42578125,
+			"y": 419.99609375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.11,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 1.04,
+								"y": 0.44,
+								"z": 0.5
+							},
+							{
+								"x": 2.73,
+								"y": 1.43,
+								"z": 0.5
+							},
+							{
+								"x": 6.05,
+								"y": 2.77,
+								"z": 0.5
+							},
+							{
+								"x": 10.5,
+								"y": 4.27,
+								"z": 0.5
+							},
+							{
+								"x": 15.84,
+								"y": 5.84,
+								"z": 0.5
+							},
+							{
+								"x": 21.36,
+								"y": 6.87,
+								"z": 0.5
+							},
+							{
+								"x": 26.98,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 33.31,
+								"y": 8.23,
+								"z": 0.5
+							},
+							{
+								"x": 40.36,
+								"y": 9.04,
+								"z": 0.5
+							},
+							{
+								"x": 46.94,
+								"y": 9.46,
+								"z": 0.5
+							},
+							{
+								"x": 52,
+								"y": 9.61,
+								"z": 0.5
+							},
+							{
+								"x": 57.39,
+								"y": 9.61,
+								"z": 0.5
+							},
+							{
+								"x": 63.11,
+								"y": 9.11,
+								"z": 0.5
+							},
+							{
+								"x": 68.55,
+								"y": 7.86,
+								"z": 0.5
+							},
+							{
+								"x": 73,
+								"y": 6.53,
+								"z": 0.5
+							},
+							{
+								"x": 76.1,
+								"y": 5.38,
+								"z": 0.5
+							},
+							{
+								"x": 77.62,
+								"y": 4.19,
+								"z": 0.5
+							},
+							{
+								"x": 78.33,
+								"y": 3.05,
+								"z": 0.5
+							},
+							{
+								"x": 78.68,
+								"y": 1.89,
+								"z": 0.5
+							},
+							{
+								"x": 78.83,
+								"y": 0.77,
+								"z": 0.5
+							},
+							{
+								"x": 78.96,
+								"y": -0.21,
+								"z": 0.5
+							},
+							{
+								"x": 79.11,
+								"y": -0.96,
+								"z": 0.5
+							},
+							{
+								"x": 79.39,
+								"y": -1.52,
+								"z": 0.5
+							},
+							{
+								"x": 79.66,
+								"y": -1.93,
+								"z": 0.5
+							},
+							{
+								"x": 79.79,
+								"y": -2.2,
+								"z": 0.5
+							},
+							{
+								"x": 79.79,
+								"y": -2.44,
+								"z": 0.5
+							},
+							{
+								"x": 79.79,
+								"y": -2.64,
+								"z": 0.5
+							},
+							{
+								"x": 79.79,
+								"y": -2.76,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a6",
+			"id": "shape:DrggNaYz6Rk_ieKWskDsU",
+			"typeName": "shape"
+		},
+		"asset:-2122303015": {
+			"meta": {},
+			"type": "image",
+			"props": {
+				"name": "tldrawFile",
+				"src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPIAAAB0CAYAAAC/gW9hAAAKsWlDQ1BJQ0MgUHJvZmlsZQAASImVlwdUE+kWgP+Z9JDQAhGQEnqTLhBASggtgIJ0sBGSAKGEmIKAHVlcgRVFRQTLiq6CKNgoYkMsWFgE7HWDLALKulgQFZU3wCHs7jvvvfPunH/ud27uf8uc+XPuAEDWYAuFabAyAOkCiSjM35sWExtHw/UDFHIRgD7QYXPEQkZoaDBAZFr/XT7eB9CEvmM1Eevff/+vosLliTkAQKEIJ3DFnHSETyPrA0cokgCAqkLshiskwgluR1hNhBSIsGyCk6b4wwQnTDIaP+kTEcZEWBsAPInNFiUBQDJD7LRMThIShxSAsK2AyxcgnIWwR3p6BhfhJoTNEB8hwhPx6Ql/iZP0t5gJ8phsdpKcp3qZFLwPXyxMY2f/n4/jf0t6mnQ6hwmySMmigDBEI3VBD1MzguQsSFgQMs187qT/JCdLAyKnmSNmxk0zl+0TJN+btiB4mhP5fix5HAkrYpp5Yt/waRZlhMlzJYqYjGlmi2bySlMj5fZkHksePyc5InqaM/lRC6ZZnBoeNOPDlNtF0jB5/TyBv/dMXj957+niv/TLZ8n3SpIjAuS9s2fq5wkYMzHFMfLauDwf3xmfSLm/UOItzyVMC5X789L85XZxZrh8rwR5IWf2hsqfYQo7MHSaQTiQACngAj7IADTgg2gxEII0wAbZEl6WZKIhZoYwW8RPSpbQGMhJ49FYAo71HJq9rb0DABPnduq1eE+dPI8Q9eaMbUM1AO5nxsfHz87YAjsBOBEPALF+xma2BADlfgCun+NIRZlTNvTEDQOIQAmoAU2gCwyBGbAC9sAJuAEv4AsCQQiIALFgKeCAZJAORGAFWAXWg3xQCLaAHaAc7AMHQBU4Bk6CRnAOXALXwC3QCe6BJ0AG+sBrMAw+gjEIgnAQGaJAmpAeZAxZQvYQHfKAfKFgKAyKheKhJEgASaFV0AaoECqByqH9UDV0AjoDXYJuQF3QI6gHGoTeQV9gFEyC1WAd2AS2gekwAw6CI+AlcBK8HM6B8+DNcBlcCR+FG+BL8C34HiyDX8MjyN+dAoqK0kdZoegoJioEFYdKRIlQa1AFqFJUJaoW1YxqQ91ByVBDqM9oLJqCpqGt0G7oAHQkmoNejl6DLkKXo6vQDegr6DvoHvQw+juGjNHGWGJcMSxMDCYJswKTjynFHMLUY65i7mH6MB+xWCwVa4p1xgZgY7Ep2JXYIuwebB22BduF7cWO4HA4TZwlzh0XgmPjJLh83C7cUdxFXDeuD/cJr4DXw9vj/fBxeAE+F1+KP4K/gO/G9+PHCMoEY4IrIYTAJWQTigkHCc2E24Q+whhRhWhKdCdGEFOI64llxFriVeJT4nsFBQUDBReFhQp8hXUKZQrHFa4r9Ch8JqmSLEhM0mKSlLSZdJjUQnpEek8mk03IXuQ4soS8mVxNvkx+Tv6kSFG0VmQpchXXKlYoNih2K75RIigZKzGUlirlKJUqnVK6rTSkTFA2UWYqs5XXKFcon1F+oDyiQlGxUwlRSVcpUjmickNlQBWnaqLqq8pVzVM9oHpZtZeCohhSmBQOZQPlIOUqpU8Nq2aqxlJLUStUO6bWoTasrqo+Vz1KPUu9Qv28uoyKoppQWdQ0ajH1JPU+9cssnVmMWbxZm2bVzuqeNaoxW8NLg6dRoFGncU/jiyZN01czVXOrZqPmMy20loXWQq0VWnu1rmoNzVab7TabM7tg9snZj7VhbQvtMO2V2ge027VHdHR1/HWEOrt0LusM6VJ1vXRTdLfrXtAd1KPoeejx9bbrXdR7RVOnMWhptDLaFdqwvrZ+gL5Uf79+h/6YgalBpEGuQZ3BM0OiId0w0XC7YavhsJGe0XyjVUY1Ro+NCcZ042TjncZtxqMmpibRJhtNGk0GTDVMWaY5pjWmT83IZp5my80qze6aY83p5qnme8w7LWALR4tkiwqL25awpZMl33KPZdcczByXOYI5lXMeWJGsGFaZVjVWPdZU62DrXOtG6zc2RjZxNltt2my+2zraptketH1ip2oXaJdr12z3zt7CnmNfYX/Xgezg57DWocnh7VzLuby5e+c+dKQ4znfc6Njq+M3J2UnkVOs06GzkHO+82/kBXY0eSi+iX3fBuHi7rHU55/LZ1clV4nrS9U83K7dUtyNuA/NM5/HmHZzX627gznbf7y7zoHnEe/zsIfPU92R7Vnq+8DL04nod8upnmDNSGEcZb7xtvUXe9d6jTFfmamaLD8rH36fAp8NX1TfSt9z3uZ+BX5Jfjd+wv6P/Sv+WAExAUMDWgAcsHRaHVc0aDnQOXB14JYgUFB5UHvQi2CJYFNw8H54fOH/b/KcLjBcIFjSGgBBWyLaQZ6GmoctDzy7ELgxdWLHwZZhd2KqwtnBK+LLwI+EfI7wjiiOeRJpFSiNbo5SiFkdVR41G+0SXRMtibGJWx9yK1YrlxzbF4eKi4g7FjSzyXbRjUd9ix8X5i+8vMV2SteTGUq2laUvPL1Naxl52Kh4THx1/JP4rO4RdyR5JYCXsThjmMDk7Oa+5Xtzt3EGeO6+E15/onliSOJDknrQtaTDZM7k0eYjP5Jfz36YEpOxLGU0NST2cOp4WnVaXjk+PTz8jUBWkCq5k6GZkZXQJLYX5Qtly1+U7lg+LgkSHxJB4ibhJooYMSO1SM+kP0p5Mj8yKzE8rolacylLJEmS1Z1tkb8ruz/HL+WUleiVnZesq/VXrV/WsZqzevwZak7Cmda3h2ry1fev811WtJ65PXf9rrm1uSe6HDdEbmvN08tbl9f7g/0NNvmK+KP/BRreN+35E/8j/sWOTw6Zdm74XcAtuFtoWlhZ+LeIU3fzJ7qeyn8Y3J27uKHYq3rsFu0Ww5f5Wz61VJSolOSW92+Zva9hO216w/cOOZTtulM4t3beTuFO6U1YWXNa0y2jXll1fy5PL71V4V9Tt1t69affoHu6e7r1ee2v36ewr3PflZ/7PD/f772+oNKksPYA9kHng5cGog22/0H+pPqR1qPDQt8OCw7KqsKor1c7V1Ue0jxTXwDXSmsGji492HvM51lRrVbu/jlpXeBwclx5/dSL+xP2TQSdbT9FP1Z42Pr27nlJf0AA1ZDcMNyY3yppim7rOBJ5pbXZrrj9rffbwOf1zFefVzxdfIF7IuzB+MefiSIuwZehS0qXe1mWtTy7HXL57ZeGVjqtBV69f87t2uY3RdvG6+/VzN1xvnLlJv9l4y+lWQ7tje/2vjr/Wdzh1NNx2vt3U6dLZ3DWv60K3Z/elOz53rt1l3b11b8G9rvuR9x8+WPxA9pD7cOBR2qO3jzMfjz1Z9xTztOCZ8rPS59rPK38z/61O5iQ73+PT0/4i/MWTXk7v69/Fv3/ty3tJflnar9dfPWA/cG7Qb7Dz1aJXfa+Fr8eG8v9Q+WP3G7M3p//0+rN9OGa4763o7fi7ovea7w9/mPuhdSR05PnH9I9jowWfND9VfaZ/bvsS/aV/bMVX3Neyb+bfmr8HfX86nj4+LmSL2JOjAApZcGIiAO8OA0COBYCCzBDERVNz9aRAU98CkwT+E0/N3pPiBEAtoibGI2YLAMeRZbIOACUvACZGowgvADs4yNf0DDw5r08IFvlyqXW9OKqf/nxONfinTM3yf6n7nxrIo/5N/wvqIQ1oPGOfkQAAAIplWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAACQAAAAAQAAAJAAAAABAAOShgAHAAAAEgAAAHigAgAEAAAAAQAAAPKgAwAEAAAAAQAAAHQAAAAAQVNDSUkAAABTY3JlZW5zaG90ufUwPwAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAAdZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8ZXhpZjpQaXhlbFlEaW1lbnNpb24+MTE2PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjI0MjwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlVzZXJDb21tZW50PlNjcmVlbnNob3Q8L2V4aWY6VXNlckNvbW1lbnQ+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgquVEKwAAAAHGlET1QAAAACAAAAAAAAADoAAAAoAAAAOgAAADoAAA9bG3y9EwAADydJREFUeAHsXQl0FEUTLtTgLwIiUVBOBUI4AgkkEOQKAsoVEAM8UYGAHPqr+CuCCnhwBeXSJ8gVLsOpCF4ERFCIIdxHoiTBHAgJCQo+DsUTVP75hvQy29Mzu7Ob4M6m6z3o6e7qmp7q/aa7q6onZYjosvKPwsJbIqG0g/vUVP4nNSA1YB8NlFG6KoFsn/GSPZUaEGpAAlmoFlkoNWAvDUgg22u8ZG+lBoQakEAWqkUWSg3YSwMSyPYaL9lbqQGhBiSQhWqRhVID9tKABLK9xkv2VmpAqAEJZKFaZKHUgL00IIFsr/GSvZUaEGpAAlmoFlkoNWAvDUgg22u8ZG+lBoQakEAWqkUWSg3YSwMSyPYaL9lbDzQQWL8N1YseTYHBrdXWOYkzr6QbZnggzTebSCD75rjIXhWTBiJHfeQAMC/yTNYu2vvmg3yxLfN+DeTXJkyg7j2ihQOTkZ5Ojw0ZLKyzWpickkI33vgfYbMF8+fRsqVLhXWysGQ1ENRzDAUpM7EZYXbO8YOZ2a+B/OmGRGrR8so5a34wf/nlFwqqW4cv9ih/8odTVKYMVKmnFcsT6IUxY/QVsqRYNQDQaqlyUGvDmVjLh2u21MY12p3N2WU7cEsgY/S8JAlkLxXoRXN+/+uFKF1TO83WtgFyQEAAtY+Koq5du1LLyEiqWbMWDRkcS18lJekGgBXIGZlpwj9Td5bO3j753lkxdCZ7p7diSry9TwP51ltvpQXxiygkJIRwzS9fRz79FK374ANDJUkgG6rGLyq6LzxV4s9hF4OYTwO5UaNG9OX2JMPBkkA2VI3fV1yL2Zgp0Q5LbAlkNlpepHKP7IXyPGxq5lbyUKRhMwlkQ9W4VyFnZPf0VBq55IzsPOpyRnbWh0c5OSN7pDavGhUnkLEPZlFfok7JGVmkFRdlL770EoWFNVO5yleoQBEREYYtjh07RnnHjzvVx8cvpO3btqll3hq7HurfXwko6UFNmzSlKlWr0nXXXUcXL16k/Lw8mjdvLq1ZvVq9T+H3P6h1Th0pyqxcsZzGjHYOSpgxcybVqFFTx/7HH3+olnhW8eiAgfS/Z5+lKlWqKAEnN9L4cWNp6ZIlrNopbdCgAY0dP56CgupTYOXKVO7mm+mGG26gy5cvq//Onz9PGRkZlPxVEi2Kj6c///zTqT0yr7z6GmEVJKKVK1fQxsREXdXESZOofv1gXfnhw4dpatwUXXmP6GgaoDyXiBIV+auU+7hDxQVkBlIzeXYwePncjLzvwEHFtaT/kbszuOB5Z84cipsyWWX3FMgA7Np166hNm7amt/3u6FGK7tGd0jOPWAJy7nfH6GYFaDwBdNXuqEo33XQTJSXvoFq1ajmxLFm8mF4eP86p7IEHetPLr76qvBhqOJWbZfAymjxpIi1etMiJLXHTZxQeHu5UxjL79++nXtE9WNaRGr3ELl26RLVqVHfwsYsNGzcZvpwPHjxI0d27MVbD1Ax0ho0EFQzErMpMLs/L2vhKKoHMjcQtlSrRF19ucxsYP3z/PVUODKSyZctykq5kRTOyKyBvS/qKGjZsqJPHA/n1N6bR4CFDdHzuFvB9e+K/TxLCWkV0/vw5ahjsPPO2bduOPli/XsSult3XuROlKzOzlrKyc6jiLbdoixzXE5V7I6TVjIrLyCUCpivZvjwzSyBzv5oPP/qY7ml95ZQMV+VRlgcLhJgBefq0aYTthYi0QB6thH0+P9o5LFHUxqwMK4DOHe+lzMxMlQ2++sxvs4RNwFuzejX6+++/HfXYIgwYOMiR5y/mz5tHkyZOcBTjZZd3osCR5y8aNQimc+fO8cWOvNmM6WBy40IEYndl+2qAiASyZuDvuPNOOpSapgs80bBYvrQKZPyQKyt7XBExIGPVkJ6Rqe6BRXxWyk6eLKTwZldsEmgHIAPQIuobE0M7d6Y4qnbu3kN16hjHq+MF0eneDg7+zvfdRytWrnLktRd4bgDZjNwFm5nxSjSruisXfRO1N+vztarzOSBPnhJHYUU/rHLlyhkaX6AgLGsLCgsdurr8zz80atRzlJuTo5ZZ3SO/u3w5denS1SFPdHE0N5ewXwy8LZCiojoYLqlZWytAZm2MUgZkzMSYkY3o9OnTNPalF2nrli1KP2+j99euFRqkWPs6d9Wm33//Xc0uS1iuhsGyOm3Kz7AnCk+avkywF69d8+re/Y1p0yl28GCtSMf15s2baUis8ewORnciudhsixjsyOc/dMjHhQiEVkDMhG16vCq79JnU54Cs1cy19iMbGW5Yn/gf8p3VqlHyjhQqX748Y9GlJQHkuKmvG+6NsfTtENWeYIhjVEGx/mfl5BquNPr16UMpKTtUdliVFy9Zypo6pQcOHKCeinEPBG8CDFeuqF3bNo4X6xfbtlPjxo2FTYYNfUxoFdcyuwIyAzFrw4OZB6AnIIZsXg6737+ZSiAXaR+WcljMjQizXGiTEF113379aM47c3XlrMBTIGNPClfTxo2JdEBZATCCNdgTMjMywU00Z/ZsVez1119PmGn5uHZU/qS4sBoE11f5psRNpaHDhqnXZv+99eYswr4fdPTYccIqiyfR/pvnQd6VMQo8/B6WgZkv9xTE/MsC9/QFkkAuGoWu3brRsncTDMdk1swZNHPGDGH98fwTqp9XVOkJkC9dukjdlFNe+PiBp4TVTGSrVhQaGkbByt6zadNQQxfZJ598TE+MGOG41Z59+6l27dqOPLvQAg4fU4DPWkuo518AaWmp1K1LF6pYsaK6KtDys+s8xS/fqmULljVMGSgNGYoqeNDy/J6CGHIkkHltupG/lkvrZ58bZWgtRlcf6NWT9u3dK+z13v0HdD5fxugJkOGCgSvGXUKwyMhnnqF7O3aienXrUgUFNDygzGQhgOaRh/s7WMzcWg/160vJycmUX1BIOFqqpR9//JFuv/12bZG698YePCamD82dP9+pjmXeXbZM3dOzvFnqzqyM9kZgdvdlIOqDaI8t4vs3yuSMXKT1uYqrJKZPX8MxCGnUkM6cOSOsNwuksArkfxSD3d21a6kRZMKbaQqrV69BU+LiCNZgRHF5SjyQQ5o0oa1ffCkUh5fMOiVYBr52nmCMEy23I5o3p7HjxlGfvmL9ivzNvGxt3t0ZlQezNyD21ZmY6UUCuUgTCStW0P33d2F60aWwvsIKK6K169ZTu3btRFVkFciiwAuR4PEvv0JPjxwpqrJcxgMZAuDvFQW5HDp0iPbs3k1PPvWU032wrA4OqkfZuVeNbIwBe/D+/R+mOspqgSfess3XG+Wtzsz+DGLoSAK56JcCt9ew4cONfjcUpQA1O1scLGEUiQVhVoEMa3Ob1vcY9gMVcOHAleOKfv7pJ8pV5KWlptLAQYN0S2HWXgTkTYo7qFmz5ozFkZ49e5by8o7r6vLz8ymyRQSlfXOYqipx6VqC7zkiooXQjpCaeoi6K/YAq+TurAy5mJl5V5SV+/nykpo9h62B/OILY2h5QgJ7Fl1qxY88KDaWpk0XG7MgeMTwYbTh009190DB14fT1YMNokqrQN6/bx/16in+8ieTf1gJBrlN8Q8bEWSMGDFc9bMznowj3xoGmoiAjNkesz5PMMSdPXtOB9ZVq1bS6FGjaP7ChdS7t/MnZgsKCgxDXhEXj/h4q2QFyFZl8/wSyLxGLOZdGbtcfaHSCpBd+UXhZ4W/lSfMPpiFjMgqkHfv2kUxD/Y2EkfwCYuWr6wBVg1YPfAkMk4xHhGQA5X4cRwGERGWw/yyGy8fvEA6de5MK1etdmqGfT8OoojIzPYg4mdlEshME1dSn56RETKZmva1c481ORzFa9K4EV24cEFTevXSCpBx4ui743lXG3NX+DE2DWmsM3jFL1pMPXv14rivZosbyM0Vw9HGzzZfvQF3tXXrFho0YIBTKT5YiIgtI0ravp0e7v+QrvpIVhZVqiQO19Qya086AbDwQxsBV9vOXXuAtg279mbPy2S4m/q6oQvP4dNARgfNDu2jHrPDnj171GAFHA3ELI1wP5AVIIP/m/QMnfsE5Yx+/fVX1Q0F/y5cL5MmTzGMsGJtihvI9YKCaEfKTiZel6KP9erc7ShHoAv28GbRZ9jDIo6aJ1cGQMZ/5MgR6tghimXJVQw2Y9yy5XOKHTiQZS2n7hq8LAvmGvDWb67aJ7I+D2QsI7GcdJe8OY+Mkzw40eOK/vrrL0IElDu+2uIGMvrmKpQULzd8/ODU6VMUGdnKpWvKyOCEs84LlI8QuKLZb79Nr0+Nc7AhhPSxoUMdeaMLBKEgGMVTuhazsh1mY+jP54EsMp6YDbw3QIZcqy8Os76griSALLIMu+qHWT0/ozJerDrghnL1wkJUFqKzGDUNDaXPt2xlWWEKdxVcep6GnDKhJblXtguIoQufBzL2rlnKaaaAgLJs7ExTb4HsynotujmWpkZfExEZ5IzOI0O2K2MXeKI6dKD33l+LS7cJ9gREgIkIp8iahYWKqtT4c7Mvtvz2229U9+67dG3zFUu12ZidOHGCWkaE69p5WgBAsz/3wmS4+rtPjA9WafyZGLRnlKv8TSg7fJie9dfngYyOIlBjkXKAgLeUsofQpt4CGbIQgTR7zjtuGWwQXlhYWCB01UBWSQAZcs2OBKJeSwidREQWvsklIq2xiq+frsSXDxwUyxc78ghbRfgqT4gMQ4SYEYn0YsTrabk7s7WdZl0zPdgCyHgAHKZPUCyvzcObm77ptfu1VavXUMdOnYTPrz3JI2IIDQuj1WveM/S9wuI6aeJE9QN8jzzyKM166y2RGPVUEf8ROrOTSCKrs1CwUghXD144Rh8iwF7+c8Xw97jiU27Xvj2tee99I1Hq97VEy1wEhSA4xIheU74XFr9wga7a1ZlpBIFgb17SZGYQs4N/2F392AbI2gfCFyO7dO2mBkXgaxZfp6VRdk42ZSpficTsU5yE5SgA0759FAWUDaCTimtlr2IlZ+d3i/NenspqrPxJHfjBsTfF3vPCzz8T9r3rlZho7ad5PJVv93aYmUFsqQ0A223p7GoMbAlkVw8l66UGSpsGJJBL24jL5/VLDUgg++WwyocqbRqQQC5tIy6f1y81IIHsl8MqH6q0aUACubSNuHxev9SABLJfDqt8qNKmAQnk0jbi8nn9UgMSyH45rPKhSpsGJJBL24jL5/VLDUgg++WwyocqbRr4PwAAAP//xq33/QAADoNJREFU7VwHexbFFj5ICyWUEEgooiC9BYgURapIC6Hb6CCIoIjtll9wn3tVpDdBUBSRErogiiCIBaSFDiIBBClJIJTQ0TvvCWedbDZfME8Sv9VzniffzszOzs6+u+/MmXPOJB8R/Wb+qGF0Uxxo1/atfNQfRUAR8A8C+UxXlcj+eV/aU0XAEwElsicsWqgI+AsBJbK/3pf2VhHwRECJ7AmLFioC/kJAieyv96W9VQQ8EVAie8KihYqAvxBQIvvrfWlvFQFPBJTInrBooSLgLwSUyP56X9pbRcATASWyJyzehZ27dqPaderxyfkffUCnfznlXfEeS2N79KLqNWpx7aWLF1DC0Z/u8UqtpgikR0CJnB6PgLmefZ6mKlUf4jpK5IBQ6ck8RsD3RA4JCaGQkCJ09epVunnzRrbgKxcRSbVq1zUkrUrL4hbRxYspnu0okT1h0cIgQMB3RK5QsRI1in6Y7q/8ABP4vvvuSwfj1aupdPTIEdqze9c9q75PPdufKt1fmdv5cM4sSkw8l65NySiRBQk9BhsCviHyAw9WoU5dYqlY8eLpMLx18yZdv36dChUuTIXNny2XL12iZUsWUuI5b2JKXSWyIKFHvyIQ9ETOly8fPdaqLTVp1pwx/vXXX+ng/n20c8c2Onf2DP32G2/ecvAvX6Ei1a3fgOrUrU8FChTg8k1ffUnbtm5x6rgTSmQ3Ipr3GwJBT2TbUnz8WAKtXBZn1sI3s8S5aLFiFNu9F1WsdD/XXb1yOR08sM+5rkjRolSoYCHOdzX1IiIjOb0sbiElJyU59VKNqn771i3OZ0e1LlMmnCIrVKASJUrSuXNn6cTxYwQtAoL71qiZudUa12Agu3YN6/+0a7Cer2iWFwUKFqQftnzH7dg/xYuHUkT58lSqZCkKKVKEoJVgqYA/eQ67PjScAvkL8IB46dJF+5STLlSoEBUpUpTz6Af64yW4d/78+fnU5cuXCIOuSt4gENRErlOvPqvTgGLLd9/QN19v/MOodOvZh6pVr8HXvf/eDDqfnMxpuzxQoyD20Z+OcJU/QuTQ0BKEQUjW3vY9zp09S3GL5lObdu0dd5bb/RRmBoDBzz3Pl21cv47id+2g2B69Hav57du3aeI7bzrNlipVmlqb9h6qVt0psxOoD80kfueOdFrMy6/909Fcpk0eT9eM0dAtHTrFUL0GUVx89swZmjd3trsKwVaBtsRmMX3yBGOATM1QTwtyB4GgJXIxM6MOHzmaP4xjCUdpyaJPHATwsTSKbkL1GzSkEiVLmhniGh358RDtNQYurIef6NiFCpoZCx/ujRs3aOjwkby2PrB/L61ZtYLbyU0ig1T9Bg3NsGZ3HsAkMKCcOf0LYbCCZEVkPCeeWcQmcliZMtRvwBAqaGZOW1BHlhdSvnnTV7T1+28lS/bgBGyAkVtGjHo5nW1i4ri3Mszu0Hye7juAL025cIFmz5zmbkbzuYhA0BK5+aOP0aOPtSJ8jO9OncgGLcGhr/loI4366BaocquWLyGQFDJjygRKTU2levWjqEPnGFb1pk58h9XU0mFlqKhRryHtO3SiMuFlOf3lF2spybJaJyclOve2P/pAfuSBQ4ZReNly3B5+dmzbSocPHaSrpi8RkeWpVdvHKTQ01DmPRCAiHzqwn2rWrsP1oSofP55Av5w6aQaueC6z8QBea9esohPHjrEKDLX4kRYtKbpJM66Ln5nTJhNUXwhmWsy4ENzn05XLOC0/oSVK0PAXXpIsH919RWGLVm2oWfNH+fz2H7bQxg1fclp/8gaBoCXyCy+NMUQrRrt2bKf169Y6aOBjwUcDgZq3edMGJhpmtkaNH+Zy/NgzFtaTL415nWf3FUsXm9n7sFMPiZw0dtWoVZu6duvptL9qxVI6fPCAk0cCM+czfQdS2XK/k91NDlu1lot3bv+Bvlq/Lp1qXDosjIYMe0Gq0GerV9L+vXucvCR69H6Kqj5UjbNffLaa3XPIAGNgDYH2MmXCWE7LT4OGjXmgQ/7y5cs8AMXv3E4Y8GwZMHiY8zyfzJvLA419XtO5i0BQEtn+iG2/btlyETRg8HOMCD6q92ZMSWdQsWcmqNgfvj/LQU9mScwUmDFsyUki93ryGXqwSlVu/uTPJ2jh/I/sWznpchER1H9Q2rOgMCsiZ9YWjFVVqqRFm926fYtnVecmVsK2N7hnTCw9SpUuzbVnvzuNUlIuOFeKFgJ1OTHxLIeUQiuYOX2yUwfLmNGv/oPz0IomjP1fusHGqaiJXEMgKImMMEh8QPgoxr/9X+fh27XvSA0bR3MeBMHHbQtm5LbtO3DR3j3x9PmaT53TMiO5Z3hUyEkiv/LGvx2Dz+IFH7OV2umEK2HPYlkRefGC+aatBFcL955FAM2Tz/TjC3468iMtX7LIubhl63aOe2/Dus/ZtYeTsJiPef1f/Dxw9yUaIx2WKBBZtiAt7wtpGAZhIFTJWwSCksggK0iLWXfmtEkOIjLjXjfGramTxjnlksD6s9/AIZy1P0gUxHTrQTVr1aHdu3bSus/XyCV8zCkiFy4cQi+Oec1pe+rEcUbtv+bk3YlOMbHs70Z5VkR+583/uC/3zGNNXPmBBwluKmg2YUb1LmlcUbYhDJszcD8R+N6f7T+Is3DxxS2cz+nI8hWo74DBnEYZbAcjXkxTw7EO37dnN5+zB1gMnhhEVfIWgaAkcouWranZIy14DWy7OsRVkpmaiTUgZl7Igo8/pFMnf3bQhEUVllWs7bDGsyWniAwD2pBhI5ymsyKfGPRwQSAiZzZwOTcyCRA3uklTHqzEBWSft9NuIuOcYGurxvIecB7q8p07d9jwBQMYvAQrlsbhFD03YhQPFkir2wko5L0EJZEbRzehNo8/wcEMshbDjDL6lTcYIfsjsiGTWRdlk8ePTbeJQlwoXtbmnCIy1plYb4pkRWRY5UFmSCAiYyacO+f39b60L0d7RpQyrGnh3kpOTqIL589zcAis8xAvInfr2dv422vy+Xlz55hB9LSxR6QZsLBdE7hBHn+iI0U1iuaglknj3+ZAkZGjX+Fz6nZiGP6Un6AkMgI44EJyr5Fl/QnXCyyjthQ3Rp/njb8TgsgpfGQiZY0raMCQYZxFuURWyfmcIrI92KDt6cb9BZdTZtKla3eqVacunw5EZJtI7rYQg977qWedYiwdxJLvFJqEvUb2InLtuvWoc0w3vuTbzZtou3GZycC52fI92+thDC7hxm3XJbY7X7dt6/fGd7/evq2m8wiBoCSybdGdM2uGmVGSGQ64WeBugXwwe6YJpUzkNIwyMcblI+GOcD1NGveWYzkVS3JmM0ZOERmdERUVaYST/nj4EJKeYluLs0vkmFiz9r/rYw5kaGpoDIHt7hoC3QE26By2go56+VXu55nTp03QyDeOPx6EFd86AkzwjBAMGPC/5+Q/W+CG9ecPIxCURAYx4ffFDGdbmbFnWEZ/PCkMM9g4AZUQBMdsBDIjxhizw7GEBGPlbuyojDDY4Bq39Hm6LxuIUL7mUxPdtG+vuwrnxRWDTGZWZDtiDAMNBhwvQegmBhCR7BJZ1v5oJ9DmEHuwgu0ANgS3DBo63AmM2W1CQuFDdms3uEaMjogbh10AwS3uwdPdtuZzF4GgJDIeua1ZIyMkER+IHdnVvmNnahDVKAMqCHmcO2cmtWzdNl0Uk1T8euMGz00GOG/HEgea1ewNHHa4p9wDR9vghjziwxEnbgs2dCCkEkYjkewSuWPnrrzbC+0g8AQBKG6xfcg4l1m8tL1mh4ENA6KXPQKGSBjCEEAiW0fdLi13HzSfuwgELZFtw5F7BoG7BDMv1LqkxESjvh5kww62NCKKq4b5P1j1oxpScTNTIDAEu4QC/X8t2/8MuDEoYKcU1Ej4T1OvXOG30LT5I7ylUl4J+oUZHh8z6l26eJFPyYwl9bAmBfERSBFpXGTNTcgkrrGJkF0iY8smyCyCUNDDB/fTKWNHgNspqlFjVn3te2W2xIDlu7+JEbfFK1LMXvpIXa96ck6PuY9A0BIZj24TZ0/8Lvb/uvcf5wREiEwaOfrVDBsM0La9+wlbH2H99nLvIEYZscoQqJrYNIHwx8wEPvLvv/2aN3igTnaJjGUIBg7Zhul1PxgNsc5FdBv67jYi2tfAwGX7nDMz2Nm2AFw/bZLZOZXJ9ka7fU3nDgJBTWQ8sr1+hRtladwCwoySleCDRfgiZsF7EcxG3Xs9mWEzg01ktANfNGKp3f+pxCYy6mH3VjvjqpH/kokyEcR6r129iipVrkzde/bh4kWfzKOfTxyXKhwyKa6sQFZrXIBAlFZt2rEW4jRwN4HnX71qOfvUR5nBCuoyxMt6j3I8G+LFIe5QTC68+wOsZMsk3sucWdPt05rOYwSCnsjYqI6wS3tdDKvq7vgd5uM8SVfMLp5bZuM/6mEPcFh4uFEl6zKB7pj19RSz2wkz0L0KtgvinwFgA/1FE3N85UqaWu2+HveC+o81PDbki/rtrof1cHh4OWMVDuEoL2zw99rz674uO3ncA9FccMWhXykpKWaZ8Ps/SchOm3qNPxAIeiILjFWrVTfBCJ0yzJhy3uuIdeEC429OSkpzU3nV0TJF4K+AgG+ILGAjnjrKuEXw3zSh3orVFOdhaU1NvWIMX6dp397dGTZVSBt6VAT+agj4jsheLwDWZaiSKorA3xWBvwSR/64vT59bERAElMiChB4VAR8joET28cvTrisCgoASWZDQoyLgYwSUyD5+edp1RUAQUCILEnpUBHyMgBLZxy9Pu64ICAJKZEFCj4qAjxFQIvv45WnXFQFBQIksSOhREfAxAkpkH7887boiIAgokQUJPSoCPkZAiezjl6ddVwQEASWyIKFHRcDHCCiRffzytOuKgCCgRBYk9KgI+BgBJbKPX552XREQBJTIgoQeFQEfI6BE9vHL064rAoKAElmQ0KMi4GMElMg+fnnadUVAEPg/Ozet4kLk2xYAAAAASUVORK5CYII=",
+				"w": 121,
+				"h": 58,
+				"mimeType": "image/png",
+				"isAnimated": false
+			},
+			"id": "asset:-2122303015",
+			"typeName": "asset"
+		},
+		"shape:o_2EMovbM7LMmTV9n7Pxt": {
+			"x": 476.55859375,
+			"y": 459.5078125,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "image",
+			"props": {
+				"w": 121,
+				"h": 58,
+				"assetId": "asset:-2122303015",
+				"playing": true,
+				"url": "",
+				"crop": null
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a7",
+			"id": "shape:o_2EMovbM7LMmTV9n7Pxt",
+			"typeName": "shape"
+		},
+		"shape:W25cQBiKtpEgJQAWccWrs": {
+			"x": 413.796875,
+			"y": 391.796875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "text",
+			"props": {
+				"color": "black",
+				"size": "m",
+				"w": 152.609375,
+				"text": "page 2 crew",
+				"font": "draw",
+				"align": "middle",
+				"autoSize": true,
+				"scale": 1
+			},
+			"parentId": "page:page2",
+			"index": "a1",
+			"id": "shape:W25cQBiKtpEgJQAWccWrs",
+			"typeName": "shape"
+		},
+		"shape:XNOJzB586-5whTtAYC6M_": {
+			"x": 496.5859375,
+			"y": 410.23046875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "arrow",
+			"parentId": "page:page2",
+			"index": "a4",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "binding",
+					"boundShapeId": "shape:W25cQBiKtpEgJQAWccWrs",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"end": {
+					"type": "binding",
+					"boundShapeId": "shape:EL15Akq9Nx9_NPdglsqgG",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"id": "shape:XNOJzB586-5whTtAYC6M_",
+			"typeName": "shape"
+		},
+		"shape:EL15Akq9Nx9_NPdglsqgG": {
+			"x": 448.4184995968317,
+			"y": 519.76171875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "geo",
+			"props": {
+				"w": 83.33559924570821,
+				"h": 80.22879950084786,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:page2",
+			"index": "a3",
+			"id": "shape:EL15Akq9Nx9_NPdglsqgG",
+			"typeName": "shape"
+		},
+		"shape:eDog8u-JyLF-5AsQruvyM": {
+			"x": 471.9453125,
+			"y": 552.609375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:page2",
+			"index": "a5",
+			"id": "shape:eDog8u-JyLF-5AsQruvyM",
+			"typeName": "shape"
+		},
+		"shape:KEjUdOIrvizOLzPSVy7ia": {
+			"x": 507.15625,
+			"y": 552.609375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.13,
+								"y": 0,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:page2",
+			"index": "a6",
+			"id": "shape:KEjUdOIrvizOLzPSVy7ia",
+			"typeName": "shape"
+		},
+		"shape:9mTeZ081zvz7RULyU3iwv": {
+			"x": 481.96484375,
+			"y": 564.5234375,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.35,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 0.92,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": 2.15,
+								"y": -0.14,
+								"z": 0.5
+							},
+							{
+								"x": 3.6,
+								"y": 0.05,
+								"z": 0.5
+							},
+							{
+								"x": 5.12,
+								"y": 0.54,
+								"z": 0.5
+							},
+							{
+								"x": 6.6,
+								"y": 0.88,
+								"z": 0.5
+							},
+							{
+								"x": 8.29,
+								"y": 1.04,
+								"z": 0.5
+							},
+							{
+								"x": 10.45,
+								"y": 1.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.27,
+								"y": 1.04,
+								"z": 0.5
+							},
+							{
+								"x": 13.35,
+								"y": 1,
+								"z": 0.5
+							},
+							{
+								"x": 14.04,
+								"y": 0.81,
+								"z": 0.5
+							},
+							{
+								"x": 14.57,
+								"y": 0.2,
+								"z": 0.5
+							},
+							{
+								"x": 14.82,
+								"y": -0.55,
+								"z": 0.5
+							},
+							{
+								"x": 14.85,
+								"y": -1.27,
+								"z": 0.5
+							},
+							{
+								"x": 14.97,
+								"y": -1.87,
+								"z": 0.5
+							},
+							{
+								"x": 15.06,
+								"y": -2.09,
+								"z": 0.5
+							},
+							{
+								"x": 15.06,
+								"y": -2.25,
+								"z": 0.5
+							},
+							{
+								"x": 15.06,
+								"y": -2.74,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:page2",
+			"index": "a7",
+			"id": "shape:9mTeZ081zvz7RULyU3iwv",
+			"typeName": "shape"
+		},
+		"shape:v37oWIZEkIqKGdGZghrfA": {
+			"x": -1838.9140660856651,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:v37oWIZEkIqKGdGZghrfA",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8",
+			"props": {
+				"color": "black",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:O-pU2_ggUM64ZWU1r7oEB": {
+			"x": -1624.6911969546622,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:O-pU2_ggUM64ZWU1r7oEB",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9",
+			"props": {
+				"color": "grey",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:Db4p1ma1mBBGp46eN64w1": {
+			"x": -1410.4683278236594,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Db4p1ma1mBBGp46eN64w1",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aA",
+			"props": {
+				"color": "light-violet",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:WDS44YHks5BXIyPHQQJ0R": {
+			"x": -1838.9140660856651,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WDS44YHks5BXIyPHQQJ0R",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8V",
+			"props": {
+				"color": "black",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:UDQEf9jgTpNzI3CfOyG1R": {
+			"x": -1624.6911969546622,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UDQEf9jgTpNzI3CfOyG1R",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9V",
+			"props": {
+				"color": "grey",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:jTgf4aMkA3yUUQjqZ1Esg": {
+			"x": -1410.4683278236594,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jTgf4aMkA3yUUQjqZ1Esg",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aB",
+			"props": {
+				"color": "light-violet",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:dpCjCMsd1fav6Fq0nWxxN": {
+			"x": -1838.9140660856651,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dpCjCMsd1fav6Fq0nWxxN",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8l",
+			"props": {
+				"color": "black",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:bzp3tr2VD3-XFJuyzl4LG": {
+			"x": -1624.6911969546622,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bzp3tr2VD3-XFJuyzl4LG",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9l",
+			"props": {
+				"color": "grey",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:dgFDz6VnCOj59T5GZmM8I": {
+			"x": -1410.4683278236594,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dgFDz6VnCOj59T5GZmM8I",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aC",
+			"props": {
+				"color": "light-violet",
+				"size": "s",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:r_8EdkdPAkGazaReo3UQM": {
+			"x": -1196.2454586926567,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:r_8EdkdPAkGazaReo3UQM",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8G",
+			"props": {
+				"color": "violet",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:FE4rMcHsBATODJGlmGggN": {
+			"x": -1196.2454586926567,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FE4rMcHsBATODJGlmGggN",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8d",
+			"props": {
+				"color": "violet",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:aOl46rKwMP2CvXVaZVy0t": {
+			"x": -1196.2454586926567,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aOl46rKwMP2CvXVaZVy0t",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8t",
+			"props": {
+				"color": "violet",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:xGsZcSEb-eQyVcD7E3pBq": {
+			"x": -982.022589561654,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xGsZcSEb-eQyVcD7E3pBq",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9G",
+			"props": {
+				"color": "blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:TVn_nW2-fSrgqTf9d7QEn": {
+			"x": -982.022589561654,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TVn_nW2-fSrgqTf9d7QEn",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9d",
+			"props": {
+				"color": "blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:z1SAUTRV8b_6AyT3rqEE3": {
+			"x": -982.022589561654,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:z1SAUTRV8b_6AyT3rqEE3",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9t",
+			"props": {
+				"color": "blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:fcKJybwVMa3XfwuZnNGhG": {
+			"x": -767.7997204306512,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fcKJybwVMa3XfwuZnNGhG",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aAV",
+			"props": {
+				"color": "light-blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:ydx11LNtZV7x0cb32nA9g": {
+			"x": -767.7997204306512,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ydx11LNtZV7x0cb32nA9g",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aBV",
+			"props": {
+				"color": "light-blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:125gTSb1JtEqiHRnytqnZ": {
+			"x": -767.7997204306512,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:125gTSb1JtEqiHRnytqnZ",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aD",
+			"props": {
+				"color": "light-blue",
+				"size": "m",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:VNznAJwAoRLvDTD7vFO8w": {
+			"x": -553.5768512996483,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VNznAJwAoRLvDTD7vFO8w",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8O",
+			"props": {
+				"color": "yellow",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:MRUayz0sC3jFIbBOWV_5s": {
+			"x": -553.5768512996483,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MRUayz0sC3jFIbBOWV_5s",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8h",
+			"props": {
+				"color": "yellow",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:ZtYO6CBivoWvNy79Rh-zT": {
+			"x": -553.5768512996483,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZtYO6CBivoWvNy79Rh-zT",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8x",
+			"props": {
+				"color": "yellow",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:COnl317kfUp6dJd7xhfXY": {
+			"x": -339.35398216864564,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:COnl317kfUp6dJd7xhfXY",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9O",
+			"props": {
+				"color": "orange",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:aw9nV-ewq8iioGZqGMGQV": {
+			"x": -339.35398216864564,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aw9nV-ewq8iioGZqGMGQV",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9h",
+			"props": {
+				"color": "orange",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:6D1qvd4nHRtCAXVZdhaYU": {
+			"x": -339.35398216864564,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6D1qvd4nHRtCAXVZdhaYU",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9x",
+			"props": {
+				"color": "orange",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:YqkJCgfMRka-CQaMkzBVf": {
+			"x": -125.13111303764299,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YqkJCgfMRka-CQaMkzBVf",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aAl",
+			"props": {
+				"color": "green",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:gaR2bbGFa1YDKnt1evH1p": {
+			"x": -125.13111303764299,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gaR2bbGFa1YDKnt1evH1p",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aBl",
+			"props": {
+				"color": "green",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:hA__THRSe75eJR1wBMrg3": {
+			"x": -125.13111303764299,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hA__THRSe75eJR1wBMrg3",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aE",
+			"props": {
+				"color": "green",
+				"size": "l",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:xve9FUlVoYepJAPJ_zIOs": {
+			"x": 89.09175609335989,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xve9FUlVoYepJAPJ_zIOs",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8S",
+			"props": {
+				"color": "light-green",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:aD1P1eAkCMTNX8yHQlodJ": {
+			"x": 89.09175609335989,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aD1P1eAkCMTNX8yHQlodJ",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8j",
+			"props": {
+				"color": "light-green",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:bgt1lyKEZhyHSEs_M2LGY": {
+			"x": 89.09175609335989,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bgt1lyKEZhyHSEs_M2LGY",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a8z",
+			"props": {
+				"color": "light-green",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:yLLyULpv9npz3LkaB06B5": {
+			"x": 303.31462522436277,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yLLyULpv9npz3LkaB06B5",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9S",
+			"props": {
+				"color": "light-red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:doBNMKxkygcuV97zErC-G": {
+			"x": 303.31462522436277,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:doBNMKxkygcuV97zErC-G",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9j",
+			"props": {
+				"color": "light-red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:jwAfEXnooGCD8rq56Up8l": {
+			"x": 303.31462522436277,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jwAfEXnooGCD8rq56Up8l",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "a9z",
+			"props": {
+				"color": "light-red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:t6eRtjdirUdF57OR86MB6": {
+			"x": 517.5374943553652,
+			"y": 7604.549881178025,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:t6eRtjdirUdF57OR86MB6",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aAt",
+			"props": {
+				"color": "red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:0kdXpX9RoqxnZ5a_WKjrl": {
+			"x": 517.5374943553652,
+			"y": 7813.403435567038,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0kdXpX9RoqxnZ5a_WKjrl",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aBt",
+			"props": {
+				"color": "red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:rih8sUJ5RdLq3erx3V3cy": {
+			"x": 517.5374943553652,
+			"y": 8023.6423279395285,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rih8sUJ5RdLq3erx3V3cy",
+			"type": "note",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aF",
+			"props": {
+				"color": "red",
+				"size": "xl",
+				"text": "Sticky note",
+				"font": "draw",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"typeName": "shape"
+		},
+		"shape:XYHwYMObc4GBNzeUkEPIm": {
+			"x": -259.0812996416322,
+			"y": 1415.1839298200061,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XYHwYMObc4GBNzeUkEPIm",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGV",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:YZbcyoc6eVXgRqXmpyd7x": {
+			"x": -259.0812996416322,
+			"y": 1428.272063943046,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YZbcyoc6eVXgRqXmpyd7x",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHG",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:CT3GcujN92TvVvij28qoj": {
+			"x": -259.0812996416322,
+			"y": 1434.7440241266677,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CT3GcujN92TvVvij28qoj",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHl",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:0SweYa0DRsVCbxOi2E1CT": {
+			"x": -259.0812996416322,
+			"y": 1422.8007706363828,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0SweYa0DRsVCbxOi2E1CT",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJ",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:kgYsiWwB4OCLyrHPRlaex": {
+			"x": 290.69396489540804,
+			"y": 1415.1839298200061,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:kgYsiWwB4OCLyrHPRlaex",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGl",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:p84ZWa7fxpwU7bzQN-EZJ": {
+			"x": 290.69396489540804,
+			"y": 1428.272063943046,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:p84ZWa7fxpwU7bzQN-EZJ",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHO",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:H64ci4TCzpMhea1EqGKil": {
+			"x": 290.69396489540804,
+			"y": 1434.7440241266677,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:H64ci4TCzpMhea1EqGKil",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHt",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:RURApB6z-X6Oq9xKl95gB": {
+			"x": 290.69396489540804,
+			"y": 1422.8007706363828,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RURApB6z-X6Oq9xKl95gB",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aK",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:BYpKYw_wdGF4ZFGrOKbLN": {
+			"x": 823.6985627854997,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BYpKYw_wdGF4ZFGrOKbLN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL",
+			"typeName": "shape"
+		},
+		"shape:ZxXu3NiB0PiYYCz-za2VO": {
+			"x": 912.8193315569235,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZxXu3NiB0PiYYCz-za2VO",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM",
+			"typeName": "shape"
+		},
+		"shape:OzAtgAddOWowkpoaDLIrf": {
+			"x": 1001.9401003283474,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OzAtgAddOWowkpoaDLIrf",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN",
+			"typeName": "shape"
+		},
+		"shape:LDo0u1PDMsgiCF8gxycR4": {
+			"x": 1091.0608690997713,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LDo0u1PDMsgiCF8gxycR4",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aO",
+			"typeName": "shape"
+		},
+		"shape:gFuDFYVxJ44FnVm3vfjli": {
+			"x": 823.6985627854997,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gFuDFYVxJ44FnVm3vfjli",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLV",
+			"typeName": "shape"
+		},
+		"shape:e3o6Hn4SI6_QbjqKIR_uK": {
+			"x": 912.8193315569235,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:e3o6Hn4SI6_QbjqKIR_uK",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMV",
+			"typeName": "shape"
+		},
+		"shape:XAKnXzlIjbZ9OJ89cLtKt": {
+			"x": 1001.9401003283474,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XAKnXzlIjbZ9OJ89cLtKt",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNV",
+			"typeName": "shape"
+		},
+		"shape:Er1KUbOqGKmxKmDvfkUy9": {
+			"x": 1091.0608690997713,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Er1KUbOqGKmxKmDvfkUy9",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aP",
+			"typeName": "shape"
+		},
+		"shape:5yqSo2aF6YQoUpzMbCtmI": {
+			"x": 823.6985627854997,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5yqSo2aF6YQoUpzMbCtmI",
+			"type": "geo",
+			"props": {
+				"w": 64.60315211307564,
+				"h": 48.96301770717472,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLl",
+			"typeName": "shape"
+		},
+		"shape:_9u-7i3pSrNFQpjMvgxnK": {
+			"x": 912.8193315569235,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_9u-7i3pSrNFQpjMvgxnK",
+			"type": "geo",
+			"props": {
+				"w": 63.360892260497934,
+				"h": 49.195177683622035,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMl",
+			"typeName": "shape"
+		},
+		"shape:Lw3XxAeVoKWWIuN41bNO5": {
+			"x": 1001.9401003283474,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Lw3XxAeVoKWWIuN41bNO5",
+			"type": "geo",
+			"props": {
+				"w": 66.87337465809267,
+				"h": 48.97377021353676,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNl",
+			"typeName": "shape"
+		},
+		"shape:86ciiHNEAXWTfs4sI90EO": {
+			"x": 1091.0608690997713,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:86ciiHNEAXWTfs4sI90EO",
+			"type": "geo",
+			"props": {
+				"w": 63.49092845281507,
+				"h": 49.70805530562984,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aQ",
+			"typeName": "shape"
+		},
+		"shape:Qpm0UTzjK2PIkUHYsi2Oe": {
+			"x": 823.6985627854997,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Qpm0UTzjK2PIkUHYsi2Oe",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLt",
+			"typeName": "shape"
+		},
+		"shape:lutVFtOQ45zqqANxN1hiC": {
+			"x": 912.8193315569235,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lutVFtOQ45zqqANxN1hiC",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMt",
+			"typeName": "shape"
+		},
+		"shape:KTUJa0PJFFMVyu1nOovLu": {
+			"x": 1001.9401003283474,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KTUJa0PJFFMVyu1nOovLu",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNt",
+			"typeName": "shape"
+		},
+		"shape:nJIGf0tfWnHa-owYw2fRU": {
+			"x": 1091.0608690997713,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nJIGf0tfWnHa-owYw2fRU",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aR",
+			"typeName": "shape"
+		},
+		"shape:3-wg1Br2LxCNMSJJ02tSq": {
+			"x": 823.6985627854997,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3-wg1Br2LxCNMSJJ02tSq",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLx",
+			"typeName": "shape"
+		},
+		"shape:R3RhaTZNFyQzu4jf7Jvvt": {
+			"x": 912.8193315569235,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R3RhaTZNFyQzu4jf7Jvvt",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMx",
+			"typeName": "shape"
+		},
+		"shape:rhdHcIgGglkF7nlHB-rhE": {
+			"x": 1001.9401003283474,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rhdHcIgGglkF7nlHB-rhE",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNx",
+			"typeName": "shape"
+		},
+		"shape:e9LV-mNHaAYsyH1QJIb8-": {
+			"x": 1091.0608690997713,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:e9LV-mNHaAYsyH1QJIb8-",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aS",
+			"typeName": "shape"
+		},
+		"shape:tYT10zYg7tmVG0LlZPHrH": {
+			"x": 823.6985627854997,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tYT10zYg7tmVG0LlZPHrH",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLz",
+			"typeName": "shape"
+		},
+		"shape:2qfJEHxMioLhHR_D9kJ-V": {
+			"x": 912.8193315569235,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2qfJEHxMioLhHR_D9kJ-V",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMz",
+			"typeName": "shape"
+		},
+		"shape:s46l-S7TZu7LaM4kfTNdv": {
+			"x": 1001.9401003283474,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:s46l-S7TZu7LaM4kfTNdv",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNz",
+			"typeName": "shape"
+		},
+		"shape:AeoWQNTktqBRVnKjjGWzf": {
+			"x": 1091.0608690997713,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AeoWQNTktqBRVnKjjGWzf",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aT",
+			"typeName": "shape"
+		},
+		"shape:4jF89wMBcCC4SEsFMYBnw": {
+			"x": 823.6985627854997,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4jF89wMBcCC4SEsFMYBnw",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzV",
+			"typeName": "shape"
+		},
+		"shape:OAbt17v6BJp9Wy7K5XNEw": {
+			"x": 912.8193315569235,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OAbt17v6BJp9Wy7K5XNEw",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzV",
+			"typeName": "shape"
+		},
+		"shape:i8WBghktMV3E7muMq2BMa": {
+			"x": 1001.9401003283474,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:i8WBghktMV3E7muMq2BMa",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzV",
+			"typeName": "shape"
+		},
+		"shape:5X_0oyFgn-0xdbVzf9dQL": {
+			"x": 1091.0608690997713,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5X_0oyFgn-0xdbVzf9dQL",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aU",
+			"typeName": "shape"
+		},
+		"shape:Bw_mCrIjnSYkWeNEaVLOa": {
+			"x": 823.6985627854997,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Bw_mCrIjnSYkWeNEaVLOa",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzl",
+			"typeName": "shape"
+		},
+		"shape:6uXqMQgPTcJOkVqq80Fy5": {
+			"x": 912.8193315569235,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6uXqMQgPTcJOkVqq80Fy5",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzl",
+			"typeName": "shape"
+		},
+		"shape:i4-F9C_rXM9w73Cb7t5Yf": {
+			"x": 1001.9401003283474,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:i4-F9C_rXM9w73Cb7t5Yf",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzl",
+			"typeName": "shape"
+		},
+		"shape:NODIGBp7sItyIclTVs2MX": {
+			"x": 1091.0608690997713,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:NODIGBp7sItyIclTVs2MX",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aV",
+			"typeName": "shape"
+		},
+		"shape:naaKpT_x8CNRfknhuEHrN": {
+			"x": 823.6985627854997,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:naaKpT_x8CNRfknhuEHrN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzt",
+			"typeName": "shape"
+		},
+		"shape:PFfcfu0J0WJnVI4gaDCzp": {
+			"x": 912.8193315569235,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PFfcfu0J0WJnVI4gaDCzp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzt",
+			"typeName": "shape"
+		},
+		"shape:sSoa5eu21LrlE5OHyh3CJ": {
+			"x": 1001.9401003283474,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sSoa5eu21LrlE5OHyh3CJ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzt",
+			"typeName": "shape"
+		},
+		"shape:hckqOoB31RLqlCGwK1N3W": {
+			"x": 1091.0608690997713,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hckqOoB31RLqlCGwK1N3W",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aW",
+			"typeName": "shape"
+		},
+		"shape:gHhgq4dbeRbzYxpd9Q8pw": {
+			"x": 823.6985627854997,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gHhgq4dbeRbzYxpd9Q8pw",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzx",
+			"typeName": "shape"
+		},
+		"shape:eOvFnOp60bE_zLVtHkaEi": {
+			"x": 912.8193315569235,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:eOvFnOp60bE_zLVtHkaEi",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzx",
+			"typeName": "shape"
+		},
+		"shape:F42WcYz3JA3SvvphoqBPu": {
+			"x": 1001.9401003283474,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:F42WcYz3JA3SvvphoqBPu",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzx",
+			"typeName": "shape"
+		},
+		"shape:X3Hi7PRM9xLAsB0k39X54": {
+			"x": 1091.0608690997713,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X3Hi7PRM9xLAsB0k39X54",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aX",
+			"typeName": "shape"
+		},
+		"shape:urv5_Al5-8pSyytBTSdwb": {
+			"x": 823.6985627854997,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:urv5_Al5-8pSyytBTSdwb",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzz",
+			"typeName": "shape"
+		},
+		"shape:uObXPxkdJK8N_INULJvqE": {
+			"x": 912.8193315569235,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uObXPxkdJK8N_INULJvqE",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzz",
+			"typeName": "shape"
+		},
+		"shape:RsyjF7JSpd3LecEB8LFeB": {
+			"x": 1001.9401003283474,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RsyjF7JSpd3LecEB8LFeB",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzz",
+			"typeName": "shape"
+		},
+		"shape:IXPN77UQF3QsM2FDGzVDZ": {
+			"x": 1091.0608690997713,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IXPN77UQF3QsM2FDGzVDZ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aY",
+			"typeName": "shape"
+		},
+		"shape:tNEsjnyrNkj2v7P7WYpd7": {
+			"x": 823.6985627854997,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tNEsjnyrNkj2v7P7WYpd7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzV",
+			"typeName": "shape"
+		},
+		"shape:LCh3auqSs9OMybGRZtXxc": {
+			"x": 912.8193315569235,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LCh3auqSs9OMybGRZtXxc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzV",
+			"typeName": "shape"
+		},
+		"shape:3akbwGbXnwNwvodsNAsdx": {
+			"x": 1001.9401003283474,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3akbwGbXnwNwvodsNAsdx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzV",
+			"typeName": "shape"
+		},
+		"shape:xlG3fbMLnBRCeWcVJLM7K": {
+			"x": 1091.0608690997713,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xlG3fbMLnBRCeWcVJLM7K",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aZ",
+			"typeName": "shape"
+		},
+		"shape:jm7qjuxxJXMC0szVGXGLC": {
+			"x": 823.6985627854997,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jm7qjuxxJXMC0szVGXGLC",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzl",
+			"typeName": "shape"
+		},
+		"shape:NPR5axf5kknV3z_4qZF3I": {
+			"x": 912.8193315569235,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:NPR5axf5kknV3z_4qZF3I",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzl",
+			"typeName": "shape"
+		},
+		"shape:M9-eiXU3DWX7z5MzTqsxf": {
+			"x": 1001.9401003283474,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:M9-eiXU3DWX7z5MzTqsxf",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzl",
+			"typeName": "shape"
+		},
+		"shape:5WsB9gJoFgwM3f_9Kh8Jb": {
+			"x": 1091.0608690997713,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5WsB9gJoFgwM3f_9Kh8Jb",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aa",
+			"typeName": "shape"
+		},
+		"shape:lLMYqCEPtX59eqPK5XS0o": {
+			"x": 823.6985627854997,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lLMYqCEPtX59eqPK5XS0o",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzt",
+			"typeName": "shape"
+		},
+		"shape:wkJRUp6MByo-e1FOt3FYT": {
+			"x": 912.8193315569235,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:wkJRUp6MByo-e1FOt3FYT",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzt",
+			"typeName": "shape"
+		},
+		"shape:WZXEyEv2Px0qRae0nfH4z": {
+			"x": 1001.9401003283474,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WZXEyEv2Px0qRae0nfH4z",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzt",
+			"typeName": "shape"
+		},
+		"shape:ERktfGMKZ99SrSSRKxLBo": {
+			"x": 1091.0608690997713,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ERktfGMKZ99SrSSRKxLBo",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ab",
+			"typeName": "shape"
+		},
+		"shape:-QJKz5re6OCkh3IGIYBd8": {
+			"x": 823.6985627854997,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-QJKz5re6OCkh3IGIYBd8",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzx",
+			"typeName": "shape"
+		},
+		"shape:Ver_5mCE0q2x4ddFCLkiQ": {
+			"x": 912.8193315569235,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Ver_5mCE0q2x4ddFCLkiQ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzx",
+			"typeName": "shape"
+		},
+		"shape:gkCwf-QX4yBBH4gFHvBu8": {
+			"x": 1001.9401003283474,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gkCwf-QX4yBBH4gFHvBu8",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzx",
+			"typeName": "shape"
+		},
+		"shape:IRUNLqwJJImk2TqXzk0Ci": {
+			"x": 1091.0608690997713,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IRUNLqwJJImk2TqXzk0Ci",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ac",
+			"typeName": "shape"
+		},
+		"shape:SAFffahXJMFAkgnai654g": {
+			"x": 823.6985627854997,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SAFffahXJMFAkgnai654g",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzz",
+			"typeName": "shape"
+		},
+		"shape:mI9GX_tadBui5MKh6pjV7": {
+			"x": 912.8193315569235,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mI9GX_tadBui5MKh6pjV7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzz",
+			"typeName": "shape"
+		},
+		"shape:nGUnQPXCf5ZKvNAoNRgJ1": {
+			"x": 1001.9401003283474,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nGUnQPXCf5ZKvNAoNRgJ1",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzz",
+			"typeName": "shape"
+		},
+		"shape:pjmikwygQvTyPmNb0KQns": {
+			"x": 1091.0608690997713,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pjmikwygQvTyPmNb0KQns",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ad",
+			"typeName": "shape"
+		},
+		"shape:6e-hwHJaa2i-kJZ5o-Vcy": {
+			"x": 823.6985627854997,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6e-hwHJaa2i-kJZ5o-Vcy",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzV",
+			"typeName": "shape"
+		},
+		"shape:MSPSpgPWuucj-kmFiqw8_": {
+			"x": 912.8193315569235,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MSPSpgPWuucj-kmFiqw8_",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzV",
+			"typeName": "shape"
+		},
+		"shape:CTrzl5W0-5Sm4v2qU7vNZ": {
+			"x": 1001.9401003283474,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CTrzl5W0-5Sm4v2qU7vNZ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzV",
+			"typeName": "shape"
+		},
+		"shape:del80gloLFmnJwxWejbA0": {
+			"x": 1091.0608690997713,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:del80gloLFmnJwxWejbA0",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ae",
+			"typeName": "shape"
+		},
+		"shape:PIjb_uR3o4-nLgSEaU-7Y": {
+			"x": 823.6985627854997,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PIjb_uR3o4-nLgSEaU-7Y",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzl",
+			"typeName": "shape"
+		},
+		"shape:icahIIqiD9ZEYszIsqdpm": {
+			"x": 912.8193315569235,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:icahIIqiD9ZEYszIsqdpm",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzl",
+			"typeName": "shape"
+		},
+		"shape:lvS61blTMwxmElcnnQmi3": {
+			"x": 1001.9401003283474,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lvS61blTMwxmElcnnQmi3",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzl",
+			"typeName": "shape"
+		},
+		"shape:y6dmCO4q0kfiQbxF4Splx": {
+			"x": 1091.0608690997713,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:y6dmCO4q0kfiQbxF4Splx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "af",
+			"typeName": "shape"
+		},
+		"shape:1oXkJZTXBu6k68qLzQ78c": {
+			"x": 1196.4032148861895,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1oXkJZTXBu6k68qLzQ78c",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLG",
+			"typeName": "shape"
+		},
+		"shape:FZkVUJdt8keiW_OLaJxfU": {
+			"x": 1196.4032148861895,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FZkVUJdt8keiW_OLaJxfU",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLd",
+			"typeName": "shape"
+		},
+		"shape:SxDaJBrawTiN4g_utJW7f": {
+			"x": 1196.4032148861895,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SxDaJBrawTiN4g_utJW7f",
+			"type": "geo",
+			"props": {
+				"w": 67.3168793579456,
+				"h": 49.19954602239783,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLp",
+			"typeName": "shape"
+		},
+		"shape:mAqnC7yT6bvM2mnvJENjs": {
+			"x": 1196.4032148861895,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mAqnC7yT6bvM2mnvJENjs",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLv",
+			"typeName": "shape"
+		},
+		"shape:cBZQe0jhdpW9Uf4u2-Fcp": {
+			"x": 1196.4032148861895,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cBZQe0jhdpW9Uf4u2-Fcp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLy",
+			"typeName": "shape"
+		},
+		"shape:GX6I3zpEo442rrz9DVqPd": {
+			"x": 1196.4032148861895,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:GX6I3zpEo442rrz9DVqPd",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzG",
+			"typeName": "shape"
+		},
+		"shape:uEhVmgmzl9Wmdk9mJUkUi": {
+			"x": 1196.4032148861895,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uEhVmgmzl9Wmdk9mJUkUi",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzd",
+			"typeName": "shape"
+		},
+		"shape:ah_aAe_6qOOv4U4bRZt4_": {
+			"x": 1196.4032148861895,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ah_aAe_6qOOv4U4bRZt4_",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzp",
+			"typeName": "shape"
+		},
+		"shape:MxYRNGLBf-sooqq3VlOhe": {
+			"x": 1196.4032148861895,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MxYRNGLBf-sooqq3VlOhe",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzv",
+			"typeName": "shape"
+		},
+		"shape:OYm-xIXhdPiVaJmeSTW-K": {
+			"x": 1196.4032148861895,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OYm-xIXhdPiVaJmeSTW-K",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzy",
+			"typeName": "shape"
+		},
+		"shape:5m-jWfRoCOddUaecKP1U6": {
+			"x": 1196.4032148861895,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5m-jWfRoCOddUaecKP1U6",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzG",
+			"typeName": "shape"
+		},
+		"shape:2cwtrCTsxVRYsnRQQX8d0": {
+			"x": 1196.4032148861895,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2cwtrCTsxVRYsnRQQX8d0",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzd",
+			"typeName": "shape"
+		},
+		"shape:CYdKc2Nk8VuXh8WafQuGZ": {
+			"x": 1196.4032148861895,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CYdKc2Nk8VuXh8WafQuGZ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzp",
+			"typeName": "shape"
+		},
+		"shape:4y-eOtOlige-PqHB-lUVU": {
+			"x": 1196.4032148861895,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4y-eOtOlige-PqHB-lUVU",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzv",
+			"typeName": "shape"
+		},
+		"shape:E0TZXUk-Bf1HCm5pTUesF": {
+			"x": 1196.4032148861895,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:E0TZXUk-Bf1HCm5pTUesF",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzy",
+			"typeName": "shape"
+		},
+		"shape:341KK0o1C2fcjxxazD3m4": {
+			"x": 1196.4032148861895,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:341KK0o1C2fcjxxazD3m4",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzG",
+			"typeName": "shape"
+		},
+		"shape:LvyAxcJm29m01MXeuIE53": {
+			"x": 1196.4032148861895,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LvyAxcJm29m01MXeuIE53",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzd",
+			"typeName": "shape"
+		},
+		"shape:aQcXASbcLMVhegdC_h_OC": {
+			"x": 1196.4032148861895,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aQcXASbcLMVhegdC_h_OC",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzt",
+			"typeName": "shape"
+		},
+		"shape:UE4MSA7UZyhH3PfZGPthk": {
+			"x": 1285.5239836576134,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UE4MSA7UZyhH3PfZGPthk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMG",
+			"typeName": "shape"
+		},
+		"shape:PJGqz1Vt2iqU4kkH_qYL7": {
+			"x": 1285.5239836576134,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PJGqz1Vt2iqU4kkH_qYL7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMd",
+			"typeName": "shape"
+		},
+		"shape:YqcfN6B5IT4Oe-wiaLEvz": {
+			"x": 1285.5239836576134,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YqcfN6B5IT4Oe-wiaLEvz",
+			"type": "geo",
+			"props": {
+				"w": 64.68249228556668,
+				"h": 48.56478826797975,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMp",
+			"typeName": "shape"
+		},
+		"shape:aN26Nd3nONH6SunhTqtVI": {
+			"x": 1285.5239836576134,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aN26Nd3nONH6SunhTqtVI",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMv",
+			"typeName": "shape"
+		},
+		"shape:ey8xUxT6ndTcT6siTiOyJ": {
+			"x": 1285.5239836576134,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ey8xUxT6ndTcT6siTiOyJ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMy",
+			"typeName": "shape"
+		},
+		"shape:lwxhS7BegHmVbEQuhAZpj": {
+			"x": 1285.5239836576134,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lwxhS7BegHmVbEQuhAZpj",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzG",
+			"typeName": "shape"
+		},
+		"shape:ehJ91CqRM1kJmDP3GGkOQ": {
+			"x": 1285.5239836576134,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ehJ91CqRM1kJmDP3GGkOQ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzd",
+			"typeName": "shape"
+		},
+		"shape:PKoPjMRH18z6bRgBMhHZ0": {
+			"x": 1285.5239836576134,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PKoPjMRH18z6bRgBMhHZ0",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzp",
+			"typeName": "shape"
+		},
+		"shape:A1ZoC5j2vo5prTSR5Fjq7": {
+			"x": 1285.5239836576134,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:A1ZoC5j2vo5prTSR5Fjq7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzv",
+			"typeName": "shape"
+		},
+		"shape:CgOTKWLte2HPzk5Z1tuXX": {
+			"x": 1285.5239836576134,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CgOTKWLte2HPzk5Z1tuXX",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzy",
+			"typeName": "shape"
+		},
+		"shape:DlBaPkhcuZtLGkD4mBKKb": {
+			"x": 1285.5239836576134,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DlBaPkhcuZtLGkD4mBKKb",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzG",
+			"typeName": "shape"
+		},
+		"shape:xBKqHebyl3rmZ84eLFiVM": {
+			"x": 1285.5239836576134,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xBKqHebyl3rmZ84eLFiVM",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzd",
+			"typeName": "shape"
+		},
+		"shape:STAsbdMhQZZ46l00_GfJk": {
+			"x": 1285.5239836576134,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:STAsbdMhQZZ46l00_GfJk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzp",
+			"typeName": "shape"
+		},
+		"shape:1uIcYIKqJX7rpqnwE-IAO": {
+			"x": 1285.5239836576134,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1uIcYIKqJX7rpqnwE-IAO",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzv",
+			"typeName": "shape"
+		},
+		"shape:SI5cE5bcTGgdrkENBIXIp": {
+			"x": 1285.5239836576134,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SI5cE5bcTGgdrkENBIXIp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzy",
+			"typeName": "shape"
+		},
+		"shape:XCnEXHx5ZCDYY36z1mAKn": {
+			"x": 1285.5239836576134,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XCnEXHx5ZCDYY36z1mAKn",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzG",
+			"typeName": "shape"
+		},
+		"shape:gA59cWPIhaxfYgVSZEpI2": {
+			"x": 1285.5239836576134,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gA59cWPIhaxfYgVSZEpI2",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzd",
+			"typeName": "shape"
+		},
+		"shape:xgp1w6StuF2IF8a7KudGD": {
+			"x": 1285.5239836576134,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xgp1w6StuF2IF8a7KudGD",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzt",
+			"typeName": "shape"
+		},
+		"shape:KFQ90Ee9KzwttHBr6Zz3e": {
+			"x": 1374.6447524290375,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KFQ90Ee9KzwttHBr6Zz3e",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNG",
+			"typeName": "shape"
+		},
+		"shape:-MZFlBbxkIqit-CkqJCbO": {
+			"x": 1374.6447524290375,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-MZFlBbxkIqit-CkqJCbO",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNd",
+			"typeName": "shape"
+		},
+		"shape:277yra8wJLpHxt4YD4Om7": {
+			"x": 1374.6447524290375,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:277yra8wJLpHxt4YD4Om7",
+			"type": "geo",
+			"props": {
+				"w": 65.3245382384166,
+				"h": 49.504203150109475,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNp",
+			"typeName": "shape"
+		},
+		"shape:rR_aJMTx4VY7hW1lPjJfj": {
+			"x": 1374.6447524290375,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rR_aJMTx4VY7hW1lPjJfj",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNv",
+			"typeName": "shape"
+		},
+		"shape:yOy8ClYZQXmgIWGNzmLsc": {
+			"x": 1374.6447524290375,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yOy8ClYZQXmgIWGNzmLsc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNy",
+			"typeName": "shape"
+		},
+		"shape:lKFCbMpJA8TBcgFGRvFck": {
+			"x": 1374.6447524290375,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lKFCbMpJA8TBcgFGRvFck",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzG",
+			"typeName": "shape"
+		},
+		"shape:zY1nzV7uRkb6bGiebFdr2": {
+			"x": 1374.6447524290375,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zY1nzV7uRkb6bGiebFdr2",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzd",
+			"typeName": "shape"
+		},
+		"shape:_gJQ5_ee9f4cCnvsuxZlI": {
+			"x": 1374.6447524290375,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_gJQ5_ee9f4cCnvsuxZlI",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzp",
+			"typeName": "shape"
+		},
+		"shape:YVL9imFCMQBQmi0hqnHMX": {
+			"x": 1374.6447524290375,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YVL9imFCMQBQmi0hqnHMX",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzv",
+			"typeName": "shape"
+		},
+		"shape:w1ONN_7Pg8O8cbjm2fJvX": {
+			"x": 1374.6447524290375,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:w1ONN_7Pg8O8cbjm2fJvX",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzy",
+			"typeName": "shape"
+		},
+		"shape:MIs7fuLYb-01zMrlxme2o": {
+			"x": 1374.6447524290375,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MIs7fuLYb-01zMrlxme2o",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzG",
+			"typeName": "shape"
+		},
+		"shape:xg7e1pP7SF9w64raAO9CG": {
+			"x": 1374.6447524290375,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xg7e1pP7SF9w64raAO9CG",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzd",
+			"typeName": "shape"
+		},
+		"shape:c3Pa71ISn5Z_eDHTVsv8i": {
+			"x": 1374.6447524290375,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:c3Pa71ISn5Z_eDHTVsv8i",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzp",
+			"typeName": "shape"
+		},
+		"shape:JXCi81N4Wh_0NGg1CRWEk": {
+			"x": 1374.6447524290375,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JXCi81N4Wh_0NGg1CRWEk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzv",
+			"typeName": "shape"
+		},
+		"shape:crRC5tbyjf4jdTxprFjBj": {
+			"x": 1374.6447524290375,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:crRC5tbyjf4jdTxprFjBj",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzy",
+			"typeName": "shape"
+		},
+		"shape:5-h1aQEN5eTGaa1GqIprC": {
+			"x": 1374.6447524290375,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5-h1aQEN5eTGaa1GqIprC",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzG",
+			"typeName": "shape"
+		},
+		"shape:9sCl0jqCVDzyW9IfBBc0t": {
+			"x": 1374.6447524290375,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9sCl0jqCVDzyW9IfBBc0t",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzd",
+			"typeName": "shape"
+		},
+		"shape:V9cH8uW4JB3TesjeoJkH1": {
+			"x": 1374.6447524290375,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:V9cH8uW4JB3TesjeoJkH1",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzt",
+			"typeName": "shape"
+		},
+		"shape:jhSKufM533fTtf0Vj0dFN": {
+			"x": 1463.765521200461,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jhSKufM533fTtf0Vj0dFN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOV",
+			"typeName": "shape"
+		},
+		"shape:bqmLwnUaaBjGpuNjCIobW": {
+			"x": 1463.765521200461,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bqmLwnUaaBjGpuNjCIobW",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aPV",
+			"typeName": "shape"
+		},
+		"shape:2gUhec7QbRL4BgPY3TN6l": {
+			"x": 1463.765521200461,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2gUhec7QbRL4BgPY3TN6l",
+			"type": "geo",
+			"props": {
+				"w": 65.47184270113989,
+				"h": 49.024036721840154,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aQV",
+			"typeName": "shape"
+		},
+		"shape:FohledeFDn3DNO7XJliJP": {
+			"x": 1463.765521200461,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FohledeFDn3DNO7XJliJP",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aRV",
+			"typeName": "shape"
+		},
+		"shape:19w7nFCvX6I-BGi4atfgZ": {
+			"x": 1463.765521200461,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:19w7nFCvX6I-BGi4atfgZ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aSV",
+			"typeName": "shape"
+		},
+		"shape:_E2A8_Kl8WIgar6CUL2WM": {
+			"x": 1463.765521200461,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_E2A8_Kl8WIgar6CUL2WM",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aTV",
+			"typeName": "shape"
+		},
+		"shape:HsF0U9HP2d90OO77QwESt": {
+			"x": 1463.765521200461,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HsF0U9HP2d90OO77QwESt",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aUV",
+			"typeName": "shape"
+		},
+		"shape:YRksXusA2vqBlaOQ6K5bh": {
+			"x": 1463.765521200461,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YRksXusA2vqBlaOQ6K5bh",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aVV",
+			"typeName": "shape"
+		},
+		"shape:x7apFQYRcGnfrhAqKZqsP": {
+			"x": 1463.765521200461,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:x7apFQYRcGnfrhAqKZqsP",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aWV",
+			"typeName": "shape"
+		},
+		"shape:sHCjdKnaKmNl3FvfFz1KT": {
+			"x": 1463.765521200461,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sHCjdKnaKmNl3FvfFz1KT",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aXV",
+			"typeName": "shape"
+		},
+		"shape:h56_UR95jl1_etngN18S5": {
+			"x": 1463.765521200461,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:h56_UR95jl1_etngN18S5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aYV",
+			"typeName": "shape"
+		},
+		"shape:yaYT8WE2cFoCtuUOEbzeM": {
+			"x": 1463.765521200461,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yaYT8WE2cFoCtuUOEbzeM",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aZV",
+			"typeName": "shape"
+		},
+		"shape:RJZp-6r5uLfKm4AZAiLDj": {
+			"x": 1463.765521200461,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RJZp-6r5uLfKm4AZAiLDj",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aaV",
+			"typeName": "shape"
+		},
+		"shape:aAlTUiq7vHJ_qZyjJ6KxP": {
+			"x": 1463.765521200461,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aAlTUiq7vHJ_qZyjJ6KxP",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "abV",
+			"typeName": "shape"
+		},
+		"shape:FFQTHIKrcKTM6fx8EvnoF": {
+			"x": 1463.765521200461,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FFQTHIKrcKTM6fx8EvnoF",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "acV",
+			"typeName": "shape"
+		},
+		"shape:HDI4Lz225PgnK9mlDH4ED": {
+			"x": 1463.765521200461,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HDI4Lz225PgnK9mlDH4ED",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "adV",
+			"typeName": "shape"
+		},
+		"shape:mVXX1ml29irr2GMIj_4q0": {
+			"x": 1463.765521200461,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mVXX1ml29irr2GMIj_4q0",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aeV",
+			"typeName": "shape"
+		},
+		"shape:KYgp4XTV57mdLccSMFyP5": {
+			"x": 1463.765521200461,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KYgp4XTV57mdLccSMFyP5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ag",
+			"typeName": "shape"
+		},
+		"shape:R9bE1rM_WGSYveeEjAzB9": {
+			"x": 1560.3144357716753,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R9bE1rM_WGSYveeEjAzB9",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLO",
+			"typeName": "shape"
+		},
+		"shape:pes9dnU4b2ll98TCnzyiU": {
+			"x": 1560.3144357716753,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pes9dnU4b2ll98TCnzyiU",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLh",
+			"typeName": "shape"
+		},
+		"shape:M3BPFaH9HdBtx29DsyfkR": {
+			"x": 1560.3144357716753,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:M3BPFaH9HdBtx29DsyfkR",
+			"type": "geo",
+			"props": {
+				"w": 65.2476608600241,
+				"h": 48.87909787377132,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLr",
+			"typeName": "shape"
+		},
+		"shape:xpH1phcJHxX6ZKQ3zprr4": {
+			"x": 1560.3144357716753,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xpH1phcJHxX6ZKQ3zprr4",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLw",
+			"typeName": "shape"
+		},
+		"shape:uOtEWORaAgXlJpXmtVGBx": {
+			"x": 1560.3144357716753,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uOtEWORaAgXlJpXmtVGBx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLyV",
+			"typeName": "shape"
+		},
+		"shape:nmDg4kN4VZPb3gIjcyv2c": {
+			"x": 1560.3144357716753,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nmDg4kN4VZPb3gIjcyv2c",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzO",
+			"typeName": "shape"
+		},
+		"shape:QUIdqIvQ0yYjo8i4piNic": {
+			"x": 1560.3144357716753,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QUIdqIvQ0yYjo8i4piNic",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzh",
+			"typeName": "shape"
+		},
+		"shape:R_Q5tbabJ0XVCWuakwweo": {
+			"x": 1560.3144357716753,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R_Q5tbabJ0XVCWuakwweo",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzr",
+			"typeName": "shape"
+		},
+		"shape:HhmxadNG8XyntX139TTnS": {
+			"x": 1560.3144357716753,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HhmxadNG8XyntX139TTnS",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzw",
+			"typeName": "shape"
+		},
+		"shape:posotZsotVBVPCQmBwkxh": {
+			"x": 1560.3144357716753,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:posotZsotVBVPCQmBwkxh",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzyV",
+			"typeName": "shape"
+		},
+		"shape:Hol50ZRVzcjg8TO3rNzSr": {
+			"x": 1560.3144357716753,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Hol50ZRVzcjg8TO3rNzSr",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzO",
+			"typeName": "shape"
+		},
+		"shape:mFHLdcE6fsxDZ9af_9NcH": {
+			"x": 1560.3144357716753,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mFHLdcE6fsxDZ9af_9NcH",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzh",
+			"typeName": "shape"
+		},
+		"shape:EudekAKXeq95pZ4bI_AGB": {
+			"x": 1560.3144357716753,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EudekAKXeq95pZ4bI_AGB",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzr",
+			"typeName": "shape"
+		},
+		"shape:vkpyMIrR35V_Bs35ek_yN": {
+			"x": 1560.3144357716753,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vkpyMIrR35V_Bs35ek_yN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzw",
+			"typeName": "shape"
+		},
+		"shape:37kBnikj58zY53hLEPci9": {
+			"x": 1560.3144357716753,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:37kBnikj58zY53hLEPci9",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzyV",
+			"typeName": "shape"
+		},
+		"shape:7DY-z3VW2A-o_awpfw18l": {
+			"x": 1560.3144357716753,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7DY-z3VW2A-o_awpfw18l",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzO",
+			"typeName": "shape"
+		},
+		"shape:ucPapMRL27E05KNxYqNm3": {
+			"x": 1560.3144357716753,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ucPapMRL27E05KNxYqNm3",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzh",
+			"typeName": "shape"
+		},
+		"shape:LgnV8mWoG4CpVdMtw9wP8": {
+			"x": 1560.3144357716753,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LgnV8mWoG4CpVdMtw9wP8",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzx",
+			"typeName": "shape"
+		},
+		"shape:HJoCzqSWtSzkRhVzXe28w": {
+			"x": 1649.4352045430992,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HJoCzqSWtSzkRhVzXe28w",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMO",
+			"typeName": "shape"
+		},
+		"shape:Rkje867llqH__PBCz7twa": {
+			"x": 1649.4352045430992,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Rkje867llqH__PBCz7twa",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMh",
+			"typeName": "shape"
+		},
+		"shape:90wHAwmkiCM2bH3uzoZfA": {
+			"x": 1649.4352045430992,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:90wHAwmkiCM2bH3uzoZfA",
+			"type": "geo",
+			"props": {
+				"w": 65.51261552568276,
+				"h": 49.754420611227125,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMr",
+			"typeName": "shape"
+		},
+		"shape:7fKYRvJZ-EUsXopoj1sZ7": {
+			"x": 1649.4352045430992,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7fKYRvJZ-EUsXopoj1sZ7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMw",
+			"typeName": "shape"
+		},
+		"shape:_WDUybr2fL2oT5rOK8x2Q": {
+			"x": 1649.4352045430992,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_WDUybr2fL2oT5rOK8x2Q",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMyV",
+			"typeName": "shape"
+		},
+		"shape:MuUtW1ATPWX_KxLg1xVAJ": {
+			"x": 1649.4352045430992,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MuUtW1ATPWX_KxLg1xVAJ",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzO",
+			"typeName": "shape"
+		},
+		"shape:EUHUVWf5p_JPpukKlJQBb": {
+			"x": 1649.4352045430992,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EUHUVWf5p_JPpukKlJQBb",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzh",
+			"typeName": "shape"
+		},
+		"shape:ZePu9RH5G4orkMStSnPpy": {
+			"x": 1649.4352045430992,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZePu9RH5G4orkMStSnPpy",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzr",
+			"typeName": "shape"
+		},
+		"shape:-pVgiRoWU1q-TdarwWydN": {
+			"x": 1649.4352045430992,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-pVgiRoWU1q-TdarwWydN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzw",
+			"typeName": "shape"
+		},
+		"shape:Oi8N6NiO_CKao16Z-Fq-v": {
+			"x": 1649.4352045430992,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Oi8N6NiO_CKao16Z-Fq-v",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzyV",
+			"typeName": "shape"
+		},
+		"shape:jErR2z230TJ02ypz7BPDd": {
+			"x": 1649.4352045430992,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jErR2z230TJ02ypz7BPDd",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzO",
+			"typeName": "shape"
+		},
+		"shape:GK7T2DJx5yefiAx0bNjbc": {
+			"x": 1649.4352045430992,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:GK7T2DJx5yefiAx0bNjbc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzh",
+			"typeName": "shape"
+		},
+		"shape:yw4lk9zkBI4RjGVhi8X2K": {
+			"x": 1649.4352045430992,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yw4lk9zkBI4RjGVhi8X2K",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzr",
+			"typeName": "shape"
+		},
+		"shape:fVDWmlta7rpw_vNYDzzvg": {
+			"x": 1649.4352045430992,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fVDWmlta7rpw_vNYDzzvg",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzw",
+			"typeName": "shape"
+		},
+		"shape:cCCO2Q0uuOmMdEa4xzojx": {
+			"x": 1649.4352045430992,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cCCO2Q0uuOmMdEa4xzojx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzyV",
+			"typeName": "shape"
+		},
+		"shape:FIz0r8sT8wb82tM3ATk1r": {
+			"x": 1649.4352045430992,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FIz0r8sT8wb82tM3ATk1r",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzO",
+			"typeName": "shape"
+		},
+		"shape:QSlhmX5aGhyGwGDTC_4rR": {
+			"x": 1649.4352045430992,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QSlhmX5aGhyGwGDTC_4rR",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzh",
+			"typeName": "shape"
+		},
+		"shape:B2sBH4CQXsp0zXV6LKkhM": {
+			"x": 1649.4352045430992,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:B2sBH4CQXsp0zXV6LKkhM",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzx",
+			"typeName": "shape"
+		},
+		"shape:GIV2mSyyUaWV6TBk-CjPl": {
+			"x": 1738.555973314523,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:GIV2mSyyUaWV6TBk-CjPl",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNO",
+			"typeName": "shape"
+		},
+		"shape:ohz3yz7ZvS2xQGrIuiOjo": {
+			"x": 1738.555973314523,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ohz3yz7ZvS2xQGrIuiOjo",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNh",
+			"typeName": "shape"
+		},
+		"shape:WPfVw8p4hw5zPcOqqmoTZ": {
+			"x": 1738.555973314523,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WPfVw8p4hw5zPcOqqmoTZ",
+			"type": "geo",
+			"props": {
+				"w": 65.60494582773022,
+				"h": 48.11251020627201,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNr",
+			"typeName": "shape"
+		},
+		"shape:X4SR28KtrgxlR9gCvmoMp": {
+			"x": 1738.555973314523,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X4SR28KtrgxlR9gCvmoMp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNw",
+			"typeName": "shape"
+		},
+		"shape:uGFwSbIOXQxJRRiUHcGiR": {
+			"x": 1738.555973314523,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uGFwSbIOXQxJRRiUHcGiR",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNyV",
+			"typeName": "shape"
+		},
+		"shape:FlFjzeNbDVJr7CTMGJiyV": {
+			"x": 1738.555973314523,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FlFjzeNbDVJr7CTMGJiyV",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzO",
+			"typeName": "shape"
+		},
+		"shape:j-HE-0955lzqOeIE9lWci": {
+			"x": 1738.555973314523,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:j-HE-0955lzqOeIE9lWci",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzh",
+			"typeName": "shape"
+		},
+		"shape:j1hw0ey3rhMQ_h4bXrMhD": {
+			"x": 1738.555973314523,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:j1hw0ey3rhMQ_h4bXrMhD",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzr",
+			"typeName": "shape"
+		},
+		"shape:1FkwGPfb0Jma_GSuL4JE5": {
+			"x": 1738.555973314523,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1FkwGPfb0Jma_GSuL4JE5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzw",
+			"typeName": "shape"
+		},
+		"shape:_xQ6pBNs47pUord2BkzHE": {
+			"x": 1738.555973314523,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_xQ6pBNs47pUord2BkzHE",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzyV",
+			"typeName": "shape"
+		},
+		"shape:9AHWfjdKYFw27C81rPzCB": {
+			"x": 1738.555973314523,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9AHWfjdKYFw27C81rPzCB",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzO",
+			"typeName": "shape"
+		},
+		"shape:jljAhIR1FZBMwzAju6Q9R": {
+			"x": 1738.555973314523,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jljAhIR1FZBMwzAju6Q9R",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzh",
+			"typeName": "shape"
+		},
+		"shape:Dy8mvy5KMThGxdhTLuYVp": {
+			"x": 1738.555973314523,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Dy8mvy5KMThGxdhTLuYVp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzr",
+			"typeName": "shape"
+		},
+		"shape:_d7AxiFDkzsObuCH8QtOC": {
+			"x": 1738.555973314523,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_d7AxiFDkzsObuCH8QtOC",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzw",
+			"typeName": "shape"
+		},
+		"shape:8mdQYk8Q7kiZ7ATYe_cKm": {
+			"x": 1738.555973314523,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8mdQYk8Q7kiZ7ATYe_cKm",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzyV",
+			"typeName": "shape"
+		},
+		"shape:CIw409pjhaQ2KW83-8TdF": {
+			"x": 1738.555973314523,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CIw409pjhaQ2KW83-8TdF",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzO",
+			"typeName": "shape"
+		},
+		"shape:sT6ux29xMyhRYk7Xx0O02": {
+			"x": 1738.555973314523,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sT6ux29xMyhRYk7Xx0O02",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzh",
+			"typeName": "shape"
+		},
+		"shape:7iAn-16ktTfbYQtaKm6ga": {
+			"x": 1738.555973314523,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7iAn-16ktTfbYQtaKm6ga",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzx",
+			"typeName": "shape"
+		},
+		"shape:vMCgw1sVJn0yxEoWaKD4T": {
+			"x": 1827.676742085947,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vMCgw1sVJn0yxEoWaKD4T",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOl",
+			"typeName": "shape"
+		},
+		"shape:88RZR0MsoQbdwZ6OvP0ih": {
+			"x": 1827.676742085947,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:88RZR0MsoQbdwZ6OvP0ih",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aPl",
+			"typeName": "shape"
+		},
+		"shape:AYIzp3BzcOgqMEYvzT88_": {
+			"x": 1827.676742085947,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AYIzp3BzcOgqMEYvzT88_",
+			"type": "geo",
+			"props": {
+				"w": 66.27363332367243,
+				"h": 48.83609110121798,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aQl",
+			"typeName": "shape"
+		},
+		"shape:xu7LB3HlIb_z8cpc7O-Qa": {
+			"x": 1827.676742085947,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xu7LB3HlIb_z8cpc7O-Qa",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aRl",
+			"typeName": "shape"
+		},
+		"shape:w7cVquzNWtlWh6OIVH32b": {
+			"x": 1827.676742085947,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:w7cVquzNWtlWh6OIVH32b",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aSl",
+			"typeName": "shape"
+		},
+		"shape:qMBFjrxuA6qzQVriFu_9c": {
+			"x": 1827.676742085947,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qMBFjrxuA6qzQVriFu_9c",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aTl",
+			"typeName": "shape"
+		},
+		"shape:A1uSGyfrXCP5uevfNMnew": {
+			"x": 1827.676742085947,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:A1uSGyfrXCP5uevfNMnew",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aUl",
+			"typeName": "shape"
+		},
+		"shape:faJk_QFRTaCzB4KFZYt-M": {
+			"x": 1827.676742085947,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:faJk_QFRTaCzB4KFZYt-M",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aVl",
+			"typeName": "shape"
+		},
+		"shape:Lj8wJjGhoYtbmxboXATyi": {
+			"x": 1827.676742085947,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Lj8wJjGhoYtbmxboXATyi",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aWl",
+			"typeName": "shape"
+		},
+		"shape:gDxsUW1rNThFH2RXdIuE6": {
+			"x": 1827.676742085947,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gDxsUW1rNThFH2RXdIuE6",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aXl",
+			"typeName": "shape"
+		},
+		"shape:MBVuMxZE2_QHYxb4_RGAX": {
+			"x": 1827.676742085947,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MBVuMxZE2_QHYxb4_RGAX",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aYl",
+			"typeName": "shape"
+		},
+		"shape:x4yq83soa-4wFvx7mCxT2": {
+			"x": 1827.676742085947,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:x4yq83soa-4wFvx7mCxT2",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aZl",
+			"typeName": "shape"
+		},
+		"shape:N7mggkvmX1BvwooPcQmYe": {
+			"x": 1827.676742085947,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N7mggkvmX1BvwooPcQmYe",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aal",
+			"typeName": "shape"
+		},
+		"shape:c7yrA_Yk_uE87qy4MBfrJ": {
+			"x": 1827.676742085947,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:c7yrA_Yk_uE87qy4MBfrJ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "abl",
+			"typeName": "shape"
+		},
+		"shape:IQPUYIK8BISTuSAivXLzv": {
+			"x": 1827.676742085947,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IQPUYIK8BISTuSAivXLzv",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "acl",
+			"typeName": "shape"
+		},
+		"shape:9qa8cS5Rju9fHbthwwEaa": {
+			"x": 1827.676742085947,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9qa8cS5Rju9fHbthwwEaa",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "adl",
+			"typeName": "shape"
+		},
+		"shape:sKMX2OqtmzClS-ewc5rsk": {
+			"x": 1827.676742085947,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sKMX2OqtmzClS-ewc5rsk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ael",
+			"typeName": "shape"
+		},
+		"shape:tgQ4GIlfUur-e9Xjb6QIo": {
+			"x": 1827.676742085947,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tgQ4GIlfUur-e9Xjb6QIo",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ah",
+			"typeName": "shape"
+		},
+		"shape:vEDS0DlC98MnziETbJcM0": {
+			"x": 1941.6515409417523,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vEDS0DlC98MnziETbJcM0",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLS",
+			"typeName": "shape"
+		},
+		"shape:Mrfpn2AIaxgsmUPgExkpk": {
+			"x": 1941.6515409417523,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Mrfpn2AIaxgsmUPgExkpk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLj",
+			"typeName": "shape"
+		},
+		"shape:oaNI8l5fCJ7VyWkrmRB_t": {
+			"x": 1941.6515409417523,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:oaNI8l5fCJ7VyWkrmRB_t",
+			"type": "geo",
+			"props": {
+				"w": 65.21877815751515,
+				"h": 48.26234021273327,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLs",
+			"typeName": "shape"
+		},
+		"shape:JAXebc7TqQCzIxzu6-QIc": {
+			"x": 1941.6515409417523,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JAXebc7TqQCzIxzu6-QIc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLwV",
+			"typeName": "shape"
+		},
+		"shape:QLi-KN5nFWTnTWZ3D8uYS": {
+			"x": 1941.6515409417523,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QLi-KN5nFWTnTWZ3D8uYS",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLyl",
+			"typeName": "shape"
+		},
+		"shape:HXXYWY6frShvHSzFPY0gS": {
+			"x": 1941.6515409417523,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HXXYWY6frShvHSzFPY0gS",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzS",
+			"typeName": "shape"
+		},
+		"shape:Q-SJw6ErwVv4p0krNJ0eY": {
+			"x": 1941.6515409417523,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Q-SJw6ErwVv4p0krNJ0eY",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzj",
+			"typeName": "shape"
+		},
+		"shape:7flK1hqwFCoKfSEvVC1QP": {
+			"x": 1941.6515409417523,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7flK1hqwFCoKfSEvVC1QP",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzs",
+			"typeName": "shape"
+		},
+		"shape:zZIdVY79JUmRRz_Ok2U4I": {
+			"x": 1941.6515409417523,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zZIdVY79JUmRRz_Ok2U4I",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzwV",
+			"typeName": "shape"
+		},
+		"shape:ljX9eD0uA4d3xaCW2nE4r": {
+			"x": 1941.6515409417523,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ljX9eD0uA4d3xaCW2nE4r",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzyl",
+			"typeName": "shape"
+		},
+		"shape:qbqG0AwM9zILCegQgtd7e": {
+			"x": 1941.6515409417523,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qbqG0AwM9zILCegQgtd7e",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzS",
+			"typeName": "shape"
+		},
+		"shape:K5d0qoiNq4wo1uTT8loMX": {
+			"x": 1941.6515409417523,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:K5d0qoiNq4wo1uTT8loMX",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzj",
+			"typeName": "shape"
+		},
+		"shape:x5DDsYqq6b2XrAufM_bXD": {
+			"x": 1941.6515409417523,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:x5DDsYqq6b2XrAufM_bXD",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzs",
+			"typeName": "shape"
+		},
+		"shape:6l2VtIXLl47xLsm16jqJK": {
+			"x": 1941.6515409417523,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6l2VtIXLl47xLsm16jqJK",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzwV",
+			"typeName": "shape"
+		},
+		"shape:sCUzrPHFCNhydJTQMmlJA": {
+			"x": 1941.6515409417523,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sCUzrPHFCNhydJTQMmlJA",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzyl",
+			"typeName": "shape"
+		},
+		"shape:5rFhStqcuMKpO3oUAAtq9": {
+			"x": 1941.6515409417523,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5rFhStqcuMKpO3oUAAtq9",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzS",
+			"typeName": "shape"
+		},
+		"shape:dQRQUE8-6L0t9701jAU1_": {
+			"x": 1941.6515409417523,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dQRQUE8-6L0t9701jAU1_",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzj",
+			"typeName": "shape"
+		},
+		"shape:MywQKLkZpW5YD5u-AWtGp": {
+			"x": 1941.6515409417523,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MywQKLkZpW5YD5u-AWtGp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLzzzz",
+			"typeName": "shape"
+		},
+		"shape:qlfJiGE2CNY2bwah9p23d": {
+			"x": 2030.7723097131761,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qlfJiGE2CNY2bwah9p23d",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMS",
+			"typeName": "shape"
+		},
+		"shape:rxRWfxA3OQ9IPvocYmHmq": {
+			"x": 2030.7723097131761,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rxRWfxA3OQ9IPvocYmHmq",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMj",
+			"typeName": "shape"
+		},
+		"shape:KrDf6zZd9Aic3O6r4kwas": {
+			"x": 2030.7723097131761,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KrDf6zZd9Aic3O6r4kwas",
+			"type": "geo",
+			"props": {
+				"w": 64.02061383405258,
+				"h": 49.324811118833196,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMs",
+			"typeName": "shape"
+		},
+		"shape:Fyy2vUyyD1DdSP4onZr-L": {
+			"x": 2030.7723097131761,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Fyy2vUyyD1DdSP4onZr-L",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMwV",
+			"typeName": "shape"
+		},
+		"shape:e-nT_dHOOlk7-VYqArbv6": {
+			"x": 2030.7723097131761,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:e-nT_dHOOlk7-VYqArbv6",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMyl",
+			"typeName": "shape"
+		},
+		"shape:W-jmW5_oSZDyzADY21A0U": {
+			"x": 2030.7723097131761,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:W-jmW5_oSZDyzADY21A0U",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzS",
+			"typeName": "shape"
+		},
+		"shape:upsTKIDGjMkwtLIHnWXQN": {
+			"x": 2030.7723097131761,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:upsTKIDGjMkwtLIHnWXQN",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzj",
+			"typeName": "shape"
+		},
+		"shape:iPMqGmhRm6mRtWbNtyrsF": {
+			"x": 2030.7723097131761,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iPMqGmhRm6mRtWbNtyrsF",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzs",
+			"typeName": "shape"
+		},
+		"shape:xk_xFZ64Fj5vjaSySOMv2": {
+			"x": 2030.7723097131761,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xk_xFZ64Fj5vjaSySOMv2",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzwV",
+			"typeName": "shape"
+		},
+		"shape:okNk3WPgc-E3ZYjQayRGe": {
+			"x": 2030.7723097131761,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:okNk3WPgc-E3ZYjQayRGe",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzyl",
+			"typeName": "shape"
+		},
+		"shape:Cudgo35gCy0andTXwb8n-": {
+			"x": 2030.7723097131761,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Cudgo35gCy0andTXwb8n-",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzS",
+			"typeName": "shape"
+		},
+		"shape:YBUsfEy5omzxjH39f4OFk": {
+			"x": 2030.7723097131761,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YBUsfEy5omzxjH39f4OFk",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzj",
+			"typeName": "shape"
+		},
+		"shape:fpI2HweEpo7aABRsMK1PY": {
+			"x": 2030.7723097131761,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fpI2HweEpo7aABRsMK1PY",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzs",
+			"typeName": "shape"
+		},
+		"shape:agDHj-qEZfEFG3Yo1SEQS": {
+			"x": 2030.7723097131761,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:agDHj-qEZfEFG3Yo1SEQS",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzwV",
+			"typeName": "shape"
+		},
+		"shape:4V-jzR-TzhLa0BtfWCdgL": {
+			"x": 2030.7723097131761,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4V-jzR-TzhLa0BtfWCdgL",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzyl",
+			"typeName": "shape"
+		},
+		"shape:IcSGZbcjBqHW--dpIWx69": {
+			"x": 2030.7723097131761,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IcSGZbcjBqHW--dpIWx69",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzS",
+			"typeName": "shape"
+		},
+		"shape:X7qy0UrSjWFpQ3bc290jF": {
+			"x": 2030.7723097131761,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X7qy0UrSjWFpQ3bc290jF",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzj",
+			"typeName": "shape"
+		},
+		"shape:rfZ86Ti1qdJjWgq2LR5cl": {
+			"x": 2030.7723097131761,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rfZ86Ti1qdJjWgq2LR5cl",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMzzzz",
+			"typeName": "shape"
+		},
+		"shape:oG9CYVdXBs7JZUPvczYVi": {
+			"x": 2119.8930784845998,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:oG9CYVdXBs7JZUPvczYVi",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNS",
+			"typeName": "shape"
+		},
+		"shape:vHUXX9hRJlUEuQ2LhCLUx": {
+			"x": 2119.8930784845998,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vHUXX9hRJlUEuQ2LhCLUx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNj",
+			"typeName": "shape"
+		},
+		"shape:P18I4toLsUXs0f_AR2Sev": {
+			"x": 2119.8930784845998,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:P18I4toLsUXs0f_AR2Sev",
+			"type": "geo",
+			"props": {
+				"w": 66.07949931043422,
+				"h": 48.97553030349153,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNs",
+			"typeName": "shape"
+		},
+		"shape:woJGBmOjq8gPsya8Wf66n": {
+			"x": 2119.8930784845998,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:woJGBmOjq8gPsya8Wf66n",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNwV",
+			"typeName": "shape"
+		},
+		"shape:bb0lQot3aixub4XifOSmw": {
+			"x": 2119.8930784845998,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bb0lQot3aixub4XifOSmw",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNyl",
+			"typeName": "shape"
+		},
+		"shape:PIXsOQ33zbWv8nslilUsy": {
+			"x": 2119.8930784845998,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PIXsOQ33zbWv8nslilUsy",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzS",
+			"typeName": "shape"
+		},
+		"shape:6kghwby20VmVBh-opXvkB": {
+			"x": 2119.8930784845998,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6kghwby20VmVBh-opXvkB",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzj",
+			"typeName": "shape"
+		},
+		"shape:4xszl_IIVojcqpEM8Vtee": {
+			"x": 2119.8930784845998,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4xszl_IIVojcqpEM8Vtee",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzs",
+			"typeName": "shape"
+		},
+		"shape:voopIq_D7f0yMgqPPl9qw": {
+			"x": 2119.8930784845998,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:voopIq_D7f0yMgqPPl9qw",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzwV",
+			"typeName": "shape"
+		},
+		"shape:CljzoieSxbwD8F0yDT9mK": {
+			"x": 2119.8930784845998,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CljzoieSxbwD8F0yDT9mK",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzyl",
+			"typeName": "shape"
+		},
+		"shape:ehL7MdUTSAS2gOU4xf-Bd": {
+			"x": 2119.8930784845998,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ehL7MdUTSAS2gOU4xf-Bd",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzS",
+			"typeName": "shape"
+		},
+		"shape:N9-uqSrUC_iOhHawL1WOq": {
+			"x": 2119.8930784845998,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N9-uqSrUC_iOhHawL1WOq",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzj",
+			"typeName": "shape"
+		},
+		"shape:jlc7CshbEN3xkLweeKjf4": {
+			"x": 2119.8930784845998,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jlc7CshbEN3xkLweeKjf4",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzs",
+			"typeName": "shape"
+		},
+		"shape:93EtCOHgJsLmw8fSSxmoA": {
+			"x": 2119.8930784845998,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:93EtCOHgJsLmw8fSSxmoA",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzwV",
+			"typeName": "shape"
+		},
+		"shape:Iop1qEu0dXNIPU2xbG_Oh": {
+			"x": 2119.8930784845998,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Iop1qEu0dXNIPU2xbG_Oh",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzyl",
+			"typeName": "shape"
+		},
+		"shape:lMoq4hLHiBRRJc-6YNM9G": {
+			"x": 2119.8930784845998,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lMoq4hLHiBRRJc-6YNM9G",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzS",
+			"typeName": "shape"
+		},
+		"shape:TJmgBv5JVHaa0-K8q0x3G": {
+			"x": 2119.8930784845998,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TJmgBv5JVHaa0-K8q0x3G",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzj",
+			"typeName": "shape"
+		},
+		"shape:4xwEaOJ9eti0m9_rZxDh1": {
+			"x": 2119.8930784845998,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4xwEaOJ9eti0m9_rZxDh1",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNzzzz",
+			"typeName": "shape"
+		},
+		"shape:tEyOaTcJ_uZWm1-imyBOV": {
+			"x": 2209.013847256024,
+			"y": 1460.028085528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tEyOaTcJ_uZWm1-imyBOV",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOt",
+			"typeName": "shape"
+		},
+		"shape:M21xeUrlMSk7Ps5RvJMWl": {
+			"x": 2209.013847256024,
+			"y": 1528.1976019957335,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:M21xeUrlMSk7Ps5RvJMWl",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "ellipse",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aPt",
+			"typeName": "shape"
+		},
+		"shape:WRL5F8Z1XgGjphS857R0s": {
+			"x": 2209.013847256024,
+			"y": 1599.6764292733824,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WRL5F8Z1XgGjphS857R0s",
+			"type": "geo",
+			"props": {
+				"w": 67.30364394987447,
+				"h": 49.57989618586922,
+				"geo": "cloud",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aQt",
+			"typeName": "shape"
+		},
+		"shape:vPW59CeOyjKBjK0qhP98Z": {
+			"x": 2209.013847256024,
+			"y": 1670.7265893476233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vPW59CeOyjKBjK0qhP98Z",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "triangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aRt",
+			"typeName": "shape"
+		},
+		"shape:SsW3a7zqolwwtbvCV_hUh": {
+			"x": 2209.013847256024,
+			"y": 1734.9980920453017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SsW3a7zqolwwtbvCV_hUh",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "diamond",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aSt",
+			"typeName": "shape"
+		},
+		"shape:e2ExX1XzaTGECMKsOzrEw": {
+			"x": 2209.013847256024,
+			"y": 1800.675623170159,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:e2ExX1XzaTGECMKsOzrEw",
+			"type": "geo",
+			"props": {
+				"w": 70.54441039901512,
+				"h": 45.97415461845719,
+				"geo": "pentagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aTt",
+			"typeName": "shape"
+		},
+		"shape:s60Cz7I6YxsF0tdoVNv8L": {
+			"x": 2209.013847256024,
+			"y": 1868.2450055527247,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:s60Cz7I6YxsF0tdoVNv8L",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "octagon",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aUt",
+			"typeName": "shape"
+		},
+		"shape:7HwujQEWFbVeKAL14X9hP": {
+			"x": 2209.013847256024,
+			"y": 1948.034261013782,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7HwujQEWFbVeKAL14X9hP",
+			"type": "geo",
+			"props": {
+				"w": 73.99709959984733,
+				"h": 50.3642957335091,
+				"geo": "star",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aVt",
+			"typeName": "shape"
+		},
+		"shape:h3eMz7hwEIZcBmHcfFOJ5": {
+			"x": 2209.013847256024,
+			"y": 2034.1230369035825,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:h3eMz7hwEIZcBmHcfFOJ5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aWt",
+			"typeName": "shape"
+		},
+		"shape:X_hlb1pkoLqzOLmunRagx": {
+			"x": 2209.013847256024,
+			"y": 2116.1813707613474,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X_hlb1pkoLqzOLmunRagx",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rhombus-2",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aXt",
+			"typeName": "shape"
+		},
+		"shape:bcli4vkT5sYmRL-cbWMhd": {
+			"x": 2209.013847256024,
+			"y": 2204.772592799054,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bcli4vkT5sYmRL-cbWMhd",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "oval",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aYt",
+			"typeName": "shape"
+		},
+		"shape:ICFzk4R6ZRmYgtelhaFgD": {
+			"x": 2209.013847256024,
+			"y": 2282.8186016329173,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ICFzk4R6ZRmYgtelhaFgD",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "trapezoid",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aZt",
+			"typeName": "shape"
+		},
+		"shape:gz-JM2AWZiivXzvSDZR3-": {
+			"x": 2209.013847256024,
+			"y": 2357.2066503310307,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gz-JM2AWZiivXzvSDZR3-",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-right",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aat",
+			"typeName": "shape"
+		},
+		"shape:mPSb0PSm4Ax9m09MFsvRP": {
+			"x": 2209.013847256024,
+			"y": 2425.1475442898836,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mPSb0PSm4Ax9m09MFsvRP",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-left",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "abt",
+			"typeName": "shape"
+		},
+		"shape:KHtbMMf0poLk5dV_XuOuP": {
+			"x": 2209.013847256024,
+			"y": 2495.4889745878227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KHtbMMf0poLk5dV_XuOuP",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-up",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "act",
+			"typeName": "shape"
+		},
+		"shape:vOu4w81N94jmF-3jEnYzo": {
+			"x": 2209.013847256024,
+			"y": 2567.5507892621063,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vOu4w81N94jmF-3jEnYzo",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "arrow-down",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "adt",
+			"typeName": "shape"
+		},
+		"shape:o-1OsYpKNUFy0C-kymslT": {
+			"x": 2209.013847256024,
+			"y": 2637.989384126151,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:o-1OsYpKNUFy0C-kymslT",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "x-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aet",
+			"typeName": "shape"
+		},
+		"shape:BqwMRQs7Snju9YfkBpZUu": {
+			"x": 2209.013847256024,
+			"y": 2717.6643283329663,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BqwMRQs7Snju9YfkBpZUu",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "check-box",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ai",
+			"typeName": "shape"
+		},
+		"shape:23v_1pJUjfhLq58WBpcuc": {
+			"x": -259.0812996416322,
+			"y": 1538.7899855213743,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:23v_1pJUjfhLq58WBpcuc",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGd",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:dfmNS0wfBE2W_hENwR6y5": {
+			"x": 290.69396489540804,
+			"y": 1538.7899855213743,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dfmNS0wfBE2W_hENwR6y5",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aH",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Mb9IGvhXLInPco2BYf1o0": {
+			"x": -259.0812996416322,
+			"y": 1551.8781196444143,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Mb9IGvhXLInPco2BYf1o0",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHK",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:uc9K6LAgH4invmOwjfYck": {
+			"x": 290.69396489540804,
+			"y": 1551.8781196444143,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uc9K6LAgH4invmOwjfYck",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHa",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:NZP15gUcvyYtiKRdL9yJ2": {
+			"x": -259.0812996416322,
+			"y": 1558.3500798280356,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:NZP15gUcvyYtiKRdL9yJ2",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHp",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:aeq8WCOd2fsO0aFpoFVFx": {
+			"x": 290.69396489540804,
+			"y": 1558.3500798280356,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aeq8WCOd2fsO0aFpoFVFx",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aI",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:0r1IDMhXenLWYpGBRW8JN": {
+			"x": -259.0812996416322,
+			"y": 1546.406826337751,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0r1IDMhXenLWYpGBRW8JN",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJV",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:DWGKqJZ-ui7QB6jteegpg": {
+			"x": 290.69396489540804,
+			"y": 1546.406826337751,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DWGKqJZ-ui7QB6jteegpg",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKV",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:tdmMI4HbqF1MdC6y_HhTB": {
+			"x": -259.0812996416322,
+			"y": 1649.584967900862,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tdmMI4HbqF1MdC6y_HhTB",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGh",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:vMC9If_u5na8H0zCAWwCD": {
+			"x": 290.69396489540804,
+			"y": 1649.584967900862,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vMC9If_u5na8H0zCAWwCD",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aH8",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:TPKS8Wz_fXUW9LarHmOth": {
+			"x": -259.0812996416322,
+			"y": 1662.6731020239017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TPKS8Wz_fXUW9LarHmOth",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHM",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:HpWU8_9_UMw5AZEQazaKD": {
+			"x": 290.69396489540804,
+			"y": 1662.6731020239017,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HpWU8_9_UMw5AZEQazaKD",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHg",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:OpwsQqGaond-aXtInw3bn": {
+			"x": -259.0812996416322,
+			"y": 1669.1450622075233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OpwsQqGaond-aXtInw3bn",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHr",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:YkDAbKruIPh0z1-FkJQyX": {
+			"x": 290.69396489540804,
+			"y": 1669.1450622075233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YkDAbKruIPh0z1-FkJQyX",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIV",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:bt2Oq0ihyMXF0-cxBQ2KN": {
+			"x": -259.0812996416322,
+			"y": 1657.2018087172387,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bt2Oq0ihyMXF0-cxBQ2KN",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJl",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:VR2yxPiYO34b7C3XevHJO": {
+			"x": 290.69396489540804,
+			"y": 1657.2018087172387,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VR2yxPiYO34b7C3XevHJO",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKl",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Y-2S-BR5QNRS1GuNJovVf": {
+			"x": -259.0812996416322,
+			"y": 1750.832616242599,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Y-2S-BR5QNRS1GuNJovVf",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGj",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:LtsPosoBlr6ljR6RCViy3": {
+			"x": 290.69396489540804,
+			"y": 1750.832616242599,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LtsPosoBlr6ljR6RCViy3",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHC",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:3-MYNkWPxnxHKoWrIVeH8": {
+			"x": -259.0812996416322,
+			"y": 1763.920750365639,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3-MYNkWPxnxHKoWrIVeH8",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHN",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:_nmKz_Bg8LNnCRzvbVns5": {
+			"x": 290.69396489540804,
+			"y": 1763.920750365639,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_nmKz_Bg8LNnCRzvbVns5",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHj",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Pd1kc1rntoB8kDilOb9m6": {
+			"x": -259.0812996416322,
+			"y": 1770.3927105492605,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Pd1kc1rntoB8kDilOb9m6",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHs",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:jrfd1Rc3NmLqNN1GZ5-F4": {
+			"x": 290.69396489540804,
+			"y": 1770.3927105492605,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jrfd1Rc3NmLqNN1GZ5-F4",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIl",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:jdk2p4hwvzLt22oGA5mLL": {
+			"x": -259.0812996416322,
+			"y": 1758.449457058976,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jdk2p4hwvzLt22oGA5mLL",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJt",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:1ico__SmLmnMhKcBRbfEp": {
+			"x": 290.69396489540804,
+			"y": 1758.449457058976,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1ico__SmLmnMhKcBRbfEp",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKt",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:4wvUQRqICIuR7pYcMT13M": {
+			"x": -259.0812996416322,
+			"y": 1915.8245610317265,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4wvUQRqICIuR7pYcMT13M",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGZ",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:mt_kBP8Vj13A2CivDs9j6": {
+			"x": -259.0812996416322,
+			"y": 2039.4306167330947,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mt_kBP8Vj13A2CivDs9j6",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGf",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:NkwwrtPxQNZBi1trRcL6x": {
+			"x": -259.0812996416322,
+			"y": 2150.225599112582,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:NkwwrtPxQNZBi1trRcL6x",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGi",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:4oBwGr5pIwGCKcQ97hkns": {
+			"x": -259.0812996416322,
+			"y": 2251.4732474543193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4oBwGr5pIwGCKcQ97hkns",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGk",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:PSOORi4qaiM1tEdkXRXLL": {
+			"x": 290.69396489540804,
+			"y": 1915.8245610317265,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PSOORi4qaiM1tEdkXRXLL",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGt",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:c5z9FgFRVmeFVTuZ7obKI": {
+			"x": 290.69396489540804,
+			"y": 2039.4306167330947,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:c5z9FgFRVmeFVTuZ7obKI",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aH4",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Dfmswo5_yjX_iBe36f4JM": {
+			"x": 290.69396489540804,
+			"y": 2150.225599112582,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Dfmswo5_yjX_iBe36f4JM",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHA",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:l4afRmFE--ZVvOVgnOuq2": {
+			"x": 290.69396489540804,
+			"y": 2251.4732474543193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:l4afRmFE--ZVvOVgnOuq2",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHE",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:JJOQ8qxhhoc6C1XeFbl3v": {
+			"x": -259.0812996416322,
+			"y": 1928.9126951547664,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JJOQ8qxhhoc6C1XeFbl3v",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHI",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:E72oRy65BmXQsNea6Ho-i": {
+			"x": -259.0812996416322,
+			"y": 2052.518750856135,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:E72oRy65BmXQsNea6Ho-i",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHL",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Z7RA8D1HLCZwMOHiH_4LH": {
+			"x": -259.0812996416322,
+			"y": 2163.313733235622,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Z7RA8D1HLCZwMOHiH_4LH",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHMV",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:oKnJ2bNK8xTPIIarZlcAz": {
+			"x": -259.0812996416322,
+			"y": 2264.5613815773595,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:oKnJ2bNK8xTPIIarZlcAz",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHNV",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:1L68BMaRq8lAt4V18bFBu": {
+			"x": 290.69396489540804,
+			"y": 1928.9126951547664,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1L68BMaRq8lAt4V18bFBu",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHU",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:DY9u1ScZ4SjoKiF-5u4Pl": {
+			"x": 290.69396489540804,
+			"y": 2052.518750856135,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DY9u1ScZ4SjoKiF-5u4Pl",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHd",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:1W1pTHTZ9LOj5H6teN2nH": {
+			"x": 290.69396489540804,
+			"y": 2163.313733235622,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1W1pTHTZ9LOj5H6teN2nH",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHi",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:qQh_buWtkRgFbQdevaOA_": {
+			"x": 290.69396489540804,
+			"y": 2264.5613815773595,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qQh_buWtkRgFbQdevaOA_",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHk",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:PIDfCItVApY1_2tinpCFi": {
+			"x": -259.0812996416322,
+			"y": 1935.384655338388,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PIDfCItVApY1_2tinpCFi",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHn",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:CdaCwSQJzplHfOAygQGBE": {
+			"x": -259.0812996416322,
+			"y": 2058.990711039756,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CdaCwSQJzplHfOAygQGBE",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHq",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:OYDF3d60XSCz_02h5_ljv": {
+			"x": -259.0812996416322,
+			"y": 2169.7856934192437,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OYDF3d60XSCz_02h5_ljv",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHrV",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:pYTJ5ZFOb3JFog29UXm70": {
+			"x": -259.0812996416322,
+			"y": 2271.033341760981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pYTJ5ZFOb3JFog29UXm70",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHsV",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Paub0omp9VXR5XPF3x9Xp": {
+			"x": 290.69396489540804,
+			"y": 1935.384655338388,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Paub0omp9VXR5XPF3x9Xp",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHx",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Z9wYFYpTnwqOrfkb7PPZa": {
+			"x": 290.69396489540804,
+			"y": 2058.990711039756,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Z9wYFYpTnwqOrfkb7PPZa",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIG",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:MIY9zI12Co2kNwsulHzxA": {
+			"x": 290.69396489540804,
+			"y": 2169.7856934192437,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MIY9zI12Co2kNwsulHzxA",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aId",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Iu-tj5EnOanorAUFNJU3Z": {
+			"x": 290.69396489540804,
+			"y": 2271.033341760981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Iu-tj5EnOanorAUFNJU3Z",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIt",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:acaL1KYn32HlNBLY5S1-v": {
+			"x": -259.0812996416322,
+			"y": 1923.4414018481032,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:acaL1KYn32HlNBLY5S1-v",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJG",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:nrCqmVWs0DzA4dovphhiI": {
+			"x": -259.0812996416322,
+			"y": 2047.0474575494713,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nrCqmVWs0DzA4dovphhiI",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJd",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:KS7zlcQGRwel6iLGBoFhk": {
+			"x": -259.0812996416322,
+			"y": 2157.842439928959,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KS7zlcQGRwel6iLGBoFhk",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJp",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:73rx9BtPRikyF__h0ZS_f": {
+			"x": -259.0812996416322,
+			"y": 2259.0900882706965,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:73rx9BtPRikyF__h0ZS_f",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJx",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:DFpviBzD-2Y8YVasPPFYd": {
+			"x": 290.69396489540804,
+			"y": 1923.4414018481032,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DFpviBzD-2Y8YVasPPFYd",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKG",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:tu4ZGKXJIxo4TC-88kVf5": {
+			"x": 290.69396489540804,
+			"y": 2047.0474575494713,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tu4ZGKXJIxo4TC-88kVf5",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKd",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:XMxreDqHcH2SuOlylz7Xg": {
+			"x": 290.69396489540804,
+			"y": 2157.842439928959,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XMxreDqHcH2SuOlylz7Xg",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKp",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:0o513f5lIPoTg9vEHRd43": {
+			"x": 290.69396489540804,
+			"y": 2259.0900882706965,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0o513f5lIPoTg9vEHRd43",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKx",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:exXAfWjCG_VI0S7VmUYNJ": {
+			"x": -259.0812996416322,
+			"y": 2388.04616728611,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:exXAfWjCG_VI0S7VmUYNJ",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGb",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:uRImZWG7iyPPKuQhrcWXh": {
+			"x": -259.0812996416322,
+			"y": 2511.6522229874786,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uRImZWG7iyPPKuQhrcWXh",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGg",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:xr3TQ-kGNAgJ7EIOAwNBZ": {
+			"x": -259.0812996416322,
+			"y": 2622.447205366966,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xr3TQ-kGNAgJ7EIOAwNBZ",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGiV",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:SPOku2yC_3gd1ji3kHstN": {
+			"x": -259.0812996416322,
+			"y": 2723.6948537087032,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SPOku2yC_3gd1ji3kHstN",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGkV",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:lc-CpsvD2VBThNp6E9dKR": {
+			"x": 290.69396489540804,
+			"y": 2388.04616728611,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lc-CpsvD2VBThNp6E9dKR",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGx",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:nL_NcHlM48XFgg3qzQBgV": {
+			"x": 290.69396489540804,
+			"y": 2511.6522229874786,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nL_NcHlM48XFgg3qzQBgV",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aH6",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:L6lgL58GpPz-T7YX6RkVG": {
+			"x": 290.69396489540804,
+			"y": 2622.447205366966,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:L6lgL58GpPz-T7YX6RkVG",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHB",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:R7_em_T6BtVnxgyFVSDuw": {
+			"x": 290.69396489540804,
+			"y": 2723.6948537087032,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R7_em_T6BtVnxgyFVSDuw",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHF",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:XuHPiEuJNhSruMxm_HVye": {
+			"x": -259.0812996416322,
+			"y": 2401.1343014091503,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XuHPiEuJNhSruMxm_HVye",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHJ",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:bck-jIF6zUHJrLakEZ7wF": {
+			"x": -259.0812996416322,
+			"y": 2524.7403571105187,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bck-jIF6zUHJrLakEZ7wF",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHLV",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:KmgKXNsoJKaRFS5f49SCl": {
+			"x": -259.0812996416322,
+			"y": 2635.5353394900058,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KmgKXNsoJKaRFS5f49SCl",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHMl",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:xjJBBKOWMv032TDQKzIc2": {
+			"x": -259.0812996416322,
+			"y": 2736.7829878317434,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xjJBBKOWMv032TDQKzIc2",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHNl",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:y7Yq9SQ3GmPBZLcEKwY_I": {
+			"x": 290.69396489540804,
+			"y": 2401.1343014091503,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:y7Yq9SQ3GmPBZLcEKwY_I",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHX",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:AzcTJFdHFE-opT0k9Ajyt": {
+			"x": 290.69396489540804,
+			"y": 2524.7403571105187,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AzcTJFdHFE-opT0k9Ajyt",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHf",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:fc8IDnLOBmPlnM-s8DnCy": {
+			"x": 290.69396489540804,
+			"y": 2635.5353394900058,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fc8IDnLOBmPlnM-s8DnCy",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHiV",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:_9f7DhaA4vZvNrdqBPgIA": {
+			"x": 290.69396489540804,
+			"y": 2736.7829878317434,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_9f7DhaA4vZvNrdqBPgIA",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHkV",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:JCwGGOJBneV7pmX4kgezE": {
+			"x": -259.0812996416322,
+			"y": 2407.606261592772,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JCwGGOJBneV7pmX4kgezE",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHo",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:PoYtEo_vxSLH1K-kdhB1S": {
+			"x": -259.0812996416322,
+			"y": 2531.21231729414,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PoYtEo_vxSLH1K-kdhB1S",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHqV",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:q8TfPnbtXek-U0jH93Y8r": {
+			"x": -259.0812996416322,
+			"y": 2642.0072996736276,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:q8TfPnbtXek-U0jH93Y8r",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHrl",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:7UenujjWRt-6wBe9Sj4_4": {
+			"x": -259.0812996416322,
+			"y": 2743.254948015365,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7UenujjWRt-6wBe9Sj4_4",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHsl",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:fRsNOA4nzOuJtZrfrJLzL": {
+			"x": 290.69396489540804,
+			"y": 2407.606261592772,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fRsNOA4nzOuJtZrfrJLzL",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHz",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:MlVyoZ1FBYbdbAQG3-ma3": {
+			"x": 290.69396489540804,
+			"y": 2531.21231729414,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MlVyoZ1FBYbdbAQG3-ma3",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIO",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:UYZaAHFfNOt5eZuJRHEMY": {
+			"x": 290.69396489540804,
+			"y": 2642.0072996736276,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UYZaAHFfNOt5eZuJRHEMY",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIh",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:vl7qbmbNU7b_UzNhf4WtE": {
+			"x": 290.69396489540804,
+			"y": 2743.254948015365,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vl7qbmbNU7b_UzNhf4WtE",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIx",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:CxKft06-uMogRscirJLUh": {
+			"x": -259.0812996416322,
+			"y": 2395.663008102487,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CxKft06-uMogRscirJLUh",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJO",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:zn30yNPi_zHxuusu8SmmC": {
+			"x": -259.0812996416322,
+			"y": 2519.2690638038553,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zn30yNPi_zHxuusu8SmmC",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJh",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:j-zAXmmFRZTHdoh4ct-RQ": {
+			"x": -259.0812996416322,
+			"y": 2630.0640461833427,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:j-zAXmmFRZTHdoh4ct-RQ",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJr",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:zJvmRlJW2yw2s16Wf9HE8": {
+			"x": -259.0812996416322,
+			"y": 2731.3116945250804,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zJvmRlJW2yw2s16Wf9HE8",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJz",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:U31xcYtFH67KBY8pae9Zs": {
+			"x": 290.69396489540804,
+			"y": 2395.663008102487,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:U31xcYtFH67KBY8pae9Zs",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKO",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:SDYw9mpY1IdR6rnqUGzsI": {
+			"x": 290.69396489540804,
+			"y": 2519.2690638038553,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SDYw9mpY1IdR6rnqUGzsI",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKh",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Fw8EWc3WLQRgm11RMjHzo": {
+			"x": 290.69396489540804,
+			"y": 2630.0640461833427,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Fw8EWc3WLQRgm11RMjHzo",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKr",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:ltMisDoGfi-xJ6XB713pW": {
+			"x": 290.69396489540804,
+			"y": 2731.3116945250804,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ltMisDoGfi-xJ6XB713pW",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKz",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:UlAN3QtQPcf8P2PGnHtSD": {
+			"x": -259.0812996416322,
+			"y": 2858.095982794634,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UlAN3QtQPcf8P2PGnHtSD",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGc",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:W2O-_rsJbiryK1prkJyPx": {
+			"x": -259.0812996416322,
+			"y": 2981.7020384960024,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:W2O-_rsJbiryK1prkJyPx",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGgV",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:mjUubBJrGRinA84mfqaYL": {
+			"x": -259.0812996416322,
+			"y": 3092.49702087549,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mjUubBJrGRinA84mfqaYL",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGil",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:KcVXHcJQRkjFG9D20Syci": {
+			"x": -259.0812996416322,
+			"y": 3193.744669217227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KcVXHcJQRkjFG9D20Syci",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGkl",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:mtfJ674mgSZ8P6DWGrb6H": {
+			"x": 290.69396489540804,
+			"y": 2858.095982794634,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mtfJ674mgSZ8P6DWGrb6H",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aGz",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:ZdGnu-AXmvccviCDIbmYO": {
+			"x": 290.69396489540804,
+			"y": 2981.7020384960024,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZdGnu-AXmvccviCDIbmYO",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aH7",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:lmrem60njAkLByK740DMM": {
+			"x": 290.69396489540804,
+			"y": 3092.49702087549,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lmrem60njAkLByK740DMM",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHBV",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:bsOKsWu5KDY3nOZgmEAXZ": {
+			"x": 290.69396489540804,
+			"y": 3193.744669217227,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bsOKsWu5KDY3nOZgmEAXZ",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHFV",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.06220257987061,
+						"y": 92.54213910199667
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:3uCjOWXo8id0TRO4Dyd2X": {
+			"x": -259.0812996416322,
+			"y": 2871.184116917674,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3uCjOWXo8id0TRO4Dyd2X",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHJV",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:EU30MnEFJJGwDsnSUhVRw": {
+			"x": -259.0812996416322,
+			"y": 2994.7901726190426,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EU30MnEFJJGwDsnSUhVRw",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHLl",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:YWvWvrsz7VZTKZ1BH612-": {
+			"x": -259.0812996416322,
+			"y": 3105.5851549985296,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YWvWvrsz7VZTKZ1BH612-",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHMt",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:163LQaair2hAf9LsUcDbd": {
+			"x": -259.0812996416322,
+			"y": 3206.832803340267,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:163LQaair2hAf9LsUcDbd",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHNt",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:EnGtZ39BzVDr6bh7YjTQm": {
+			"x": 290.69396489540804,
+			"y": 2871.184116917674,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EnGtZ39BzVDr6bh7YjTQm",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHZ",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:XayFO5W6JkqJ_qUohjP9I": {
+			"x": 290.69396489540804,
+			"y": 2994.7901726190426,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XayFO5W6JkqJ_qUohjP9I",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHfV",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:mkT_SSQffXjxNOM2GBoOY": {
+			"x": 290.69396489540804,
+			"y": 3105.5851549985296,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mkT_SSQffXjxNOM2GBoOY",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHil",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:TzomE7RGZmHFOyD5eRILG": {
+			"x": 290.69396489540804,
+			"y": 3206.832803340267,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TzomE7RGZmHFOyD5eRILG",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHkl",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.25867110324572,
+						"y": 68.89093276824845
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:Z2BP5cTCfTaSbomzePqOf": {
+			"x": -259.0812996416322,
+			"y": 2877.656077101296,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Z2BP5cTCfTaSbomzePqOf",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHoV",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:W1-YTs9P9ZrsMl3bv2XIY": {
+			"x": -259.0812996416322,
+			"y": 3001.262132802664,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:W1-YTs9P9ZrsMl3bv2XIY",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHql",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:PiPC2vm5fivQ7SVCTOTgw": {
+			"x": -259.0812996416322,
+			"y": 3112.0571151821514,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PiPC2vm5fivQ7SVCTOTgw",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHrt",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:jKaEdWEr372_doShpFMaI": {
+			"x": -259.0812996416322,
+			"y": 3213.3047635238886,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jKaEdWEr372_doShpFMaI",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHst",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:fodDMGi6RXvBVs5eTiu1d": {
+			"x": 290.69396489540804,
+			"y": 2877.656077101296,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fodDMGi6RXvBVs5eTiu1d",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aHzV",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:jyfa5gkAvQSK1izkO1Y-U": {
+			"x": 290.69396489540804,
+			"y": 3001.262132802664,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jyfa5gkAvQSK1izkO1Y-U",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIS",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:upH1-bs5j5ulGfSz-wT0q": {
+			"x": 290.69396489540804,
+			"y": 3112.0571151821514,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:upH1-bs5j5ulGfSz-wT0q",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIj",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:mTv6yAzSy1kXwGz2gUP7m": {
+			"x": 290.69396489540804,
+			"y": 3213.3047635238886,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mTv6yAzSy1kXwGz2gUP7m",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aIz",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 229.08509912361876,
+						"y": 50.006204081018716
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:fxREg_eWoDWFDYQNXs1WR": {
+			"x": -259.0812996416322,
+			"y": 2865.7128236110107,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fxREg_eWoDWFDYQNXs1WR",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJS",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:_SJo4MFq8z3ZQCQ29Izlm": {
+			"x": -259.0812996416322,
+			"y": 2989.318879312379,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_SJo4MFq8z3ZQCQ29Izlm",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJj",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:rRt0ZuAAZKOV_4GL08iC3": {
+			"x": -259.0812996416322,
+			"y": 3100.1138616918665,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rRt0ZuAAZKOV_4GL08iC3",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJs",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:hodWY80RdDOU01-SSTxNL": {
+			"x": -259.0812996416322,
+			"y": 3201.361510033604,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hodWY80RdDOU01-SSTxNL",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aJzV",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "cubic",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:V0oasBaMM3UPimYv0sVVz": {
+			"x": 290.69396489540804,
+			"y": 2865.7128236110107,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:V0oasBaMM3UPimYv0sVVz",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKS",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:-I5fA7zfEpXrFt5JcuUF2": {
+			"x": 290.69396489540804,
+			"y": 2989.318879312379,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-I5fA7zfEpXrFt5JcuUF2",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKj",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:s5-zIUIE4twTfxZcHPn3x": {
+			"x": 290.69396489540804,
+			"y": 3100.1138616918665,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:s5-zIUIE4twTfxZcHPn3x",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKs",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:30VfArm8gs2fH3cHyvm7x": {
+			"x": 290.69396489540804,
+			"y": 3201.361510033604,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:30VfArm8gs2fH3cHyvm7x",
+			"type": "line",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aKzV",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"color": "black",
+				"spline": "line",
+				"handles": {
+					"start": {
+						"id": "start",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1",
+						"x": 0,
+						"y": 0
+					},
+					"end": {
+						"id": "end",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a2",
+						"x": 460.8578876470081,
+						"y": -1.7237149003800947e-16
+					},
+					"handle:a1V": {
+						"id": "handle:a1V",
+						"type": "vertex",
+						"canBind": false,
+						"index": "a1V",
+						"x": 230.6332710878141,
+						"y": 54.58592500103621
+					}
+				}
+			},
+			"typeName": "shape"
+		},
+		"shape:t7wtH7UpwlxvPGF2oNGDG": {
+			"x": 828.3437441614171,
+			"y": 2844.561653560181,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:t7wtH7UpwlxvPGF2oNGDG",
+			"type": "frame",
+			"props": {
+				"w": 421.69057272075224,
+				"h": 421.69057272075224,
+				"name": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aj",
+			"typeName": "shape"
+		},
+		"shape:dJO3dII1OgMqoTBZ55da0": {
+			"x": 871.1868323189601,
+			"y": 3120.731766570472,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dJO3dII1OgMqoTBZ55da0",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ak",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "binding",
+					"boundShapeId": "shape:t7wtH7UpwlxvPGF2oNGDG",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"end": {
+					"type": "point",
+					"x": 478.28108247981413,
+					"y": -237.96098719033853
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:mqA8ycIQ9r4587zj6T7_q": {
+			"x": 1192.7697762376397,
+			"y": 3036.8851328803084,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mqA8ycIQ9r4587zj6T7_q",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "anV",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "binding",
+					"boundShapeId": "shape:SoRC97hcxnz7ZtjP7k47U",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"end": {
+					"type": "binding",
+					"boundShapeId": "shape:t7wtH7UpwlxvPGF2oNGDG",
+					"normalizedAnchor": {
+						"x": 0.20982350982350984,
+						"y": 0.7445221445221445
+					},
+					"isExact": false
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:z8QOXwsD12C-bVn3WWZk5": {
+			"x": 1154.9257504806492,
+			"y": 3147.9738481914596,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:z8QOXwsD12C-bVn3WWZk5",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "am",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 229.90070118495373,
+					"y": 16.583968244528933
+				},
+				"end": {
+					"type": "binding",
+					"boundShapeId": "shape:TN4SgkjwSoshfhulfjE-K",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:TN4SgkjwSoshfhulfjE-K": {
+			"x": 123.61445593275994,
+			"y": 74.67700518577931,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TN4SgkjwSoshfhulfjE-K",
+			"type": "geo",
+			"props": {
+				"w": 85.32107625212439,
+				"h": 103.22502164736125,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "shape:t7wtH7UpwlxvPGF2oNGDG",
+			"index": "a1",
+			"typeName": "shape"
+		},
+		"shape:SoRC97hcxnz7ZtjP7k47U": {
+			"x": 1390.611883432534,
+			"y": 2955.0746341566623,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SoRC97hcxnz7ZtjP7k47U",
+			"type": "geo",
+			"props": {
+				"w": 53.37482074297668,
+				"h": 70.66090449320109,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "an",
+			"typeName": "shape"
+		},
+		"shape:xgWQM8pPdycjiT61X4lYO": {
+			"x": 973.7939923213091,
+			"y": 2946.059471063531,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xgWQM8pPdycjiT61X4lYO",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ao",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "binding",
+					"boundShapeId": "shape:TN4SgkjwSoshfhulfjE-K",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"end": {
+					"type": "binding",
+					"boundShapeId": "shape:SoRC97hcxnz7ZtjP7k47U",
+					"normalizedAnchor": {
+						"x": 0.5,
+						"y": 0.5
+					},
+					"isExact": false
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:U9YWfkDoIySAQ_OjgNpEP": {
+			"x": 1158.4784549394685,
+			"y": 3105.7205370587008,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:U9YWfkDoIySAQ_OjgNpEP",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ajV",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "binding",
+					"boundShapeId": "shape:t7wtH7UpwlxvPGF2oNGDG",
+					"normalizedAnchor": {
+						"x": 0.7828837828837827,
+						"y": 0.6193140193140187
+					},
+					"isExact": false
+				},
+				"end": {
+					"type": "binding",
+					"boundShapeId": "shape:t7wtH7UpwlxvPGF2oNGDG",
+					"normalizedAnchor": {
+						"x": 0.2452214452214452,
+						"y": 0.7429903429903424
+					},
+					"isExact": false
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:w0dPW9ph6czk-MBzpiYnc": {
+			"x": 1492.3138815502646,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:w0dPW9ph6czk-MBzpiYnc",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ap",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:7BAYJzy5uGSEDYr5FGw6v": {
+			"x": 1585.86380903772,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7BAYJzy5uGSEDYr5FGw6v",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aq",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:OosiTC9av_DDWEEUFr5dG": {
+			"x": 1679.4137365251756,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OosiTC9av_DDWEEUFr5dG",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ar",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:ePkcxQotEVwEa9XfLOwdl": {
+			"x": 1772.9636640126312,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ePkcxQotEVwEa9XfLOwdl",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "as",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:7boD_141j8dl6PWO28o8l": {
+			"x": 1492.3138815502646,
+			"y": 2941.349634009681,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7boD_141j8dl6PWO28o8l",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apV",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:jqYgEVOOJKV4y7lgG-6xo": {
+			"x": 1585.86380903772,
+			"y": 2941.349634009681,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jqYgEVOOJKV4y7lgG-6xo",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqV",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:pZl9ZVP2KaHn0avlNhl1q": {
+			"x": 1679.4137365251756,
+			"y": 2941.349634009681,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pZl9ZVP2KaHn0avlNhl1q",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arV",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:ysFnS7R8jXvVtDpAqrTUF": {
+			"x": 1772.9636640126312,
+			"y": 2941.349634009681,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ysFnS7R8jXvVtDpAqrTUF",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "at",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:hQcn3G_KkgfwW9r_fYdBF": {
+			"x": 1492.3138815502646,
+			"y": 3065.1552527155027,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hQcn3G_KkgfwW9r_fYdBF",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apl",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:t3grIPmVf2sKDth4EXTin": {
+			"x": 1585.86380903772,
+			"y": 3065.1552527155027,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:t3grIPmVf2sKDth4EXTin",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aql",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:qWCi3JZsNeTHOe8Zf_OLD": {
+			"x": 1679.4137365251756,
+			"y": 3065.1552527155027,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qWCi3JZsNeTHOe8Zf_OLD",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arl",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:lIN7rfP3Jjv03XKRwu5Ez": {
+			"x": 1772.9636640126312,
+			"y": 3065.1552527155027,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lIN7rfP3Jjv03XKRwu5Ez",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "au",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:XgCnlZdUV2qobh9BvNEsJ": {
+			"x": 1492.3138815502646,
+			"y": 3195.219066856921,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XgCnlZdUV2qobh9BvNEsJ",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apt",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:HDU_F3SQ_9mfzS9a1-Jmh": {
+			"x": 1585.86380903772,
+			"y": 3195.219066856921,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HDU_F3SQ_9mfzS9a1-Jmh",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqt",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:7ZWdB7CeeKRBa5BXWulVb": {
+			"x": 1679.4137365251756,
+			"y": 3195.219066856921,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7ZWdB7CeeKRBa5BXWulVb",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "art",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:QWxiJ57fuoLklp7zCPueq": {
+			"x": 1772.9636640126312,
+			"y": 3195.219066856921,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QWxiJ57fuoLklp7zCPueq",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "av",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": 0,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:KZSlV3vu0n_FlWAy7WqoF": {
+			"x": 1866.5135915000867,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KZSlV3vu0n_FlWAy7WqoF",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apG",
+			"props": {
+				"dash": "draw",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -26.629719652615496,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:6Snmkh4xfqIlNEVKKC5np": {
+			"x": 1960.0635189875422,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6Snmkh4xfqIlNEVKKC5np",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqG",
+			"props": {
+				"dash": "draw",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -24.39733738946812,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:KNMxN9gAViwmhD7ItOqOP": {
+			"x": 2053.6134464749975,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KNMxN9gAViwmhD7ItOqOP",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arG",
+			"props": {
+				"dash": "draw",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -30.947862602826415,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:gSo5BWwKYwDM0xCYswCv4": {
+			"x": 2147.163373962453,
+			"y": 2833.4209162642646,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gSo5BWwKYwDM0xCYswCv4",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "asV",
+			"props": {
+				"dash": "draw",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -36.314106965932936,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:2s--gP-r2TLLnWlBeTYiO": {
+			"x": 1866.5135915000867,
+			"y": 2957.4960757212193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2s--gP-r2TLLnWlBeTYiO",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apO",
+			"props": {
+				"dash": "dashed",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -26.629719652615496,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:0D-gUiTxINAtSFt94Lw6j": {
+			"x": 1960.0635189875422,
+			"y": 2957.4960757212193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0D-gUiTxINAtSFt94Lw6j",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqO",
+			"props": {
+				"dash": "dashed",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -24.39733738946812,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:L2B97lymWV7C2Xvn9nFEe": {
+			"x": 2053.6134464749975,
+			"y": 2957.4960757212193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:L2B97lymWV7C2Xvn9nFEe",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arO",
+			"props": {
+				"dash": "dashed",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -30.947862602826415,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:YOUQLEGsZ8I0EoAoG2V3U": {
+			"x": 2147.163373962453,
+			"y": 2957.4960757212193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YOUQLEGsZ8I0EoAoG2V3U",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "asl",
+			"props": {
+				"dash": "dashed",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -36.314106965932936,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:nt-L54fUsYjqUA3aw1c5g": {
+			"x": 1866.5135915000867,
+			"y": 3085.3015467904193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nt-L54fUsYjqUA3aw1c5g",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apS",
+			"props": {
+				"dash": "dotted",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -26.629719652615496,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:0KFrjzDeLb2r_rMD02yHl": {
+			"x": 1960.0635189875422,
+			"y": 3085.3015467904193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0KFrjzDeLb2r_rMD02yHl",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqS",
+			"props": {
+				"dash": "dotted",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -24.39733738946812,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:Wdu5SwQnH2wMlT--FQRW_": {
+			"x": 2053.6134464749975,
+			"y": 3085.3015467904193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Wdu5SwQnH2wMlT--FQRW_",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arS",
+			"props": {
+				"dash": "dotted",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -30.947862602826415,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:-Z7j9fWN2xufnFuJQnvuF": {
+			"x": 2147.163373962453,
+			"y": 3085.3015467904193,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-Z7j9fWN2xufnFuJQnvuF",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ast",
+			"props": {
+				"dash": "dotted",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -36.314106965932936,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:SIAR9TnScvMVFTWDOSPRW": {
+			"x": 1866.5135915000867,
+			"y": 3205.2113258941768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SIAR9TnScvMVFTWDOSPRW",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "apU",
+			"props": {
+				"dash": "solid",
+				"size": "s",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -26.629719652615496,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:oz9AhCRTXogyGlr1pnAD0": {
+			"x": 1960.0635189875422,
+			"y": 3205.2113258941768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:oz9AhCRTXogyGlr1pnAD0",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aqU",
+			"props": {
+				"dash": "solid",
+				"size": "m",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -24.39733738946812,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:KgeMeW1TAk7BTjDmCwAEW": {
+			"x": 2053.6134464749975,
+			"y": 3205.2113258941768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KgeMeW1TAk7BTjDmCwAEW",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "arU",
+			"props": {
+				"dash": "solid",
+				"size": "l",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -30.947862602826415,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:OYBHK6WWADjnW_hzZhgHD": {
+			"x": 2147.163373962453,
+			"y": 3205.2113258941768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OYBHK6WWADjnW_hzZhgHD",
+			"type": "arrow",
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "asx",
+			"props": {
+				"dash": "solid",
+				"size": "xl",
+				"fill": "none",
+				"color": "black",
+				"labelColor": "black",
+				"bend": -36.314106965932936,
+				"start": {
+					"type": "point",
+					"x": 0,
+					"y": 0
+				},
+				"end": {
+					"type": "point",
+					"x": 83.54992748745553,
+					"y": 78.10670605552968
+				},
+				"arrowheadStart": "none",
+				"arrowheadEnd": "arrow",
+				"text": "",
+				"font": "draw"
+			},
+			"typeName": "shape"
+		},
+		"shape:67c6gs0hrJ2PZuTd48yNP": {
+			"x": -1856.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:67c6gs0hrJ2PZuTd48yNP",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL8",
+			"typeName": "shape"
+		},
+		"shape:p67OAG-v4s76-VwRAoM2i": {
+			"x": -1856.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:p67OAG-v4s76-VwRAoM2i",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLK",
+			"typeName": "shape"
+		},
+		"shape:_IKMwsbh1soNMELaTOUCb": {
+			"x": -1856.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_IKMwsbh1soNMELaTOUCb",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQ",
+			"typeName": "shape"
+		},
+		"shape:CmZBjWmatl5jcHoMw1JjD": {
+			"x": -1856.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CmZBjWmatl5jcHoMw1JjD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLU",
+			"typeName": "shape"
+		},
+		"shape:aujZiBWZddmH4aSCN-K03": {
+			"x": 3327.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aujZiBWZddmH4aSCN-K03",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM8",
+			"typeName": "shape"
+		},
+		"shape:VKQ207QLXqHEZ4Pm5G5uQ": {
+			"x": 3327.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VKQ207QLXqHEZ4Pm5G5uQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMK",
+			"typeName": "shape"
+		},
+		"shape:lphR82qiBEZ79fH40sdIt": {
+			"x": 3327.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lphR82qiBEZ79fH40sdIt",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQ",
+			"typeName": "shape"
+		},
+		"shape:IAXRLengvSp7WXsywG286": {
+			"x": 3327.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IAXRLengvSp7WXsywG286",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMU",
+			"typeName": "shape"
+		},
+		"shape:_osiSo2GfuW7zdEeHLt7z": {
+			"x": 2247.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_osiSo2GfuW7zdEeHLt7z",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN8",
+			"typeName": "shape"
+		},
+		"shape:oBP80zrsl5u6pgFEbOdxf": {
+			"x": 2247.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:oBP80zrsl5u6pgFEbOdxf",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNK",
+			"typeName": "shape"
+		},
+		"shape:apfIavqlkp67_IbCjSSrV": {
+			"x": 2247.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:apfIavqlkp67_IbCjSSrV",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQ",
+			"typeName": "shape"
+		},
+		"shape:HQ09uXQSzDJOIwzwSmgDz": {
+			"x": -1640.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HQ09uXQSzDJOIwzwSmgDz",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNU",
+			"typeName": "shape"
+		},
+		"shape:9EQfUd1YF735SpX03SbRi": {
+			"x": 1167.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9EQfUd1YF735SpX03SbRi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOG",
+			"typeName": "shape"
+		},
+		"shape:6Fyz-rz3OETlttt0qUMMF": {
+			"x": 1167.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6Fyz-rz3OETlttt0qUMMF",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOd",
+			"typeName": "shape"
+		},
+		"shape:9O9_o69Y94MgcP7abkHn7": {
+			"x": 1167.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9O9_o69Y94MgcP7abkHn7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOp",
+			"typeName": "shape"
+		},
+		"shape:bRWUOrrIUGVSHNuSB9ey6": {
+			"x": 3543.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bRWUOrrIUGVSHNuSB9ey6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOx",
+			"typeName": "shape"
+		},
+		"shape:UGNzs9afK19Oyi0Ula5Gf": {
+			"x": 735.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UGNzs9afK19Oyi0Ula5Gf",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLC",
+			"typeName": "shape"
+		},
+		"shape:Gf7TvoDbnEkQctEGXlq5B": {
+			"x": 735.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Gf7TvoDbnEkQctEGXlq5B",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLM",
+			"typeName": "shape"
+		},
+		"shape:VcHb55vP6nsaUY0nI_8-j": {
+			"x": 735.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VcHb55vP6nsaUY0nI_8-j",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLR",
+			"typeName": "shape"
+		},
+		"shape:o0WlWp1TxRHAm_4a00ZsM": {
+			"x": 735.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:o0WlWp1TxRHAm_4a00ZsM",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUV",
+			"typeName": "shape"
+		},
+		"shape:twu848MH-C2cr9E1DH0Lv": {
+			"x": -344.68828586514974,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:twu848MH-C2cr9E1DH0Lv",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMC",
+			"typeName": "shape"
+		},
+		"shape:joBOfIIhxZ0Zvmlpdmoc8": {
+			"x": -344.68828586514974,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:joBOfIIhxZ0Zvmlpdmoc8",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMM",
+			"typeName": "shape"
+		},
+		"shape:e6QBqHyqvs_V6kM_uVtrD": {
+			"x": -344.6882858651502,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:e6QBqHyqvs_V6kM_uVtrD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMR",
+			"typeName": "shape"
+		},
+		"shape:B0wYdWFZzDBdkh5YX5sT4": {
+			"x": 3759.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:B0wYdWFZzDBdkh5YX5sT4",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUV",
+			"typeName": "shape"
+		},
+		"shape:zFcyraOEAHsp3F7hLCuOy": {
+			"x": -1424.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zFcyraOEAHsp3F7hLCuOy",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNC",
+			"typeName": "shape"
+		},
+		"shape:ek8SQLT8_WCmhsiaSYk5E": {
+			"x": -1424.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ek8SQLT8_WCmhsiaSYk5E",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNM",
+			"typeName": "shape"
+		},
+		"shape:IE1IYcKP_Kye-oLyTNkuS": {
+			"x": -1424.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IE1IYcKP_Kye-oLyTNkuS",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNR",
+			"typeName": "shape"
+		},
+		"shape:ICAZX70gmH05Bm4OmAyvQ": {
+			"x": 951.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ICAZX70gmH05Bm4OmAyvQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUV",
+			"typeName": "shape"
+		},
+		"shape:rGkWPdyVaCDNeivJXFuD7": {
+			"x": 3759.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rGkWPdyVaCDNeivJXFuD7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOO",
+			"typeName": "shape"
+		},
+		"shape:Q5ku3WnLeqg22uHZHhPxe": {
+			"x": 3759.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Q5ku3WnLeqg22uHZHhPxe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOh",
+			"typeName": "shape"
+		},
+		"shape:IZg-4Gc2jxsJ757-Gw5nF": {
+			"x": 3759.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IZg-4Gc2jxsJ757-Gw5nF",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOr",
+			"typeName": "shape"
+		},
+		"shape:bZtCH4LKemjO7nPUQFHV6": {
+			"x": -128.68828586514974,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bZtCH4LKemjO7nPUQFHV6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOz",
+			"typeName": "shape"
+		},
+		"shape:hoyfGizMtcQDy_9R-CyjD": {
+			"x": 2031.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hoyfGizMtcQDy_9R-CyjD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLE",
+			"typeName": "shape"
+		},
+		"shape:UvRJa8RIb1Sef46oo5iUL": {
+			"x": 2031.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UvRJa8RIb1Sef46oo5iUL",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLN",
+			"typeName": "shape"
+		},
+		"shape:byFMxvgKNb5k7H4NvF9-F": {
+			"x": 2031.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:byFMxvgKNb5k7H4NvF9-F",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRV",
+			"typeName": "shape"
+		},
+		"shape:1upDQ4E2XxPNvZloU2PVO": {
+			"x": 2031.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1upDQ4E2XxPNvZloU2PVO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUl",
+			"typeName": "shape"
+		},
+		"shape:nq2k2iQ64SDzntIhGILbt": {
+			"x": 951.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nq2k2iQ64SDzntIhGILbt",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aME",
+			"typeName": "shape"
+		},
+		"shape:ZHAQS7_c2AXavJyTdqpFO": {
+			"x": 951.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZHAQS7_c2AXavJyTdqpFO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMN",
+			"typeName": "shape"
+		},
+		"shape:LMf_OSerRkpgaM0A0BP-3": {
+			"x": 951.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LMf_OSerRkpgaM0A0BP-3",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRV",
+			"typeName": "shape"
+		},
+		"shape:L8SACVLE7ya89pkbXBIYz": {
+			"x": -1208.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:L8SACVLE7ya89pkbXBIYz",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUl",
+			"typeName": "shape"
+		},
+		"shape:zPrTqK4tgfM8MD9Wjb53f": {
+			"x": -128.68828586514974,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zPrTqK4tgfM8MD9Wjb53f",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNE",
+			"typeName": "shape"
+		},
+		"shape:hpw5YoijUtHiMl4iyvKnG": {
+			"x": -128.68828586514974,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hpw5YoijUtHiMl4iyvKnG",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNN",
+			"typeName": "shape"
+		},
+		"shape:9Kq3_viXKYz5WY_lXBwCN": {
+			"x": -128.68828586514974,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9Kq3_viXKYz5WY_lXBwCN",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRV",
+			"typeName": "shape"
+		},
+		"shape:vGWllF25AYiseoAUT9svY": {
+			"x": 2247.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vGWllF25AYiseoAUT9svY",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUl",
+			"typeName": "shape"
+		},
+		"shape:X7qBs9jHj9YpbkLStTNJM": {
+			"x": -1208.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X7qBs9jHj9YpbkLStTNJM",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOS",
+			"typeName": "shape"
+		},
+		"shape:fnkhJZ0fBNCFmFzJqfeMI": {
+			"x": -1208.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fnkhJZ0fBNCFmFzJqfeMI",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOj",
+			"typeName": "shape"
+		},
+		"shape:iozhkZo1AcsbnS67fSrHD": {
+			"x": -1208.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iozhkZo1AcsbnS67fSrHD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOs",
+			"typeName": "shape"
+		},
+		"shape:JA9K5onmgndLpSJmZUItO": {
+			"x": 1167.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JA9K5onmgndLpSJmZUItO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzV",
+			"typeName": "shape"
+		},
+		"shape:v5HLrkaxpDt9pcFikMr5k": {
+			"x": -560.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:v5HLrkaxpDt9pcFikMr5k",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLA",
+			"typeName": "shape"
+		},
+		"shape:R53yEmf7KSZQ0kyNkDi2e": {
+			"x": -560.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R53yEmf7KSZQ0kyNkDi2e",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLL",
+			"typeName": "shape"
+		},
+		"shape:I-6eAIxqNgfeiPtdfTdbO": {
+			"x": -560.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:I-6eAIxqNgfeiPtdfTdbO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQV",
+			"typeName": "shape"
+		},
+		"shape:N7wWTWt8VAI6ZTLT8V2i3": {
+			"x": -560.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N7wWTWt8VAI6ZTLT8V2i3",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUG",
+			"typeName": "shape"
+		},
+		"shape:rjjAs_rY3GkWM82v3W7PQ": {
+			"x": -1640.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rjjAs_rY3GkWM82v3W7PQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMA",
+			"typeName": "shape"
+		},
+		"shape:U509zGRhXAz6NEDyU-1M0": {
+			"x": -1640.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:U509zGRhXAz6NEDyU-1M0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aML",
+			"typeName": "shape"
+		},
+		"shape:42Ftsey4TgRU8p87DbsnY": {
+			"x": -1640.6882858651497,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:42Ftsey4TgRU8p87DbsnY",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQV",
+			"typeName": "shape"
+		},
+		"shape:g-R1Hr36dRotkol-bSQ8G": {
+			"x": 2463.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:g-R1Hr36dRotkol-bSQ8G",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUG",
+			"typeName": "shape"
+		},
+		"shape:GCyYjDeuczxSyWAQRm4W9": {
+			"x": 3543.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:GCyYjDeuczxSyWAQRm4W9",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNA",
+			"typeName": "shape"
+		},
+		"shape:qCql-bmQ68s1f1o1XG4eD": {
+			"x": 3543.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qCql-bmQ68s1f1o1XG4eD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNL",
+			"typeName": "shape"
+		},
+		"shape:y8U11EFss5vv6FuQmLBKY": {
+			"x": 3543.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:y8U11EFss5vv6FuQmLBKY",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQV",
+			"typeName": "shape"
+		},
+		"shape:aM0GI7is1Ia1L_ZrLagHE": {
+			"x": -344.68828586514974,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aM0GI7is1Ia1L_ZrLagHE",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUG",
+			"typeName": "shape"
+		},
+		"shape:EmckmMIuUcEy61SGE9GV4": {
+			"x": 2463.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EmckmMIuUcEy61SGE9GV4",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOK",
+			"typeName": "shape"
+		},
+		"shape:7lbTMSn2xry8QjvFU_5yu": {
+			"x": 2463.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7lbTMSn2xry8QjvFU_5yu",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "yellow",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOf",
+			"typeName": "shape"
+		},
+		"shape:Rlly989hI3lcTORTJkQp1": {
+			"x": 2463.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Rlly989hI3lcTORTJkQp1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOq",
+			"typeName": "shape"
+		},
+		"shape:nLagVTm_PJNdGmF7ciK3j": {
+			"x": -1424.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nLagVTm_PJNdGmF7ciK3j",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOy",
+			"typeName": "shape"
+		},
+		"shape:QVQoXDQIHshAhhDq8f_hJ": {
+			"x": -1208.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QVQoXDQIHshAhhDq8f_hJ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL9",
+			"typeName": "shape"
+		},
+		"shape:fjfSjRCBF6SvliDP1-q5J": {
+			"x": 87.31171413485026,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fjfSjRCBF6SvliDP1-q5J",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLB",
+			"typeName": "shape"
+		},
+		"shape:2JdyHz8Qh0_DErpYGnPKJ": {
+			"x": 1383.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2JdyHz8Qh0_DErpYGnPKJ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLD",
+			"typeName": "shape"
+		},
+		"shape:MP3B1abFin4yZt5nIw0Eg": {
+			"x": 2679.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MP3B1abFin4yZt5nIw0Eg",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLF",
+			"typeName": "shape"
+		},
+		"shape:IhuzMqYo88CmT4GJEx0X9": {
+			"x": -1208.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IhuzMqYo88CmT4GJEx0X9",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLKV",
+			"typeName": "shape"
+		},
+		"shape:6vIQ-Zi0dcwba8DIVqIL_": {
+			"x": 87.31171413485026,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6vIQ-Zi0dcwba8DIVqIL_",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLLV",
+			"typeName": "shape"
+		},
+		"shape:Asj0jo8-6OblmcyXpqYs-": {
+			"x": 1383.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Asj0jo8-6OblmcyXpqYs-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLMV",
+			"typeName": "shape"
+		},
+		"shape:Qn_57p7YCON0Zb_eYgr9S": {
+			"x": 2679.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Qn_57p7YCON0Zb_eYgr9S",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLNV",
+			"typeName": "shape"
+		},
+		"shape:SIOkwa_0GsAdWkxa7Ik5R": {
+			"x": -1208.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SIOkwa_0GsAdWkxa7Ik5R",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQG",
+			"typeName": "shape"
+		},
+		"shape:Mvye4u3vAsSihMSwqI6Tx": {
+			"x": 87.31171413485026,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Mvye4u3vAsSihMSwqI6Tx",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQl",
+			"typeName": "shape"
+		},
+		"shape:vEelWh2__EchkKvZdqtQq": {
+			"x": 1383.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vEelWh2__EchkKvZdqtQq",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRG",
+			"typeName": "shape"
+		},
+		"shape:8-7PsQpZ4-hxJKWWX2L5L": {
+			"x": 2679.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8-7PsQpZ4-hxJKWWX2L5L",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRl",
+			"typeName": "shape"
+		},
+		"shape:T63MqIgjEnMykJFRuW0CT": {
+			"x": -1208.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:T63MqIgjEnMykJFRuW0CT",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLU8",
+			"typeName": "shape"
+		},
+		"shape:jpqPs6nTAxbAex6UPabe6": {
+			"x": 87.31171413485026,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jpqPs6nTAxbAex6UPabe6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUO",
+			"typeName": "shape"
+		},
+		"shape:3WIlSEqkw8WJa_Qq2K7-D": {
+			"x": 1383.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3WIlSEqkw8WJa_Qq2K7-D",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUd",
+			"typeName": "shape"
+		},
+		"shape:ltqJOhhjW9czUoZ63brFr": {
+			"x": 2679.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ltqJOhhjW9czUoZ63brFr",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUt",
+			"typeName": "shape"
+		},
+		"shape:jkig4mctp_OFjK_MUZL6Q": {
+			"x": 3975.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jkig4mctp_OFjK_MUZL6Q",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM9",
+			"typeName": "shape"
+		},
+		"shape:gXklfOQf3i6tejtmwlvEe": {
+			"x": -992.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gXklfOQf3i6tejtmwlvEe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMB",
+			"typeName": "shape"
+		},
+		"shape:pt-d2gbSn4urWsxe1aHCw": {
+			"x": 303.31171413485026,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pt-d2gbSn4urWsxe1aHCw",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMD",
+			"typeName": "shape"
+		},
+		"shape:MtZxL3kgmh2e3dtkZqG2q": {
+			"x": 1599.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MtZxL3kgmh2e3dtkZqG2q",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMF",
+			"typeName": "shape"
+		},
+		"shape:cl8BMa9bd8hw6BYWrnONj": {
+			"x": 3975.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cl8BMa9bd8hw6BYWrnONj",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMKV",
+			"typeName": "shape"
+		},
+		"shape:3HvtWepvUd83ceJz8O_gh": {
+			"x": -992.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3HvtWepvUd83ceJz8O_gh",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMLV",
+			"typeName": "shape"
+		},
+		"shape:7NZXxv0BOLnw4bisFdJxH": {
+			"x": 303.31171413485026,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7NZXxv0BOLnw4bisFdJxH",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMMV",
+			"typeName": "shape"
+		},
+		"shape:U34JIohcCM-w0gKLOR-PO": {
+			"x": 1599.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:U34JIohcCM-w0gKLOR-PO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMNV",
+			"typeName": "shape"
+		},
+		"shape:o83QRhPq8XJqOZhs-OZaQ": {
+			"x": 3975.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:o83QRhPq8XJqOZhs-OZaQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQG",
+			"typeName": "shape"
+		},
+		"shape:XAsMK2ZbSgGsF20K4olO1": {
+			"x": -992.6882858651502,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XAsMK2ZbSgGsF20K4olO1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQl",
+			"typeName": "shape"
+		},
+		"shape:FBz6lnPmPjaNPc6k-2MRI": {
+			"x": 303.31171413485026,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FBz6lnPmPjaNPc6k-2MRI",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRG",
+			"typeName": "shape"
+		},
+		"shape:bLUPMqSSkrRMheTijIJ4S": {
+			"x": 1599.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bLUPMqSSkrRMheTijIJ4S",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRl",
+			"typeName": "shape"
+		},
+		"shape:El4WyAvYXH8lhsqUc-aIU": {
+			"x": 3975.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:El4WyAvYXH8lhsqUc-aIU",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMU8",
+			"typeName": "shape"
+		},
+		"shape:mwz5eXSfrDDAd7mpccOuC": {
+			"x": 3111.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:mwz5eXSfrDDAd7mpccOuC",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUO",
+			"typeName": "shape"
+		},
+		"shape:d2ckm6j1E50DgMry384oK": {
+			"x": -1856.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:d2ckm6j1E50DgMry384oK",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUd",
+			"typeName": "shape"
+		},
+		"shape:stz6chvvVwv4BGmKNWWD1": {
+			"x": -560.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:stz6chvvVwv4BGmKNWWD1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUt",
+			"typeName": "shape"
+		},
+		"shape:jfoZ-2_o71421ud8xIYcw": {
+			"x": 2895.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jfoZ-2_o71421ud8xIYcw",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN9",
+			"typeName": "shape"
+		},
+		"shape:iNl7c32XR-AlW43iJRVQX": {
+			"x": 4191.31171413485,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iNl7c32XR-AlW43iJRVQX",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNB",
+			"typeName": "shape"
+		},
+		"shape:-v_r0ub28n5F46mKZQMK5": {
+			"x": -776.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-v_r0ub28n5F46mKZQMK5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aND",
+			"typeName": "shape"
+		},
+		"shape:TCUiRnuBBz8HbqYg1IoBj": {
+			"x": 519.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TCUiRnuBBz8HbqYg1IoBj",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNF",
+			"typeName": "shape"
+		},
+		"shape:zX0q2Fl3z8FNZ7mRjPZNC": {
+			"x": 2895.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:zX0q2Fl3z8FNZ7mRjPZNC",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNKV",
+			"typeName": "shape"
+		},
+		"shape:qM7okX9pUfcfXp4uMEjH5": {
+			"x": 4191.31171413485,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qM7okX9pUfcfXp4uMEjH5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNLV",
+			"typeName": "shape"
+		},
+		"shape:N91vBe2NwMxXmocSo0K5Y": {
+			"x": -776.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N91vBe2NwMxXmocSo0K5Y",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNMV",
+			"typeName": "shape"
+		},
+		"shape:VCVbdEzYjLbzodxIyv_y3": {
+			"x": 519.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VCVbdEzYjLbzodxIyv_y3",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNNV",
+			"typeName": "shape"
+		},
+		"shape:J3UmLFGRLXKmBHxU1dVfG": {
+			"x": 2895.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:J3UmLFGRLXKmBHxU1dVfG",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQG",
+			"typeName": "shape"
+		},
+		"shape:8foUIB_uXjHoZ3G5uffPu": {
+			"x": 4191.31171413485,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8foUIB_uXjHoZ3G5uffPu",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQl",
+			"typeName": "shape"
+		},
+		"shape:cCekLjoRxAfkyh31A9EZB": {
+			"x": -776.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cCekLjoRxAfkyh31A9EZB",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRG",
+			"typeName": "shape"
+		},
+		"shape:v7h1mlotOIQkGHd0YDt8Q": {
+			"x": 519.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:v7h1mlotOIQkGHd0YDt8Q",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRl",
+			"typeName": "shape"
+		},
+		"shape:FMnQdF0jyNHnAXS_M6N9C": {
+			"x": -992.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FMnQdF0jyNHnAXS_M6N9C",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNU8",
+			"typeName": "shape"
+		},
+		"shape:qrTgLKyRNsZwH1W79uEMG": {
+			"x": 303.31171413485026,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qrTgLKyRNsZwH1W79uEMG",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUO",
+			"typeName": "shape"
+		},
+		"shape:7zEkMpylOweTRvl9NxRAL": {
+			"x": 1599.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7zEkMpylOweTRvl9NxRAL",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUd",
+			"typeName": "shape"
+		},
+		"shape:h4KtKUK3mcSJeWZCarrCe": {
+			"x": 2895.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:h4KtKUK3mcSJeWZCarrCe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUt",
+			"typeName": "shape"
+		},
+		"shape:MkJ2_PapRLvkzhr9OXsOr": {
+			"x": 1815.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MkJ2_PapRLvkzhr9OXsOr",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOI",
+			"typeName": "shape"
+		},
+		"shape:fo7eTBWR6zjW8qcqsJiot": {
+			"x": 3111.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fo7eTBWR6zjW8qcqsJiot",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOM",
+			"typeName": "shape"
+		},
+		"shape:DtG0eWFZQJQruQ8EIbNpg": {
+			"x": -1856.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DtG0eWFZQJQruQ8EIbNpg",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOQ",
+			"typeName": "shape"
+		},
+		"shape:ZfHEb3GvaMtMiC9np-n1O": {
+			"x": -560.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZfHEb3GvaMtMiC9np-n1O",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOU",
+			"typeName": "shape"
+		},
+		"shape:98V54vGeLwO8GY_uCyofE": {
+			"x": 1815.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:98V54vGeLwO8GY_uCyofE",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOe",
+			"typeName": "shape"
+		},
+		"shape:6v09QBkm6A8pL0iVPeAJT": {
+			"x": 3111.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6v09QBkm6A8pL0iVPeAJT",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOg",
+			"typeName": "shape"
+		},
+		"shape:DodW95FdBSn_ZHd-tnB1A": {
+			"x": -1856.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DodW95FdBSn_ZHd-tnB1A",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOi",
+			"typeName": "shape"
+		},
+		"shape:JNH_7AWmfjpzQYdvxKWFD": {
+			"x": -560.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JNH_7AWmfjpzQYdvxKWFD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOk",
+			"typeName": "shape"
+		},
+		"shape:dr7rUIZw41Crmg_QuHyxF": {
+			"x": 1815.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dr7rUIZw41Crmg_QuHyxF",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOpV",
+			"typeName": "shape"
+		},
+		"shape:N5ZTSgI_Y5rrXjO7f4pI1": {
+			"x": 3111.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N5ZTSgI_Y5rrXjO7f4pI1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOqV",
+			"typeName": "shape"
+		},
+		"shape:ww6w-wUgeWVoi6yI4N7Fe": {
+			"x": -1856.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ww6w-wUgeWVoi6yI4N7Fe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOrV",
+			"typeName": "shape"
+		},
+		"shape:MjFhnGtP55hMna8-eVY9G": {
+			"x": -560.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MjFhnGtP55hMna8-eVY9G",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-green",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOsV",
+			"typeName": "shape"
+		},
+		"shape:dYAPNJ3QCgoxBmZqLZNDQ": {
+			"x": 4191.31171413485,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dYAPNJ3QCgoxBmZqLZNDQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "grey",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOxV",
+			"typeName": "shape"
+		},
+		"shape:X7Ng2CtUvzw-mPbv0UYjD": {
+			"x": -776.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:X7Ng2CtUvzw-mPbv0UYjD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "violet",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOyV",
+			"typeName": "shape"
+		},
+		"shape:SunQmUjmvVtLmab8v82So": {
+			"x": 519.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:SunQmUjmvVtLmab8v82So",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-blue",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzG",
+			"typeName": "shape"
+		},
+		"shape:tm4F2UV8qtquQMxvS-j5d": {
+			"x": 1815.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tm4F2UV8qtquQMxvS-j5d",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "orange",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "middle",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzl",
+			"typeName": "shape"
+		},
+		"shape:_gngEcO2LTaj75nAKxfxw": {
+			"x": -1640.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_gngEcO2LTaj75nAKxfxw",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL8V",
+			"typeName": "shape"
+		},
+		"shape:O8VuqHWBhHGyCdX5scloT": {
+			"x": -992.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:O8VuqHWBhHGyCdX5scloT",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL9V",
+			"typeName": "shape"
+		},
+		"shape:BU1rnRyp0kNB86ikFUCqi": {
+			"x": -344.68828586514974,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BU1rnRyp0kNB86ikFUCqi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLAV",
+			"typeName": "shape"
+		},
+		"shape:69awhQ_mkxxRwC-ZWCxw-": {
+			"x": 303.31171413485026,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:69awhQ_mkxxRwC-ZWCxw-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLBV",
+			"typeName": "shape"
+		},
+		"shape:WPQ2nNWmt9wYLZDHoIzIe": {
+			"x": 951.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WPQ2nNWmt9wYLZDHoIzIe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLCV",
+			"typeName": "shape"
+		},
+		"shape:hqluRVAei8P7RUyBLOh8N": {
+			"x": 1599.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hqluRVAei8P7RUyBLOh8N",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLDV",
+			"typeName": "shape"
+		},
+		"shape:AGur81MYWJ-4xXELa1D6y": {
+			"x": 2247.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AGur81MYWJ-4xXELa1D6y",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLEV",
+			"typeName": "shape"
+		},
+		"shape:QHeG3otvF25Pdf24BjOkJ": {
+			"x": 2895.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:QHeG3otvF25Pdf24BjOkJ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLFV",
+			"typeName": "shape"
+		},
+		"shape:aDiU6hs3gz4AOB7TX2ioc": {
+			"x": -1640.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:aDiU6hs3gz4AOB7TX2ioc",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLKG",
+			"typeName": "shape"
+		},
+		"shape:OK_oOaapvndZ1KPn4ZSaM": {
+			"x": -992.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OK_oOaapvndZ1KPn4ZSaM",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLKl",
+			"typeName": "shape"
+		},
+		"shape:JNilAc7WLtJCkbWc5mnmW": {
+			"x": -344.68828586514974,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JNilAc7WLtJCkbWc5mnmW",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLLG",
+			"typeName": "shape"
+		},
+		"shape:6w5ZOOsw1JB6KbEKdxSQg": {
+			"x": 303.31171413485026,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6w5ZOOsw1JB6KbEKdxSQg",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLLl",
+			"typeName": "shape"
+		},
+		"shape:BzeaPu93LzWfQHZU9mDXA": {
+			"x": 951.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BzeaPu93LzWfQHZU9mDXA",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLMG",
+			"typeName": "shape"
+		},
+		"shape:-wAHROtZlfIjHN8Wiu5tj": {
+			"x": 1599.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-wAHROtZlfIjHN8Wiu5tj",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLMl",
+			"typeName": "shape"
+		},
+		"shape:pg8nKPA9SxtFiGN1TG1aQ": {
+			"x": 2247.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pg8nKPA9SxtFiGN1TG1aQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLNG",
+			"typeName": "shape"
+		},
+		"shape:eHU8SmL5DkJtunROkf33E": {
+			"x": 2895.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:eHU8SmL5DkJtunROkf33E",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLNl",
+			"typeName": "shape"
+		},
+		"shape:ne3GZXG4IrFU7nH33bMee": {
+			"x": -1640.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ne3GZXG4IrFU7nH33bMee",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQ8",
+			"typeName": "shape"
+		},
+		"shape:0S2JMw_rIqhLzQenjBGhS": {
+			"x": -992.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0S2JMw_rIqhLzQenjBGhS",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQO",
+			"typeName": "shape"
+		},
+		"shape:xcoqKephk3fh7b0-qz11p": {
+			"x": -344.68828586514974,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xcoqKephk3fh7b0-qz11p",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQd",
+			"typeName": "shape"
+		},
+		"shape:kp-LuvT09RufnR4bcIPQV": {
+			"x": 303.31171413485026,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:kp-LuvT09RufnR4bcIPQV",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQt",
+			"typeName": "shape"
+		},
+		"shape:6FPQYPpr7wLh4W05JH8_z": {
+			"x": 951.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6FPQYPpr7wLh4W05JH8_z",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLR8",
+			"typeName": "shape"
+		},
+		"shape:5xgBwKipPtJ0W0eWCgvR7": {
+			"x": 1599.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5xgBwKipPtJ0W0eWCgvR7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRO",
+			"typeName": "shape"
+		},
+		"shape:gz3UUXuVLa_sRSKMeVO9Y": {
+			"x": 2247.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gz3UUXuVLa_sRSKMeVO9Y",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRd",
+			"typeName": "shape"
+		},
+		"shape:PSSQbOEUkCNxK13O4nGYR": {
+			"x": 2895.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PSSQbOEUkCNxK13O4nGYR",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRt",
+			"typeName": "shape"
+		},
+		"shape:hBGusilUNgunUIQtSfNZ-": {
+			"x": -1640.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hBGusilUNgunUIQtSfNZ-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLU4",
+			"typeName": "shape"
+		},
+		"shape:fwiNmAFXSmAUvInUN4z3Y": {
+			"x": -992.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fwiNmAFXSmAUvInUN4z3Y",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUC",
+			"typeName": "shape"
+		},
+		"shape:lKtrGu4H0DsUGOUhi6Mok": {
+			"x": -344.68828586514974,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lKtrGu4H0DsUGOUhi6Mok",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUK",
+			"typeName": "shape"
+		},
+		"shape:4JSOwPO0DvCa-IH2Q6C0G": {
+			"x": 303.31171413485026,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4JSOwPO0DvCa-IH2Q6C0G",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUS",
+			"typeName": "shape"
+		},
+		"shape:ud7_0OnP9qMthq_DtHA1r": {
+			"x": 951.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ud7_0OnP9qMthq_DtHA1r",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUZ",
+			"typeName": "shape"
+		},
+		"shape:XCmQE20pD3KYXIry5HWq0": {
+			"x": 1599.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XCmQE20pD3KYXIry5HWq0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUh",
+			"typeName": "shape"
+		},
+		"shape:8Xi28I_w2T5aBlAJpmsf-": {
+			"x": 2247.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8Xi28I_w2T5aBlAJpmsf-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUp",
+			"typeName": "shape"
+		},
+		"shape:KizUNOpiYkAbO0Brv8UPl": {
+			"x": 2895.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KizUNOpiYkAbO0Brv8UPl",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUx",
+			"typeName": "shape"
+		},
+		"shape:1K7r25Wg2bzCBbflZRcNs": {
+			"x": 3543.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1K7r25Wg2bzCBbflZRcNs",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM8V",
+			"typeName": "shape"
+		},
+		"shape:y8ji5rMWDBLK2LxxWbaKX": {
+			"x": 4191.31171413485,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:y8ji5rMWDBLK2LxxWbaKX",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM9V",
+			"typeName": "shape"
+		},
+		"shape:rLgSndlpIu8bbMdDMEPKf": {
+			"x": -1424.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rLgSndlpIu8bbMdDMEPKf",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMAV",
+			"typeName": "shape"
+		},
+		"shape:rYD3HIoHPHIxy20O7OYPp": {
+			"x": -776.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rYD3HIoHPHIxy20O7OYPp",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMBV",
+			"typeName": "shape"
+		},
+		"shape:0HyzVrC39vZFOKpT7pRO9": {
+			"x": -128.68828586514974,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0HyzVrC39vZFOKpT7pRO9",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMCV",
+			"typeName": "shape"
+		},
+		"shape:ceOjLPEfLeTM4D74z8SWo": {
+			"x": 519.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ceOjLPEfLeTM4D74z8SWo",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMDV",
+			"typeName": "shape"
+		},
+		"shape:-1UOhdYpHEjEjtwEJiZXN": {
+			"x": 1167.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-1UOhdYpHEjEjtwEJiZXN",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMEV",
+			"typeName": "shape"
+		},
+		"shape:i62AVFFcf5nMxIruE7Fy_": {
+			"x": 1815.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:i62AVFFcf5nMxIruE7Fy_",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMFV",
+			"typeName": "shape"
+		},
+		"shape:HndFZGX27buokN9D4AhWs": {
+			"x": 3543.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HndFZGX27buokN9D4AhWs",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMKG",
+			"typeName": "shape"
+		},
+		"shape:vzY3QgS5WWBOSTbo85262": {
+			"x": 4191.31171413485,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vzY3QgS5WWBOSTbo85262",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMKl",
+			"typeName": "shape"
+		},
+		"shape:rsAv4-ugOhMpVUUfkzc8K": {
+			"x": -1424.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rsAv4-ugOhMpVUUfkzc8K",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMLG",
+			"typeName": "shape"
+		},
+		"shape:yFCnvXVMULT_8aFJFwnx_": {
+			"x": -776.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yFCnvXVMULT_8aFJFwnx_",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMLl",
+			"typeName": "shape"
+		},
+		"shape:XjOtdg3M5zPJ1NXm-rRqR": {
+			"x": -128.68828586514974,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XjOtdg3M5zPJ1NXm-rRqR",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMMG",
+			"typeName": "shape"
+		},
+		"shape:UlaWbpT-y84S08meImlbi": {
+			"x": 519.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UlaWbpT-y84S08meImlbi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMMl",
+			"typeName": "shape"
+		},
+		"shape:JWT8ef3q7ehS_5RPb1Pm4": {
+			"x": 1167.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JWT8ef3q7ehS_5RPb1Pm4",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMNG",
+			"typeName": "shape"
+		},
+		"shape:4scUUFNV69vfuOVqACDxW": {
+			"x": 1815.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4scUUFNV69vfuOVqACDxW",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMNl",
+			"typeName": "shape"
+		},
+		"shape:r0YwqeMQoXxYr9JSEIVb3": {
+			"x": 3543.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:r0YwqeMQoXxYr9JSEIVb3",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQ8",
+			"typeName": "shape"
+		},
+		"shape:ZfDPuGQn12YIEfj9q0p37": {
+			"x": 4191.31171413485,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZfDPuGQn12YIEfj9q0p37",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQO",
+			"typeName": "shape"
+		},
+		"shape:19NCx8ncrkNrqepzav2pA": {
+			"x": -1424.6882858651497,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:19NCx8ncrkNrqepzav2pA",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQd",
+			"typeName": "shape"
+		},
+		"shape:rjUunj_JxmbEMgtul_yhB": {
+			"x": -776.6882858651502,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rjUunj_JxmbEMgtul_yhB",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQt",
+			"typeName": "shape"
+		},
+		"shape:YVSHo3daNw0Ex8ELHoyv6": {
+			"x": -128.68828586514974,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YVSHo3daNw0Ex8ELHoyv6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMR8",
+			"typeName": "shape"
+		},
+		"shape:fMYZWfUp4GcyoArrehI4Y": {
+			"x": 519.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fMYZWfUp4GcyoArrehI4Y",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRO",
+			"typeName": "shape"
+		},
+		"shape:2WS-wD6qjRJmst1tu0fsN": {
+			"x": 1167.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2WS-wD6qjRJmst1tu0fsN",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRd",
+			"typeName": "shape"
+		},
+		"shape:jZ9OadFKqNS_9PonxWtB6": {
+			"x": 1815.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jZ9OadFKqNS_9PonxWtB6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRt",
+			"typeName": "shape"
+		},
+		"shape:2NBKbGmUzxx34Ac8Bq3NV": {
+			"x": 3543.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2NBKbGmUzxx34Ac8Bq3NV",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMU4",
+			"typeName": "shape"
+		},
+		"shape:DgIGzwgJIIbN9zUFqkN2K": {
+			"x": 4191.31171413485,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DgIGzwgJIIbN9zUFqkN2K",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUC",
+			"typeName": "shape"
+		},
+		"shape:0IAkWc2PDp3X2vM9j_GPw": {
+			"x": 2679.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0IAkWc2PDp3X2vM9j_GPw",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUK",
+			"typeName": "shape"
+		},
+		"shape:Veyjj5cpiSFfNvLjiQ3Lu": {
+			"x": 3327.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Veyjj5cpiSFfNvLjiQ3Lu",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUS",
+			"typeName": "shape"
+		},
+		"shape:8vctWkI9zuOBzXZjtPn18": {
+			"x": 3975.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8vctWkI9zuOBzXZjtPn18",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUZ",
+			"typeName": "shape"
+		},
+		"shape:o-3UnHL3wF5gCJtmdwcp2": {
+			"x": -1640.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:o-3UnHL3wF5gCJtmdwcp2",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUh",
+			"typeName": "shape"
+		},
+		"shape:my-A2djR8T9upwRjfLfC6": {
+			"x": -992.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:my-A2djR8T9upwRjfLfC6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUp",
+			"typeName": "shape"
+		},
+		"shape:LGOaxBxJpXTaOVoAqhrqF": {
+			"x": -344.68828586514974,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LGOaxBxJpXTaOVoAqhrqF",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUx",
+			"typeName": "shape"
+		},
+		"shape:0RAPKf10AXTHjP1VOABqI": {
+			"x": 2463.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0RAPKf10AXTHjP1VOABqI",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN8V",
+			"typeName": "shape"
+		},
+		"shape:U7fChNA2flevjbtQf6j3R": {
+			"x": 3111.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:U7fChNA2flevjbtQf6j3R",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN9V",
+			"typeName": "shape"
+		},
+		"shape:eT7CRGO-wNPHmrsP-pHP-": {
+			"x": 3759.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:eT7CRGO-wNPHmrsP-pHP-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNAV",
+			"typeName": "shape"
+		},
+		"shape:YXJm2wQqSo5_K1aXiO9ef": {
+			"x": -1856.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YXJm2wQqSo5_K1aXiO9ef",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNBV",
+			"typeName": "shape"
+		},
+		"shape:Nwu0rNWKLJPrf-x_Vvazr": {
+			"x": -1208.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Nwu0rNWKLJPrf-x_Vvazr",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNCV",
+			"typeName": "shape"
+		},
+		"shape:uQxWpJ1HLRaIF57hm1RWq": {
+			"x": -560.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uQxWpJ1HLRaIF57hm1RWq",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNDV",
+			"typeName": "shape"
+		},
+		"shape:yZzQ8wUjp_moYzXyFjZG7": {
+			"x": 87.31171413485026,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yZzQ8wUjp_moYzXyFjZG7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNEV",
+			"typeName": "shape"
+		},
+		"shape:66CsxctK9UNUFdEBmKWl-": {
+			"x": 735.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:66CsxctK9UNUFdEBmKWl-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNFV",
+			"typeName": "shape"
+		},
+		"shape:VJ5plX-AqkTi4N3K0v2H9": {
+			"x": 2463.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VJ5plX-AqkTi4N3K0v2H9",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNKG",
+			"typeName": "shape"
+		},
+		"shape:iBY9plFnX-_DsWKvhDVQK": {
+			"x": 3111.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iBY9plFnX-_DsWKvhDVQK",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNKl",
+			"typeName": "shape"
+		},
+		"shape:UQOAYhl_BNGl_2C8MB5Om": {
+			"x": 3759.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UQOAYhl_BNGl_2C8MB5Om",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNLG",
+			"typeName": "shape"
+		},
+		"shape:ap1Lj9Xf6tfqFh0oF0rEZ": {
+			"x": -1856.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ap1Lj9Xf6tfqFh0oF0rEZ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNLl",
+			"typeName": "shape"
+		},
+		"shape:AZrBBr5K74N_pWNKKY0Go": {
+			"x": -1208.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AZrBBr5K74N_pWNKKY0Go",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNMG",
+			"typeName": "shape"
+		},
+		"shape:IPzNDFQL_6bf9T5zDVsYZ": {
+			"x": -560.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IPzNDFQL_6bf9T5zDVsYZ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNMl",
+			"typeName": "shape"
+		},
+		"shape:gST8yDebjRuRtrBRcKlwh": {
+			"x": 87.31171413485026,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gST8yDebjRuRtrBRcKlwh",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNNG",
+			"typeName": "shape"
+		},
+		"shape:rWlPyPyf7ZA7h8gGindl6": {
+			"x": 735.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rWlPyPyf7ZA7h8gGindl6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNNl",
+			"typeName": "shape"
+		},
+		"shape:M_KOTa5roAnL7K4-uZQr5": {
+			"x": 2463.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:M_KOTa5roAnL7K4-uZQr5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQ8",
+			"typeName": "shape"
+		},
+		"shape:5PubOIwETSLeksnHVZJC0": {
+			"x": 3111.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5PubOIwETSLeksnHVZJC0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQO",
+			"typeName": "shape"
+		},
+		"shape:iucqM0-geSDJte_FYRZJ8": {
+			"x": 3759.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iucqM0-geSDJte_FYRZJ8",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQd",
+			"typeName": "shape"
+		},
+		"shape:yQrLI5-5hhefKEza1uXKd": {
+			"x": -1856.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yQrLI5-5hhefKEza1uXKd",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQt",
+			"typeName": "shape"
+		},
+		"shape:med5rfrZCIopxCgihFrC6": {
+			"x": -1208.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:med5rfrZCIopxCgihFrC6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNR8",
+			"typeName": "shape"
+		},
+		"shape:0iIhU7AEtAIUmzBswTjGb": {
+			"x": -560.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0iIhU7AEtAIUmzBswTjGb",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRO",
+			"typeName": "shape"
+		},
+		"shape:N1zUhLzc88Sm77DvOnlQh": {
+			"x": 87.31171413485026,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N1zUhLzc88Sm77DvOnlQh",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRd",
+			"typeName": "shape"
+		},
+		"shape:1ltAKAUVvZ0jR6rcD7mOM": {
+			"x": 735.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1ltAKAUVvZ0jR6rcD7mOM",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRt",
+			"typeName": "shape"
+		},
+		"shape:GaOODLyvKrqarMxN_uGZW": {
+			"x": -1424.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:GaOODLyvKrqarMxN_uGZW",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNU4",
+			"typeName": "shape"
+		},
+		"shape:7giTQ7tt44bllUfOS0Mfa": {
+			"x": -776.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7giTQ7tt44bllUfOS0Mfa",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUC",
+			"typeName": "shape"
+		},
+		"shape:vvyYEBf9p39yvzGw7rYyZ": {
+			"x": -128.68828586514974,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vvyYEBf9p39yvzGw7rYyZ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUK",
+			"typeName": "shape"
+		},
+		"shape:XkkQkR0J5awFnaRWrU1Rp": {
+			"x": 519.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XkkQkR0J5awFnaRWrU1Rp",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUS",
+			"typeName": "shape"
+		},
+		"shape:ASHbHdiUcocpr6lpvpS_X": {
+			"x": 1167.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ASHbHdiUcocpr6lpvpS_X",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUZ",
+			"typeName": "shape"
+		},
+		"shape:LRyr1viWxNIsAHH1oXGUs": {
+			"x": 1815.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LRyr1viWxNIsAHH1oXGUs",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUh",
+			"typeName": "shape"
+		},
+		"shape:PNsL2PSh1BOmD5UK1cveO": {
+			"x": 2463.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PNsL2PSh1BOmD5UK1cveO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUp",
+			"typeName": "shape"
+		},
+		"shape:8pwXBp3Ln4Z5ljXbSKmJ6": {
+			"x": 3111.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8pwXBp3Ln4Z5ljXbSKmJ6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUx",
+			"typeName": "shape"
+		},
+		"shape:tKQmpvg4RuTYj65ux5R-j": {
+			"x": 1383.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tKQmpvg4RuTYj65ux5R-j",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOH",
+			"typeName": "shape"
+		},
+		"shape:4BEmR6WWIDbKVIGXA0gd0": {
+			"x": 2031.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4BEmR6WWIDbKVIGXA0gd0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOJ",
+			"typeName": "shape"
+		},
+		"shape:k-CA3zyPmGlidnNd6xKD8": {
+			"x": 2679.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:k-CA3zyPmGlidnNd6xKD8",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOL",
+			"typeName": "shape"
+		},
+		"shape:9jPdK0Pdx9-528tmVQrDR": {
+			"x": 3327.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9jPdK0Pdx9-528tmVQrDR",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aON",
+			"typeName": "shape"
+		},
+		"shape:EmXR8lrmzVxH62pDE7rMB": {
+			"x": 3975.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EmXR8lrmzVxH62pDE7rMB",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOP",
+			"typeName": "shape"
+		},
+		"shape:CAFGJvyatpfJySRl3iZec": {
+			"x": -1640.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CAFGJvyatpfJySRl3iZec",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOR",
+			"typeName": "shape"
+		},
+		"shape:dx1806rcrfV7_dYULQJBA": {
+			"x": -992.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dx1806rcrfV7_dYULQJBA",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOT",
+			"typeName": "shape"
+		},
+		"shape:S_9GZI1KvBaehEbK7hSqd": {
+			"x": -344.68828586514974,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:S_9GZI1KvBaehEbK7hSqd",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOUV",
+			"typeName": "shape"
+		},
+		"shape:tks88-AczAs3LMhCUnkm_": {
+			"x": 1383.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tks88-AczAs3LMhCUnkm_",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOdV",
+			"typeName": "shape"
+		},
+		"shape:iykli_DM7Dg0LcE187W0O": {
+			"x": 2031.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iykli_DM7Dg0LcE187W0O",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOeV",
+			"typeName": "shape"
+		},
+		"shape:Q_Dl6Hitz6vjeRYdgGE4n": {
+			"x": 2679.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Q_Dl6Hitz6vjeRYdgGE4n",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOfV",
+			"typeName": "shape"
+		},
+		"shape:XTCK6KG7tnrBL5Tpee0SQ": {
+			"x": 3327.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XTCK6KG7tnrBL5Tpee0SQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOgV",
+			"typeName": "shape"
+		},
+		"shape:EuJooZ7k7xxFUsPJrgS0g": {
+			"x": 3975.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EuJooZ7k7xxFUsPJrgS0g",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOhV",
+			"typeName": "shape"
+		},
+		"shape:0b4gDyf05xjhUeyzIlVNk": {
+			"x": -1640.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0b4gDyf05xjhUeyzIlVNk",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOiV",
+			"typeName": "shape"
+		},
+		"shape:tX3_evcc3iLQ-9k5VXjYO": {
+			"x": -992.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tX3_evcc3iLQ-9k5VXjYO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOjV",
+			"typeName": "shape"
+		},
+		"shape:x5kiXOaVPUm_JO9KyI9IS": {
+			"x": -344.68828586514974,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:x5kiXOaVPUm_JO9KyI9IS",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOkV",
+			"typeName": "shape"
+		},
+		"shape:RhPYIXLRZSPakgukVBPdv": {
+			"x": 1383.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RhPYIXLRZSPakgukVBPdv",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOpG",
+			"typeName": "shape"
+		},
+		"shape:XrA20zYEbeJKyz81jnNnK": {
+			"x": 2031.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XrA20zYEbeJKyz81jnNnK",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOpl",
+			"typeName": "shape"
+		},
+		"shape:W4M0cZbfaVLRBq40sNLkP": {
+			"x": 2679.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:W4M0cZbfaVLRBq40sNLkP",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOqG",
+			"typeName": "shape"
+		},
+		"shape:MyuGnTJK82lO5Dl9Q1NVn": {
+			"x": 3327.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MyuGnTJK82lO5Dl9Q1NVn",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOql",
+			"typeName": "shape"
+		},
+		"shape:pDbZY1ZAHts_KOmHHQf8J": {
+			"x": 3975.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pDbZY1ZAHts_KOmHHQf8J",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOrG",
+			"typeName": "shape"
+		},
+		"shape:uzf2t3MnpjoTrMm4tEsqV": {
+			"x": -1640.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:uzf2t3MnpjoTrMm4tEsqV",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOrl",
+			"typeName": "shape"
+		},
+		"shape:rWIx-EvSx86j-75SqlydO": {
+			"x": -992.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rWIx-EvSx86j-75SqlydO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOsG",
+			"typeName": "shape"
+		},
+		"shape:q6UMktf2T_u2MrxstFX3R": {
+			"x": -344.68828586514974,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:q6UMktf2T_u2MrxstFX3R",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOsl",
+			"typeName": "shape"
+		},
+		"shape:L-Nb6CGhnZ1BDae-uUvwL": {
+			"x": 3759.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:L-Nb6CGhnZ1BDae-uUvwL",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "light-red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOxG",
+			"typeName": "shape"
+		},
+		"shape:3r4gSu_Z98IB7rzErsmal": {
+			"x": -1856.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3r4gSu_Z98IB7rzErsmal",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "red",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOxl",
+			"typeName": "shape"
+		},
+		"shape:HOJw8Z9Jl6vXmnvuudTLe": {
+			"x": -1208.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HOJw8Z9Jl6vXmnvuudTLe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOyG",
+			"typeName": "shape"
+		},
+		"shape:h09lIyk-Z9sNyxmUreDUr": {
+			"x": -560.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:h09lIyk-Z9sNyxmUreDUr",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOyl",
+			"typeName": "shape"
+		},
+		"shape:hYsnTbLU7zt5D3NAJofmo": {
+			"x": 87.31171413485026,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hYsnTbLU7zt5D3NAJofmo",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOz8",
+			"typeName": "shape"
+		},
+		"shape:CZWVLx1DmUGNv-pljiGRi": {
+			"x": 735.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CZWVLx1DmUGNv-pljiGRi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzO",
+			"typeName": "shape"
+		},
+		"shape:eLAliCAVCgALxIhUu2v1v": {
+			"x": 1383.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:eLAliCAVCgALxIhUu2v1v",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzd",
+			"typeName": "shape"
+		},
+		"shape:xuKwDXTaknG6uaSvyoqfG": {
+			"x": 2031.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xuKwDXTaknG6uaSvyoqfG",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "start",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzt",
+			"typeName": "shape"
+		},
+		"shape:iMEsy1t7nBwOmHw2EeuoK": {
+			"x": -1424.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iMEsy1t7nBwOmHw2EeuoK",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL8l",
+			"typeName": "shape"
+		},
+		"shape:PqypMnzXhUlj2CHAqOyF5": {
+			"x": -776.6882858651497,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PqypMnzXhUlj2CHAqOyF5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL9l",
+			"typeName": "shape"
+		},
+		"shape:h36R6OURt011zAGIVQQVU": {
+			"x": -128.68828586514974,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:h36R6OURt011zAGIVQQVU",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLAl",
+			"typeName": "shape"
+		},
+		"shape:O2kJm9Xmuvsm8kagRF7p-": {
+			"x": 519.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:O2kJm9Xmuvsm8kagRF7p-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLBl",
+			"typeName": "shape"
+		},
+		"shape:5DTb3VWc5meaOXRLVO86n": {
+			"x": 1167.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5DTb3VWc5meaOXRLVO86n",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLCl",
+			"typeName": "shape"
+		},
+		"shape:hBQgeEF-WUoTrobTWEjpX": {
+			"x": 1815.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:hBQgeEF-WUoTrobTWEjpX",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLDl",
+			"typeName": "shape"
+		},
+		"shape:CxJj3pi-jXyijokNjG6OE": {
+			"x": 2463.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:CxJj3pi-jXyijokNjG6OE",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLEl",
+			"typeName": "shape"
+		},
+		"shape:sBp7JyE1Xndg5NKnfUuer": {
+			"x": 3111.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sBp7JyE1Xndg5NKnfUuer",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLFl",
+			"typeName": "shape"
+		},
+		"shape:nILwjDtsJyvBiA8QcyIbD": {
+			"x": -1424.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nILwjDtsJyvBiA8QcyIbD",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLKO",
+			"typeName": "shape"
+		},
+		"shape:N7gV1rNQduNTeztJ4O9-N": {
+			"x": -776.6882858651497,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:N7gV1rNQduNTeztJ4O9-N",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLKt",
+			"typeName": "shape"
+		},
+		"shape:rjKAUSUWJ8wXLuup5cPKe": {
+			"x": -128.68828586514974,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rjKAUSUWJ8wXLuup5cPKe",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLLO",
+			"typeName": "shape"
+		},
+		"shape:R5aK-wpKu4B8ga1BWQHWZ": {
+			"x": 519.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R5aK-wpKu4B8ga1BWQHWZ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLLt",
+			"typeName": "shape"
+		},
+		"shape:TpLxTZl5SrmRqZMBCaheI": {
+			"x": 1167.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TpLxTZl5SrmRqZMBCaheI",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLMO",
+			"typeName": "shape"
+		},
+		"shape:53flWpbVZf1aas47bbmpH": {
+			"x": 1815.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:53flWpbVZf1aas47bbmpH",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLMt",
+			"typeName": "shape"
+		},
+		"shape:J0tUZeC4xSEbdnCen1E3i": {
+			"x": 2463.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:J0tUZeC4xSEbdnCen1E3i",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLNO",
+			"typeName": "shape"
+		},
+		"shape:LQz-Jxnm_2Xt9Wv6JjI5n": {
+			"x": 3111.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:LQz-Jxnm_2Xt9Wv6JjI5n",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLNt",
+			"typeName": "shape"
+		},
+		"shape:FpbCrW7tG19D77-aLkprz": {
+			"x": -1424.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FpbCrW7tG19D77-aLkprz",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQC",
+			"typeName": "shape"
+		},
+		"shape:vjq_8nvBTTuZWx4z2-IPw": {
+			"x": -776.6882858651497,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vjq_8nvBTTuZWx4z2-IPw",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQS",
+			"typeName": "shape"
+		},
+		"shape:H6ZBpvUKeVHTmndFRQm-8": {
+			"x": -128.68828586514974,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:H6ZBpvUKeVHTmndFRQm-8",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQh",
+			"typeName": "shape"
+		},
+		"shape:m8cQYds5pAXsx06Q4vpiP": {
+			"x": 519.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:m8cQYds5pAXsx06Q4vpiP",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLQx",
+			"typeName": "shape"
+		},
+		"shape:bpF9NhEbmxSHPgEdOepx-": {
+			"x": 1167.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bpF9NhEbmxSHPgEdOepx-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRC",
+			"typeName": "shape"
+		},
+		"shape:Hehi75SDTq7VPNQGFIb02": {
+			"x": 1815.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Hehi75SDTq7VPNQGFIb02",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRS",
+			"typeName": "shape"
+		},
+		"shape:4C0Ki5uOlI_D0ehgUJgTS": {
+			"x": 2463.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4C0Ki5uOlI_D0ehgUJgTS",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRh",
+			"typeName": "shape"
+		},
+		"shape:pRaGwo_kgCOtDejC-Vq4b": {
+			"x": 3111.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pRaGwo_kgCOtDejC-Vq4b",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLRx",
+			"typeName": "shape"
+		},
+		"shape:sRQpW8QaaPYIq-LrTI0lW": {
+			"x": -1424.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sRQpW8QaaPYIq-LrTI0lW",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLU6",
+			"typeName": "shape"
+		},
+		"shape:4WnqvwSafeSXsj6yG9tP-": {
+			"x": -776.6882858651497,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4WnqvwSafeSXsj6yG9tP-",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUE",
+			"typeName": "shape"
+		},
+		"shape:lti2Nhs97NLp7KKFO6usj": {
+			"x": -128.68828586514974,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lti2Nhs97NLp7KKFO6usj",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUM",
+			"typeName": "shape"
+		},
+		"shape:xQYu3oy8O7uZTrCzUdOUZ": {
+			"x": 519.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:xQYu3oy8O7uZTrCzUdOUZ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUU",
+			"typeName": "shape"
+		},
+		"shape:wr19ycPDtE3IjwJb27loQ": {
+			"x": 1167.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:wr19ycPDtE3IjwJb27loQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUb",
+			"typeName": "shape"
+		},
+		"shape:c3XelNrICowevJVUhH4Uo": {
+			"x": 1815.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:c3XelNrICowevJVUhH4Uo",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUj",
+			"typeName": "shape"
+		},
+		"shape:8iLPIOH9o6y3_s5M0diiY": {
+			"x": 2463.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8iLPIOH9o6y3_s5M0diiY",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUr",
+			"typeName": "shape"
+		},
+		"shape:WNbDgri4jp7B5RvejGz5n": {
+			"x": 3111.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WNbDgri4jp7B5RvejGz5n",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aLUz",
+			"typeName": "shape"
+		},
+		"shape:UfkryWuI7-k79FjsuN6Iv": {
+			"x": 3759.3117141348503,
+			"y": 3557.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UfkryWuI7-k79FjsuN6Iv",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM8l",
+			"typeName": "shape"
+		},
+		"shape:W2WkXeMUpmRF8ho0VSWBi": {
+			"x": -1856.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:W2WkXeMUpmRF8ho0VSWBi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM9l",
+			"typeName": "shape"
+		},
+		"shape:kDM1Bkwiq_NPRnoF6HB_O": {
+			"x": -1208.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:kDM1Bkwiq_NPRnoF6HB_O",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMAl",
+			"typeName": "shape"
+		},
+		"shape:2kUDZN2ANi0hZWkhdxKIs": {
+			"x": -560.6882858651497,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2kUDZN2ANi0hZWkhdxKIs",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMBl",
+			"typeName": "shape"
+		},
+		"shape:vRpFIm0f-9D00JPplmwec": {
+			"x": 87.31171413485026,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:vRpFIm0f-9D00JPplmwec",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMCl",
+			"typeName": "shape"
+		},
+		"shape:48HH5fjwO88ozJpeQ1ZV1": {
+			"x": 735.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:48HH5fjwO88ozJpeQ1ZV1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMDl",
+			"typeName": "shape"
+		},
+		"shape:IY_R3WMj1xJR5_3IZ6J35": {
+			"x": 1383.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IY_R3WMj1xJR5_3IZ6J35",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMEl",
+			"typeName": "shape"
+		},
+		"shape:0FfUt55mkpiBvhfgTb3a7": {
+			"x": 2031.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:0FfUt55mkpiBvhfgTb3a7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMFl",
+			"typeName": "shape"
+		},
+		"shape:8Xn7d2cGAU6xyn75wP6aN": {
+			"x": 3759.3117141348503,
+			"y": 4567.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8Xn7d2cGAU6xyn75wP6aN",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMKO",
+			"typeName": "shape"
+		},
+		"shape:MPLAa6lLAB2ecW-Xv4jSi": {
+			"x": -1856.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:MPLAa6lLAB2ecW-Xv4jSi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMKt",
+			"typeName": "shape"
+		},
+		"shape:nEyhGHt5ee3yp1WuSVJo2": {
+			"x": -1208.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nEyhGHt5ee3yp1WuSVJo2",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMLO",
+			"typeName": "shape"
+		},
+		"shape:DrKjWGFHEGgdKlRMFUD6X": {
+			"x": -560.6882858651497,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DrKjWGFHEGgdKlRMFUD6X",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMLt",
+			"typeName": "shape"
+		},
+		"shape:r6c5htwX6dg8UYOoNQF48": {
+			"x": 87.31171413485026,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:r6c5htwX6dg8UYOoNQF48",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMMO",
+			"typeName": "shape"
+		},
+		"shape:yhqGCCX1O-SNtChDXK62J": {
+			"x": 735.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yhqGCCX1O-SNtChDXK62J",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMMt",
+			"typeName": "shape"
+		},
+		"shape:cxUZpHsWyWmlFyfIaCwPi": {
+			"x": 1383.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cxUZpHsWyWmlFyfIaCwPi",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMNO",
+			"typeName": "shape"
+		},
+		"shape:ANhF8Pn21M3wH64-JcpLI": {
+			"x": 2031.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ANhF8Pn21M3wH64-JcpLI",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMNt",
+			"typeName": "shape"
+		},
+		"shape:S3C3egXganiVdmNTWSn36": {
+			"x": 3759.3117141348503,
+			"y": 5588.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:S3C3egXganiVdmNTWSn36",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQC",
+			"typeName": "shape"
+		},
+		"shape:H2e-IChsfnn_FRohJ-ygP": {
+			"x": -1856.6882858651497,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:H2e-IChsfnn_FRohJ-ygP",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQS",
+			"typeName": "shape"
+		},
+		"shape:EISI_fHfbsIkhaAe511xd": {
+			"x": -1208.6882858651497,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EISI_fHfbsIkhaAe511xd",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQh",
+			"typeName": "shape"
+		},
+		"shape:tzMuWh-n-vZv8fI8IQkMk": {
+			"x": -560.6882858651502,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tzMuWh-n-vZv8fI8IQkMk",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMQx",
+			"typeName": "shape"
+		},
+		"shape:WoLgf54ehK_uO5cBG-DId": {
+			"x": 87.31171413485026,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WoLgf54ehK_uO5cBG-DId",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRC",
+			"typeName": "shape"
+		},
+		"shape:JT5btf-a0E_JbV5K46y8N": {
+			"x": 735.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JT5btf-a0E_JbV5K46y8N",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRS",
+			"typeName": "shape"
+		},
+		"shape:ycxFgXN2fjYe3Jz-OHHNx": {
+			"x": 1383.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ycxFgXN2fjYe3Jz-OHHNx",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRh",
+			"typeName": "shape"
+		},
+		"shape:2mixRqmOOAwASOYhCEOsu": {
+			"x": 2031.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2mixRqmOOAwASOYhCEOsu",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMRx",
+			"typeName": "shape"
+		},
+		"shape:tFJv3TaDYt8O9-bHkowD6": {
+			"x": 3759.3117141348503,
+			"y": 6627.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tFJv3TaDYt8O9-bHkowD6",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMU6",
+			"typeName": "shape"
+		},
+		"shape:7K-9y-WwPLVkDtYE7HK7k": {
+			"x": -1856.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7K-9y-WwPLVkDtYE7HK7k",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUE",
+			"typeName": "shape"
+		},
+		"shape:dm46K-4Gp4iHdGbDh6mc1": {
+			"x": 2895.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dm46K-4Gp4iHdGbDh6mc1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUM",
+			"typeName": "shape"
+		},
+		"shape:l703XYg6fEoyoQ1STlAZ0": {
+			"x": 3543.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:l703XYg6fEoyoQ1STlAZ0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUU",
+			"typeName": "shape"
+		},
+		"shape:KVbMR14v8DlynaxcTGUNR": {
+			"x": 4191.31171413485,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KVbMR14v8DlynaxcTGUNR",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUb",
+			"typeName": "shape"
+		},
+		"shape:6oQdIMOnIJ3aFwY8CEQBE": {
+			"x": -1424.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6oQdIMOnIJ3aFwY8CEQBE",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUj",
+			"typeName": "shape"
+		},
+		"shape:DtwYJK5S7dhyzDyTZfBlr": {
+			"x": -776.6882858651497,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DtwYJK5S7dhyzDyTZfBlr",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUr",
+			"typeName": "shape"
+		},
+		"shape:cd2qVbH1EplqNRpavYgC9": {
+			"x": -128.68828586514974,
+			"y": 7275.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cd2qVbH1EplqNRpavYgC9",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aMUz",
+			"typeName": "shape"
+		},
+		"shape:NmxaEwMWJ6P8wcqMrM-1e": {
+			"x": 2679.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:NmxaEwMWJ6P8wcqMrM-1e",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN8l",
+			"typeName": "shape"
+		},
+		"shape:BVPB0HdocR7W0wFNcTD3G": {
+			"x": 3327.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BVPB0HdocR7W0wFNcTD3G",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN9l",
+			"typeName": "shape"
+		},
+		"shape:1Id-NTXwnx26M2MAOAOB5": {
+			"x": 3975.3117141348503,
+			"y": 3773.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1Id-NTXwnx26M2MAOAOB5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNAl",
+			"typeName": "shape"
+		},
+		"shape:TVNQxFcWNlYa3eaxhD6Y_": {
+			"x": -1640.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:TVNQxFcWNlYa3eaxhD6Y_",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNBl",
+			"typeName": "shape"
+		},
+		"shape:gN4bj2aY7rbdK4nbWJ2Ky": {
+			"x": -992.6882858651497,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gN4bj2aY7rbdK4nbWJ2Ky",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNCl",
+			"typeName": "shape"
+		},
+		"shape:fWcLS1d_ITYoBdxRe9tHb": {
+			"x": -344.68828586514974,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fWcLS1d_ITYoBdxRe9tHb",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNDl",
+			"typeName": "shape"
+		},
+		"shape:sIGWuLk4k9Oz6qUes0naj": {
+			"x": 303.31171413485026,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:sIGWuLk4k9Oz6qUes0naj",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNEl",
+			"typeName": "shape"
+		},
+		"shape:ZiMRjXj3T73rZ4Ojfdolx": {
+			"x": 951.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZiMRjXj3T73rZ4Ojfdolx",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNFl",
+			"typeName": "shape"
+		},
+		"shape:tlRxv2NHGyxcSQ-2ICy5f": {
+			"x": 2679.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tlRxv2NHGyxcSQ-2ICy5f",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNKO",
+			"typeName": "shape"
+		},
+		"shape:Xy-N70tS6StK6qik0W1to": {
+			"x": 3327.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Xy-N70tS6StK6qik0W1to",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNKt",
+			"typeName": "shape"
+		},
+		"shape:afnZMZGQ5SoRZ6JRWR75m": {
+			"x": 3975.3117141348503,
+			"y": 4783.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:afnZMZGQ5SoRZ6JRWR75m",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNLO",
+			"typeName": "shape"
+		},
+		"shape:DAAm7gXyNevINSWCmZEC1": {
+			"x": -1640.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DAAm7gXyNevINSWCmZEC1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNLt",
+			"typeName": "shape"
+		},
+		"shape:2HfLOrcjMUAZdDoc1-Gu4": {
+			"x": -992.6882858651497,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2HfLOrcjMUAZdDoc1-Gu4",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNMO",
+			"typeName": "shape"
+		},
+		"shape:AQhLY2NtoFLGlEsDPxUk7": {
+			"x": -344.68828586514974,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:AQhLY2NtoFLGlEsDPxUk7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNMt",
+			"typeName": "shape"
+		},
+		"shape:bRv7l3avoZAGa3N6SBpTs": {
+			"x": 303.31171413485026,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bRv7l3avoZAGa3N6SBpTs",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNNO",
+			"typeName": "shape"
+		},
+		"shape:FMB3k0RcLuGeFgWRexrNW": {
+			"x": 951.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:FMB3k0RcLuGeFgWRexrNW",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNNt",
+			"typeName": "shape"
+		},
+		"shape:ZzsE62xZKDFa42ItU-xGX": {
+			"x": 2679.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZzsE62xZKDFa42ItU-xGX",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQC",
+			"typeName": "shape"
+		},
+		"shape:wHIquyahgpZltaD57D53O": {
+			"x": 3327.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:wHIquyahgpZltaD57D53O",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQS",
+			"typeName": "shape"
+		},
+		"shape:jhMaMxD5bluvf3UZLIVj7": {
+			"x": 3975.3117141348503,
+			"y": 5804.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jhMaMxD5bluvf3UZLIVj7",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQh",
+			"typeName": "shape"
+		},
+		"shape:Is-d--AIU0-yQjpJa5V4j": {
+			"x": -1640.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Is-d--AIU0-yQjpJa5V4j",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNQx",
+			"typeName": "shape"
+		},
+		"shape:EaW2b9m24JKzx50oScpG1": {
+			"x": -992.6882858651497,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EaW2b9m24JKzx50oScpG1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRC",
+			"typeName": "shape"
+		},
+		"shape:4tUhOAcHUOfM-PZn63LAl": {
+			"x": -344.68828586514974,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4tUhOAcHUOfM-PZn63LAl",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRS",
+			"typeName": "shape"
+		},
+		"shape:9e9L6qwMXQILLNX2WsjVK": {
+			"x": 303.31171413485026,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9e9L6qwMXQILLNX2WsjVK",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRh",
+			"typeName": "shape"
+		},
+		"shape:iGeEqcfmKyN3X1_1bOGWy": {
+			"x": 951.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:iGeEqcfmKyN3X1_1bOGWy",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNRx",
+			"typeName": "shape"
+		},
+		"shape:E8JGhdkY1Heds3vCO8sPG": {
+			"x": -1208.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:E8JGhdkY1Heds3vCO8sPG",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNU6",
+			"typeName": "shape"
+		},
+		"shape:HD3QfjCGos3s-tetmRWsn": {
+			"x": -560.6882858651497,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HD3QfjCGos3s-tetmRWsn",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "middle",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUE",
+			"typeName": "shape"
+		},
+		"shape:a605gsGbUuGjM3V6Uwlo0": {
+			"x": 87.31171413485026,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:a605gsGbUuGjM3V6Uwlo0",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUM",
+			"typeName": "shape"
+		},
+		"shape:9HTzOe_08F3R8AWXzG4a3": {
+			"x": 735.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9HTzOe_08F3R8AWXzG4a3",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUU",
+			"typeName": "shape"
+		},
+		"shape:6NCvjFt5dKKrxBTK4LLTO": {
+			"x": 1383.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6NCvjFt5dKKrxBTK4LLTO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUb",
+			"typeName": "shape"
+		},
+		"shape:1cXZssJYCbso2mx6loPef": {
+			"x": 2031.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1cXZssJYCbso2mx6loPef",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUj",
+			"typeName": "shape"
+		},
+		"shape:bzC-KCsloM4uVzyNNfZ3B": {
+			"x": 2679.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:bzC-KCsloM4uVzyNNfZ3B",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUr",
+			"typeName": "shape"
+		},
+		"shape:rNB1jIehPWJ1nxYQLQ-ke": {
+			"x": 3327.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:rNB1jIehPWJ1nxYQLQ-ke",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aNUz",
+			"typeName": "shape"
+		},
+		"shape:wcJ3jqqxYzonKqbPk5rIq": {
+			"x": 1599.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:wcJ3jqqxYzonKqbPk5rIq",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOHV",
+			"typeName": "shape"
+		},
+		"shape:3_tc9uzXsw4UqxmDLQQhA": {
+			"x": 2247.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:3_tc9uzXsw4UqxmDLQQhA",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOJV",
+			"typeName": "shape"
+		},
+		"shape:D757kSYrio_E4vkaLKd5J": {
+			"x": 2895.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:D757kSYrio_E4vkaLKd5J",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOLV",
+			"typeName": "shape"
+		},
+		"shape:opdSzf8xosCGLqOuCRA-d": {
+			"x": 3543.3117141348503,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:opdSzf8xosCGLqOuCRA-d",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aONV",
+			"typeName": "shape"
+		},
+		"shape:pf7MRw4EEMS4ziWudXbA8": {
+			"x": 4191.31171413485,
+			"y": 3989.020273028397,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pf7MRw4EEMS4ziWudXbA8",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOPV",
+			"typeName": "shape"
+		},
+		"shape:idXIw-DbkLH4-sG7VIo7n": {
+			"x": -1424.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:idXIw-DbkLH4-sG7VIo7n",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aORV",
+			"typeName": "shape"
+		},
+		"shape:90Yj7bM6AznMMl6WyNfFf": {
+			"x": -776.6882858651497,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:90Yj7bM6AznMMl6WyNfFf",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOTV",
+			"typeName": "shape"
+		},
+		"shape:lyyDa-6cFbTwF2gpZNgX5": {
+			"x": -128.68828586514974,
+			"y": 4205.020273028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:lyyDa-6cFbTwF2gpZNgX5",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOUl",
+			"typeName": "shape"
+		},
+		"shape:PhEYq6d24HiISTI-n-lFn": {
+			"x": 1599.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:PhEYq6d24HiISTI-n-lFn",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOdl",
+			"typeName": "shape"
+		},
+		"shape:gYKFnAlc4ZsWbLj6FkS0U": {
+			"x": 2247.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gYKFnAlc4ZsWbLj6FkS0U",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOel",
+			"typeName": "shape"
+		},
+		"shape:95Nl5-cpSRzmlY6HFUf_1": {
+			"x": 2895.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:95Nl5-cpSRzmlY6HFUf_1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOfl",
+			"typeName": "shape"
+		},
+		"shape:VK0BcD3cGR_z3QV-Sg2bc": {
+			"x": 3543.3117141348503,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VK0BcD3cGR_z3QV-Sg2bc",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOgl",
+			"typeName": "shape"
+		},
+		"shape:JYuHXIwrKSbCn5Or8ADVP": {
+			"x": 4191.31171413485,
+			"y": 4999.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JYuHXIwrKSbCn5Or8ADVP",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOhl",
+			"typeName": "shape"
+		},
+		"shape:KUfZ27HDgNVHpYOsgCp4m": {
+			"x": -1424.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:KUfZ27HDgNVHpYOsgCp4m",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOil",
+			"typeName": "shape"
+		},
+		"shape:2FwBMz3DvDIacQQSso--v": {
+			"x": -776.6882858651497,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2FwBMz3DvDIacQQSso--v",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOjl",
+			"typeName": "shape"
+		},
+		"shape:VDVbk3-PzWpNrPeTkpn22": {
+			"x": -128.68828586514974,
+			"y": 5215.090585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VDVbk3-PzWpNrPeTkpn22",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dashed",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOkl",
+			"typeName": "shape"
+		},
+		"shape:ZJs9j1bOAV-KqGfJimBR1": {
+			"x": 1599.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZJs9j1bOAV-KqGfJimBR1",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOpO",
+			"typeName": "shape"
+		},
+		"shape:tjAVivm5mpDCu8W93C6Un": {
+			"x": 2247.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:tjAVivm5mpDCu8W93C6Un",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOpt",
+			"typeName": "shape"
+		},
+		"shape:gPlpsCNM-PJ9Nc6YS2ROo": {
+			"x": 2895.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gPlpsCNM-PJ9Nc6YS2ROo",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOqO",
+			"typeName": "shape"
+		},
+		"shape:7dW_SyKkSoEaj1jwBLtzE": {
+			"x": 3543.3117141348503,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:7dW_SyKkSoEaj1jwBLtzE",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOqt",
+			"typeName": "shape"
+		},
+		"shape:Q9ufddMM8Nv2mOgBji0jg": {
+			"x": 4191.31171413485,
+			"y": 6020.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Q9ufddMM8Nv2mOgBji0jg",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOrO",
+			"typeName": "shape"
+		},
+		"shape:V98mg-v9L3fz62NHmq2SC": {
+			"x": -1424.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:V98mg-v9L3fz62NHmq2SC",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOrt",
+			"typeName": "shape"
+		},
+		"shape:HxuCMh9T0x9zObozxdruV": {
+			"x": -776.6882858651497,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HxuCMh9T0x9zObozxdruV",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOsO",
+			"typeName": "shape"
+		},
+		"shape:imavkFmMpYh4FGQENCi-2": {
+			"x": -128.68828586514974,
+			"y": 6236.989023028396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:imavkFmMpYh4FGQENCi-2",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "dotted",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOst",
+			"typeName": "shape"
+		},
+		"shape:p40AQnSEZVjtt5VBihnTQ": {
+			"x": 3975.3117141348503,
+			"y": 6843.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:p40AQnSEZVjtt5VBihnTQ",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOxO",
+			"typeName": "shape"
+		},
+		"shape:UqEqTuRNwcMJenQ6Diyow": {
+			"x": -1640.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:UqEqTuRNwcMJenQ6Diyow",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOxt",
+			"typeName": "shape"
+		},
+		"shape:RtKIXffoJXvASSGVufH8F": {
+			"x": -992.6882858651497,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RtKIXffoJXvASSGVufH8F",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOyO",
+			"typeName": "shape"
+		},
+		"shape:ziX5D2xoNB69uNeSwUOsv": {
+			"x": -344.68828586514974,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ziX5D2xoNB69uNeSwUOsv",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOyt",
+			"typeName": "shape"
+		},
+		"shape:EIdNQqbb9ZOj9d40DhYAO": {
+			"x": 303.31171413485026,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EIdNQqbb9ZOj9d40DhYAO",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzC",
+			"typeName": "shape"
+		},
+		"shape:fGZBfxMjQo_oA-D_f-PMo": {
+			"x": 951.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:fGZBfxMjQo_oA-D_f-PMo",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzS",
+			"typeName": "shape"
+		},
+		"shape:HGXjbFXY5OS7a3hPB6NOx": {
+			"x": 1599.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HGXjbFXY5OS7a3hPB6NOx",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzh",
+			"typeName": "shape"
+		},
+		"shape:jiB6Oc0H4crCCdp2yKNIp": {
+			"x": 2247.3117141348503,
+			"y": 7059.215585528396,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:jiB6Oc0H4crCCdp2yKNIp",
+			"type": "geo",
+			"props": {
+				"w": 200,
+				"h": 200,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"font": "draw",
+				"text": "hello",
+				"align": "end",
+				"verticalAlign": "end",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOzx",
+			"typeName": "shape"
+		},
+		"shape:E92zeAj65G8rqcyqakhb-": {
+			"x": 2329.9059341913858,
+			"y": 1465.533260559233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:E92zeAj65G8rqcyqakhb-",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aw",
+			"typeName": "shape"
+		},
+		"shape:9-uE3oJexmD9ZJgBhdcih": {
+			"x": 2420.7305339734053,
+			"y": 1465.533260559233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:9-uE3oJexmD9ZJgBhdcih",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ax",
+			"typeName": "shape"
+		},
+		"shape:JVKh6nBGbvW-2XVt0OM8l": {
+			"x": 2517.3871691727795,
+			"y": 1465.533260559233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:JVKh6nBGbvW-2XVt0OM8l",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ay",
+			"typeName": "shape"
+		},
+		"shape:ighozSUdo75PFS6l7fjj5": {
+			"x": 2615.4898880572136,
+			"y": 1465.533260559233,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ighozSUdo75PFS6l7fjj5",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "az",
+			"typeName": "shape"
+		},
+		"shape:p_xglRHg89YGZh1zrXRwU": {
+			"x": 2329.9059341913858,
+			"y": 1571.4606183805731,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:p_xglRHg89YGZh1zrXRwU",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "awV",
+			"typeName": "shape"
+		},
+		"shape:Q3rxBLG5Z_6QDH22eeH59": {
+			"x": 2420.7305339734053,
+			"y": 1571.4606183805731,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Q3rxBLG5Z_6QDH22eeH59",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "axV",
+			"typeName": "shape"
+		},
+		"shape:2_NasJS2y8tEsSEt0rvl_": {
+			"x": 2517.3871691727795,
+			"y": 1571.4606183805731,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:2_NasJS2y8tEsSEt0rvl_",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ayV",
+			"typeName": "shape"
+		},
+		"shape:ydcjp86LOdJVtKaQ6nB1s": {
+			"x": 2615.4898880572136,
+			"y": 1571.4606183805731,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ydcjp86LOdJVtKaQ6nB1s",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dashed",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b00",
+			"typeName": "shape"
+		},
+		"shape:BSlgoxhRiJx62ARe4Ihid": {
+			"x": 2329.9059341913858,
+			"y": 1674.2370251160928,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:BSlgoxhRiJx62ARe4Ihid",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "awl",
+			"typeName": "shape"
+		},
+		"shape:DfIG-9msA6FsrFlgyQuFe": {
+			"x": 2420.7305339734053,
+			"y": 1674.2370251160928,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:DfIG-9msA6FsrFlgyQuFe",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "axl",
+			"typeName": "shape"
+		},
+		"shape:37spm5Lt6S8ufWXCERuxB": {
+			"x": 2517.3871691727795,
+			"y": 1674.2370251160928,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:37spm5Lt6S8ufWXCERuxB",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ayl",
+			"typeName": "shape"
+		},
+		"shape:6yk1FbAKH3vDXi3H38pHq": {
+			"x": 2615.4898880572136,
+			"y": 1674.2370251160928,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:6yk1FbAKH3vDXi3H38pHq",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "dotted",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b01",
+			"typeName": "shape"
+		},
+		"shape:R2Mkaotw-ROZOksPuoCoq": {
+			"x": 2329.9059341913858,
+			"y": 1779.132533021417,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R2Mkaotw-ROZOksPuoCoq",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "awt",
+			"typeName": "shape"
+		},
+		"shape:4crhrHgtCGNQdXDbZrk0_": {
+			"x": 2420.7305339734053,
+			"y": 1779.132533021417,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:4crhrHgtCGNQdXDbZrk0_",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "axt",
+			"typeName": "shape"
+		},
+		"shape:D4ALUpOldnSXExscTCEaF": {
+			"x": 2517.3871691727795,
+			"y": 1779.132533021417,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:D4ALUpOldnSXExscTCEaF",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "ayt",
+			"typeName": "shape"
+		},
+		"shape:gCUK5BZjwUre0SKfyFIlT": {
+			"x": 2615.4898880572136,
+			"y": 1779.132533021417,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gCUK5BZjwUre0SKfyFIlT",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -0.22,
+								"y": 0.23,
+								"z": 0.5
+							},
+							{
+								"x": 0.66,
+								"y": 0.46,
+								"z": 0.5
+							},
+							{
+								"x": 5.05,
+								"y": 0.4,
+								"z": 0.5
+							},
+							{
+								"x": 13.11,
+								"y": -0.77,
+								"z": 0.5
+							},
+							{
+								"x": 22.54,
+								"y": -3.4,
+								"z": 0.5
+							},
+							{
+								"x": 30.92,
+								"y": -6.64,
+								"z": 0.5
+							},
+							{
+								"x": 36.72,
+								"y": -10.32,
+								"z": 0.5
+							},
+							{
+								"x": 39.12,
+								"y": -13.99,
+								"z": 0.5
+							},
+							{
+								"x": 39.42,
+								"y": -17.26,
+								"z": 0.5
+							},
+							{
+								"x": 38.29,
+								"y": -19.94,
+								"z": 0.5
+							},
+							{
+								"x": 33.76,
+								"y": -21.69,
+								"z": 0.5
+							},
+							{
+								"x": 25.82,
+								"y": -22.48,
+								"z": 0.5
+							},
+							{
+								"x": 18.16,
+								"y": -22.64,
+								"z": 0.5
+							},
+							{
+								"x": 12.74,
+								"y": -22.38,
+								"z": 0.5
+							},
+							{
+								"x": 8.98,
+								"y": -20.16,
+								"z": 0.5
+							},
+							{
+								"x": 8.19,
+								"y": -14.27,
+								"z": 0.5
+							},
+							{
+								"x": 12.51,
+								"y": -4.22,
+								"z": 0.5
+							},
+							{
+								"x": 18.89,
+								"y": 7.38,
+								"z": 0.5
+							},
+							{
+								"x": 23.71,
+								"y": 18.54,
+								"z": 0.5
+							},
+							{
+								"x": 26.33,
+								"y": 28.93,
+								"z": 0.5
+							},
+							{
+								"x": 25.65,
+								"y": 39,
+								"z": 0.5
+							},
+							{
+								"x": 21.14,
+								"y": 47.08,
+								"z": 0.5
+							},
+							{
+								"x": 14.6,
+								"y": 51.59,
+								"z": 0.5
+							},
+							{
+								"x": 8.09,
+								"y": 54.3,
+								"z": 0.5
+							},
+							{
+								"x": 3.33,
+								"y": 54.96,
+								"z": 0.5
+							},
+							{
+								"x": 1.46,
+								"y": 52.43,
+								"z": 0.5
+							},
+							{
+								"x": 2.71,
+								"y": 45.19,
+								"z": 0.5
+							},
+							{
+								"x": 13.83,
+								"y": 33.13,
+								"z": 0.5
+							},
+							{
+								"x": 35.4,
+								"y": 19.51,
+								"z": 0.5
+							},
+							{
+								"x": 56.33,
+								"y": 8.61,
+								"z": 0.5
+							},
+							{
+								"x": 73.67,
+								"y": -0.36,
+								"z": 0.5
+							},
+							{
+								"x": 85.3,
+								"y": -7.41,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": false,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b02",
+			"typeName": "shape"
+		},
+		"shape:prX0ec6A16p8nxA0GlwIW": {
+			"x": 2371.7005741023604,
+			"y": 1868.3630634213816,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:prX0ec6A16p8nxA0GlwIW",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b03",
+			"typeName": "shape"
+		},
+		"shape:nZSvit8zimVYilSTclTPI": {
+			"x": 2464.1897523970865,
+			"y": 1868.3630634213816,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:nZSvit8zimVYilSTclTPI",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b04",
+			"typeName": "shape"
+		},
+		"shape:1hmS9Aq6LDGFlGjFOum0Z": {
+			"x": 2559.0540010591035,
+			"y": 1868.3630634213816,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1hmS9Aq6LDGFlGjFOum0Z",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b05",
+			"typeName": "shape"
+		},
+		"shape:_-f5Yc-UEp_T47UCgwm86": {
+			"x": 2655.430321132026,
+			"y": 1868.3630634213816,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:_-f5Yc-UEp_T47UCgwm86",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "s",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b06",
+			"typeName": "shape"
+		},
+		"shape:T_f9L7UntgXD_dgtr6NCG": {
+			"x": 2371.7005741023604,
+			"y": 1914.1336108884768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:T_f9L7UntgXD_dgtr6NCG",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b03V",
+			"typeName": "shape"
+		},
+		"shape:C1U1bxZKtLObaO858xsXk": {
+			"x": 2464.1897523970865,
+			"y": 1914.1336108884768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:C1U1bxZKtLObaO858xsXk",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b04V",
+			"typeName": "shape"
+		},
+		"shape:YdIE_dlzusds2HX7xdyMa": {
+			"x": 2559.0540010591035,
+			"y": 1914.1336108884768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:YdIE_dlzusds2HX7xdyMa",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b05V",
+			"typeName": "shape"
+		},
+		"shape:pHA9CQdWmeGqBkUW9lVHm": {
+			"x": 2655.430321132026,
+			"y": 1914.1336108884768,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:pHA9CQdWmeGqBkUW9lVHm",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "m",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b07",
+			"typeName": "shape"
+		},
+		"shape:cTwbmvg0PYO6EfAykIiOa": {
+			"x": 2371.7005741023604,
+			"y": 1957.8232369283446,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:cTwbmvg0PYO6EfAykIiOa",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b03l",
+			"typeName": "shape"
+		},
+		"shape:XXBAbC2nq_sFsowVIAJjs": {
+			"x": 2464.1897523970865,
+			"y": 1957.8232369283446,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:XXBAbC2nq_sFsowVIAJjs",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b04l",
+			"typeName": "shape"
+		},
+		"shape:VgY67SQ6pzJ7ppJuK5mp2": {
+			"x": 2559.0540010591035,
+			"y": 1957.8232369283446,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VgY67SQ6pzJ7ppJuK5mp2",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b05l",
+			"typeName": "shape"
+		},
+		"shape:HE3Tbyn7cl8gyKpyrWTuB": {
+			"x": 2655.430321132026,
+			"y": 1957.8232369283446,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:HE3Tbyn7cl8gyKpyrWTuB",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "l",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b08",
+			"typeName": "shape"
+		},
+		"shape:yv9STg2dkP41U1MLrSGNs": {
+			"x": 2371.7005741023604,
+			"y": 2002.7332164220306,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:yv9STg2dkP41U1MLrSGNs",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "none",
+				"dash": "solid",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b03t",
+			"typeName": "shape"
+		},
+		"shape:D-P0DiUIoul0ycV4JUXLv": {
+			"x": 2464.1897523970865,
+			"y": 2002.7332164220306,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:D-P0DiUIoul0ycV4JUXLv",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "semi",
+				"dash": "solid",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b04t",
+			"typeName": "shape"
+		},
+		"shape:VBOX4so4RrjUud7FdPjRU": {
+			"x": 2559.0540010591035,
+			"y": 2002.7332164220306,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VBOX4so4RrjUud7FdPjRU",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "solid",
+				"dash": "solid",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b05t",
+			"typeName": "shape"
+		},
+		"shape:IJJBtrltM_yFT87eP3oFN": {
+			"x": 2655.430321132026,
+			"y": 2002.7332164220306,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:IJJBtrltM_yFT87eP3oFN",
+			"type": "draw",
+			"props": {
+				"segments": [
+					{
+						"type": "free",
+						"points": [
+							{
+								"x": 0,
+								"y": 0,
+								"z": 0.5
+							},
+							{
+								"x": -1.09,
+								"y": 0.55,
+								"z": 0.5
+							},
+							{
+								"x": -2.2,
+								"y": 1.6,
+								"z": 0.5
+							},
+							{
+								"x": -4.7,
+								"y": 4.58,
+								"z": 0.5
+							},
+							{
+								"x": -9.4,
+								"y": 10.28,
+								"z": 0.5
+							},
+							{
+								"x": -15.89,
+								"y": 17.94,
+								"z": 0.5
+							},
+							{
+								"x": -23.71,
+								"y": 26.94,
+								"z": 0.5
+							},
+							{
+								"x": -31.63,
+								"y": 37.22,
+								"z": 0.5
+							},
+							{
+								"x": -37.9,
+								"y": 47.13,
+								"z": 0.5
+							},
+							{
+								"x": -41.7,
+								"y": 54.97,
+								"z": 0.5
+							},
+							{
+								"x": -43.52,
+								"y": 61.22,
+								"z": 0.5
+							},
+							{
+								"x": -44.22,
+								"y": 67.12,
+								"z": 0.5
+							},
+							{
+								"x": -44.34,
+								"y": 72.27,
+								"z": 0.5
+							},
+							{
+								"x": -43.8,
+								"y": 76.56,
+								"z": 0.5
+							},
+							{
+								"x": -41.58,
+								"y": 80.35,
+								"z": 0.5
+							},
+							{
+								"x": -37.96,
+								"y": 83.17,
+								"z": 0.5
+							},
+							{
+								"x": -32.49,
+								"y": 84.73,
+								"z": 0.5
+							},
+							{
+								"x": -23.23,
+								"y": 85.21,
+								"z": 0.5
+							},
+							{
+								"x": -12,
+								"y": 81.92,
+								"z": 0.5
+							},
+							{
+								"x": -1.29,
+								"y": 74.63,
+								"z": 0.5
+							},
+							{
+								"x": 9.2,
+								"y": 66.22,
+								"z": 0.5
+							},
+							{
+								"x": 19.47,
+								"y": 57.14,
+								"z": 0.5
+							},
+							{
+								"x": 28.07,
+								"y": 47.85,
+								"z": 0.5
+							},
+							{
+								"x": 34.14,
+								"y": 39.18,
+								"z": 0.5
+							},
+							{
+								"x": 37.97,
+								"y": 31.85,
+								"z": 0.5
+							},
+							{
+								"x": 40.24,
+								"y": 24.85,
+								"z": 0.5
+							},
+							{
+								"x": 41.52,
+								"y": 18.29,
+								"z": 0.5
+							},
+							{
+								"x": 41.98,
+								"y": 12.72,
+								"z": 0.5
+							},
+							{
+								"x": 42.06,
+								"y": 6.91,
+								"z": 0.5
+							},
+							{
+								"x": 41.33,
+								"y": 1.17,
+								"z": 0.5
+							},
+							{
+								"x": 39.74,
+								"y": -3.28,
+								"z": 0.5
+							},
+							{
+								"x": 37.96,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 35.98,
+								"y": -9.12,
+								"z": 0.5
+							},
+							{
+								"x": 33.73,
+								"y": -11.14,
+								"z": 0.5
+							},
+							{
+								"x": 31.44,
+								"y": -12.48,
+								"z": 0.5
+							},
+							{
+								"x": 28.79,
+								"y": -13.51,
+								"z": 0.5
+							},
+							{
+								"x": 25.92,
+								"y": -14.1,
+								"z": 0.5
+							},
+							{
+								"x": 23.49,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 21.01,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 18.23,
+								"y": -14.23,
+								"z": 0.5
+							},
+							{
+								"x": 15.27,
+								"y": -14.04,
+								"z": 0.5
+							},
+							{
+								"x": 12.23,
+								"y": -13.53,
+								"z": 0.5
+							},
+							{
+								"x": 9.61,
+								"y": -12.94,
+								"z": 0.5
+							},
+							{
+								"x": 7.68,
+								"y": -12.3,
+								"z": 0.5
+							},
+							{
+								"x": 6.18,
+								"y": -11.52,
+								"z": 0.5
+							},
+							{
+								"x": 5.02,
+								"y": -10.78,
+								"z": 0.5
+							},
+							{
+								"x": 4.03,
+								"y": -10.07,
+								"z": 0.5
+							},
+							{
+								"x": 3.11,
+								"y": -9.41,
+								"z": 0.5
+							},
+							{
+								"x": 2.28,
+								"y": -8.89,
+								"z": 0.5
+							},
+							{
+								"x": 1.54,
+								"y": -8.46,
+								"z": 0.5
+							},
+							{
+								"x": 1.05,
+								"y": -8.1,
+								"z": 0.5
+							},
+							{
+								"x": 0.7,
+								"y": -7.75,
+								"z": 0.5
+							},
+							{
+								"x": 0.43,
+								"y": -7.39,
+								"z": 0.5
+							},
+							{
+								"x": 0.25,
+								"y": -7.04,
+								"z": 0.5
+							},
+							{
+								"x": 0.12,
+								"y": -6.74,
+								"z": 0.5
+							},
+							{
+								"x": 0.04,
+								"y": -6.48,
+								"z": 0.5
+							},
+							{
+								"x": 0,
+								"y": -6.28,
+								"z": 0.5
+							},
+							{
+								"x": 0.07,
+								"y": -6.21,
+								"z": 0.5
+							},
+							{
+								"x": 0.31,
+								"y": -6.21,
+								"z": 0.5
+							}
+						]
+					}
+				],
+				"color": "black",
+				"fill": "pattern",
+				"dash": "solid",
+				"size": "xl",
+				"isComplete": true,
+				"isClosed": true,
+				"isPen": false
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "b09",
+			"typeName": "shape"
+		},
+		"shape:Y-RNZI0kCIm1cfrq380tp": {
+			"x": 2320.5383081066075,
+			"y": 2127.742336216381,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Y-RNZI0kCIm1cfrq380tp",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL4",
+			"typeName": "shape"
+		},
+		"shape:kwqilkm_qj0bkPeIBpqN8": {
+			"x": 2409.659076878031,
+			"y": 2127.742336216381,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:kwqilkm_qj0bkPeIBpqN8",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM4",
+			"typeName": "shape"
+		},
+		"shape:wzdreIn-lrivnrX33jfGF": {
+			"x": 2498.7798456494547,
+			"y": 2127.742336216381,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:wzdreIn-lrivnrX33jfGF",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN4",
+			"typeName": "shape"
+		},
+		"shape:8NwS1iOlT-3S1hklDcmWc": {
+			"x": 2587.900614420879,
+			"y": 2127.742336216381,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:8NwS1iOlT-3S1hklDcmWc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aO8",
+			"typeName": "shape"
+		},
+		"shape:k6X_klIC0tdRf50y-lVog": {
+			"x": 2336.837678818715,
+			"y": 2153.6216955397117,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:k6X_klIC0tdRf50y-lVog",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL6",
+			"typeName": "shape"
+		},
+		"shape:c6QiPSwMZtSeYctltuWki": {
+			"x": 2425.958447590139,
+			"y": 2153.6216955397117,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:c6QiPSwMZtSeYctltuWki",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM6",
+			"typeName": "shape"
+		},
+		"shape:BcPsqsxxb92Uyagm5dPl7": {
+			"x": 2515.0792163615624,
+			"y": 2153.6216955397117,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:BcPsqsxxb92Uyagm5dPl7",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN6",
+			"typeName": "shape"
+		},
+		"shape:xJiq2X0VhJ2Ht79tNZBXb": {
+			"x": 2604.1999851329865,
+			"y": 2153.6216955397117,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:xJiq2X0VhJ2Ht79tNZBXb",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "none",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOC",
+			"typeName": "shape"
+		},
+		"shape:ZDRB73mj1n8QTCLyhQFu5": {
+			"x": 2320.5383081066075,
+			"y": 2227.9749996826504,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:ZDRB73mj1n8QTCLyhQFu5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL5",
+			"typeName": "shape"
+		},
+		"shape:2yK-kN1RVmEvNJqQCxQ37": {
+			"x": 2336.837678818715,
+			"y": 2253.854359005981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:2yK-kN1RVmEvNJqQCxQ37",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL7",
+			"typeName": "shape"
+		},
+		"shape:1KQ5UTW3w1ZkwiPerI50z": {
+			"x": 2409.659076878031,
+			"y": 2227.9749996826504,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1KQ5UTW3w1ZkwiPerI50z",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM5",
+			"typeName": "shape"
+		},
+		"shape:36ROdWhjuvfJxnGfDYaoa": {
+			"x": 2425.958447590139,
+			"y": 2253.854359005981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:36ROdWhjuvfJxnGfDYaoa",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM7",
+			"typeName": "shape"
+		},
+		"shape:dItJmYuee0s-EvJvA6fvt": {
+			"x": 2498.7798456494547,
+			"y": 2227.9749996826504,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:dItJmYuee0s-EvJvA6fvt",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN5",
+			"typeName": "shape"
+		},
+		"shape:soXLUhPqG187h78lxTd0y": {
+			"x": 2515.0792163615624,
+			"y": 2253.854359005981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:soXLUhPqG187h78lxTd0y",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN7",
+			"typeName": "shape"
+		},
+		"shape:qwD_eFzNnAawFyCtKw9EV": {
+			"x": 2587.900614420879,
+			"y": 2227.9749996826504,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qwD_eFzNnAawFyCtKw9EV",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOA",
+			"typeName": "shape"
+		},
+		"shape:8WttAcWOX89x-8Lr96Rnl": {
+			"x": 2604.1999851329865,
+			"y": 2253.854359005981,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:8WttAcWOX89x-8Lr96Rnl",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "semi",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOE",
+			"typeName": "shape"
+		},
+		"shape:R1HFhhOJuTv8yBxBAA4XQ": {
+			"x": 2320.5383081066075,
+			"y": 2322.176882797105,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:R1HFhhOJuTv8yBxBAA4XQ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL5V",
+			"typeName": "shape"
+		},
+		"shape:iuDhdLZmzYYEjfxzbfUrq": {
+			"x": 2336.837678818715,
+			"y": 2348.056242120436,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:iuDhdLZmzYYEjfxzbfUrq",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL7V",
+			"typeName": "shape"
+		},
+		"shape:afM-6EiKzEIgt6_u2iYfm": {
+			"x": 2409.659076878031,
+			"y": 2322.176882797105,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:afM-6EiKzEIgt6_u2iYfm",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM5V",
+			"typeName": "shape"
+		},
+		"shape:FKpif8usLRjQp12ijiFrq": {
+			"x": 2425.958447590139,
+			"y": 2348.056242120436,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:FKpif8usLRjQp12ijiFrq",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM7V",
+			"typeName": "shape"
+		},
+		"shape:WaLWMiWSObHfbWdXKwG32": {
+			"x": 2498.7798456494547,
+			"y": 2322.176882797105,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:WaLWMiWSObHfbWdXKwG32",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN5V",
+			"typeName": "shape"
+		},
+		"shape:j51Zyx0x3n6EenJgH-kDJ": {
+			"x": 2515.0792163615624,
+			"y": 2348.056242120436,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:j51Zyx0x3n6EenJgH-kDJ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN7V",
+			"typeName": "shape"
+		},
+		"shape:EEep7jJOTKAY7jHe1QGcO": {
+			"x": 2587.900614420879,
+			"y": 2322.176882797105,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:EEep7jJOTKAY7jHe1QGcO",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOB",
+			"typeName": "shape"
+		},
+		"shape:RSysWIvV1RE23PbI_0Hkc": {
+			"x": 2604.1999851329865,
+			"y": 2348.056242120436,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:RSysWIvV1RE23PbI_0Hkc",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "solid",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOF",
+			"typeName": "shape"
+		},
+		"shape:gi9zZUKrLM6lfGWMQpT94": {
+			"x": 2320.5383081066075,
+			"y": 2426.4232288784715,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:gi9zZUKrLM6lfGWMQpT94",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL5l",
+			"typeName": "shape"
+		},
+		"shape:jOBLBXYXRS_yD_RUZnK0I": {
+			"x": 2336.837678818715,
+			"y": 2452.3025882018023,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:jOBLBXYXRS_yD_RUZnK0I",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "s",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aL7l",
+			"typeName": "shape"
+		},
+		"shape:RGTuekk9bsd8FrjyOrUHE": {
+			"x": 2409.659076878031,
+			"y": 2426.4232288784715,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:RGTuekk9bsd8FrjyOrUHE",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM5l",
+			"typeName": "shape"
+		},
+		"shape:FPz0BrUt6Y4wiGD-H5yOO": {
+			"x": 2425.958447590139,
+			"y": 2452.3025882018023,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:FPz0BrUt6Y4wiGD-H5yOO",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "m",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aM7l",
+			"typeName": "shape"
+		},
+		"shape:5pGNil-pTbpVTkt9wAZCu": {
+			"x": 2498.7798456494547,
+			"y": 2426.4232288784715,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:5pGNil-pTbpVTkt9wAZCu",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN5l",
+			"typeName": "shape"
+		},
+		"shape:Qe2Ewba_-XCDktXluipA1": {
+			"x": 2515.0792163615624,
+			"y": 2452.3025882018023,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:Qe2Ewba_-XCDktXluipA1",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "l",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aN7l",
+			"typeName": "shape"
+		},
+		"shape:qUPYEpNo3ytSP0IfH5zgJ": {
+			"x": 2587.900614420879,
+			"y": 2426.4232288784715,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:qUPYEpNo3ytSP0IfH5zgJ",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOBV",
+			"typeName": "shape"
+		},
+		"shape:RC0me0o0ZHkQ-xfNt2LK5": {
+			"x": 2604.1999851329865,
+			"y": 2452.3025882018023,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 0.5,
+			"meta": {},
+			"id": "shape:RC0me0o0ZHkQ-xfNt2LK5",
+			"type": "geo",
+			"props": {
+				"w": 74.1747826657256,
+				"h": 50.82777526293191,
+				"geo": "rectangle",
+				"color": "black",
+				"labelColor": "black",
+				"fill": "pattern",
+				"dash": "draw",
+				"size": "xl",
+				"font": "draw",
+				"text": "",
+				"align": "middle",
+				"verticalAlign": "start",
+				"growY": 0,
+				"url": ""
+			},
+			"parentId": "page:3qj9EtNgqSCW_6knX2K9_",
+			"index": "aOFV",
+			"typeName": "shape"
+		}
+	},
+	"schema": {
+		"schemaVersion": 1,
+		"storeVersion": 4,
+		"recordVersions": {
+			"asset": {
+				"version": 1,
+				"subTypeKey": "type",
+				"subTypeVersions": {
+					"image": 2,
+					"video": 2,
+					"bookmark": 0
+				}
+			},
+			"camera": {
+				"version": 1
+			},
+			"document": {
+				"version": 2
+			},
+			"instance": {
+				"version": 20
+			},
+			"instance_page_state": {
+				"version": 4
+			},
+			"page": {
+				"version": 1
+			},
+			"shape": {
+				"version": 3,
+				"subTypeKey": "type",
+				"subTypeVersions": {
+					"group": 0,
+					"text": 1,
+					"bookmark": 1,
+					"draw": 1,
+					"geo": 7,
+					"note": 4,
+					"line": 0,
+					"frame": 0,
+					"arrow": 1,
+					"highlight": 0,
+					"embed": 4,
+					"image": 2,
+					"video": 1
+				}
+			},
+			"instance_presence": {
+				"version": 5
+			},
+			"pointer": {
+				"version": 1
+			}
+		}
+	}
+}

--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -27,6 +27,7 @@ import MultipleExample from './examples/MultipleExample'
 import PersistenceExample from './examples/PersistenceExample'
 import ScrollExample from './examples/ScrollExample'
 import ShapeMetaExample from './examples/ShapeMetaExample'
+import SnapshotExample from './examples/SnapshotExample/SnapshotExample'
 import StoreEventsExample from './examples/StoreEventsExample'
 import UiEventsExample from './examples/UiEventsExample'
 import UserPresenceExample from './examples/UserPresenceExample'
@@ -134,6 +135,11 @@ export const allExamples: Example[] = [
 		title: 'Persistence',
 		path: '/persistence',
 		element: <PersistenceExample />,
+	},
+	{
+		title: 'Snapshots',
+		path: '/snapshots',
+		element: <SnapshotExample />,
 	},
 	{
 		title: 'Custom styles',

--- a/apps/examples/tsconfig.json
+++ b/apps/examples/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../../config/tsconfig.base.json",
-	"include": ["src", "e2e", "./vite.config.ts"],
+	"include": ["src", "e2e", "./vite.config.ts", "**/*.json"],
 	"exclude": ["node_modules", "dist", "**/*.css", ".tsbuild*", "./scripts/legacy-translations"],
 	"compilerOptions": {
 		"outDir": "./.tsbuild"

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -31,6 +31,7 @@ import { SerializedStore } from '@tldraw/store';
 import { ShapeProps } from '@tldraw/tlschema';
 import { Signal } from '@tldraw/state';
 import { StoreSchema } from '@tldraw/store';
+import { StoreSnapshot } from '@tldraw/store';
 import { StyleProp } from '@tldraw/tlschema';
 import { TLArrowShape } from '@tldraw/tlschema';
 import { TLArrowShapeArrowheadStyle } from '@tldraw/tlschema';
@@ -2005,6 +2006,7 @@ export type TldrawEditorProps = TldrawEditorBaseProps & ({
     store: TLStore | TLStoreWithStatus;
 } | {
     store?: undefined;
+    snapshot?: StoreSnapshot<TLRecord>;
     initialData?: SerializedStore<TLRecord>;
     persistenceKey?: string;
     sessionId?: string;
@@ -2603,6 +2605,7 @@ export function useIsEditing(shapeId: TLShapeId): boolean;
 export function useLocalStore({ persistenceKey, sessionId, ...rest }: {
     persistenceKey?: string;
     sessionId?: string;
+    snapshot?: StoreSnapshot<TLRecord>;
 } & TLStoreOptions): TLStoreWithStatus;
 
 // @internal (undocumented)
@@ -2626,7 +2629,9 @@ export function useSelectionEvents(handle: TLSelectionHandle): {
 };
 
 // @public (undocumented)
-export function useTLStore(opts: TLStoreOptions): TLStore;
+export function useTLStore(opts: TLStoreOptions & {
+    snapshot?: StoreSnapshot<TLRecord>;
+}): TLStore;
 
 // @public (undocumented)
 export function useTransform(ref: React.RefObject<HTMLElement | SVGElement>, x?: number, y?: number, scale?: number, rotate?: number, additionalOffset?: VecLike): void;

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -1,4 +1,4 @@
-import { SerializedStore, Store } from '@tldraw/store'
+import { SerializedStore, Store, StoreSnapshot } from '@tldraw/store'
 import { TLRecord, TLStore } from '@tldraw/tlschema'
 import { Required, annotateError } from '@tldraw/utils'
 import React, {
@@ -46,6 +46,7 @@ export type TldrawEditorProps = TldrawEditorBaseProps &
 		  }
 		| {
 				store?: undefined
+				snapshot?: StoreSnapshot<TLRecord>
 				initialData?: SerializedStore<TLRecord>
 				persistenceKey?: string
 				sessionId?: string
@@ -186,7 +187,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 function TldrawEditorWithOwnStore(
 	props: Required<TldrawEditorProps & { store: undefined; user: TLUser }, 'shapeUtils' | 'tools'>
 ) {
-	const { defaultName, initialData, shapeUtils, persistenceKey, sessionId, user } = props
+	const { defaultName, snapshot, initialData, shapeUtils, persistenceKey, sessionId, user } = props
 
 	const syncedStore = useLocalStore({
 		shapeUtils,
@@ -194,6 +195,7 @@ function TldrawEditorWithOwnStore(
 		persistenceKey,
 		sessionId,
 		defaultName,
+		snapshot,
 	})
 
 	return <TldrawEditorWithLoadingStore {...props} store={syncedStore} user={user} />

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -1,3 +1,5 @@
+import { StoreSnapshot } from '@tldraw/store'
+import { TLRecord } from '@tldraw/tlschema'
 import { useEffect, useState } from 'react'
 import { TLStoreOptions } from '../config/createTLStore'
 import { TLStoreWithStatus } from '../utils/sync/StoreWithStatus'
@@ -10,7 +12,11 @@ export function useLocalStore({
 	persistenceKey,
 	sessionId,
 	...rest
-}: { persistenceKey?: string; sessionId?: string } & TLStoreOptions): TLStoreWithStatus {
+}: {
+	persistenceKey?: string
+	sessionId?: string
+	snapshot?: StoreSnapshot<TLRecord>
+} & TLStoreOptions): TLStoreWithStatus {
 	const [state, setState] = useState<{ id: string; storeWithStatus: TLStoreWithStatus } | null>(
 		null
 	)

--- a/packages/editor/src/lib/hooks/useTLStore.ts
+++ b/packages/editor/src/lib/hooks/useTLStore.ts
@@ -1,9 +1,17 @@
+import { StoreSnapshot } from '@tldraw/store'
+import { TLRecord } from '@tldraw/tlschema'
 import { useEffect, useRef, useState } from 'react'
 import { TLStoreOptions, createTLStore } from '../config/createTLStore'
 
 /** @public */
-export function useTLStore(opts: TLStoreOptions) {
-	const [store, setStore] = useState(() => createTLStore(opts))
+export function useTLStore(opts: TLStoreOptions & { snapshot?: StoreSnapshot<TLRecord> }) {
+	const [store, setStore] = useState(() => {
+		const store = createTLStore(opts)
+		if (opts.snapshot) {
+			store.loadSnapshot(opts.snapshot)
+		}
+		return store
+	})
 	// prev
 	const ref = useRef(opts)
 	useEffect(() => void (ref.current = opts))
@@ -15,6 +23,9 @@ export function useTLStore(opts: TLStoreOptions) {
 		)
 	) {
 		const newStore = createTLStore(opts)
+		if (opts.snapshot) {
+			newStore.loadSnapshot(opts.snapshot)
+		}
 		setStore(newStore)
 		return newStore
 	}

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -40,6 +40,7 @@ import { SelectionHandle } from '@tldraw/editor';
 import { SerializedSchema } from '@tldraw/editor';
 import { ShapeUtil } from '@tldraw/editor';
 import { StateNode } from '@tldraw/editor';
+import { StoreSnapshot } from '@tldraw/editor';
 import { SvgExportContext } from '@tldraw/editor';
 import { TLAnyShapeUtilConstructor } from '@tldraw/editor';
 import { TLArrowShape } from '@tldraw/editor';
@@ -50,7 +51,7 @@ import { TLCancelEvent } from '@tldraw/editor';
 import { TLClickEvent } from '@tldraw/editor';
 import { TLClickEventInfo } from '@tldraw/editor';
 import { TLDefaultSizeStyle } from '@tldraw/editor';
-import { TldrawEditorProps } from '@tldraw/editor';
+import { TldrawEditorBaseProps } from '@tldraw/editor';
 import { TLDrawShape } from '@tldraw/editor';
 import { TLDrawShapeSegment } from '@tldraw/editor';
 import { TLEmbedShape } from '@tldraw/editor';
@@ -80,6 +81,7 @@ import { TLParentId } from '@tldraw/editor';
 import { TLPointerEvent } from '@tldraw/editor';
 import { TLPointerEventInfo } from '@tldraw/editor';
 import { TLPointerEventName } from '@tldraw/editor';
+import { TLRecord } from '@tldraw/editor';
 import { TLRotationSnapshot } from '@tldraw/editor';
 import { TLSchema } from '@tldraw/editor';
 import { TLScribble } from '@tldraw/editor';
@@ -90,6 +92,7 @@ import { TLShapePartial } from '@tldraw/editor';
 import { TLShapeUtilCanvasSvgDef } from '@tldraw/editor';
 import { TLShapeUtilFlag } from '@tldraw/editor';
 import { TLStore } from '@tldraw/editor';
+import { TLStoreWithStatus } from '@tldraw/editor';
 import { TLTextShape } from '@tldraw/editor';
 import { TLTickEvent } from '@tldraw/editor';
 import { TLUnknownShape } from '@tldraw/editor';
@@ -1092,7 +1095,15 @@ function Title({ className, children }: {
 }): JSX.Element;
 
 // @public (undocumented)
-export function Tldraw(props: TldrawEditorProps & TldrawUiProps & Partial<TLExternalContentProps> & {
+export function Tldraw(props: TldrawEditorBaseProps & ({
+    store: TLStore | TLStoreWithStatus;
+} | {
+    store?: undefined;
+    persistenceKey?: string;
+    sessionId?: string;
+    defaultName?: string;
+    snapshot?: StoreSnapshot<TLRecord>;
+}) & TldrawUiProps & Partial<TLExternalContentProps> & {
     assetUrls?: RecursivePartial<TLEditorAssetUrls>;
 }): JSX.Element;
 

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -4,8 +4,13 @@ import {
 	ErrorScreen,
 	LoadingScreen,
 	RecursivePartial,
+	StoreSnapshot,
 	TLOnMountHandler,
+	TLRecord,
+	TLStore,
+	TLStoreWithStatus,
 	TldrawEditor,
+	TldrawEditorBaseProps,
 	TldrawEditorProps,
 	assert,
 	useEditor,
@@ -31,7 +36,22 @@ import { usePreloadAssets } from './utils/usePreloadAssets'
 
 /** @public */
 export function Tldraw(
-	props: TldrawEditorProps &
+	props: TldrawEditorBaseProps &
+		(
+			| {
+					store: TLStore | TLStoreWithStatus
+			  }
+			| {
+					store?: undefined
+					persistenceKey?: string
+					sessionId?: string
+					defaultName?: string
+					/**
+					 * A snapshot to load for the store's initial data / schema.
+					 */
+					snapshot?: StoreSnapshot<TLRecord>
+			  }
+		) &
 		TldrawUiProps &
 		Partial<TLExternalContentProps> & {
 			/**


### PR DESCRIPTION
This PR:
- adds a `snapshot` prop to the <Tldraw> component. It does basically the same thing as calling `loadSnapshot` after creating the store, but happens before the editor actually loads.
- adds a largeish example (including a JSON snapshot) to the examples

We have some very complex ways of juggling serialized data between multiplayer, file formats, and the snapshot APIs. I'd like to see these simplified, or at least for our documentation to reflect a narrow subset of all the options available.

The most common questions seem to be:

Q: How do I serialize data?
A: Via the `Editor.getSnapshot()` method

Q: How do I restore serialized data?
A: Via the `Editor.loadSnapshot()` method OR via the `<Tldraw>` component's `snapshot` prop

The store has an `initialData` constructor prop, however this is quite complex as the store also requires a schema class instance with which to migrate the data. In our components (<Tldraw> and <TldrawEditor>) we were also accepting `initialData`, however we weren't accepting a schema, and either way I think it's unrealistic to also expect users to create schemas themselves and pass those in.

AFAIK the `initialData` prop is only used in the file loading, which is a good example of how complex it looks like to create a schema and migrate data outside of the components.

### Change Type

- [x] `minor` — New feature
