### PR TITLE
[wip] Viewport focus of editing shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2698,12 +2698,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this._tickCameraState()
 		this.updateRenderingBounds()
 
-		const { editingShapeId } = this
-
-		if (editingShapeId) {
-			this.panZoomIntoView([editingShapeId])
-		}
-
 		return this
 	}
 


### PR DESCRIPTION
When editing shapes the viewport would be reset to the shape whenever it moved out of camera bounds, it looked kinda janky. We're now going to let the user scroll away if they'd like.


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

Removed a feature to reset the viewport back to a shape that is being edited.

(Before) Don't be held back by the past
![Kapture 2023-09-15 at 10 57 29](https://github.com/tldraw/tldraw/assets/98838967/d8891621-766e-46a2-b1ca-afa968b7f08c)

(After) You are free to find new avenues of exploration
![Kapture 2023-09-15 at 11 02 36](https://github.com/tldraw/tldraw/assets/98838967/82f318ab-944b-41bd-8297-a35467a15987)
