### PR TITLE
Fix an issue with `addEventListener` in old Safari (pre v14)

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -23,7 +23,11 @@ export function useDocumentEvents() {
 			const media = matchMedia(mqString)
 			// Safari only started supporting `addEventListener('change',...) in version 14
 			// https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event
-			const safariCb = (_ev: any) => updatePixelRatio
+			const safariCb = (ev: any) => {
+				if (ev.type === 'change') {
+					updatePixelRatio()
+				}
+			}
 			if (media.addEventListener) {
 				media.addEventListener('change', updatePixelRatio)
 			} else if (media.addListener) {

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -21,9 +21,20 @@ export function useDocumentEvents() {
 			}
 			const mqString = `(resolution: ${window.devicePixelRatio}dppx)`
 			const media = matchMedia(mqString)
-			media.addEventListener('change', updatePixelRatio)
+			// Safari only started supporting `addEventListener('change',...) in version 14
+			// https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event
+			const safariCb = (_ev: any) => updatePixelRatio
+			if (media.addEventListener) {
+				media.addEventListener('change', updatePixelRatio)
+			} else if (media.addListener) {
+				media.addListener(safariCb)
+			}
 			remove = () => {
-				media.removeEventListener('change', updatePixelRatio)
+				if (media.removeEventListener) {
+					media.removeEventListener('change', updatePixelRatio)
+				} else if (media.removeListener) {
+					media.removeListener(safariCb)
+				}
 			}
 			editor.updateInstanceState({ devicePixelRatio: window.devicePixelRatio })
 		}


### PR DESCRIPTION
Seems Safari only added `MediaQueryList: change event` in version 14. This is a workaround for older versions.
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Fixes an issue with `addEventListener` on MediaQueryList object in old versions of Safari.