### PR TITLE
fix line bugs

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
@@ -146,7 +146,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 		const line = editor.currentPageShapes[editor.currentPageShapes.length - 1]
 		assert(editor.isShapeOfType<TLLineShape>(line, 'line'))
 		const handles = Object.values(line.props.handles)
-		expect(handles.length).toBe(3)
+		expect(handles.length).toBe(2)
 	})
 
 	it('extends a line by shift-click dragging', () => {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -65,8 +65,8 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 					canBind: false,
 					canSnap: true,
 					index: 'a2',
-					x: 0,
-					y: 0,
+					x: 0.1,
+					y: 0.1,
 				},
 			},
 		}
@@ -243,7 +243,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				)
 			}
 		}
-
 		// Cubic style spline
 		if (shape.props.spline === 'cubic') {
 			const splinePath = getSvgPathForLineGeometry(spline)
@@ -255,7 +254,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 							strokeWidth={strokeWidth}
 							stroke={theme[color].solid}
 							fill="none"
-							d={'M0,0 ' + splinePath}
+							d={splinePath}
 						/>
 					</SVGContainer>
 				)

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -247,7 +247,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		// Cubic style spline
 		if (shape.props.spline === 'cubic') {
 			const splinePath = getSvgPathForLineGeometry(spline)
-
 			if (dash === 'solid') {
 				return (
 					<SVGContainer id={shape.id}>
@@ -256,7 +255,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 							strokeWidth={strokeWidth}
 							stroke={theme[color].solid}
 							fill="none"
-							d={splinePath}
+							d={'M0,0 ' + splinePath}
 						/>
 					</SVGContainer>
 				)

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -119,11 +119,11 @@ export class Pointing extends StateNode {
 				if (this.markId) this.editor.bailToMark(this.markId)
 				throw Error('No handles found')
 			}
-
+			const lastHandle = last(handles)!
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
 				isCreating: true,
-				handle: last(handles),
+				handle: { ...lastHandle, x: lastHandle.x - 0.1, y: lastHandle.y - 0.1 },
 				onInteractionEnd: 'line',
 			})
 		}

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -54,10 +54,11 @@ export class Pointing extends StateNode {
 
 			if (Vec2d.Dist(endHandle, prevEndHandle) < MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES) {
 				// If the end handle is too close to the previous end handle, we'll just extend the previous end handle
-				nextEndHandleIndex = prevEndHandle.index
-				nextEndHandleId = prevEndHandle.id
+
+				nextEndHandleIndex = endHandle.index
+				nextEndHandleId = endHandle.id
 				nextEndHandle = {
-					...prevEndHandle,
+					...endHandle,
 					x: currentPagePoint.x - shapePagePoint.x,
 					y: currentPagePoint.y - shapePagePoint.y,
 				}
@@ -113,6 +114,7 @@ export class Pointing extends StateNode {
 
 		if (this.editor.inputs.isDragging) {
 			const handles = this.editor.getShapeHandles(this.shape)
+			console
 			if (!handles) {
 				if (this.markId) this.editor.bailToMark(this.markId)
 				throw Error('No handles found')
@@ -121,11 +123,7 @@ export class Pointing extends StateNode {
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
 				isCreating: true,
-				handle: {
-					...last(handles)!,
-					x: 0,
-					y: 0,
-				},
+				handle: last(handles),
 				onInteractionEnd: 'line',
 			})
 		}

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -63,20 +63,20 @@ export class Pointing extends StateNode {
 				nextEndHandleId = endHandle.id
 				nextEndHandle = {
 					...endHandle,
-					x: currentPagePoint.x - shapePagePoint.x + 0.1,
-					y: currentPagePoint.y - shapePagePoint.y + 0.1,
+					x: nextPoint.x + 0.1,
+					y: nextPoint.y + 0.1,
 				}
 			} else {
 				// Otherwise, we'll create a new end handle
 				nextEndHandleIndex = getIndexAbove(endHandle.index)
 				nextEndHandleId = 'handle:' + nextEndHandleIndex
 				nextEndHandle = {
-					x: currentPagePoint.x - shapePagePoint.x + 0.1,
-					y: currentPagePoint.y - shapePagePoint.y + 0.1,
-					index: nextEndHandleIndex,
-					canBind: false,
-					type: 'vertex',
 					id: nextEndHandleId,
+					type: 'vertex',
+					index: nextEndHandleIndex,
+					x: nextPoint.x + 0.1,
+					y: nextPoint.y + 0.1,
+					canBind: false,
 				}
 			}
 

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -52,23 +52,27 @@ export class Pointing extends StateNode {
 
 			let nextEndHandleIndex: string, nextEndHandleId: string, nextEndHandle: TLHandle
 
-			if (Vec2d.Dist(endHandle, prevEndHandle) < MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES) {
-				// If the end handle is too close to the previous end handle, we'll just extend the previous end handle
+			const nextPoint = Vec2d.Sub(currentPagePoint, shapePagePoint)
 
+			if (
+				Vec2d.Dist(endHandle, prevEndHandle) < MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES ||
+				Vec2d.Dist(nextPoint, endHandle) < MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES
+			) {
+				// If the end handle is too close to the previous end handle, we'll just extend the previous end handle
 				nextEndHandleIndex = endHandle.index
 				nextEndHandleId = endHandle.id
 				nextEndHandle = {
 					...endHandle,
-					x: currentPagePoint.x - shapePagePoint.x,
-					y: currentPagePoint.y - shapePagePoint.y,
+					x: currentPagePoint.x - shapePagePoint.x + 0.1,
+					y: currentPagePoint.y - shapePagePoint.y + 0.1,
 				}
 			} else {
 				// Otherwise, we'll create a new end handle
 				nextEndHandleIndex = getIndexAbove(endHandle.index)
 				nextEndHandleId = 'handle:' + nextEndHandleIndex
 				nextEndHandle = {
-					x: currentPagePoint.x - shapePagePoint.x,
-					y: currentPagePoint.y - shapePagePoint.y,
+					x: currentPagePoint.x - shapePagePoint.x + 0.1,
+					y: currentPagePoint.y - shapePagePoint.y + 0.1,
 					index: nextEndHandleIndex,
 					canBind: false,
 					type: 'vertex',
@@ -123,6 +127,7 @@ export class Pointing extends StateNode {
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
 				isCreating: true,
+				// remove the offset that we added to the handle when we created it
 				handle: { ...lastHandle, x: lastHandle.x - 0.1, y: lastHandle.y - 0.1 },
 				onInteractionEnd: 'line',
 			})

--- a/packages/tldraw/src/lib/shapes/shared/polygon-helpers.ts
+++ b/packages/tldraw/src/lib/shapes/shared/polygon-helpers.ts
@@ -102,11 +102,7 @@ export function getDrawLinePathData(id: string, outline: VecLike[], strokeWidth:
 		s1 = Vec2d.AddXY(outline[i + 1], random() * offset, random() * offset)
 
 		const delta = Vec2d.Sub(p1, p0)
-		let distance = Vec2d.Len(delta)
-		//dodge a divide by zero error if the points are the same
-		if (distance === 0) {
-			distance = 0.01
-		}
+		const distance = Vec2d.Len(delta)
 		const vector = Vec2d.Div(delta, distance).mul(Math.min(distance / 4, roundness))
 
 		const q0 = Vec2d.Add(p0, vector)

--- a/packages/tldraw/src/lib/shapes/shared/polygon-helpers.ts
+++ b/packages/tldraw/src/lib/shapes/shared/polygon-helpers.ts
@@ -102,7 +102,11 @@ export function getDrawLinePathData(id: string, outline: VecLike[], strokeWidth:
 		s1 = Vec2d.AddXY(outline[i + 1], random() * offset, random() * offset)
 
 		const delta = Vec2d.Sub(p1, p0)
-		const distance = Vec2d.Len(delta)
+		let distance = Vec2d.Len(delta)
+		//dodge a divide by zero error if the points are the same
+		if (distance === 0) {
+			distance = 0.01
+		}
 		const vector = Vec2d.Div(delta, distance).mul(Math.min(distance / 4, roundness))
 
 		const q0 = Vec2d.Add(p0, vector)

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -110,19 +110,21 @@ export const Toolbar = memo(function Toolbar() {
 		<div className="tlui-toolbar">
 			<div className="tlui-toolbar__inner">
 				<div className="tlui-toolbar__left">
-					{!isReadonly && breakpoint < 6 && !editor.isInAny('hand', 'zoom') && (
+					{!isReadonly && (
 						<div
 							className={classNames('tlui-toolbar__extras', {
 								'tlui-toolbar__extras__hidden': !showExtraActions,
 							})}
 						>
-							<div className="tlui-toolbar__extras__controls">
-								<UndoButton />
-								<RedoButton />
-								<TrashButton />
-								<DuplicateButton />
-								<ActionsMenu />
-							</div>
+							{breakpoint < 6 && !editor.isInAny('hand', 'zoom') && (
+								<div className="tlui-toolbar__extras__controls">
+									<UndoButton />
+									<RedoButton />
+									<TrashButton />
+									<DuplicateButton />
+									<ActionsMenu />
+								</div>
+							)}
 							<ToggleToolLockedButton activeToolId={activeToolId} />
 						</div>
 					)}


### PR DESCRIPTION
closes #1913 

Some lines aren't rendering:
<img width="500" alt="shapes" src="https://github.com/tldraw/tldraw/assets/98838967/bd01bb0f-a967-46ce-9056-a81421224931">

When we begin drawing a line it's nice for the user to be able to see a dot, so we put down two points. The end point for a new line was set to the same position as the first point, which was causing a bunch of divide by zero errors. Offsetting it slightly fixes that.

Now when two handles are too close together we extend the second one instead of drawing a third. This will probably only ever happen with the first two points of a line.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Select the Line tool and set spline to line and dash to draw
2. Click around the canvas
3. You should now be able to actually see a line
4. Now set spline to cubic and dash to solid
5. shift click around the canvas
6. You should be able to see a line!

### Release Notes

- This PR patches a couple of bugs which led to straight draw lines and beziered dash lines not rendering on the canvas

Before & After:

<image width="250" src="https://github.com/tldraw/tldraw/assets/98838967/e0ca7d54-506f-4014-b65a-6b61a98e3665" />
<image width="250" src="https://github.com/tldraw/tldraw/assets/98838967/90c9fa12-1bcb-430d-80c7-97e1faacea16" />




