### PR TITLE
Export TLCommandHistoryOptions type

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2033,6 +2033,13 @@ export type TLCommandHandler<Data> = {
 };
 
 // @public (undocumented)
+export type TLCommandHistoryOptions = Partial<{
+    squashing: boolean;
+    ephemeral: boolean;
+    preservesRedoStack: boolean;
+}>;
+
+// @public (undocumented)
 export type TLCompleteEvent = (info: TLCompleteEventInfo) => void;
 
 // @public (undocumented)

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -14508,7 +14508,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -15286,7 +15286,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -16217,7 +16217,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -16704,7 +16704,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -16769,7 +16769,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -16848,7 +16848,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -16926,7 +16926,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -17025,7 +17025,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -17949,7 +17949,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -18099,7 +18099,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -18178,7 +18178,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -18261,7 +18261,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -18357,7 +18357,7 @@
                 {
                   "kind": "Reference",
                   "text": "TLCommandHistoryOptions",
-                  "canonicalReference": "@tldraw/editor!~TLCommandHistoryOptions:type"
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
                 },
                 {
                   "kind": "Content",
@@ -35951,6 +35951,37 @@
           "typeTokenRange": {
             "startIndex": 1,
             "endIndex": 2
+          }
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type TLCommandHistoryOptions = "
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<{\n    squashing: boolean;\n    ephemeral: boolean;\n    preservesRedoStack: boolean;\n}>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/types/history-types.ts",
+          "releaseTag": "Public",
+          "name": "TLCommandHistoryOptions",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
           }
         },
         {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -17,6 +17,7 @@ export {
 	type Atom,
 	type Signal,
 } from '@tldraw/state'
+export type { TLCommandHistoryOptions } from './lib/editor/types/history-types'
 // eslint-disable-next-line local/no-export-star
 export * from '@tldraw/store'
 // eslint-disable-next-line local/no-export-star


### PR DESCRIPTION
Export TLCommandHistoryOptions type.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Added TLCommandHistoryOptions to the exported types.