### PR TITLE
Fix ExplodedExample.tsx

### DIFF
--- a/apps/examples/src/examples/ExplodedExample.tsx
+++ b/apps/examples/src/examples/ExplodedExample.tsx
@@ -3,9 +3,9 @@ import {
 	ContextMenu,
 	TldrawEditor,
 	TldrawUi,
-	defaultShapeUtils,
 	defaultShapeTools,
-	defaultTools
+	defaultShapeUtils,
+	defaultTools,
 } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 

--- a/apps/examples/src/examples/ExplodedExample.tsx
+++ b/apps/examples/src/examples/ExplodedExample.tsx
@@ -4,7 +4,8 @@ import {
 	TldrawEditor,
 	TldrawUi,
 	defaultShapeUtils,
-	defaultTools,
+	defaultShapeTools,
+	defaultTools
 } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 
@@ -14,7 +15,7 @@ export default function ExplodedExample() {
 			<TldrawEditor
 				initialState="select"
 				shapeUtils={defaultShapeUtils}
-				tools={defaultTools}
+				tools={[...defaultTools, ...defaultShapeTools]}
 				persistenceKey="exploded-example"
 			>
 				<TldrawUi>


### PR DESCRIPTION
Previous implementation was incorrect, causing the following bug:

![image](https://github.com/tldraw/tldraw/assets/26308297/03f2a996-dd58-4864-8f89-8e7af2ecca69)


### Change Type

- [] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know