### PR TITLE
VS code bump 2.0.16

### DIFF
--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.16
+- Fixed keyboard shortcuts.
+- Fixed edit link button stopping the mouse events from working.
+- Fixed a bug with grouping / ungrouping which prevented the actions menu from closing correctly.
+- Fixed arrowheads not being correctly localized in the Style panel.
+- Fixed a bug where arrows with length 0 could crash the app.
+
 ## 2.0.15
 - Bug fixes and performance improvements.
 

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.15",
+	"version": "2.0.16",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
Bumps the version for VS code extension.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
