### PR TITLE
[fix] pinch events

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8568,34 +8568,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.setSelectedShapes(this._selectedShapeIdsAtPointerDown, { squashing: true })
 							this._selectedShapeIdsAtPointerDown = []
 
-							const {
-								camera: { x: cx, y: cy, z: cz },
-							} = this
-
-							let zoom: number | undefined
-
-							if (cz > 0.9 && cz < 1.05) {
-								zoom = 1
-							} else if (cz > 0.49 && cz < 0.505) {
-								zoom = 0.5
-							}
-
-							if (cz > this._pinchStart - 0.1 && cz < this._pinchStart + 0.05) {
-								zoom = this._pinchStart
-							}
-
-							if (zoom !== undefined) {
-								const { x, y } = this.viewportScreenCenter
-								this.setCamera(
-									{
-										x: cx + (x / zoom - x) - (x / cz - x),
-										y: cy + (y / zoom - y) - (y / cz - y),
-										z: zoom,
-									},
-									{ duration: 100 }
-								)
-							}
-
 							if (this._didPinch) {
 								this._didPinch = false
 								requestAnimationFrame(() => {


### PR DESCRIPTION
This PR improves pinch events on touch screens.

It tries to avoid zooming unless we're sure that the user is zooming (or at least, that they've started zooming). It removes behavior that snaps the pinch to a certain zoom (e.g. 100%, 50%).

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On iPad, try to two-finger pan without zooming.
2. Perform a zoom.
3. Perform a two-finger pan, then a zoom.

### Release Notes

- Improve pinch gesture events.