### PR TITLE
Add `getSvgAsImage` to exports.

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -686,6 +686,13 @@ export function getResizedImageDataUrl(dataURLForImage: string, width: number, h
 }): Promise<string>;
 
 // @public (undocumented)
+export function getSvgAsImage(svg: SVGElement, isSafari: boolean, options: {
+    type: 'jpeg' | 'png' | 'svg' | 'webp';
+    quality: number;
+    scale: number;
+}): Promise<Blob | null>;
+
+// @public (undocumented)
 function Group({ children, size, }: {
     children: any;
     size?: 'medium' | 'small' | 'tiny' | 'wide';

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -7619,6 +7619,98 @@
           "name": "getResizedImageDataUrl"
         },
         {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!getSvgAsImage:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function getSvgAsImage(svg: "
+            },
+            {
+              "kind": "Reference",
+              "text": "SVGElement",
+              "canonicalReference": "!SVGElement:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ", isSafari: "
+            },
+            {
+              "kind": "Content",
+              "text": "boolean"
+            },
+            {
+              "kind": "Content",
+              "text": ", options: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    type: 'jpeg' | 'png' | 'svg' | 'webp';\n    quality: number;\n    scale: number;\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Reference",
+              "text": "Promise",
+              "canonicalReference": "!Promise:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Blob",
+              "canonicalReference": "!Blob:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/utils/export/export.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 7,
+            "endIndex": 11
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "svg",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "isSafari",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "options",
+              "parameterTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "getSvgAsImage"
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@tldraw/tldraw!HandTool:class",
           "docComment": "/**\n * @public\n */\n",

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -151,6 +151,7 @@ export {
 } from './lib/utils/assets/assets'
 export { getEmbedInfo } from './lib/utils/embeds/embeds'
 export { copyAs } from './lib/utils/export/copyAs'
+export { getSvgAsImage } from './lib/utils/export/export'
 export { exportAs } from './lib/utils/export/exportAs'
 export { setDefaultEditorAssetUrls } from './lib/utils/static-assets/assetUrls'
 export { truncateStringWithEllipsis } from './lib/utils/text/text'


### PR DESCRIPTION
This PR adds `getSvgAsImage` to the package's exports.

### Change Type

- [x] `minor` — New feature
