### PR TITLE
Fix iconleft padding

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -138,7 +138,7 @@
 }
 
 .tlui-button__icon-left {
-	margin-right: 4px;
+	margin-right: var(--space-2);
 }
 
 /* Hinted */

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -137,6 +137,10 @@
 	padding: 0px;
 }
 
+.tlui-button__icon-left {
+	margin-right: 4px;
+}
+
 /* Hinted */
 
 .tlui-button__icon[data-state='hinted']::after {


### PR DESCRIPTION
This PR fixes the icon padding (or margin) for helper buttons like Back to Content.

Before:
<img width="393" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/c584901c-e826-433a-b76c-08f67a13807c">

After:
<img width="446" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/ed9aeb3b-70df-43a0-9241-c329093c5cf5">


### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes the icon padding in back to content / pen mode buttons.