### PR TITLE
Fix nudge bug

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5133,7 +5133,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		for (const id of ids) {
 			const shape = this.getShape(id)!
-			const localDelta = Vec.Cast(offset)
+			const localDelta = Vec.From(offset)
 			const parentTransform = this.getShapeParentTransform(shape)
 			if (parentTransform) localDelta.rot(-parentTransform.rotation())
 

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -1,4 +1,4 @@
-import { TLShapeId, createShapeId } from '@tldraw/editor'
+import { TLShapeId, Vec, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -39,22 +39,22 @@ function nudgeAndGet(ids: TLShapeId[], key: string, shiftKey: boolean) {
 	switch (key) {
 		case 'ArrowLeft': {
 			editor.mark('nudge')
-			editor.nudgeShapes(editor.getSelectedShapeIds(), { x: -step, y: 0 })
+			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(-step, 0))
 			break
 		}
 		case 'ArrowRight': {
 			editor.mark('nudge')
-			editor.nudgeShapes(editor.getSelectedShapeIds(), { x: step, y: 0 })
+			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(step, 0))
 			break
 		}
 		case 'ArrowUp': {
 			editor.mark('nudge')
-			editor.nudgeShapes(editor.getSelectedShapeIds(), { x: 0, y: -step })
+			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(0, -step))
 			break
 		}
 		case 'ArrowDown': {
 			editor.mark('nudge')
-			editor.nudgeShapes(editor.getSelectedShapeIds(), { x: 0, y: step })
+			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(0, step))
 			break
 		}
 	}


### PR DESCRIPTION
This PR fixes a bug in the nudge code. The offset was previously mutated in a loop by a `Vec.Cast`.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Select some shapes
2. nudge em

- [x] Unit Tests

### Release Notes

- Fixes a bug with keyboard nudging.
