### PR TITLE
VS Code bump 2.0.20

### DIFF
--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.0.20
+
+- Adds edge scrolling functionality. The camera will now move when the pointer is close to the edge of the screen (when resizing, moving, or brush selecting),
+- Improves the default font appearance.
+- Improves the interactions on top of locked shapes. Dragging selected shapes on top and behind them should now work as expected.
+- Fixes an issue with downscaling images that could make the document size grow significantly.
+- Fixes the context menu not closing in some cases.
+- Fixes page names getting cut off.
+- Fixes an issue with loosing focus when deleting from the user interface.
+- Fixes the missing padding on some buttons.
+
 ## 2.0.19
 
 - Adds fit to content option for frames.

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tldraw-vscode",
 	"description": "The tldraw extension for VS Code.",
-	"version": "2.0.19",
+	"version": "2.0.20",
 	"private": true,
 	"packageManager": "yarn@3.5.0",
 	"author": {


### PR DESCRIPTION
VS Code version bump.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

