### PR TITLE
Cache playwright browsers.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Get installed Playwright version
         id: playwright-version
         run: |
+          cd apps/examples
           yarn info @playwright/test --json > playwright.json
           echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright.json').children.Version)")" >> $GITHUB_ENV
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,8 +37,23 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Install Playwright browsers
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: |
+          yarn info @playwright/test --json > playwright.json
+          echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright.json').children.Version)")" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Check for Playwright browsers cache
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests
         run: 'yarn e2e'


### PR DESCRIPTION
Adds caching for playwright browsers, should make the e2e tests run much faster.

![CleanShot 2023-10-11 at 13 06 48](https://github.com/tldraw/tldraw/assets/2523721/6eb7fb00-d70e-4019-9e81-736b2a19e1bb)

Here's how it looks like when there's a cache hit (added an empty commit to this PR to test it out)
![CleanShot 2023-10-11 at 13 19 30](https://github.com/tldraw/tldraw/assets/2523721/b6a2cfcf-8322-413f-822b-8ed211f5c9a3)


### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [x] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

