### PR TITLE
[fix] css for editing page title

### DIFF
--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,6 +14606,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1329,7 +1329,7 @@
 }
 
 .tlui-page-menu__item__button__checkbox {
-	padding-left: 36px;
+	padding-left: 35px;
 }
 
 .tlui-page-menu__item__button__check {
@@ -1391,10 +1391,6 @@
 /* The more menu has complex CSS here: */
 /* If the user can hover, then visible but opacity zero until hover */
 /* If the user cannot hover, then not displayed unless editing, and then opacity 1 */
-
-.tlui-page_menu__item__button + .tlui-page_menu__item__submenu {
-	background-color: red;
-}
 
 .tlui-page_menu__item__submenu {
 	pointer-events: all;

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -330,7 +330,7 @@ export const PageMenu = function PageMenu() {
 										// to be fighting over scroll position. Nothing
 										// else seems to work!
 										<Button
-											type="icon"
+											type="normal"
 											className="tlui-page-menu__item__button"
 											onClick={() => {
 												const name = window.prompt('Rename page', page.name)


### PR DESCRIPTION
This PR fixes the CSS styling for the editing page title on mobile.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. View the page menu on mobile.
2. Start editing the pages.
3. The page title should not move.
