### PR TITLE
[fix] X box shape arrow intersections

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1013,8 +1013,6 @@ export abstract class Geometry2d {
     // (undocumented)
     nearestPointOnLineSegment(A: Vec2d, B: Vec2d): Vec2d;
     // (undocumented)
-    get outerVertices(): Vec2d[];
-    // (undocumented)
     get snapPoints(): Vec2d[];
     // (undocumented)
     _snapPoints: undefined | Vec2d[];

--- a/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
@@ -86,11 +86,7 @@ export function getCurvedArrowInfo(
 
 		let point: VecLike | undefined
 
-		let intersections = fn(
-			centerInStartShapeLocalSpace,
-			handleArc.radius,
-			editor.getShapeGeometry(startShapeInfo.shape).vertices
-		)
+		let intersections = fn(centerInStartShapeLocalSpace, handleArc.radius, startShapeInfo.outline)
 
 		if (intersections) {
 			// Filter out any intersections that aren't in the arc
@@ -155,11 +151,7 @@ export function getCurvedArrowInfo(
 
 		let point: VecLike | undefined
 
-		let intersections = fn(
-			centerInEndShapeLocalSpace,
-			handleArc.radius,
-			editor.getShapeGeometry(endShapeInfo.shape).vertices
-		)
+		let intersections = fn(centerInEndShapeLocalSpace, handleArc.radius, endShapeInfo.outline)
 
 		if (intersections) {
 			intersections = intersections.filter(

--- a/packages/editor/src/lib/editor/shapes/shared/arrow/shared.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/shared.ts
@@ -1,6 +1,7 @@
 import { TLArrowShape, TLArrowShapeTerminal, TLShape } from '@tldraw/tlschema'
 import { Matrix2d } from '../../../../primitives/Matrix2d'
 import { Vec2d } from '../../../../primitives/Vec2d'
+import { Group2d } from '../../../../primitives/geometry/Group2d'
 import { Editor } from '../../../Editor'
 
 export function getIsArrowStraight(shape: TLArrowShape) {
@@ -28,13 +29,19 @@ export function getBoundShapeInfoForTerminal(
 	const transform = editor.getShapePageTransform(shape)!
 	const geometry = editor.getShapeGeometry(shape)
 
+	// This is hacky: we're only looking at the first child in the group. Really the arrow should
+	// consider all items in the group which are marked as snappable as separate polygons with which
+	// to intersect, in the case of a group that has multiple children which do not overlap; or else
+	// flatten the geometry into a set of polygons and intersect with that.
+	const outline = geometry instanceof Group2d ? geometry.children[0].vertices : geometry.vertices
+
 	return {
 		shape,
 		transform,
 		isClosed: geometry.isClosed,
 		isExact: terminal.isExact,
 		didIntersect: false,
-		outline: geometry.outerVertices,
+		outline,
 	}
 }
 

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -85,10 +85,6 @@ export abstract class Geometry2d {
 		return this._vertices
 	}
 
-	get outerVertices() {
-		return this.vertices
-	}
-
 	getBounds() {
 		return Box2d.FromPoints(this.vertices)
 	}


### PR DESCRIPTION
This PR fixes an issue with curved arrows binding to shapes with lines (xbox, checkbox).

### Change Type

- [x] `patch` — Bug fix
