### PR TITLE
fix screen bounds not updating

### DIFF
--- a/packages/editor/src/lib/hooks/useScreenBounds.ts
+++ b/packages/editor/src/lib/hooks/useScreenBounds.ts
@@ -8,9 +8,7 @@ export function useScreenBounds() {
 	useLayoutEffect(() => {
 		const updateBounds = throttle(
 			() => {
-				if (editor.instanceState.isFocused) {
-					editor.updateViewportScreenBounds()
-				}
+				editor.updateViewportScreenBounds()
 			},
 			200,
 			{


### PR DESCRIPTION
There are a lot of cases (eg when interacting with the ui) where the editor loses focus. This check was preventing us from updating the viewport screen bounds when appropriate. This function is throttled and pretty cheap anyway (if the viewport is equal its a no-op) so let's just remove the condition

### Change Type

- [x] `patch` — Bug fix

