### PR TITLE
[feature] Things on the canvas

### DIFF
--- a/apps/examples/src/examples/OnTheCanvas.tsx
+++ b/apps/examples/src/examples/OnTheCanvas.tsx
@@ -1,0 +1,87 @@
+import { stopEventPropagation, Tldraw, TLEditorComponents, track, useEditor } from '@tldraw/tldraw'
+import '@tldraw/tldraw/tldraw.css'
+import { useState } from 'react'
+
+// The "OnTheCanvas" component is rendered on top of the canvas, but behind the UI.
+function MyComponent() {
+	const [state, setState] = useState(0)
+
+	return (
+		<>
+			<div
+				style={{
+					position: 'absolute',
+					top: 50,
+					left: 50,
+					width: 'fit-content',
+					padding: 12,
+					borderRadius: 8,
+					backgroundColor: 'goldenrod',
+					zIndex: 0,
+					pointerEvents: 'all',
+					userSelect: 'unset',
+				}}
+				onPointerDown={stopEventPropagation}
+				onPointerMove={stopEventPropagation}
+			>
+				The count is {state}! <button onClick={() => setState((s) => s - 1)}>+1</button>
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					top: 150,
+					left: 150,
+					width: 128,
+					padding: 12,
+					borderRadius: 8,
+					backgroundColor: 'pink',
+					zIndex: 99999999,
+					pointerEvents: 'all',
+					userSelect: 'unset',
+				}}
+				onPointerDown={stopEventPropagation}
+				onPointerMove={stopEventPropagation}
+			>
+				The count is {state}! <button onClick={() => setState((s) => s + 1)}>+1</button>
+			</div>
+		</>
+	)
+}
+
+// The "InFrontOfTheCanvas" component is rendered on top of the canvas, but behind the UI.
+const MyComponentInFront = track(() => {
+	const editor = useEditor()
+	const { selectionRotatedPageBounds } = editor
+
+	if (!selectionRotatedPageBounds) return null
+
+	const pageCoordinates = editor.pageToScreen(selectionRotatedPageBounds.point)
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				top: Math.max(64, pageCoordinates.y - 64),
+				left: Math.max(64, pageCoordinates.x),
+				padding: 12,
+				background: '#efefef',
+			}}
+		>
+			This does not scale with the zoom
+		</div>
+	)
+})
+
+const components: Partial<TLEditorComponents> = {
+	OnTheCanvas: MyComponent,
+	InFrontOfTheCanvas: MyComponentInFront,
+	SnapLine: null,
+}
+
+export default function OnTheCanvasExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="things-on-the-canvas-example" components={components} />
+		</div>
+	)
+}

--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -26,6 +26,7 @@ import ExternalContentSourcesExample from './examples/ExternalContentSourcesExam
 import HideUiExample from './examples/HideUiExample'
 import MetaExample from './examples/MetaExample'
 import MultipleExample from './examples/MultipleExample'
+import OnTheCanvasExample from './examples/OnTheCanvas'
 import PersistenceExample from './examples/PersistenceExample'
 import ReadOnlyExample from './examples/ReadOnlyExample'
 import ScrollExample from './examples/ScrollExample'
