### PR TITLE
Mark an undo before toggling lock

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -1082,6 +1082,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: false,
 				kbd: '!l',
 				onSelect(source) {
+					editor.mark('locking')
 					trackEvent('toggle-lock', { source })
 					editor.toggleLock(editor.selectedShapeIds)
 				},


### PR DESCRIPTION
This PR adds a history mark before toggling locked.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a shape.
2. Use the menu or a shortcut to toggle locked.
3. Undo.
4. The locked should undo but the shape should still be there.

### Release Notes

- Mark an undo before toggling locked.