### PR TITLE
[fix] polygon bounds

### DIFF
--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -764,19 +764,3 @@ export function toFixed(v: number) {
 export const isSafeFloat = (n: number) => {
 	return Math.abs(n) < Number.MAX_SAFE_INTEGER
 }
-
-/**
- * Get the centroid of a regular polygon.
- * @param points - The points that make up the polygon.
- * @public
- */
-export function getCentroidOfRegularPolygon(points: VecLike[]) {
-	const len = points.length
-	let x = 0
-	let y = 0
-	for (let i = 0; i < len; i++) {
-		x += points[i].x
-		y += points[i].y
-	}
-	return new Vec2d(x / len, y / len)
-}

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -314,8 +314,11 @@ export function getPolygonVertices(width: number, height: number, sides: number)
 	const cx = width / 2
 	const cy = height / 2
 	const pointsOnPerimeter: Vec2d[] = []
+
 	let minX = Infinity
+	let maxX = -Infinity
 	let minY = Infinity
+	let maxY = -Infinity
 	for (let i = 0; i < sides; i++) {
 		const step = PI2 / sides
 		const t = -TAU + i * step
@@ -323,14 +326,25 @@ export function getPolygonVertices(width: number, height: number, sides: number)
 		const y = cy + cy * Math.sin(t)
 		if (x < minX) minX = x
 		if (y < minY) minY = y
+		if (x > maxX) maxX = x
+		if (y > maxY) maxY = y
 		pointsOnPerimeter.push(new Vec2d(x, y))
 	}
 
-	if (minX !== 0 || minY !== 0) {
+	// Bounds of calculated points
+	const w = maxX - minX
+	const h = maxY - minY
+
+	// Difference between input bounds and calculated bounds
+	const dx = width - w
+	const dy = height - h
+
+	// If there's a difference, scale the points to the input bounds
+	if (dx !== 0 || dy !== 0) {
 		for (let i = 0; i < pointsOnPerimeter.length; i++) {
 			const pt = pointsOnPerimeter[i]
-			pt.x -= minX
-			pt.y -= minY
+			pt.x = ((pt.x - minX) / w) * width
+			pt.y = ((pt.y - minY) / h) * height
 		}
 	}
 
@@ -749,4 +763,20 @@ export function toFixed(v: number) {
  */
 export const isSafeFloat = (n: number) => {
 	return Math.abs(n) < Number.MAX_SAFE_INTEGER
+}
+
+/**
+ * Get the centroid of a regular polygon.
+ * @param points - The points that make up the polygon.
+ * @public
+ */
+export function getCentroidOfRegularPolygon(points: VecLike[]) {
+	const len = points.length
+	let x = 0
+	let y = 0
+	for (let i = 0; i < len; i++) {
+		x += points[i].x
+		y += points[i].y
+	}
+	return new Vec2d(x / len, y / len)
 }

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -26,6 +26,7 @@ import {
 	getPolygonVertices,
 } from '@tldraw/editor'
 
+import { getCentroidOfRegularPolygon } from '@tldraw/editor/src/lib/primitives/utils'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { TextLabel } from '../shared/TextLabel'
 import {
@@ -321,10 +322,12 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 
 		const labelSize = getLabelSize(this.editor, shape)
 		const labelWidth = Math.min(w, Math.max(labelSize.w, Math.min(32, Math.max(1, w - 8))))
-		const labelHeight = Math.min(h, Math.max(labelSize.h, Math.min(32, Math.max(1, w - 8))))
+		const labelHeight = Math.min(h, Math.max(labelSize.h, Math.min(32, Math.max(1, w - 8)))) // not sure if bug
 
 		const lines = getLines(shape.props, strokeWidth)
 		const edges = lines ? lines.map((line) => new Polyline2d({ points: line })) : []
+
+		const centroid = getCentroidOfRegularPolygon(body.vertices)
 
 		return new Group2d({
 			children: [
@@ -335,13 +338,13 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 							? 0
 							: shape.props.align === 'end'
 							? w - labelWidth
-							: (w - labelWidth) / 2,
+							: centroid.x - labelWidth / 2,
 					y:
 						shape.props.verticalAlign === 'start'
 							? 0
 							: shape.props.verticalAlign === 'end'
 							? h - labelHeight
-							: (h - labelHeight) / 2,
+							: centroid.y - labelHeight / 2,
 					width: labelWidth,
 					height: labelHeight,
 					isFilled: true,

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -20,13 +20,13 @@ import {
 	TLOnResizeHandler,
 	TLShapeUtilCanvasSvgDef,
 	Vec2d,
+	VecLike,
 	geoShapeMigrations,
 	geoShapeProps,
 	getDefaultColorTheme,
 	getPolygonVertices,
 } from '@tldraw/editor'
 
-import { getCentroidOfRegularPolygon } from '@tldraw/editor/src/lib/primitives/utils'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { TextLabel } from '../shared/TextLabel'
 import {
@@ -327,7 +327,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const lines = getLines(shape.props, strokeWidth)
 		const edges = lines ? lines.map((line) => new Polyline2d({ points: line })) : []
 
-		const centroid = getCentroidOfRegularPolygon(body.vertices)
+		// todo: use centroid for label position
 
 		return new Group2d({
 			children: [
@@ -338,13 +338,13 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 							? 0
 							: shape.props.align === 'end'
 							? w - labelWidth
-							: centroid.x - labelWidth / 2,
+							: (w - labelWidth) / 2,
 					y:
 						shape.props.verticalAlign === 'start'
 							? 0
 							: shape.props.verticalAlign === 'end'
 							? h - labelHeight
-							: centroid.y - labelHeight / 2,
+							: (h - labelHeight) / 2,
 					width: labelWidth,
 					height: labelHeight,
 					isFilled: true,
@@ -1153,4 +1153,20 @@ function getCheckBoxLines(w: number, h: number) {
 			new Vec2d(clampX(ox + size * 0.82), clampY(oy + size * 0.22)),
 		],
 	]
+}
+
+/**
+ * Get the centroid of a regular polygon.
+ * @param points - The points that make up the polygon.
+ * @internal
+ */
+export function getCentroidOfRegularPolygon(points: VecLike[]) {
+	const len = points.length
+	let x = 0
+	let y = 0
+	for (let i = 0; i < len; i++) {
+		x += points[i].x
+		y += points[i].y
+	}
+	return new Vec2d(x / len, y / len)
 }


### PR DESCRIPTION
This PR fixes the bounds calculation for polygons. It solves the bug reported here: https://github.com/tldraw/tldraw/issues/2309 . Note that this may produce visual changes for hexagons and other shapes.

![Kapture 2023-12-24 at 10 35 13](https://github.com/tldraw/tldraw/assets/23072548/773e89ee-f8c3-4875-b942-30860b1cdf22)

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a hexagon shape with a label.
2. The label should be correctly centered.

### Release Notes

- Fixed a bug with the bounds calculation for polygons.