### PR TITLE
bump prerelease from alpha to beta

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
-	"packages": [
-		"packages/*"
-	],
-	"version": "2.0.0-alpha.17"
+	"packages": ["packages/*"],
+	"version": "2.0.0-beta.0"
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/assets",
 	"description": "A tiny little drawing app (assets).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"author": {
 		"name": "tldraw GB Ltd.",
 		"email": "hello@tldraw.com"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/editor",
 	"description": "A tiny little drawing app (editor).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/state",
 	"description": "A tiny little drawing app (state).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/store",
 	"description": "A tiny little drawing app (store).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/tldraw",
 	"description": "A tiny little drawing editor.",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/tlschema/package.json
+++ b/packages/tlschema/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/tlschema",
 	"description": "A tiny little drawing app (schema).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/utils",
 	"description": "A tiny little drawing app (private utilities).",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tldraw/validate",
 	"description": "A runtime validation library by tldraw.",
-	"version": "2.0.0-alpha.17",
+	"version": "2.0.0-beta.0",
 	"packageManager": "yarn@3.5.0",
 	"author": {
 		"name": "tldraw GB Ltd.",


### PR DESCRIPTION
This switches us from the 'alpha' to 'beta' prerelease tag. After we make our first deploy folks will be able to install the latest version by doing `npm install @tldraw/tldraw@beta`. 

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]


[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

