### PR TITLE
[fix] huge images, use downscale for image scaling

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -673,7 +673,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 export function getEmbedInfo(inputUrl: string): TLEmbedResult;
 
 // @public
-export function getResizedImageDataUrl(dataURLForImage: string, width: number, height: number): Promise<string>;
+export function getResizedImageDataUrl(dataURLForImage: string, width: number, height: number, type?: string, quality?: number): Promise<string>;
 
 // @public (undocumented)
 function Group({ children, size, }: {

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -673,7 +673,10 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 export function getEmbedInfo(inputUrl: string): TLEmbedResult;
 
 // @public
-export function getResizedImageDataUrl(dataURLForImage: string, width: number, height: number, type?: string, quality?: number): Promise<string>;
+export function getResizedImageDataUrl(dataURLForImage: string, width: number, height: number, opts?: {
+    type?: string | undefined;
+    quality?: number | undefined;
+}): Promise<string>;
 
 // @public (undocumented)
 function Group({ children, size, }: {

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -7264,6 +7264,22 @@
             },
             {
               "kind": "Content",
+              "text": ", type?: "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": ", quality?: "
+            },
+            {
+              "kind": "Content",
+              "text": "number"
+            },
+            {
+              "kind": "Content",
               "text": "): "
             },
             {
@@ -7282,8 +7298,8 @@
           ],
           "fileUrlPath": "packages/tldraw/src/lib/utils/assets.ts",
           "returnTypeTokenRange": {
-            "startIndex": 7,
-            "endIndex": 9
+            "startIndex": 11,
+            "endIndex": 13
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -7311,6 +7327,22 @@
                 "endIndex": 6
               },
               "isOptional": false
+            },
+            {
+              "parameterName": "type",
+              "parameterTypeTokenRange": {
+                "startIndex": 7,
+                "endIndex": 8
+              },
+              "isOptional": true
+            },
+            {
+              "parameterName": "quality",
+              "parameterTypeTokenRange": {
+                "startIndex": 9,
+                "endIndex": 10
+              },
+              "isOptional": true
             }
           ],
           "name": "getResizedImageDataUrl"

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -7236,7 +7236,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!getResizedImageDataUrl:function(1)",
-          "docComment": "/**\n * Get the size of an image from its source.\n *\n * @param dataURLForImage - The image file as a string.\n *\n * @param width - The desired width.\n *\n * @param height - The desired height.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Get the size of an image from its source.\n *\n * @param dataURLForImage - The image file as a string.\n *\n * @param width - The desired width.\n *\n * @param height - The desired height.\n *\n * @param opts - Options for the image.\n *\n * @example\n * ```ts\n * const size = await getImageSize('https://example.com/image.jpg')\n * const dataUrl = await getResizedImageDataUrl('https://example.com/image.jpg', size.w, size.h, { type: \"image/jpeg\", quality: 0.92 })\n * ```\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7264,19 +7264,11 @@
             },
             {
               "kind": "Content",
-              "text": ", type?: "
+              "text": ", opts?: "
             },
             {
               "kind": "Content",
-              "text": "string"
-            },
-            {
-              "kind": "Content",
-              "text": ", quality?: "
-            },
-            {
-              "kind": "Content",
-              "text": "number"
+              "text": "{\n    type?: string | undefined;\n    quality?: number | undefined;\n}"
             },
             {
               "kind": "Content",
@@ -7298,8 +7290,8 @@
           ],
           "fileUrlPath": "packages/tldraw/src/lib/utils/assets.ts",
           "returnTypeTokenRange": {
-            "startIndex": 11,
-            "endIndex": 13
+            "startIndex": 9,
+            "endIndex": 11
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -7329,18 +7321,10 @@
               "isOptional": false
             },
             {
-              "parameterName": "type",
+              "parameterName": "opts",
               "parameterTypeTokenRange": {
                 "startIndex": 7,
                 "endIndex": 8
-              },
-              "isOptional": true
-            },
-            {
-              "parameterName": "quality",
-              "parameterTypeTokenRange": {
-                "startIndex": 9,
-                "endIndex": 10
               },
               "isOptional": true
             }

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -55,6 +55,7 @@
 		"@tldraw/editor": "workspace:*",
 		"canvas-size": "^1.2.6",
 		"classnames": "^2.3.2",
+		"downscale": "^1.0.6",
 		"hotkeys-js": "^3.11.2",
 		"lz-string": "^1.4.4"
 	},
@@ -68,6 +69,7 @@
 		"@testing-library/react": "^14.0.0",
 		"@types/canvas-size": "^1.2.0",
 		"@types/classnames": "^2.3.1",
