### PR TITLE
Fix validation for local files.

### DIFF
--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -617,6 +617,13 @@ function parseUrl(str: string) {
 	try {
 		return new URL(str)
 	} catch (error) {
+		if (str.startsWith('/') || str.startsWith('./')) {
+			try {
+				return new URL(str, 'http://example.com')
+			} catch (error) {
+				throw new ValidationError(`Expected a valid url, got ${JSON.stringify(str)}`)
+			}
+		}
 		throw new ValidationError(`Expected a valid url, got ${JSON.stringify(str)}`)
 	}
 }


### PR DESCRIPTION
Allow urls for local files. This addresses the comment from [here](https://github.com/tldraw/tldraw/pull/2428#issuecomment-1886221841).

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Local images example should now work. We use images from the public folder there.