### PR TITLE
Fix lines being draggable via their background

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -786,6 +786,8 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     hideRotateHandle: () => boolean;
     // (undocumented)
+    hideSelectionBoundsBg: () => boolean;
+    // (undocumented)
     hideSelectionBoundsFg: () => boolean;
     // (undocumented)
     indicator(shape: TLLineShape): JSX.Element;

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -41,6 +41,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	override hideResizeHandles = () => true
 	override hideRotateHandle = () => true
 	override hideSelectionBoundsFg = () => true
+	override hideSelectionBoundsBg = () => true
 
 	override getDefaultProps(): TLLineShape['props'] {
 		return {

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -312,6 +312,38 @@ describe('when shape is hollow', () => {
 		editor.expectToBeIn('select.pointing_canvas')
 		editor.pointerUp()
 	})
+
+	it('does not drag line shape', () => {
+		editor
+			.selectAll()
+			.deleteShapes(editor.selectedShapeIds)
+			.setCurrentTool('line')
+			.pointerMove(500, 500)
+			.pointerDown()
+			.pointerMove(600, 600)
+			.pointerUp()
+			.selectAll()
+			.setCurrentTool('select')
+
+		expect(editor.selectedShapeIds.length).toBe(1)
+
+		// Not inside of the shape but inside of the selection bounds
+		editor.pointerMove(510, 590)
+		expect(editor.hoveredShapeId).toBe(null)
+
+		// Line shapes have `hideSelectionBoundsBg` set to true
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_canvas')
+
+		editor.selectAll()
+		editor.rotateSelection(Math.PI)
+		editor.setCurrentTool('select')
+		editor.pointerMove(590, 510)
+
+		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_canvas')
+		editor.pointerUp()
+	})
 })
 
 describe('when shape is a frame', () => {


### PR DESCRIPTION
Fixes #1914 

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Draw a line shape at a 45 degree angle.
2. Select the line.
3. Click and drag the empty space next to the line.
4. It should select the canvas.

- [x] Unit Tests
- [ ] End to end tests

### Release Notes

- None - unreleased bug