### PR TITLE
[fix] masked bounds calculation

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4040,7 +4040,23 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!pageBounds) return
 		const pageMask = this._shapeMaskCache.get(shape)
 		if (pageMask) {
+			const { corners } = pageBounds
+			let a: VecLike,
+				b: VecLike,
+				isSame = true
+			for (let i = 0; i < pageMask.length; i++) {
+				a = pageMask[i]
+				b = corners[i]
+				if (!Vec2d.Equals(a, b)) {
+					isSame = false
+					break
+				}
+			}
+
+			if (isSame) return pageBounds.clone()
+
 			const intersection = intersectPolygonPolygon(pageMask, pageBounds.corners)
+
 			if (!intersection) return
 			return Box2d.FromPoints(intersection)
 		}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4043,6 +4043,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const { corners } = pageBounds
 			if (corners.every((p, i) => Vec2d.Equals(p, pageMask[i]))) return pageBounds.clone()
 
+			// todo: find out why intersect polygon polygon for identical polygons produces zero w/h intersections
 			const intersection = intersectPolygonPolygon(pageMask, corners)
 			if (!intersection) return
 			return Box2d.FromPoints(intersection)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4041,22 +4041,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const pageMask = this._shapeMaskCache.get(shape)
 		if (pageMask) {
 			const { corners } = pageBounds
-			let a: VecLike,
-				b: VecLike,
-				isSame = true
-			for (let i = 0; i < pageMask.length; i++) {
-				a = pageMask[i]
-				b = corners[i]
-				if (!Vec2d.Equals(a, b)) {
-					isSame = false
-					break
-				}
-			}
+			if (corners.every((p, i) => Vec2d.Equals(p, pageMask[i]))) return pageBounds.clone()
 
-			if (isSame) return pageBounds.clone()
-
-			const intersection = intersectPolygonPolygon(pageMask, pageBounds.corners)
-
+			const intersection = intersectPolygonPolygon(pageMask, corners)
 			if (!intersection) return
 			return Box2d.FromPoints(intersection)
 		}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3938,12 +3938,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.store.createComputedCache<string, TLShape>('clipPathCache', (shape) => {
 			const pageMask = this._shapeMaskCache.get(shape.id)
 			if (!pageMask) return undefined
-			const pageTransform = this._shapePageTransformCache.get(shape.id)
-			if (!pageTransform) return undefined
-
 			if (pageMask.length === 0) {
 				return `polygon(0px 0px, 0px 0px, 0px 0px)`
 			}
+
+			const pageTransform = this._shapePageTransformCache.get(shape.id)
+			if (!pageTransform) return undefined
 
 			const localMask = Matrix2d.applyToPoints(Matrix2d.Inverse(pageTransform), pageMask)
 
@@ -4040,6 +4040,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!pageBounds) return
 		const pageMask = this._shapeMaskCache.get(shape)
 		if (pageMask) {
+			if (pageMask.length === 0) return undefined
+
 			const { corners } = pageBounds
 			if (corners.every((p, i) => Vec2d.Equals(p, pageMask[i]))) return pageBounds.clone()
 


### PR DESCRIPTION
This PR fixes a bug where frames with children that have identical dimensions would not be able to export as images.

When calculating masked page bounds, identical shapes would produce a zero width/height masked page bounds.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a frame.
2. Create an image that is a child of the frame and the exact dimensions of the frame (possibly using the console)
3. Export the image

### Release Notes

- Fix bug with getmaskedpagebounds calculation for identical parent / child sizes