### PR TITLE
instant bookmarks

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
@@ -18,11 +18,14 @@ export async function pasteUrl(
 ) {
 	// Lets see if its an image and we have CORs
 	try {
-		const resp = await fetch(url)
-		if (resp.headers.get('content-type')?.match(/^image\//)) {
-			editor.mark('paste')
-			pasteFiles(editor, [url])
-			return
+		// skip this step if the url doesn't contain an image extension, treat it as a regular bookmark
+		if (new URL(url).pathname.match(/\.(png|jpe?g|gif|svg|webp)$/i)) {
+			const resp = await fetch(url, { method: 'HEAD' })
+			if (resp.headers.get('content-type')?.match(/^image\//)) {
+				editor.mark('paste')
+				pasteFiles(editor, [url])
+				return
+			}
 		}
 	} catch (err: any) {
 		if (err.message !== 'Failed to fetch') {


### PR DESCRIPTION
this PR does a couple of things when creating bookmarks

- any time a url was pasted it was previously calling `fetch` on the url to check whether the url is an image that we have cors access to. In that case we can paste the image itself rather than a bookmark. But that's gonna be a relatively rare use case, and the check itself seemed to cost anywhere from 200ms to +1s which is certainly not worth it when the fallback behaviour (create a regular bookmark) is fine. So i moved that check behind a url pathname extension check. i.e. if the url pathname ends with .gif, .jpg, .jpeg, .svg, or .png, then it will check whether we can paste the image directly, otherwise it will always do a regular bookmark.
- we create an asset-less bookmark shape on the canvas while we wait for the asset to load if it is not already available. This means the user gets immediate feedback that their paste succeeded, but they won't see the actual bookmark details for a little bit.

It looks like this

![Kapture 2023-11-08 at 10 34 35](https://github.com/tldraw/tldraw/assets/1242537/89c93612-a794-419f-aa68-1efdb82bfbf2)

### Change Type

- [x] `minor` — New feature


### Release Notes

- Improves ux around pasting bookmarks
