### PR TITLE
Update version for assets

### DIFF
--- a/packages/tldraw/src/lib/ui/version.ts
+++ b/packages/tldraw/src/lib/ui/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-alpha.12'
+export const version = '2.0.0-alpha.17'


### PR DESCRIPTION
Updates version used by [assetUrls](https://github.com/tldraw/tldraw/blob/7e587b0613f8099af7a997b81720b2ee0b8ffcda/packages/tldraw/src/lib/ui/assetUrls.ts#L2) from `alpha.12` -> `alpha.17`

This is to make 4 icons added in later version available by default from `defaultUiAssetUrls`

* `geo-check-box.svg`
* `geo-cloud.svg`
* `tool-highlight.svg`
* `tool-laser.svg`

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [x] I don't know