### PR TITLE
Allow users to select shapes when drag starts on top of a locked shape.

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/children/Idle.ts
@@ -90,7 +90,10 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'shape': {
-				if (this.editor.isShapeOrAncestorLocked(info.shape)) break
+				if (this.editor.isShapeOrAncestorLocked(info.shape)) {
+					this.parent.transition('pointing_canvas', info)
+					break
+				}
 				this.parent.transition('pointing_shape', info)
 				break
 			}

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -106,10 +106,10 @@ describe('Locked shapes', () => {
 	it('Cannot be moved', () => {
 		const shape = editor.getShape(ids.lockedShapeA)
 		editor.pointerDown(150, 150, { target: 'shape', shape })
-		editor.expectToBeIn('select.idle')
+		editor.expectToBeIn('select.pointing_canvas')
 
 		editor.pointerMove(10, 10)
-		editor.expectToBeIn('select.idle')
+		editor.expectToBeIn('select.brushing')
 
 		editor.pointerUp()
 		editor.expectToBeIn('select.idle')
@@ -125,7 +125,7 @@ describe('Locked shapes', () => {
 
 		editor
 			.pointerDown(10, 10, { target: 'shape', shape })
-			.expectToBeIn('select.idle')
+			.expectToBeIn('select.pointing_canvas')
 			.pointerUp()
 			.expectToBeIn('select.idle')
 		expect(editor.selectedShapeIds).not.toContain(shape.id)


### PR DESCRIPTION
Allows you to start brush selecting shapes on top of a locked shapes. In this case we treat the click on top of the locked shape as if we clicked on the canvas (we transition from `idle` -> `pointing_canvas`).

Fixes https://github.com/tldraw/tldraw/issues/2158

Before:

https://github.com/tldraw/tldraw/assets/2523721/7d6eb237-e084-4c40-b777-21d4a67fc796

After:

https://github.com/tldraw/tldraw/assets/2523721/0a73d1da-8250-4ba0-90ee-47d3e794a813

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a locked shape (for geo shape it should have some background)
2. Add a few shapes on top of that shape.
3. Start draging on top of the locked shape. You should be able to brush select other shapes.

- [x] Unit Tests
- [ ] End to end tests

### Release Notes

- Allows brush selecting when you start it on top of a locked shape.