### PR TITLE
fix cropped image size

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -134,7 +134,10 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 						/>
 					</div>
 				)}
-				<HTMLContainer id={shape.id} style={{ overflow: 'hidden' }}>
+				<HTMLContainer
+					id={shape.id}
+					style={{ overflow: 'hidden', width: shape.props.w, height: shape.props.h }}
+				>
 					<div className="tl-image-container" style={containerStyle}>
 						{asset?.props.src ? (
 							<div


### PR DESCRIPTION
closes #2080 

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes a rendering issue where cropped images were sometimes bleeding outside their bounds.
