### PR TITLE
Stop shape text labels being hoverable when context menu is open 

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1079,7 +1079,7 @@ input,
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	pointer-events: all;
+	pointer-events: none;
 	min-height: auto;
 }
 


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/2351

This css change shouldn't affect any other interactions.

Tested on:
- Mac Chrome
- Mac Chrome with touch
- Mac Safari
- Mac Firefox

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Right click to open context menu.
2. Click on a filled shape's text label.
3. Make sure the context menu has closed.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
