### PR TITLE
Fix shape opacity when erasing

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3025,25 +3025,19 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// If renderingBoundsMargin is set to Infinity, then we won't cull offscreen shapes
 		const isCullingOffScreenShapes = Number.isFinite(this.renderingBoundsMargin)
 
-		let shape: TLShape | undefined
-		let isShapeErasing: boolean
-		let isCulled: boolean
-		let util: ShapeUtil
-		let maskedPageBounds: Box2d | undefined
-
 		const addShapeById = (id: TLShapeId, opacity: number, isAncestorErasing: boolean) => {
-			shape = this.getShape(id)
+			const shape = this.getShape(id)
 			if (!shape) return
 
 			opacity *= shape.opacity
-			isShapeErasing = false
-			isCulled = false
-			util = this.getShapeUtil(shape)
-			maskedPageBounds = this.getShapeMaskedPageBounds(id)
+			let isCulled = false
+			let isShapeErasing = false
+			const util = this.getShapeUtil(shape)
+			const maskedPageBounds = this.getShapeMaskedPageBounds(id)
 
 			if (useEditorState) {
-				if (!isAncestorErasing && erasingShapeIds.includes(id)) {
-					isShapeErasing = true
+				isShapeErasing = !isAncestorErasing && erasingShapeIds.includes(id)
+				if (isShapeErasing) {
 					opacity *= 0.32
 				}
 


### PR DESCRIPTION
Closes #2051 

This was another bug related to the usage of parent-scope `let` assignments to avoid stack allocations in a hot code path, so I switched to `const`s and local `let`s which we really should have done last week. I think the compiler should be able to optimize this well enough.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes opacity of shapes while erasing in a group or frame.
