### PR TITLE
[fix] migrations for page state

### DIFF
--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -585,6 +585,66 @@ describe('Renaming properties in instancePageState', () => {
 	})
 })
 
+describe('Renaming properties again in instancePageState', () => {
+	const { up, down } =
+		instancePageStateMigrations.migrators[instancePageStateVersions.RenamePropertiesAgain]
+	test('up works as expected', () => {
+		expect(
+			up({
+				selectedIds: [],
+				hintingIds: [],
+				erasingIds: [],
+				hoveredId: null,
+				editingId: null,
+				croppingId: null,
+				focusLayerId: null,
+				meta: {
+					name: 'hallo',
+				},
+			})
+		).toEqual({
+			selectedShapeIds: [],
+			hintingShapeIds: [],
+			erasingShapeIds: [],
+			hoveredShapeId: null,
+			editingShapeId: null,
+			croppingShapeId: null,
+			focusedGroupId: null,
+			meta: {
+				name: 'hallo',
+			},
+		})
+	})
+
+	test('down works as expected', () => {
+		expect(
+			down({
+				selectedShapeIds: [],
+				hintingShapeIds: [],
+				erasingShapeIds: [],
+				hoveredShapeId: null,
+				editingShapeId: null,
+				croppingShapeId: null,
+				focusedGroupId: null,
+				meta: {
+					name: 'hallo',
+				},
+			})
+		).toEqual({
+			selectedIds: [],
+			hintingIds: [],
+			erasingIds: [],
+			hoveredId: null,
+			editingId: null,
+			croppingId: null,
+			focusLayerId: null,
+			meta: {
+				name: 'hallo',
+			},
+		})
+	})
+})
+
 describe('Adding followingUserId prop to instance', () => {
 	const { up, down } = instanceMigrations.migrators[6]
 	test('up works as expected', () => {

--- a/packages/tlschema/src/records/TLPageState.ts
+++ b/packages/tlschema/src/records/TLPageState.ts
@@ -52,11 +52,12 @@ export const instancePageStateVersions = {
 	RemoveInstanceIdAndCameraId: 2,
 	AddMeta: 3,
 	RenameProperties: 4,
+	RenamePropertiesAgain: 5,
 } as const
 
 /** @public */
 export const instancePageStateMigrations = defineMigrations({
-	currentVersion: instancePageStateVersions.RenameProperties,
+	currentVersion: instancePageStateVersions.RenamePropertiesAgain,
 	migrators: {
 		[instancePageStateVersions.AddCroppingId]: {
 			up(instance) {
@@ -93,6 +94,8 @@ export const instancePageStateMigrations = defineMigrations({
 			},
 		},
 		[instancePageStateVersions.RenameProperties]: {
+			// this migration is cursed: it was written wrong and doesn't do anything.
+			// rather than replace it, I've added another migration below that fixes it.
 			up: (record) => {
 				const {
 					selectedShapeIds,
@@ -134,6 +137,52 @@ export const instancePageStateMigrations = defineMigrations({
 					editingShapeId: editingShapeId,
 					croppingShapeId: croppingShapeId,
 					focusedGroupId: focusedGroupId,
+					...rest,
+				}
+			},
+		},
+		[instancePageStateVersions.RenamePropertiesAgain]: {
+			up: (record) => {
+				const {
+					selectedIds,
+					hintingIds,
+					erasingIds,
+					hoveredId,
+					editingId,
+					croppingId,
+					focusLayerId,
+					...rest
+				} = record
+				return {
+					selectedShapeIds: selectedIds,
+					hintingShapeIds: hintingIds,
+					erasingShapeIds: erasingIds,
+					hoveredShapeId: hoveredId,
+					editingShapeId: editingId,
+					croppingShapeId: croppingId,
+					focusedGroupId: focusLayerId,
+					...rest,
+				}
+			},
+			down: (record) => {
+				const {
+					selectedShapeIds,
+					hintingShapeIds,
+					erasingShapeIds,
+					hoveredShapeId,
+					editingShapeId,
+					croppingShapeId,
+					focusedGroupId,
+					...rest
+				} = record
+				return {
+					selectedIds: selectedShapeIds,
+					hintingIds: hintingShapeIds,
+					erasingIds: erasingShapeIds,
+					hoveredId: hoveredShapeId,
+					editingId: editingShapeId,
+					croppingId: croppingShapeId,
+					focusLayerId: focusedGroupId,
 					...rest,
 				}
 			},


### PR DESCRIPTION
This PR adds an additional migration that fixes a bad (a->a) migration that I added in the previous version. 

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. On the tldraw app, open a file.

- [x] Unit Tests