### PR TITLE
Only allow side resizing when we have some shapes that are not aspect ratio locked

### DIFF
--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -37,7 +37,6 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 			!editor.getIsMenuOpen() && editor.getInstanceState().cursor.type === 'default'
 		const isCoarsePointer = editor.getInstanceState().isCoarsePointer
 
-		const shapes = editor.getSelectedShapes()
 		const onlyShape = editor.getOnlySelectedShape()
 		const isLockedShape = onlyShape && editor.isShapeOrAncestorLocked(onlyShape)
 

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -162,10 +162,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 
 		let hideEdgeTargetsDueToCoarsePointer = isCoarsePointer
 
-		if (
-			hideEdgeTargetsDueToCoarsePointer &&
-			shapes.some((shape) => !editor.getShapeUtil(shape).isAspectRatioLocked(shape))
-		) {
+		if (hideEdgeTargetsDueToCoarsePointer && onlyShape && onlyShape.type === 'text') {
 			hideEdgeTargetsDueToCoarsePointer = false
 		}
 

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -164,7 +164,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 
 		if (
 			hideEdgeTargetsDueToCoarsePointer &&
-			shapes.every((shape) => editor.getShapeUtil(shape).isAspectRatioLocked(shape))
+			shapes.some((shape) => !editor.getShapeUtil(shape).isAspectRatioLocked(shape))
 		) {
 			hideEdgeTargetsDueToCoarsePointer = false
 		}


### PR DESCRIPTION
Only allow edges resizing on mobile when a single text shape is selected. Disabled it for all other cases.

Fixes [#2349](https://github.com/tldraw/tldraw/issues/2349)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


### Release Notes

- Don't allow edges resizing on mobile. The only exception is a single text shape.
