### PR TITLE
[experiment] Draw on tick 2

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -414,6 +414,7 @@ export const debugFlags: {
     logMessages: DebugFlag<any[]>;
     resetConnectionEveryPing: DebugFlag<boolean>;
     debugCursors: DebugFlag<boolean>;
+    throttleTick: DebugFlag<boolean>;
     forceSrgb: DebugFlag<boolean>;
     debugGeometry: DebugFlag<boolean>;
     hideShapes: DebugFlag<boolean>;

--- a/packages/editor/src/lib/editor/managers/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager.ts
@@ -1,12 +1,15 @@
 import { Vec2d } from '../../primitives/Vec2d'
 import { Editor } from '../Editor'
 
+const FPS = 2
+
 export class TickManager {
 	constructor(public editor: Editor) {
 		this.editor.disposables.add(this.dispose)
 		this.start()
 	}
 
+	tickLength = 1000 / FPS
 	raf: any
 	isPaused = true
 	last = 0
@@ -31,12 +34,12 @@ export class TickManager {
 
 		this.editor.emit('frame', elapsed)
 
-		if (this.t < 16) {
+		if (this.t < this.tickLength) {
 			this.raf = requestAnimationFrame(this.tick)
 			return
 		}
 
-		this.t -= 16
+		this.t -= this.tickLength
 		this.updatePointerVelocity(elapsed)
 		this.editor.emit('tick', elapsed)
 		this.raf = requestAnimationFrame(this.tick)

--- a/packages/editor/src/lib/editor/managers/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager.ts
@@ -1,12 +1,26 @@
+import { react } from '@tldraw/state'
 import { Vec2d } from '../../primitives/Vec2d'
+import { debugFlags } from '../../utils/debug-flags'
 import { Editor } from '../Editor'
 
-const FPS = 2
+const FPS = 60
 
 export class TickManager {
 	constructor(public editor: Editor) {
-		this.editor.disposables.add(this.dispose)
+		const unsub = react('debug flag change', this.reactToDebugFlag)
+		this.editor.disposables.add(() => {
+			unsub()
+			this.dispose()
+		})
 		this.start()
+	}
+
+	reactToDebugFlag = () => {
+		if (debugFlags.throttleTick.value) {
+			this.tickLength = 1000 / 30
+		} else {
+			this.tickLength = 1000 / FPS
+		}
 	}
 
 	tickLength = 1000 / FPS

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -49,6 +49,9 @@ export const debugFlags = {
 	debugCursors: createDebugValue('debugCursors', {
 		defaults: { all: false },
 	}),
+	throttleTick: createDebugValue('throttleTick', {
+		defaults: { all: false },
+	}),
 	forceSrgb: createDebugValue('forceSrgbColors', { defaults: { all: false } }),
 	debugGeometry: createDebugValue('debugGeometry', { defaults: { all: false } }),
 	hideShapes: createDebugValue('hideShapes', { defaults: { all: false } }),

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -308,7 +308,7 @@ export { Dialog }
 // @public (undocumented)
 export class DrawShapeTool extends StateNode {
     // (undocumented)
-    static children: () => (typeof Drawing | typeof Idle_2)[];
+    static children: () => (typeof Drawing | typeof DrawingSimple | typeof Idle_2)[];
     // (undocumented)
     static id: string;
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14592,7 +14592,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14615,7 +14615,6 @@
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -2757,6 +2757,15 @@
                 },
                 {
                   "kind": "Reference",
+                  "text": "DrawingSimple",
+                  "canonicalReference": "@tldraw/tldraw!~DrawingSimple:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | typeof "
+                },
+                {
+                  "kind": "Reference",
                   "text": "Idle",
                   "canonicalReference": "@tldraw/tldraw!~Idle_2:class"
                 },
@@ -2775,7 +2784,7 @@
               "name": "children",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 6
+                "endIndex": 8
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
@@ -1,12 +1,13 @@
 import { StateNode } from '@tldraw/editor'
 import { Drawing } from './toolStates/Drawing'
+import { DrawingSimple } from './toolStates/Drawing_Simple'
 import { Idle } from './toolStates/Idle'
 
 /** @public */
 export class DrawShapeTool extends StateNode {
 	static override id = 'draw'
 	static override initial = 'idle'
-	static override children = () => [Idle, Drawing]
+	static override children = () => [Idle, Drawing, DrawingSimple]
 
 	override shapeType = 'draw'
 

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing_Simple.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing_Simple.ts
@@ -1,0 +1,160 @@
+import {
+	StateNode,
+	TLDrawShape,
+	TLEventHandlers,
+	TLHighlightShape,
+	TLPointerEventInfo,
+	TLShapePartial,
+	Vec2d,
+	createShapeId,
+	structuredClone,
+} from '@tldraw/editor'
+
+type DrawableShape = TLDrawShape | TLHighlightShape
+
+export class DrawingSimple extends StateNode {
+	static override id = 'drawing-simple'
+
+	info = {} as TLPointerEventInfo
+
+	initialShape = {} as DrawableShape
+
+	override shapeType = 'draw'
+
+	util = this.editor.getShapeUtil(this.shapeType)
+
+	isPen = false
+
+	markId = null as null | string
+
+	interval = -1 as any
+
+	override onEnter = (info: TLPointerEventInfo) => {
+		this.markId = null
+		this.info = info
+		this.editor.addListener('tick', this.updateShapes)
+		this.startShape()
+	}
+
+	override onExit? = () => {
+		this.editor.removeListener('tick', this.updateShapes)
+		this.editor.snaps.clear()
+	}
+
+	private startShape() {
+		const {
+			inputs: { originPagePoint },
+		} = this.editor
+
+		const id = createShapeId()
+
+		this.editor.createShapes<DrawableShape>([
+			{
+				id,
+				type: 'draw',
+				x: originPagePoint.x,
+				y: originPagePoint.y,
+				props: {
+					isPen: this.isPen,
+					segments: [
+						{
+							type: 'free',
+							points: [
+								{
+									x: 0,
+									y: 0,
+									z: +(0.5).toFixed(2),
+								},
+							],
+						},
+					],
+				},
+			},
+		])
+
+		this.initialShape = this.editor.getShape<DrawableShape>(id)!
+		this._collectedPoints = [new Vec2d()]
+		this._collectedSegments = structuredClone(this.initialShape.props.segments)
+	}
+
+	updateShapes = () => {
+		this._updateShapes()
+	}
+
+	_collectedPoints: Vec2d[] = []
+	_collectedSegments: DrawableShape['props']['segments'] = []
+	_isDirty = false
+
+	override onPointerMove = () => {
+		const {
+			initialShape,
+			_collectedPoints,
+			_collectedSegments,
+			editor: { inputs },
+		} = this
+		const shape = this.editor.getShape<DrawableShape>(initialShape.id)!
+		const point = this.editor.getPointInShapeSpace(shape, inputs.currentPagePoint)
+		point.z = this.isPen ? +(point.z! * 1.25).toFixed(2) : 0.5
+
+		// Add point to collected points (not used yet)
+		_collectedPoints.push(point)
+
+		// Add point to segments
+		const segment = _collectedSegments[_collectedSegments.length - 1]
+		segment.points.push(point.toFixed().toJson())
+		this._isDirty = true
+	}
+
+	private _updateShapes = () => {
+		if (!this._isDirty) return
+		const { initialShape } = this
+
+		const shapePartial: TLShapePartial<DrawableShape> = {
+			id: initialShape.id,
+			type: 'draw',
+			props: {
+				segments: structuredClone([...this._collectedSegments]),
+			},
+		}
+
+		this.editor.updateShapes([shapePartial], { squashing: true })
+		this._isDirty = false
+	}
+
+	override onPointerUp: TLEventHandlers['onPointerUp'] = () => {
+		this.complete()
+	}
+
+	override onCancel: TLEventHandlers['onCancel'] = () => {
+		this.cancel()
+	}
+
+	override onComplete: TLEventHandlers['onComplete'] = () => {
+		this.complete()
+	}
+
+	override onInterrupt: TLEventHandlers['onInterrupt'] = () => {
+		if (this.editor.inputs.isDragging) {
+			return
+		}
+
+		if (this.markId) {
+			this.editor.bailToMark(this.markId)
+		}
+		this.cancel()
+	}
+
+	complete() {
+		const { initialShape } = this
+		if (!initialShape) return
+		this.editor.updateShapes([
+			{ id: initialShape.id, type: initialShape.type, props: { isComplete: true } },
+		])
+
+		this.parent.transition('idle', {})
+	}
+
+	cancel() {
+		this.parent.transition('idle', this.info)
+	}
+}

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
@@ -4,7 +4,7 @@ export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onPointerDown: TLEventHandlers['onPointerDown'] = (info) => {
-		this.parent.transition('drawing', info)
+		this.parent.transition('drawing-simple', info)
 	}
 
 	override onEnter = () => {

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -216,6 +216,7 @@ const DebugMenuContent = track(function DebugMenuContent({
 				<DebugFlagToggle flag={debugFlags.forceSrgb} />
 				<DebugFlagToggle flag={debugFlags.debugGeometry} />
 				<DebugFlagToggle flag={debugFlags.hideShapes} />
+				<DebugFlagToggle flag={debugFlags.throttleTick} />
 			</DropdownMenu.Group>
 			<DropdownMenu.Group>
 				{Object.values(featureFlags).map((flag) => {


### PR DESCRIPTION
This PR adds a simple proof of concept for improving performance in tldraw by updating shapes only on ticks. During a drawing session, a user's points are collected as usual as the pointer moves, but they are only used to update the shape when the tick event fires (and then, only if new points have been added).

To test, turn on the Throttle Tick debug flag.

### Change Type

- [x] `minor` — New feature

### Test Plan

1. Use the drawing tool
2. 

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
