### PR TITLE
fix(vscode): restore focus after loading file to enable shortcuts

### DIFF
--- a/packages/tldraw/src/lib/utils/file.ts
+++ b/packages/tldraw/src/lib/utils/file.ts
@@ -296,9 +296,7 @@ export async function parseAndLoadDocument(
 		if (bounds) {
 			editor.zoomToBounds(bounds, 1)
 		}
-		if (editor.instanceState.isFocused !== isFocused) {
-			editor.updateInstanceState({ isFocused })
-		}
+		editor.updateInstanceState({ isFocused })
 	})
 
 	if (forceDarkMode) editor.user.updateUserPreferences({ isDarkMode: true })


### PR DESCRIPTION
It looks like loading the file unfocused the editor. And since it [wasn't focused we didn't register keyboard shortcuts](https://github.com/tldraw/tldraw/blob/mitja/fix-keyboardshortcuts/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts#L27).

This makes sure that the focus after loading the file stays the same as it was before loading it.

Fixes: #2028
Fixes: #2116

### Change type

- [x] `bugfix`

### Test plan

1. Run the VS Code extension.
2. Open a new file with the `tldraw: New project` command.
3. Make sure keyboard shortcuts are working.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes keyboard shortcuts for VS Code extension.