### PR TITLE
Allow clicks on editing frame label

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -31,6 +31,10 @@ export const FrameHeading = function FrameHeading({
 	const handlePointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			const event = getPointerInfo(e)
+
+			// If we're editing the frame label, we shouldn't hijack the pointer event
+			if (editor.editingShapeId === id) return
+
 			editor.dispatch({
 				type: 'pointer',
 				name: 'pointer_down',


### PR DESCRIPTION
This PR doesn't target main!

It targets #1955

Hey @MitjaBezensek, this should let the user click on a frame label they're editing without losing focus of it!
Feel free to merge this into your branch, or copy-paste the line of code!