### PR TITLE
Call devFreeze on initialData

### DIFF
--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -187,7 +187,10 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 				objectMapFromEntries(
 					objectMapEntries(initialData).map(([id, record]) => [
 						id,
-						atom('atom:' + id, this.schema.validateRecord(this, record, 'initialize', null)),
+						atom(
+							'atom:' + id,
+							devFreeze(this.schema.validateRecord(this, record, 'initialize', null))
+						),
 					])
 				)
 			)


### PR DESCRIPTION
I noticed we weren't freezing the initialData passed into the store.

### Change Type

- [x] `patch` — Bug fix

