### PR TITLE
Allow right clicking selection backgrounds

### DIFF
--- a/packages/editor/src/lib/hooks/useSelectionEvents.ts
+++ b/packages/editor/src/lib/hooks/useSelectionEvents.ts
@@ -13,16 +13,16 @@ export function useSelectionEvents(handle: TLSelectionHandle) {
 			const onPointerDown: React.PointerEventHandler = (e) => {
 				if ((e as any).isKilled) return
 
-				if (e.button === 2) {
-					editor.dispatch({
-						type: 'pointer',
-						target: 'selection',
-						handle,
-						name: 'right_click',
-						...getPointerInfo(e),
-					})
-					return
-				}
+				// if (e.button === 2) {
+				// 	editor.dispatch({
+				// 		type: 'pointer',
+				// 		target: 'selection',
+				// 		handle,
+				// 		name: 'right_click',
+				// 		...getPointerInfo(e),
+				// 	})
+				// 	return
+				// }
 
 				if (e.button !== 0) return
 

--- a/packages/editor/src/lib/hooks/useSelectionEvents.ts
+++ b/packages/editor/src/lib/hooks/useSelectionEvents.ts
@@ -13,16 +13,16 @@ export function useSelectionEvents(handle: TLSelectionHandle) {
 			const onPointerDown: React.PointerEventHandler = (e) => {
 				if ((e as any).isKilled) return
 
-				// if (e.button === 2) {
-				// 	editor.dispatch({
-				// 		type: 'pointer',
-				// 		target: 'selection',
-				// 		handle,
-				// 		name: 'right_click',
-				// 		...getPointerInfo(e),
-				// 	})
-				// 	return
-				// }
+				if (e.button === 2) {
+					editor.dispatch({
+						type: 'pointer',
+						target: 'selection',
+						handle,
+						name: 'right_click',
+						...getPointerInfo(e),
+					})
+					return
+				}
 
 				if (e.button !== 0) return
 

--- a/packages/editor/src/lib/hooks/useSelectionEvents.ts
+++ b/packages/editor/src/lib/hooks/useSelectionEvents.ts
@@ -12,6 +12,18 @@ export function useSelectionEvents(handle: TLSelectionHandle) {
 		function selectionEvents() {
 			const onPointerDown: React.PointerEventHandler = (e) => {
 				if ((e as any).isKilled) return
+
+				if (e.button === 2) {
+					editor.dispatch({
+						type: 'pointer',
+						target: 'selection',
+						handle,
+						name: 'right_click',
+						...getPointerInfo(e),
+					})
+					return
+				}
+
 				if (e.button !== 0) return
 
 				// Because the events are probably set on SVG elements,

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -332,25 +332,25 @@ export class Idle extends StateNode {
 					return
 				}
 
-				const {
-					onlySelectedShape,
-					selectedShapeIds,
-					inputs: { currentPagePoint },
-				} = this.editor
+				// const {
+				// 	onlySelectedShape,
+				// 	selectedShapeIds,
+				// 	inputs: { currentPagePoint },
+				// } = this.editor
 
-				if (
-					selectedShapeIds.length > 1 ||
-					(onlySelectedShape &&
-						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
-				) {
-					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
-						this.onRightClick({
-							...info,
-							target: 'selection',
-						})
-						return
-					}
-				}
+				// if (
+				// 	selectedShapeIds.length > 1 ||
+				// 	(onlySelectedShape &&
+				// 		!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+				// ) {
+				// 	if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
+				// 		this.onRightClick({
+				// 			...info,
+				// 			target: 'selection',
+				// 		})
+				// 		return
+				// 	}
+				// }
 
 				this.editor.selectNone()
 				break

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -332,25 +332,25 @@ export class Idle extends StateNode {
 					return
 				}
 
-				// const {
-				// 	onlySelectedShape,
-				// 	selectedShapeIds,
-				// 	inputs: { currentPagePoint },
-				// } = this.editor
+				const {
+					onlySelectedShape,
+					selectedShapeIds,
+					inputs: { currentPagePoint },
+				} = this.editor
 
-				// if (
-				// 	selectedShapeIds.length > 1 ||
-				// 	(onlySelectedShape &&
-				// 		!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
-				// ) {
-				// 	if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
-				// 		this.onRightClick({
-				// 			...info,
-				// 			target: 'selection',
-				// 		})
-				// 		return
-				// 	}
-				// }
+				if (
+					selectedShapeIds.length > 1 ||
+					(onlySelectedShape &&
+						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+				) {
+					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
+						this.onRightClick({
+							...info,
+							target: 'selection',
+						})
+						return
+					}
+				}
 
 				this.editor.selectNone()
 				break

--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -332,6 +332,26 @@ export class Idle extends StateNode {
 					return
 				}
 
+				const {
+					onlySelectedShape,
+					selectedShapeIds,
+					inputs: { currentPagePoint },
+				} = this.editor
+
+				if (
+					selectedShapeIds.length > 1 ||
+					(onlySelectedShape &&
+						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+				) {
+					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
+						this.onRightClick({
+							...info,
+							target: 'selection',
+						})
+						return
+					}
+				}
+
 				this.editor.selectNone()
 				break
 			}

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1611,3 +1611,23 @@ it('selects one of the selected shapes on pointer up', () => {
 	editor.pointerUp()
 	expect(editor.selectedShapeIds).toEqual([ids.box1])
 })
+
+describe('right clicking', () => {
+	it('selects on right click', () => {
+		editor.createShapes([{ id: ids.box1, type: 'geo' }])
+		expect(editor.selectedShapeIds).toEqual([])
+		editor.pointerMove(4, 4)
+		editor.pointerDown(4, 4, { target: 'canvas', button: 2 })
+		editor.pointerUp()
+		expect(editor.selectedShapeIds).toEqual([ids.box1])
+	})
+
+	it('keeps selection when right-clicking a selection background', () => {
+		editor.createShapes([{ id: ids.box1, type: 'geo' }])
+		editor.selectAll()
+		editor.pointerMove(30, 30)
+		editor.pointerDown(30, 30, { target: 'canvas', button: 2 })
+		editor.pointerUp()
+		expect(editor.selectedShapeIds).toEqual([ids.box1])
+	})
+})

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1630,4 +1630,26 @@ describe('right clicking', () => {
 		editor.pointerUp()
 		expect(editor.selectedShapeIds).toEqual([ids.box1])
 	})
+
+	it('keeps selection when right-clicking a selection background', () => {
+		editor
+			.selectAll()
+			.deleteShapes(editor.selectedShapeIds)
+			.setCurrentTool('arrow')
+			.pointerMove(500, 500)
+			.pointerDown()
+			.pointerMove(600, 600)
+			.pointerUp()
+			.selectAll()
+			.setCurrentTool('select')
+
+		expect(editor.selectedShapeIds.length).toBe(1)
+
+		// Not inside of the shape but inside of the selection bounds
+		editor.pointerMove(510, 590)
+		expect(editor.hoveredShapeId).toBe(null)
+		editor.pointerDown(30, 30, { target: 'canvas', button: 2 })
+		editor.pointerUp()
+		expect(editor.selectedShapeIds).toEqual([])
+	})
 })


### PR DESCRIPTION
This PR fixes not being able to right-click the selection background of shapes.
* It still lets you right-click outside of a selection to deselect.
* It still lets you right-click a different shape inside the selection bounds.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Draw a squiggle.
2. Select it.
3. Right-click somewhere inside the selection bounds (but NOT on the squiggle itself).
4. The context menu should open.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Improved right click behaviour.
