### PR TITLE
[fix] Screen bounds offset after editing text

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/children/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/EditingShape.ts
@@ -31,6 +31,10 @@ export class EditingShape extends StateNode {
 
 		// Check for changes on editing end
 		util.onEditEnd?.(shape)
+
+		setTimeout(() => {
+			this.editor.updateViewportScreenBounds()
+		}, 500)
 	}
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {


### PR DESCRIPTION
This PR fixes an issue where the screen bounds could be wrong after editing text on iOS / mobile.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On iOS, create a text shape at the bottom of the screen.
2. Edit the text shape.
3. Stop editing.
4. Drag a selection box to confirm that the page bounds is still correct.
