### PR TITLE
auto-it/typescript fails the release, patch the problem away while mods are asleep

### DIFF
--- a/.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch
+++ b/.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/auto.js b/dist/auto.js
+index f85465f2bf6968bbc2a8c9d66eaa181a6a3cdabd..8723c86f2be2c41a7638fc842964093808c55cc4 100644
+--- a/dist/auto.js
++++ b/dist/auto.js
+@@ -34,7 +34,7 @@ const is_binary_1 = tslib_1.__importDefault(require("./utils/is-binary"));
+ const git_reset_1 = require("./utils/git-reset");
+ try {
+     if (require.resolve("typescript")) {
+-        require("ts-node/register/transpile-only");
++        // require("ts-node/register/transpile-only");
+     }
+ }
+ catch (error) {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
 	"resolutions": {
 		"@microsoft/api-extractor@^7.35.4": "patch:@microsoft/api-extractor@npm%3A7.35.4#./.yarn/patches/@microsoft-api-extractor-npm-7.35.4-5f4f0357b4.patch",
 		"vectra@^0.4.4": "patch:vectra@npm%3A0.4.4#./.yarn/patches/vectra-npm-0.4.4-6aac3f6c29.patch",
-		"domino@^2.1.6": "patch:domino@npm%3A2.1.6#./.yarn/patches/domino-npm-2.1.6-b0dc3de857.patch"
+		"domino@^2.1.6": "patch:domino@npm%3A2.1.6#./.yarn/patches/domino-npm-2.1.6-b0dc3de857.patch",
+		"@auto-it/core@^10.45.0": "patch:@auto-it/core@npm%3A10.46.0#./.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch",
+		"@auto-it/core@10.46.0": "patch:@auto-it/core@npm%3A10.46.0#./.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch"
 	},
 	"dependencies": {
 		"@sentry/cli": "^2.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,7 +71,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@auto-it/core@npm:10.46.0, @auto-it/core@npm:^10.45.0":
+"@auto-it/core@npm:10.46.0":
   version: 10.46.0
   resolution: "@auto-it/core@npm:10.46.0"
   dependencies:
@@ -121,6 +121,59 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 717677f9ab4d62a96c47db71fc3f99976b8d4d6992bf96aec8f76044d5217022c3b18975ddc9263eb05cdc88b09e04b4faf7dfa6667ef45cbf7aec626ef4b432
+  languageName: node
+  linkType: hard
+
+"@auto-it/core@patch:@auto-it/core@npm%3A10.46.0#./.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch::locator=%40tldraw%2Fmonorepo%40workspace%3A.":
+  version: 10.46.0
+  resolution: "@auto-it/core@patch:@auto-it/core@npm%3A10.46.0#./.yarn/patches/@auto-it-core-npm-10.46.0-4ce8f196af.patch::version=10.46.0&hash=3c4496&locator=%40tldraw%2Fmonorepo%40workspace%3A."
+  dependencies:
+    "@auto-it/bot-list": 10.46.0
+    "@endemolshinegroup/cosmiconfig-typescript-loader": ^3.0.2
+    "@octokit/core": ^3.5.1
+    "@octokit/plugin-enterprise-compatibility": 1.3.0
+    "@octokit/plugin-retry": ^3.0.9
+    "@octokit/plugin-throttling": ^3.6.2
+    "@octokit/rest": ^18.12.0
+    await-to-js: ^3.0.0
+    chalk: ^4.0.0
+    cosmiconfig: 7.0.0
+    deepmerge: ^4.0.0
+    dotenv: ^8.0.0
+    endent: ^2.1.0
+    enquirer: ^2.3.4
+    env-ci: ^5.0.1
+    fast-glob: ^3.1.1
+    fp-ts: ^2.5.3
+    fromentries: ^1.2.0
+    gitlog: ^4.0.3
+    https-proxy-agent: ^5.0.0
+    import-cwd: ^3.0.0
+    import-from: ^3.0.0
+    io-ts: ^2.1.2
+    lodash.chunk: ^4.2.0
+    log-symbols: ^4.0.0
+    node-fetch: 2.6.7
+    parse-author: ^2.0.0
+    parse-github-url: 1.0.2
+    pretty-ms: ^7.0.0
+    requireg: ^0.2.2
+    semver: ^7.0.0
+    signale: ^1.4.0
+    tapable: ^2.2.0
+    terminal-link: ^2.1.1
+    tinycolor2: ^1.4.1
+    ts-node: ^10.9.1
+    tslib: 2.1.0
+    type-fest: ^0.21.1
+    typescript-memoize: ^1.0.0-alpha.3
+    url-join: ^4.0.0
+  peerDependencies:
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 7c4aef7889aa0c0d04c404ec7fd9f38c8eceb85569473080c3f0ea62d8877a9bf3c8e57a721c2f634d8892c70de797ecc733cccf301d7fbe1285c69050324ee2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently main can't be released: https://github.com/tldraw/tldraw/actions/runs/7557438453/job/20576664393

The issue was bisected down to https://github.com/tldraw/tldraw/commit/29044867dd2e49a3711e95c547fa9352e66720b9 and can be "fixed" by forcing TypeScript to the previous resolution (5.3.3->4.9.5).

It looks like Auto runs node-ts on everything, and Typescript picks up a module/moduleResolution mismatch somewhere. It is likely that the mismatch is not in our code, since blind replacement of all instances of `"moduleResolution"` to `"NodeNext"` in the project doesn't help.

It is likely that the relevant TypeScript change is this one: https://www.typescriptlang.org/docs/handbook/modules/reference.html#the-moduleresolution-compiler-option

Further investigation is pending, but this PR should fix the release process.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package