### PR TITLE
fix new page naming

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3791,7 +3791,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const pages = this.getPages()
 
 			const name = getIncrementedName(
-				page.name ?? 'Page',
+				page.name ?? 'Page 1',
 				pages.map((p) => p.name)
 			)
 

--- a/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MoveToPageMenu.tsx
@@ -82,7 +82,7 @@ export const MoveToPageMenu = track(function MoveToPageMenu() {
 								const ids = editor.getSelectedShapeIds()
 								editor.batch(() => {
 									editor.mark('move_shapes_to_page')
-									editor.createPage({ name: 'Page', id: newPageId })
+									editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
 									editor.moveShapesToPage(ids, newPageId)
 								})
 							}}


### PR DESCRIPTION
When creating a new page from the "move to page" menu it would be created as just "Page" instead of "page 1" etc.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Start from an empty canvas
2. Add some stuff to the canvas
3. Select it, right click, and choose "move to page" -> "new page"
4. The newly created page should be called "page 2"


### Release Notes

- Fix naming of pages created by the "move to page" action
