### PR TITLE
Increase flexibility of the export as hook

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1661,7 +1661,7 @@ export function useDefaultHelpers(): {
 export function useDialogs(): TLUiDialogsContextType;
 
 // @public (undocumented)
-export function useExportAs(): (ids?: TLShapeId[], format?: TLExportType) => Promise<void>;
+export function useExportAs(): (editor: Editor, format?: TLExportType, defaultName?: string) => Promise<void>;
 
 // @public (undocumented)
 export function useHelpMenuSchema(): TLUiMenuSchema;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -17942,16 +17942,16 @@
             },
             {
               "kind": "Content",
-              "text": "(ids?: "
+              "text": "(editor: "
             },
             {
               "kind": "Reference",
-              "text": "TLShapeId",
-              "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+              "text": "Editor",
+              "canonicalReference": "@tldraw/editor!Editor:class"
             },
             {
               "kind": "Content",
-              "text": "[], format?: "
+              "text": ", format?: "
             },
             {
               "kind": "Reference",
@@ -17960,7 +17960,7 @@
             },
             {
               "kind": "Content",
-              "text": ") => "
+              "text": ", defaultName?: string) => "
             },
             {
               "kind": "Reference",

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -163,7 +163,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('export-as', { format: 'svg', source })
-					exportAs(editor.selectedShapeIds, 'svg')
+					exportAs(editor, 'svg')
 				},
 			},
 			{
@@ -174,7 +174,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('export-as', { format: 'png', source })
-					exportAs(editor.selectedShapeIds, 'png')
+					exportAs(editor, 'png')
 				},
 			},
 			{
@@ -185,7 +185,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('export-as', { format: 'json', source })
-					exportAs(editor.selectedShapeIds, 'json')
+					exportAs(editor, 'json')
 				},
 			},
 			{

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -1,4 +1,4 @@
-import { TLFrameShape, TLShapeId, useEditor } from '@tldraw/editor'
+import { Editor, TLFrameShape } from '@tldraw/editor'
 import { useCallback } from 'react'
 import {
 	TLExportType,
@@ -11,15 +11,12 @@ import { useTranslation } from './useTranslation/useTranslation'
 
 /** @public */
 export function useExportAs() {
-	const editor = useEditor()
 	const { addToast } = useToasts()
 	const msg = useTranslation()
 
 	return useCallback(
-		async function exportAs(
-			ids: TLShapeId[] = editor.selectedShapeIds,
-			format: TLExportType = 'png'
-		) {
+		async function exportAs(editor: Editor, format: TLExportType = 'png', defaultName?: string) {
+			let ids = editor.selectedShapeIds
 			if (ids.length === 0) {
 				ids = [...editor.currentPageShapeIds]
 			}
@@ -35,7 +32,7 @@ export function useExportAs() {
 
 			if (!svg) throw new Error('Could not construct SVG.')
 
-			let name = 'shapes'
+			let name = defaultName ?? 'shapes'
 
 			if (ids.length === 1) {
 				const first = editor.getShape(ids[0])!
@@ -94,6 +91,6 @@ export function useExportAs() {
 					throw new Error(`Export type ${format} not supported.`)
 			}
 		},
-		[editor, addToast, msg]
+		[addToast, msg]
 	)
 }


### PR DESCRIPTION
Increases the flexibility of the `useExportAs` hook. Adds an optional parameter for `defaultName`, which will allow users to use the existing hook, but provide a default name when exporting. This only overrides the default name for multiple shapes, we keep the existing logic for exporting a single shape or a frame.

This also changes the passed in parameter of `ids`(selected shape ids) to `editor` (tldraw `Editor`). Seems like we always passed in `editor.selectedShapeIds` anyway, so it should not change our own usage. The reason for passing in editor is that if we want to override actions that rely on `useExportAs`, we do that when `EditorContext` is not set yet - we have to do this in the `overrides` prop for `Tldraw` component, but the `EditorContext` is not created at that point.

Since we change the type of params it's a breaking change.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [x] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Make the `useExportAs` hook more flexible - allows passing in a `defaultName` used for setting the exported file name. 
