### PR TITLE
Fix the problem with text not being correctly aligned in small geo shapes.

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -524,7 +524,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 				<SVGContainer id={id}>{getShape()}</SVGContainer>
 				<HTMLContainer
 					id={shape.id}
-					style={{ overflow: 'hidden', width: shape.props.w, height: shape.props.h }}
+					style={{ overflow: 'hidden', width: shape.props.w, height: shape.props.h + props.growY }}
 				>
 					<TextLabel
 						id={id}


### PR DESCRIPTION
Seems like the `HTMLContainer` didn't have the correct size, so text label was positioned a bit further up than it should be.

Fixes [#2156](https://github.com/tldraw/tldraw/issues/2156)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Create a small geo shape
2. Add some text to it. Test it with text that wraps to new lines.
3. Make sure text is centred.


### Release Notes

- Fixes position of Text labels in geo shapes.