### PR TITLE
Prevent diff mutation

### DIFF
--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -881,7 +881,7 @@ export function squashRecordDiffs<T extends UnknownRecord>(
 				continue
 			}
 			if (result.updated[id]) {
-				result.updated[id][1] = to
+				result.updated[id] = [result.updated[id][0], to]
 				delete result.removed[id]
 				continue
 			}
@@ -937,7 +937,7 @@ function squashHistoryEntries<T extends UnknownRecord>(
 
 	result.push(current)
 
-	return result
+	return devFreeze(result)
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.ts
@@ -62,7 +62,7 @@ describe('Translating', () => {
 		editor.select(id)
 
 		const shape = editor.getShape<TLLineShape>(id)!
-		shape.rotation = Math.PI / 2
+		editor.updateShape({ ...shape, rotation: Math.PI / 2 })
 
 		editor.pointerDown(250, 250, { target: 'shape', shape: shape })
 		editor.pointerMove(300, 400) // Move shape by 50, 150


### PR DESCRIPTION
We had a bug in `squashRecordDiffs` where it could potentially mutate 'updated' entries. 

### Change Type

- [x] `patch` — Bug fix


### Release Notes

- Fix `squashRecordDiffs` to prevent a bug where it mutates the 'updated' entires