### PR TITLE
Revert back to the previous color.

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -145,7 +145,7 @@
 	--color-grid: #909090;
 	--color-low: #2c3136;
 	--color-low-border: #30363b;
-	--color-culled: blue;
+	--color-culled: rgb(47, 52, 57);
 	--color-muted-none: rgba(255, 255, 255, 0);
 	--color-muted-0: rgba(255, 255, 255, 0.02);
 	--color-muted-1: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
Fixes the color of culled shapes when using dark mode. Reverted to the color that was set before the blue test color.


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Fixes the color of culled shapes when using dark mode.
