### PR TITLE
[fix] Hovered indicators shown when coarse pointer

### DIFF
--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -346,11 +346,14 @@ function SelectedIdIndicators() {
 const HoveredShapeIndicator = function HoveredShapeIndicator() {
 	const editor = useEditor()
 	const { HoveredShapeIndicator } = useEditorComponents()
+	const isCoarsePointer = useValue('coarse pointer', () => editor.instanceState.isCoarsePointer, [
+		editor,
+	])
 	const hoveredShapeId = useValue('hovered id', () => editor.currentPageState.hoveredShapeId, [
 		editor,
 	])
 
-	if (!hoveredShapeId || !HoveredShapeIndicator) return null
+	if (isCoarsePointer || !hoveredShapeId || !HoveredShapeIndicator) return null
 
 	return <HoveredShapeIndicator shapeId={hoveredShapeId} />
 }


### PR DESCRIPTION
This PR hides hovered indicators when using a coarse pointer.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On an iPad or touch device, use the draw tool.
2. Select the select tool.
3. You should not see the hovered indicator on the drawn shape.


### Release Notes

- Hide hovered indicators on mobile / coarse pointer devices.