### PR TITLE
Fix arrow labels not being editable from other arrow labels

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
@@ -19,15 +19,21 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 	const {
 		rInput,
 		isEditing,
+		isEditingSameShapeType,
 		handleFocus,
 		handleBlur,
 		handleKeyDown,
 		handleChange,
 		isEmpty,
 		handleInputPointerDown,
+		handleDoubleClick,
 	} = useEditableText(id, 'arrow', text)
 
-	if (!isEditing && isEmpty) {
+	const isInteractive = isEditing || isEditingSameShapeType
+	const finalText = TextHelpers.normalizeTextForDom(text)
+	const hasText = finalText.trim().length > 0
+
+	if (!isInteractive && !hasText) {
 		return null
 	}
 
@@ -50,7 +56,7 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 				<p style={{ width: width ? width : '9px' }}>
 					{text ? TextHelpers.normalizeTextForDom(text) : ' '}
 				</p>
-				{isEditing && (
+				{isInteractive && (
 					// Consider replacing with content-editable
 					<textarea
 						ref={rInput}
@@ -61,7 +67,7 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 						autoCapitalize="false"
 						autoCorrect="false"
 						autoSave="false"
-						autoFocus
+						autoFocus={isEditing}
 						placeholder=""
 						spellCheck="true"
 						wrap="off"
@@ -74,6 +80,7 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 						onBlur={handleBlur}
 						onContextMenu={stopEventPropagation}
 						onPointerDown={handleInputPointerDown}
+						onDoubleClick={handleDoubleClick}
 					/>
 				)}
 			</div>

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -85,48 +85,46 @@ export const TextLabel = React.memo(function TextLabel<
 					: {}),
 			}}
 		>
-			{isEmpty && !isInteractive ? null : (
-				<div
-					className="tl-text-label__inner"
-					style={{
-						fontSize: LABEL_FONT_SIZES[size],
-						lineHeight: LABEL_FONT_SIZES[size] * TEXT_PROPS.lineHeight + 'px',
-						minHeight: TEXT_PROPS.lineHeight + 32,
-						minWidth: 0,
-						color: theme[labelColor].solid,
-					}}
-				>
-					<div className="tl-text tl-text-content" dir="ltr">
-						{finalText}
-					</div>
-					{isInteractive && (
-						<textarea
-							ref={rInput}
-							className="tl-text tl-text-input"
-							name="text"
-							tabIndex={-1}
-							autoComplete="false"
-							autoCapitalize="false"
-							autoCorrect="false"
-							autoSave="false"
-							autoFocus={isEditing}
-							placeholder=""
-							spellCheck="true"
-							wrap="off"
-							dir="auto"
-							datatype="wysiwyg"
-							defaultValue={text}
-							onFocus={handleFocus}
-							onChange={handleChange}
-							onKeyDown={handleKeyDown}
-							onBlur={handleBlur}
-							onContextMenu={stopEventPropagation}
-							onPointerDown={handleInputPointerDown}
-							onDoubleClick={handleDoubleClick}
-						/>
-					)}
+			<div
+				className="tl-text-label__inner"
+				style={{
+					fontSize: LABEL_FONT_SIZES[size],
+					lineHeight: LABEL_FONT_SIZES[size] * TEXT_PROPS.lineHeight + 'px',
+					minHeight: TEXT_PROPS.lineHeight + 32,
+					minWidth: 0,
+					color: theme[labelColor].solid,
+				}}
+			>
+				<div className="tl-text tl-text-content" dir="ltr">
+					{finalText}
 				</div>
-			)}
+				{isInteractive && (
+					<textarea
+						ref={rInput}
+						className="tl-text tl-text-input"
+						name="text"
+						tabIndex={-1}
+						autoComplete="false"
+						autoCapitalize="false"
+						autoCorrect="false"
+						autoSave="false"
+						autoFocus={isEditing}
+						placeholder=""
+						spellCheck="true"
+						wrap="off"
+						dir="auto"
+						datatype="wysiwyg"
+						defaultValue={text}
+						onFocus={handleFocus}
+						onChange={handleChange}
+						onKeyDown={handleKeyDown}
+						onBlur={handleBlur}
+						onContextMenu={stopEventPropagation}
+						onPointerDown={handleInputPointerDown}
+						onDoubleClick={handleDoubleClick}
+					/>
+				)}
+			</div>
 		</div>
 	)
 })

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -84,6 +84,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 			handleKeyDown,
 			handleBlur,
 			handleInputPointerDown,
+			handleDoubleClick,
 		} = useEditableText(id, type, text)
 
 		const zoomLevel = useValue('zoomLevel', () => this.editor.zoomLevel, [this.editor])
@@ -137,6 +138,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 							onTouchEnd={stopEventPropagation}
 							onContextMenu={stopEventPropagation}
 							onPointerDown={handleInputPointerDown}
+							onDoubleClick={handleDoubleClick}
 						/>
 					) : null}
 				</div>


### PR DESCRIPTION
This PR fixes a bug with editing arrow labels.

Previously, it was slightly broken, where you could click between them, but it sometimes selected the whole thing, and sometimes selected nothing. The cursor also wasn't the 'caret' cursor.

This PR also does some girl-scout cleaning up to make our three 'label' components more consistent.

Alternatively, we could make arrow labels behave differently to other labels, because they're usually smaller? Let me know if we want to change to that direction.


![2023-09-28 at 12 07 44 - Indigo Ferret](https://github.com/tldraw/tldraw/assets/15892272/bc77ba90-6885-458d-94d6-c335dbd053e5)

You might notice another 'flashing selection' issue in the above gif. There is still more to fix. Working on it right now! Will either add to this PR or create stacked PRs - whatever happens first.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Make two arrows.
2. Give them both labels.
3. While editing one arrow label, click into the **center** of the other arrow label.
4. Make sure that you are able to click into that arrow label, and start typing in text to the **center** of the label.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- None: Unreleased bug