### PR TITLE
bump nanoid

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -59,7 +59,7 @@
 		"is-plain-object": "^5.0.0",
 		"lodash.throttle": "^4.1.1",
 		"lodash.uniq": "^4.5.0",
-		"nanoid": "^3.3.6"
+		"nanoid": "4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -44,7 +44,7 @@
 		"@tldraw/state": "workspace:*",
 		"@tldraw/utils": "workspace:*",
 		"lodash.isequal": "^4.5.0",
-		"nanoid": "^3.3.6"
+		"nanoid": "4.0.2"
 	},
 	"devDependencies": {
 		"@peculiar/webcrypto": "^1.4.0",

--- a/packages/tlschema/package.json
+++ b/packages/tlschema/package.json
@@ -60,6 +60,6 @@
 		"@tldraw/store": "workspace:*",
 		"@tldraw/utils": "workspace:*",
 		"@tldraw/validate": "workspace:*",
-		"nanoid": "^3.3.6"
+		"nanoid": "4.0.2"
 	}
 }

--- a/public-yarn.lock
+++ b/public-yarn.lock
@@ -4633,7 +4633,7 @@ __metadata:
     lazyrepo: 0.0.0-alpha.27
     lodash.throttle: ^4.1.1
     lodash.uniq: ^4.5.0
-    nanoid: ^3.3.6
+    nanoid: 4.0.2
     react-test-renderer: ^18.2.0
     resize-observer-polyfill: ^1.5.1
   peerDependencies:
@@ -4731,7 +4731,7 @@ __metadata:
     "@types/lodash.isequal": ^4.5.6
     lazyrepo: 0.0.0-alpha.27
     lodash.isequal: ^4.5.0
-    nanoid: ^3.3.6
+    nanoid: 4.0.2
     raf: ^3.4.1
   languageName: unknown
   linkType: soft
@@ -4780,7 +4780,7 @@ __metadata:
     "@tldraw/validate": "workspace:*"
     kleur: ^4.1.5
     lazyrepo: 0.0.0-alpha.27
-    nanoid: ^3.3.6
+    nanoid: 4.0.2
   languageName: unknown
   linkType: soft
 
@@ -13505,6 +13505,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:4.0.2":
+  version: 4.0.2
+  resolution: "nanoid@npm:4.0.2"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 747c399cea4664dd0be1d0ec498ffd1ef8f1f5221676fc8b577e3f46f66d9afcddb9595d63d19a2e78d0bc6cc33984f65e66bf1682c850b9e26288883d96b53f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps nanoid to bring in line with brivate to make sure our nanoid mock in our fuzz test works. Supersedes https://github.com/tldraw/brivate/pull/3027#pullrequestreview-1676280991

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [x] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


