### PR TITLE
Fix style panel opening when disabled

### DIFF
--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -24,7 +24,9 @@ export function MobileStylePanel() {
 
 	const disableStylePanel = useValue(
 		'isHandOrEraserToolActive',
-		() => editor.isInAny('hand', 'zoom', 'eraser', 'laser'),
+		() =>
+			(editor.isIn('select') && editor.selectedShapeIds.length === 0) ||
+			editor.isInAny('hand', 'zoom', 'eraser', 'laser'),
 		[editor]
 	)
 


### PR DESCRIPTION
Closes #1982

When choosing whether to disable the mobile style menu, we now also check if the select tool is active and whether any shapes have been selected.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On a small screen
2. Choose the select tool
3. Deselect all shapes
4. Click on the disabled style menu button

Expected: Nothing should happen
Actual: The style menu opens

### Release Notes

- When select tool is active, the style menu shouldn't be openable unless a shape is also selected.

Before/After

<img width="300" src="https://github.com/tldraw/tldraw/assets/98838967/91ea55c8-0fcc-4f73-b61e-565829a5f25e" />
<img width="300" src="https://github.com/tldraw/tldraw/assets/98838967/ee4070fe-e236-4818-8fb4-43520210102b" />




