### PR TITLE
Fix clicking off the context menu

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -85,7 +85,7 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 	const disabled = !selectToolActive || noItemsToShow
 
 	return (
-		<_ContextMenu.Root dir="ltr" onOpenChange={handleOpenChange}>
+		<_ContextMenu.Root dir="ltr" onOpenChange={handleOpenChange} modal={false}>
 			<_ContextMenu.Trigger
 				onContextMenu={disabled ? preventDefault : undefined}
 				dir="ltr"


### PR DESCRIPTION
This PR fixes not being able to close the context menu by clicking
- your selected shape
- the ui


![2023-12-19 at 14 19 14 - Cyan Bovid](https://github.com/tldraw/tldraw/assets/15892272/88b492c2-8f3b-40bc-9dec-744fe72cda3b)

![2023-12-19 at 14 21 36 - Amaranth Vulture](https://github.com/tldraw/tldraw/assets/15892272/1f19751d-499b-40c3-9b28-9f41a2f27ab2)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fix not being able to close the context menu by clicking on the UI or your selected shape.
