### PR TITLE
avoid pixel rounding / transformation miscalc for overlay items

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -26,6 +26,8 @@
 	--layer-canvas: 200;
 	/* Misc */
 	--tl-zoom: 1;
+	--tl-dpr-multiple: 100;
+	--tl-dpr-multiple-px: calc(var(--tl-dpr-multiple) * 1px);
 
 	/* Cursor SVGs */
 	--tl-cursor-none: none;
@@ -245,8 +247,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 100px;
-	width: 100px;
+	height: var(--tl-dpr-multiple-px);
+	width: var(--tl-dpr-multiple-px);
 	overflow: visible;
 	pointer-events: none;
 	transform-origin: top left;
@@ -256,8 +258,8 @@ input,
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	height: 100px;
-	width: 100px;
+	height: var(--tl-dpr-multiple-px);
+	width: var(--tl-dpr-multiple-px);
 	pointer-events: none;
 }
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -33,6 +33,7 @@ import { useLocalStore } from './hooks/useLocalStore'
 import { useSafariFocusOutFix } from './hooks/useSafariFocusOutFix'
 import { useZoomCss } from './hooks/useZoomCss'
 import { TLStoreWithStatus } from './utils/sync/StoreWithStatus'
+import { useDPRMultiple } from './hooks/useDPRMultiple'
 
 /**
  * Props for the {@link @tldraw/tldraw#Tldraw} and {@link TldrawEditor} components.
@@ -345,6 +346,7 @@ function Layout({ children }: { children: any }) {
 	useDarkMode()
 	useSafariFocusOutFix()
 	useForceUpdate()
+	useDPRMultiple()
 
 	return children ?? <Canvas />
 }

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -20,6 +20,7 @@ import { Editor } from './editor/Editor'
 import { TLStateNodeConstructor } from './editor/tools/StateNode'
 import { ContainerProvider, useContainer } from './hooks/useContainer'
 import { useCursor } from './hooks/useCursor'
+import { useDPRMultiple } from './hooks/useDPRMultiple'
 import { useDarkMode } from './hooks/useDarkMode'
 import { EditorContext } from './hooks/useEditor'
 import {
@@ -33,7 +34,6 @@ import { useLocalStore } from './hooks/useLocalStore'
 import { useSafariFocusOutFix } from './hooks/useSafariFocusOutFix'
 import { useZoomCss } from './hooks/useZoomCss'
 import { TLStoreWithStatus } from './utils/sync/StoreWithStatus'
-import { useDPRMultiple } from './hooks/useDPRMultiple'
 
 /**
  * Props for the {@link @tldraw/tldraw#Tldraw} and {@link TldrawEditor} components.

--- a/packages/editor/src/lib/hooks/useDPRMultiple.ts
+++ b/packages/editor/src/lib/hooks/useDPRMultiple.ts
@@ -5,15 +5,15 @@ import { useEditor } from './useEditor'
 
 // Euclidean algorithm to find the GCD
 function gcd(a: number, b: number): number {
-  return (b === 0) ? a : gcd(b, a % b)
+	return b === 0 ? a : gcd(b, a % b)
 }
 
 function nearestMultiple(float: number) {
-  const decimal = float.toString().split('.')[1]
-  if (!decimal) return 1
-  const denominator = Math.pow(10, decimal.length)
-  const numerator = parseInt(decimal, 10)
-  return denominator / gcd(numerator, denominator)
+	const decimal = float.toString().split('.')[1]
+	if (!decimal) return 1
+	const denominator = Math.pow(10, decimal.length)
+	const numerator = parseInt(decimal, 10)
+	return denominator / gcd(numerator, denominator)
 }
 
 export function useDPRMultiple() {
@@ -21,7 +21,8 @@ export function useDPRMultiple() {
 	const container = useContainer()
 
 	React.useEffect(() => {
-		const setDPRMultiple = (s: number) => container.style.setProperty('--tl-dpr-multiple', s.toString())
+		const setDPRMultiple = (s: number) =>
+			container.style.setProperty('--tl-dpr-multiple', s.toString())
 
 		const scheduler = new EffectScheduler('useDPRMultiple', () => {
 			const dpr = editor.instanceState.devicePixelRatio

--- a/packages/editor/src/lib/hooks/useDPRMultiple.ts
+++ b/packages/editor/src/lib/hooks/useDPRMultiple.ts
@@ -1,4 +1,4 @@
-import { EffectScheduler } from '@tldraw/state'
+import { react } from '@tldraw/state'
 import * as React from 'react'
 import { useContainer } from './useContainer'
 import { useEditor } from './useEditor'
@@ -21,19 +21,9 @@ export function useDPRMultiple() {
 	const container = useContainer()
 
 	React.useEffect(() => {
-		const setDPRMultiple = (s: number) =>
-			container.style.setProperty('--tl-dpr-multiple', s.toString())
-
-		const scheduler = new EffectScheduler('useDPRMultiple', () => {
+		return react('useDPRMultiple', () => {
 			const dpr = editor.instanceState.devicePixelRatio
-			setDPRMultiple(nearestMultiple(dpr))
+			container.style.setProperty('--tl-dpr-multiple', nearestMultiple(dpr).toString())
 		})
-
-		scheduler.attach()
-		scheduler.execute()
-
-		return () => {
-			scheduler.detach()
-		}
 	}, [editor, container])
 }

--- a/packages/editor/src/lib/hooks/useDPRMultiple.ts
+++ b/packages/editor/src/lib/hooks/useDPRMultiple.ts
@@ -1,0 +1,38 @@
+import { EffectScheduler } from '@tldraw/state'
+import * as React from 'react'
+import { useContainer } from './useContainer'
+import { useEditor } from './useEditor'
+
+// Euclidean algorithm to find the GCD
+function gcd(a: number, b: number): number {
+  return (b === 0) ? a : gcd(b, a % b)
+}
+
+function nearestMultiple(float: number) {
+  const decimal = float.toString().split('.')[1]
+  if (!decimal) return 1
+  const denominator = Math.pow(10, decimal.length)
+  const numerator = parseInt(decimal, 10)
+  return denominator / gcd(numerator, denominator)
+}
+
+export function useDPRMultiple() {
+	const editor = useEditor()
+	const container = useContainer()
+
+	React.useEffect(() => {
+		const setDPRMultiple = (s: number) => container.style.setProperty('--tl-dpr-multiple', s.toString())
+
+		const scheduler = new EffectScheduler('useDPRMultiple', () => {
+			const dpr = editor.instanceState.devicePixelRatio
+			setDPRMultiple(nearestMultiple(dpr))
+		})
+
+		scheduler.attach()
+		scheduler.execute()
+
+		return () => {
+			scheduler.detach()
+		}
+	}, [editor, container])
+}

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -12,21 +12,21 @@ export function useDocumentEvents() {
 	const isAppFocused = useValue('isFocused', () => editor.instanceState.isFocused, [editor])
 
 	useEffect(() => {
-		if (typeof matchMedia === undefined) return;
+		if (typeof matchMedia === undefined) return
 		// https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes
-		let remove: Function | null = null;
+		let remove: Function | null = null
 		const updatePixelRatio = () => {
 			if (remove != null) {
 				remove()
 			}
 			const mqString = `(resolution: ${window.devicePixelRatio}dppx)`
 			const media = matchMedia(mqString)
-			media.addEventListener("change", updatePixelRatio)
+			media.addEventListener('change', updatePixelRatio)
 			remove = () => {
-				media.removeEventListener("change", updatePixelRatio)
-			};
+				media.removeEventListener('change', updatePixelRatio)
+			}
 			editor.updateInstanceState({ devicePixelRatio: window.devicePixelRatio })
-		};
+		}
 		updatePixelRatio()
 		return () => {
 			remove?.()

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -14,7 +14,7 @@ export function useDocumentEvents() {
 	useEffect(() => {
 		if (typeof matchMedia === undefined) return
 		// https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes
-		let remove: Function | null = null
+		let remove: (() => void) | null = null
 		const updatePixelRatio = () => {
 			if (remove != null) {
 				remove()

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -12,17 +12,24 @@ export function useDocumentEvents() {
 	const isAppFocused = useValue('isFocused', () => editor.instanceState.isFocused, [editor])
 
 	useEffect(() => {
-		if (typeof matchMedia !== undefined) return
-
-		function updateDevicePixelRatio() {
+		if (typeof matchMedia === undefined) return;
+		// https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes
+		let remove: Function | null = null;
+		const updatePixelRatio = () => {
+			if (remove != null) {
+				remove()
+			}
+			const mqString = `(resolution: ${window.devicePixelRatio}dppx)`
+			const media = matchMedia(mqString)
+			media.addEventListener("change", updatePixelRatio)
+			remove = () => {
+				media.removeEventListener("change", updatePixelRatio)
+			};
 			editor.updateInstanceState({ devicePixelRatio: window.devicePixelRatio })
-		}
-
-		const MM = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
-
-		MM.addEventListener('change', updateDevicePixelRatio)
+		};
+		updatePixelRatio()
 		return () => {
-			MM.removeEventListener('change', updateDevicePixelRatio)
+			remove?.()
 		}
 	}, [editor])
 

--- a/packages/tldraw/setupTests.js
+++ b/packages/tldraw/setupTests.js
@@ -15,7 +15,19 @@ document.fonts = {
 	[Symbol.iterator]: () => [][Symbol.iterator](),
 }
 
-global.matchMedia = () => false
+Object.defineProperty(window, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation((query) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: jest.fn(), // Deprecated
+		removeListener: jest.fn(), // Deprecated
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+		dispatchEvent: jest.fn(),
+	})),
+})
 
 Object.defineProperty(global.URL, 'createObjectURL', {
 	writable: true,


### PR DESCRIPTION
Fixes pixel rounding when calculating css transformations for overlay items. Also fixes issue where `editor.instanceState.devicePixelRatio` wasn't properly updating.

TLDR; `width * window.devicePixelRatio` should be integer to avoid rounding. `--tl-dpr-multiple` is smallest integer to multiply `window.devicePixelRatio` such that its product is an integer.

#1852 
#1836 
#1834

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

Would need to add a test checking when `window.devicePixelRatio` changes, that `editor.instanceState.devicePixelRatio` is equal.

