### PR TITLE
Fix first handle of line snapping to itself

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/DraggingHandle.ts
@@ -240,11 +240,6 @@ export class DraggingHandle extends StateNode {
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')
 
-			// Get all the outline segments from the shape
-			const additionalSegments = util
-				.getOutlineSegments(shape)
-				.map((segment) => Matrix2d.applyToPoints(pageTransform, segment))
-
 			// We want to skip the segments that include the handle, so
 			// find the index of the handle that shares the same index property
 			// as the initial dragging handle; this catches a quirk of create handles
@@ -254,7 +249,11 @@ export class DraggingHandle extends StateNode {
 				.sort(sortByIndex)
 				.findIndex(({ index }) => initialHandle.index === index)
 
-			additionalSegments.splice(handleIndex - 1, 2)
+			// Get all the outline segments from the shape
+			const additionalSegments = util
+				.getOutlineSegments(shape)
+				.map((segment) => Matrix2d.applyToPoints(pageTransform, segment))
+				.filter((_segment, i) => i !== handleIndex - 1 && i !== handleIndex)
 
 			const snapDelta = snaps.getSnappingHandleDelta({
 				additionalSegments,


### PR DESCRIPTION
This PR stops the first handle of a line snapping to itself.

This is an extra fix that I noticed while testing #1910
![2023-09-18 at 16 00 56 - Maroon Crab](https://github.com/tldraw/tldraw/assets/15892272/f09e18f7-efdd-4b6d-acaf-272f44b98644)


### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Draw a line.
2. Switch to the select tool.
3. Create another segment in the line by dragging out its 'middle' handle. 
4. Move the **first** handle of the line.
5. ... while holding ctrl/cmd.
6. Make sure the handle doesn't try to snap to itself.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed a bug where the first handle of a line shape could snap to itself.