@@ -83,6 +84,11 @@ export const allExamples: Example[] = [
 		title: 'Readonly Example',
 		path: 'readonly',
 		element: <ReadOnlyExample />,
+	},
+	{
+		title: 'Things on the canvas',
+		path: 'things-on-the-canvas',
+		element: <OnTheCanvasExample />,
 	},
 	{
 		title: 'Scroll example',

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -460,6 +460,9 @@ export const DefaultHandles: TLHandlesComponent;
 export const DefaultHoveredShapeIndicator: TLHoveredShapeIndicatorComponent;
 
 // @public (undocumented)
+export const DefaultOnTheCanvas: TLOnTheCanvas;
+
+// @public (undocumented)
 export const DefaultScribble: TLScribbleComponent;
 
 // @public (undocumented)
@@ -2321,6 +2324,9 @@ export type TLOnRotateHandler<T extends TLShape> = TLEventChangeHandler<T>;
 
 // @public (undocumented)
 export type TLOnRotateStartHandler<T extends TLShape> = TLEventStartHandler<T>;
+
+// @public (undocumented)
+export type TLOnTheCanvas = ComponentType<object>;
 
 // @public (undocumented)
 export type TLOnTranslateEndHandler<T extends TLShape> = TLEventChangeHandler<T>;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -460,9 +460,6 @@ export const DefaultHandles: TLHandlesComponent;
 export const DefaultHoveredShapeIndicator: TLHoveredShapeIndicatorComponent;
 
 // @public (undocumented)
-export const DefaultOnTheCanvas: TLOnTheCanvas;
-
-// @public (undocumented)
 export const DefaultScribble: TLScribbleComponent;
 
 // @public (undocumented)
@@ -2246,6 +2243,9 @@ export type TLHistoryMark = {
 export type TLHoveredShapeIndicatorComponent = ComponentType<{
     shapeId: TLShapeId;
 }>;
+
+// @public (undocumented)
+export type TLInFrontOfTheCanvas = ComponentType<object>;
 
 // @public (undocumented)
 export type TLInterruptEvent = (info: TLInterruptEventInfo) => void;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -5894,30 +5894,6 @@
         },
         {
           "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!DefaultOnTheCanvas:var",
-          "docComment": "/**\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "DefaultOnTheCanvas: "
-            },
-            {
-              "kind": "Reference",
-              "text": "TLOnTheCanvas",
-              "canonicalReference": "@tldraw/editor!TLOnTheCanvas:type"
-            }
-          ],
-          "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "DefaultOnTheCanvas",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
-        },
-        {
-          "kind": "Variable",
           "canonicalReference": "@tldraw/editor!DefaultScribble:var",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -37971,6 +37947,37 @@
           "typeTokenRange": {
             "startIndex": 1,
             "endIndex": 5
+          }
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/editor!TLInFrontOfTheCanvas:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type TLInFrontOfTheCanvas = "
+            },
+            {
+              "kind": "Reference",
+              "text": "ComponentType",
+              "canonicalReference": "@types/react!React.ComponentType:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<object>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultInFrontOfTheCanvas.tsx",
+          "releaseTag": "Public",
+          "name": "TLInFrontOfTheCanvas",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
           }
         },
         {

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -5894,6 +5894,30 @@
         },
         {
           "kind": "Variable",
+          "canonicalReference": "@tldraw/editor!DefaultOnTheCanvas:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "DefaultOnTheCanvas: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLOnTheCanvas",
+              "canonicalReference": "@tldraw/editor!TLOnTheCanvas:type"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx",
+          "isReadonly": true,
+          "releaseTag": "Public",
+          "name": "DefaultOnTheCanvas",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
+        },
+        {
+          "kind": "Variable",
           "canonicalReference": "@tldraw/editor!DefaultScribble:var",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -39007,6 +39031,37 @@
           "typeTokenRange": {
             "startIndex": 3,
             "endIndex": 5
+          }
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/editor!TLOnTheCanvas:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type TLOnTheCanvas = "
+            },
+            {
+              "kind": "Reference",
+              "text": "ComponentType",
+              "canonicalReference": "@types/react!React.ComponentType:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<object>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx",
+          "releaseTag": "Public",
+          "name": "TLOnTheCanvas",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
           }
         },
         {

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -285,18 +285,6 @@ input,
 	z-index: var(--layer-background);
 }
 
-/* -------------- Things on the canvas -------------- */
-
-.tl-things-on-the-canvas {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	overflow: visible;
-	pointer-events: all;
-}
-
 /* --------------------- Grid Layer --------------------- */
 
 .tl-grid {

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -285,6 +285,18 @@ input,
 	z-index: var(--layer-background);
 }
 
