### PR TITLE
Update README and examples copy in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Welcome to the public monorepo for [tldraw](https://github.com/tldraw/tldraw). t
 
 ## Local development
 
-The local development server will run our examples app. The basic example will show any changes you've made to the codebase. To run the local development server, first clone this repo.
+The local development server will run our examples app. The basic example will show any changes you've made to the codebase.
+
+To run the local development server, first clone this repo.
 
 Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to the public monorepo for [tldraw](https://github.com/tldraw/tldraw). t
 
 ## Local development
 
-To run the local development server, first clone this repo.
+The local development server will run our examples app. The basic example will show any changes you've made to the codebase. To run the local development server, first clone this repo.
 
 Install dependencies:
 

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -10,6 +10,6 @@ Here's a [very simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2l
 
 <Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />
 
-You can also find simple [framework-specific examples](https://github.com/tldraw/examples). For a multiplayer example using a collaboration backend, see our [Yjs example](https://github.com/tldraw/tldraw-yjs-example).
+The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src) contains a lot of helpful examples showing how to customise the UI, use the editor API, handle assets, create custom shapes/tools and much more. However, the examples app is best experienced via cloning and running the [tldraw repo](https://github.com/tldraw/tldraw) locally.
 
-For more specific examples of how to use the tldraw component, check out the [tldraw repository's examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src). The [tldraw repo](https://github.com/tldraw/tldraw) has more information about running the examples locally.
+We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -6,10 +6,11 @@ date: 10/11/2023
 order: 3
 ---
 
-Here's a [very simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
-
-<Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />
+Below is a [very simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
 
 The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src) contains a lot of helpful examples showing how to customise the UI, use the editor API, handle assets, create custom shapes/tools and much more. However, the examples app is best experienced via cloning and running the [tldraw repo](https://github.com/tldraw/tldraw) locally.
 
 We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).
+
+<h2>A simple example of the Tldraw component:</h2>
+<Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -12,5 +12,5 @@ The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/exampl
 
 We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).
 
-<h2>A simple example of the Tldraw component:</h2>
+### A simple example of the Tldraw component:
 <Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -6,8 +6,6 @@ date: 10/11/2023
 order: 3
 ---
 
-Below is a [simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
-
 The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src) contains a lot of helpful examples showing how to customise the UI, use the editor API, handle assets, create custom shapes/tools and much more. However, the examples app is best experienced via cloning and running the [tldraw repo](https://github.com/tldraw/tldraw) locally.
 
 We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -6,9 +6,10 @@ date: 10/11/2023
 order: 3
 ---
 
-The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src) contains a lot of helpful examples showing how to customise the UI, use the editor API, handle assets, create custom shapes/tools and much more. However, the examples app is best experienced via cloning and running the [tldraw repo](https://github.com/tldraw/tldraw) locally.
+Here's a [very simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
 
-We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).
-
-### A simple example of the tldraw component:
 <Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />
+
+You can also find simple [framework-specific examples](https://github.com/tldraw/examples). For a multiplayer example using a collaboration backend, see our [Yjs example](https://github.com/tldraw/tldraw-yjs-example).
+
+For more specific examples of how to use the tldraw component, check out the [tldraw repository's examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src). The [tldraw repo](https://github.com/tldraw/tldraw) has more information about running the examples locally.

--- a/apps/docs/content/getting-started/examples.mdx
+++ b/apps/docs/content/getting-started/examples.mdx
@@ -6,11 +6,11 @@ date: 10/11/2023
 order: 3
 ---
 
-Below is a [very simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
+Below is a [simple sandbox](https://codesandbox.io/s/tldraw-example-canary-2lrzmy) showing the tldraw component.
 
 The [tldraw examples app](https://github.com/tldraw/tldraw/blob/main/apps/examples/src) contains a lot of helpful examples showing how to customise the UI, use the editor API, handle assets, create custom shapes/tools and much more. However, the examples app is best experienced via cloning and running the [tldraw repo](https://github.com/tldraw/tldraw) locally.
 
 We also have a couple of repos outside of the examples app: some [framework-specific examples](https://github.com/tldraw/examples), and an [example multiplayer implementation using Yjs](https://github.com/tldraw/tldraw-yjs-example).
 
-### A simple example of the Tldraw component:
+### A simple example of the tldraw component:
 <Embed src="https://codesandbox.io/embed/2lrzmy?view=Editor+%2B+Preview&module=%2Fsrc%2Fapp.tsx" />

--- a/apps/examples/src/examples/develop/README.md
+++ b/apps/examples/src/examples/develop/README.md
@@ -1,5 +1,5 @@
 ---
-title: Basic (development)
+title: Basic
 component: ./BasicExample.tsx
 order: 1
 ---


### PR DESCRIPTION
This PR should make the examples page copy clearer:

1. Moved the examples app copy above the framework specific and yjs copy, as it's more likely to be what the user is looking for.
2. Moved the codesandbox below the copy, user no longer needs to scroll to see most of the text.
3. Gives more hints about what can be found in the examples app and also highlights that running it locally is the better experience.
4. Added some clarification on the relationship between the framework-specific examples/yjs example and the examples app
5. Updates the tldraw repo README accordingly.
6. Removes (development) from the Basic example.

Next steps:
- The codesandbox
   - quite noisy, would be good to hide the navigation
   - doesn't reliably show the code and implementation at the same time
   - Should stack vertically on small screens

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [x] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Update examples copy and tldraw README
