### PR TITLE
Dont lower opacity of shapes that cant be deleted

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
@@ -110,7 +110,11 @@ export class Erasing extends StateNode {
 
 		const erasing = new Set<TLShapeId>(erasingShapeIds)
 
-		for (const shape of currentPageShapes) {
+		const currentPageShapesFiltered = currentPageShapes.filter((shape) => {
+			return excludedShapeIds.has(shape.id)
+		})
+
+		for (const shape of currentPageShapesFiltered) {
 			if (this.editor.isShapeOfType<TLGroupShape>(shape, 'group')) continue
 
 			// Avoid testing masked shapes, unless the pointer is inside the mask


### PR DESCRIPTION
closes [#2058](https://github.com/tldraw/tldraw/issues/2058)
Shapes that can't be deleted now don't lower their opacity when scribbled with eraser.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Lock a shape
2. Scribble over it with the eraser tool
3. The opacity should remain the same.


### Release Notes

- Shapes that can't be deleted don't lower their opacity when scribbled with the eraser tool
