### PR TITLE
Same first page id for all editors

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/__snapshots__/LineShapeUtil.test.ts.snap
+++ b/packages/tldraw/src/lib/shapes/line/__snapshots__/LineShapeUtil.test.ts.snap
@@ -7,7 +7,7 @@ Object {
   "isLocked": false,
   "meta": Object {},
   "opacity": 1,
-  "parentId": "page:id51",
+  "parentId": "page:page",
   "props": Object {
     "color": "black",
     "dash": "draw",

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -80,7 +80,9 @@ export const onValidationFailure: StoreSchemaOptions<
 }
 
 function getDefaultPages() {
-	return [PageRecordType.create({ name: 'Page 1', index: 'a1', meta: {} })]
+	return [
+		PageRecordType.create({ id: 'page:page' as TLPageId, name: 'Page 1', index: 'a1', meta: {} }),
+	]
 }
 
 /** @internal */


### PR DESCRIPTION
This PR changes the default state of the editor to use `page:page` as its first page's id. This removes some randomness that makes certain seed-based tests impossible. It should have no effect on the way that the app works.

### Change Type

- [x] `minor` — New feature
