### PR TITLE
Don't show scrollbars.

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -304,6 +304,7 @@
 	display: grid;
 	grid-template-columns: repeat(4, auto);
 	grid-auto-flow: row;
+	overflow: hidden;
 }
 .tlui-buttons__grid > .tlui-button {
 	margin: -2px;


### PR DESCRIPTION
Fixes [#2159](https://github.com/tldraw/tldraw/issues/2159)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Probably best to test the whole UI to make sure things with `.tlui-buttons__grid` still render correctly. Things that are affected by this: UserPresencePicker, ActionsMenu, ButtonPicker (used in style panel), DoubleDropdown (arrowheads picker), DropdownPicker (Style panel), Toolbar (overflowing tools).

### Release Notes

- Hide the horizontal scrollbar in the vertical alignment for Firefox.
