### PR TITLE
Sliiiightly darken muted-2 color.

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -102,7 +102,7 @@
 	--color-culled: rgb(235, 238, 240);
 	--color-muted-0: rgba(0, 0, 0, 0.02);
 	--color-muted-1: rgba(0, 0, 0, 0.1);
-	--color-muted-2: rgba(0, 0, 0, 0.035);
+	--color-muted-2: rgba(0, 0, 0, 0.042);
 	--color-hint: rgba(0, 0, 0, 0.055);
 	--color-overlay: rgba(0, 0, 0, 0.2);
 	--color-divider: #e8e8e8;


### PR DESCRIPTION
This PR slightly darkens the muted-2 color, shown when hovering menu items.

<img width="881" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/ffe5f0c6-323e-4e78-a4eb-0a28a4b026c0">


### Change Type

- [x] `patch` — Bug fix