### PR TITLE
[not sure] Remove ui on its own layer

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -24,7 +24,7 @@
 	user-select: none;
 	contain: strict;
 	z-index: var(--layer-panels);
-	-webkit-transform: translate3d(0, 0, 0);
+	/* -webkit-transform: translate3d(0, 0, 0); */
 	--sab: env(safe-area-inset-bottom);
 }
 


### PR DESCRIPTION
This PR removes the css that forces the ui to be on its own rendering layer.

### Change Type

- [x] I don't know
