### PR TITLE
[fix] locked shape of opacity problem with eraser.pointing

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/children/Pointing.ts
@@ -23,7 +23,10 @@ export class Pointing extends StateNode {
 
 		for (let n = sortedShapesOnCurrentPage.length, i = n - 1; i >= 0; i--) {
 			const shape = sortedShapesOnCurrentPage[i]
-			if (this.editor.isShapeOfType<TLGroupShape>(shape, 'group')) {
+			if (
+				this.editor.isShapeOrAncestorLocked(shape) ||
+				this.editor.isShapeOfType<TLGroupShape>(shape, 'group')
+			) {
 				continue
 			}
 


### PR DESCRIPTION
locked shape of opacity problem with the pointing state of the eraser tool
this is only in the pointing (clicking) state.
I don't know if this is intended or a bug, but it's true that it's a little uncomfortable. 

![blinks](https://github.com/tldraw/tldraw/assets/59823089/6292aa54-120d-4cbc-b712-a78f408d248b)
blinks when the user starts to remove the handwriting on locked content.

Defs https://github.com/tldraw/tldraw/pull/2061

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Make a locked shape
2. Click erase over the shape
3. The shape shouldn't change opacity

### Release Notes

- locked shape of opacity problem with eraser.pointing
Before/after:
![A](https://github.com/tldraw/tldraw/assets/59823089/7483506c-72ac-45cc-93aa-f2a794ea8ff0) ![B](https://github.com/tldraw/tldraw/assets/59823089/ef0f988c-83f5-46a2-b891-0a391bca2f87)
