### PR TITLE
fix clipping on nested non-intersecting frames

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3951,7 +3951,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/** @internal */
 	@computed private get _shapeMaskCache(): ComputedCache<Vec2d[], TLShape> {
-		return this.store.createComputedCache<Vec2d[], TLShape>('pageMaskCache', (shape) => {
+		return this.store.createComputedCache('pageMaskCache', (shape) => {
 			if (isPageId(shape.parentId)) {
 				return undefined
 			}
@@ -3973,7 +3973,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					if (intersection) {
 						return intersection.map(Vec2d.Cast)
 					}
-					return undefined
+					return []
 				})
 
 			return pageMask


### PR DESCRIPTION
Previously, if a shape had two frame parents and those frames didn't intersect, we'd render the shape without any clipping. This is because in the case that we don't find an intersection we were returning undefined (meaning nothing is masked out) instead of an empty array (meaning everything is masked out)

![Kapture 2023-09-19 at 16 34 08](https://github.com/tldraw/tldraw/assets/1489520/3192c3df-5a71-4dea-a720-6319a803cd1c)

Fixes #1933 

### Change Type

- [x] `patch` — Bug fix


### Test Plan

1. create a frame (A)
2. create a shape (B) to the left of frame A
3. create a frame (C) with another shape (D) inside to the left of shape B
4. select shape B and frame C
5. drag shape B into frame A
6. make sure both frame C and shape D are completely clipped


