### PR TITLE
Fix arrow dropdown localizations.

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DoubleDropdownPicker.tsx
@@ -72,9 +72,9 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 							title={
 								msg(labelA) +
 								' — ' +
-								(valueA === null
+								(valueA === null || valueA.type === 'mixed'
 									? msg('style-panel.mixed')
-									: msg(`${uiTypeA}-style.${valueA}` as TLUiTranslationKey))
+									: msg(`${uiTypeA}-style.${valueA.value}` as TLUiTranslationKey))
 							}
 							icon={iconA as any}
 							invertIcon
@@ -115,9 +115,9 @@ export const DoubleDropdownPicker = React.memo(function DoubleDropdownPicker<T e
 							title={
 								msg(labelB) +
 								' — ' +
-								(valueB === null
+								(valueB === null || valueB.type === 'mixed'
 									? msg('style-panel.mixed')
-									: msg(`${uiTypeB}-style.${valueB}` as TLUiTranslationKey))
+									: msg(`${uiTypeB}-style.${valueB.value}` as TLUiTranslationKey))
 							}
 							icon={iconB as any}
 							smallIcon


### PR DESCRIPTION
**Before**

![image](https://github.com/tldraw/tldraw/assets/2523721/161bc39b-f657-4983-8eaa-7de61c87b3bb)

**After**

![image](https://github.com/tldraw/tldraw/assets/2523721/f75794ce-96a1-4a9e-914d-cc9664702b6b)



### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Create an arrow.
2. Hover over the arrow head style dropdowns. They should be correctly translated.
3. Also test it for when you have arrows with different styles selected. This should show the `mixed` option.

### Release Notes

- Fix arrow headstyle dropdown translations.
