### PR TITLE
Stop bookmark shape jumping position when content is fetched

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -381,7 +381,8 @@ export function registerDefaultExternalContentHandlers(
 
 			editor.updateShapes([
 				{
-					...shape,
+					type: shape.type,
+					id: shape.id,
 					props: {
 						...shape.props,
 						assetId: asset.id,


### PR DESCRIPTION
This PR stops the bookmark shape changing position when content is fetched. (When you paste it and move it before it loads).

### Change Type

- [x] `patch` — Bug fix
### Test Plan

1. Paste a link.
2. Before the content fetches, move the shape.
3. Make sure it doesn't move back to the original paste position.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed a bug where pasted bookmark shapes could change position when their content loads.