### PR TITLE
VS Code 2.0.19

### DIFF
--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.19
+
+- Adds fit to content option for frames.
+- Fixes an issue with loading older files.
+- Fixes and issue with some event handlers not being cleaned up correctly.
+
 ## 2.0.18
 
 - Adds the option to remove frames, but keep the children.

--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Adds fit to content option for frames.
 - Fixes an issue with loading older files.
-- Fixes and issue with some event handlers not being cleaned up correctly.
+- Fixes an issue with some event handlers not being cleaned up correctly.
 
 ## 2.0.18
 

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.18",
+	"version": "2.0.19",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
 VS Code version bump.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Version bump for VS Code.
