### PR TITLE
[fix] Frame label not following staying aligned correctly on rotation

### DIFF
--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,6 +14606,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -50,6 +50,10 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	override component(shape: TLFrameShape) {
+		// We use this to get the latest shape props, which triggers a re-render
+		// so that we can update the label on rotation
+		this.editor.getShape(shape.id)
+
 		const bounds = this.editor.getShapeGeometry(shape).bounds
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -50,10 +50,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	override component(shape: TLFrameShape) {
-		// We use this to get the latest shape props, which triggers a re-render
-		// so that we can update the label on rotation
-		this.editor.getShape(shape.id)
-
 		const bounds = this.editor.getShapeGeometry(shape).bounds
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -6,6 +6,7 @@ import {
 	toDomPrecision,
 	useEditor,
 	useIsEditing,
+	useValue,
 } from '@tldraw/editor'
 import { useCallback, useEffect, useRef } from 'react'
 import { FrameLabelInput } from './FrameLabelInput'
@@ -22,8 +23,12 @@ export const FrameHeading = function FrameHeading({
 	height: number
 }) {
 	const editor = useEditor()
+	const pageRotation = useValue(
+		'shape rotation',
+		() => canonicalizeRotation(editor.getShapePageTransform(id)!.rotation()),
+		[editor, id]
+	)
 
-	const pageRotation = canonicalizeRotation(editor.getShapePageTransform(id)!.rotation())
 	const isEditing = useIsEditing(id)
 
 	const rInput = useRef<HTMLInputElement>(null)


### PR DESCRIPTION
closes #2157 
@ds300 fixed this

The Frame shape component now re-renders on rotation, ensuring that the label position is always correct.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Make a frame shape
2. rotate it 90 degrees
before: it would stay where it was until the props of the shape changed i.e on resize
now: it updates immediately

### Release Notes

- Frame labels immediately update their position on rotation.