### PR TITLE
fix(eraser): prevent opacity change on locked shapes

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Erasing.ts
@@ -28,8 +28,10 @@ export class Erasing extends StateNode {
 		this.excludedShapeIds = new Set(
 			this.editor.currentPageShapes
 				.filter((shape) => {
+					//If the shape is locked, we shouldn't erase it
+					if (this.editor.isShapeOrAncestorLocked(shape)) return true
+					//If the shape is a group or frame, check we're inside it when we start erasing
 					if (
-						this.editor.isShapeOrAncestorLocked(shape) ||
 						this.editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
 						this.editor.isShapeOfType<TLFrameShape>(shape, 'frame')
 					) {


### PR DESCRIPTION
Opacity used to lower on locked shapes, now it doesn't

### Change type

- [x] `bugfix`

### Test plan

1. Make a locked shape
2. Scribble erase over the shape
3. The shape shouldn't change opacity

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Locked shapes don't change opacity when scribble erasing.

Before/after:

<image width="250" src="https://github.com/tldraw/tldraw/assets/98838967/763a93eb-ffaa-405c-9255-e68ba88ed9a2" />

<image width="250" src="https://github.com/tldraw/tldraw/assets/98838967/dc9d3f77-c1c5-40f2-a9fe-10c723b6a21c" />