### PR TITLE
Fix migrations.

### DIFF
--- a/packages/tlschema/src/records/TLPageState.ts
+++ b/packages/tlschema/src/records/TLPageState.ts
@@ -149,6 +149,7 @@ export const instancePageStateMigrations = defineMigrations({
 					erasingIds,
 					hoveredId,
 					editingId,
+					croppingShapeId,
 					croppingId,
 					focusLayerId,
 					...rest
@@ -160,7 +161,7 @@ export const instancePageStateMigrations = defineMigrations({
 					erasingShapeIds: erasingIds,
 					hoveredShapeId: hoveredId,
 					editingShapeId: editingId,
-					croppingShapeId: croppingId,
+					croppingShapeId: croppingShapeId ?? croppingId ?? null,
 					focusedGroupId: focusLayerId,
 				}
 			},


### PR DESCRIPTION
Fix `instance_page_state` migrations. We discovered this in a file that a user sent.

I updated the existing migration since it caused data loss. It looks like we had a few migrations dealing with `croppingShapeId`:
- First we added the prop with the name `croppingShapeId` and value of `null` (`AddCroppingId` migration)
- We then have a dummy migration, which doesn't change anything (`RenameProperties` migration)
- We then override the existing value of `croppingShapeId` with an non-existent property `croppingId`. This clears out the value and leads to data loss. (`RenamePropertiesAgain` migration).

So we now avoid that by first looking at `croppingShapeId`, but we still keep the `croppingId` as a fallback. Felt safer this way.


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


### Release Notes

- Fix migrations of `instance_page_state`.
