### PR TITLE
Add timestamp to file names

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -35,7 +35,7 @@ export function useExportAs() {
 
 			if (!svg) throw new Error('Could not construct SVG.')
 
-			let name = 'shapes'
+			let name = 'shapes ' + getTimestamp()
 
 			if (ids.length === 1) {
 				const first = editor.getShape(ids[0])!
@@ -49,7 +49,7 @@ export function useExportAs() {
 			switch (format) {
 				case 'svg': {
 					const dataURL = await getSvgAsDataUrl(svg)
-					downloadDataURLAsFile(dataURL, `${name || 'shapes'}.svg`)
+					downloadDataURLAsFile(dataURL, `${name}.svg`)
 					return
 				}
 				case 'webp':
@@ -72,7 +72,7 @@ export function useExportAs() {
 
 					const dataURL = URL.createObjectURL(image)
 
-					downloadDataURLAsFile(dataURL, `${name || 'shapes'}.${format}`)
+					downloadDataURLAsFile(dataURL, `${name}.${format}`)
 
 					URL.revokeObjectURL(dataURL)
 					return
@@ -96,4 +96,14 @@ export function useExportAs() {
 		},
 		[editor, addToast, msg]
 	)
+}
+
+function getTimestamp() {
+	const now = new Date()
+
+	const hours = String(now.getHours()).padStart(2, '0')
+	const minutes = String(now.getMinutes()).padStart(2, '0')
+	const seconds = String(now.getSeconds()).padStart(2, '0')
+
+	return `${hours}-${minutes}-${seconds}`
 }

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -35,7 +35,7 @@ export function useExportAs() {
 
 			if (!svg) throw new Error('Could not construct SVG.')
 
-			let name = 'shapes ' + getTimestamp()
+			let name = 'shapes' + getTimestamp()
 
 			if (ids.length === 1) {
 				const first = editor.getShape(ids[0])!
@@ -101,9 +101,12 @@ export function useExportAs() {
 function getTimestamp() {
 	const now = new Date()
 
+	const year = String(now.getFullYear()).slice(2)
+	const month = String(now.getMonth() + 1).padStart(2, '0')
+	const day = String(now.getDate()).padStart(2, '0')
 	const hours = String(now.getHours()).padStart(2, '0')
 	const minutes = String(now.getMinutes()).padStart(2, '0')
 	const seconds = String(now.getSeconds()).padStart(2, '0')
 
-	return `${hours}-${minutes}-${seconds}`
+	return ` at ${year}-${month}-${day} ${hours}.${minutes}.${seconds}`
 }


### PR DESCRIPTION
closes #2091
Added a little timestamp to filenames so that you don't get asked if you want to download them again on android devices.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. export as png
2. export again
3. the two files now have different names, wow!

### Release Notes

- Add timestamp to exported image file names
