### PR TITLE
Fix "custom UI" example

### DIFF
--- a/apps/examples/src/examples/CustomUiExample/CustomUiExample.tsx
+++ b/apps/examples/src/examples/CustomUiExample/CustomUiExample.tsx
@@ -1,4 +1,4 @@
-import { Canvas, Tldraw, track, useEditor } from '@tldraw/tldraw'
+import { Tldraw, track, useEditor } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 import { useEffect } from 'react'
 import './custom-ui.css'
@@ -7,7 +7,6 @@ export default function CustomUiExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw hideUi>
-				<Canvas />
 				<CustomUi />
 			</Tldraw>
 		</div>


### PR DESCRIPTION
Remove unwanted `<Canvas>` which was resulting in duplicate rendering


### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Copy the "custom UI" example found [here](https://github.com/tldraw/tldraw/blob/main/apps/examples/src/examples/CustomUiExample)
2. Run it
3. You will see two instances of canvas rendering (have to inspect the DOM, it's not obvious visually :))
4. With my change the issue is gone

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed double rendering of canvas in the "custom UI" example
