### PR TITLE
Fix alt + shift keyboard shortcuts

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -82,7 +82,11 @@ function getHotkeysStringFromKbd(kbd: string) {
 				if (chars[0] === '!') {
 					str = `shift+${chars[1]}`
 				} else if (chars[0] === '?') {
-					str = `alt+${chars[1]}`
+					if (chars.length === 3 && chars[1] === '!') {
+						str = `alt+shift+${chars[2]}`
+					} else {
+						str = `alt+${chars[1]}`
+					}
 				} else if (chars[0] === '$') {
 					if (chars[1] === '!') {
 						str = `cmd+shift+${chars[2]},ctrl+shift+${chars[2]}`


### PR DESCRIPTION
Fixes keyboard shortcuts that use `alt + shift` modifier (distribute horizontally and vertically fall into this category).

Fixes [#2054](https://github.com/tldraw/tldraw/issues/2054)

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create multiple shapes
2. Use `alt + shift + v / h` to distribute vertically or horizontally.

### Release Notes

- Fixes keyboard shortcuts that use `alt` and `shift` modifiers.
