### PR TITLE
[fix] Move to page button / toasts styling

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1101,7 +1101,7 @@
 }
 
 .tlui-toast__title {
-	font-weight: inherit;
+	font-weight: bold;
 	color: var(--color-text-1);
 }
 
@@ -1112,11 +1112,16 @@
 	padding: 0px;
 }
 
+.tlui-toast__icon + .tlui-toast__main > .tlui-toast__actions {
+	margin-left: -12px;
+	padding-left: 0px;
+}
+
 .tlui-toast__actions {
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
-	margin-left: -12px;
+	margin-left: 0;
 }
 
 .tlui-toast__close {

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -95,7 +95,7 @@ const DebugMenuContent = track(function DebugMenuContent({
 							id: uniqueId(),
 							title: 'Something happened',
 							description: 'Hey, attend to this thing over here. It might be important!',
-							keepOpen: true,
+							keepOpen: false,
 							// icon?: string
 							// title?: string
 							// description?: string

--- a/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
@@ -64,7 +64,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 									title={page.name}
 									className="tlui-context-menu__move-to-page__name"
 								>
-									<span>{page.name}</span>
+									<span className="tlui-button__label">{page.name}</span>
 								</Button>
 							</_ContextMenu.Item>
 						))}
@@ -93,7 +93,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 								title={msg('context.pages.new-page')}
 								className="tlui-context-menu__move-to-page__name"
 							>
-								{msg('context.pages.new-page')}
+								<span className="tlui-button__label">{msg('context.pages.new-page')}</span>
 							</Button>
 						</_ContextMenu.Item>
 					</_ContextMenu.Group>


### PR DESCRIPTION
This PR fixes the alignment in the Move to Page menu buttons.

Before:
<img width="502" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/55529136-6572-4354-be7d-472119cbe589">

After:
<img width="429" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/8fe473ab-23f7-4bcd-9ee8-5b71a3dcc8fc">

It also fixes an alignment issue in the toast component.

Before:
<img width="223" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/0fc3bb05-5f05-4e1a-b887-ea2e97f09f20">
After:
<img width="329" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/498eac3c-7651-40a7-b05c-1f45a09fc6b3">

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Move a shape to a page.