### PR TITLE
Fix video shape controls

### DIFF
--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -184,6 +184,7 @@ const TLVideoUtilComponent = track(function TLVideoUtilComponent(props: {
 					{asset?.props.src ? (
 						<video
 							ref={rVideo}
+							style={isEditing ? { pointerEvents: 'all' } : undefined}
 							className={`tl-video tl-video-shape-${shape.id.split(':')[1]}`}
 							width="100%"
 							height="100%"


### PR DESCRIPTION
The video shape was not interactive in it's editing mode, so I just updated it to have `pointer-events: all` when editing.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes pointer events for editing video shapes.
