### PR TITLE
test(e2e): fix export snapshot race condition

### DIFF
--- a/apps/examples/e2e/tests/export-snapshots.spec.ts
+++ b/apps/examples/e2e/tests/export-snapshots.spec.ts
@@ -207,7 +207,7 @@ test.describe('Export snapshots', () => {
 	}
 
 	async function snapshotTest(page: Page) {
-		page.waitForEvent('download').then(async (download) => {
+		const downloadAndSnapshot = page.waitForEvent('download').then(async (download) => {
 			const path = (await download.path()) as string
 			assert(path)
 			await rename(path, path + '.svg')
@@ -230,5 +230,6 @@ test.describe('Export snapshots', () => {
 			})
 		})
 		await page.evaluate(() => (window as any)['tldraw-export']())
+		await downloadAndSnapshot
 	}
 })

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -15576,7 +15576,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
+          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu.d.ts",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -15599,6 +15599,7 @@
                   "text": ";"
                 }
               ],
+              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu.tsx",
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",


### PR DESCRIPTION
Fixes a race condition with our snapshot export tests that was causing them to be flaky.

### Change type

- [x] `other`

### Test plan

- [x] End to end tests

### Release notes

- Fixed a race condition in snapshot export tests.