### PR TITLE
Fix bookmark info for VS Code

### DIFF
--- a/apps/vscode/extension/src/WebViewMessageHandler.ts
+++ b/apps/vscode/extension/src/WebViewMessageHandler.ts
@@ -8,6 +8,7 @@ import { UnknownRecord } from '@tldraw/tldraw'
 // @ts-ignore
 import type { VscodeMessage } from '../../messages'
 import { nicelog } from './utils'
+const BOOKMARK_ENDPOINT = 'https://bookmark-extractor.tldraw.com/api/bookmark'
 
 export const GlobalStateKeys = {
 	ShowV1FileOpenWarning: 'showV1fileOpenWarning',
@@ -73,7 +74,7 @@ export class WebViewMessageHandler {
 			}
 			case 'vscode:bookmark/request': {
 				const url = e.data.url
-				fetch('https://www.tldraw.com/api/bookmark', {
+				fetch(BOOKMARK_ENDPOINT, {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',


### PR DESCRIPTION
During the SPA spike we replaced our bookmark API endpoint with a completely new service just for bookmarks, but we forgot to update the URL in the vs code extension. This should now make the bookmark images and descriptions work again in VS Code.

Fixes https://github.com/tldraw/tldraw/issues/2363

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Run the VS Code extension.
2. Paste a link (like https://github.com/tldraw/tldraw)
3. The bookmark should have an image and description.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fix bookmark image and description for VS code extension.
