### PR TITLE
remove erroneous mount entry from fly.toml

### DIFF
--- a/apps/huppy/fly.toml
+++ b/apps/huppy/fly.toml
@@ -2,7 +2,6 @@
 app = "tldraw-repo-sync"
 kill_signal = "SIGINT"
 kill_timeout = 5
-mounts = []
 primary_region = "lhr"
 processes = []
 


### PR DESCRIPTION
Fly CLI complains about the duplicate `mount` entry to `fly.toml`, failing the build

### Change Type

- [x] `internal` — Any other changes that don't affect the published package