### PR TITLE
Fix crash with zero length arrow

### DIFF
--- a/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/curved-arrow.ts
@@ -49,6 +49,25 @@ export function getCurvedArrowInfo(
 	const b = terminalsInArrowSpace.end.clone()
 	const c = middle.clone()
 
+	if (Vec2d.Equals(a, b)) {
+		return {
+			isStraight: true,
+			start: {
+				handle: a,
+				point: a,
+				arrowhead: shape.props.arrowheadStart,
+			},
+			end: {
+				handle: b,
+				point: b,
+				arrowhead: shape.props.arrowheadEnd,
+			},
+			middle: c,
+			isValid: false,
+			length: 0,
+		}
+	}
+
 	const isClockwise = shape.props.bend < 0
 	const distFn = isClockwise ? clockwiseAngleDist : counterClockwiseAngleDist
 

--- a/packages/editor/src/lib/editor/shapes/shared/arrow/straight-arrow.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/straight-arrow.ts
@@ -25,6 +25,26 @@ export function getStraightArrowInfo(editor: Editor, shape: TLArrowShape): TLArr
 	const a = terminalsInArrowSpace.start.clone()
 	const b = terminalsInArrowSpace.end.clone()
 	const c = Vec2d.Med(a, b)
+
+	if (Vec2d.Equals(a, b)) {
+		return {
+			isStraight: true,
+			start: {
+				handle: a,
+				point: a,
+				arrowhead: shape.props.arrowheadStart,
+			},
+			end: {
+				handle: b,
+				point: b,
+				arrowhead: shape.props.arrowheadEnd,
+			},
+			middle: c,
+			isValid: false,
+			length: 0,
+		}
+	}
+
 	const uAB = Vec2d.Sub(b, a).uni()
 
 	// Update the arrowhead points using intersections with the bound shapes, if any.

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,6 +14606,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",


### PR DESCRIPTION
This PR fixes a bug with zero length arrows.

Before:

![2023-11-07 at 15 17 47 - Harlequin Mouse](https://github.com/tldraw/tldraw/assets/15892272/4c0b9609-f4f0-49cc-8575-ffd58973e81f)

After:

![2023-11-07 at 15 30 07 - Scarlet Dinosaur](https://github.com/tldraw/tldraw/assets/15892272/af3188f1-c996-46e1-a2ff-48de31e0fc05)

Fixes #2166

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Draw a rectangle.
2. Clone it.
3. Connect their centers with an arrow.
4. Hold control/command.
5. Drag one rectangle onto the other so they're in the exact same place.
6. Erase both rectangles (but NOT the invisible arrow).
7. Select all.
8. Hover the minimap.
9. Repeat but curve the arrow slightly before moving the rectangles together.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fix a hyper niche arrow crash with zero length arrows.
