### PR TITLE
use github.ref rather than github.event.ref in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,23 +10,23 @@ on:
 env:
   CI: 1
   PRINT_GITHUB_ANNOTATIONS: 1
-  TLDRAW_ENV: ${{ (github.event.ref == 'refs/heads/production' && 'production') || (github.event.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
+  TLDRAW_ENV: ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
 defaults:
   run:
     shell: bash
 
 jobs:
   deploy:
-    name: Deploy to ${{ (github.event.ref == 'refs/heads/production' && 'production') || (github.event.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
+    name: Deploy to ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
     timeout-minutes: 15
     runs-on: ubuntu-latest-16-cores-open
-    environment: ${{ github.event.ref == 'refs/heads/production' && 'deploy-production' || 'deploy-staging' }}
-    concurrency: ${{ github.event.ref == 'refs/heads/production' && 'deploy-production' || github.event.ref }}
+    environment: ${{ github.ref == 'refs/heads/production' && 'deploy-production' || 'deploy-staging' }}
+    concurrency: ${{ github.ref == 'refs/heads/production' && 'deploy-production' || github.ref }}
 
     steps:
       - name: Notify initial start
         uses: MineBartekSA/discord-webhook@v2
-        if: github.event.ref == 'refs/heads/production'
+        if: github.ref == 'refs/heads/production'
         with:
           webhook: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
           content: 'Preparing ${{ env.TLDRAW_ENV }} deploy: ${{ github.event.head_commit.message }} by ${{ github.event.head_commit.author.name }}'


### PR DESCRIPTION
`github.event.ref` is only there on certain events, but `github.ref` is always there

### Change Type


- [x] `internal` — Any other changes that don't affect the published package[^2]