+		"@types/downscale": "^1.0.4",
 		"@types/lz-string": "^1.3.34",
 		"chokidar-cli": "^3.0.0",
 		"jest-canvas-mock": "^2.5.2",

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -97,7 +97,10 @@ export function registerDefaultExternalContentHandlers(
 
 				// Always rescale the image
 				if (file.type === 'image/jpeg' || file.type === 'image/png') {
-					dataUrl = await getResizedImageDataUrl(dataUrl, size.w, size.h, file.type, 0.8)
+					dataUrl = await getResizedImageDataUrl(dataUrl, size.w, size.h, {
+						type: file.type,
+						quality: 0.92,
+					})
 				}
 
 				const assetId: TLAssetId = AssetRecordType.createId(getHashForString(dataUrl))

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -91,10 +91,13 @@ export function registerDefaultExternalContentHandlers(
 				if (isFinite(maxImageDimension)) {
 					const resizedSize = containBoxSize(size, { w: maxImageDimension, h: maxImageDimension })
 					if (size !== resizedSize && (file.type === 'image/jpeg' || file.type === 'image/png')) {
-						// If we created a new size and the type is an image, rescale the image
-						dataUrl = await getResizedImageDataUrl(dataUrl, size.w, size.h)
+						size = resizedSize
 					}
-					size = resizedSize
+				}
+
+				// Always rescale the image
+				if (file.type === 'image/jpeg' || file.type === 'image/png') {
+					dataUrl = await getResizedImageDataUrl(dataUrl, size.w, size.h, file.type, 0.8)
 				}
 
 				const assetId: TLAssetId = AssetRecordType.createId(getHashForString(dataUrl))

--- a/packages/tldraw/src/lib/utils/assets.ts
+++ b/packages/tldraw/src/lib/utils/assets.ts
@@ -40,20 +40,27 @@ export function containBoxSize(
 /**
  * Get the size of an image from its source.
  *
+ * @example
+ * ```ts
+ * const size = await getImageSize('https://example.com/image.jpg')
+ * const dataUrl = await getResizedImageDataUrl('https://example.com/image.jpg', size.w, size.h, { type: "image/jpeg", quality: 0.92 })
+ * ```
+ *
  * @param dataURLForImage - The image file as a string.
  * @param width - The desired width.
  * @param height - The desired height.
+ * @param opts - Options for the image.
  * @public
  */
 export async function getResizedImageDataUrl(
 	dataURLForImage: string,
 	width: number,
 	height: number,
-	type = 'image/png',
-	quality = 0.8
+	opts = {} as { type?: string; quality?: number }
 ): Promise<string> {
 	let desiredWidth = width * 2
 	let desiredHeight = height * 2
+	const { type = 'image/jpeg', quality = 0.92 } = opts
 
 	const canvasSizes = await getBrowserCanvasMaxSize()
 

--- a/public-yarn.lock
+++ b/public-yarn.lock
@@ -4608,10 +4608,12 @@ __metadata:
     "@tldraw/editor": "workspace:*"
     "@types/canvas-size": ^1.2.0
     "@types/classnames": ^2.3.1
+    "@types/downscale": ^1.0.4
     "@types/lz-string": ^1.3.34
     canvas-size: ^1.2.6
     chokidar-cli: ^3.0.0
     classnames: ^2.3.2
+    downscale: ^1.0.6
     hotkeys-js: ^3.11.2
     jest-canvas-mock: ^2.5.2
     jest-environment-jsdom: ^28.1.2
@@ -4872,6 +4874,13 @@ __metadata:
   dependencies:
     "@types/ms": "*"
   checksum: 0a7b89d8ed72526858f0b61c6fd81f477853e8c4415bb97f48b1b5545248d2ae389931680b94b393b993a7cfe893537a200647d93defe6d87159b96812305adc
+  languageName: node
+  linkType: hard
+
+"@types/downscale@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@types/downscale@npm:1.0.4"
+  checksum: b29ca279b616e06896c01795effa5c483e243e85a137462f98eb43dec3598acab3f72b0637225a4087080e0326cf4bde89ba21d0473a9254a7661c5fd29f98d9
   languageName: node
   linkType: hard
 
@@ -7924,6 +7933,13 @@ __metadata:
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
+  languageName: node
+  linkType: hard
+
+"downscale@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "downscale@npm:1.0.6"
+  checksum: f69beb8fe7711964b259ef3d3502fd9f5dd0c4472aa279537dc58d69dcff8a619c77b0209db65841aab014930b97e82f92d43558acc1e569407b8fbc63fb04ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR improves our method for handling images, which is especially useful when using a local tldraw editor. Previously, we were only downsample images that were above the browser's maximum size. We now downsample all images. This will result in smaller images in almost all cases. It will also prevent very large jpeg images from being converted to png images, which could often lead to an increase in file size!

### Change Type

- [x] `minor` — New feature

### Test Plan

1. Add some images (jpegs or pngs) to the canvas.

### Release Notes

- Improved image rescaling.