### PR TITLE
Another typo fix.

### DIFF
--- a/apps/examples/README.md
+++ b/apps/examples/README.md
@@ -16,7 +16,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -105,7 +105,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/apps/vscode/extension/README.md
+++ b/apps/vscode/extension/README.md
@@ -26,7 +26,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Contact
 

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -18,7 +18,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -16,7 +16,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -62,7 +62,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/packages/tlschema/README.md
+++ b/packages/tlschema/README.md
@@ -80,7 +80,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -18,7 +18,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -18,7 +18,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/master/LICENSE.md). This license does not permit commercial use.
 
-If you wish to use this project in commercial product, you need to purchase a commercial license. matPlease contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
+If you wish to use this project in commercial product, you need to purchase a commercial license. Please contact us at [hello@tldraw.com](mailto:hello@tldraw.com) for more inforion about obtaining a commercial license.
 
 ## Trademarks
 


### PR DESCRIPTION
This PR fixes a typo in the readme.

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]