### PR TITLE
[fix] quick actions

### DIFF
--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -82,6 +82,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 			(onlyShape ? !editor.getShapeUtil(onlyShape).hideSelectionBoundsFg(onlyShape) : true) &&
 			!isChangingStyle
 
+		// todo: consider having this be opt-out on the current state; if any has an opt-out, then don't show it
 		let shouldDisplayBox =
 			(showSelectionBounds &&
 				editor.isInAny(

--- a/packages/tldraw/src/lib/ui/components/DuplicateButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/DuplicateButton.tsx
@@ -10,13 +10,11 @@ export const DuplicateButton = track(function DuplicateButton() {
 	const msg = useTranslation()
 	const action = actions['duplicate']
 
-	const noSelected = editor.selectedShapeIds.length <= 0
-
 	return (
 		<Button
 			icon={action.icon}
 			onClick={() => action.onSelect('quick-actions')}
-			disabled={noSelected}
+			disabled={editor.isIn('select') && editor.selectedShapeIds.length > 0}
 			title={`${msg(action.label!)} ${kbdStr(action.kbd!)}`}
 			smallIcon
 		/>

--- a/packages/tldraw/src/lib/ui/components/MenuZone.tsx
+++ b/packages/tldraw/src/lib/ui/components/MenuZone.tsx
@@ -15,7 +15,7 @@ export const MenuZone = track(function MenuZone() {
 	const breakpoint = useBreakpoint()
 	const isReadonly = useReadonly()
 
-	const showQuickActions = !isReadonly && !editor.isInAny('hand', 'zoom', 'eraser')
+	// todo: Someday, de-select the selected shapes when leaving the select tool and re-select them when re-entering that tool
 
 	return (
 		<div className="tlui-menu-zone">
@@ -23,7 +23,7 @@ export const MenuZone = track(function MenuZone() {
 				<Menu />
 				<div className="tlui-menu-zone__divider" />
 				<PageMenu />
-				{breakpoint >= 6 && showQuickActions && (
+				{breakpoint >= 6 && !isReadonly && !editor.isIn('hand') && (
 					<>
 						<div className="tlui-menu-zone__divider" />
 						<UndoButton />

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -110,21 +110,19 @@ export const Toolbar = memo(function Toolbar() {
 		<div className="tlui-toolbar">
 			<div className="tlui-toolbar__inner">
 				<div className="tlui-toolbar__left">
-					{!isReadonly && (
+					{!isReadonly && breakpoint < 6 && !editor.isIn('hand') && (
 						<div
 							className={classNames('tlui-toolbar__extras', {
 								'tlui-toolbar__extras__hidden': !showExtraActions,
 							})}
 						>
-							{breakpoint < 6 && (
-								<div className="tlui-toolbar__extras__controls">
-									<UndoButton />
-									<RedoButton />
-									<TrashButton />
-									<DuplicateButton />
-									<ActionsMenu />
-								</div>
-							)}
+							<div className="tlui-toolbar__extras__controls">
+								<UndoButton />
+								<RedoButton />
+								<TrashButton />
+								<DuplicateButton />
+								<ActionsMenu />
+							</div>
 							<ToggleToolLockedButton activeToolId={activeToolId} />
 						</div>
 					)}

--- a/packages/tldraw/src/lib/ui/components/TrashButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/TrashButton.tsx
@@ -15,13 +15,11 @@ export const TrashButton = track(function TrashButton() {
 
 	if (isReadonly) return null
 
-	const noSelected = editor.selectedShapeIds.length <= 0
-
 	return (
 		<Button
 			icon={action.icon}
 			onClick={() => action.onSelect('quick-actions')}
-			disabled={noSelected}
+			disabled={editor.isIn('select') && editor.selectedShapeIds.length > 0}
 			title={`${msg(action.label!)} ${kbdStr(action.kbd!)}`}
 			smallIcon
 		/>

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -83,8 +83,18 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {
-		function canActOnSelectedShapes() {
-			return !(editor.isIn('select') && editor.selectedShapeIds.length > 0)
+		function mustGoBackToSelectToolFirst() {
+			if (!editor.isIn('select')) {
+				editor.complete()
+				editor.setCurrentTool('select')
+				return true
+			}
+
+			return false
+		}
+
+		function hasSelectedShapes() {
+			return editor.selectedShapeIds.length > 0
 		}
 
 		const actions = makeActions([
@@ -94,7 +104,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'link',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('edit-link', { source })
 					editor.mark('edit-link')
 					addDialog({ component: EditLinkDialog })
@@ -214,7 +226,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.toggle-auto-size',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('toggle-auto-size', { source })
 					editor.mark('toggling auto size')
 					editor.updateShapes(
@@ -279,7 +293,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.convert-to-bookmark',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					editor.batch(() => {
 						trackEvent('convert-to-bookmark', { source })
 						const shapes = editor.selectedShapes
@@ -321,7 +337,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.convert-to-embed',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('convert-to-embed', { source })
 
 					editor.batch(() => {
@@ -377,7 +395,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'duplicate',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('duplicate-shapes', { source })
 					const ids = editor.selectedShapeIds
@@ -402,7 +421,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'ungroup',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('ungroup-shapes', { source })
 					editor.mark('ungroup')
@@ -416,7 +436,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'group',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('group-shapes', { source })
 					const { onlySelectedShape } = editor
@@ -436,7 +457,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-left',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'left', source })
 					editor.mark('align left')
@@ -451,7 +473,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-center-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-horizontal', source })
 					editor.mark('align center horizontal')
@@ -465,7 +488,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-right',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'right', source })
 					editor.mark('align right')
@@ -480,7 +504,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-center-vertical',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-vertical', source })
 					editor.mark('align center vertical')
@@ -494,7 +519,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?W',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'top', source })
 					editor.mark('align top')
@@ -508,7 +534,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?S',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'bottom', source })
 					editor.mark('align bottom')
@@ -523,7 +550,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?!h',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'horizontal', source })
 					editor.mark('distribute horizontal')
@@ -538,7 +566,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?!V',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'vertical', source })
 					editor.mark('distribute vertical')
@@ -552,7 +581,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stretch-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'horizontal', source })
 					editor.mark('stretch horizontal')
@@ -566,7 +596,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stretch-vertical',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'vertical', source })
 					editor.mark('stretch vertical')
@@ -580,7 +611,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!h',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'horizontal', source })
 					editor.mark('flip horizontal')
@@ -594,7 +626,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!v',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'vertical', source })
 					editor.mark('flip vertical')
@@ -607,7 +640,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'pack',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('pack-shapes', { source })
 					editor.mark('pack')
@@ -621,7 +655,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stack-vertical',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'vertical', source })
 					editor.mark('stack-vertical')
@@ -635,7 +670,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stack-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'horizontal', source })
 					editor.mark('stack-horizontal')
@@ -649,7 +685,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'bring-to-front',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toFront', source })
 					editor.mark('bring to front')
@@ -663,7 +700,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?]',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'forward', source })
 					editor.mark('bring forward')
@@ -677,7 +715,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?[',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'backward', source })
 					editor.mark('send backward')
@@ -691,7 +730,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '[',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toBack', source })
 					editor.mark('send to back')
@@ -704,7 +744,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$x',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					editor.mark('cut')
 					cut(source)
@@ -716,7 +757,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$c',
 				readonlyOk: true,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					copy(source)
 				},
@@ -743,13 +785,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					editor.batch(() => {
-						if (!editor.isIn('select')) return
+						if (mustGoBackToSelectToolFirst()) return
 
 						trackEvent('select-all-shapes', { source })
-						if (editor.currentToolId !== 'select') {
-							editor.cancel()
-							editor.setCurrentTool('select')
-						}
 
 						editor.mark('select all kbd')
 						editor.selectAll()
@@ -761,7 +799,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.select-none',
 				readonlyOk: true,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('select-none-shapes', { source })
 					editor.mark('select none')
@@ -775,7 +814,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'trash',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('delete-shapes', { source })
 					editor.mark('delete')
 					editor.deleteShapes(editor.selectedShapeIds)
@@ -787,7 +828,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'rotate-cw',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('rotate-cw', { source })
 					editor.mark('rotate-cw')
 					const offset = editor.selectionRotation % (TAU / 2)
@@ -801,7 +844,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'rotate-ccw',
 				readonlyOk: false,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('rotate-ccw', { source })
 					editor.mark('rotate-ccw')
 					const offset = editor.selectionRotation % (TAU / 2)
@@ -856,7 +901,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!2',
 				readonlyOk: true,
 				onSelect(source) {
-					if (!canActOnSelectedShapes()) return
+					if (!hasSelectedShapes()) return
+					if (mustGoBackToSelectToolFirst()) return
+
 					trackEvent('zoom-to-selection', { source })
 					editor.zoomToSelection({ duration: ANIMATION_MEDIUM_MS })
 				},

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -83,6 +83,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {
+		function canActOnSelectedShapes() {
+			return !(editor.isIn('select') && editor.selectedShapeIds.length > 0)
+		}
+
 		const actions = makeActions([
 			{
 				id: 'edit-link',
@@ -90,6 +94,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'link',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
 					trackEvent('edit-link', { source })
 					editor.mark('edit-link')
 					addDialog({ component: EditLinkDialog })
@@ -209,6 +214,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.toggle-auto-size',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
 					trackEvent('toggle-auto-size', { source })
 					editor.mark('toggling auto size')
 					editor.updateShapes(
@@ -273,6 +279,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.convert-to-bookmark',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
 					editor.batch(() => {
 						trackEvent('convert-to-bookmark', { source })
 						const shapes = editor.selectedShapes
@@ -314,6 +321,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.convert-to-embed',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
 					trackEvent('convert-to-embed', { source })
 
 					editor.batch(() => {
@@ -369,7 +377,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'duplicate',
 				readonlyOk: false,
 				onSelect(source) {
-					if (editor.currentToolId !== 'select') return
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('duplicate-shapes', { source })
 					const ids = editor.selectedShapeIds
 					const commonBounds = Box2d.Common(compact(ids.map((id) => editor.getShapePageBounds(id))))
@@ -393,6 +402,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'ungroup',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('ungroup-shapes', { source })
 					editor.mark('ungroup')
 					editor.ungroupShapes(editor.selectedShapeIds)
@@ -405,6 +416,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'group',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('group-shapes', { source })
 					const { onlySelectedShape } = editor
 					if (onlySelectedShape && editor.isShapeOfType<TLGroupShape>(onlySelectedShape, 'group')) {
@@ -423,6 +436,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-left',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'left', source })
 					editor.mark('align left')
 					editor.alignShapes(editor.selectedShapeIds, 'left')
@@ -436,6 +451,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-center-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'center-horizontal', source })
 					editor.mark('align center horizontal')
 					editor.alignShapes(editor.selectedShapeIds, 'center-horizontal')
@@ -448,6 +465,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-right',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'right', source })
 					editor.mark('align right')
 					editor.alignShapes(editor.selectedShapeIds, 'right')
@@ -461,6 +480,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'align-center-vertical',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'center-vertical', source })
 					editor.mark('align center vertical')
 					editor.alignShapes(editor.selectedShapeIds, 'center-vertical')
@@ -473,6 +494,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?W',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'top', source })
 					editor.mark('align top')
 					editor.alignShapes(editor.selectedShapeIds, 'top')
@@ -485,6 +508,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?S',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('align-shapes', { operation: 'bottom', source })
 					editor.mark('align bottom')
 					editor.alignShapes(editor.selectedShapeIds, 'bottom')
@@ -498,6 +523,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?!h',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('distribute-shapes', { operation: 'horizontal', source })
 					editor.mark('distribute horizontal')
 					editor.distributeShapes(editor.selectedShapeIds, 'horizontal')
@@ -511,6 +538,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?!V',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('distribute-shapes', { operation: 'vertical', source })
 					editor.mark('distribute vertical')
 					editor.distributeShapes(editor.selectedShapeIds, 'vertical')
@@ -523,6 +552,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stretch-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('stretch-shapes', { operation: 'horizontal', source })
 					editor.mark('stretch horizontal')
 					editor.stretchShapes(editor.selectedShapeIds, 'horizontal')
@@ -535,6 +566,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stretch-vertical',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('stretch-shapes', { operation: 'vertical', source })
 					editor.mark('stretch vertical')
 					editor.stretchShapes(editor.selectedShapeIds, 'vertical')
@@ -547,6 +580,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!h',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('flip-shapes', { operation: 'horizontal', source })
 					editor.mark('flip horizontal')
 					editor.flipShapes(editor.selectedShapeIds, 'horizontal')
@@ -559,6 +594,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!v',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('flip-shapes', { operation: 'vertical', source })
 					editor.mark('flip vertical')
 					editor.flipShapes(editor.selectedShapeIds, 'vertical')
@@ -570,6 +607,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'pack',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('pack-shapes', { source })
 					editor.mark('pack')
 					editor.packShapes(editor.selectedShapeIds, 16)
@@ -582,6 +621,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stack-vertical',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('stack-shapes', { operation: 'vertical', source })
 					editor.mark('stack-vertical')
 					editor.stackShapes(editor.selectedShapeIds, 'vertical', 16)
@@ -594,6 +635,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'stack-horizontal',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('stack-shapes', { operation: 'horizontal', source })
 					editor.mark('stack-horizontal')
 					editor.stackShapes(editor.selectedShapeIds, 'horizontal', 16)
@@ -606,6 +649,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'bring-to-front',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('reorder-shapes', { operation: 'toFront', source })
 					editor.mark('bring to front')
 					editor.bringToFront(editor.selectedShapeIds)
@@ -618,6 +663,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?]',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('reorder-shapes', { operation: 'forward', source })
 					editor.mark('bring forward')
 					editor.bringForward(editor.selectedShapeIds)
@@ -630,6 +677,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?[',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('reorder-shapes', { operation: 'backward', source })
 					editor.mark('send backward')
 					editor.sendBackward(editor.selectedShapeIds)
@@ -642,6 +691,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '[',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('reorder-shapes', { operation: 'toBack', source })
 					editor.mark('send to back')
 					editor.sendToBack(editor.selectedShapeIds)
@@ -653,6 +704,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$x',
 				readonlyOk: false,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					editor.mark('cut')
 					cut(source)
 				},
@@ -663,6 +716,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$c',
 				readonlyOk: true,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					copy(source)
 				},
 			},
@@ -688,6 +743,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					editor.batch(() => {
+						if (!editor.isIn('select')) return
+
 						trackEvent('select-all-shapes', { source })
 						if (editor.currentToolId !== 'select') {
 							editor.cancel()
@@ -704,6 +761,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.select-none',
 				readonlyOk: true,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
+
 					trackEvent('select-none-shapes', { source })
 					editor.mark('select none')
 					editor.selectNone()
@@ -716,7 +775,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'trash',
 				readonlyOk: false,
 				onSelect(source) {
-					if (editor.currentToolId !== 'select') return
+					if (!canActOnSelectedShapes()) return
 					trackEvent('delete-shapes', { source })
 					editor.mark('delete')
 					editor.deleteShapes(editor.selectedShapeIds)
@@ -728,7 +787,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'rotate-cw',
 				readonlyOk: false,
 				onSelect(source) {
-					if (editor.selectedShapeIds.length === 0) return
+					if (!canActOnSelectedShapes()) return
 					trackEvent('rotate-cw', { source })
 					editor.mark('rotate-cw')
 					const offset = editor.selectionRotation % (TAU / 2)
@@ -742,7 +801,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				icon: 'rotate-ccw',
 				readonlyOk: false,
 				onSelect(source) {
-					if (editor.selectedShapeIds.length === 0) return
+					if (!canActOnSelectedShapes()) return
 					trackEvent('rotate-ccw', { source })
 					editor.mark('rotate-ccw')
 					const offset = editor.selectionRotation % (TAU / 2)
@@ -797,6 +856,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!2',
 				readonlyOk: true,
 				onSelect(source) {
+					if (!canActOnSelectedShapes()) return
 					trackEvent('zoom-to-selection', { source })
 					editor.zoomToSelection({ duration: ANIMATION_MEDIUM_MS })
 				},

--- a/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
@@ -1,8 +1,9 @@
-import { Editor, TLBookmarkShape, TLEmbedShape, compact, useEditor, useValue } from '@tldraw/editor'
+import { Editor, TLBookmarkShape, TLEmbedShape, useEditor, useValue } from '@tldraw/editor'
 import React, { useMemo } from 'react'
 import { getEmbedInfo } from '../../utils/embeds'
 import {
 	TLUiMenuSchema,
+	compactMenuItems,
 	menuCustom,
 	menuGroup,
 	menuItem,
@@ -48,6 +49,7 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 	const breakpoint = useBreakpoint()
 	const isMobile = breakpoint < 5
 
+	const isSelectTool = useValue('isSelectTool', () => editor.currentToolId === 'select', [editor])
 	const isDarkMode = useValue('isDarkMode', () => editor.user.isDarkMode, [editor])
 	const animationSpeed = useValue('animationSpeed', () => editor.user.animationSpeed, [editor])
 	const isGridMode = useValue('isGridMode', () => editor.instanceState.isGridMode, [editor])
@@ -108,7 +110,7 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 	)
 
 	const menuSchema = useMemo<TLUiMenuSchema>(() => {
-		const menuSchema = compact([
+		const menuSchema = compactMenuItems([
 			menuGroup(
 				'menu',
 				menuSubmenu(
@@ -124,64 +126,71 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 						menuItem(actions['undo'], { disabled: !canUndo }),
 						menuItem(actions['redo'], { disabled: !canRedo })
 					),
-					menuGroup(
-						'clipboard-actions',
-						menuItem(actions['cut'], { disabled: noneSelected }),
-						menuItem(actions['copy'], { disabled: noneSelected }),
-						menuItem(actions['paste'], { disabled: !showMenuPaste })
-					),
-					menuGroup(
-						'conversions',
-						menuSubmenu(
-							'copy-as',
-							'menu.copy-as',
-							menuGroup(
-								'copy-as-group',
-								menuItem(actions['copy-as-svg'], { disabled: emptyPage }),
-								menuItem(actions['copy-as-png'], { disabled: emptyPage || !hasClipboardWrite }),
-								menuItem(actions['copy-as-json'], { disabled: emptyPage })
+					isSelectTool
+						? menuGroup(
+								'clipboard-actions',
+								menuItem(actions['cut'], { disabled: noneSelected }),
+								menuItem(actions['copy'], { disabled: noneSelected }),
+								menuItem(actions['paste'], { disabled: !showMenuPaste })
+						  )
+						: null,
+					isSelectTool &&
+						menuGroup(
+							'conversions',
+							menuSubmenu(
+								'copy-as',
+								'menu.copy-as',
+								menuGroup(
+									'copy-as-group',
+									menuItem(actions['copy-as-svg'], { disabled: emptyPage }),
+									menuItem(actions['copy-as-png'], { disabled: emptyPage || !hasClipboardWrite }),
+									menuItem(actions['copy-as-json'], { disabled: emptyPage })
+								),
+								menuGroup(
+									'export-bg',
+									menuItem(actions['toggle-transparent'], { checked: !exportBackground })
+								)
 							),
-							menuGroup(
-								'export-bg',
-								menuItem(actions['toggle-transparent'], { checked: !exportBackground })
+							menuSubmenu(
+								'export-as',
+								'menu.export-as',
+								menuGroup(
+									'export-as-group',
+									menuItem(actions['export-as-svg'], { disabled: emptyPage }),
+									menuItem(actions['export-as-png'], { disabled: emptyPage }),
+									menuItem(actions['export-as-json'], { disabled: emptyPage })
+								),
+								menuGroup(
+									'export-bg',
+									menuItem(actions['toggle-transparent'], { checked: !exportBackground })
+								)
 							)
 						),
-						menuSubmenu(
-							'export-as',
-							'menu.export-as',
-							menuGroup(
-								'export-as-group',
-								menuItem(actions['export-as-svg'], { disabled: emptyPage }),
-								menuItem(actions['export-as-png'], { disabled: emptyPage }),
-								menuItem(actions['export-as-json'], { disabled: emptyPage })
-							),
-							menuGroup(
-								'export-bg',
-								menuItem(actions['toggle-transparent'], { checked: !exportBackground })
-							)
+					isSelectTool &&
+						menuGroup(
+							'set-selection-group',
+							menuItem(actions['select-all'], { disabled: emptyPage }),
+							menuItem(actions['select-none'], { disabled: !oneSelected })
+						),
+					isSelectTool &&
+						menuGroup(
+							'selection',
+							showAutoSizeToggle && menuItem(actions['toggle-auto-size']),
+							showEditLink && menuItem(actions['edit-link']),
+							menuItem(actions['duplicate'], { disabled: !oneSelected }),
+							allowGroup && menuItem(actions['group']),
+							allowUngroup && menuItem(actions['ungroup']),
+							menuItem(actions['unlock-all'], { disabled: emptyPage })
+						),
+					isSelectTool &&
+						menuGroup('delete-group', menuItem(actions['delete'], { disabled: !oneSelected })),
+					isSelectTool &&
+						menuGroup(
+							'embeds',
+							oneEmbedSelected && menuItem(actions['open-embed-link']),
+							oneEmbedSelected && menuItem(actions['convert-to-bookmark']),
+							oneEmbeddableBookmarkSelected && menuItem(actions['convert-to-embed'])
 						)
-					),
-					menuGroup(
-						'set-selection-group',
-						menuItem(actions['select-all'], { disabled: emptyPage }),
-						menuItem(actions['select-none'], { disabled: !oneSelected })
-					),
-					menuGroup(
-						'selection',
-						showAutoSizeToggle && menuItem(actions['toggle-auto-size']),
-						showEditLink && menuItem(actions['edit-link']),
-						menuItem(actions['duplicate'], { disabled: !oneSelected }),
-						allowGroup && menuItem(actions['group']),
-						allowUngroup && menuItem(actions['ungroup']),
-						menuItem(actions['unlock-all'], { disabled: emptyPage })
-					),
-					menuGroup('delete-group', menuItem(actions['delete'], { disabled: !oneSelected })),
-					menuGroup(
-						'embeds',
-						oneEmbedSelected && menuItem(actions['open-embed-link']),
-						oneEmbedSelected && menuItem(actions['convert-to-bookmark']),
-						oneEmbeddableBookmarkSelected && menuItem(actions['convert-to-embed'])
-					)
 				),
 				menuSubmenu(
 					'view',
@@ -196,7 +205,8 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 					)
 				)
 			),
-			menuGroup('extras', menuItem(actions['insert-embed']), menuItem(actions['insert-media'])),
+			isSelectTool &&
+				menuGroup('extras', menuItem(actions['insert-embed']), menuItem(actions['insert-media'])),
 			menuGroup(
 				'preferences',
 				menuSubmenu(
@@ -232,6 +242,7 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 		editor,
 		overrides,
 		actions,
+		isSelectTool,
 		oneSelected,
 		twoSelected,
 		threeSelected,


### PR DESCRIPTION
This PR:

- improves the quick actions bar, enabling undo / redo actions when the eraser is selected.
- for actions that effect selected shapes, calling the action when the select tool is not selected will select the select tool
- actions that effect selected shapes are hidden from the menu when the select tool is not selected

### Change Type

- [x] `major`

### Test Plan

1. Select the eraser tool, the undo / redo buttons should still be there.

1. Select two shapes
2. Select the draw tool
3. The menu should not display most options, e.g. cut or paste, but should display undo / redo
4. Press Shift+H
5. The shapes should not move, but the select tool should be selected again

### Release Notes

- Improve the menu / kbds behavior when select tool is not active