### PR TITLE
Fix cleanupText

### DIFF
--- a/packages/tldraw/src/lib/utils/text.test.ts
+++ b/packages/tldraw/src/lib/utils/text.test.ts
@@ -4,4 +4,8 @@ describe(cleanupText, () => {
 	it('can handle the empty string', () => {
 		expect(cleanupText('')).toBe('')
 	})
+	it('can handle space-only strings', () => {
+		expect(cleanupText(' ')).toBe('')
+		expect(cleanupText('   ')).toBe('')
+	})
 })

--- a/packages/tldraw/src/lib/utils/text.test.ts
+++ b/packages/tldraw/src/lib/utils/text.test.ts
@@ -1,0 +1,7 @@
+import { cleanupText } from './text'
+
+describe(cleanupText, () => {
+	it('can handle the empty string', () => {
+		expect(cleanupText('')).toBe('')
+	})
+})

--- a/packages/tldraw/src/lib/utils/text.ts
+++ b/packages/tldraw/src/lib/utils/text.ts
@@ -24,7 +24,7 @@ function stripCommonMinimumIndentation(text: string): string {
 	const lines = text.split('\n')
 
 	// remove any leading lines that are only whitespace or newlines
-	while (lines[0].trim().length === 0) {
+	while (lines[0] && lines[0].trim().length === 0) {
 		lines.shift()
 	}
 


### PR DESCRIPTION
Fixes a bug with our cleanupText helper where it fails on the empty string or string with only space character(s).

Fixes https://tldraw.sentry.io/issues/4593272987

### Change Type

- [x] `patch` — Bug fix


[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [x] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes a minor bug where cleaning up text would fail.
