### PR TITLE
Fix the first run of dev script.

### DIFF
--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -32,7 +32,7 @@ const config = {
 		},
 		dev: {
 			execution: 'independent',
-			runsAfter: { 'refresh-assets': {} },
+			runsAfter: { predev: {}, 'refresh-assets': {} },
 			cache: 'none',
 			workspaceOverrides: {
 				'apps/vscode/*': { runsAfter: { build: { in: 'self-only' } } },

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -31,7 +31,8 @@
 	"scripts": {
 		"test": "lazy inherit",
 		"test-coverage": "lazy inherit",
-		"dev": "chokidar '../{editor/editor,tldraw/src/lib/ui}.css' -c 'node ./scripts/copy-css-files.mjs' --initial",
+		"predev": "node ./scripts/copy-css-files.mjs",
+		"dev": "chokidar '../{editor/editor,tldraw/src/lib/ui}.css' -c 'node ./scripts/copy-css-files.mjs'",
 		"prebuild": "node ./scripts/copy-css-files.mjs",
 		"build": "yarn run -T tsx ../../scripts/build-package.ts",
 		"build-api": "yarn run -T tsx ../../scripts/build-api.ts",


### PR DESCRIPTION
When you first clone the repo and run the `dev` script for the first time you get the following error:
![image](https://github.com/tldraw/tldraw/assets/2523721/89cd0904-3d63-4569-b950-c1e23573f800)

This is because the `dev` script in examples runs before `dev` in `tldraw` (which creates the `tldraw.css` file). We now have a `predev` step that does it.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Clone the repo from start (or delete `packages/tldraw/tldraw.css` file)
2. Run `yarn dev`
3. You should not see the above error.

### Release Notes

- Fix first `yarn dev` experience.