### PR TITLE
fix(editor): cleanup event handlers in safari double tap hook

### DIFF
--- a/packages/editor/src/lib/hooks/useFixSafariDoubleTapZoomPencilEvents.ts
+++ b/packages/editor/src/lib/hooks/useFixSafariDoubleTapZoomPencilEvents.ts
@@ -38,7 +38,7 @@ export function useFixSafariDoubleTapZoomPencilEvents(ref: React.RefObject<HTMLE
 		elm.addEventListener('touchend', handleEvent)
 		return () => {
 			elm.removeEventListener('touchstart', handleEvent)
-			elm.addEventListener('touchend', handleEvent)
+			elm.removeEventListener('touchend', handleEvent)
 		}
 	}, [editor, ref])
 }


### PR DESCRIPTION
We probably don't want to add the listener here.

### Change type

- [x] `bugfix` 

### Test plan

1. Verify Safari double tap zoom pencil events are correctly cleaned up.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixes an issue where event handlers were not correctly cleaned up in Safari.