### PR TITLE
Fix yarn clean

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -35,7 +35,5 @@ rm -rf {packages,apps}/vscode/extension/temp
 rm -rf {packages,apps}/vscode/extension/editor
 rm -rf apps/docs/content.json
 
-# need to run yarn directly
-# because yarn messes with the PATH, aliasing itself to some tmp dir 
-# which is apparently deleted by our clean script
-node "$(dirname -- "$0")/../.yarn/releases/yarn-3.5.0.cjs"
+corepack enable
+yarn


### PR DESCRIPTION
`scripts/clean.sh` was using a hardcoded Yarn [to avoid `npx yarn` using Yarn 1](https://github.com/tldraw/tldraw/commit/4242f6ee3db910013bb6de6dc396f254f238c71d). However, apparently the Blessed Way of using Yarn is to use `corepack` and have it install the Yarn version specified in `packageManager`.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package