### PR TITLE
fix(firefox): resolve dropdowns not opening with touch

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -33,7 +33,13 @@ export function Trigger({
 	'data-testid'?: string
 }) {
 	return (
-		<DropdownMenu.Trigger dir="ltr" data-testid={testId} asChild>
+		<DropdownMenu.Trigger
+			dir="ltr"
+			data-testid={testId}
+			asChild
+			// Firefox fix: Stop the dropdown immediately closing after touch
+			onTouchEnd={(e) => preventDefault(e)}
+		>
 			{children}
 		</DropdownMenu.Trigger>
 	)


### PR DESCRIPTION
Fixes #1921

### Change type

- [x] `bugfix` 

### Test plan

1. On firefox...
2. Use a touch device (or devtools)...
3. Try to open a dropdown menu, eg: main menu, styles menu, more tools menu.
4. Make sure the menu opens correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Firefox: Fixed dropdown menus not opening with touch.