### PR TITLE
Use VS Codes theme (light or dark) for tldraw dark mode option

### DIFF
--- a/apps/vscode/editor/src/FileOpen.tsx
+++ b/apps/vscode/editor/src/FileOpen.tsx
@@ -33,6 +33,7 @@ export function FileOpen({
 			await parseAndLoadDocument(editor, fileContents, msg, addToast, onV1FileLoad, forceDarkMode)
 		}
 
+		editor.user.updateUserPreferences({ isDarkMode: forceDarkMode })
 		loadFile()
 		setIsFileLoaded(true)
 		return () => {

--- a/apps/vscode/extension/src/TldrawDocument.ts
+++ b/apps/vscode/extension/src/TldrawDocument.ts
@@ -41,7 +41,7 @@ export class TLDrawDocument implements vscode.CustomDocument {
 		public documentData: TldrawFile,
 		backupId: string | undefined
 	) {
-		this.isBlankDocument = backupId === 'undefined'
+		this.isBlankDocument = backupId === undefined
 	}
 
 	static async create(uri: vscode.Uri, backupId: string | undefined) {

--- a/apps/vscode/extension/src/WebViewMessageHandler.ts
+++ b/apps/vscode/extension/src/WebViewMessageHandler.ts
@@ -43,9 +43,8 @@ export class WebViewMessageHandler {
 						userId: this.userId,
 						assetSrc: this.assetSrc,
 						isDarkMode:
-							this.document.isBlankDocument &&
-							(vscode.window.activeColorTheme.kind === 2 ||
-								vscode.window.activeColorTheme.kind === 3),
+							vscode.window.activeColorTheme.kind === 2 ||
+							vscode.window.activeColorTheme.kind === 3,
 					},
 				} as VscodeMessage)
 				break


### PR DESCRIPTION
This always uses VS code's theme type (light / dark) to set the tldraw dark mode option. This doesn't work if you switch the theme after you have already opened a document - don't think there's an event for that. But it will work if you reopen it. You can also change it from the preferences, but it will reset when you open new files.

It's a bit annoying in some cases though:
1. Open the first document. It will take VS Code's dark / light mode setting. Let's say it's light.
3. Change the dark mode to dark from within tldraw. This will update the dark mode in all open tldraw windows.
4. If you now open a new tldraw document it will again read the VS Code's setting and override the previous step. This will also apply to all the other open windows.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
5.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
