### PR TITLE
add missing semicolon

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -144,7 +144,7 @@
 	--color-brush-stroke: rgba(180, 180, 180, 0.25);
 	--color-grid: #909090;
 	--color-low: #2c3136;
-	--color-low-border: #30363b
+	--color-low-border: #30363b;
 	--color-culled: blue;
 	--color-muted-none: rgba(255, 255, 255, 0);
 	--color-muted-0: rgba(255, 255, 255, 0.02);


### PR DESCRIPTION
Fixes #2152

A semicolon was missing from the editor.css file

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan


### Release Notes

- Fix typo in CSS file
