### PR TITLE
Replace "original tldraw issue" with docs link.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Original tldraw
-    url: https://github.com/tldraw/tldraw-v1/issues/new
-    about: Is your issue for the original tldraw? Report it on the original tldraw repo instead.
+  - name: tldraw docs
+    url: https://tldraw.dev
+    about: Looking for help with the tldraw library? Try the tldraw docs!


### PR DESCRIPTION
This PR removes our "original tldraw issue" contact link, replacing it with a docs link.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know
