### PR TITLE
Use media query to set default dark mode

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1202,6 +1202,9 @@ export function intersectPolygonPolygon(polygonA: VecLike[], polygonB: VecLike[]
 // @public
 export function isAngleBetween(a: number, b: number, c: number): boolean;
 
+// @internal (undocumented)
+export function isDarkModeByDefault(): boolean;
+
 // @public
 export const isSafeFloat: (n: number) => boolean;
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -108,6 +108,7 @@ export {
 	USER_COLORS,
 	getFreshUserPreferences,
 	getUserPreferences,
+	isDarkModeByDefault,
 	setUserPreferences,
 	type TLUserPreferences,
 } from './lib/config/TLUserPreferences'

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -99,11 +99,18 @@ export function getFreshUserPreferences(): TLUserPreferences {
 		locale: typeof window !== 'undefined' ? getDefaultTranslationLocale() : 'en',
 		name: 'New User',
 		color: getRandomColor(),
-		// TODO: detect dark mode
-		isDarkMode: false,
+		isDarkMode: isDarkModeByDefault(),
 		animationSpeed: 1,
 		isSnapMode: false,
 	}
+}
+
+/** @internal */
+export function isDarkModeByDefault() {
+	if (typeof window === 'undefined') {
+		return false
+	}
+	return window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
 }
 
 function migrateUserPreferences(userData: unknown) {


### PR DESCRIPTION
This PR makes it so that if you have `(prefers-color-scheme: dark)` then it will set dark mode to true by default when creating your user. This is technically a breaking change.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [x] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Determines initial dark mode choice based on the browser/os configuration.
