### PR TITLE
Tighten up editor ui

### DIFF
--- a/apps/examples/e2e/shared-e2e.ts
+++ b/apps/examples/e2e/shared-e2e.ts
@@ -38,6 +38,7 @@ export async function setupPage(page: PlaywrightTestArgs['page']) {
 	await page.evaluate(() => {
 		editor.user.updateUserPreferences({ animationSpeed: 0 })
 	})
+	await page.mouse.move(50, 50)
 }
 
 export async function setupPageWithShapes(page: PlaywrightTestArgs['page']) {

--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -119,19 +119,19 @@ test.describe('Focus', () => {
 
 		await (await page.$('body'))?.click()
 
-		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
-		expect(await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
 		await page.keyboard.press('d')
 
 		expect(
-			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
-		expect(await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
@@ -140,10 +140,10 @@ test.describe('Focus', () => {
 		await page.keyboard.press('d')
 
 		expect(
-			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 		expect(
-			await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
+			await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 	})
 
@@ -154,10 +154,10 @@ test.describe('Focus', () => {
 		const EditorA = (await page.$(`.tl-container`))!
 		expect(EditorA).toBeTruthy()
 
-		const drawButton = await EditorA.$('.tlui-button-2[data-testid="tools.draw"]')
+		const drawButton = await EditorA.$('.tlui-button[data-testid="tools.draw"]')
 
 		// select button should be selected, not the draw button
-		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
@@ -165,13 +165,13 @@ test.describe('Focus', () => {
 
 		// draw button should be selected now
 		expect(
-			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 
 		await page.keyboard.press('v')
 
 		// select button should be selected again
-		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 	})

--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -119,19 +119,19 @@ test.describe('Focus', () => {
 
 		await (await page.$('body'))?.click()
 
-		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
-		expect(await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
 		await page.keyboard.press('d')
 
 		expect(
-			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
-		expect(await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
@@ -140,10 +140,10 @@ test.describe('Focus', () => {
 		await page.keyboard.press('d')
 
 		expect(
-			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 		expect(
-			await EditorB.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
+			await EditorB.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 	})
 
@@ -154,10 +154,10 @@ test.describe('Focus', () => {
 		const EditorA = (await page.$(`.tl-container`))!
 		expect(EditorA).toBeTruthy()
 
-		const drawButton = await EditorA.$('.tlui-button[data-testid="tools.draw"]')
+		const drawButton = await EditorA.$('.tlui-button-2[data-testid="tools.draw"]')
 
 		// select button should be selected, not the draw button
-		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 
@@ -165,13 +165,13 @@ test.describe('Focus', () => {
 
 		// draw button should be selected now
 		expect(
-			await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')
+			await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')
 		).not.toBe(null)
 
 		await page.keyboard.press('v')
 
 		// select button should be selected again
-		expect(await EditorA.$('.tlui-button[data-testid="tools.draw"][data-state="selected"]')).toBe(
+		expect(await EditorA.$('.tlui-button-2[data-testid="tools.draw"][data-state="selected"]')).toBe(
 			null
 		)
 	})

--- a/apps/examples/e2e/tests/test-shapes.spec.ts
+++ b/apps/examples/e2e/tests/test-shapes.spec.ts
@@ -124,7 +124,7 @@ test.describe('Shape Tools', () => {
 			expect(await getAllShapeTypes(page)).toEqual([shape])
 
 			// Reset for next time
-			await page.mouse.click(0, 0) // to ensure we're not focused
+			await page.mouse.click(50, 50) // to ensure we're not focused
 			await page.keyboard.press('v') // go to the select tool
 			await page.keyboard.press('Control+a')
 			await page.keyboard.press('Backspace')
@@ -163,7 +163,7 @@ test.describe('Shape Tools', () => {
 			expect(await getAllShapeTypes(page)).toEqual([shape])
 
 			// Reset for next time
-			await page.mouse.click(0, 0) // to ensure we're not focused
+			await page.mouse.click(50, 50) // to ensure we're not focused
 			await page.keyboard.press('v')
 			await page.keyboard.press('Control+a')
 			await page.keyboard.press('Backspace')

--- a/apps/examples/e2e/tests/test-shapes.spec.ts
+++ b/apps/examples/e2e/tests/test-shapes.spec.ts
@@ -76,8 +76,14 @@ test.describe('Shape Tools', () => {
 				if (!(await page.getByTestId(`tools.more`).isVisible())) {
 					throw Error(`Tool more is not visible`)
 				}
-
 				await page.getByTestId('tools.more').click()
+
+				if (!(await page.getByTestId(`tools.more.${tool}`).isVisible())) {
+					throw Error(`Tool in more panel is not visible`)
+				}
+				await page.getByTestId(`tools.more.${tool}`).click()
+
+				await page.getByTestId(`tools.more`).click()
 			}
 
 			if (!(await page.getByTestId(`tools.${tool}`).isVisible())) {
@@ -105,6 +111,8 @@ test.describe('Shape Tools', () => {
 		for (const { tool, shape } of clickableShapeCreators) {
 			// Find and click the button
 			if (!(await page.getByTestId(`tools.${tool}`).isVisible())) {
+				await page.getByTestId('tools.more').click()
+				await page.getByTestId(`tools.more.${tool}`).click()
 				await page.getByTestId('tools.more').click()
 			}
 			await page.getByTestId(`tools.${tool}`).click()
@@ -142,7 +150,10 @@ test.describe('Shape Tools', () => {
 			// Find and click the button
 			if (!(await page.getByTestId(`tools.${tool}`).isVisible())) {
 				await page.getByTestId('tools.more').click()
+				await page.getByTestId(`tools.more.${tool}`).click()
+				await page.getByTestId('tools.more').click()
 			}
+
 			await page.getByTestId(`tools.${tool}`).click()
 
 			// Button should be selected

--- a/apps/examples/e2e/tests/test-smoke.spec.ts
+++ b/apps/examples/e2e/tests/test-smoke.spec.ts
@@ -71,7 +71,8 @@ test.describe('smoke tests', () => {
 		expect(await getSelectedShapeColor()).toBe('black')
 
 		// when on a mobile device...
-		const hasMobileMenu = await page.isVisible('.tlui-toolbar__styles__button')
+		const mobileStylesButton = page.getByTestId('mobile.styles')
+		const hasMobileMenu = await mobileStylesButton.isVisible()
 
 		if (hasMobileMenu) {
 			// open the style menu

--- a/apps/examples/src/examples/end-to-end/end-to-end.tsx
+++ b/apps/examples/src/examples/end-to-end/end-to-end.tsx
@@ -1,5 +1,6 @@
-import { Tldraw } from '@tldraw/tldraw'
+import { Tldraw, useActions } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
+import { useEffect } from 'react'
 ;(window as any).__tldraw_ui_event = { id: 'NOTHING_YET' }
 ;(window as any).__tldraw_editor_events = []
 
@@ -15,7 +16,19 @@ export default function EndToEnd() {
 				onUiEvent={(name, data) => {
 					;(window as any).__tldraw_ui_event = { name, data }
 				}}
-			/>
+			>
+				<SneakyExportButton />
+			</Tldraw>
 		</div>
 	)
+}
+
+function SneakyExportButton() {
+	const actions = useActions()
+
+	useEffect(() => {
+		;(window as any)['tldraw-export'] = () => actions['export-as-svg'].onSelect('unknown')
+	}, [actions])
+
+	return null
 }

--- a/assets/icons/icon/checkbox-empty.svg
+++ b/assets/icons/icon/checkbox-empty.svg
@@ -1,3 +1,3 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 3L27 3L27 27L3 27L3 3Z" stroke="black" stroke-width="2"/>
+<path d="M8 8H22V22H8V8Z" stroke="black" stroke-width="2"/>
 </svg>

--- a/assets/icons/icon/checkbox-empty.svg
+++ b/assets/icons/icon/checkbox-empty.svg
@@ -1,3 +1,3 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8 8H22V22H8V8Z" stroke="black" stroke-width="2"/>
+<path d="M8 8H22V22H8V8Z" stroke="black" stroke-opacity="0.5" stroke-width="2"/>
 </svg>

--- a/assets/translations/main.json
+++ b/assets/translations/main.json
@@ -295,7 +295,7 @@
 	"style-panel.align": "Align",
 	"style-panel.vertical-align": "Vertical align",
 	"style-panel.position": "Position",
-	"style-panel.arrowheads": "Arrowheads",
+	"style-panel.arrowheads": "Arrows",
 	"style-panel.arrowhead-start": "Start",
 	"style-panel.arrowhead-end": "End",
 	"style-panel.color": "Color",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -6827,7 +6827,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#animateShape:member(1)",
-              "docComment": "/**\n * Animate a shape.\n *\n * @param partial - The shape partial to update.\n *\n * @param options - (optional) The animation's options.\n *\n * @example\n * ```ts\n * editor.animateShape({ id: 'box1', type: 'box', x: 100, y: 100 })\n * editor.animateShape({ id: 'box1', type: 'box', x: 100, y: 100 }, { duration: 100, ease: t => t*t })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Animate a shape.\n *\n * @param partial - The shape partial to update.\n *\n * @param options - The animation's options.\n *\n * @example\n * ```ts\n * editor.animateShape({ id: 'box1', type: 'box', x: 100, y: 100 })\n * editor.animateShape({ id: 'box1', type: 'box', x: 100, y: 100 }, { duration: 100, ease: t => t*t })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6901,7 +6901,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#animateShapes:member(1)",
-              "docComment": "/**\n * Animate shapes.\n *\n * @param partials - The shape partials to update.\n *\n * @param options - (optional) The animation's options.\n *\n * @example\n * ```ts\n * editor.animateShapes([{ id: 'box1', type: 'box', x: 100, y: 100 }])\n * editor.animateShapes([{ id: 'box1', type: 'box', x: 100, y: 100 }], { duration: 100, ease: t => t*t })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Animate shapes.\n *\n * @param partials - The shape partials to update.\n *\n * @param options - The animation's options.\n *\n * @example\n * ```ts\n * editor.animateShapes([{ id: 'box1', type: 'box', x: 100, y: 100 }])\n * editor.animateShapes([{ id: 'box1', type: 'box', x: 100, y: 100 }], { duration: 100, ease: t => t*t })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7588,7 +7588,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#centerOnPoint:member(1)",
-              "docComment": "/**\n * Center the camera on a point (in the current page space).\n *\n * @param point - The point in the current page space to center on.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.centerOnPoint({ x: 100, y: 100 })\n * editor.centerOnPoint({ x: 100, y: 100 }, { duration: 200 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Center the camera on a point (in the current page space).\n *\n * @param point - The point in the current page space to center on.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.centerOnPoint({ x: 100, y: 100 })\n * editor.centerOnPoint({ x: 100, y: 100 }, { duration: 200 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -9068,7 +9068,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#duplicateShapes:member(1)",
-              "docComment": "/**\n * Duplicate shapes.\n *\n * @param shapes - The shapes (or shape ids) to duplicate.\n *\n * @param offset - (optional) The offset (in pixels) to apply to the duplicated shapes.\n *\n * @example\n * ```ts\n * editor.duplicateShapes(['box1', 'box2'], { x: 8, y: 8 })\n * editor.duplicateShapes(editor.selectedShapes, { x: 8, y: 8 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Duplicate shapes.\n *\n * @param shapes - The shapes (or shape ids) to duplicate.\n *\n * @param offset - The offset (in pixels) to apply to the duplicated shapes.\n *\n * @example\n * ```ts\n * editor.duplicateShapes(['box1', 'box2'], { x: 8, y: 8 })\n * editor.duplicateShapes(editor.selectedShapes, { x: 8, y: 8 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -12360,7 +12360,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#groupShapes:member(1)",
-              "docComment": "/**\n * Create a group containing the provided shapes.\n *\n * @param shapes - The shapes (or shape ids) to group. Defaults to the selected shapes.\n *\n * @param groupId - (optional) The id of the group to create.\n *\n * @public\n */\n",
+              "docComment": "/**\n * Create a group containing the provided shapes.\n *\n * @param shapes - The shapes (or shape ids) to group. Defaults to the selected shapes.\n *\n * @param groupId - The id of the group to create.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -13511,7 +13511,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#mark:member(1)",
-              "docComment": "/**\n * Create a new \"mark\", or stopping point, in the undo redo history. Creating a mark will clear any redos.\n *\n * @param markId - The mark's id, usually the reason for adding the mark.\n *\n * @param onUndo - (optional) Whether to stop at the mark when undoing.\n *\n * @param onRedo - (optional) Whether to stop at the mark when redoing.\n *\n * @example\n * ```ts\n * editor.mark()\n * editor.mark('flip shapes')\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Create a new \"mark\", or stopping point, in the undo redo history. Creating a mark will clear any redos.\n *\n * @param markId - The mark's id, usually the reason for adding the mark.\n *\n * @param onUndo - Whether to stop at the mark when undoing.\n *\n * @param onRedo - Whether to stop at the mark when redoing.\n *\n * @example\n * ```ts\n * editor.mark()\n * editor.mark('flip shapes')\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -13670,7 +13670,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#nudgeShapes:member(1)",
-              "docComment": "/**\n * Move shapes by a delta.\n *\n * @param shapes - The shapes (or shape ids) to move.\n *\n * @param direction - The direction in which to move the shapes.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.nudgeShapes(['box1', 'box2'], { x: 8, y: 8 })\n * editor.nudgeShapes(editor.selectedShapes, { x: 8, y: 8 }, { squashing: true })\n * ```\n *\n */\n",
+              "docComment": "/**\n * Move shapes by a delta.\n *\n * @param shapes - The shapes (or shape ids) to move.\n *\n * @param direction - The direction in which to move the shapes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.nudgeShapes(['box1', 'box2'], { x: 8, y: 8 })\n * editor.nudgeShapes(editor.selectedShapes, { x: 8, y: 8 }, { squashing: true })\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -14028,7 +14028,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#pan:member(1)",
-              "docComment": "/**\n * Pan the camera.\n *\n * @param offset - The offset in the current page space.\n *\n * @param animation - (optional) The animation options.\n *\n * @example\n * ```ts\n * editor.pan({ x: 100, y: 100 })\n * editor.pan({ x: 100, y: 100 }, { duration: 1000 })\n * ```\n *\n */\n",
+              "docComment": "/**\n * Pan the camera.\n *\n * @param offset - The offset in the current page space.\n *\n * @param animation - The animation options.\n *\n * @example\n * ```ts\n * editor.pan({ x: 100, y: 100 })\n * editor.pan({ x: 100, y: 100 }, { duration: 1000 })\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -14846,7 +14846,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#reparentShapes:member(1)",
-              "docComment": "/**\n * Reparent shapes to a new parent. This operation preserves the shape's current page positions / rotations.\n *\n * @param shapes - The shapes (or shape ids) of the shapes to reparent.\n *\n * @param parentId - The id of the new parent shape.\n *\n * @param insertIndex - (optional) The index to insert the children.\n *\n * @example\n * ```ts\n * editor.reparentShapes([box1, box2], 'frame1')\n * editor.reparentShapes([box1.id, box2.id], 'frame1')\n * editor.reparentShapes([box1.id, box2.id], 'frame1', 4)\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Reparent shapes to a new parent. This operation preserves the shape's current page positions / rotations.\n *\n * @param shapes - The shapes (or shape ids) of the shapes to reparent.\n *\n * @param parentId - The id of the new parent shape.\n *\n * @param insertIndex - The index to insert the children.\n *\n * @example\n * ```ts\n * editor.reparentShapes([box1, box2], 'frame1')\n * editor.reparentShapes([box1.id, box2.id], 'frame1')\n * editor.reparentShapes([box1.id, box2.id], 'frame1', 4)\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -14941,7 +14941,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#resetZoom:member(1)",
-              "docComment": "/**\n * Set the zoom back to 100%.\n *\n * @param point - (optional) The screen point to zoom out on. Defaults to the viewport screen center.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.resetZoom()\n * editor.resetZoom(editor.viewportScreenCenter)\n * editor.resetZoom(editor.viewportScreenCenter, { duration: 200 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Set the zoom back to 100%.\n *\n * @param point - The screen point to zoom out on. Defaults to the viewport screen center.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.resetZoom()\n * editor.resetZoom(editor.viewportScreenCenter)\n * editor.resetZoom(editor.viewportScreenCenter, { duration: 200 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -15675,7 +15675,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#setCamera:member(1)",
-              "docComment": "/**\n * Set the current camera.\n *\n * @param point - The new camera position.\n *\n * @param animation - (optional) Options for an animation.\n *\n * @example\n * ```ts\n * editor.setCamera({ x: 0, y: 0})\n * editor.setCamera({ x: 0, y: 0, z: 1.5})\n * editor.setCamera({ x: 0, y: 0, z: 1.5}, { duration: 1000, easing: (t) => t * t })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Set the current camera.\n *\n * @param point - The new camera position.\n *\n * @param animation - Options for an animation.\n *\n * @example\n * ```ts\n * editor.setCamera({ x: 0, y: 0})\n * editor.setCamera({ x: 0, y: 0, z: 1.5})\n * editor.setCamera({ x: 0, y: 0, z: 1.5}, { duration: 1000, easing: (t) => t * t })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -15803,7 +15803,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#setCurrentPage:member(1)",
-              "docComment": "/**\n * Set the current page.\n *\n * @param page - The page (or page id) to set as the current page.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.setCurrentPage('page1')\n * editor.setCurrentPage(myPage1)\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Set the current page.\n *\n * @param page - The page (or page id) to set as the current page.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.setCurrentPage('page1')\n * editor.setCurrentPage(myPage1)\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -16509,7 +16509,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#setStyleForNextShapes:member(1)",
-              "docComment": "/**\n * Set the value of a {@link @tldraw/tlschema#StyleProp} for the selected shapes.\n *\n * @param style - The style to set.\n *\n * @param value - The value to set.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red', { ephemeral: true })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Set the value of a {@link @tldraw/tlschema#StyleProp} for the selected shapes.\n *\n * @param style - The style to set.\n *\n * @param value - The value to set.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red', { ephemeral: true })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -16608,7 +16608,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#setStyleForSelectedShapes:member(1)",
-              "docComment": "/**\n * Set the value of a {@link @tldraw/tlschema#StyleProp}. This change will be applied to the currently selected shapes.\n *\n * @param style - The style to set.\n *\n * @param value - The value to set.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red', { ephemeral: true })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Set the value of a {@link @tldraw/tlschema#StyleProp}. This change will be applied to the currently selected shapes.\n *\n * @param style - The style to set.\n *\n * @param value - The value to set.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')\n * editor.setStyleForSelectedShapes(DefaultColorStyle, 'red', { ephemeral: true })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -17588,7 +17588,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateCurrentPageState:member(1)",
-              "docComment": "/**\n * Update this instance's page state.\n *\n * @param partial - The partial of the page state object containing the changes.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateInstancePageState({ id: 'page1', editingShapeId: 'shape:123' })\n * editor.updateInstancePageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update this instance's page state.\n *\n * @param partial - The partial of the page state object containing the changes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateInstancePageState({ id: 'page1', editingShapeId: 'shape:123' })\n * editor.updateInstancePageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -17738,7 +17738,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateInstanceState:member(1)",
-              "docComment": "/**\n * Update the instance's state.\n *\n * @param partial - A partial object to update the instance state with.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update the instance's state.\n *\n * @param partial - A partial object to update the instance state with.\n *\n * @param historyOptions - The history options for the change.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -17826,7 +17826,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updatePage:member(1)",
-              "docComment": "/**\n * Update a page.\n *\n * @param partial - The partial of the shape to update.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.updatePage({ id: 'page2', name: 'Page 2' })\n * editor.updatePage({ id: 'page2', name: 'Page 2' }, { squashing: true })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update a page.\n *\n * @param partial - The partial of the shape to update.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updatePage({ id: 'page2', name: 'Page 2' })\n * editor.updatePage({ id: 'page2', name: 'Page 2' }, { squashing: true })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -17905,7 +17905,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateShape:member(1)",
-              "docComment": "/**\n * Update a shape using a partial of the shape.\n *\n * @param partial - The shape partial to update.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateShape({ id: 'box1', type: 'geo', props: { w: 100, h: 100 } })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update a shape using a partial of the shape.\n *\n * @param partial - The shape partial to update.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateShape({ id: 'box1', type: 'geo', props: { w: 100, h: 100 } })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18001,7 +18001,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateShapes:member(1)",
-              "docComment": "/**\n * Update shapes using partials of each shape.\n *\n * @param partials - The shape partials to update.\n *\n * @param historyOptions - (optional) The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateShapes([{ id: 'box1', type: 'geo', props: { w: 100, h: 100 } }])\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update shapes using partials of each shape.\n *\n * @param partials - The shape partials to update.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateShapes([{ id: 'box1', type: 'geo', props: { w: 100, h: 100 } }])\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18097,7 +18097,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateViewportScreenBounds:member(1)",
-              "docComment": "/**\n * Update the viewport. The viewport will measure the size and screen position of its container element. This should be done whenever the container's position on the screen changes.\n *\n * @param center - (optional) Whether to preserve the viewport page center as the viewport changes.\n *\n * @example\n * ```ts\n * editor.updateViewportScreenBounds()\n * editor.updateViewportScreenBounds(true)\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update the viewport. The viewport will measure the size and screen position of its container element. This should be done whenever the container's position on the screen changes.\n *\n * @param center - Whether to preserve the viewport page center as the viewport changes.\n *\n * @example\n * ```ts\n * editor.updateViewportScreenBounds()\n * editor.updateViewportScreenBounds(true)\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18392,7 +18392,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomIn:member(1)",
-              "docComment": "/**\n * Zoom the camera in.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomIn()\n * editor.zoomIn(editor.viewportScreenCenter, { duration: 120 })\n * editor.zoomIn(editor.inputs.currentScreenPoint, { duration: 120 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Zoom the camera in.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomIn()\n * editor.zoomIn(editor.viewportScreenCenter, { duration: 120 })\n * editor.zoomIn(editor.inputs.currentScreenPoint, { duration: 120 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18488,7 +18488,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomOut:member(1)",
-              "docComment": "/**\n * Zoom the camera out.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomOut()\n * editor.zoomOut(editor.viewportScreenCenter, { duration: 120 })\n * editor.zoomOut(editor.inputs.currentScreenPoint, { duration: 120 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Zoom the camera out.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomOut()\n * editor.zoomOut(editor.viewportScreenCenter, { duration: 120 })\n * editor.zoomOut(editor.inputs.currentScreenPoint, { duration: 120 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18554,7 +18554,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomToBounds:member(1)",
-              "docComment": "/**\n * Zoom the camera to fit a bounding box (in the current page space).\n *\n * @param bounds - The bounding box.\n *\n * @param targetZoom - The desired zoom level. Defaults to 0.1.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToBounds(myBounds)\n * editor.zoomToBounds(myBounds, 1)\n * editor.zoomToBounds(myBounds, 1, { duration: 100 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Zoom the camera to fit a bounding box (in the current page space).\n *\n * @param bounds - The bounding box.\n *\n * @param targetZoom - The desired zoom level. Defaults to 0.1.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToBounds(myBounds)\n * editor.zoomToBounds(myBounds, 1)\n * editor.zoomToBounds(myBounds, 1, { duration: 100 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18636,7 +18636,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomToContent:member(1)",
-              "docComment": "/**\n * Move the camera to the nearest content.\n *\n * @param opts - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToContent()\n * editor.zoomToContent({ duration: 200 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Move the camera to the nearest content.\n *\n * @param opts - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToContent()\n * editor.zoomToContent({ duration: 200 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18667,7 +18667,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomToFit:member(1)",
-              "docComment": "/**\n * Zoom the camera to fit the current page's content in the viewport.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToFit()\n * editor.zoomToFit({ duration: 200 })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Zoom the camera to fit the current page's content in the viewport.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToFit()\n * editor.zoomToFit({ duration: 200 })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18716,7 +18716,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#zoomToSelection:member(1)",
-              "docComment": "/**\n * Zoom the camera to fit the current selection in the viewport.\n *\n * @param animation - (optional) The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToSelection()\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Zoom the camera to fit the current selection in the viewport.\n *\n * @param animation - The options for an animation.\n *\n * @example\n * ```ts\n * editor.zoomToSelection()\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -21388,7 +21388,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@tldraw/editor!getIndices:function(1)",
-          "docComment": "/**\n * Get n number of indices, starting at an index.\n *\n * @param n - The number of indices to get.\n *\n * @param start - (optional) The index to start at.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Get n number of indices, starting at an index.\n *\n * @param n - The number of indices to get.\n *\n * @param start - The index to start at.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21571,7 +21571,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@tldraw/editor!getIndicesBetween:function(1)",
-          "docComment": "/**\n * Get a number of indices between two indices.\n *\n * @param below - (optional) The index below.\n *\n * @param above - (optional) The index above.\n *\n * @param n - The number of indices to get.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Get a number of indices between two indices.\n *\n * @param below - The index below.\n *\n * @param above - The index above.\n *\n * @param n - The number of indices to get.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36204,7 +36204,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@tldraw/editor!TLEditorOptions#inferDarkMode:member",
-              "docComment": "/**\n * (optional) Whether to infer dark mode from the user's system preferences. Defaults to false.\n */\n",
+              "docComment": "/**\n * Whether to infer dark mode from the user's system preferences. Defaults to false.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -36231,7 +36231,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@tldraw/editor!TLEditorOptions#initialState:member",
-              "docComment": "/**\n * (optional) The editor's initial active tool (or other state node id).\n */\n",
+              "docComment": "/**\n * The editor's initial active tool (or other state node id).\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -36367,7 +36367,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@tldraw/editor!TLEditorOptions#user:member",
-              "docComment": "/**\n * (optional) A user defined externally to replace the default user.\n */\n",
+              "docComment": "/**\n * A user defined externally to replace the default user.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -22,8 +22,11 @@
 	--radius-3: 9px;
 	--radius-4: 12px;
 	--radius-5: 16px;
+	--layer-background: 100;
 	--layer-grid: 150;
 	--layer-canvas: 200;
+	--layer-shapes: 300;
+	--layer-overlays: 400;
 	/* Misc */
 	--tl-zoom: 1;
 	--tl-dpr-multiple: 100;
@@ -142,7 +145,7 @@
 	--color-grid: #909090;
 	--color-low: #2c3136;
 	--color-low-border: #30363b
-	--color-culled: rgb(47, 52, 57);
+	--color-culled: blue;
 	--color-muted-none: rgba(255, 255, 255, 0);
 	--color-muted-0: rgba(255, 255, 255, 0.02);
 	--color-muted-1: rgba(255, 255, 255, 0.1);
@@ -238,12 +241,12 @@ input,
 
 .tl-shapes {
 	position: relative;
-	z-index: 2;
+	z-index: var(--layer-shapes);
 }
 
 .tl-overlays {
 	position: relative;
-	z-index: 3;
+	z-index: var(--layer-overlays);
 }
 
 .tl-overlays__item {
@@ -279,6 +282,7 @@ input,
 	position: absolute;
 	background-color: var(--color-background);
 	inset: 0px;
+	z-index: var(--layer-background);
 }
 
 /* --------------------- Grid Layer --------------------- */
@@ -291,7 +295,7 @@ input,
 	height: 100%;
 	touch-action: none;
 	pointer-events: none;
-	z-index: 2;
+	z-index: var(--layer-grid);
 	contain: strict;
 }
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -98,8 +98,10 @@
 	--color-brush-fill: rgba(144, 144, 144, 0.102);
 	--color-brush-stroke: rgba(144, 144, 144, 0.251);
 	--color-grid: rgb(109, 109, 109);
-	--color-low: rgb(237, 240, 242);
+	--color-low: hsl(204, 16%, 94%);
+	--color-low-border: hsl(204, 16%, 92%);
 	--color-culled: rgb(235, 238, 240);
+	--color-muted-none: rgba(0, 0, 0, 0);
 	--color-muted-0: rgba(0, 0, 0, 0.02);
 	--color-muted-1: rgba(0, 0, 0, 0.1);
 	--color-muted-2: rgba(0, 0, 0, 0.042);
@@ -139,7 +141,9 @@
 	--color-brush-stroke: rgba(180, 180, 180, 0.25);
 	--color-grid: #909090;
 	--color-low: #2c3136;
+	--color-low-border: hsl(210, 10%, 21%);
 	--color-culled: rgb(47, 52, 57);
+	--color-muted-none: rgba(255, 255, 255, 0);
 	--color-muted-0: rgba(255, 255, 255, 0.02);
 	--color-muted-1: rgba(255, 255, 255, 0.1);
 	--color-muted-2: rgba(255, 255, 255, 0.05);

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -121,8 +121,7 @@
 	--color-selection-stroke: #2f80ed;
 	--color-text-0: #1d1d1d;
 	--color-text-1: #2d2d2d;
-	--color-text-2: #5f6369;
-	--color-text-3: #b6b7ba;
+	--color-text-3: #97989a;
 	--color-text-shadow: #ffffff;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
@@ -164,9 +163,8 @@
 	--color-selection-stroke: #2f80ed;
 	--color-text-0: #f0eded;
 	--color-text-1: #d9d9d9;
-	--color-text-2: #8e9094;
 	--color-text-3: #7d848a;
-	--color-text-shadow: #262b30;
+	--color-text-shadow: #292f35;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
 	--color-text: #f8f9fa;
@@ -977,7 +975,7 @@ input,
 	color: var(--color-text);
 	text-overflow: ellipsis;
 	text-decoration: none;
-	color: var(--color-text-2);
+	color: var(--color-text-1);
 	cursor: var(--tl-cursor-pointer);
 }
 
@@ -1584,7 +1582,7 @@ it from receiving any pointer events or affecting the cursor. */
 	text-decoration: none;
 }
 .tl-error-boundary__content a:hover {
-	color: var(--color-text-2);
+	color: var(--color-text-1);
 }
 
 .tl-error-boundary__content__error {

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -19,9 +19,8 @@
 	--radius-0: 2px;
 	--radius-1: 4px;
 	--radius-2: 6px;
-	--radius-3: 8px;
-	--radius-4: 12px;
-	--radius-5: 16px;
+	--radius-3: 9px;
+	--radius-4: 13px;
 	--layer-background: 100;
 	--layer-grid: 150;
 	--layer-canvas: 200;
@@ -129,12 +128,12 @@
 	--color-text: #000000;
 	--color-laser: #ff0000;
 
-	--shadow-1: 0px 1px 2px rgba(0, 0, 0, 0.22), 0px 1px 3px rgba(0, 0, 0, 0.09);
-	--shadow-2: 0px 0px 2px rgba(0, 0, 0, 0.12), 0px 2px 3px rgba(0, 0, 0, 0.24),
+	--shadow-1: 0px 1px 2px rgba(0, 0, 0, 0.25), 0px 1px 3px rgba(0, 0, 0, 0.09);
+	--shadow-2: 0px 0px 2px rgba(0, 0, 0, 0.16), 0px 2px 3px rgba(0, 0, 0, 0.24),
 		0px 2px 6px rgba(0, 0, 0, 0.1), inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-3: 0px 1px 2px rgba(0, 0, 0, 0.25), 0px 2px 6px rgba(0, 0, 0, 0.14),
+	--shadow-3: 0px 1px 2px rgba(0, 0, 0, 0.28), 0px 2px 6px rgba(0, 0, 0, 0.14),
 		inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-4: 0px 0px 3px rgba(0, 0, 0, 0.16), 0px 5px 4px rgba(0, 0, 0, 0.16),
+	--shadow-4: 0px 0px 3px rgba(0, 0, 0, 0.19), 0px 5px 4px rgba(0, 0, 0, 0.16),
 		0px 2px 16px rgba(0, 0, 0, 0.06), inset 0px 0px 0px 1px var(--color-panel-contrast);
 }
 
@@ -167,7 +166,7 @@
 	--color-text-3: #7d848a;
 	--color-text-shadow: #292f35;
 	--color-primary: #2f80ed;
-	--color-warn: #d10b0b;
+	--color-warn: #ef6464;
 	--color-text: #f8f9fa;
 	--color-laser: #ff0000;
 
@@ -1525,17 +1524,18 @@ it from receiving any pointer events or affecting the cursor. */
 	width: 400px;
 	max-height: 100%;
 	background-color: var(--color-panel);
-	padding: var(--space-6);
-	border-radius: var(--radius-4);
+	padding: 16px;
+	border-radius: 16px;
 	box-shadow: var(--shadow-2);
 	font-size: 14px;
 	font-weight: 400;
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-5);
 	overflow: auto;
 	z-index: 600;
+	gap: 12px;
 }
+
 .tl-error-boundary__content__expanded {
 	width: 600px;
 }
@@ -1558,7 +1558,7 @@ it from receiving any pointer events or affecting the cursor. */
 	overflow: auto;
 	font-size: 12px;
 	max-height: 320px;
-	margin: 0px;
+
 }
 
 .tl-error-boundary__content button {
@@ -1603,8 +1603,8 @@ it from receiving any pointer events or affecting the cursor. */
 	display: flex;
 	justify-content: space-between;
 	gap: var(--space-4);
-	margin: calc(var(--space-4) * -1);
-	margin-top: 0px;
+	margin: 0px;
+	margin-left: -4px;
 }
 .tl-error-boundary__content__actions__group {
 	display: flex;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -161,7 +161,7 @@
 	--color-text-0: #f0eded;
 	--color-text-1: #d9d9d9;
 	--color-text-2: #8e9094;
-	--color-text-3: #515a62;
+	--color-text-3: #7d848a;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
 	--color-text: #f8f9fa;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -141,7 +141,7 @@
 	--color-brush-stroke: rgba(180, 180, 180, 0.25);
 	--color-grid: #909090;
 	--color-low: #2c3136;
-	--color-low-border: hsl(210, 10%, 21%);
+	--color-low-border: #30363b
 	--color-culled: rgb(47, 52, 57);
 	--color-muted-none: rgba(255, 255, 255, 0);
 	--color-muted-0: rgba(255, 255, 255, 0.02);
@@ -590,7 +590,7 @@ input,
 	transform-origin: top right;
 	background-color: var(--color-background);
 	padding: 2px 4px;
-	border-radius: 4px;
+	border-radius: var(--radius-1);
 }
 
 /* --------------------- Nametag -------------------- */

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -121,7 +121,7 @@
 	--color-selection-stroke: #2f80ed;
 	--color-text-0: #1d1d1d;
 	--color-text-1: #2d2d2d;
-	--color-text-3: #97989a;
+	--color-text-3: #a4a5a7;
 	--color-text-shadow: #ffffff;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
@@ -163,7 +163,7 @@
 	--color-selection-stroke: #2f80ed;
 	--color-text-0: #f0eded;
 	--color-text-1: #d9d9d9;
-	--color-text-3: #7d848a;
+	--color-text-3: #6d747b;
 	--color-text-shadow: #292f35;
 	--color-primary: #2f80ed;
 	--color-warn: #ef6464;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -18,8 +18,8 @@
 	/* Radius */
 	--radius-0: 2px;
 	--radius-1: 4px;
-	--radius-2: 7px;
-	--radius-3: 9px;
+	--radius-2: 6px;
+	--radius-3: 8px;
 	--radius-4: 12px;
 	--radius-5: 16px;
 	--layer-background: 100;
@@ -27,6 +27,7 @@
 	--layer-canvas: 200;
 	--layer-shapes: 300;
 	--layer-overlays: 400;
+	--layer-following-indicator: 1000;
 	/* Misc */
 	--tl-zoom: 1;
 	--tl-dpr-multiple: 100;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -123,6 +123,7 @@
 	--color-text-1: #2d2d2d;
 	--color-text-2: #5f6369;
 	--color-text-3: #b6b7ba;
+	--color-text-shadow: #ffffff;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
 	--color-text: #000000;
@@ -165,6 +166,7 @@
 	--color-text-1: #d9d9d9;
 	--color-text-2: #8e9094;
 	--color-text-3: #7d848a;
+	--color-text-shadow: #262b30;
 	--color-primary: #2f80ed;
 	--color-warn: #d10b0b;
 	--color-text: #f8f9fa;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1024,10 +1024,11 @@ export function parseTldrawJsonFile({ json, schema, }: {
 function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxItemProps): JSX.Element;
 
 // @public (undocumented)
-function Root({ id, children, modal, }: {
+function Root({ id, children, modal, debugOpen, }: {
     id: string;
     children: any;
     modal?: boolean;
+    debugOpen?: boolean;
 }): JSX.Element;
 
 // @public (undocumented)
@@ -1309,7 +1310,7 @@ export interface TLUiButtonProps extends React_3.HTMLAttributes<HTMLButtonElemen
     // (undocumented)
     spinner?: boolean;
     // (undocumented)
-    type?: 'danger' | 'normal' | 'primary';
+    type: 'danger' | 'help' | 'icon' | 'low' | 'menu' | 'normal' | 'primary' | 'tool';
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1519,7 +1519,7 @@ export interface TLUiToast {
     // (undocumented)
     description?: string;
     // (undocumented)
-    icon?: string;
+    icon?: TLUiIconType;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -1535,7 +1535,7 @@ export interface TLUiToastAction {
     // (undocumented)
     onClick: () => void;
     // (undocumented)
-    type: 'primary' | 'secondary' | 'warn';
+    type: 'danger' | 'normal' | 'primary';
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14579,7 +14579,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14602,7 +14602,6 @@
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,7 +14606,6 @@
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,6 +14606,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -16742,8 +16742,9 @@
                   "text": "icon?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "string"
+                  "kind": "Reference",
+                  "text": "TLUiIconType",
+                  "canonicalReference": "@tldraw/tldraw!TLUiIconType:type"
                 },
                 {
                   "kind": "Content",
@@ -16923,7 +16924,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "'primary' | 'secondary' | 'warn'"
+                  "text": "'danger' | 'normal' | 'primary'"
                 },
                 {
                   "kind": "Content",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -4137,11 +4137,11 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "export declare function Root({ id, children, modal, }: "
+                  "text": "export declare function Root({ id, children, modal, debugOpen, }: "
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n    id: string;\n    children: any;\n    modal?: boolean;\n}"
+                  "text": "{\n    id: string;\n    children: any;\n    modal?: boolean;\n    debugOpen?: boolean;\n}"
                 },
                 {
                   "kind": "Content",
@@ -4166,7 +4166,7 @@
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "{ id, children, modal, }",
+                  "parameterName": "{ id, children, modal, debugOpen, }",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2
@@ -14541,11 +14541,11 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "type?: "
+                  "text": "type: "
                 },
                 {
                   "kind": "Content",
-                  "text": "'danger' | 'normal' | 'primary'"
+                  "text": "'danger' | 'help' | 'icon' | 'low' | 'menu' | 'normal' | 'primary' | 'tool'"
                 },
                 {
                   "kind": "Content",
@@ -14553,7 +14553,7 @@
                 }
               ],
               "isReadonly": false,
-              "isOptional": true,
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "type",
               "propertyTypeTokenRange": {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -16,8 +16,8 @@
 
 .tlui-button-2 {
 	position: relative;
-	height: 44px;
-	min-width: 44px;
+	height: 40px;
+	min-width: 40px;
 	padding: 0px 12px;
 	display: flex;
 	align-items: center;
@@ -91,7 +91,6 @@
 .tlui-button-2__low {
 	border-radius: var(--radius-3);
 	background-color: var(--color-low);
-	border: 1px solid var(--color-low-border);
 }
 
 @media (hover: hover) {
@@ -108,6 +107,7 @@
 
 .tlui-button-2__danger {
 	color: var(--color-warn);
+	text-shadow: none;
 }
 
 @media (hover: hover) {
@@ -117,6 +117,7 @@
 
 	.tlui-button-2__danger:not(:disabled, :focus-visible):hover {
 		color: var(--color-warn);
+		text-shadow: none;
 	}
 }
 
@@ -170,6 +171,15 @@
 	min-width: 128px;
 	width: 100%;
 	gap: 8px;
+	margin: -4px 0px;
+}
+
+.tlui-button-2__menu:nth-child(1) {
+	margin-top: 0px;
+}
+
+.tlui-button-2__menu:nth-last-child(1) {
+	margin-bottom: 0px;
 }
 
 @media (hover: hover) {
@@ -230,7 +240,7 @@
 @media (hover: hover) {
 	.tlui-button-2__tool::after {
 		inset: 4px;
-		border-radius: var(--radius-3);
+		border-radius: 8px;
 	}
 
 	.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):hover {
@@ -459,7 +469,7 @@
 	height: 3px;
 	width: 100%;
 	background-color: var(--color-muted-1);
-	border-radius: var(--radius-4);
+	border-radius: 14px;
 }
 
 .tlui-slider__range {
@@ -468,7 +478,7 @@
 	left: 0px;
 	height: 3px;
 	background-color: var(--color-selected);
-	border-radius: var(--radius-4);
+	border-radius: 14px;
 }
 
 .tlui-slider__thumb {
@@ -586,15 +596,6 @@
 	position: relative;
 	z-index: var(--layer-panels);
 	width: fit-content;
-}
-
-.tlui-menu-zone::before {
-	content: '';
-	display: block;
-	position: absolute;
-	top: 0px;
-	left: 0px;
-	inset: 0px -4px -4px 0px;
 	border-right: 4px solid var(--color-background);
 	border-bottom: 4px solid var(--color-background);
 	border-bottom-right-radius: var(--radius-4);
@@ -927,7 +928,7 @@
 	display: flex;
 	flex-direction: row;
 	background-color: var(--color-low);
-	border-radius: var(--radius-4);
+	border-radius: 11px;
 	z-index: var(--layer-panels);
 	pointer-events: all;
 	position: relative;
@@ -1032,28 +1033,6 @@
 .tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
 	border-radius: var(--radius-1);
 	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
-}
-
-.tlui-menu__button {
-	width: 100%;
-	justify-content: space-between;
-}
-
-.tlui-menu__button__wide {
-	max-width: initial;
-}
-
-.tlui-menu__button:nth-child(n + 2) {
-	margin-top: -8px;
-}
-
-.tlui-menu__button:nth-last-child(n + 2) {
-	margin-bottom: -8px;
-}
-
-.tlui-menu__button > span:only-child {
-	text-align: left;
-	flex-grow: 2;
 }
 
 /* ------------------ Actions Menu ------------------ */
@@ -1206,26 +1185,6 @@
 	border-right: 4px solid var(--color-background);
 	border-top-right-radius: var(--radius-4);
 	background-color: var(--color-low);
-}
-
-.tlui-navigation-zone__controls {
-	display: flex;
-	flex-direction: row;
-	width: min-content;
-	background-color: none;
-	overflow: hidden;
-}
-
-.tlui-navigation-zone__controls > .tlui-button {
-	margin-left: -2px;
-	margin-right: -2px;
-}
-
-.tlui-navigation-zone__controls > .tlui-button:nth-of-type(1) {
-	margin-left: 0px;
-}
-.tlui-navigation-zone__controls > .tlui-button:nth-last-of-type(1) {
-	margin-right: 0px;
 }
 
 .tlui-navigation-zone__toggle .tlui-icon {
@@ -1552,6 +1511,7 @@
 
 .tlui-embed-dialog__warning {
 	color: var(--color-warn);
+	text-shadow: none;
 }
 
 .tlui-embed-dialog__instruction__link {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -419,7 +419,7 @@
 	align-items: flex-start;
 	width: min-content;
 	gap: var(--space-3);
-	margin: var(--space-3);
+	margin: var(--space-2) var(--space-3);
 	white-space: nowrap;
 	pointer-events: none;
 	z-index: var(--layer-panels);

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -28,6 +28,7 @@
 	cursor: pointer;
 	pointer-events: all;
 	font-weight: inherit;
+	font-family: inherit;
 	text-rendering: optimizeLegibility;
 	font-size: 12px;
 	gap: 0px;
@@ -36,6 +37,11 @@
 }
 
 .tlui-button-2:disabled {
+	color: var(--color-text-3);
+	text-shadow: none;
+}
+
+.tlui-button-2:disabled .tlui-kbd {
 	color: var(--color-text-3);
 }
 
@@ -180,7 +186,8 @@
 }
 
 .tlui-button-2__checkbox__indicator {
-	width: 16px;
+	width: 15px;
+	height: 15px;
 }
 
 /* Tool lock button */
@@ -470,12 +477,12 @@
 	top: -1px;
 	background-color: var(--color-panel);
 	border-radius: 999px;
-	box-shadow: inset 0px 0px 0px 2px var(--color-text-2);
+	box-shadow: inset 0px 0px 0px 2px var(--color-text-1);
 }
 
 .tlui-slider__thumb:active {
 	cursor: grabbing;
-	box-shadow: inset 0px 0px 0px 2px var(--color-text-2), var(--shadow-1);
+	box-shadow: inset 0px 0px 0px 2px var(--color-text-1), var(--shadow-1);
 }
 
 .tlui-slider__thumb:focus-visible {
@@ -495,7 +502,7 @@
 	grid-auto-columns: minmax(1em, auto);
 	gap: 1px;
 	align-self: bottom;
-	color: var(--color-text-2);
+	color: var(--color-text-1);
 	margin-left: var(--space-4);
 }
 
@@ -1027,10 +1034,7 @@
 	font-size: inherit;
 	font-weight: inherit;
 	margin: 0px;
-	color: var(--color-text-2);
-	letter-spacing: 0.5px;
-	text-transform: uppercase;
-	font-size: 9px;
+	color: var(--color-text-3);
 	height: 32px;
 	display: flex;
 	align-items: center;

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1135,12 +1135,6 @@
 	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
-.tlui-toolbar__divider {
-	display: block;
-	background: var(--color-divider);
-	height: 18px;
-	width: 1px;
-}
 /* -------------------- Help Zone ------------------- */
 
 .tlui-help-menu {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -75,7 +75,7 @@
 		opacity: 0;
 	}
 
-	.tlui-button-2:hover::after {
+	.tlui-button-2:not(:disabled, :focus-visible):hover::after {
 		opacity: 1;
 	}
 }
@@ -286,14 +286,14 @@
 	display: flex;
 	flex-direction: row;
 }
-.tlui-buttons__horizontal > .tlui-button-2 {
+.tlui-buttons__horizontal > * {
 	margin-left: -2px;
 	margin-right: -2px;
 }
-.tlui-buttons__horizontal > .tlui-button-2:nth-of-type(1) {
+.tlui-buttons__horizontal > *:nth-child(1) {
 	margin-left: 0px;
 }
-.tlui-buttons__horizontal > .tlui-button-2:nth-last-of-type(1) {
+.tlui-buttons__horizontal > *:nth-last-child(1) {
 	margin-right: 0px;
 }
 
@@ -707,49 +707,6 @@
 
 .tlui-menu-zone *[data-state='open']::after {
 	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
-}
-
-.tlui-menu-zone__controls {
-	position: relative;
-	display: flex;
-	align-items: center;
-	grid-row: 1;
-	grid-column: 1;
-	width: fit-content;
-	border-radius: var(--radius-1) var(--radius-1) var(--radius-4) var(--radius-1);
-	display: flex;
-	flex-direction: row;
-	z-index: var(--layer-panels);
-	pointer-events: all;
-}
-
-.tlui-menu-zone__divider {
-	width: 1px;
-	height: 18px;
-	background-color: var(--color-muted-1);
-}
-
-.tlui-menu-zone__controls > * {
-	margin-left: -2px;
-	margin-right: -2px;
-}
-
-.tlui-menu-zone__controls > *:first-child {
-	margin-left: 0px;
-}
-
-.tlui-menu-zone__controls > *:last-child {
-	margin-right: 0px;
-}
-
-.tlui-menu-zone__controls > .tlui-menu-zone__divider {
-	margin-left: 0px;
-	margin-right: 0px;
-}
-
-.tlui-menu-zone__controls .tlui-icon {
-	width: 15px;
-	height: 15px;
 }
 
 /* ------------------- Style Panel ------------------ */
@@ -1534,18 +1491,15 @@
 
 .tlui-navigation-zone__toggle .tlui-icon {
 	opacity: 0.24;
-	transition: opacity 0.2s ease-in-out;
 }
 
 .tlui-navigation-zone__toggle:active .tlui-icon {
 	opacity: 1;
-	transition: opacity 0.12s ease-in-out;
 }
 
 @media (hover: hover) {
 	.tlui-navigation-zone__toggle:hover .tlui-icon {
 		opacity: 1;
-		transition: opacity 0.12s ease-in-out;
 	}
 }
 
@@ -1821,7 +1775,7 @@
 }
 
 @media (hover: hover) {
-	.tlui-embed-dialog__item:hover::after {
+	.tlui-embed-dialog__item:not(:disabled, :focus-visible):hover::after {
 		display: block;
 		content: '';
 		position: absolute;

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -72,7 +72,7 @@
 	align-items: flex-start;
 	width: min-content;
 	gap: var(--space-3);
-	margin: var(--space-3) var(--space-2);
+	margin: var(--space-3);
 	white-space: nowrap;
 	pointer-events: none;
 	z-index: var(--layer-panels);
@@ -1765,4 +1765,7 @@
 	animation-duration: 0.12s;
 	animation-delay: 2s;
 	animation-fill-mode: forwards;
+}
+
+.tlui-button-2 {
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -35,7 +35,7 @@
 	text-shadow: 1px 1px var(--color-panel);
 }
 
-.tlui-button:disabled {
+.tlui-button-2:disabled {
 	color: var(--color-text-3);
 }
 
@@ -274,6 +274,12 @@
 	}
 }
 
+/* Icon */
+
+.tlui-button-2__icon-left {
+	margin-right: var(--space-4);
+}
+
 /* Button Row */
 
 .tlui-buttons__horizontal {
@@ -507,7 +513,7 @@
 }
 
 /* --------------------- Button --------------------- */
-
+/* 
 .tlui-button {
 	margin: 0px;
 	position: relative;
@@ -571,25 +577,21 @@
 	.tlui-button:not([data-state='selected'], :disabled):hover::after {
 		background: var(--color-muted-2);
 	}
-}
+} */
 
-.tlui-icon-left {
-	margin-right: var(--space-4);
-}
-
-.tlui-button > * {
+/* .tlui-button > * {
 	position: relative;
 	z-index: 100;
 	color: inherit;
-}
-
+} */
+/* 
 .tlui-button > svg {
 	width: 18px;
 	height: 18px;
 	pointer-events: none;
-}
+} */
 
-.tlui-button:not(:disabled, :focus-visible, [data-state='open']):active {
+/* .tlui-button:not(:disabled, :focus-visible, [data-state='open']):active {
 	z-index: 2;
 	color: var(--color-text-0);
 }
@@ -611,25 +613,25 @@
 
 .tlui-button:disabled {
 	color: var(--color-text-3);
+} */
+
+/* Squished */
+
+/* .tlui-button.squished {
+	height: 36px;
+	width: 44px;
 }
+
+.tlui-button.squished {
+	height: 36px;
+	width: 44px;
+} */
 
 /* Focus Mode Button */
 
 .tlui-focus-button {
 	z-index: var(--layer-panels);
 	pointer-events: all;
-}
-
-/* Squished */
-
-.tlui-button.squished {
-	height: 36px;
-	width: 44px;
-}
-
-.tlui-button.squished {
-	height: 36px;
-	width: 44px;
 }
 
 /* --------------------- Popover -------------------- */
@@ -645,7 +647,7 @@
 	max-height: 75vh;
 	margin: 0px;
 	border: none;
-	border-radius: var(--radius-1);
+	border-radius: var(--radius-3);
 	background-color: var(--color-panel);
 	box-shadow: var(--shadow-3);
 	z-index: var(--layer-menus);
@@ -760,10 +762,10 @@
 	height: fit-content;
 	max-height: 100%;
 	margin: var(--space-3);
-	overflow: hidden;
 	touch-action: auto;
 	overscroll-behavior: none;
 	overflow-y: auto;
+	overflow-x: hidden;
 	color: var(--color-text);
 }
 
@@ -771,6 +773,8 @@
 	position: relative;
 	z-index: var(--layer-panels);
 	pointer-events: all;
+	width: 148px;
+	max-width: 148px;
 }
 
 .tlui-style-panel::-webkit-scrollbar {
@@ -803,29 +807,31 @@
 .tlui-style-panel__row {
 	display: flex;
 }
-.tlui-style-panel__row > *:nth-child(2) {
-	margin-left: -4px;
+/* Only really used for the alignment picker */
+.tlui-style-panel__row__extra-button {
+	margin-left: -2px;
+}
+
+.tlui-style-panel__double-select-picker__wrapper {
+	width: 100%;
+	max-width: 100%;
 }
 
 .tlui-style-panel__double-select-picker {
-	display: grid;
-	grid-template-columns: 1fr auto auto;
+	display: flex;
+	grid-template-columns: 1fr auto;
 	align-items: center;
 	padding-left: var(--space-4);
+	color: var(--color-text-1);
 	font-size: 12px;
-	width: 164px;
-}
-
-.tlui-style-panel__double-select-picker > .tlui-button {
-	min-width: 44px;
-	margin-left: -4px;
 }
 
 .tlui-style-panel__double-select-picker-label {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	color: var(--color-text-1);
+	flex-grow: 2;
+	max-width: 100%;
 }
 
 .tlui-style-panel__section *[data-state='open']::after {
@@ -839,8 +845,8 @@
 	margin: 0px;
 	position: relative;
 	z-index: 1;
-	height: 44px;
-	max-height: 44px;
+	height: 40px;
+	max-height: 40px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -848,13 +854,14 @@
 	font-size: 12px;
 	font-weight: inherit;
 	color: var(--color-text-1);
-	padding: 13px;
+	padding: var(--space-4);
 	padding-left: 0px;
 	border: none;
 	outline: none;
 	text-overflow: ellipsis;
 	width: 100%;
 	user-select: all;
+	text-rendering: optimizeLegibility;
 	-webkit-user-select: auto !important;
 }
 
@@ -1140,19 +1147,6 @@
 	margin-right: 0px;
 	pointer-events: all;
 	width: fit-content;
-}
-
-.tlui-toolbar__extras__controls > * {
-	margin-left: -2px;
-	margin-left: -2px;
-}
-
-.tlui-toolbar__extras__controls > *:nth-of-type(1) {
-	margin-left: 0px;
-}
-
-.tlui-toolbar__extras__controls > *:nth-last-of-type(1) {
-	margin-right: 0px;
 }
 
 .tlui-toolbar__tools {
@@ -1463,7 +1457,7 @@
 }
 
 /* --------------------- Mobile --------------------- */
-
+/* 
 @media (max-width: 640px) {
 	.tlui-menu__group .tlui-button {
 		height: 40px;
@@ -1476,7 +1470,7 @@
 	.tlui-menu__group .tlui-button > .tlui-icon-left {
 		display: none;
 	}
-}
+} */
 
 /* --------------------- Bottom --------------------- */
 
@@ -1625,7 +1619,6 @@
 	align-items: center;
 	width: 100%;
 	padding-left: var(--space-4);
-	min-height: 44px;
 	border-bottom: 1px solid var(--color-divider);
 }
 
@@ -1636,7 +1629,6 @@
 .tlui-page-menu__header__title {
 	color: var(--color-text);
 	font-size: 12px;
-	font-weight: 500;
 	flex-grow: 2;
 }
 
@@ -1663,14 +1655,16 @@
 	flex-direction: row;
 	align-items: center;
 	justify-content: space-between;
+	gap: 0px;
 }
 
 .tlui-page-menu__item:nth-of-type(n + 2) {
 	margin-top: -4px;
 }
 
-.tlui-page-menu__item__button {
+.tlui-page-menu__item__button:not(:only-child) {
 	flex-grow: 2;
+	margin-right: -2px;
 }
 
 .tlui-page-menu__item__button > span {
@@ -1725,6 +1719,7 @@
 .tlui-page_menu__item__sortable__handle {
 	touch-action: none;
 	width: 32px;
+	min-width: 0px;
 	height: 40px;
 	cursor: grab;
 	color: var(--color-text-3);
@@ -1737,7 +1732,7 @@
 }
 
 .tlui-page-menu__item__input {
-	margin-left: 13px;
+	margin-left: 12px;
 	height: 100%;
 }
 
@@ -1745,12 +1740,17 @@
 /* If the user can hover, then visible but opacity zero until hover */
 /* If the user cannot hover, then not displayed unless editing, and then opacity 1 */
 
+.tlui-page_menu__item__button + .tlui-page_menu__item__submenu {
+	background-color: red;
+}
+
 .tlui-page_menu__item__submenu {
 	pointer-events: all;
 	flex: 0;
 	cursor: pointer;
 	margin: 0px;
 	display: none;
+	margin-left: -2px;
 }
 
 .tlui-page_menu__item__submenu[data-isediting='true'] {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -81,7 +81,7 @@
 		opacity: 0;
 	}
 
-	.tlui-button:not(:disabled, :focus-visible):hover::after {
+	.tlui-button:not(:disabled):hover::after {
 		opacity: 1;
 	}
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -57,8 +57,8 @@
 
 .tlui-button-2:focus-visible:not(:hover) {
 	outline: 1px solid var(--color-selected);
-	outline-offset: 0px;
-	border-radius: 2px;
+	outline-offset: -4px;
+	border-radius: var(--radius-3);
 }
 
 .tlui-button-2::after {
@@ -67,7 +67,7 @@
 	position: absolute;
 	inset: 4px;
 	background-color: transparent;
-	border-radius: 6px;
+	border-radius: var(--radius-2);
 }
 
 .tlui-button-2[aria-expanded='true']::after {
@@ -89,7 +89,7 @@
 /* Low button  */
 
 .tlui-button-2__low {
-	border-radius: 8px;
+	border-radius: var(--radius-3);
 	background-color: var(--color-low);
 	border: 1px solid var(--color-low-border);
 }
@@ -153,7 +153,7 @@
 @media (hover: hover) {
 	.tlui-button-2__icon::after {
 		inset: 4px;
-		border-radius: 6px;
+		border-radius: var(--radius-2);
 	}
 
 	.tlui-button-2__icon[data-state='hinted']:not(:disabled, :focus-visible):hover::after {
@@ -175,7 +175,7 @@
 @media (hover: hover) {
 	.tlui-button-2__menu::after {
 		inset: 4px;
-		border-radius: 6px;
+		border-radius: var(--radius-2);
 	}
 }
 
@@ -227,20 +227,10 @@
 	margin-right: 0px;
 }
 
-.tlui-layout__mobile .tlui-button-2__tool {
-	height: 48px;
-	width: 44px;
-}
-
-.tlui-layout__mobile .tlui-button-2__tool > .tlui-icon {
-	height: 16px;
-	width: 16px;
-}
-
 @media (hover: hover) {
 	.tlui-button-2__tool::after {
 		inset: 4px;
-		border-radius: 8px;
+		border-radius: var(--radius-3);
 	}
 
 	.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):hover {
@@ -335,6 +325,26 @@
 	text-align: center;
 }
 
+@media (max-width: 640px) {
+	.tlui-button-2__tool {
+		height: 48px;
+		width: 44px;
+	}
+
+	.tlui-button-2__tool > .tlui-icon {
+		height: 16px;
+		width: 16px;
+	}
+
+	.tlui-kbd {
+		visibility: hidden;
+	}
+
+	.tlui-menu__group .tlui-button-2__icon-left {
+		display: none;
+	}
+}
+
 /* --------------------- Layout --------------------- */
 
 .tlui-layout {
@@ -403,12 +413,6 @@
 	white-space: nowrap;
 	pointer-events: none;
 	z-index: var(--layer-panels);
-}
-
-.tlui-helper-buttons > .tlui-button {
-	pointer-events: all;
-	background-color: var(--color-low);
-	border-radius: var(--radius-3);
 }
 
 /* ---------------------- Icon ---------------------- */
@@ -518,121 +522,6 @@
 .tlui-kbd:not(:last-child) {
 	margin-right: var(--space-2);
 }
-
-/* --------------------- Button --------------------- */
-/* 
-.tlui-button {
-	margin: 0px;
-	position: relative;
-	height: 44px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-family: inherit;
-	font-size: 12px;
-	font-weight: inherit;
-	color: var(--color-text-1);
-	padding: 0px 13px;
-	cursor: pointer;
-	border: none;
-	outline: none;
-	user-select: none;
-	white-space: nowrap;
-	overflow: hidden;
-	background: transparent;
-	text-shadow: 1px 1px 0px var(--color-panel);
-}
-
-.tlui-button::after {
-	content: '';
-	position: absolute;
-	right: 4px;
-	bottom: 4px;
-	display: block;
-	width: calc(100% - 8px);
-	height: calc(100% - 8px);
-	border-radius: var(--radius-3);
-	background-color: transparent;
-	pointer-events: none;
-}
-
-.tlui-button > span {
-	text-overflow: ellipsis;
-	overflow: hidden;
-	display: flex;
-	align-items: center;
-}
-
-.tlui-button > span:not(:only-child) {
-	flex-grow: 2;
-}
-
-.tlui-button > span > svg {
-	margin-left: var(--space-2);
-}
-
-.tlui-button:disabled {
-	cursor: default;
-	color: var(--color-text-3);
-}
-
-.tlui-button:not([data-state='selected'], :disabled):active::after {
-	background: var(--color-muted-2);
-}
-
-@media (hover: hover) {
-	.tlui-button:not([data-state='selected'], :disabled):hover::after {
-		background: var(--color-muted-2);
-	}
-} */
-
-/* .tlui-button > * {
-	position: relative;
-	z-index: 100;
-	color: inherit;
-} */
-/* 
-.tlui-button > svg {
-	width: 18px;
-	height: 18px;
-	pointer-events: none;
-} */
-
-/* .tlui-button:not(:disabled, :focus-visible, [data-state='open']):active {
-	z-index: 2;
-	color: var(--color-text-0);
-}
-
-.tlui-button:not(:hover, :disabled, [data-state='open']):focus-visible::after {
-	box-shadow: inset 0 0 0 2px var(--color-focus);
-}
-
-.tlui-button[data-state='selected']:not(:hover, :disabled):focus-visible::after {
-	box-shadow: inset 0 0 0 2px var(--color-focus);
-}
-
-@media (hover: hover) {
-	.tlui-button:not(:disabled, :focus-visible):hover {
-		z-index: 2;
-		color: var(--color-text-0);
-	}
-}
-
-.tlui-button:disabled {
-	color: var(--color-text-3);
-} */
-
-/* Squished */
-
-/* .tlui-button.squished {
-	height: 36px;
-	width: 44px;
-}
-
-.tlui-button.squished {
-	height: 36px;
-	width: 44px;
-} */
 
 /* Focus Mode Button */
 
@@ -984,81 +873,6 @@
 	margin-right: -4px;
 }
 
-.tlui-dialog__scrim {
-	display: block;
-	content: '';
-	bottom: 0px;
-	width: 100%;
-	height: 40px;
-	position: absolute;
-	background: linear-gradient(transparent, var(--color-panel));
-	border-bottom-left-radius: var(--radius-4);
-	border-bottom-right-radius: var(--radius-4);
-	pointer-events: none;
-}
-
-/* ---------------- Shortcuts ---------------- */
-
-.tlui-shortcuts-dialog__header {
-	border-bottom: 1px solid var(--color-divider);
-}
-
-.tlui-shortcuts-dialog__body {
-	position: relative;
-	columns: 1;
-	column-gap: var(--space-9);
-	pointer-events: all;
-	touch-action: auto;
-}
-
-@media (min-width: 475px) {
-	.tlui-shortcuts-dialog__body {
-		columns: 2;
-		column-gap: var(--space-9);
-	}
-}
-
-@media (min-width: 960px) {
-	.tlui-shortcuts-dialog__body {
-		columns: 3;
-		column-gap: var(--space-9);
-	}
-}
-
-.tlui-shortcuts-dialog__group {
-	break-inside: avoid-column;
-	padding-bottom: var(--space-6);
-}
-
-.tlui-shortcuts-dialog__group__title {
-	font-size: inherit;
-	font-weight: inherit;
-	margin: 0px;
-	color: var(--color-text-3);
-	height: 32px;
-	display: flex;
-	align-items: center;
-}
-
-.tlui-shortcuts-dialog__group__content {
-	display: flex;
-	flex-direction: column;
-	color: var(--color-text-1);
-}
-
-.tlui-shortcuts-dialog__key-pair {
-	display: flex;
-	gap: var(--space-4);
-	align-items: center;
-	justify-content: space-between;
-	height: 32px;
-}
-
-.tlui-shortcuts-dialog__key-pair__key {
-	flex: 1;
-	font-size: 12px;
-}
-
 /* --------------------- Toolbar -------------------- */
 
 /* Wide container */
@@ -1126,13 +940,15 @@
 	width: 40px;
 }
 
-.tlui-layout__mobile .tlui-toolbar__overflow {
-	width: 32px;
-	padding: 0px;
-}
+@media (max-width: 640px) {
+	.tlui-toolbar__overflow {
+		width: 32px;
+		padding: 0px;
+	}
 
-.tlui-toolbar *[data-state='open']::after {
-	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	.tlui-toolbar *[data-state='open']::after {
+		background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	}
 }
 
 /* -------------------- Help Zone ------------------- */
@@ -1239,66 +1055,6 @@
 	text-align: left;
 	flex-grow: 2;
 }
-
-/* ------------------- Button Grid ------------------ */
-/* 
-.tlui-button-grid__button {
-	width: 44px;
-	height: 44px;
-}
-
-.tlui-button-grid__four {
-	display: grid;
-	grid-template-columns: 40px 40px 40px 44px;
-}
-
-.tlui-button-grid__four > .tlui-button-grid__button:nth-child(n + 5) {
-	margin-top: -2px;
-}
-
-.tlui-button-grid__four > .tlui-button-grid__button:nth-last-child(n + 5) {
-	margin-bottom: -2px;
-}
-
-.tlui-button-grid__three {
-	display: grid;
-	grid-template-columns: 40px 40px 44px;
-}
-
-.tlui-button-grid__three > .tlui-button-grid__button:nth-child(n + 4) {
-	margin-top: -2px;
-}
-
-.tlui-button-grid__three > .tlui-button-grid__button:nth-last-child(n + 4) {
-	margin-bottom: -2px;
-}
-
-.tlui-button-grid__two {
-	display: grid;
-	grid-template-columns: 40px 44px;
-}
-
-.tlui-button-grid__two > .tlui-button-grid__button:nth-child(n + 3) {
-	margin-top: -2px;
-}
-
-.tlui-button-grid__two > .tlui-button-grid__button:nth-last-child(n + 3) {
-	margin-bottom: -2px;
-} */
-
-/* 
-.tlui-button-grid__button:not(:nth-child(4n - 3)) {
-	margin-left: -2px;
-}
-
-.tlui-button-grid__button:not(:nth-child(4n)) {
-	margin-right: -2px;
-}*/
-/* 
-
-.tlui-button-grid__button:nth-last-child(1) {
-	margin-right: 0px;
-} */
 
 /* ------------------ Actions Menu ------------------ */
 
@@ -1411,22 +1167,6 @@
 		animation: swipe-out 100ms ease-out;
 	}
 }
-
-/* --------------------- Mobile --------------------- */
-/* 
-@media (max-width: 640px) {
-	.tlui-menu__group .tlui-button {
-		height: 40px;
-	}
-
-	.tlui-menu__group .tlui-button > .tlui-kbd {
-		display: none;
-	}
-
-	.tlui-menu__group .tlui-button > .tlui-icon-left {
-		display: none;
-	}
-} */
 
 /* --------------------- Bottom --------------------- */
 
@@ -1765,8 +1505,9 @@
 	display: flex;
 	text-align: left;
 	gap: var(--space-3);
+	margin: 0px -8px;
 	cursor: pointer;
-	padding: 0;
+	padding: 0px 4px;
 	align-items: center;
 	color: var(--color-text);
 	font-size: var(--font-size-1);
@@ -1778,17 +1519,13 @@
 		display: block;
 		content: '';
 		position: absolute;
-		inset: 0px;
+		inset: 4px;
 		background-color: var(--color-muted-2);
-		border-radius: var(--radius-4);
+		border-radius: var(--radius-1);
 	}
 }
 
 .tlui-embed-dialog__item__image {
-	padding: var(--space-3);
-}
-
-.tlui-embed-dialog__item__image__img {
 	width: 24px;
 	height: 24px;
 	display: flex;
@@ -1827,13 +1564,13 @@
 	color: var(--color-text-1);
 }
 
-.tlui-following {
+.tlui-following-indicator {
 	display: block;
 	position: absolute;
 	inset: 0px;
 	border-width: 2px;
 	border-style: solid;
-	z-index: 9999999;
+	z-index: var(--layer-following-indicator);
 	pointer-events: none;
 }
 
@@ -1856,4 +1593,66 @@
 	animation-duration: 0.12s;
 	animation-delay: 2s;
 	animation-fill-mode: forwards;
+}
+
+/* --------------- Keyboard shortcuts --------------- */
+
+.tlui-shortcuts-dialog__header {
+	border-bottom: 1px solid var(--color-divider);
+}
+
+.tlui-shortcuts-dialog__body {
+	position: relative;
+	columns: 1;
+	column-gap: var(--space-9);
+	pointer-events: all;
+	touch-action: auto;
+}
+
+@media (min-width: 475px) {
+	.tlui-shortcuts-dialog__body {
+		columns: 2;
+		column-gap: var(--space-9);
+	}
+}
+
+@media (min-width: 960px) {
+	.tlui-shortcuts-dialog__body {
+		columns: 3;
+		column-gap: var(--space-9);
+	}
+}
+
+.tlui-shortcuts-dialog__group {
+	break-inside: avoid-column;
+	padding-bottom: var(--space-6);
+}
+
+.tlui-shortcuts-dialog__group__title {
+	font-size: inherit;
+	font-weight: inherit;
+	margin: 0px;
+	color: var(--color-text-3);
+	height: 32px;
+	display: flex;
+	align-items: center;
+}
+
+.tlui-shortcuts-dialog__group__content {
+	display: flex;
+	flex-direction: column;
+	color: var(--color-text-1);
+}
+
+.tlui-shortcuts-dialog__key-pair {
+	display: flex;
+	gap: var(--space-4);
+	align-items: center;
+	justify-content: space-between;
+	height: 32px;
+}
+
+.tlui-shortcuts-dialog__key-pair__key {
+	flex: 1;
+	font-size: 12px;
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -953,7 +953,7 @@
 	cursor: default;
 	background-color: var(--color-panel);
 	box-shadow: var(--shadow-3);
-	border-radius: var(--radius-4);
+	border-radius: var(--radius-3);
 	font-size: 12px;
 	overflow: hidden;
 	min-width: 300px;
@@ -986,7 +986,7 @@
 }
 
 .tlui-dialog__body {
-	padding: var(--space-4) var(--space-6);
+	padding: var(--space-4) var(--space-4);
 	flex: 0 1;
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -1398,7 +1398,7 @@
 	gap: var(--space-3);
 	background-color: var(--color-panel);
 	box-shadow: var(--shadow-2);
-	border-radius: var(--radius-4);
+	border-radius: var(--radius-3);
 	font-size: 12px;
 }
 
@@ -1722,10 +1722,6 @@
 
 .tlui-page_menu__item__sortable__title > .tlui-input__wrapper {
 	height: 100%;
-}
-
-.tlui-page_menu__item__sortable__button {
-	flex: 0;
 }
 
 .tlui-page_menu__item__sortable:focus-within {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -109,7 +109,7 @@
 }
 
 .tlui-slider__container {
-	width: 164px;
+	width: 100%;
 	padding: 0px var(--space-4);
 }
 
@@ -397,7 +397,7 @@
 	max-height: 75vh;
 	margin: 0px;
 	border: none;
-	border-radius: var(--radius-4);
+	border-radius: var(--radius-3);
 	background-color: var(--color-panel);
 	box-shadow: var(--shadow-3);
 	z-index: var(--layer-menus);
@@ -451,7 +451,7 @@
 	inset: 0px -4px -4px 0px;
 	border-right: 4px solid var(--color-background);
 	border-bottom: 4px solid var(--color-background);
-	border-bottom-right-radius: var(--radius-5);
+	border-bottom-right-radius: var(--radius-4);
 	background-color: var(--color-low);
 }
 
@@ -504,7 +504,7 @@
 
 .tlui-style-panel__wrapper {
 	box-shadow: var(--shadow-2);
-	border-radius: var(--radius-4);
+	border-radius: var(--radius-3);
 	pointer-events: all;
 	background-color: var(--color-panel);
 	height: fit-content;
@@ -1367,7 +1367,7 @@
 	border-radius: 0;
 	border-top: 4px solid var(--color-background);
 	border-right: 4px solid var(--color-background);
-	border-top-right-radius: var(--radius-5);
+	border-top-right-radius: var(--radius-4);
 	background-color: var(--color-low);
 }
 
@@ -1421,11 +1421,6 @@
 	position: relative;
 	width: 100%;
 	height: 100%;
-}
-
-.tlui-zoom-menu__button__pct {
-	width: 60px;
-	text-align: center;
 }
 
 /* ----------------------- ... ---------------------- */
@@ -1767,5 +1762,180 @@
 	animation-fill-mode: forwards;
 }
 
+/* -------------------------------------------------- */
+/*                     UI Refresh                     */
+/* -------------------------------------------------- */
+
+/* Button */
+
 .tlui-button-2 {
+	position: relative;
+	height: 44px;
+	min-width: 44px;
+	padding: 0px 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: transparent;
+	border: transparent;
+	color: currentColor;
+	cursor: pointer;
+	pointer-events: all;
+	font-weight: 500;
+	text-rendering: optimizeLegibility;
+	font-size: 12px;
+	gap: 0px;
+	color: var(--color-text-1);
+	text-shadow: 1px 1px var(--color-panel);
+}
+
+.tlui-button-2__label {
+	flex-grow: 2;
+	text-align: left;
+}
+
+.tlui-button-2:focus-visible:not(:hover) {
+	outline: 1px solid var(--color-selected);
+	outline-offset: 0px;
+	border-radius: 2px;
+}
+
+.tlui-button-2::after {
+	display: block;
+	content: '';
+	position: absolute;
+	inset: 2px;
+	background-color: transparent;
+	border-radius: 6px;
+	z-index: 1;
+}
+
+.tlui-button-2[aria-expanded='true']::after {
+	background-color: var(--color-muted-0);
+	opacity: 1;
+}
+
+@media (hover: hover) {
+	.tlui-button-2::after {
+		background-color: var(--color-muted-2);
+		opacity: 0;
+	}
+
+	.tlui-button-2:hover::after {
+		opacity: 1;
+	}
+}
+/* Low button  */
+
+.tlui-button-2__low {
+	border-radius: 8px;
+	background-color: var(--color-low);
+	border: 1px solid var(--color-low-border);
+}
+
+@media (hover: hover) {
+	.tlui-button-2__low::after {
+		background-color: var(--color-muted-2);
+	}
+}
+
+/* Panel button */
+
+.tlui-button-2__panel {
+	position: relative;
+}
+
+/* Tool button  */
+
+.tlui-button-2__tool {
+	position: relative;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__tool::after {
+		inset: 4px;
+		border-radius: 8px;
+	}
+}
+
+/* Icon button */
+
+.tlui-button-2__icon {
+	height: 40px;
+	width: 40px;
+	min-height: 40px;
+	min-width: 40px;
+	padding: 0px;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__icon::after {
+		inset: 4px;
+		border-radius: 6px;
+	}
+}
+
+/* Menu button */
+
+.tlui-button-2__menu {
+	height: 40px;
+	min-height: 40px;
+	min-width: 128px;
+	width: auto;
+	gap: 8px;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__menu::after {
+		inset: 4px;
+		border-radius: 6px;
+	}
+}
+
+/* Button Row */
+
+.tlui-buttons__horizontal {
+	display: flex;
+	flex-direction: row;
+}
+.tlui-buttons__horizontal > .tlui-button-2 {
+	margin-left: -2px;
+	margin-right: -2px;
+}
+.tlui-buttons__horizontal > .tlui-button-2:nth-of-type(1) {
+	margin-left: 0px;
+}
+.tlui-buttons__horizontal > .tlui-button-2:nth-last-of-type(1) {
+	margin-right: 0px;
+}
+
+/* Button Grid */
+
+.tlui-buttons__grid {
+	display: grid;
+	grid-template-columns: repeat(4, auto);
+	grid-auto-flow: row;
+}
+.tlui-buttons__grid > .tlui-button-2 {
+	margin: -2px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n) {
+	margin-right: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n - 3) {
+	margin-left: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(-n + 4) {
+	margin-top: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-last-of-type(-n + 4) {
+	margin-bottom: 0px;
+}
+
+/* Zoom button */
+
+.tlui-zoom-menu__button__pct {
+	width: 60px;
+	min-width: 60px;
+	text-align: center;
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -27,12 +27,12 @@
 	color: currentColor;
 	cursor: pointer;
 	pointer-events: all;
-	font-weight: 500;
+	font-weight: inherit;
 	text-rendering: optimizeLegibility;
 	font-size: 12px;
 	gap: 0px;
 	color: var(--color-text-1);
-	text-shadow: 1px 1px var(--color-panel);
+	text-shadow: 1px 1px var(--color-text-shadow);
 }
 
 .tlui-button-2:disabled {
@@ -257,10 +257,10 @@
 /* Help */
 
 .tlui-button-2__help {
-	height: 40px;
-	width: 40px;
+	height: 32px;
+	width: 32px;
 	padding: 0px;
-	min-width: 40px;
+	min-width: 32px;
 	border-radius: 100%;
 	background-color: var(--color-low);
 	border: 1px solid var(--color-low-border);
@@ -946,7 +946,6 @@
 	font-size: 12px;
 	margin: 0px;
 	color: var(--color-text-1);
-	font-weight: 500;
 }
 
 .tlui-dialog__header__close {
@@ -1026,7 +1025,7 @@
 
 .tlui-shortcuts-dialog__group__title {
 	font-size: inherit;
-	font-weight: 500;
+	font-weight: inherit;
 	margin: 0px;
 	color: var(--color-text-2);
 	letter-spacing: 0.5px;
@@ -1143,9 +1142,11 @@
 .tlui-help-menu {
 	pointer-events: all;
 	position: absolute;
-	bottom: var(--space-3);
-	right: var(--space-3);
+	bottom: var(--space-2);
+	right: var(--space-2);
 	z-index: var(--layer-panels);
+	border: 4px solid var(--color-background);
+	border-radius: 100%;
 }
 
 /* ------------------ Context Menu ------------------ */
@@ -1367,8 +1368,8 @@
 }
 
 .tlui-toast__title {
-	font-weight: 600;
-	color: var(--color-text);
+	font-weight: inherit;
+	color: var(--color-text-1);
 }
 
 .tlui-toast__description {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -14,7 +14,7 @@
 
 /* Button */
 
-.tlui-button-2 {
+.tlui-button {
 	position: relative;
 	height: 40px;
 	min-width: 40px;
@@ -36,32 +36,32 @@
 	text-shadow: 1px 1px var(--color-text-shadow);
 }
 
-.tlui-button-2:disabled {
+.tlui-button:disabled {
 	color: var(--color-text-3);
 	text-shadow: none;
 }
 
-.tlui-button-2:disabled .tlui-kbd {
+.tlui-button:disabled .tlui-kbd {
 	color: var(--color-text-3);
 }
 
-.tlui-button-2 > * {
+.tlui-button > * {
 	position: relative;
 	z-index: 1;
 }
 
-.tlui-button-2__label {
+.tlui-button__label {
 	flex-grow: 2;
 	text-align: left;
 }
 
-.tlui-button-2:focus-visible:not(:hover) {
+.tlui-button:focus-visible:not(:hover) {
 	outline: 1px solid var(--color-selected);
 	outline-offset: -4px;
 	border-radius: var(--radius-3);
 }
 
-.tlui-button-2::after {
+.tlui-button::after {
 	display: block;
 	content: '';
 	position: absolute;
@@ -70,52 +70,52 @@
 	border-radius: var(--radius-2);
 }
 
-.tlui-button-2[aria-expanded='true']::after {
+.tlui-button[aria-expanded='true']::after {
 	background-color: var(--color-muted-0);
 	opacity: 1;
 }
 
 @media (hover: hover) {
-	.tlui-button-2::after {
+	.tlui-button::after {
 		background-color: var(--color-muted-2);
 		opacity: 0;
 	}
 
-	.tlui-button-2:not(:disabled, :focus-visible):hover::after {
+	.tlui-button:not(:disabled, :focus-visible):hover::after {
 		opacity: 1;
 	}
 }
 
 /* Low button  */
 
-.tlui-button-2__low {
+.tlui-button__low {
 	border-radius: var(--radius-3);
 	background-color: var(--color-low);
 }
 
 @media (hover: hover) {
-	.tlui-button-2__low::after {
+	.tlui-button__low::after {
 		background-color: var(--color-muted-2);
 	}
 }
 
 /* Primary / danger buttons */
 
-.tlui-button-2__primary {
+.tlui-button__primary {
 	color: var(--color-primary);
 }
 
-.tlui-button-2__danger {
+.tlui-button__danger {
 	color: var(--color-warn);
 	text-shadow: none;
 }
 
 @media (hover: hover) {
-	.tlui-button-2__primary:not(:disabled, :focus-visible):hover {
+	.tlui-button__primary:not(:disabled, :focus-visible):hover {
 		color: var(--color-primary);
 	}
 
-	.tlui-button-2__danger:not(:disabled, :focus-visible):hover {
+	.tlui-button__danger:not(:disabled, :focus-visible):hover {
 		color: var(--color-warn);
 		text-shadow: none;
 	}
@@ -123,13 +123,13 @@
 
 /* Panel button */
 
-.tlui-button-2__panel {
+.tlui-button__panel {
 	position: relative;
 }
 
 /* Icon button */
 
-.tlui-button-2__icon {
+.tlui-button__icon {
 	height: 40px;
 	width: 40px;
 	min-height: 40px;
@@ -139,25 +139,25 @@
 
 /* Hinted */
 
-.tlui-button-2__icon[data-state='hinted']::after {
+.tlui-button__icon[data-state='hinted']::after {
 	background: var(--color-hint);
 	opacity: 1;
 	/* box-shadow: inset 0 0 0 1px var(--color-muted-1); */
 }
 
-.tlui-button-2__icon[data-state='hinted']:not(:disabled, :focus-visible):active::after {
+.tlui-button__icon[data-state='hinted']:not(:disabled, :focus-visible):active::after {
 	background: var(--color-hint);
 	opacity: 1;
 	/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
 }
 
 @media (hover: hover) {
-	.tlui-button-2__icon::after {
+	.tlui-button__icon::after {
 		inset: 4px;
 		border-radius: var(--radius-2);
 	}
 
-	.tlui-button-2__icon[data-state='hinted']:not(:disabled, :focus-visible):hover::after {
+	.tlui-button__icon[data-state='hinted']:not(:disabled, :focus-visible):hover::after {
 		background: var(--color-hint);
 		/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
 	}
@@ -165,7 +165,7 @@
 
 /* Menu button */
 
-.tlui-button-2__menu {
+.tlui-button__menu {
 	height: 40px;
 	min-height: 40px;
 	min-width: 128px;
@@ -174,16 +174,16 @@
 	margin: -4px 0px;
 }
 
-.tlui-button-2__menu:nth-child(1) {
+.tlui-button__menu:nth-child(1) {
 	margin-top: 0px;
 }
 
-.tlui-button-2__menu:nth-last-child(1) {
+.tlui-button__menu:nth-last-child(1) {
 	margin-bottom: 0px;
 }
 
 @media (hover: hover) {
-	.tlui-button-2__menu::after {
+	.tlui-button__menu::after {
 		inset: 4px;
 		border-radius: var(--radius-2);
 	}
@@ -191,11 +191,11 @@
 
 /* Menu checkbox button */
 
-.tlui-button-2__checkbox {
+.tlui-button__checkbox {
 	padding-left: 8px;
 }
 
-.tlui-button-2__checkbox__indicator {
+.tlui-button__checkbox__indicator {
 	width: 15px;
 	height: 15px;
 }
@@ -221,7 +221,7 @@
 
 /* Tool button  */
 
-.tlui-button-2__tool {
+.tlui-button__tool {
 	position: relative;
 	height: 48px;
 	width: 48px;
@@ -229,41 +229,41 @@
 	margin-right: -2px;
 }
 
-.tlui-button-2__tool:nth-of-type(1) {
+.tlui-button__tool:nth-of-type(1) {
 	margin-left: 0px;
 }
 
-.tlui-button-2__tool:nth-last-of-type(1) {
+.tlui-button__tool:nth-last-of-type(1) {
 	margin-right: 0px;
 }
 
 @media (hover: hover) {
-	.tlui-button-2__tool::after {
+	.tlui-button__tool::after {
 		inset: 4px;
 		border-radius: 8px;
 	}
 
-	.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):hover {
+	.tlui-button__tool[data-state='selected']:not(:disabled, :focus-visible):hover {
 		color: var(--color-selected-contrast);
 	}
 }
 
-.tlui-button-2__tool[data-state='selected'] {
+.tlui-button__tool[data-state='selected'] {
 	color: var(--color-selected-contrast);
 }
 
-.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):active {
+.tlui-button__tool[data-state='selected']:not(:disabled, :focus-visible):active {
 	color: var(--color-selected-contrast);
 }
 
-.tlui-button-2__tool[data-state='selected']:not(:disabled)::after {
+.tlui-button__tool[data-state='selected']:not(:disabled)::after {
 	background: var(--color-selected);
 	opacity: 1;
 }
 
 /* Help */
 
-.tlui-button-2__help {
+.tlui-button__help {
 	height: 32px;
 	width: 32px;
 	padding: 0px;
@@ -274,7 +274,7 @@
 }
 
 @media (hover: hover) {
-	.tlui-button-2__help::after {
+	.tlui-button__help::after {
 		background-color: var(--color-muted-2);
 		border-radius: 100%;
 		inset: 4px;
@@ -283,7 +283,7 @@
 
 /* Icon */
 
-.tlui-button-2__icon-left {
+.tlui-button__icon-left {
 	margin-right: var(--space-4);
 }
 
@@ -311,19 +311,19 @@
 	grid-template-columns: repeat(4, auto);
 	grid-auto-flow: row;
 }
-.tlui-buttons__grid > .tlui-button-2 {
+.tlui-buttons__grid > .tlui-button {
 	margin: -2px;
 }
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n) {
+.tlui-buttons__grid > .tlui-button:nth-of-type(4n) {
 	margin-right: 0px;
 }
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n - 3) {
+.tlui-buttons__grid > .tlui-button:nth-of-type(4n - 3) {
 	margin-left: 0px;
 }
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(-n + 4) {
+.tlui-buttons__grid > .tlui-button:nth-of-type(-n + 4) {
 	margin-top: 0px;
 }
-.tlui-buttons__grid > .tlui-button-2:nth-last-of-type(-n + 4) {
+.tlui-buttons__grid > .tlui-button:nth-last-of-type(-n + 4) {
 	margin-bottom: 0px;
 }
 
@@ -336,12 +336,12 @@
 }
 
 @media (max-width: 640px) {
-	.tlui-button-2__tool {
+	.tlui-button__tool {
 		height: 48px;
 		width: 44px;
 	}
 
-	.tlui-button-2__tool > .tlui-icon {
+	.tlui-button__tool > .tlui-icon {
 		height: 16px;
 		width: 16px;
 	}
@@ -350,7 +350,7 @@
 		visibility: hidden;
 	}
 
-	.tlui-menu__group .tlui-button-2__icon-left {
+	.tlui-menu__group .tlui-button__icon-left {
 		display: none;
 	}
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -19,7 +19,6 @@
 	height: 100%;
 	max-height: 100%;
 	overflow: clip;
-	padding: var(--space-2);
 	pointer-events: none;
 	user-select: none;
 	contain: strict;
@@ -417,7 +416,6 @@
 /* ------------------- Status Bar ------------------- */
 
 .tlui-debug-panel {
-	margin-top: var(--space-2);
 	background-color: var(--color-low);
 	width: 100%;
 	display: grid;
@@ -450,9 +448,10 @@
 	position: absolute;
 	top: 0px;
 	left: 0px;
-	inset: -4px;
-	border: 4px solid var(--color-background);
-	border-radius: var(--radius-1) var(--radius-1) var(--radius-5) var(--radius-1);
+	inset: 0px -4px -4px 0px;
+	border-right: 4px solid var(--color-background);
+	border-bottom: 4px solid var(--color-background);
+	border-bottom-right-radius: var(--radius-5);
 	background-color: var(--color-low);
 }
 
@@ -510,7 +509,7 @@
 	background-color: var(--color-panel);
 	height: fit-content;
 	max-height: 100%;
-	margin: var(--space-2) var(--space-2);
+	margin: var(--space-3);
 	overflow: hidden;
 	touch-action: auto;
 	overscroll-behavior: none;
@@ -853,7 +852,7 @@
 	align-items: center;
 	justify-content: center;
 	flex-grow: 2;
-	padding-bottom: calc(var(--space-2) + var(--sab));
+	padding-bottom: calc(var(--space-3) + var(--sab));
 }
 
 /* Centered Content */
@@ -1016,16 +1015,16 @@
 .tlui-help-menu {
 	pointer-events: all;
 	position: absolute;
-	bottom: var(--space-2);
-	right: var(--space-2);
+	bottom: var(--space-3);
+	right: var(--space-3);
 }
 
 .tlui-help-menu__button {
 	position: relative;
 	background-color: var(--color-low);
 	border-radius: 100%;
-	height: 48px;
-	width: 48px;
+	height: 40px;
+	width: 40px;
 	overflow: visible;
 	z-index: var(--layer-panels);
 	border: 4px solid var(--color-background);
@@ -1352,7 +1351,6 @@
 	display: flex;
 	width: min-content;
 	flex-direction: column;
-	background-color: var(--color-low);
 	z-index: var(--layer-panels);
 	pointer-events: all;
 	position: absolute;
@@ -1365,9 +1363,10 @@
 	display: block;
 	position: absolute;
 	z-index: -1;
-	inset: -4px;
-	border: 4px solid var(--color-background);
-	border-radius: var(--radius-1);
+	inset: -4px -4px 0px 0px;
+	border-radius: 0;
+	border-top: 4px solid var(--color-background);
+	border-right: 4px solid var(--color-background);
 	border-top-right-radius: var(--radius-5);
 	background-color: var(--color-low);
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -35,6 +35,15 @@
 	text-shadow: 1px 1px var(--color-panel);
 }
 
+.tlui-button:disabled {
+	color: var(--color-text-3);
+}
+
+.tlui-button-2 > * {
+	position: relative;
+	z-index: 1;
+}
+
 .tlui-button-2__label {
 	flex-grow: 2;
 	text-align: left;
@@ -53,7 +62,6 @@
 	inset: 4px;
 	background-color: transparent;
 	border-radius: 6px;
-	z-index: 1;
 }
 
 .tlui-button-2[aria-expanded='true']::after {
@@ -86,6 +94,26 @@
 	}
 }
 
+/* Primary / danger buttons */
+
+.tlui-button-2__primary {
+	color: var(--color-primary);
+}
+
+.tlui-button-2__danger {
+	color: var(--color-warn);
+}
+
+@media (hover: hover) {
+	.tlui-button-2__primary:not(:disabled, :focus-visible):hover {
+		color: var(--color-primary);
+	}
+
+	.tlui-button-2__danger:not(:disabled, :focus-visible):hover {
+		color: var(--color-warn);
+	}
+}
+
 /* Panel button */
 
 .tlui-button-2__panel {
@@ -102,10 +130,29 @@
 	padding: 0px;
 }
 
+/* Hinted */
+
+.tlui-button-2__icon[data-state='hinted']::after {
+	background: var(--color-hint);
+	opacity: 1;
+	/* box-shadow: inset 0 0 0 1px var(--color-muted-1); */
+}
+
+.tlui-button-2__icon[data-state='hinted']:not(:disabled, :focus-visible):active::after {
+	background: var(--color-hint);
+	opacity: 1;
+	/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
+}
+
 @media (hover: hover) {
 	.tlui-button-2__icon::after {
 		inset: 4px;
 		border-radius: 6px;
+	}
+
+	.tlui-button-2__icon[data-state='hinted']:not(:disabled, :focus-visible):hover::after {
+		background: var(--color-hint);
+		/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
 	}
 }
 
@@ -132,7 +179,11 @@
 	padding-left: 8px;
 }
 
-/* Tool button */
+.tlui-button-2__checkbox__indicator {
+	width: 16px;
+}
+
+/* Tool lock button */
 
 .tlui-toolbar__lock-button {
 	position: absolute;
@@ -184,6 +235,23 @@
 		inset: 4px;
 		border-radius: 8px;
 	}
+
+	.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):hover {
+		color: var(--color-selected-contrast);
+	}
+}
+
+.tlui-button-2__tool[data-state='selected'] {
+	color: var(--color-selected-contrast);
+}
+
+.tlui-button-2__tool[data-state='selected']:not(:disabled, :focus-visible):active {
+	color: var(--color-selected-contrast);
+}
+
+.tlui-button-2__tool[data-state='selected']:not(:disabled)::after {
+	background: var(--color-selected);
+	opacity: 1;
 }
 
 /* Help */
@@ -443,7 +511,6 @@
 .tlui-button {
 	margin: 0px;
 	position: relative;
-	z-index: 1;
 	height: 44px;
 	display: flex;
 	align-items: center;
@@ -465,7 +532,6 @@
 
 .tlui-button::after {
 	content: '';
-	z-index: 1;
 	position: absolute;
 	right: 4px;
 	bottom: 4px;
@@ -541,62 +607,10 @@
 		z-index: 2;
 		color: var(--color-text-0);
 	}
-
-	/* 
-	.tlui-button:not(:disabled, :focus-visible):hover::after {
-		box-shadow: inset 0 0 0 1px var(--color-muted-1);
-	} */
-
-	.tlui-button__primary:not(:disabled, :focus-visible):hover {
-		color: var(--color-primary);
-	}
-
-	.tlui-button__warning:not(:disabled, :focus-visible):hover {
-		color: var(--color-warn);
-	}
 }
 
 .tlui-button:disabled {
 	color: var(--color-text-3);
-}
-
-/* Selected */
-
-.tlui-button[data-state='selected'] {
-	color: var(--color-selected-contrast);
-}
-
-.tlui-button[data-state='selected']:not(:disabled, :focus-visible):active {
-	color: var(--color-selected-contrast);
-}
-
-@media (hover: hover) {
-	.tlui-button[data-state='selected']:not(:disabled, :focus-visible):hover {
-		color: var(--color-selected-contrast);
-	}
-}
-
-.tlui-button[data-state='selected']:not(:disabled)::after {
-	background: var(--color-selected);
-}
-
-/* Hinted */
-
-.tlui-button[data-state='hinted']::after {
-	background: var(--color-hint);
-	/* box-shadow: inset 0 0 0 1px var(--color-muted-1); */
-}
-
-.tlui-button[data-state='hinted']:not(:disabled, :focus-visible):active::after {
-	background: var(--color-hint);
-	/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
-}
-
-@media (hover: hover) {
-	.tlui-button[data-state='hinted']:not(:disabled, :focus-visible):hover::after {
-		background: var(--color-hint);
-		/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
-	}
 }
 
 /* Focus Mode Button */
@@ -616,18 +630,6 @@
 .tlui-button.squished {
 	height: 36px;
 	width: 44px;
-}
-
-.tlui-button__primary {
-	color: var(--color-primary);
-}
-
-.tlui-button__warning {
-	color: var(--color-warn);
-}
-
-.tlui-button__danger {
-	color: var(--color-warn);
 }
 
 /* --------------------- Popover -------------------- */
@@ -669,7 +671,7 @@
 	grid-template-columns: 1fr auto auto;
 	justify-content: space-between;
 	padding-left: var(--space-4);
-	border-radius: var(--radius-1);
+	border-top: 1px solid var(--color-background);
 	font-size: 12px;
 	color: var(--color-text-1);
 	z-index: var(--layer-panels);
@@ -726,7 +728,8 @@
 }
 
 .tlui-menu-zone__controls > * {
-	margin: 0px -2px;
+	margin-left: -2px;
+	margin-right: -2px;
 }
 
 .tlui-menu-zone__controls > *:first-child {
@@ -738,7 +741,8 @@
 }
 
 .tlui-menu-zone__controls > .tlui-menu-zone__divider {
-	margin: 0px;
+	margin-left: 0px;
+	margin-right: 0px;
 }
 
 .tlui-menu-zone__controls .tlui-icon {
@@ -1117,52 +1121,38 @@
 /* Row of controls + lock button */
 .tlui-toolbar__extras {
 	position: relative;
+	z-index: 1;
 	width: 100%;
-	height: 44px;
 	pointer-events: none;
-}
-
-.tlui-toolbar__extras__hidden {
-	display: none;
+	top: 4px;
 }
 
 .tlui-toolbar__extras__controls {
 	display: flex;
-	flex-direction: row;
-	background-color: var(--color-low);
-	border-top-left-radius: var(--radius-3);
-	border-top-right-radius: var(--radius-3);
 	position: relative;
-	bottom: -4px;
+	flex-direction: row;
+	z-index: 1;
+	background-color: var(--color-low);
+	border-top-left-radius: var(--radius-4);
+	border-top-right-radius: var(--radius-4);
+	border: 4px solid var(--color-background);
 	margin-left: 8px;
 	margin-right: 0px;
 	pointer-events: all;
 	width: fit-content;
 }
 
-.tlui-toolbar__extras__controls::before {
-	content: '';
-	display: block;
-	position: absolute;
-	z-index: -1;
-	top: 0px;
-	left: 0px;
-	inset: -4px;
-	border: 4px solid var(--color-background);
-	border-radius: var(--radius-4);
-	border-bottom-left-radius: 0px;
-	border-bottom-right-radius: 0px;
-	background-color: var(--color-background);
+.tlui-toolbar__extras__controls > * {
+	margin-left: -2px;
+	margin-left: -2px;
 }
 
-.tlui-toolbar__extras__controls > .tlui-button,
-.tlui-toolbar__extras__controls > .tlui-popover > .tlui-button {
-	height: 40px;
-	width: 40px;
+.tlui-toolbar__extras__controls > *:nth-of-type(1) {
+	margin-left: 0px;
 }
 
-.tlui-toolbar__extras__controls .tlui-button::after {
-	border-radius: var(--radius-2);
+.tlui-toolbar__extras__controls > *:nth-last-of-type(1) {
+	margin-right: 0px;
 }
 
 .tlui-toolbar__tools {
@@ -1204,6 +1194,7 @@
 	position: absolute;
 	bottom: var(--space-3);
 	right: var(--space-3);
+	z-index: var(--layer-panels);
 }
 
 /* ------------------ Context Menu ------------------ */
@@ -1388,11 +1379,11 @@
 .tlui-toast__icon {
 	padding-top: var(--space-4);
 	padding-left: var(--space-4);
+	color: var(--color-text-1);
 }
 
 .tlui-toast__container {
 	min-width: 200px;
-	max-width: 280px;
 	display: flex;
 	flex-direction: row;
 	gap: var(--space-3);
@@ -1404,6 +1395,7 @@
 
 .tlui-toast__main {
 	flex-grow: 2;
+	max-width: 280px;
 }
 
 .tlui-toast__main:nth-child(1) > .tlui-toast__content {
@@ -1439,10 +1431,12 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
+	margin-left: -12px;
 }
 
 .tlui-toast__close {
 	align-self: flex-end;
+	flex-shrink: 0;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -8,6 +8,252 @@
 	--layer-cursor: 700;
 }
 
+/* -------------------------------------------------- */
+/*                     UI Refresh                     */
+/* -------------------------------------------------- */
+
+/* Button */
+
+.tlui-button-2 {
+	position: relative;
+	height: 44px;
+	min-width: 44px;
+	padding: 0px 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: transparent;
+	border: transparent;
+	color: currentColor;
+	cursor: pointer;
+	pointer-events: all;
+	font-weight: 500;
+	text-rendering: optimizeLegibility;
+	font-size: 12px;
+	gap: 0px;
+	color: var(--color-text-1);
+	text-shadow: 1px 1px var(--color-panel);
+}
+
+.tlui-button-2__label {
+	flex-grow: 2;
+	text-align: left;
+}
+
+.tlui-button-2:focus-visible:not(:hover) {
+	outline: 1px solid var(--color-selected);
+	outline-offset: 0px;
+	border-radius: 2px;
+}
+
+.tlui-button-2::after {
+	display: block;
+	content: '';
+	position: absolute;
+	inset: 4px;
+	background-color: transparent;
+	border-radius: 6px;
+	z-index: 1;
+}
+
+.tlui-button-2[aria-expanded='true']::after {
+	background-color: var(--color-muted-0);
+	opacity: 1;
+}
+
+@media (hover: hover) {
+	.tlui-button-2::after {
+		background-color: var(--color-muted-2);
+		opacity: 0;
+	}
+
+	.tlui-button-2:hover::after {
+		opacity: 1;
+	}
+}
+
+/* Low button  */
+
+.tlui-button-2__low {
+	border-radius: 8px;
+	background-color: var(--color-low);
+	border: 1px solid var(--color-low-border);
+}
+
+@media (hover: hover) {
+	.tlui-button-2__low::after {
+		background-color: var(--color-muted-2);
+	}
+}
+
+/* Panel button */
+
+.tlui-button-2__panel {
+	position: relative;
+}
+
+/* Icon button */
+
+.tlui-button-2__icon {
+	height: 40px;
+	width: 40px;
+	min-height: 40px;
+	min-width: 40px;
+	padding: 0px;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__icon::after {
+		inset: 4px;
+		border-radius: 6px;
+	}
+}
+
+/* Menu button */
+
+.tlui-button-2__menu {
+	height: 40px;
+	min-height: 40px;
+	min-width: 128px;
+	width: 100%;
+	gap: 8px;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__menu::after {
+		inset: 4px;
+		border-radius: 6px;
+	}
+}
+
+/* Menu checkbox button */
+
+.tlui-button-2__checkbox {
+	padding-left: 8px;
+}
+
+/* Tool button */
+
+.tlui-toolbar__lock-button {
+	position: absolute;
+	top: 4px;
+	right: 0px;
+	pointer-events: all;
+	height: 40px;
+	width: 40px;
+	min-width: 0px;
+	border-radius: var(--radius-2);
+}
+
+.tlui-toolbar__lock-button::after {
+	top: 4px;
+	left: 8px;
+	inset: 4px;
+}
+
+/* Tool button  */
+
+.tlui-button-2__tool {
+	position: relative;
+	height: 48px;
+	width: 48px;
+	margin-left: -2px;
+	margin-right: -2px;
+}
+
+.tlui-button-2__tool:nth-of-type(1) {
+	margin-left: 0px;
+}
+
+.tlui-button-2__tool:nth-last-of-type(1) {
+	margin-right: 0px;
+}
+
+.tlui-layout__mobile .tlui-button-2__tool {
+	height: 48px;
+	width: 44px;
+}
+
+.tlui-layout__mobile .tlui-button-2__tool > .tlui-icon {
+	height: 16px;
+	width: 16px;
+}
+
+@media (hover: hover) {
+	.tlui-button-2__tool::after {
+		inset: 4px;
+		border-radius: 8px;
+	}
+}
+
+/* Help */
+
+.tlui-button-2__help {
+	height: 40px;
+	width: 40px;
+	padding: 0px;
+	min-width: 40px;
+	border-radius: 100%;
+	background-color: var(--color-low);
+	border: 1px solid var(--color-low-border);
+}
+
+@media (hover: hover) {
+	.tlui-button-2__help::after {
+		background-color: var(--color-muted-2);
+		border-radius: 100%;
+		inset: 4px;
+	}
+}
+
+/* Button Row */
+
+.tlui-buttons__horizontal {
+	display: flex;
+	flex-direction: row;
+}
+.tlui-buttons__horizontal > .tlui-button-2 {
+	margin-left: -2px;
+	margin-right: -2px;
+}
+.tlui-buttons__horizontal > .tlui-button-2:nth-of-type(1) {
+	margin-left: 0px;
+}
+.tlui-buttons__horizontal > .tlui-button-2:nth-last-of-type(1) {
+	margin-right: 0px;
+}
+
+/* Button Grid */
+
+.tlui-buttons__grid {
+	display: grid;
+	grid-template-columns: repeat(4, auto);
+	grid-auto-flow: row;
+}
+.tlui-buttons__grid > .tlui-button-2 {
+	margin: -2px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n) {
+	margin-right: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n - 3) {
+	margin-left: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-of-type(-n + 4) {
+	margin-top: 0px;
+}
+.tlui-buttons__grid > .tlui-button-2:nth-last-of-type(-n + 4) {
+	margin-bottom: 0px;
+}
+
+/* Zoom button */
+
+.tlui-zoom-menu__button__pct {
+	width: 60px;
+	min-width: 60px;
+	text-align: center;
+}
+
 /* --------------------- Layout --------------------- */
 
 .tlui-layout {
@@ -397,7 +643,7 @@
 	max-height: 75vh;
 	margin: 0px;
 	border: none;
-	border-radius: var(--radius-3);
+	border-radius: var(--radius-1);
 	background-color: var(--color-panel);
 	box-shadow: var(--shadow-3);
 	z-index: var(--layer-menus);
@@ -919,28 +1165,6 @@
 	border-radius: var(--radius-2);
 }
 
-.tlui-toolbar__lock-button {
-	position: absolute;
-	top: 0px;
-	right: 0px;
-	pointer-events: all;
-	height: 40px;
-	width: 48px;
-	right: -4px;
-}
-
-.tlui-toolbar__lock-button::after {
-	border-radius: 100%;
-	top: 4px;
-	left: 8px;
-	height: 32px;
-	width: 32px;
-}
-
-.tlui-toolbar__lock-button__mobile {
-	right: -8px;
-}
-
 .tlui-toolbar__tools {
 	display: flex;
 	flex-direction: row;
@@ -952,34 +1176,6 @@
 	align-items: center;
 	background: var(--color-panel);
 	box-shadow: var(--shadow-2);
-}
-
-.tlui-toolbar__tools__button {
-	height: 48px;
-	width: 48px;
-}
-
-.tlui-toolbar__tools__button:nth-of-type(n + 2) {
-	margin-left: -2px;
-}
-
-.tlui-toolbar__tools__button:nth-last-of-type(n + 2) {
-	margin-right: -2px;
-}
-
-.tlui-toolbar__tools__button {
-	height: 48px;
-	width: 48px;
-}
-
-.tlui-layout__mobile .tlui-toolbar__tools__button {
-	height: 48px;
-	width: 44px;
-}
-
-.tlui-layout__mobile .tlui-toolbar__tools__button > .tlui-icon {
-	height: 16px;
-	width: 16px;
 }
 
 .tlui-toolbar__overflow {
@@ -995,15 +1191,6 @@
 	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
-.tlui-toolbar__styles__button {
-	width: 44px;
-	height: 44px;
-}
-
-.tlui-layout__mobile .tlui-toolbar__styles__button {
-	height: 48px;
-}
-
 .tlui-toolbar__divider {
 	display: block;
 	background: var(--color-divider);
@@ -1017,26 +1204,6 @@
 	position: absolute;
 	bottom: var(--space-3);
 	right: var(--space-3);
-}
-
-.tlui-help-menu__button {
-	position: relative;
-	background-color: var(--color-low);
-	border-radius: 100%;
-	height: 40px;
-	width: 40px;
-	overflow: visible;
-	z-index: var(--layer-panels);
-	border: 4px solid var(--color-background);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	pointer-events: all;
-	z-index: 1;
-}
-
-.tlui-help-menu__button::after {
-	border-radius: 100%;
 }
 
 /* ------------------ Context Menu ------------------ */
@@ -1059,7 +1226,7 @@
 	height: fit-content;
 	width: fit-content;
 	max-height: 80vh;
-	border-radius: var(--radius-4);
+	border-radius: var(--radius-3);
 	pointer-events: all;
 	touch-action: auto;
 	overflow-y: auto;
@@ -1132,22 +1299,8 @@
 	flex-grow: 2;
 }
 
-.tlui-menu__checkbox-item {
-	padding-left: 28px;
-}
-
-.tlui-menu__checkbox-item__check {
-	position: absolute;
-	left: 0px;
-	width: 24px;
-	padding-left: 10px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-}
-
 /* ------------------- Button Grid ------------------ */
-
+/* 
 .tlui-button-grid__button {
 	width: 44px;
 	height: 44px;
@@ -1190,7 +1343,7 @@
 
 .tlui-button-grid__two > .tlui-button-grid__button:nth-last-child(n + 3) {
 	margin-bottom: -2px;
-}
+} */
 
 /* 
 .tlui-button-grid__button:not(:nth-child(4n - 3)) {
@@ -1760,182 +1913,4 @@
 	animation-duration: 0.12s;
 	animation-delay: 2s;
 	animation-fill-mode: forwards;
-}
-
-/* -------------------------------------------------- */
-/*                     UI Refresh                     */
-/* -------------------------------------------------- */
-
-/* Button */
-
-.tlui-button-2 {
-	position: relative;
-	height: 44px;
-	min-width: 44px;
-	padding: 0px 12px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background-color: transparent;
-	border: transparent;
-	color: currentColor;
-	cursor: pointer;
-	pointer-events: all;
-	font-weight: 500;
-	text-rendering: optimizeLegibility;
-	font-size: 12px;
-	gap: 0px;
-	color: var(--color-text-1);
-	text-shadow: 1px 1px var(--color-panel);
-}
-
-.tlui-button-2__label {
-	flex-grow: 2;
-	text-align: left;
-}
-
-.tlui-button-2:focus-visible:not(:hover) {
-	outline: 1px solid var(--color-selected);
-	outline-offset: 0px;
-	border-radius: 2px;
-}
-
-.tlui-button-2::after {
-	display: block;
-	content: '';
-	position: absolute;
-	inset: 2px;
-	background-color: transparent;
-	border-radius: 6px;
-	z-index: 1;
-}
-
-.tlui-button-2[aria-expanded='true']::after {
-	background-color: var(--color-muted-0);
-	opacity: 1;
-}
-
-@media (hover: hover) {
-	.tlui-button-2::after {
-		background-color: var(--color-muted-2);
-		opacity: 0;
-	}
-
-	.tlui-button-2:hover::after {
-		opacity: 1;
-	}
-}
-/* Low button  */
-
-.tlui-button-2__low {
-	border-radius: 8px;
-	background-color: var(--color-low);
-	border: 1px solid var(--color-low-border);
-}
-
-@media (hover: hover) {
-	.tlui-button-2__low::after {
-		background-color: var(--color-muted-2);
-	}
-}
-
-/* Panel button */
-
-.tlui-button-2__panel {
-	position: relative;
-}
-
-/* Tool button  */
-
-.tlui-button-2__tool {
-	position: relative;
-}
-
-@media (hover: hover) {
-	.tlui-button-2__tool::after {
-		inset: 4px;
-		border-radius: 8px;
-	}
-}
-
-/* Icon button */
-
-.tlui-button-2__icon {
-	height: 40px;
-	width: 40px;
-	min-height: 40px;
-	min-width: 40px;
-	padding: 0px;
-}
-
-@media (hover: hover) {
-	.tlui-button-2__icon::after {
-		inset: 4px;
-		border-radius: 6px;
-	}
-}
-
-/* Menu button */
-
-.tlui-button-2__menu {
-	height: 40px;
-	min-height: 40px;
-	min-width: 128px;
-	width: auto;
-	gap: 8px;
-}
-
-@media (hover: hover) {
-	.tlui-button-2__menu::after {
-		inset: 4px;
-		border-radius: 6px;
-	}
-}
-
-/* Button Row */
-
-.tlui-buttons__horizontal {
-	display: flex;
-	flex-direction: row;
-}
-.tlui-buttons__horizontal > .tlui-button-2 {
-	margin-left: -2px;
-	margin-right: -2px;
-}
-.tlui-buttons__horizontal > .tlui-button-2:nth-of-type(1) {
-	margin-left: 0px;
-}
-.tlui-buttons__horizontal > .tlui-button-2:nth-last-of-type(1) {
-	margin-right: 0px;
-}
-
-/* Button Grid */
-
-.tlui-buttons__grid {
-	display: grid;
-	grid-template-columns: repeat(4, auto);
-	grid-auto-flow: row;
-}
-.tlui-buttons__grid > .tlui-button-2 {
-	margin: -2px;
-}
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n) {
-	margin-right: 0px;
-}
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(4n - 3) {
-	margin-left: 0px;
-}
-.tlui-buttons__grid > .tlui-button-2:nth-of-type(-n + 4) {
-	margin-top: 0px;
-}
-.tlui-buttons__grid > .tlui-button-2:nth-last-of-type(-n + 4) {
-	margin-bottom: 0px;
-}
-
-/* Zoom button */
-
-.tlui-zoom-menu__button__pct {
-	width: 60px;
-	min-width: 60px;
-	text-align: center;
 }

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -141,6 +141,7 @@ const TldrawUiContent = React.memo(function TldrawUI({
 				{isFocusMode ? (
 					<div className="tlui-layout__top">
 						<Button
+							type="icon"
 							className="tlui-focus-button"
 							title={`${msg('focus-mode.toggle-focus-mode')}`}
 							icon="dot"

--- a/packages/tldraw/src/lib/ui/components/ActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu.tsx
@@ -25,9 +25,9 @@ export const ActionsMenu = memo(function ActionsMenu() {
 				return (
 					<Button
 						key={id}
-						className="tlui-button-grid__button"
 						data-testid={`menu-item.${item.id}`}
 						icon={icon}
+						type="icon"
 						title={
 							label
 								? kbd
@@ -46,13 +46,14 @@ export const ActionsMenu = memo(function ActionsMenu() {
 	}
 
 	return (
-		<Popover id="actions menu">
+		<Popover id="actions-menu">
 			<PopoverTrigger>
 				<Button
 					className="tlui-menu__trigger"
 					data-testid="main.action-menu"
 					icon="dots-vertical"
 					title={msg('actions-menu.title')}
+					type="icon" // needs to be here because the trigger also passes down type="button"
 					smallIcon
 				/>
 			</PopoverTrigger>
@@ -63,7 +64,7 @@ export const ActionsMenu = memo(function ActionsMenu() {
 					dir="ltr"
 					sideOffset={6}
 				>
-					<div className="tlui-actions-menu tlui-button-grid__four">
+					<div className="tlui-actions-menu tlui-buttons__grid">
 						{menuSchema.map(getActionMenuItem)}
 					</div>
 				</PopoverPrimitive.Content>

--- a/packages/tldraw/src/lib/ui/components/BackToContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/BackToContent.tsx
@@ -43,6 +43,7 @@ export function BackToContent() {
 		<Button
 			iconLeft={action.icon}
 			label={action.label}
+			type="low"
 			onClick={() => {
 				action.onSelect('helper-buttons')
 				setShowBackToContent(false)

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -145,7 +145,6 @@ function ContextMenuContent() {
 						<_ContextMenu.SubTrigger dir="ltr" disabled={item.disabled} asChild>
 							<Button
 								type="menu"
-								className="tlui-menu__button"
 								label={item.label}
 								data-testid={`menu-item.${item.id}`}
 								icon="chevron-right"
@@ -196,7 +195,6 @@ function ContextMenuContent() {
 					<_ContextMenu.Item key={id} dir="ltr" asChild>
 						<Button
 							type="menu"
-							className="tlui-menu__button"
 							data-testid={`menu-item.${id}`}
 							kbd={kbd}
 							label={labelToUse}

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -144,6 +144,7 @@ function ContextMenuContent() {
 					<_ContextMenu.Sub key={item.id} onOpenChange={handleSubOpenChange}>
 						<_ContextMenu.SubTrigger dir="ltr" disabled={item.disabled} asChild>
 							<Button
+								type="menu"
 								className="tlui-menu__button"
 								label={item.label}
 								data-testid={`menu-item.${item.id}`}
@@ -170,7 +171,7 @@ function ContextMenuContent() {
 					return (
 						<_ContextMenu.CheckboxItem
 							key={id}
-							className="tlui-button tlui-menu__button tlui-menu__checkbox-item"
+							className="tlui-button-2 tlui-button-2__menu"
 							dir="ltr"
 							disabled={item.disabled}
 							onSelect={(e) => {
@@ -199,6 +200,7 @@ function ContextMenuContent() {
 				return (
 					<_ContextMenu.Item key={id} dir="ltr" asChild>
 						<Button
+							type="menu"
 							className="tlui-menu__button"
 							data-testid={`menu-item.${id}`}
 							kbd={kbd}

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -171,7 +171,7 @@ function ContextMenuContent() {
 					return (
 						<_ContextMenu.CheckboxItem
 							key={id}
-							className="tlui-button-2 tlui-button-2__menu"
+							className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
 							dir="ltr"
 							disabled={item.disabled}
 							onSelect={(e) => {
@@ -181,17 +181,12 @@ function ContextMenuContent() {
 							title={labelStr ? labelStr : undefined}
 							checked={item.checked}
 						>
-							<div
-								className="tlui-menu__checkbox-item__check"
-								style={{
-									transformOrigin: '75% center',
-									transform: `scale(${item.checked ? 1 : 0.5})`,
-									opacity: item.checked ? 1 : 0.5,
-								}}
-							>
-								<Icon small icon={item.checked ? 'check' : 'checkbox-empty'} />
-							</div>
-							{labelStr && <span>{labelStr}</span>}
+							<Icon small icon={item.checked ? 'check' : 'checkbox-empty'} />
+							{labelStr && (
+								<span className="tlui-button-2__label" draggable={false}>
+									{labelStr}
+								</span>
+							)}
 							{kbd && <Kbd>{kbd}</Kbd>}
 						</_ContextMenu.CheckboxItem>
 					)

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -170,7 +170,7 @@ function ContextMenuContent() {
 					return (
 						<_ContextMenu.CheckboxItem
 							key={id}
-							className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
+							className="tlui-button tlui-button__menu tlui-button__checkbox"
 							dir="ltr"
 							disabled={item.disabled}
 							onSelect={(e) => {
@@ -182,7 +182,7 @@ function ContextMenuContent() {
 						>
 							<Icon small icon={item.checked ? 'check' : 'checkbox-empty'} />
 							{labelStr && (
-								<span className="tlui-button-2__label" draggable={false}>
+								<span className="tlui-button__label" draggable={false}>
 									{labelStr}
 								</span>
 							)}

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -95,10 +95,41 @@ const DebugMenuContent = track(function DebugMenuContent({
 							id: uniqueId(),
 							title: 'Something happened',
 							description: 'Hey, attend to this thing over here. It might be important!',
+							keepOpen: true,
 							// icon?: string
 							// title?: string
 							// description?: string
 							// actions?: TLUiToastAction[]
+						})
+						addToast({
+							id: uniqueId(),
+							title: 'Something happened',
+							description: 'Hey, attend to this thing over here. It might be important!',
+							keepOpen: true,
+							icon: 'twitter',
+							actions: [
+								{
+									label: 'Primary',
+									type: 'primary',
+									onClick: () => {
+										void null
+									},
+								},
+								{
+									label: 'Normal',
+									type: 'normal',
+									onClick: () => {
+										void null
+									},
+								},
+								{
+									label: 'Danger',
+									type: 'danger',
+									onClick: () => {
+										void null
+									},
+								},
+							],
 						})
 					}}
 					label={untranslated('Show toast')}

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -242,7 +242,7 @@ function Toggle({
 			checked={value}
 			onSelect={() => onChange(!value)}
 		>
-			<span className="tlui-button-2__label" draggable={false}>
+			<span className="tlui-button__label" draggable={false}>
 				{label}
 			</span>
 		</DropdownMenu.CheckboxItem>

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -14,7 +14,7 @@ import {
 import * as React from 'react'
 import { useDialogs } from '../hooks/useDialogsProvider'
 import { useToasts } from '../hooks/useToastsProvider'
-import { useTranslation } from '../hooks/useTranslation/useTranslation'
+import { untranslated, useTranslation } from '../hooks/useTranslation/useTranslation'
 import { Button } from './primitives/Button'
 import * as Dialog from './primitives/Dialog'
 import * as DropdownMenu from './primitives/DropdownMenu'
@@ -53,7 +53,7 @@ export const DebugPanel = React.memo(function DebugPanel({
 			<ShapeCount />
 			<DropdownMenu.Root id="debug">
 				<DropdownMenu.Trigger>
-					<Button icon="dots-horizontal" title={msg('debug-panel.more')} />
+					<Button type="icon" icon="dots-horizontal" title={msg('debug-panel.more')} />
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content side="top" align="end" alignOffset={0}>
 					<DebugMenuContent renderDebugMenuItems={renderDebugMenuItems} />
@@ -83,13 +83,13 @@ const DebugMenuContent = track(function DebugMenuContent({
 	const editor = useEditor()
 	const { addToast } = useToasts()
 	const { addDialog } = useDialogs()
-
 	const [error, setError] = React.useState<boolean>(false)
 
 	return (
 		<>
 			<DropdownMenu.Group>
 				<DropdownMenu.Item
+					type="menu"
 					onClick={() => {
 						addToast({
 							id: uniqueId(),
@@ -101,11 +101,11 @@ const DebugMenuContent = track(function DebugMenuContent({
 							// actions?: TLUiToastAction[]
 						})
 					}}
-				>
-					<span>Show toast</span>
-				</DropdownMenu.Item>
+					label={untranslated('Show toast')}
+				/>
 
 				<DropdownMenu.Item
+					type="menu"
 					onClick={() => {
 						addDialog({
 							component: ({ onClose }) => (
@@ -124,13 +124,15 @@ const DebugMenuContent = track(function DebugMenuContent({
 							},
 						})
 					}}
-				>
-					<span>Show dialog</span>
-				</DropdownMenu.Item>
-				<DropdownMenu.Item onClick={() => createNShapes(editor, 100)}>
-					<span>Create 100 shapes</span>
-				</DropdownMenu.Item>
+					label={untranslated('Show dialog')}
+				/>
 				<DropdownMenu.Item
+					type="menu"
+					onClick={() => createNShapes(editor, 100)}
+					label={untranslated('Create 100 shapes')}
+				/>
+				<DropdownMenu.Item
+					type="menu"
 					onClick={() => {
 						function countDescendants({ children }: HTMLElement) {
 							let count = 0
@@ -158,27 +160,25 @@ const DebugMenuContent = track(function DebugMenuContent({
 
 						window.alert(`Shapes ${shapes.length}, DOM nodes:${descendants}`)
 					}}
-				>
-					<span>Count shapes and nodes</span>
-				</DropdownMenu.Item>
-
+					label={untranslated('Count shapes / nodes')}
+				/>
 				{(() => {
 					if (error) throw Error('oh no!')
 				})()}
 				<DropdownMenu.Item
+					type="menu"
 					onClick={() => {
 						setError(true)
 					}}
-				>
-					<span>Throw error</span>
-				</DropdownMenu.Item>
+					label={untranslated('Throw error')}
+				/>
 				<DropdownMenu.Item
+					type="menu"
 					onClick={() => {
 						hardResetEditor()
 					}}
-				>
-					<span>Hard reset</span>
-				</DropdownMenu.Item>
+					label={untranslated('Hard reset')}
+				/>
 			</DropdownMenu.Group>
 			<DropdownMenu.Group>
 				<DebugFlagToggle flag={debugFlags.debugSvg} />
@@ -206,8 +206,14 @@ function Toggle({
 	onChange: (newValue: boolean) => void
 }) {
 	return (
-		<DropdownMenu.CheckboxItem title={label} checked={value} onSelect={() => onChange(!value)}>
-			{label}
+		<DropdownMenu.CheckboxItem
+			title={untranslated(label)}
+			checked={value}
+			onSelect={() => onChange(!value)}
+		>
+			<span className="tlui-button-2__label" draggable={false}>
+				{label}
+			</span>
 		</DropdownMenu.CheckboxItem>
 	)
 }
@@ -262,6 +268,7 @@ function ExampleDialog({
 			<Dialog.Footer className="tlui-dialog__footer__actions">
 				{displayDontShowAgain && (
 					<Button
+						type="menu"
 						onClick={() => setDontShowAgain(!dontShowAgain)}
 						iconLeft={dontShowAgain ? 'checkbox-checked' : 'checkbox-empty'}
 						style={{ marginRight: 'auto' }}
@@ -269,7 +276,9 @@ function ExampleDialog({
 						{`Don't show again`}
 					</Button>
 				)}
-				<Button onClick={onCancel}>{cancel}</Button>
+				<Button type="menu" onClick={onCancel}>
+					{cancel}
+				</Button>
 				<Button type="primary" onClick={async () => onContinue()}>
 					{confirm}
 				</Button>

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -268,15 +268,15 @@ function ExampleDialog({
 			<Dialog.Footer className="tlui-dialog__footer__actions">
 				{displayDontShowAgain && (
 					<Button
-						type="menu"
+						type="normal"
 						onClick={() => setDontShowAgain(!dontShowAgain)}
-						iconLeft={dontShowAgain ? 'checkbox-checked' : 'checkbox-empty'}
+						iconLeft={dontShowAgain ? 'check' : 'checkbox-empty'}
 						style={{ marginRight: 'auto' }}
 					>
 						{`Don't show again`}
 					</Button>
 				)}
-				<Button type="menu" onClick={onCancel}>
+				<Button type="normal" onClick={onCancel}>
 					{cancel}
 				</Button>
 				<Button type="primary" onClick={async () => onContinue()}>

--- a/packages/tldraw/src/lib/ui/components/DuplicateButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/DuplicateButton.tsx
@@ -13,6 +13,7 @@ export const DuplicateButton = track(function DuplicateButton() {
 	return (
 		<Button
 			icon={action.icon}
+			type="icon"
 			onClick={() => action.onSelect('quick-actions')}
 			disabled={!(editor.isIn('select') && editor.selectedShapeIds.length > 0)}
 			title={`${msg(action.label!)} ${kbdStr(action.kbd!)}`}

--- a/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
@@ -157,7 +157,7 @@ export const EditLinkDialogInner = track(function EditLinkDialogInner({
 				</div>
 			</Dialog.Body>
 			<Dialog.Footer className="tlui-dialog__footer__actions">
-				<Button onClick={handleCancel} onTouchEnd={handleCancel}>
+				<Button type="normal" onClick={handleCancel} onTouchEnd={handleCancel}>
 					{msg('edit-link-dialog.cancel')}
 				</Button>
 				{isRemoving ? (

--- a/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from 'react'
 import { TLEmbedResult, getEmbedInfo } from '../../utils/embeds'
 import { useAssetUrls } from '../hooks/useAssetUrls'
 import { TLUiDialogProps } from '../hooks/useDialogsProvider'
-import { useTranslation } from '../hooks/useTranslation/useTranslation'
+import { untranslated, useTranslation } from '../hooks/useTranslation/useTranslation'
 import { Button } from './primitives/Button'
 import * as Dialog from './primitives/Dialog'
 import { Icon } from './primitives/Icon'
@@ -122,25 +122,20 @@ export const EmbedDialog = track(function EmbedDialog({ onClose }: TLUiDialogPro
 					<Dialog.Body className="tlui-embed-dialog__list">
 						{EMBED_DEFINITIONS.map((def) => {
 							return (
-								<button
+								<Button
+									type="menu"
 									key={def.type}
-									className="tlui-embed-dialog__item"
 									onClick={() => setEmbedDefinition(def)}
+									label={untranslated(def.title)}
 								>
-									<div className="tlui-embed-dialog__item__image">
-										<div
-											className="tlui-embed-dialog__item__image__img"
-											style={{
-												backgroundImage: `url(${assetUrls.embedIcons[def.type]})`,
-											}}
-										/>
-									</div>
-									<div className="tlui-embed-dialog__item__title">{def.title}</div>
-								</button>
+									<div
+										className="tlui-embed-dialog__item__image"
+										style={{ backgroundImage: `url(${assetUrls.embedIcons[def.type]})` }}
+									/>
+								</Button>
 							)
 						})}
 					</Dialog.Body>
-					<div className="tlui-dialog__scrim" />
 				</>
 			)}
 		</>

--- a/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
@@ -88,6 +88,7 @@ export const EmbedDialog = track(function EmbedDialog({ onClose }: TLUiDialogPro
 					</Dialog.Body>
 					<Dialog.Footer className="tlui-dialog__footer__actions">
 						<Button
+							type="normal"
 							onClick={() => {
 								setEmbedDefinition(null)
 								setEmbedInfoForUrl(null)
@@ -96,7 +97,7 @@ export const EmbedDialog = track(function EmbedDialog({ onClose }: TLUiDialogPro
 							label="embed-dialog.back"
 						/>
 						<div className="tlui-embed__spacer" />
-						<Button label="embed-dialog.cancel" onClick={onClose} />
+						<Button type="normal" label="embed-dialog.cancel" onClick={onClose} />
 						<Button
 							type="primary"
 							disabled={!embedInfoForUrl}

--- a/packages/tldraw/src/lib/ui/components/FollowingIndicator.tsx
+++ b/packages/tldraw/src/lib/ui/components/FollowingIndicator.tsx
@@ -10,5 +10,5 @@ export function FollowingIndicator() {
 function FollowingIndicatorInner({ userId }: { userId: string }) {
 	const presence = usePresence(userId)
 	if (!presence) return null
-	return <div className="tlui-following" style={{ borderColor: presence.color }} />
+	return <div className="tlui-following-indicator" style={{ borderColor: presence.color }} />
 }

--- a/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
@@ -35,7 +35,7 @@ export const HelpMenu = React.memo(function HelpMenu() {
 				<Trigger asChild dir="ltr">
 					<Button
 						type="help"
-						className="tlui-button-2"
+						className="tlui-button"
 						smallIcon
 						title={msg('help-menu.title')}
 						icon="question-mark"

--- a/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
@@ -11,7 +11,6 @@ import { TLUiIconType } from '../icon-types'
 import { LanguageMenu } from './LanguageMenu'
 import { Button } from './primitives/Button'
 import * as M from './primitives/DropdownMenu'
-import { Icon } from './primitives/Icon'
 
 interface HelpMenuLink {
 	label: TLUiTranslationKey
@@ -34,9 +33,13 @@ export const HelpMenu = React.memo(function HelpMenu() {
 		<div className="tlui-help-menu">
 			<Root dir="ltr" open={isOpen} onOpenChange={onOpenChange} modal={false}>
 				<Trigger asChild dir="ltr">
-					<Button type="help" className="tlui-button-2" title={msg('help-menu.title')}>
-						<Icon icon="question-mark" small />
-					</Button>
+					<Button
+						type="help"
+						className="tlui-button-2"
+						smallIcon
+						title={msg('help-menu.title')}
+						icon="question-mark"
+					/>
 				</Trigger>
 				<Portal container={container} dir="ltr">
 					<Content

--- a/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
@@ -37,7 +37,7 @@ export const HelpMenu = React.memo(function HelpMenu() {
 					dir="ltr"
 					title={msg('help-menu.title')}
 				>
-					<Icon icon="question-mark" />
+					<Icon icon="question-mark" small />
 				</Trigger>
 				<Portal container={container} dir="ltr">
 					<Content

--- a/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu.tsx
@@ -9,6 +9,7 @@ import { TLUiTranslationKey } from '../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../hooks/useTranslation/useTranslation'
 import { TLUiIconType } from '../icon-types'
 import { LanguageMenu } from './LanguageMenu'
+import { Button } from './primitives/Button'
 import * as M from './primitives/DropdownMenu'
 import { Icon } from './primitives/Icon'
 
@@ -32,12 +33,10 @@ export const HelpMenu = React.memo(function HelpMenu() {
 	return (
 		<div className="tlui-help-menu">
 			<Root dir="ltr" open={isOpen} onOpenChange={onOpenChange} modal={false}>
-				<Trigger
-					className="tlui-button tlui-help-menu__button"
-					dir="ltr"
-					title={msg('help-menu.title')}
-				>
-					<Icon icon="question-mark" small />
+				<Trigger asChild dir="ltr">
+					<Button type="help" className="tlui-button-2" title={msg('help-menu.title')}>
+						<Icon icon="question-mark" small />
+					</Button>
 				</Trigger>
 				<Portal container={container} dir="ltr">
 					<Content
@@ -90,6 +89,7 @@ function HelpMenuContent() {
 				const { id, kbd, label, onSelect, icon } = item.actionItem
 				return (
 					<M.Item
+						type="menu"
 						key={id}
 						kbd={kbd}
 						label={label}

--- a/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
@@ -25,7 +25,7 @@ export function LanguageMenu() {
 							checked={locale === currentLanguage}
 							onSelect={() => handleLanguageSelect(locale)}
 						>
-							<span>{label}</span>
+							<span className="tlui-button-2__label">{label}</span>
 						</D.RadioItem>
 					))}
 				</D.Group>

--- a/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
@@ -25,7 +25,7 @@ export function LanguageMenu() {
 							checked={locale === currentLanguage}
 							onSelect={() => handleLanguageSelect(locale)}
 						>
-							<span className="tlui-button-2__label">{label}</span>
+							<span className="tlui-button__label">{label}</span>
 						</D.RadioItem>
 					))}
 				</D.Group>

--- a/packages/tldraw/src/lib/ui/components/Menu.tsx
+++ b/packages/tldraw/src/lib/ui/components/Menu.tsx
@@ -22,6 +22,7 @@ export const Menu = React.memo(function Menu() {
 					data-testid="main.menu"
 					title={msg('menu.title')}
 					icon="menu"
+					smallIcon
 				/>
 			</M.Trigger>
 			<M.Content alignOffset={0} sideOffset={6}>

--- a/packages/tldraw/src/lib/ui/components/Menu.tsx
+++ b/packages/tldraw/src/lib/ui/components/Menu.tsx
@@ -101,7 +101,7 @@ function MenuContent() {
 							checked={item.checked}
 							disabled={item.disabled}
 						>
-							{labelStr && <span>{labelStr}</span>}
+							{labelStr && <span className="tlui-button-2__label">{labelStr}</span>}
 							{kbd && <Kbd>{kbd}</Kbd>}
 						</M.CheckboxItem>
 					)

--- a/packages/tldraw/src/lib/ui/components/Menu.tsx
+++ b/packages/tldraw/src/lib/ui/components/Menu.tsx
@@ -102,7 +102,7 @@ function MenuContent() {
 							checked={item.checked}
 							disabled={item.disabled}
 						>
-							{labelStr && <span className="tlui-button-2__label">{labelStr}</span>}
+							{labelStr && <span className="tlui-button__label">{labelStr}</span>}
 							{kbd && <Kbd>{kbd}</Kbd>}
 						</M.CheckboxItem>
 					)

--- a/packages/tldraw/src/lib/ui/components/Menu.tsx
+++ b/packages/tldraw/src/lib/ui/components/Menu.tsx
@@ -17,6 +17,7 @@ export const Menu = React.memo(function Menu() {
 		<M.Root id="main menu">
 			<M.Trigger>
 				<Button
+					type="icon"
 					className="tlui-menu__trigger"
 					data-testid="main.menu"
 					title={msg('menu.title')}
@@ -109,6 +110,7 @@ function MenuContent() {
 				// Item is a button
 				return (
 					<M.Item
+						type="menu"
 						key={id}
 						data-testid={`menu-item.${item.id}`}
 						kbd={kbd}

--- a/packages/tldraw/src/lib/ui/components/MenuZone.tsx
+++ b/packages/tldraw/src/lib/ui/components/MenuZone.tsx
@@ -17,13 +17,11 @@ export const MenuZone = track(function MenuZone() {
 
 	return (
 		<div className="tlui-menu-zone">
-			<div className="tlui-menu-zone__controls">
+			<div className="tlui-buttons__horizontal">
 				<Menu />
-				<div className="tlui-menu-zone__divider" />
 				<PageMenu />
 				{breakpoint >= 6 && !isReadonly && !editor.isInAny('hand', 'zoom') && (
 					<>
-						<div className="tlui-menu-zone__divider" />
 						<UndoButton />
 						<RedoButton />
 						<TrashButton />

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -40,7 +40,7 @@ export function MobileStylePanel() {
 	)
 
 	return (
-		<Popover id="style menu" onOpenChange={handleStylesOpenChange} open>
+		<Popover id="style menu" onOpenChange={handleStylesOpenChange}>
 			<PopoverTrigger disabled={disableStylePanel}>
 				<Button
 					type="tool"

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -40,7 +40,7 @@ export function MobileStylePanel() {
 	)
 
 	return (
-		<Popover id="style menu" onOpenChange={handleStylesOpenChange}>
+		<Popover id="style menu" onOpenChange={handleStylesOpenChange} open>
 			<PopoverTrigger disabled={disableStylePanel}>
 				<Button
 					type="tool"

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -43,7 +43,7 @@ export function MobileStylePanel() {
 		<Popover id="style menu" onOpenChange={handleStylesOpenChange}>
 			<PopoverTrigger disabled={disableStylePanel}>
 				<Button
-					className="tlui-toolbar__tools__button tlui-toolbar__styles__button"
+					type="tool"
 					data-testid="mobile.styles"
 					style={{
 						color: disableStylePanel ? 'var(--color-muted-1)' : currentColor,

--- a/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
@@ -16,6 +16,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 		<_ContextMenu.Sub>
 			<_ContextMenu.SubTrigger dir="ltr" asChild>
 				<Button
+					type="menu"
 					className="tlui-menu__button"
 					label="context-menu.move-to-page"
 					data-testid="menu-item.move-to-page"
@@ -60,6 +61,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 								asChild
 							>
 								<Button
+									type="menu"
 									title={page.name}
 									className="tlui-menu__button tlui-context-menu__move-to-page__name"
 								>
@@ -88,6 +90,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 							asChild
 						>
 							<Button
+								type="menu"
 								title={msg('context.pages.new-page')}
 								className="tlui-menu__button tlui-context-menu__move-to-page__name"
 							>

--- a/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
@@ -17,7 +17,6 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 			<_ContextMenu.SubTrigger dir="ltr" asChild>
 				<Button
 					type="menu"
-					className="tlui-menu__button"
 					label="context-menu.move-to-page"
 					data-testid="menu-item.move-to-page"
 					icon="chevron-right"
@@ -63,7 +62,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 								<Button
 									type="menu"
 									title={page.name}
-									className="tlui-menu__button tlui-context-menu__move-to-page__name"
+									className="tlui-context-menu__move-to-page__name"
 								>
 									<span>{page.name}</span>
 								</Button>
@@ -92,7 +91,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 							<Button
 								type="menu"
 								title={msg('context.pages.new-page')}
-								className="tlui-menu__button tlui-context-menu__move-to-page__name"
+								className="tlui-context-menu__move-to-page__name"
 							>
 								{msg('context.pages.new-page')}
 							</Button>

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/NavigationZone.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/NavigationZone.tsx
@@ -26,23 +26,25 @@ export const NavigationZone = memo(function NavigationZone() {
 
 	return (
 		<div className="tlui-navigation-zone">
-			<div className="tlui-navigation-zone__controls">
+			<div className="tlui-buttons__horizontal">
 				{breakpoint < 6 ? (
 					<ZoomMenu />
 				) : collapsed ? (
 					<>
 						<ZoomMenu />
 						<Button
+							type="icon"
+							icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'}
+							data-testid="minimap.toggle"
 							title={msg('navigation-zone.toggle-minimap')}
 							className="tlui-navigation-zone__toggle"
-							data-testid="minimap.toggle"
 							onClick={toggleMinimap}
-							icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'}
 						/>
 					</>
 				) : (
 					<>
 						<Button
+							type="icon"
 							icon="minus"
 							data-testid="minimap.zoom-out"
 							title={`${msg(actions['zoom-out'].label!)} ${kbdStr(actions['zoom-out'].kbd!)}`}
@@ -50,16 +52,19 @@ export const NavigationZone = memo(function NavigationZone() {
 						/>
 						<ZoomMenu />
 						<Button
+							type="icon"
 							icon="plus"
 							data-testid="minimap.zoom-in"
 							title={`${msg(actions['zoom-in'].label!)} ${kbdStr(actions['zoom-in'].kbd!)}`}
 							onClick={() => actions['zoom-in'].onSelect('navigation-zone')}
 						/>
 						<Button
+							type="icon"
+							icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'}
+							data-testid="minimap.toggle"
 							title={msg('navigation-zone.toggle-minimap')}
 							className="tlui-navigation-zone__toggle"
 							onClick={toggleMinimap}
-							icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'}
 						/>
 					</>
 				)}

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
@@ -75,6 +75,7 @@ function ZoomMenuItem(props: {
 
 	return (
 		<M.Item
+			type="menu"
 			label={actions[action].label}
 			kbd={actions[action].kbd}
 			data-testid={props['data-testid']}

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/ZoomMenu.tsx
@@ -24,6 +24,7 @@ export const ZoomMenu = track(function ZoomMenu() {
 		<M.Root id="zoom">
 			<M.Trigger>
 				<Button
+					type="icon"
 					title={`${msg('navigation-zone.zoom')}`}
 					data-testid="minimap.zoom-menu"
 					className={breakpoint < 5 ? 'tlui-zoom-menu__button' : 'tlui-zoom-menu__button__pct'}

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -45,13 +45,13 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	return (
 		<M.Root id={`page item submenu ${index}`}>
 			<M.Trigger>
-				<Button title={msg('page-menu.submenu.title')} icon="dots-vertical" />
+				<Button type="icon" title={msg('page-menu.submenu.title')} icon="dots-vertical" />
 			</M.Trigger>
 			<M.Content alignOffset={0}>
 				<M.Group>
 					{onRename && (
 						<DropdownMenu.Item dir="ltr" onSelect={onRename} asChild>
-							<Button className="tlui-menu__button" label="page-menu.submenu.rename" />
+							<Button type="menu" label="page-menu.submenu.rename" />
 						</DropdownMenu.Item>
 					)}
 					<DropdownMenu.Item
@@ -60,23 +60,23 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 						disabled={pages.length >= MAX_PAGES}
 						asChild
 					>
-						<Button className="tlui-menu__button" label="page-menu.submenu.duplicate-page" />
+						<Button type="menu" label="page-menu.submenu.duplicate-page" />
 					</DropdownMenu.Item>
 					{index > 0 && (
 						<DropdownMenu.Item dir="ltr" onSelect={onMoveUp} asChild>
-							<Button className="tlui-menu__button" label="page-menu.submenu.move-up" />
+							<Button type="menu" label="page-menu.submenu.move-up" />
 						</DropdownMenu.Item>
 					)}
 					{index < listSize - 1 && (
 						<DropdownMenu.Item dir="ltr" onSelect={onMoveDown} asChild>
-							<Button className="tlui-menu__button" label="page-menu.submenu.move-down" />
+							<Button type="menu" label="page-menu.submenu.move-down" />
 						</DropdownMenu.Item>
 					)}
 				</M.Group>
 				{listSize > 1 && (
 					<M.Group>
 						<DropdownMenu.Item dir="ltr" onSelect={onDelete} asChild>
-							<Button className="tlui-menu__button" label="page-menu.submenu.delete" />
+							<Button type="menu" className="tlui-menu__button" label="page-menu.submenu.delete" />
 						</DropdownMenu.Item>
 					</M.Group>
 				)}

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -76,7 +76,7 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 				{listSize > 1 && (
 					<M.Group>
 						<DropdownMenu.Item dir="ltr" onSelect={onDelete} asChild>
-							<Button type="menu" className="tlui-menu__button" label="page-menu.submenu.delete" />
+							<Button type="menu" label="page-menu.submenu.delete" />
 						</DropdownMenu.Item>
 					</M.Group>
 				)}

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -251,7 +251,7 @@ export const PageMenu = function PageMenu() {
 	}, [editor, msg, isReadonlyMode])
 
 	return (
-		<Popover id="pages" onOpenChange={onOpenChange} open={true}>
+		<Popover id="pages" onOpenChange={onOpenChange} open={isOpen}>
 			<PopoverTrigger>
 				<Button
 					className="tlui-page-menu__trigger tlui-menu__trigger"

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -1,4 +1,3 @@
-import { Root as PopoverRoot } from '@radix-ui/react-popover'
 import {
 	MAX_PAGES,
 	PageRecordType,
@@ -15,7 +14,7 @@ import { useReadonly } from '../../hooks/useReadonly'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { Button } from '../primitives/Button'
 import { Icon } from '../primitives/Icon'
-import { PopoverContent, PopoverTrigger } from '../primitives/Popover'
+import { Popover, PopoverContent, PopoverTrigger } from '../primitives/Popover'
 import { PageItemInput } from './PageItemInput'
 import { PageItemSubmenu } from './PageItemSubmenu'
 import { onMovePage } from './edit-pages-shared'
@@ -29,7 +28,7 @@ export const PageMenu = function PageMenu() {
 
 	const [isOpen, onOpenChange] = useMenuIsOpen('page-menu', handleOpenChange)
 
-	const ITEM_HEIGHT = breakpoint < 5 ? 36 : 40
+	const ITEM_HEIGHT = 36
 
 	const rSortableContainer = useRef<HTMLDivElement>(null)
 
@@ -252,165 +251,163 @@ export const PageMenu = function PageMenu() {
 	}, [editor, msg, isReadonlyMode])
 
 	return (
-		<PopoverRoot onOpenChange={onOpenChange} open={isOpen}>
-			<div className="tlui-popover">
-				<PopoverTrigger>
-					<Button
-						className="tlui-page-menu__trigger tlui-menu__trigger"
-						data-testid="main.page-menu"
-						icon="chevron-down"
-						type="menu"
-						title={currentPage.name}
+		<Popover id="pages" onOpenChange={onOpenChange} open={true}>
+			<PopoverTrigger>
+				<Button
+					className="tlui-page-menu__trigger tlui-menu__trigger"
+					data-testid="main.page-menu"
+					icon="chevron-down"
+					type="menu"
+					title={currentPage.name}
+				>
+					<div className="tlui-page-menu__name">{currentPage.name}</div>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent side="bottom" align="start" sideOffset={6}>
+				<div className="tlui-page-menu__wrapper">
+					<div className="tlui-page-menu__header">
+						<div className="tlui-page-menu__header__title">{msg('page-menu.title')}</div>
+						{!isReadonlyMode && (
+							<div className="tlui-buttons__horizontal">
+								<Button
+									type="icon"
+									data-testid="page-menu.edit"
+									title={msg(isEditing ? 'page-menu.edit-done' : 'page-menu.edit-start')}
+									icon={isEditing ? 'check' : 'edit'}
+									onClick={toggleEditing}
+								/>
+								<Button
+									type="icon"
+									data-testid="page-menu.create"
+									icon="plus"
+									title={msg(
+										maxPageCountReached
+											? 'page-menu.max-page-count-reached'
+											: 'page-menu.create-new-page'
+									)}
+									disabled={maxPageCountReached}
+									onClick={handleCreatePageClick}
+								/>
+							</div>
+						)}
+					</div>
+					<div
+						className="tlui-page-menu__list tlui-menu__group"
+						style={{ height: ITEM_HEIGHT * pages.length + 4 }}
+						ref={rSortableContainer}
 					>
-						<div className="tlui-page-menu__name">{currentPage.name}</div>
-					</Button>
-				</PopoverTrigger>
-				<PopoverContent side="bottom" align="start" sideOffset={6}>
-					<div className="tlui-page-menu__wrapper">
-						<div className="tlui-page-menu__header">
-							<div className="tlui-page-menu__header__title">{msg('page-menu.title')}</div>
-							{!isReadonlyMode && (
-								<>
-									<Button
-										type="icon"
-										data-testid="page-menu.edit"
-										title={msg(isEditing ? 'page-menu.edit-done' : 'page-menu.edit-start')}
-										icon={isEditing ? 'check' : 'edit'}
-										onClick={toggleEditing}
-									/>
-									<Button
-										type="icon"
-										data-testid="page-menu.create"
-										icon="plus"
-										title={msg(
-											maxPageCountReached
-												? 'page-menu.max-page-count-reached'
-												: 'page-menu.create-new-page'
-										)}
-										disabled={maxPageCountReached}
-										onClick={handleCreatePageClick}
-									/>
-								</>
-							)}
-						</div>
-						<div
-							className="tlui-page-menu__list tlui-menu__group"
-							style={{ height: ITEM_HEIGHT * pages.length + 4 }}
-							ref={rSortableContainer}
-						>
-							{pages.map((page, index) => {
-								const position = sortablePositionItems[page.id] ?? {
-									position: index * 40,
-									offsetY: 0,
-								}
+						{pages.map((page, index) => {
+							const position = sortablePositionItems[page.id] ?? {
+								position: index * 40,
+								offsetY: 0,
+							}
 
-								return isEditing ? (
-									<div
-										key={page.id + '_editing'}
-										data-testid={`page-menu-item-${page.id}`}
-										className="tlui-page_menu__item__sortable"
-										style={{
-											zIndex: page.id === currentPage.id ? 888 : index,
-											transform: `translate(0px, ${position.y + position.offsetY}px)`,
-										}}
-									>
+							return isEditing ? (
+								<div
+									key={page.id + '_editing'}
+									data-testid={`page-menu-item-${page.id}`}
+									className="tlui-page_menu__item__sortable"
+									style={{
+										zIndex: page.id === currentPage.id ? 888 : index,
+										transform: `translate(0px, ${position.y + position.offsetY}px)`,
+									}}
+								>
+									<Button
+										type="icon"
+										tabIndex={-1}
+										className="tlui-page_menu__item__sortable__handle"
+										icon="drag-handle-dots"
+										onPointerDown={handlePointerDown}
+										onPointerUp={handlePointerUp}
+										onPointerMove={handlePointerMove}
+										onKeyDown={handleKeyDown}
+										data-id={page.id}
+										data-index={index}
+									/>
+									{breakpoint < 5 && isCoarsePointer ? (
+										// sigh, this is a workaround for iOS Safari
+										// because the device and the radix popover seem
+										// to be fighting over scroll position. Nothing
+										// else seems to work!
 										<Button
 											type="icon"
-											tabIndex={-1}
-											className="tlui-page_menu__item__sortable__handle"
-											icon="drag-handle-dots"
-											onPointerDown={handlePointerDown}
-											onPointerUp={handlePointerUp}
-											onPointerMove={handlePointerMove}
-											onKeyDown={handleKeyDown}
-											data-id={page.id}
-											data-index={index}
-										/>
-										{breakpoint < 5 && isCoarsePointer ? (
-											// sigh, this is a workaround for iOS Safari
-											// because the device and the radix popover seem
-											// to be fighting over scroll position. Nothing
-											// else seems to work!
-											<Button
-												type="icon"
-												className="tlui-page-menu__item__button"
-												onClick={() => {
-													const name = window.prompt('Rename page', page.name)
-													if (name && name !== page.name) {
-														editor.renamePage(page.id, name)
-													}
-												}}
-												onDoubleClick={toggleEditing}
-												isChecked={page.id === currentPage.id}
-											>
-												<span>{page.name}</span>
-											</Button>
-										) : (
-											<div
-												className="tlui-page_menu__item__sortable__title"
-												style={{ height: ITEM_HEIGHT }}
-											>
-												<PageItemInput
-													id={page.id}
-													name={page.name}
-													isCurrentPage={page.id === currentPage.id}
-												/>
-											</div>
-										)}
-										{!isReadonlyMode && (
-											<div className="tlui-page_menu__item__submenu" data-isediting={isEditing}>
-												<PageItemSubmenu index={index} item={page} listSize={pages.length} />
-											</div>
-										)}
-									</div>
-								) : (
-									<div
-										key={page.id}
-										data-testid={`page-menu-item-${page.id}`}
-										className="tlui-page-menu__item"
-									>
-										<Button
-											type="icon"
-											className="tlui-page-menu__item__button tlui-page-menu__item__button__checkbox"
-											onClick={() => editor.setCurrentPage(page.id)}
+											className="tlui-page-menu__item__button"
+											onClick={() => {
+												const name = window.prompt('Rename page', page.name)
+												if (name && name !== page.name) {
+													editor.renamePage(page.id, name)
+												}
+											}}
 											onDoubleClick={toggleEditing}
 											isChecked={page.id === currentPage.id}
-											title={msg('page-menu.go-to-page')}
 										>
-											<div className="tlui-page-menu__item__button__check">
-												{page.id === currentPage.id && <Icon icon="check" />}
-											</div>
 											<span>{page.name}</span>
 										</Button>
-										{!isReadonlyMode && (
-											<div className="tlui-page_menu__item__submenu">
-												<PageItemSubmenu
-													index={index}
-													item={page}
-													listSize={pages.length}
-													onRename={() => {
-														if (editor.environment.isIos) {
-															const name = window.prompt('Rename page', page.name)
-															if (name && name !== page.name) {
-																editor.renamePage(page.id, name)
-															}
-														} else {
-															editor.batch(() => {
-																setIsEditing(true)
-																editor.setCurrentPage(page.id)
-															})
+									) : (
+										<div
+											className="tlui-page_menu__item__sortable__title"
+											style={{ height: ITEM_HEIGHT }}
+										>
+											<PageItemInput
+												id={page.id}
+												name={page.name}
+												isCurrentPage={page.id === currentPage.id}
+											/>
+										</div>
+									)}
+									{!isReadonlyMode && (
+										<div className="tlui-page_menu__item__submenu" data-isediting={isEditing}>
+											<PageItemSubmenu index={index} item={page} listSize={pages.length} />
+										</div>
+									)}
+								</div>
+							) : (
+								<div
+									key={page.id}
+									data-testid={`page-menu-item-${page.id}`}
+									className="tlui-page-menu__item"
+								>
+									<Button
+										type="icon"
+										className="tlui-page-menu__item__button tlui-page-menu__item__button__checkbox"
+										onClick={() => editor.setCurrentPage(page.id)}
+										onDoubleClick={toggleEditing}
+										isChecked={page.id === currentPage.id}
+										title={msg('page-menu.go-to-page')}
+									>
+										<div className="tlui-page-menu__item__button__check">
+											{page.id === currentPage.id && <Icon icon="check" />}
+										</div>
+										<span>{page.name}</span>
+									</Button>
+									{!isReadonlyMode && (
+										<div className="tlui-page_menu__item__submenu">
+											<PageItemSubmenu
+												index={index}
+												item={page}
+												listSize={pages.length}
+												onRename={() => {
+													if (editor.environment.isIos) {
+														const name = window.prompt('Rename page', page.name)
+														if (name && name !== page.name) {
+															editor.renamePage(page.id, name)
 														}
-													}}
-												/>
-											</div>
-										)}
-									</div>
-								)
-							})}
-						</div>
+													} else {
+														editor.batch(() => {
+															setIsEditing(true)
+															editor.setCurrentPage(page.id)
+														})
+													}
+												}}
+											/>
+										</div>
+									)}
+								</div>
+							)
+						})}
 					</div>
-				</PopoverContent>
-			</div>
-		</PopoverRoot>
+				</div>
+			</PopoverContent>
+		</Popover>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -1,3 +1,4 @@
+import { Root as PopoverRoot } from '@radix-ui/react-popover'
 import {
 	MAX_PAGES,
 	PageRecordType,
@@ -14,7 +15,7 @@ import { useReadonly } from '../../hooks/useReadonly'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { Button } from '../primitives/Button'
 import { Icon } from '../primitives/Icon'
-import { Popover, PopoverContent, PopoverTrigger } from '../primitives/Popover'
+import { PopoverContent, PopoverTrigger } from '../primitives/Popover'
 import { PageItemInput } from './PageItemInput'
 import { PageItemSubmenu } from './PageItemSubmenu'
 import { onMovePage } from './edit-pages-shared'
@@ -251,157 +252,165 @@ export const PageMenu = function PageMenu() {
 	}, [editor, msg, isReadonlyMode])
 
 	return (
-		<Popover id="page menu" onOpenChange={onOpenChange} open={isOpen}>
-			<PopoverTrigger>
-				<Button
-					className="tlui-page-menu__trigger tlui-menu__trigger"
-					data-testid="main.page-menu"
-					icon="chevron-down"
-					title={currentPage.name}
-				>
-					<div className="tlui-page-menu__name">{currentPage.name}</div>
-				</Button>
-			</PopoverTrigger>
-			<PopoverContent side="bottom" align="start" sideOffset={6}>
-				<div className="tlui-page-menu__wrapper">
-					<div className="tlui-page-menu__header">
-						<div className="tlui-page-menu__header__title">{msg('page-menu.title')}</div>
-						{!isReadonlyMode && (
-							<>
-								<Button
-									data-testid="page-menu.edit"
-									title={msg(isEditing ? 'page-menu.edit-done' : 'page-menu.edit-start')}
-									icon={isEditing ? 'check' : 'edit'}
-									onClick={toggleEditing}
-								/>
-								<Button
-									data-testid="page-menu.create"
-									icon="plus"
-									title={msg(
-										maxPageCountReached
-											? 'page-menu.max-page-count-reached'
-											: 'page-menu.create-new-page'
-									)}
-									disabled={maxPageCountReached}
-									onClick={handleCreatePageClick}
-								/>
-							</>
-						)}
-					</div>
-					<div
-						className="tlui-page-menu__list tlui-menu__group"
-						style={{ height: ITEM_HEIGHT * pages.length + 4 }}
-						ref={rSortableContainer}
+		<PopoverRoot onOpenChange={onOpenChange} open={isOpen}>
+			<div className="tlui-popover">
+				<PopoverTrigger>
+					<Button
+						className="tlui-page-menu__trigger tlui-menu__trigger"
+						data-testid="main.page-menu"
+						icon="chevron-down"
+						type="menu"
+						title={currentPage.name}
 					>
-						{pages.map((page, index) => {
-							const position = sortablePositionItems[page.id] ?? {
-								position: index * 40,
-								offsetY: 0,
-							}
-
-							return isEditing ? (
-								<div
-									key={page.id + '_editing'}
-									data-testid={`page-menu-item-${page.id}`}
-									className="tlui-page_menu__item__sortable"
-									style={{
-										zIndex: page.id === currentPage.id ? 888 : index,
-										transform: `translate(0px, ${position.y + position.offsetY}px)`,
-									}}
-								>
+						<div className="tlui-page-menu__name">{currentPage.name}</div>
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent side="bottom" align="start" sideOffset={6}>
+					<div className="tlui-page-menu__wrapper">
+						<div className="tlui-page-menu__header">
+							<div className="tlui-page-menu__header__title">{msg('page-menu.title')}</div>
+							{!isReadonlyMode && (
+								<>
 									<Button
-										tabIndex={-1}
-										className="tlui-page_menu__item__sortable__handle"
-										icon="drag-handle-dots"
-										onPointerDown={handlePointerDown}
-										onPointerUp={handlePointerUp}
-										onPointerMove={handlePointerMove}
-										onKeyDown={handleKeyDown}
-										data-id={page.id}
-										data-index={index}
+										type="icon"
+										data-testid="page-menu.edit"
+										title={msg(isEditing ? 'page-menu.edit-done' : 'page-menu.edit-start')}
+										icon={isEditing ? 'check' : 'edit'}
+										onClick={toggleEditing}
 									/>
-									{breakpoint < 5 && isCoarsePointer ? (
-										// sigh, this is a workaround for iOS Safari
-										// because the device and the radix popover seem
-										// to be fighting over scroll position. Nothing
-										// else seems to work!
-										<Button
-											className="tlui-page-menu__item__button"
-											onClick={() => {
-												const name = window.prompt('Rename page', page.name)
-												if (name && name !== page.name) {
-													editor.renamePage(page.id, name)
-												}
-											}}
-											onDoubleClick={toggleEditing}
-											isChecked={page.id === currentPage.id}
-										>
-											<span>{page.name}</span>
-										</Button>
-									) : (
-										<div
-											className="tlui-page_menu__item__sortable__title"
-											style={{ height: ITEM_HEIGHT }}
-										>
-											<PageItemInput
-												id={page.id}
-												name={page.name}
-												isCurrentPage={page.id === currentPage.id}
-											/>
-										</div>
-									)}
-									{!isReadonlyMode && (
-										<div className="tlui-page_menu__item__submenu" data-isediting={isEditing}>
-											<PageItemSubmenu index={index} item={page} listSize={pages.length} />
-										</div>
-									)}
-								</div>
-							) : (
-								<div
-									key={page.id}
-									data-testid={`page-menu-item-${page.id}`}
-									className="tlui-page-menu__item"
-								>
 									<Button
-										className="tlui-page-menu__item__button tlui-page-menu__item__button__checkbox"
-										onClick={() => editor.setCurrentPage(page.id)}
-										onDoubleClick={toggleEditing}
-										isChecked={page.id === currentPage.id}
-										title={msg('page-menu.go-to-page')}
+										type="icon"
+										data-testid="page-menu.create"
+										icon="plus"
+										title={msg(
+											maxPageCountReached
+												? 'page-menu.max-page-count-reached'
+												: 'page-menu.create-new-page'
+										)}
+										disabled={maxPageCountReached}
+										onClick={handleCreatePageClick}
+									/>
+								</>
+							)}
+						</div>
+						<div
+							className="tlui-page-menu__list tlui-menu__group"
+							style={{ height: ITEM_HEIGHT * pages.length + 4 }}
+							ref={rSortableContainer}
+						>
+							{pages.map((page, index) => {
+								const position = sortablePositionItems[page.id] ?? {
+									position: index * 40,
+									offsetY: 0,
+								}
+
+								return isEditing ? (
+									<div
+										key={page.id + '_editing'}
+										data-testid={`page-menu-item-${page.id}`}
+										className="tlui-page_menu__item__sortable"
+										style={{
+											zIndex: page.id === currentPage.id ? 888 : index,
+											transform: `translate(0px, ${position.y + position.offsetY}px)`,
+										}}
 									>
-										<div className="tlui-page-menu__item__button__check">
-											{page.id === currentPage.id && <Icon icon="check" />}
-										</div>
-										<span>{page.name}</span>
-									</Button>
-									{!isReadonlyMode && (
-										<div className="tlui-page_menu__item__submenu">
-											<PageItemSubmenu
-												index={index}
-												item={page}
-												listSize={pages.length}
-												onRename={() => {
-													if (editor.environment.isIos) {
-														const name = window.prompt('Rename page', page.name)
-														if (name && name !== page.name) {
-															editor.renamePage(page.id, name)
-														}
-													} else {
-														editor.batch(() => {
-															setIsEditing(true)
-															editor.setCurrentPage(page.id)
-														})
+										<Button
+											type="icon"
+											tabIndex={-1}
+											className="tlui-page_menu__item__sortable__handle"
+											icon="drag-handle-dots"
+											onPointerDown={handlePointerDown}
+											onPointerUp={handlePointerUp}
+											onPointerMove={handlePointerMove}
+											onKeyDown={handleKeyDown}
+											data-id={page.id}
+											data-index={index}
+										/>
+										{breakpoint < 5 && isCoarsePointer ? (
+											// sigh, this is a workaround for iOS Safari
+											// because the device and the radix popover seem
+											// to be fighting over scroll position. Nothing
+											// else seems to work!
+											<Button
+												type="icon"
+												className="tlui-page-menu__item__button"
+												onClick={() => {
+													const name = window.prompt('Rename page', page.name)
+													if (name && name !== page.name) {
+														editor.renamePage(page.id, name)
 													}
 												}}
-											/>
-										</div>
-									)}
-								</div>
-							)
-						})}
+												onDoubleClick={toggleEditing}
+												isChecked={page.id === currentPage.id}
+											>
+												<span>{page.name}</span>
+											</Button>
+										) : (
+											<div
+												className="tlui-page_menu__item__sortable__title"
+												style={{ height: ITEM_HEIGHT }}
+											>
+												<PageItemInput
+													id={page.id}
+													name={page.name}
+													isCurrentPage={page.id === currentPage.id}
+												/>
+											</div>
+										)}
+										{!isReadonlyMode && (
+											<div className="tlui-page_menu__item__submenu" data-isediting={isEditing}>
+												<PageItemSubmenu index={index} item={page} listSize={pages.length} />
+											</div>
+										)}
+									</div>
+								) : (
+									<div
+										key={page.id}
+										data-testid={`page-menu-item-${page.id}`}
+										className="tlui-page-menu__item"
+									>
+										<Button
+											type="icon"
+											className="tlui-page-menu__item__button tlui-page-menu__item__button__checkbox"
+											onClick={() => editor.setCurrentPage(page.id)}
+											onDoubleClick={toggleEditing}
+											isChecked={page.id === currentPage.id}
+											title={msg('page-menu.go-to-page')}
+										>
+											<div className="tlui-page-menu__item__button__check">
+												{page.id === currentPage.id && <Icon icon="check" />}
+											</div>
+											<span>{page.name}</span>
+										</Button>
+										{!isReadonlyMode && (
+											<div className="tlui-page_menu__item__submenu">
+												<PageItemSubmenu
+													index={index}
+													item={page}
+													listSize={pages.length}
+													onRename={() => {
+														if (editor.environment.isIos) {
+															const name = window.prompt('Rename page', page.name)
+															if (name && name !== page.name) {
+																editor.renamePage(page.id, name)
+															}
+														} else {
+															editor.batch(() => {
+																setIsEditing(true)
+																editor.setCurrentPage(page.id)
+															})
+														}
+													}}
+												/>
+											</div>
+										)}
+									</div>
+								)
+							})}
+						</div>
 					</div>
-				</div>
-			</PopoverContent>
-		</Popover>
+				</PopoverContent>
+			</div>
+		</PopoverRoot>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/PenModeToggle.tsx
+++ b/packages/tldraw/src/lib/ui/components/PenModeToggle.tsx
@@ -15,6 +15,7 @@ export const ExitPenMode = track(function ExitPenMode() {
 
 	return (
 		<Button
+			type="normal"
 			label={action.label}
 			iconLeft={action.icon}
 			onClick={() => action.onSelect('helper-buttons')}

--- a/packages/tldraw/src/lib/ui/components/RedoButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/RedoButton.tsx
@@ -16,6 +16,7 @@ export const RedoButton = memo(function RedoButton() {
 		<Button
 			data-testid="main.redo"
 			icon={redo.icon}
+			type="icon"
 			title={`${msg(redo.label!)} ${kbdStr(redo.kbd!)}`}
 			disabled={!canRedo}
 			onClick={() => redo.onSelect('quick-actions')}

--- a/packages/tldraw/src/lib/ui/components/StopFollowing.tsx
+++ b/packages/tldraw/src/lib/ui/components/StopFollowing.tsx
@@ -14,6 +14,7 @@ export const StopFollowing = track(function ExitPenMode() {
 
 	return (
 		<Button
+			type="normal"
 			label={action.label}
 			iconLeft={action.icon}
 			onClick={() => action.onSelect('people-menu')}

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
@@ -1,6 +1,5 @@
 import { Trigger } from '@radix-ui/react-dropdown-menu'
 import { SharedStyle, StyleProp, preventDefault } from '@tldraw/editor'
-import classNames from 'classnames'
 import * as React from 'react'
 import { TLUiTranslationKey } from '../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -67,6 +66,7 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 					onTouchEnd={(e) => preventDefault(e)}
 				>
 					<Button
+						type="icon"
 						data-testid={`style.${uiTypeA}`}
 						title={
 							msg(labelA) +
@@ -81,16 +81,11 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 					/>
 				</Trigger>
 				<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
-					<div
-						className={classNames('tlui-button-grid', {
-							'tlui-button-grid__two': itemsA.length < 4,
-							'tlui-button-grid__four': itemsA.length >= 4,
-						})}
-					>
+					<div className="tlui-buttons__grid">
 						{itemsA.map((item) => {
 							return (
 								<DropdownMenu.Item
-									className="tlui-button-grid__button"
+									type="icon"
 									title={
 										msg(labelA) +
 										' — ' +
@@ -114,6 +109,7 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 					onTouchEnd={(e) => preventDefault(e)}
 				>
 					<Button
+						type="icon"
 						data-testid={`style.${uiTypeB}`}
 						title={
 							msg(labelB) +
@@ -127,16 +123,11 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 					/>
 				</Trigger>
 				<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
-					<div
-						className={classNames('tlui-button-grid', {
-							'tlui-button-grid__two': itemsA.length < 4,
-							'tlui-button-grid__four': itemsA.length >= 4,
-						})}
-					>
+					<div className="tlui-buttons__grid">
 						{itemsB.map((item) => {
 							return (
 								<DropdownMenu.Item
-									className="tlui-button-grid__button"
+									type="icon"
 									title={
 										msg(labelB) +
 										' — ' +

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
@@ -59,90 +59,92 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 			<div title={msg(label)} className="tlui-style-panel__double-select-picker-label">
 				{msg(label)}
 			</div>
-			<DropdownMenu.Root id={`style panel ${uiTypeA} A`}>
-				<Trigger
-					asChild
-					// Firefox fix: Stop the dropdown immediately closing after touch
-					onTouchEnd={(e) => preventDefault(e)}
-				>
-					<Button
-						type="icon"
-						data-testid={`style.${uiTypeA}`}
-						title={
-							msg(labelA) +
-							' — ' +
-							(valueA === null
-								? msg('style-panel.mixed')
-								: msg(`${uiTypeA}-style.${valueA}` as TLUiTranslationKey))
-						}
-						icon={iconA as any}
-						invertIcon
-						smallIcon
-					/>
-				</Trigger>
-				<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
-					<div className="tlui-buttons__grid">
-						{itemsA.map((item) => {
-							return (
-								<DropdownMenu.Item
-									type="icon"
-									title={
-										msg(labelA) +
-										' — ' +
-										msg(`${uiTypeA}-style.${item.value}` as TLUiTranslationKey)
-									}
-									data-testid={`style.${uiTypeA}.${item.value}`}
-									key={item.value}
-									icon={item.icon as TLUiIconType}
-									onClick={() => onValueChange(styleA, item.value, false)}
-									invertIcon
-								/>
-							)
-						})}
-					</div>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-			<DropdownMenu.Root id={`style panel ${uiTypeB}`}>
-				<Trigger
-					asChild
-					// Firefox fix: Stop the dropdown immediately closing after touch
-					onTouchEnd={(e) => preventDefault(e)}
-				>
-					<Button
-						type="icon"
-						data-testid={`style.${uiTypeB}`}
-						title={
-							msg(labelB) +
-							' — ' +
-							(valueB === null
-								? msg('style-panel.mixed')
-								: msg(`${uiTypeB}-style.${valueB}` as TLUiTranslationKey))
-						}
-						icon={iconB as any}
-						smallIcon
-					/>
-				</Trigger>
-				<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
-					<div className="tlui-buttons__grid">
-						{itemsB.map((item) => {
-							return (
-								<DropdownMenu.Item
-									type="icon"
-									title={
-										msg(labelB) +
-										' — ' +
-										msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)
-									}
-									data-testid={`style.${uiTypeB}.${item.value}`}
-									key={item.value}
-									icon={item.icon as TLUiIconType}
-									onClick={() => onValueChange(styleB, item.value, false)}
-								/>
-							)
-						})}
-					</div>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
+			<div className="tlui-buttons__horizontal">
+				<DropdownMenu.Root id={`style panel ${uiTypeA} A`}>
+					<Trigger
+						asChild
+						// Firefox fix: Stop the dropdown immediately closing after touch
+						onTouchEnd={(e) => preventDefault(e)}
+					>
+						<Button
+							type="icon"
+							data-testid={`style.${uiTypeA}`}
+							title={
+								msg(labelA) +
+								' — ' +
+								(valueA === null
+									? msg('style-panel.mixed')
+									: msg(`${uiTypeA}-style.${valueA}` as TLUiTranslationKey))
+							}
+							icon={iconA as any}
+							invertIcon
+							smallIcon
+						/>
+					</Trigger>
+					<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
+						<div className="tlui-buttons__grid">
+							{itemsA.map((item) => {
+								return (
+									<DropdownMenu.Item
+										type="icon"
+										title={
+											msg(labelA) +
+											' — ' +
+											msg(`${uiTypeA}-style.${item.value}` as TLUiTranslationKey)
+										}
+										data-testid={`style.${uiTypeA}.${item.value}`}
+										key={item.value}
+										icon={item.icon as TLUiIconType}
+										onClick={() => onValueChange(styleA, item.value, false)}
+										invertIcon
+									/>
+								)
+							})}
+						</div>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+				<DropdownMenu.Root id={`style panel ${uiTypeB}`}>
+					<Trigger
+						asChild
+						// Firefox fix: Stop the dropdown immediately closing after touch
+						onTouchEnd={(e) => preventDefault(e)}
+					>
+						<Button
+							type="icon"
+							data-testid={`style.${uiTypeB}`}
+							title={
+								msg(labelB) +
+								' — ' +
+								(valueB === null
+									? msg('style-panel.mixed')
+									: msg(`${uiTypeB}-style.${valueB}` as TLUiTranslationKey))
+							}
+							icon={iconB as any}
+							smallIcon
+						/>
+					</Trigger>
+					<DropdownMenu.Content side="bottom" align="end" sideOffset={0} alignOffset={-2}>
+						<div className="tlui-buttons__grid">
+							{itemsB.map((item) => {
+								return (
+									<DropdownMenu.Item
+										type="icon"
+										title={
+											msg(labelB) +
+											' — ' +
+											msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)
+										}
+										data-testid={`style.${uiTypeB}.${item.value}`}
+										key={item.value}
+										icon={item.icon as TLUiIconType}
+										onClick={() => onValueChange(styleB, item.value, false)}
+									/>
+								)
+							})}
+						</div>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+			</div>
 		</div>
 	)
 })

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -1,11 +1,10 @@
 import { Trigger } from '@radix-ui/react-dropdown-menu'
 import { SharedStyle, StyleProp, preventDefault } from '@tldraw/editor'
-import classNames from 'classnames'
 import * as React from 'react'
 import { TLUiTranslationKey } from '../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TLUiIconType } from '../../icon-types'
-import { Button } from '../primitives/Button'
+import { Button, TLUiButtonProps } from '../primitives/Button'
 import * as DropdownMenu from '../primitives/DropdownMenu'
 import { StyleValuesForUi } from './styles'
 
@@ -16,6 +15,7 @@ interface DropdownPickerProps<T extends string> {
 	style: StyleProp<T>
 	value: SharedStyle<T>
 	items: StyleValuesForUi<T>
+	type: TLUiButtonProps['type']
 	onValueChange: (style: StyleProp<T>, value: T, squashing: boolean) => void
 }
 
@@ -25,6 +25,7 @@ export const DropdownPicker = React.memo(function DropdownPicker<T extends strin
 	uiType,
 	style,
 	items,
+	type,
 	value,
 	onValueChange,
 }: DropdownPickerProps<T>) {
@@ -43,6 +44,7 @@ export const DropdownPicker = React.memo(function DropdownPicker<T extends strin
 				onTouchEnd={(e) => preventDefault(e)}
 			>
 				<Button
+					type={type}
 					data-testid={`style.${uiType}`}
 					title={
 						value.type === 'mixed'
@@ -54,17 +56,11 @@ export const DropdownPicker = React.memo(function DropdownPicker<T extends strin
 				/>
 			</Trigger>
 			<DropdownMenu.Content side="left" align="center" alignOffset={0}>
-				<div
-					className={classNames('tlui-button-grid', {
-						'tlui-button-grid__two': items.length < 3,
-						'tlui-button-grid__three': items.length == 3,
-						'tlui-button-grid__four': items.length >= 4,
-					})}
-				>
+				<div className="tlui-buttons__grid">
 					{items.map((item) => {
 						return (
 							<DropdownMenu.Item
-								className="tlui-button-grid__button"
+								type="icon"
 								data-testid={`style.${uiType}.${item.value}`}
 								title={msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)}
 								key={item.value}

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
@@ -233,25 +233,27 @@ function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 						value={align}
 						onValueChange={handleValueChange}
 					/>
-					{verticalAlign === undefined ? (
-						<Button
-							type="icon"
-							title={msg('style-panel.vertical-align')}
-							data-testid="vertical-align"
-							icon="vertical-align-center"
-							disabled
-						/>
-					) : (
-						<DropdownPicker
-							type="icon"
-							id="geo-vertical-alignment"
-							uiType="verticalAlign"
-							style={DefaultVerticalAlignStyle}
-							items={STYLES.verticalAlign}
-							value={verticalAlign}
-							onValueChange={handleValueChange}
-						/>
-					)}
+					<div className="tlui-style-panel__row__extra-button">
+						{verticalAlign === undefined ? (
+							<Button
+								type="icon"
+								title={msg('style-panel.vertical-align')}
+								data-testid="vertical-align"
+								icon="vertical-align-center"
+								disabled
+							/>
+						) : (
+							<DropdownPicker
+								type="icon"
+								id="geo-vertical-alignment"
+								uiType="verticalAlign"
+								style={DefaultVerticalAlignStyle}
+								items={STYLES.verticalAlign}
+								value={verticalAlign}
+								onValueChange={handleValueChange}
+							/>
+						)}
+					</div>
 				</div>
 			)}
 		</div>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
@@ -235,6 +235,7 @@ function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 					/>
 					{verticalAlign === undefined ? (
 						<Button
+							type="icon"
 							title={msg('style-panel.vertical-align')}
 							data-testid="vertical-align"
 							icon="vertical-align-center"
@@ -242,6 +243,7 @@ function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 						/>
 					) : (
 						<DropdownPicker
+							type="icon"
 							id="geo-vertical-alignment"
 							uiType="verticalAlign"
 							style={DefaultVerticalAlignStyle}
@@ -267,6 +269,7 @@ function GeoStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	return (
 		<DropdownPicker
 			id="geo"
+			type="menu"
 			label={'style-panel.geo'}
 			uiType="geo"
 			style={GeoShapeGeoStyle}
@@ -288,6 +291,7 @@ function SplineStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	return (
 		<DropdownPicker
 			id="spline"
+			type="menu"
 			label={'style-panel.spline'}
 			uiType="spline"
 			style={LineShapeSplineStyle}

--- a/packages/tldraw/src/lib/ui/components/Toasts.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toasts.tsx
@@ -40,23 +40,14 @@ function Toast({ toast }: { toast: TLUiToast }) {
 					<div className="tlui-toast__actions">
 						{toast.actions.map((action, i) => (
 							<T.Action key={i} altText={action.label} asChild onClick={action.onClick}>
-								<Button
-									type="normal"
-									className={
-										action.type === 'warn' ? 'tlui-button__warning' : 'tlui-button__primary'
-									}
-								>
-									{action.label}
-								</Button>
+								<Button type={action.type}>{action.label}</Button>
 							</T.Action>
 						))}
-						{hasActions && (
-							<T.Close asChild>
-								<Button type="normal" className="tlui-toast__close" style={{ marginLeft: 'auto' }}>
-									{toast.closeLabel ?? msg('toast.close')}
-								</Button>
-							</T.Close>
-						)}
+						<T.Close asChild>
+							<Button type="normal" className="tlui-toast__close" style={{ marginLeft: 'auto' }}>
+								{toast.closeLabel ?? msg('toast.close')}
+							</Button>
+						</T.Close>
 					</div>
 				)}
 			</div>

--- a/packages/tldraw/src/lib/ui/components/Toasts.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toasts.tsx
@@ -41,6 +41,7 @@ function Toast({ toast }: { toast: TLUiToast }) {
 						{toast.actions.map((action, i) => (
 							<T.Action key={i} altText={action.label} asChild onClick={action.onClick}>
 								<Button
+									type="normal"
 									className={
 										action.type === 'warn' ? 'tlui-button__warning' : 'tlui-button__primary'
 									}
@@ -51,7 +52,7 @@ function Toast({ toast }: { toast: TLUiToast }) {
 						))}
 						{hasActions && (
 							<T.Close asChild>
-								<Button className="tlui-toast__close" style={{ marginLeft: 'auto' }}>
+								<Button type="normal" className="tlui-toast__close" style={{ marginLeft: 'auto' }}>
 									{toast.closeLabel ?? msg('toast.close')}
 								</Button>
 							</T.Close>
@@ -61,7 +62,9 @@ function Toast({ toast }: { toast: TLUiToast }) {
 			</div>
 			{!hasActions && (
 				<T.Close asChild>
-					<Button className="tlui-toast__close">{toast.closeLabel ?? msg('toast.close')}</Button>
+					<Button type="normal" className="tlui-toast__close">
+						{toast.closeLabel ?? msg('toast.close')}
+					</Button>
 				</T.Close>
 			)}
 		</T.Root>

--- a/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
@@ -30,6 +30,7 @@ export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonP
 
 	return (
 		<Button
+			type="normal"
 			title={msg('action.toggle-tool-lock')}
 			className={classNames('tlui-toolbar__lock-button', {
 				'tlui-toolbar__lock-button__mobile': breakpoint < 5,

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -111,7 +111,7 @@ export const Toolbar = memo(function Toolbar() {
 					{!isReadonly && (
 						<div className="tlui-toolbar__extras">
 							{breakpoint < 6 && !(activeToolId === 'hand' || activeToolId === 'zoom') && (
-								<div className="tlui-toolbar__extras__controls">
+								<div className="tlui-toolbar__extras__controls tlui-buttons__horizontal">
 									<UndoButton />
 									<RedoButton />
 									<TrashButton />

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -149,7 +149,6 @@ export const Toolbar = memo(function Toolbar() {
 						{showEditingTools && (
 							<>
 								{/* Draw / Eraser */}
-								<div className="tlui-toolbar__divider" />
 								{toolbarItems.slice(2, 4).map(({ toolItem }) => (
 									<ToolbarButton
 										key={toolItem.id}
@@ -159,7 +158,6 @@ export const Toolbar = memo(function Toolbar() {
 									/>
 								))}
 								{/* Everything Else */}
-								<div className="tlui-toolbar__divider" />
 								{itemsInPanel.map(({ toolItem }) => (
 									<ToolbarButton
 										key={toolItem.id}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -188,6 +188,7 @@ export const Toolbar = memo(function Toolbar() {
 												<Button
 													className="tlui-toolbar__tools__button tlui-toolbar__overflow"
 													icon="chevron-up"
+													type="tool"
 													data-testid="tools.more"
 													title={msg('tool-panel.more')}
 												/>
@@ -225,6 +226,7 @@ const OverflowToolsContent = track(function OverflowToolsContent({
 				return (
 					<M.Item
 						key={id}
+						type="icon"
 						className="tlui-button-grid__button"
 						data-testid={`tools.more.${id}`}
 						data-tool={id}
@@ -258,6 +260,7 @@ function ToolbarButton({
 			aria-label={item.label}
 			title={title}
 			icon={item.icon}
+			type="tool"
 			data-state={isSelected ? 'selected' : undefined}
 			onClick={() => item.onSelect('toolbar')}
 			onTouchStart={(e) => {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -186,7 +186,7 @@ export const Toolbar = memo(function Toolbar() {
 										<M.Root id="toolbar overflow" modal={false}>
 											<M.Trigger>
 												<Button
-													className="tlui-toolbar__tools__button tlui-toolbar__overflow"
+													className="tlui-toolbar__overflow"
 													icon="chevron-up"
 													type="tool"
 													data-testid="tools.more"
@@ -221,7 +221,7 @@ const OverflowToolsContent = track(function OverflowToolsContent({
 	const msg = useTranslation()
 
 	return (
-		<div className="tlui-button-grid__four tlui-button-grid__reverse">
+		<div className="tlui-buttons__grid">
 			{toolbarItems.map(({ toolItem: { id, meta, kbd, label, onSelect, icon } }) => {
 				return (
 					<M.Item
@@ -253,14 +253,13 @@ function ToolbarButton({
 }) {
 	return (
 		<Button
-			className="tlui-toolbar__tools__button"
+			type="tool"
 			data-testid={`tools.${item.id}`}
 			data-tool={item.id}
 			data-geo={item.meta?.geo ?? ''}
 			aria-label={item.label}
 			title={title}
 			icon={item.icon}
-			type="tool"
 			data-state={isSelected ? 'selected' : undefined}
 			onClick={() => item.onSelect('toolbar')}
 			onTouchStart={(e) => {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/Toolbar.tsx
@@ -226,7 +226,7 @@ const OverflowToolsContent = track(function OverflowToolsContent({
 					<M.Item
 						key={id}
 						className="tlui-button-grid__button"
-						data-testid={`tools.${id}`}
+						data-testid={`tools.more.${id}`}
 						data-tool={id}
 						data-geo={meta?.geo ?? ''}
 						aria-label={label}

--- a/packages/tldraw/src/lib/ui/components/TrashButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/TrashButton.tsx
@@ -18,6 +18,7 @@ export const TrashButton = track(function TrashButton() {
 	return (
 		<Button
 			icon={action.icon}
+			type="icon"
 			onClick={() => action.onSelect('quick-actions')}
 			disabled={!(editor.isIn('select') && editor.selectedShapeIds.length > 0)}
 			title={`${msg(action.label!)} ${kbdStr(action.kbd!)}`}

--- a/packages/tldraw/src/lib/ui/components/UndoButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/UndoButton.tsx
@@ -16,6 +16,7 @@ export const UndoButton = memo(function UndoButton() {
 		<Button
 			data-testid="main.undo"
 			icon={undo.icon}
+			type="icon"
 			title={`${msg(undo.label!)} ${kbdStr(undo.kbd!)}`}
 			disabled={!canUndo}
 			onClick={() => undo.onSelect('quick-actions')}

--- a/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
@@ -19,7 +19,7 @@ export interface TLUiButtonProps extends React.HTMLAttributes<HTMLButtonElement>
 	kbd?: string
 	isChecked?: boolean
 	invertIcon?: boolean
-	type: 'primary' | 'danger' | 'normal' | 'low' | 'icon' | 'tool' | 'menu' | 'help'
+	type: 'normal' | 'primary' | 'danger' | 'low' | 'icon' | 'tool' | 'menu' | 'help'
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
@@ -19,7 +19,7 @@ export interface TLUiButtonProps extends React.HTMLAttributes<HTMLButtonElement>
 	kbd?: string
 	isChecked?: boolean
 	invertIcon?: boolean
-	type?: 'primary' | 'danger' | 'normal'
+	type: 'primary' | 'danger' | 'normal' | 'low' | 'icon' | 'tool' | 'menu'
 }
 
 /** @public */
@@ -32,7 +32,7 @@ export const Button = React.forwardRef<HTMLButtonElement, TLUiButtonProps>(funct
 		smallIcon,
 		kbd,
 		isChecked = false,
-		type = 'normal',
+		type,
 		children,
 		spinner,
 		...props
@@ -49,12 +49,12 @@ export const Button = React.forwardRef<HTMLButtonElement, TLUiButtonProps>(funct
 			type="button"
 			{...props}
 			title={props.title ?? labelStr}
-			className={classnames('tlui-button', `tlui-button__${type}`, props.className)}
+			className={classnames('tlui-button-2', `tlui-button-2__${type}`, props.className)}
 		>
 			{iconLeft && <Icon icon={iconLeft} className="tlui-icon-left" small />}
 			{children}
 			{label && (
-				<span draggable={false}>
+				<span className="tlui-button-2__label" draggable={false}>
 					{labelStr}
 					{isChecked && <Icon icon="check" />}
 				</span>

--- a/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
@@ -19,7 +19,7 @@ export interface TLUiButtonProps extends React.HTMLAttributes<HTMLButtonElement>
 	kbd?: string
 	isChecked?: boolean
 	invertIcon?: boolean
-	type: 'primary' | 'danger' | 'normal' | 'low' | 'icon' | 'tool' | 'menu'
+	type: 'primary' | 'danger' | 'normal' | 'low' | 'icon' | 'tool' | 'menu' | 'help'
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
@@ -49,12 +49,12 @@ export const Button = React.forwardRef<HTMLButtonElement, TLUiButtonProps>(funct
 			type="button"
 			{...props}
 			title={props.title ?? labelStr}
-			className={classnames('tlui-button-2', `tlui-button-2__${type}`, props.className)}
+			className={classnames('tlui-button', `tlui-button__${type}`, props.className)}
 		>
-			{iconLeft && <Icon icon={iconLeft} className="tlui-button-2__icon-left" small />}
+			{iconLeft && <Icon icon={iconLeft} className="tlui-button__icon-left" small />}
 			{children}
 			{label && (
-				<span className="tlui-button-2__label" draggable={false}>
+				<span className="tlui-button__label" draggable={false}>
 					{labelStr}
 					{isChecked && <Icon icon="check" />}
 				</span>

--- a/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button.tsx
@@ -51,7 +51,7 @@ export const Button = React.forwardRef<HTMLButtonElement, TLUiButtonProps>(funct
 			title={props.title ?? labelStr}
 			className={classnames('tlui-button-2', `tlui-button-2__${type}`, props.className)}
 		>
-			{iconLeft && <Icon icon={iconLeft} className="tlui-icon-left" small />}
+			{iconLeft && <Icon icon={iconLeft} className="tlui-button-2__icon-left" small />}
 			{children}
 			{label && (
 				<span className="tlui-button-2__label" draggable={false}>

--- a/packages/tldraw/src/lib/ui/components/primitives/ButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/ButtonPicker.tsx
@@ -3,7 +3,6 @@ import {
 	SharedStyle,
 	StyleProp,
 	TLDefaultColorStyle,
-	clamp,
 	getDefaultColorTheme,
 	useEditor,
 	useValue,
@@ -24,7 +23,6 @@ export interface ButtonPickerProps<T extends string> {
 	style: StyleProp<T>
 	value: SharedStyle<T>
 	items: StyleValuesForUi<T>
-	columns?: 2 | 3 | 4
 	onValueChange: (style: StyleProp<T>, value: T, squashing: boolean) => void
 }
 
@@ -35,7 +33,7 @@ function _ButtonPicker<T extends string>(props: ButtonPickerProps<T>) {
 		title,
 		style,
 		value,
-		columns = clamp(items.length, 2, 4),
+		// columns = clamp(items.length, 2, 4),
 		onValueChange,
 	} = props
 	const editor = useEditor()
@@ -99,15 +97,10 @@ function _ButtonPicker<T extends string>(props: ButtonPickerProps<T>) {
 	)
 
 	return (
-		<div
-			className={classNames('tlui-button-grid', {
-				'tlui-button-grid__two': columns === 2,
-				'tlui-button-grid__three': columns === 3,
-				'tlui-button-grid__four': columns === 4,
-			})}
-		>
+		<div className={classNames('tlui-buttons__grid')}>
 			{items.map((item) => (
 				<Button
+					type="icon"
 					key={item.value}
 					data-id={item.value}
 					data-testid={`style.${uiType}.${item.value}`}

--- a/packages/tldraw/src/lib/ui/components/primitives/Dialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Dialog.tsx
@@ -22,7 +22,11 @@ export function CloseButton() {
 	return (
 		<div className="tlui-dialog__header__close">
 			<_Dialog.DialogClose data-testid="dialog.close" dir="ltr" asChild>
-				<Button aria-label="Close" onTouchEnd={(e) => (e.target as HTMLButtonElement).click()}>
+				<Button
+					type="icon"
+					aria-label="Close"
+					onTouchEnd={(e) => (e.target as HTMLButtonElement).click()}
+				>
 					<Icon small icon="cross-2" />
 				</Button>
 			</_Dialog.DialogClose>

--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -218,7 +218,6 @@ export function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxI
 			}}
 			{...rest}
 		>
-			{/* <Icon small icon={rest.checked ? 'check' : 'none'} /> */}
 			<div className="tlui-button-2__checkbox__indicator">
 				<DropdownMenu.ItemIndicator dir="ltr">
 					<Icon icon="check" small />

--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -10,15 +10,17 @@ export function Root({
 	id,
 	children,
 	modal = false,
+	debugOpen = false,
 }: {
 	id: string
 	children: any
 	modal?: boolean
+	debugOpen?: boolean
 }) {
 	const [open, onOpenChange] = useMenuIsOpen(id)
 
 	return (
-		<DropdownMenu.Root open={open} dir="ltr" modal={modal} onOpenChange={onOpenChange}>
+		<DropdownMenu.Root open={debugOpen || open} dir="ltr" modal={modal} onOpenChange={onOpenChange}>
 			{children}
 		</DropdownMenu.Root>
 	)
@@ -101,7 +103,8 @@ export function SubTrigger({
 	return (
 		<DropdownMenu.SubTrigger dir="ltr" data-direction={dataDirection} data-testid={testId} asChild>
 			<Button
-				className="tlui-menu__button tlui-menu__submenu__trigger"
+				type="menu"
+				className="tlui-menu__submenu__trigger"
 				label={label}
 				icon="chevron-right"
 			/>
@@ -171,7 +174,7 @@ export function Item({ noClose, ...props }: DropdownMenuItemProps) {
 			asChild
 			onClick={noClose || props.isChecked !== undefined ? preventDefault : undefined}
 		>
-			<Button className="tlui-menu__button" {...props} />
+			<Button {...props} />
 		</DropdownMenu.Item>
 	)
 }
@@ -190,23 +193,14 @@ export function CheckboxItem({ children, onSelect, ...rest }: DropdownMenuCheckb
 	return (
 		<DropdownMenu.CheckboxItem
 			dir="ltr"
-			className="tlui-button tlui-menu__button tlui-menu__checkbox-item"
+			className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
 			onSelect={(e) => {
 				onSelect?.(e)
 				preventDefault(e)
 			}}
 			{...rest}
 		>
-			<div
-				className="tlui-menu__checkbox-item__check"
-				style={{
-					transformOrigin: '75% center',
-					transform: `scale(${rest.checked ? 1 : 0.5})`,
-					opacity: rest.checked ? 1 : 0.5,
-				}}
-			>
-				<Icon small icon={rest.checked ? 'check' : 'checkbox-empty'} />
-			</div>
+			<Icon small icon={rest.checked ? 'check' : 'checkbox-empty'} />
 			{children}
 		</DropdownMenu.CheckboxItem>
 	)
@@ -217,14 +211,14 @@ export function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxI
 	return (
 		<DropdownMenu.CheckboxItem
 			dir="ltr"
-			className="tlui-button tlui-menu__button tlui-menu__checkbox-item"
+			className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
 			onSelect={(e) => {
 				onSelect?.(e)
 				preventDefault(e)
 			}}
 			{...rest}
 		>
-			<DropdownMenu.ItemIndicator dir="ltr" className="tlui-menu__checkbox-item__check">
+			<DropdownMenu.ItemIndicator dir="ltr">
 				<Icon icon="check" />
 			</DropdownMenu.ItemIndicator>
 			{children}

--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -193,7 +193,7 @@ export function CheckboxItem({ children, onSelect, ...rest }: DropdownMenuCheckb
 	return (
 		<DropdownMenu.CheckboxItem
 			dir="ltr"
-			className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
+			className="tlui-button tlui-button__menu tlui-button__checkbox"
 			onSelect={(e) => {
 				onSelect?.(e)
 				preventDefault(e)
@@ -211,14 +211,14 @@ export function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxI
 	return (
 		<DropdownMenu.CheckboxItem
 			dir="ltr"
-			className="tlui-button-2 tlui-button-2__menu tlui-button-2__checkbox"
+			className="tlui-button tlui-button__menu tlui-button__checkbox"
 			onSelect={(e) => {
 				onSelect?.(e)
 				preventDefault(e)
 			}}
 			{...rest}
 		>
-			<div className="tlui-button-2__checkbox__indicator">
+			<div className="tlui-button__checkbox__indicator">
 				<DropdownMenu.ItemIndicator dir="ltr">
 					<Icon icon="check" small />
 				</DropdownMenu.ItemIndicator>

--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -221,7 +221,7 @@ export function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxI
 			{/* <Icon small icon={rest.checked ? 'check' : 'none'} /> */}
 			<div className="tlui-button-2__checkbox__indicator">
 				<DropdownMenu.ItemIndicator dir="ltr">
-					<Icon icon="check" />
+					<Icon icon="check" small />
 				</DropdownMenu.ItemIndicator>
 			</div>
 			{children}

--- a/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/DropdownMenu.tsx
@@ -218,9 +218,12 @@ export function RadioItem({ children, onSelect, ...rest }: DropdownMenuCheckboxI
 			}}
 			{...rest}
 		>
-			<DropdownMenu.ItemIndicator dir="ltr">
-				<Icon icon="check" />
-			</DropdownMenu.ItemIndicator>
+			{/* <Icon small icon={rest.checked ? 'check' : 'none'} /> */}
+			<div className="tlui-button-2__checkbox__indicator">
+				<DropdownMenu.ItemIndicator dir="ltr">
+					<Icon icon="check" />
+				</DropdownMenu.ItemIndicator>
+			</div>
 			{children}
 		</DropdownMenu.CheckboxItem>
 	)

--- a/packages/tldraw/src/lib/ui/components/primitives/Popover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Popover.tsx
@@ -10,11 +10,14 @@ type PopoverProps = {
 	onOpenChange?: (isOpen: boolean) => void
 }
 
-export const Popover: FC<PopoverProps> = ({ id, children, onOpenChange }) => {
+export const Popover: FC<PopoverProps> = ({ id, children, onOpenChange, open }) => {
 	const [isOpen, handleOpenChange] = useMenuIsOpen(id, onOpenChange)
 
 	return (
-		<PopoverPrimitive.Root onOpenChange={handleOpenChange} open={isOpen}>
+		<PopoverPrimitive.Root
+			onOpenChange={handleOpenChange}
+			open={open || isOpen /* allow debugging */}
+		>
 			<div className="tlui-popover">{children}</div>
 		</PopoverPrimitive.Root>
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
@@ -35,6 +35,8 @@ export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void) {
 		[editor, id, cb]
 	)
 
+	const isOpen = useValue('is menu open', () => editor.openMenus.includes(id), [editor, id])
+
 	useEffect(() => {
 		// When the effect runs, if the menu is open then
 		// add it to the open menus list.
@@ -66,8 +68,6 @@ export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void) {
 			}
 		}
 	}, [editor, id, trackEvent])
-
-	const isOpen = useValue('is menu open', () => editor.openMenus.includes(id), [editor, id])
 
 	return [isOpen, onOpenChange] as const
 }

--- a/packages/tldraw/src/lib/ui/hooks/useToastsProvider.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useToastsProvider.tsx
@@ -1,10 +1,11 @@
 import { Editor, uniqueId } from '@tldraw/editor'
 import { createContext, useCallback, useContext, useState } from 'react'
+import { TLUiIconType } from '../icon-types'
 
 /** @public */
 export interface TLUiToast {
 	id: string
-	icon?: string
+	icon?: TLUiIconType
 	title?: string
 	description?: string
 	actions?: TLUiToastAction[]
@@ -14,7 +15,7 @@ export interface TLUiToast {
 
 /** @public */
 export interface TLUiToastAction {
-	type: 'primary' | 'secondary' | 'warn'
+	type: 'primary' | 'danger' | 'normal'
 	label: string
 	onClick: () => void
 }

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
@@ -302,7 +302,7 @@ export const DEFAULT_TRANSLATION = {
 	'style-panel.align': 'Align',
 	'style-panel.vertical-align': 'Vertical align',
 	'style-panel.position': 'Position',
-	'style-panel.arrowheads': 'Arrowheads',
+	'style-panel.arrowheads': 'Arrows',
 	'style-panel.arrowhead-start': 'Start',
 	'style-panel.arrowhead-end': 'End',
 	'style-panel.color': 'Color',

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -111,3 +111,7 @@ export function useTranslation() {
 		[translation]
 	)
 }
+
+export function untranslated(string: string) {
+	return string as TLUiTranslationKey
+}


### PR DESCRIPTION
This PR tightens up the editor UI. It removes padding around the editor.

![Kapture 2023-10-28 at 18 27 15](https://github.com/tldraw/tldraw/assets/23072548/18075308-7b62-43a1-8c80-ff4e4136197b)

<img width="1196" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/a8205ef1-b142-4fdc-9745-e400c0c4939a">

<img width="1196" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/87e9dcd1-39f5-466a-a256-9cbd2ff2cf7e">

### Change Type

- [x] `minor` — New feature

### Release Notes

- Small adjustment to editor ui.