### PR TITLE
fix scroll event coords

### DIFF
--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -115,11 +115,16 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 
 			if (delta.x === 0 && delta.y === 0) return
 
+			const container = editor.getContainer().getBoundingClientRect()
+
 			const info: TLWheelEventInfo = {
 				type: 'wheel',
 				name: 'wheel',
 				delta,
-				point: new Vec2d(event.x, event.y),
+				point: new Vec2d(event.clientX, event.clientY).sub({
+					x: container.left,
+					y: container.top,
+				}),
 				shiftKey: event.shiftKey,
 				altKey: event.altKey,
 				ctrlKey: event.metaKey || event.ctrlKey,


### PR DESCRIPTION
Follow up to #2149 to make sure it works when tldraw is not mounted at 0,0 in document space. Try it out in the 'multiple' examples

### Change Type

- [x] `patch` — Bug fix
