### PR TITLE
Stop arrow handles snapping

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
@@ -235,7 +235,7 @@ export class DraggingHandle extends StateNode {
 		// Clear any existing snaps
 		editor.snaps.clear()
 
-		if (isSnapMode ? !ctrlKey : ctrlKey) {
+		if (isSnapMode ? !ctrlKey : ctrlKey && !initialHandle.canBind) {
 			// We're snapping
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')


### PR DESCRIPTION
This PR stops arrow handles snapping. It was competing with the special arrow snapping that we do.

![2023-09-18 at 11 32 00 - Scarlet Duck](https://github.com/tldraw/tldraw/assets/15892272/12c2454a-9c48-48fc-aa2d-587bcb1e2fcf)

Closes #1892 

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Drag an arrow...
2. ... over a rectangle in different places
3. ... while holding the ctrl or cmd key

Expected: It doesn't snap with a red ❌ cross.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed arrows snapping to things they shouldn't
