### PR TITLE
docs: update misleading comment in external content sources example

### DIFF
--- a/apps/examples/src/examples/ExternalContentSourcesExample.tsx
+++ b/apps/examples/src/examples/ExternalContentSourcesExample.tsx
@@ -38,7 +38,9 @@ class DangerousHtmlExample extends BaseBoxShapeUtil<IDangerousHtmlShape> {
 
 export default function ExternalContentSourcesExample() {
 	const handleMount = useCallback((editor: Editor) => {
-		// When a user uploads a file, create an asset from it
+		// We will register a new handler for text content. When a user pastes `text/html` content into the editor,
+		// we will create a new shape with that html content.
+		// To test this copy some html content from VS Code or some other text editor.
 		editor.registerExternalContentHandler('text', async ({ point, sources }) => {
 			const htmlSource = sources?.find((s) => s.type === 'text' && s.subtype === 'html')
 


### PR DESCRIPTION
Update the External content sources example. The comment was misleading as it mentioned dragging a file, but the example only works when you paste the `text/html` content.

https://github.com/tldraw/tldraw/assets/2523721/7c4193ff-e2ba-417f-95c0-7da1f10b585b

Improves https://github.com/tldraw/tldraw/issues/2200

### Change type

- [x] `other`

### Test plan

1. Open the External Content Sources example.
2. Verify the comment accurately describes the paste behavior.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve the comment for one of our examples.