### PR TITLE
Remove topBar prop from <TldrawUi />

### DIFF
--- a/apps/examples/src/examples/ZonesExample.tsx
+++ b/apps/examples/src/examples/ZonesExample.tsx
@@ -4,7 +4,7 @@ import '@tldraw/tldraw/tldraw.css'
 export default function Example() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw shareZone={<CustomShareZone />} topZone={<CustomTopZone />} />
+			<Tldraw shareZone={<CustomShareZone />} />
 		</div>
 	)
 }
@@ -20,20 +20,6 @@ function CustomShareZone() {
 			}}
 		>
 			<p>Share Zone</p>
-		</div>
-	)
-}
-
-function CustomTopZone() {
-	return (
-		<div
-			style={{
-				width: '100%',
-				backgroundColor: 'dodgerblue',
-				textAlign: 'center',
-			}}
-		>
-			<p>Top Zone</p>
 		</div>
 	)
 }

--- a/packages/editor/src/lib/hooks/useScreenBounds.ts
+++ b/packages/editor/src/lib/hooks/useScreenBounds.ts
@@ -8,9 +8,7 @@ export function useScreenBounds() {
 	useLayoutEffect(() => {
 		const updateBounds = throttle(
 			() => {
-				if (editor.instanceState.isFocused) {
-					editor.updateViewportScreenBounds()
-				}
+				editor.updateViewportScreenBounds()
 			},
 			200,
 			{

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1133,6 +1133,7 @@ export interface TldrawUiBaseProps {
     hideUi?: boolean;
     renderDebugMenuItems?: () => React_2.ReactNode;
     shareZone?: ReactNode;
+    topZone?: ReactNode;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -963,6 +963,9 @@ export function setDefaultEditorAssetUrls(assetUrls: TLEditorAssetUrls): void;
 // @internal (undocumented)
 export function setDefaultUiAssetUrls(urls: TLUiAssetUrls): void;
 
+// @internal (undocumented)
+export function Spinner(props: React_2.SVGProps<SVGSVGElement>): JSX.Element;
+
 // @public (undocumented)
 function Sub({ id, children }: {
     id: string;
@@ -1130,7 +1133,6 @@ export interface TldrawUiBaseProps {
     hideUi?: boolean;
     renderDebugMenuItems?: () => React_2.ReactNode;
     shareZone?: ReactNode;
-    topZone?: ReactNode;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1135,6 +1135,7 @@ export interface TldrawUiBaseProps {
     hideUi?: boolean;
     renderDebugMenuItems?: () => React_2.ReactNode;
     shareZone?: ReactNode;
+    // @internal
     topZone?: ReactNode;
 }
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './lib/ui/TldrawUiContextProvider'
 export { setDefaultUiAssetUrls } from './lib/ui/assetUrls'
 export { ContextMenu, type TLUiContextMenuProps } from './lib/ui/components/ContextMenu'
+export { Spinner } from './lib/ui/components/Spinner'
 export { Button, type TLUiButtonProps } from './lib/ui/components/primitives/Button'
 export { Icon, type TLUiIconProps } from './lib/ui/components/primitives/Icon'
 export { Input, type TLUiInputProps } from './lib/ui/components/primitives/Input'

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -32,6 +32,7 @@
 	grid-row: 1;
 	display: flex;
 	min-width: 0px;
+	justify-content: space-between;
 }
 
 .tlui-layout__top__left {
@@ -41,19 +42,7 @@
 	justify-content: flex-start;
 	width: 100%;
 	height: 100%;
-	flex-shrink: 1;
-}
-
-.tlui-layout__top__center {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: flex-start;
-	width: 100%;
-	height: 100%;
-	margin-left: var(--space-2);
-	flex-grow: 1;
-	min-width: 0px;
+	flex: 0 1 0;
 }
 
 .tlui-layout__top__right {
@@ -61,9 +50,8 @@
 	flex-direction: column;
 	align-items: flex-end;
 	justify-content: flex-start;
-	width: 100%;
 	height: 100%;
-	flex-shrink: 1;
+	flex: 0 0 auto;
 	min-width: 0px;
 }
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1260,7 +1260,7 @@
 .tlui-toast__content {
 	padding-left: 0px;
 	padding-top: var(--space-4);
-	padding-bottom: var(--space-5);
+	padding-bottom: var(--space-4);
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-3);

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -52,6 +52,11 @@ export interface TldrawUiBaseProps {
 	shareZone?: ReactNode
 
 	/**
+	 * A component to use for the top zone (will be deprecated)
+	 */
+	topZone?: ReactNode
+
+	/**
 	 * Additional items to add to the debug menu (will be deprecated)
 	 */
 	renderDebugMenuItems?: () => React.ReactNode
@@ -62,6 +67,7 @@ export interface TldrawUiBaseProps {
  */
 export const TldrawUi = React.memo(function TldrawUi({
 	shareZone,
+	topZone,
 	renderDebugMenuItems,
 	children,
 	hideUi,
@@ -72,6 +78,7 @@ export const TldrawUi = React.memo(function TldrawUi({
 			<TldrawUiInner
 				hideUi={hideUi}
 				shareZone={shareZone}
+				topZone={topZone}
 				renderDebugMenuItems={renderDebugMenuItems}
 			>
 				{children}
@@ -83,6 +90,7 @@ export const TldrawUi = React.memo(function TldrawUi({
 type TldrawUiContentProps = {
 	hideUi?: boolean
 	shareZone?: ReactNode
+	topZone?: ReactNode
 	renderDebugMenuItems?: () => React.ReactNode
 }
 
@@ -105,6 +113,7 @@ const TldrawUiInner = React.memo(function TldrawUiInner({
 
 const TldrawUiContent = React.memo(function TldrawUI({
 	shareZone,
+	topZone,
 	renderDebugMenuItems,
 }: TldrawUiContentProps) {
 	const editor = useEditor()
@@ -147,6 +156,7 @@ const TldrawUiContent = React.memo(function TldrawUI({
 									<StopFollowing />
 								</div>
 							</div>
+							<div className="tlui-layout__top__center">{topZone}</div>
 							<div className="tlui-layout__top__right">
 								{shareZone}
 								{breakpoint >= 5 && !isReadonlyMode && (

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -53,6 +53,7 @@ export interface TldrawUiBaseProps {
 
 	/**
 	 * A component to use for the top zone (will be deprecated)
+	 * @internal
 	 */
 	topZone?: ReactNode
 

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -52,11 +52,6 @@ export interface TldrawUiBaseProps {
 	shareZone?: ReactNode
 
 	/**
-	 * A component to use for the top zone (will be deprecated)
-	 */
-	topZone?: ReactNode
-
-	/**
 	 * Additional items to add to the debug menu (will be deprecated)
 	 */
 	renderDebugMenuItems?: () => React.ReactNode
@@ -67,7 +62,6 @@ export interface TldrawUiBaseProps {
  */
 export const TldrawUi = React.memo(function TldrawUi({
 	shareZone,
-	topZone,
 	renderDebugMenuItems,
 	children,
 	hideUi,
@@ -78,7 +72,6 @@ export const TldrawUi = React.memo(function TldrawUi({
 			<TldrawUiInner
 				hideUi={hideUi}
 				shareZone={shareZone}
-				topZone={topZone}
 				renderDebugMenuItems={renderDebugMenuItems}
 			>
 				{children}
@@ -90,7 +83,6 @@ export const TldrawUi = React.memo(function TldrawUi({
 type TldrawUiContentProps = {
 	hideUi?: boolean
 	shareZone?: ReactNode
-	topZone?: ReactNode
 	renderDebugMenuItems?: () => React.ReactNode
 }
 
@@ -113,7 +105,6 @@ const TldrawUiInner = React.memo(function TldrawUiInner({
 
 const TldrawUiContent = React.memo(function TldrawUI({
 	shareZone,
-	topZone,
 	renderDebugMenuItems,
 }: TldrawUiContentProps) {
 	const editor = useEditor()
@@ -156,7 +147,6 @@ const TldrawUiContent = React.memo(function TldrawUI({
 									<StopFollowing />
 								</div>
 							</div>
-							<div className="tlui-layout__top__center">{topZone}</div>
 							<div className="tlui-layout__top__right">
 								{shareZone}
 								{breakpoint >= 5 && !isReadonlyMode && (

--- a/packages/tldraw/src/lib/ui/components/Spinner.tsx
+++ b/packages/tldraw/src/lib/ui/components/Spinner.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+/** @internal */
 export function Spinner(props: React.SVGProps<SVGSVGElement>) {
 	return (
 		<svg width={16} height={16} viewBox="0 0 16 16" {...props}>

--- a/packages/tldraw/src/lib/ui/components/Toasts.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toasts.tsx
@@ -31,8 +31,10 @@ function Toast({ toast }: { toast: TLUiToast }) {
 			)}
 			<div className="tlui-toast__main">
 				<div className="tlui-toast__content">
-					<T.Title className="tlui-toast__title">{toast.title}</T.Title>
-					<T.Description className="tlui-toast__description">{toast.description}</T.Description>
+					{toast.title && <T.Title className="tlui-toast__title">{toast.title}</T.Title>}
+					{toast.description && (
+						<T.Description className="tlui-toast__description">{toast.description}</T.Description>
+					)}
 				</div>
 				{toast.actions && (
 					<div className="tlui-toast__actions">


### PR DESCRIPTION
This diff removes the UI top center bar from the public API and tweaks some of the styling around the top bar as a whole. Now, the left and right bars shrink to fit their content, and the center bar is unstyled by us. It's also marked `@internal`.

This also exposes `<Spinner />` for internal use.

### Change Type

- [x] `minor` — New feature

### Test Plan

-

### Release Notes

- [BREAKING] removed topBar prop
