### PR TITLE
[fix] Hit testing against zero width / height lines

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4319,9 +4319,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				distance = minDistance
 			} else {
-				distance = geometry.bounds.containsPoint(pointInShapeSpace, margin)
-					? geometry.distanceToPoint(pointInShapeSpace, hitInside)
-					: Infinity
+				if (
+					geometry.bounds.w > 1 &&
+					geometry.bounds.h > 1 &&
+					!geometry.bounds.containsPoint(pointInShapeSpace, margin)
+				) {
+					distance = Infinity
+				} else {
+					distance = geometry.distanceToPoint(pointInShapeSpace, hitInside)
+				}
 			}
 
 			if (geometry.isClosed) {
@@ -4363,6 +4369,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					}
 				}
 			} else {
+				console.log('hello')
 				// For open shapes (e.g. lines or draw shapes) always use the margin.
 				// If the distance is less than the margin, return the shape as the hit.
 				if (distance < HIT_TEST_MARGIN / zoomLevel) {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4319,14 +4319,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				distance = minDistance
 			} else {
-				if (
-					geometry.bounds.w > margin &&
-					geometry.bounds.h > margin &&
-					!geometry.bounds.containsPoint(pointInShapeSpace, margin)
-				) {
-					distance = Infinity
-				} else {
+				// If the margin is zero and the geometry has a very small width or height,
+				// then check the actual distance. This is to prevent a bug where straight
+				// lines would never pass the broad phase (point-in-bounds) check.
+				if (margin === 0 && (geometry.bounds.w < 1 || geometry.bounds.h < 1)) {
 					distance = geometry.distanceToPoint(pointInShapeSpace, hitInside)
+				} else {
+					// Broad phase
+					if (geometry.bounds.containsPoint(pointInShapeSpace, margin)) {
+						// Narrow phase (actual distance)
+						distance = geometry.distanceToPoint(pointInShapeSpace, hitInside)
+					} else {
+						// Failed the broad phase, geddafugaotta'ere!
+						distance = Infinity
+					}
 				}
 			}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4320,8 +4320,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				distance = minDistance
 			} else {
 				if (
-					geometry.bounds.w > 1 &&
-					geometry.bounds.h > 1 &&
+					geometry.bounds.w > margin &&
+					geometry.bounds.h > margin &&
 					!geometry.bounds.containsPoint(pointInShapeSpace, margin)
 				) {
 					distance = Infinity


### PR DESCRIPTION
This PR fixes a bug where certain hit tests would always miss straight lines.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a straight line.
2. Try to bind an arrow to it.

- [x] Unit Tests

### Release Notes

- [fix] Bug where arrows would not bind to straight lines