### PR TITLE
[fix] button gaps

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -609,7 +609,7 @@
 	background-color: var(--color-panel);
 	height: fit-content;
 	max-height: 100%;
-	margin: var(--space-3);
+	margin: 4px 8px;
 	touch-action: auto;
 	overscroll-behavior: none;
 	overflow-y: auto;

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -281,12 +281,6 @@
 	}
 }
 
-/* Icon */
-
-.tlui-button__icon-left {
-	margin-right: var(--space-4);
-}
-
 /* Button Row */
 
 .tlui-buttons__horizontal {


### PR DESCRIPTION
This PR fixes an issue with gaps in our buttons introduced by #2102. 

It also adjusts the spacing for the people menu items.

Before:
<img width="263" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/204f5879-d337-4eca-921d-e052ec352d06">
<img width="274" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/0fe3a59f-9b2a-4af9-a12f-358682e31c19">
<img width="262" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/cba016ad-23a4-4550-896c-5485593c1aae">

After:
<img width="253" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/d88d0da2-e48d-42af-a6ec-050abad0be31">
<img width="262" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/c3b9602a-1f4b-494b-80c6-7a0ff60876ed">
<img width="239" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/464e1c67-65bc-4b00-9a36-224dc3de0d8d">

Closes https://github.com/tldraw/brivate/issues/3123

### Change Type

- [x] `patch` — Bug fix