### PR TITLE
debug: start adding more tooling for debugging when interacting with shapes

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -10,6 +10,7 @@ import {
 	uniqueId,
 	useEditor,
 	useValue,
+	Vec,
 } from '@tldraw/editor'
 import * as React from 'react'
 import { useDialogs } from '../hooks/useDialogsProvider'
@@ -87,10 +88,14 @@ const CurrentState = track(function CurrentState() {
 	const shape = path === 'select.idle' || !path.includes('select.') ? hoverShape : selectedShape
 	const shapeInfo =
 		shape && path.includes('select.')
-			? ` / ${shape.type || ''}${'geo' in shape.props ? ' / ' + shape.props.geo : ''} / [${editor.getPointInShapeSpace(shape, editor.inputs.currentPagePoint)}]`
+			? ` / ${shape.type || ''}${'geo' in shape.props ? ' / ' + shape.props.geo : ''} / [${Vec.ToFixed(editor.getPointInShapeSpace(shape, editor.inputs.currentPagePoint), 0)}]`
+			: ''
+	const ruler =
+		path.startsWith('select.') && !path.includes('.idle')
+			? ` / [${Vec.ToFixed(editor.inputs.originPagePoint, 0)}] → [${Vec.ToFixed(editor.inputs.currentPagePoint, 0)}] = ${Vec.Dist(editor.inputs.originPagePoint, editor.inputs.currentPagePoint).toFixed(0)}`
 			: ''
 
-	return <div className="tlui-debug-panel__current-state">{`${path}${shapeInfo}`}</div>
+	return <div className="tlui-debug-panel__current-state">{`${path}${shapeInfo}${ruler}`}</div>
 })
 
 const ShapeCount = function ShapeCount() {


### PR DESCRIPTION
I borrowed `useTick` from `GeometryDebuggingView.tsx` — didn't see a good place to have that in a shared file somewhere but lemme know if there is ¯\_(ツ)_/¯ 

https://github.com/tldraw/tldraw/assets/469604/89ae4bb1-0680-4275-8e34-ead7c0cd091e


### Change Type

- [ ] `patch` — Bug fix
- [x] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan


- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Adds more information in the debug view about what shape is selected and coordinates.
