### PR TITLE
fix cloud rendering

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/components/DashStyleCloud.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/components/DashStyleCloud.tsx
@@ -37,11 +37,13 @@ export const DashStyleCloud = React.memo(function DashStylePolygon({
 			<ShapeFill theme={theme} d={innerPath} fill={fill} color={color} />
 			<g strokeWidth={strokeWidth} stroke={theme[color].solid} fill="none" pointerEvents="all">
 				{arcs.map(({ leftPoint, rightPoint, center, radius }, i) => {
-					const angle = canonicalizeRotation(
-						canonicalizeRotation(Vec2d.Angle(center, rightPoint)) -
-							canonicalizeRotation(Vec2d.Angle(center, leftPoint))
-					)
-					const arcLength = radius * angle
+					const arcLength = center
+						? radius *
+						  canonicalizeRotation(
+								canonicalizeRotation(Vec2d.Angle(center, rightPoint)) -
+									canonicalizeRotation(Vec2d.Angle(center, leftPoint))
+						  )
+						: Vec2d.Dist(leftPoint, rightPoint)
 
 					const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
 						arcLength,
@@ -56,7 +58,11 @@ export const DashStyleCloud = React.memo(function DashStylePolygon({
 					return (
 						<path
 							key={i}
-							d={`M${leftPoint.x},${leftPoint.y}A${radius},${radius},0,0,1,${rightPoint.x},${rightPoint.y}`}
+							d={
+								center
+									? `M${leftPoint.x},${leftPoint.y}A${radius},${radius},0,0,1,${rightPoint.x},${rightPoint.y}`
+									: `M${leftPoint.x},${leftPoint.y}L${rightPoint.x},${rightPoint.y}`
+							}
 							strokeDasharray={strokeDasharray}
 							strokeDashoffset={strokeDashoffset}
 						/>
@@ -91,11 +97,13 @@ export function DashStyleCloudSvg({
 	strokeElement.setAttribute('fill', 'none')
 
 	for (const { leftPoint, rightPoint, center, radius } of arcs) {
-		const angle = canonicalizeRotation(
-			canonicalizeRotation(Vec2d.Angle(center, rightPoint)) -
-				canonicalizeRotation(Vec2d.Angle(center, leftPoint))
-		)
-		const arcLength = radius * angle
+		const arcLength = center
+			? radius *
+			  canonicalizeRotation(
+					canonicalizeRotation(Vec2d.Angle(center, rightPoint)) -
+						canonicalizeRotation(Vec2d.Angle(center, leftPoint))
+			  )
+			: Vec2d.Dist(leftPoint, rightPoint)
 
 		const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(arcLength, strokeWidth, {
 			style: dash,
@@ -106,7 +114,9 @@ export function DashStyleCloudSvg({
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 		path.setAttribute(
 			'd',
-			`M${leftPoint.x},${leftPoint.y}A${radius},${radius},0,0,1,${rightPoint.x},${rightPoint.y}`
+			center
+				? `M${leftPoint.x},${leftPoint.y}A${radius},${radius},0,0,1,${rightPoint.x},${rightPoint.y}`
+				: `M${leftPoint.x},${leftPoint.y}L${rightPoint.x},${rightPoint.y}`
 		)
 		path.setAttribute('stroke-dasharray', strokeDasharray.toString())
 		path.setAttribute('stroke-dashoffset', strokeDashoffset.toString())


### PR DESCRIPTION
Fixes #1996 

This fixes a few issues with cloud rendering:

- At small sizes the arcs could get kind of inverted after being mutated, so you'd end calculating the outline using the large arc instead of the small arc and it would balloon the size of the bounds (that was what Mitja was seeing in #1996 
- While working on the above I noticed that there are some situations where we were actually supposed to be using the large arc for rendering the svg paths but we were using the small arcs instead, making the bounds appear larger than the cloud shape when in fact the cloud shape was too small.
- I also fixed some other issues related to rendering clouds with tiny width/height. It now draws straight lines instead of arcs if the arcs are essentially flat, and it increases the number of lumps when width or height are very small to avoid certain kinds of weirdness.


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Improves cloud shape rendering
