### PR TITLE
[fix] Arrow snapping / Make snapping optional

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1587,6 +1587,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     constructor(editor: Editor);
     // @internal
     backgroundComponent?(shape: Shape): any;
+    canBeSnappedTo: TLShapeUtilFlag<Shape>;
     canBind: <K>(_shape: Shape, _otherShape?: K | undefined) => boolean;
     canCrop: TLShapeUtilFlag<Shape>;
     canDropShapes(shape: Shape, shapes: TLShape[]): boolean;

--- a/packages/editor/src/lib/editor/managers/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager.ts
@@ -261,7 +261,7 @@ export class SnapManager {
 				if (!childShape) continue
 				const util = editor.getShapeUtil(childShape)
 				// Skip any shapes that don't allow snapping
-				if (!util.canSnap(childShape)) continue
+				if (!util.canBeSnappedTo(childShape)) continue
 				// Only consider shapes if they're inside of the viewport page bounds
 				const pageBounds = editor.getShapePageBounds(childId)
 				if (!(pageBounds && renderingBounds.includes(pageBounds))) continue

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -77,6 +77,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 *
 	 * @public
 	 */
+	canBeSnappedTo: TLShapeUtilFlag<Shape> = () => true
+
+	/**
+	 * Whether the shape can snap to other shapes or alignments.
+	 *
+	 * @public
+	 */
 	canSnap: TLShapeUtilFlag<Shape> = () => true
 
 	/**

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -107,6 +107,8 @@ import { VecLike } from '@tldraw/editor';
 // @public (undocumented)
 export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
+    canBeSnappedTo: () => boolean;
+    // (undocumented)
     canBind: () => boolean;
     // (undocumented)
     canEdit: () => boolean;

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -63,6 +63,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	override canEdit = () => true
 	override canBind = () => false
 	override canSnap = () => false
+	override canBeSnappedTo = () => false
 	override hideResizeHandles: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideRotateHandle: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideSelectionBoundsBg: TLShapeUtilFlag<TLArrowShape> = () => true

--- a/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
@@ -235,7 +235,7 @@ export class DraggingHandle extends StateNode {
 		// Clear any existing snaps
 		editor.snaps.clear()
 
-		if (isSnapMode ? !ctrlKey : ctrlKey) {
+		if ((isSnapMode ? !ctrlKey : ctrlKey) && util.canSnap?.(shape)) {
 			// We're snapping
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')


### PR DESCRIPTION
This PR introduces an API to make snapping and handle snapping optional.

It updates the `ShapeUtil` flags:
- when `canBeSnappedTo` returns false, other shapes will not snap to the shape
- when `canSnap` returns false, the dragging shape will not snap to other shapes
- when `canSnapHandles` returns false, the shape's dragging handles will not snap to other shapes

> Note: Note that `canSnap` has changed. The functionality of `canSnap` has moved to `canBeSnappedTo`.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
