### PR TITLE
Fix ios export crash

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/getBrowserCanvasMaxSize.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/getBrowserCanvasMaxSize.tsx
@@ -29,9 +29,14 @@ async function calculateBrowserCanvasMaxSize(): Promise<CanvasMaxSize> {
 
 // https://github.com/jhildenbiddle/canvas-size?tab=readme-ov-file#test-results
 export const MAX_SAFE_CANVAS_DIMENSION = 8192
+export const MAX_SAFE_CANVAS_AREA = 4096 * 4096
 
 export async function clampToBrowserMaxCanvasSize(width: number, height: number) {
-	if (width <= MAX_SAFE_CANVAS_DIMENSION && height <= MAX_SAFE_CANVAS_DIMENSION) {
+	if (
+		width <= MAX_SAFE_CANVAS_DIMENSION &&
+		height <= MAX_SAFE_CANVAS_DIMENSION &&
+		width * height <= MAX_SAFE_CANVAS_AREA
+	) {
 		return [width, height]
 	}
 


### PR DESCRIPTION
This PR fixes iOS Safari sometimes crashing when exporting relatively large images
(larger than 4k, but smaller than 8k resolution)

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Copy the shapes from this snapshot: https://www.tldraw.com/s/v2_c_5Vbhjl4sO2M4JJ8IYimis
2. Paste them into the tldraw you want to test.
3. Select the pasted shapes.
4. Copy as PNG.
5. It *shouldn't* crash!

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- iOS Safari: Fixed a crash when exporting large images.