+/* -------------- Things on the canvas -------------- */
+
+.tl-things-on-the-canvas {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	width: 100px;
+	height: 100px;
+	overflow: visible;
+	pointer-events: all;
+}
+
 /* --------------------- Grid Layer --------------------- */
 
 .tl-grid {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -74,6 +74,10 @@ export {
 	type TLHoveredShapeIndicatorComponent,
 } from './lib/components/default-components/DefaultHoveredShapeIndicator'
 export {
+	DefaultOnTheCanvas,
+	type TLOnTheCanvas,
+} from './lib/components/default-components/DefaultOnTheCanvas'
+export {
 	DefaultScribble,
 	type TLScribbleComponent,
 } from './lib/components/default-components/DefaultScribble'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -73,10 +73,8 @@ export {
 	DefaultHoveredShapeIndicator,
 	type TLHoveredShapeIndicatorComponent,
 } from './lib/components/default-components/DefaultHoveredShapeIndicator'
-export {
-	DefaultOnTheCanvas,
-	type TLOnTheCanvas,
-} from './lib/components/default-components/DefaultOnTheCanvas'
+export { type TLInFrontOfTheCanvas } from './lib/components/default-components/DefaultInFrontOfTheCanvas'
+export { type TLOnTheCanvas } from './lib/components/default-components/DefaultOnTheCanvas'
 export {
 	DefaultScribble,
 	type TLScribbleComponent,

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -109,6 +109,7 @@ export function Canvas({ className }: { className?: string }) {
 				</defs>
 			</svg>
 			<div ref={rHtmlLayer} className="tl-html-layer tl-shapes" draggable={false}>
+				<OnTheCanvasWrapper />
 				<SelectionBackgroundWrapper />
 				{hideShapes ? null : debugSvg ? <ShapesWithSVGs /> : <ShapesToDisplay />}
 			</div>
@@ -126,6 +127,7 @@ export function Canvas({ className }: { className?: string }) {
 					<SelectionForegroundWrapper />
 					<LiveCollaborators />
 				</div>
+				<InFrontOfTheCanvasWrapper />
 			</div>
 		</div>
 	)
@@ -517,4 +519,16 @@ export function SelectionBackgroundWrapper() {
 	const { SelectionBackground } = useEditorComponents()
 	if (!selectionBounds || !SelectionBackground) return null
 	return <SelectionBackground bounds={selectionBounds} rotation={selectionRotation} />
+}
+
+export function OnTheCanvasWrapper() {
+	const { OnTheCanvas } = useEditorComponents()
+	if (!OnTheCanvas) return null
+	return <OnTheCanvas />
+}
+
+export function InFrontOfTheCanvasWrapper() {
+	const { InFrontOfTheCanvas } = useEditorComponents()
+	if (!InFrontOfTheCanvas) return null
+	return <InFrontOfTheCanvas />
 }

--- a/packages/editor/src/lib/components/default-components/DefaultInFrontOfTheCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultInFrontOfTheCanvas.tsx
@@ -1,0 +1,9 @@
+import { ComponentType } from 'react'
+
+/** @public */
+export type TLInFrontOfTheCanvas = ComponentType<object>
+
+/** @public */
+export const DefaultInFrontOfTheCanvas: TLInFrontOfTheCanvas = () => {
+	return <div className="tl-things-in-front-of-the-canvas" />
+}

--- a/packages/editor/src/lib/components/default-components/DefaultInFrontOfTheCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultInFrontOfTheCanvas.tsx
@@ -2,8 +2,3 @@ import { ComponentType } from 'react'
 
 /** @public */
 export type TLInFrontOfTheCanvas = ComponentType<object>
-
-/** @public */
-export const DefaultInFrontOfTheCanvas: TLInFrontOfTheCanvas = () => {
-	return <div className="tl-things-in-front-of-the-canvas" />
-}

--- a/packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx
@@ -1,0 +1,13 @@
+import { ComponentType, useRef } from 'react'
+import { useTransform } from '../../hooks/useTransform'
+
+/** @public */
+export type TLOnTheCanvas = ComponentType<object>
+
+/** @public */
+export const DefaultOnTheCanvas: TLOnTheCanvas = () => {
+	const rContainer = useRef<HTMLDivElement>(null)
+	useTransform(rContainer, 0, 0)
+
+	return <div className="tl-things-on-the-canvas" ref={rContainer} />
+}

--- a/packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultOnTheCanvas.tsx
@@ -1,13 +1,4 @@
-import { ComponentType, useRef } from 'react'
-import { useTransform } from '../../hooks/useTransform'
+import { ComponentType } from 'react'
 
 /** @public */
 export type TLOnTheCanvas = ComponentType<object>
-
-/** @public */
-export const DefaultOnTheCanvas: TLOnTheCanvas = () => {
-	const rContainer = useRef<HTMLDivElement>(null)
-	useTransform(rContainer, 0, 0)
-
-	return <div className="tl-things-on-the-canvas" ref={rContainer} />
-}

--- a/packages/editor/src/lib/hooks/useEditorComponents.tsx
+++ b/packages/editor/src/lib/hooks/useEditorComponents.tsx
@@ -21,6 +21,8 @@ import {
 	DefaultHoveredShapeIndicator,
 	TLHoveredShapeIndicatorComponent,
 } from '../components/default-components/DefaultHoveredShapeIndicator'
+import { TLInFrontOfTheCanvas } from '../components/default-components/DefaultInFrontOfTheCanvas'
+import { TLOnTheCanvas } from '../components/default-components/DefaultOnTheCanvas'
 import {
 	DefaultScribble,
 	TLScribbleComponent,
@@ -48,7 +50,7 @@ import {
 import { DefaultSpinner, TLSpinnerComponent } from '../components/default-components/DefaultSpinner'
 import { DefaultSvgDefs, TLSvgDefsComponent } from '../components/default-components/DefaultSvgDefs'
 
-interface BaseEditorComponents {
+export interface BaseEditorComponents {
 	Background: TLBackgroundComponent
 	SvgDefs: TLSvgDefsComponent
 	Brush: TLBrushComponent
@@ -68,6 +70,8 @@ interface BaseEditorComponents {
 	SelectionForeground: TLSelectionForegroundComponent
 	SelectionBackground: TLSelectionBackgroundComponent
 	HoveredShapeIndicator: TLHoveredShapeIndicatorComponent
+	OnTheCanvas: TLOnTheCanvas
+	InFrontOfTheCanvas: TLInFrontOfTheCanvas
 }
 
 /** @public */
@@ -113,6 +117,8 @@ export function EditorComponentsProvider({ overrides, children }: ComponentsCont
 					SelectionBackground: DefaultSelectionBackground,
 					SelectionForeground: DefaultSelectionForeground,
 					HoveredShapeIndicator: DefaultHoveredShapeIndicator,
+					OnTheCanvas: null,
+					InFrontOfTheCanvas: null,
 					...overrides,
 				}),
 				[overrides]

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,7 +14606,6 @@
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",


### PR DESCRIPTION
This PR adds two new component overrides to the editor's `components` slot. They are: 

- `<OnTheCanvas/>`, which renders inside of the html layer that scales and translates with the camera
- `<InFrontOfTheCanvas/>`, which renders in front of the canvas but behind any UI elements, and which does not scale / pan with the camera.

![Kapture 2023-11-06 at 12 19 15](https://github.com/tldraw/tldraw/assets/23072548/51c0421d-8b39-48b5-9b8a-c717253c3423)

### Change Type

- [x] `minor` — New feature

### Test Plan

1. See the "on the canvas" example.

### Release Notes

- [editor] Adds two new components, `OnTheCanvas` and `InFrontOfTheCanvas`.