### PR TITLE
don't overwrite bookmark position if it changed before metadata arrives

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -381,9 +381,9 @@ export function registerDefaultExternalContentHandlers(
 
 			editor.updateShapes([
 				{
-					...shape,
+					id: shape.id,
+					type: shape.type,
 					props: {
-						...shape.props,
 						assetId: asset.id,
 					},
 				},


### PR DESCRIPTION
Fixes issue when creating new bookmark shape where the position would be reset if you moved it before the bookmark metadata was fetched

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes issue when creating new bookmark shape where the position would be reset if you moved it before the bookmark metadata was fetched.
