### PR TITLE
Add prettier caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"build-api": "lazy build-api",
 		"build-package": "lazy build-package",
 		"lint": "lazy lint",
-		"format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\"",
+		"format": "prettier --write --cache \"**/*.{ts,tsx,js,jsx,json}\"",
 		"typecheck": "yarn refresh-assets && tsx scripts/typecheck.ts",
 		"check-scripts": "tsx scripts/check-scripts.ts",
 		"api-check": "lazy api-check",
@@ -56,7 +56,7 @@
 	"packageManager": "yarn@3.5.0",
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx,json}": [
-			"prettier --write"
+			"prettier --write --cache"
 		]
 	},
 	"devDependencies": {

--- a/packages/tlschema/package.json
+++ b/packages/tlschema/package.json
@@ -34,7 +34,7 @@
 		"test": "lazy inherit",
 		"test-coverage": "lazy inherit",
 		"index": "node ./scripts/build-index.js && yarn format",
-		"format": "yarn run -T prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
+		"format": "yarn run -T prettier --write --cache \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
 		"build": "yarn run -T tsx ../../scripts/build-package.ts",
 		"build-api": "yarn run -T tsx ../../scripts/build-api.ts",
 		"prepack": "yarn run -T tsx ../../scripts/prepack.ts",

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -54,6 +54,7 @@ async function main() {
 			'-T',
 			'prettier',
 			shouldFix ? '--write' : '--check',
+			'--cache',
 			...prettierFiles,
 		])
 		await exec('yarn', [


### PR DESCRIPTION
Adds `--cache` flag to prettier which significantly speeds up `yarn format`:
https://prettier.io/docs/en/cli#--cache

One downside is that changing the plugins we use with prettier will not cause the cache to invalidate. Stills seems worth it though.

> Plugins version and implementation are not used as cache keys. We recommend that you delete the cache when updating plugins.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Run `yarn format`
2. Run `yarn format` again, this time it should be significantly faster.

### Release Notes

- Speed up formatting of files via `yarn format`.
