### PR TITLE
[fix] remove findLast calls

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -672,7 +672,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getAssetForExternalContent(info: TLExternalAssetContent): Promise<TLAsset | undefined>;
     getContainer: () => HTMLElement;
     getContentFromCurrentPage(shapes: TLShape[] | TLShapeId[]): TLContent | undefined;
-    getDroppingOverShape(point: VecLike, droppingShapes?: TLShape[]): TLShape | undefined;
+    getDroppingOverShape(point: VecLike, droppingShapes?: TLShape[]): TLUnknownShape | undefined;
     getHighestIndexForParent(parent: TLPage | TLParentId | TLShape): string;
     getInitialMetaForShape(_shape: TLShape): JsonObject;
     getOutermostSelectableShape(shape: TLShape | TLShapeId, filter?: (shape: TLShape) => boolean): TLShape;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -10102,8 +10102,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                  "text": "TLUnknownShape",
+                  "canonicalReference": "@tldraw/tlschema!TLUnknownShape:type"
                 },
                 {
                   "kind": "Content",


### PR DESCRIPTION
This PR removes some calls to `findLast`, as this is not in all browsers yet.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Drag and drop.
2. Create a shape inside of a frame

- [x] Unit Tests