### PR TITLE
[improvement] Refactor curved arrows

### DIFF
--- a/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
@@ -53,6 +53,9 @@ export function getCurvedArrowInfo(
 	const c = middle.clone()
 
 	const handleArc = getArcInfo(a, b, c)
+	const angleToStart = Vec2d.Angle(handleArc.center, a)
+	const angleToMiddle = Vec2d.Angle(handleArc.center, c)
+	const angleToEnd = Vec2d.Angle(handleArc.center, b)
 
 	if (
 		handleArc.length === 0 ||
@@ -96,16 +99,16 @@ export function getCurvedArrowInfo(
 					handleArc.sweepFlag
 			)
 
-			const comparisonAngle = lerpAngles(
-				Vec2d.Angle(handleArc.center, tempA),
-				Vec2d.Angle(handleArc.center, tempC),
-				0.5
-			)
+			const comparisonAngle = lerpAngles(angleToMiddle, angleToStart, 0.5)
 
 			intersections.sort(
-				(p0, p1) =>
-					Math.abs(shortAngleDist(comparisonAngle, centerInStartShapeLocalSpace.angle(p0))) -
-					Math.abs(shortAngleDist(comparisonAngle, centerInStartShapeLocalSpace.angle(p1)))
+				isClosed
+					? (p0, p1) =>
+							Math.abs(shortAngleDist(comparisonAngle, centerInStartShapeLocalSpace.angle(p0))) -
+							Math.abs(shortAngleDist(comparisonAngle, centerInStartShapeLocalSpace.angle(p1)))
+					: (p0, p1) =>
+							Math.abs(shortAngleDist(angleToEnd, centerInStartShapeLocalSpace.angle(p0))) -
+							Math.abs(shortAngleDist(angleToEnd, centerInStartShapeLocalSpace.angle(p1)))
 			)
 
 			point = intersections[0] ?? (isClosed ? undefined : startInStartShapeLocalSpace)
@@ -145,8 +148,6 @@ export function getCurvedArrowInfo(
 		const isClosed = endShapeInfo.isClosed
 		const fn = isClosed ? intersectCirclePolygon : intersectCirclePolyline
 
-		const angleToMiddle = Vec2d.Angle(handleArc.center, middle)
-		const angleToEnd = Vec2d.Angle(handleArc.center, terminalsInArrowSpace.end)
 		const comparisonAngle = lerpAngles(angleToMiddle, angleToEnd, 0.5)
 
 		let point: VecLike | undefined
@@ -161,9 +162,13 @@ export function getCurvedArrowInfo(
 			)
 
 			intersections.sort(
-				(p0, p1) =>
-					Math.abs(shortAngleDist(comparisonAngle, centerInEndShapeLocalSpace.angle(p0))) -
-					Math.abs(shortAngleDist(comparisonAngle, centerInEndShapeLocalSpace.angle(p1)))
+				isClosed
+					? (p0, p1) =>
+							Math.abs(shortAngleDist(comparisonAngle, centerInEndShapeLocalSpace.angle(p0))) -
+							Math.abs(shortAngleDist(comparisonAngle, centerInEndShapeLocalSpace.angle(p1)))
+					: (p0, p1) =>
+							Math.abs(shortAngleDist(angleToStart, centerInEndShapeLocalSpace.angle(p0))) -
+							Math.abs(shortAngleDist(angleToStart, centerInEndShapeLocalSpace.angle(p1)))
 			)
 
 			point = intersections[0] ?? (isClosed ? undefined : endInEndShapeLocalSpace)

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -126,6 +126,17 @@ export function clockwiseAngleDist(a0: number, a1: number): number {
 }
 
 /**
+ * Get the counter-clockwise angle distance between two angles.
+ *
+ * @param a0 - The first angle.
+ * @param a1 - The second angle.
+ * @public
+ */
+export function counterClockwiseAngleDist(a0: number, a1: number): number {
+	return PI2 - clockwiseAngleDist(a0, a1)
+}
+
+/**
  * Get the short angle distance between two angles.
  *
  * @param a0 - The first angle.


### PR DESCRIPTION
This PR refactors our curved arrows to use a more reliable filter for intersections. Its mostly visible on arrows that connect to draw shapes.

Before (tldraw and staging):
<img width="744" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/81903e53-ab23-4ea0-a849-fb396e490018">

After:
<img width="668" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/67e8615e-11f1-4207-96ad-b8cc8ff92c7b">


### Change Type

- [x] `patch` — Bug fix
