### PR TITLE
add bash scripts for Vercel

### DIFF
--- a/scripts/vercel/build.sh
+++ b/scripts/vercel/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+
+.yarn/releases/yarn-3.5.0.cjs run -T lazy build --filter=apps/examples --filter=packages/tldraw

--- a/scripts/vercel/install.sh
+++ b/scripts/vercel/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+
+.yarn/releases/yarn-3.5.0.cjs


### PR DESCRIPTION
A neighbouring PR #2481 changes Yarn version, which fails the build on Vercel. This PR extracts the invocations Vercel uses into bash scripts, so they can be changed atomically.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know