### PR TITLE
Fix indicator radius for bookmarks.

### DIFF
--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -102,8 +102,8 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 			<rect
 				width={toDomPrecision(shape.props.w)}
 				height={toDomPrecision(shape.props.h)}
-				rx="8"
-				ry="8"
+				rx="6"
+				ry="6"
 			/>
 		)
 	}


### PR DESCRIPTION
Fixes the border radius for the bookmark shape indicator. The shape itself used 6px (`--radius-2` variable), while the indicator used 8px.

Before
![image](https://github.com/tldraw/tldraw/assets/2523721/c0f6f9b7-6814-4674-bb79-2fca809c199e)

After
![image](https://github.com/tldraw/tldraw/assets/2523721/67ae4fd4-f572-4477-9582-a9dd775022b3)


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


### Release Notes

- Fix the indicator for the bookmark shape. The radius now matches the shape's radius.
