### PR TITLE
Make state node methods arrow functions

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1780,11 +1780,11 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     // (undocumented)
     editor: Editor;
     // (undocumented)
-    enter(info: any, from: string): void;
+    enter: (info: any, from: string) => void;
     // (undocumented)
-    exit(info: any, from: string): void;
+    exit: (info: any, from: string) => void;
     // (undocumented)
-    handleEvent(info: Exclude<TLEventInfo, TLPinchEventInfo>): void;
+    handleEvent: (info: Exclude<TLEventInfo, TLPinchEventInfo>) => void;
     // (undocumented)
     static id: string;
     // (undocumented)
@@ -1836,7 +1836,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     // (undocumented)
     shapeType?: string;
     // (undocumented)
-    transition(id: string, info: any): this;
+    transition: (id: string, info: any) => this;
     // (undocumented)
     type: TLStateNodeType;
 }

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -74,7 +74,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 
 	isActive = false
 
-	transition(id: string, info: any) {
+	transition = (id: string, info: any) => {
 		const path = id.split('.')
 
 		let currState = this as StateNode
@@ -101,7 +101,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 		return this
 	}
 
-	handleEvent(info: Exclude<TLEventInfo, TLPinchEventInfo>) {
+	handleEvent = (info: Exclude<TLEventInfo, TLPinchEventInfo>) => {
 		const cbName = EVENT_NAME_MAP[info.name]
 		const x = this.current.value
 		this[cbName]?.(info as any)
@@ -110,7 +110,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 		}
 	}
 
-	enter(info: any, from: string) {
+	enter = (info: any, from: string) => {
 		this.isActive = true
 		this.onEnter?.(info, from)
 		if (this.children && this.initial && this.isActive) {
@@ -120,7 +120,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 		}
 	}
 
-	exit(info: any, from: string) {
+	exit = (info: any, from: string) => {
 		this.isActive = false
 		this.onExit?.(info, from)
 		if (!this.isActive) {


### PR DESCRIPTION
This PR fixes some cases where, if a member function (like `onEnter`) was not an arrow function, it would not run.

### Change Type

- [x] `patch` — Bug fix
