### PR TITLE
[wip] Center pages on load

### DIFF
--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -8,6 +8,7 @@ import {
 	useValue,
 } from '@tldraw/editor'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useActions } from '../../hooks/useActions'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useReadonly } from '../../hooks/useReadonly'
@@ -23,6 +24,8 @@ export const PageMenu = function PageMenu() {
 	const editor = useEditor()
 	const msg = useTranslation()
 	const breakpoint = useBreakpoint()
+	const actions = useActions()
+	const action = actions['back-to-content']
 
 	const handleOpenChange = useCallback(() => setIsEditing(false), [])
 
@@ -363,7 +366,10 @@ export const PageMenu = function PageMenu() {
 								>
 									<Button
 										className="tlui-page-menu__item__button tlui-page-menu__item__button__checkbox"
-										onClick={() => editor.setCurrentPage(page.id)}
+										onClick={() => {
+											editor.setCurrentPage(page.id)
+											action.onSelect('helper-buttons')
+										}}
 										onDoubleClick={toggleEditing}
 										isChecked={page.id === currentPage.id}
 										title={msg('page-menu.go-to-page')}


### PR DESCRIPTION
This PR adds a new feature that centers content on a page when navigating to it.

### Change Type

- [ ] `patch` — Bug fix
- [x] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Content on a page should be centered when navigating to it.

![before](https://github.com/tldraw/tldraw/assets/98838967/ee51a7c9-822f-4906-b846-b3a188b62e97)

![after](https://github.com/tldraw/tldraw/assets/98838967/8c62ba0f-b7f4-42a5-8b20-1dbc68eab88d)


