### PR TITLE
Fix copy as svg.

### DIFF
--- a/packages/tldraw/src/lib/utils/export/copyAs.ts
+++ b/packages/tldraw/src/lib/utils/export/copyAs.ts
@@ -39,8 +39,8 @@ export function copyAs(
 			switch (format) {
 				case 'svg': {
 					if (window.navigator.clipboard) {
-						if (write) {
-							write([
+						if (window.navigator.clipboard.write) {
+							window.navigator.clipboard.write([
 								new ClipboardItem({
 									'text/plain': new Blob([getSvgAsString(svg)], { type: 'text/plain' }),
 								}),


### PR DESCRIPTION
Fix copy as svg. It was erroring out. Not sure why the old logic didn't work 😂 

Seems like this started happening after https://github.com/tldraw/tldraw/pull/2198

### Before
![CleanShot 2023-11-30 at 10 05 45](https://github.com/tldraw/tldraw/assets/2523721/0274ea2c-7a8d-4d88-bf31-00b8669c3f43)

### After

![CleanShot 2023-11-30 at 10 04 52](https://github.com/tldraw/tldraw/assets/2523721/8b42e0fc-39fb-4573-86f6-47cc80f0e091)


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Select some shapes.
2. Copy as svg
3. Should be able to paste them and there should be no errors in the console.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes copy as svg (issue is just on staging, didn't make it to prod yet)
