### PR TITLE
Fixed a bug checking translated string keys

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/translations.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/translations.ts
@@ -56,7 +56,7 @@ export async function fetchTranslation(
 
 	const missing: string[] = []
 
-	for (const key in EN_TRANSLATION) {
+	for (const key in EN_TRANSLATION.messages) {
 		if (!messages[key as TLUiTranslationKey]) {
 			missing.push(key)
 		}


### PR DESCRIPTION
Fixed a bug checking translated string keys

Suppress the following warning message in your browser.
```
Language zh-cn: missing messages for keys:
locale
label
messages
```

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
