### PR TITLE
Only use the hack if we are in safari.

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useCopyAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useCopyAs.ts
@@ -137,7 +137,7 @@ async function getExportedSvgBlob(editor: Editor, ids: TLShapeId[]) {
 }
 
 async function getExportedImageBlob(editor: Editor, ids: TLShapeId[], format: 'png' | 'jpeg') {
-	return await getSvgAsImage(await getExportSvgElement(editor, ids), {
+	return await getSvgAsImage(await getExportSvgElement(editor, ids), editor.environment.isSafari, {
 		type: format,
 		quality: 1,
 		scale: 2,

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -54,7 +54,7 @@ export function useExportAs() {
 				}
 				case 'webp':
 				case 'png': {
-					const image = await getSvgAsImage(svg, {
+					const image = await getSvgAsImage(svg, editor.environment.isSafari, {
 						type: format,
 						quality: 1,
 						scale: 2,

--- a/packages/tldraw/src/lib/utils/export.ts
+++ b/packages/tldraw/src/lib/utils/export.ts
@@ -25,6 +25,7 @@ export function getSvgAsString(svg: SVGElement) {
 /** @public */
 export async function getSvgAsImage(
 	svg: SVGElement,
+	isSafari: boolean,
 	options: {
 		type: TLCopyType | TLExportType
 		quality: number
@@ -68,7 +69,9 @@ export async function getSvgAsImage(
 			// actually loaded. just waiting around a while is brittle, but
 			// there doesn't seem to be any better solution for now :( see
 			// https://bugs.webkit.org/show_bug.cgi?id=219770
-			await new Promise((resolve) => setTimeout(resolve, 250))
+			if (isSafari) {
+				await new Promise((resolve) => setTimeout(resolve, 250))
+			}
 
 			const canvas = document.createElement('canvas') as HTMLCanvasElement
 			const ctx = canvas.getContext('2d')!


### PR DESCRIPTION
Only use the hack if we are in safari. Should make it faster for other browsers.

Based on the suggestion from https://github.com/tldraw/tldraw/issues/2183

Fixes https://github.com/tldraw/tldraw/issues/2183

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Improve the speed of exporting to png for non Safari browsers.
