### PR TITLE
Fix vs code extension. Prepare for new release.

### DIFF
--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -30,7 +30,7 @@ The code is hot-reloaded, so the developer experience is quite nice.
 
 ## Publishing
 
-Update the `CHANGELOG.md` with the new version number and the changes.
+Update the version in the `apps/vscode/extension/package.json`. Update the `apps/vscode/extension/CHANGELOG.md` with the new version number and the changes.
 
 To publish:
 

--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -3,15 +3,7 @@ import { linksUiOverrides } from './utils/links'
 import '@tldraw/tldraw/tldraw.css'
 // eslint-disable-next-line import/no-internal-modules
 import { getAssetUrlsByImport } from '@tldraw/assets/imports'
-import {
-	Editor,
-	ErrorBoundary,
-	TLUiMenuSchema,
-	Tldraw,
-	defaultShapeTools,
-	defaultShapeUtils,
-	setRuntimeOverrides,
-} from '@tldraw/tldraw'
+import { Editor, ErrorBoundary, TLUiMenuSchema, Tldraw, setRuntimeOverrides } from '@tldraw/tldraw'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { VscodeMessage } from '../../messages'
 import '../public/index.css'
@@ -130,8 +122,6 @@ function TldrawInner({ uri, assetSrc, isDarkMode, fileContents }: TLDrawInnerPro
 
 	return (
 		<Tldraw
-			shapeUtils={defaultShapeUtils}
-			tools={defaultShapeTools}
 			assetUrls={assetUrls}
 			persistenceKey={uri}
 			onMount={handleMount}

--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.12
+- Bug fixes and performance improvements.
+
 ## 2.0.11
 - Added cloud shape.
 

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.11",
+	"version": "2.0.12",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
Fixes an issue with VS Code extension. Seem like we don't need to pass in the tools and utils any longer.

Prepares the vs code extension for a new release (bumps version, updates changelog).

### Change Type

- [x] `patch` — Bug fix