### PR TITLE
VS Code bump 2.0.17

### DIFF
--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.17
+- Improved grouping of shapes. You can now group a shape with an arrow bound to it.
+- Improved handling of images. We now downscale them, which should improve performance.
+- Improved Japanese translations.
+- Fixed the background color of culled shapes when using dark mode.
+- Fixed a bug with exporting shapes that have the same dimensions as their parent frame shape.
+
+
 ## 2.0.16
 - Fixed keyboard shortcuts.
 - Fixed edit link button stopping the mouse events from working.

--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Fixed the background color of culled shapes when using dark mode.
 - Fixed a bug with exporting shapes that have the same dimensions as their parent frame shape.
 
-
 ## 2.0.16
 - Fixed keyboard shortcuts.
 - Fixed edit link button stopping the mouse events from working.

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.16",
+	"version": "2.0.17",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
Bumps VS Code extension version.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- VS code extension 2.0.17.
