### PR TITLE
[fix] Prevent navigating back with the trackpad

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -239,6 +239,11 @@ export function useDocumentEvents() {
 
 		// Prevent wheel events that occur inside of the container
 		const handleWheel = (e: WheelEvent) => {
+			// Prevent navigating back/forward with a trackpad
+			if (Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
+				preventDefault(e)
+			}
+
 			if (container.contains(e.target as Node) && (e.ctrlKey || e.metaKey)) {
 				preventDefault(e)
 			}

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -14583,7 +14583,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -14606,6 +14606,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",


### PR DESCRIPTION
This PR prevents navigating forward/back by swiping two fingers on the trackpad.

I have no idea why this was only happening on dotcom. It doesn't happen in bublic. This feels like a strange fix, but maybe it's more effective in general anyway!

I think we should do some cross-browser testing on this one, before hitting the release button.

fixes #2155 

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Navigate to dotcom from another page (so that your browser has something in the history) (ie: not a fresh tab).
2. Hover over the UI with the cursor (eg: the toolbar).
3. With two fingers, swipe left on the trackpad.
4. The page should not go back to the previous page.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed a bug where you could accidentally go back by swiping with two fingers.