### PR TITLE
fix png images with pixel ratios <0.5 crashing the app

### DIFF
--- a/packages/utils/src/lib/media.ts
+++ b/packages/utils/src/lib/media.ts
@@ -44,8 +44,11 @@ export class MediaHelpers {
 						if (physChunk) {
 							const physData = PngHelpers.parsePhys(view, physChunk.dataOffset)
 							if (physData.unit === 0 && physData.ppux === physData.ppuy) {
-								const pixelRatio = Math.round(physData.ppux / 2834.5)
-								resolve({ w: img.width / pixelRatio, h: img.height / pixelRatio })
+								const pixelRatio = Math.max(physData.ppux / 2834.5, 1)
+								resolve({
+									w: Math.round(img.width / pixelRatio),
+									h: Math.round(img.height / pixelRatio),
+								})
 								return
 							}
 						}


### PR DESCRIPTION
When we handle pixel ratios in .png files, we were rounding the pixel ratio to the nearest integer. This mean that if an image had a pixel ration less than 0.5, it would get rounded to zero. This would cause a divide-by-zero on the width & height of the image which would crash the app.

This has a couple fixes:
- we ignore pixel ratios less that 1
- we perform rounding _after_ we apply the pixel ratio to the width/height

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Upload this funky image: ![shapes_5](https://github.com/tldraw/tldraw/assets/1489520/80fb41fa-3be1-4dbd-8e2f-d81013b09780)
2. Check the app doesn't crash

