### PR TITLE
Fix the publish script

### DIFF
--- a/scripts/publish-new.ts
+++ b/scripts/publish-new.ts
@@ -62,8 +62,7 @@ async function main() {
 		'add',
 		'lerna.json',
 		...packageJsonFilesToAdd,
-		BUBLIC_ROOT + '/packages/*/src/version.ts',
-		BUBLIC_ROOT + '/packages/*/src/lib/ui/version.ts',
+		BUBLIC_ROOT + '/packages/*/src/**/version.ts',
 	])
 
 	// this creates a new commit

--- a/scripts/publish-new.ts
+++ b/scripts/publish-new.ts
@@ -63,6 +63,7 @@ async function main() {
 		'lerna.json',
 		...packageJsonFilesToAdd,
 		BUBLIC_ROOT + '/packages/*/src/version.ts',
+		BUBLIC_ROOT + '/packages/*/src/lib/ui/version.ts',
 	])
 
 	// this creates a new commit


### PR DESCRIPTION
Follow up to https://github.com/tldraw/tldraw/pull/2439. Should fix the publishing script so that the next time we run it we don't run in the the same issue.

We could also move the file directly to the `src` dir, but it seems since only `ui` uses the version it was nested under the `ui` dir 🤷

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
