### PR TITLE
[infra] maybe fix canary publish

### DIFF
--- a/scripts/lib/publishing.ts
+++ b/scripts/lib/publishing.ts
@@ -153,5 +153,7 @@ export async function publish() {
 				await new Promise((resolve) => setTimeout(resolve, 3000))
 			}
 		}
+		nicelog('sleeping for 10 seconds to let npm think apparently')
+		await new Promise((resolve) => setTimeout(resolve, 10000))
 	}
 }


### PR DESCRIPTION
This last day or two our npm publish script has been randomly failing due to npm flakiness. I'm seeing the following error:

    Failed to save packument. A common cause is if you try to publish a new package before the previous package has been fully processed.

This doesn't seem to be our fault since we're publishing things in the right order, the version numbers and package.json files are all correct, and we're waiting for things to appear in the registry after publishing before moving on to the next package.

So I'm thinking maybe npm is a little tired right now or something and needs a little extra time to handle things.

So I've wrapped our publish command inside a retry block.

At the same time I noticed that the `--tolerate-republish` flag does not seem to be working for canary version numbers, so I've added some extra logic for that too. Hopefully this means if things fail due to persistent npm flake we can just run the action again.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
