### PR TITLE
refactor: Keep hook function convention the same

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2653,7 +2653,7 @@ export { useComputed }
 export function useContainer(): HTMLDivElement;
 
 // @public (undocumented)
-export const useEditor: () => Editor;
+export function useEditor(): Editor;
 
 // @public (undocumented)
 export function useIsCropping(shapeId: TLShapeId): boolean;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -42130,32 +42130,33 @@
           "name": "useContainer"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!useEditor:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!useEditor:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "useEditor: "
-            },
-            {
-              "kind": "Content",
-              "text": "() => "
+              "text": "export declare function useEditor(): "
             },
             {
               "kind": "Reference",
               "text": "Editor",
               "canonicalReference": "@tldraw/editor!Editor:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/hooks/useEditor.ts",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "useEditor",
-          "variableTypeTokenRange": {
+          "returnTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 3
-          }
+            "endIndex": 2
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "useEditor"
         },
         {
           "kind": "Function",

--- a/packages/editor/src/lib/hooks/useEditor.ts
+++ b/packages/editor/src/lib/hooks/useEditor.ts
@@ -4,6 +4,6 @@ import { Editor } from '../editor/Editor'
 export const EditorContext = React.createContext({} as Editor)
 
 /** @public */
-export const useEditor = (): Editor => {
+export function useEditor(): Editor {
 	return React.useContext(EditorContext)
 }


### PR DESCRIPTION
I standardized the definition of the `useEditor hook` by changing it from an `arrow function` to a `regular function`, in line with other editor-related hooks.


### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [x] Unit Tests
- [x] End to end tests

### Release Notes

- Add a brief release note for your PR here.
