### PR TITLE
Fix pinch start with toolbar open

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -27,7 +27,7 @@
 		"infinite"
 	],
 	"scripts": {
-		"dev": "vite",
+		"dev": "vite --host",
 		"build": "vite build",
 		"lint": "yarn run -T tsx ../../scripts/lint.ts",
 		"e2e": "playwright test -c ./e2e/playwright.config.ts",

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -683,7 +683,9 @@ export class Drawing extends StateNode {
 			return
 		}
 
-		this.editor.bail()
+		if (this.canDraw) {
+			this.editor.bail()
+		}
 		this.cancel()
 	}
 

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -48,7 +48,10 @@ export class Drawing extends StateNode {
 
 	canDraw = false
 
+	markId = null as null | string
+
 	override onEnter = (info: TLPointerEventInfo) => {
+		this.markId = null
 		this.info = info
 		this.canDraw = !this.editor.isMenuOpen
 		this.lastRecordedPoint = this.editor.inputs.currentPagePoint.clone()
@@ -163,7 +166,8 @@ export class Drawing extends StateNode {
 			inputs: { originPagePoint, isPen },
 		} = this.editor
 
-		this.editor.mark('draw create start')
+		this.markId = 'draw start ' + uniqueId()
+		this.editor.mark(this.markId)
 
 		this.isPen = isPen
 
@@ -683,8 +687,8 @@ export class Drawing extends StateNode {
 			return
 		}
 
-		if (this.canDraw) {
-			this.editor.bail()
+		if (this.markId) {
+			this.editor.bailToMark(this.markId)
 		}
 		this.cancel()
 	}


### PR DESCRIPTION
closes #1893 

Normally when you start a pinch it does the following within a few frames:

- first finger goes down, begins a drawing gesture, adds a mark to the undo stack
- second finger goes down, cancels the drawing gesture, bails to the mark

but when the toolbar is open, it follows the same process without adding a mark to the undo stack, so that when it bails it bails to the previous mark.

This PR updates the logic to create a mark ID when setting the mark, and only bail if the mark id was set on enter.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes a bug that could trigger undo by accident when closing the style toolbar via a pinch gesture on mobile.
