### PR TITLE
[Fix] Wheel bug

### DIFF
--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -116,16 +116,11 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 
 			if (delta.x === 0 && delta.y === 0) return
 
-			const container = editor.getContainer().getBoundingClientRect()
-
 			const info: TLWheelEventInfo = {
 				type: 'wheel',
 				name: 'wheel',
 				delta,
-				point: new Vec(event.clientX, event.clientY).sub({
-					x: container.left,
-					y: container.top,
-				}),
+				point: new Vec(event.clientX, event.clientY),
 				shiftKey: event.shiftKey,
 				altKey: event.altKey,
 				ctrlKey: event.metaKey || event.ctrlKey,


### PR DESCRIPTION
This PR fixes a bug in the wheel event that added the container offset to the pointer location.

![Kapture 2024-01-26 at 13 54 20](https://github.com/tldraw/tldraw/assets/23072548/20cdc0ed-4a43-4b11-9261-9e6aecfd3292)

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. start dragging
2. use the mousewheel / trackpad to move the camera

### Release Notes

- Fixed a bug with the mouse wheel effecting the pointer location when the editor was not full screen
