### PR TITLE
[fix] Drawing tool touch for first pen mark

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -69,13 +69,17 @@ export class Drawing extends StateNode {
 			// The user made a palm gesture before starting a pen gesture;
 			// ideally we'd start the new shape here but we could also just bail
 			// as the next interaction will work correctly
-			this.cancel()
-		}
-
-		// If we came in from a menu but have no started dragging...
-		if (!this.canDraw && inputs.isDragging) {
-			this.startShape()
-			this.canDraw = true // bad name
+			if (this.markId) {
+				this.editor.bailToMark(this.markId)
+				this.startShape()
+				return
+			}
+		} else {
+			// If we came in from a menu but have no started dragging...
+			if (!this.canDraw && inputs.isDragging) {
+				this.startShape()
+				this.canDraw = true // bad name
+			}
 		}
 
 		if (this.canDraw) {


### PR DESCRIPTION
This PR fixes a bug where a touch from a palm received at the start of a drawing operation, when that operation was the first entry into pen mode, would cause the line to fail.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On an iPad with a pencil, select the draw tool. Ensure that you're not yet in pen mode.
2. Place your palm on the iPad and immediately place the pencil on the screen.
3. Previously, you would get a line between your palm and the pencil point. Now, you should get only the pencil point.

### Release Notes

- [fix] Accidental palm inputs when using iPad pencil