### PR TITLE
[Fix] Missing bend handles on curved arrows

### DIFF
--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -249,7 +249,7 @@ function HandlesWrapper() {
 			const handles = editor.getShapeHandles(onlySelectedShape)
 			if (!handles) return null
 
-			const minDist = MIN_HANDLE_DISTANCE / editor.getZoomLevel()
+			const minDist = MIN_HANDLE_DISTANCE / zoomLevel
 
 			return handles
 				.sort((a) => (a.type === 'vertex' ? 1 : -1))
@@ -263,7 +263,7 @@ function HandlesWrapper() {
 					)
 				})
 		},
-		[editor, onlySelectedShape]
+		[editor, onlySelectedShape, zoomLevel]
 	)
 
 	if (!Handles || !onlySelectedShape || isChangingStyle || isReadonly || !handles || !transform) {

--- a/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
@@ -1,6 +1,7 @@
 import { TLHandle, TLShapeId } from '@tldraw/tlschema'
 import classNames from 'classnames'
 import { ComponentType } from 'react'
+import { COARSE_HANDLE_RADIUS, HANDLE_RADIUS } from '../../constants'
 
 /** @public */
 export type TLHandleComponent = ComponentType<{
@@ -13,9 +14,6 @@ export type TLHandleComponent = ComponentType<{
 
 /** @public */
 export const DefaultHandle: TLHandleComponent = ({ handle, isCoarse, className, zoom }) => {
-	const bgRadius = (isCoarse ? 20 : 12) / zoom
-	const fgRadius = (handle.type === 'create' && isCoarse ? 3 : 4) / zoom
-
 	if (handle.type === 'text-adjust') {
 		return (
 			<g className={classNames('tl-handle', className)}>
@@ -23,6 +21,9 @@ export const DefaultHandle: TLHandleComponent = ({ handle, isCoarse, className, 
 			</g>
 		)
 	}
+
+	const bgRadius = (isCoarse ? COARSE_HANDLE_RADIUS : HANDLE_RADIUS) / zoom
+	const fgRadius = (handle.type === 'create' && isCoarse ? 3 : 4) / zoom
 
 	return (
 		<g

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -101,3 +101,9 @@ export const EDGE_SCROLL_DISTANCE = 8
 
 /** @internal */
 export const COARSE_POINTER_WIDTH = 12
+
+/** @internal */
+export const COARSE_HANDLE_RADIUS = 20
+
+/** @internal */
+export const HANDLE_RADIUS = 12


### PR DESCRIPTION
Fixes #2660.

<img width="629" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/a661b76c-4877-42b1-aca7-5e5fcc5bc44b">

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Create a handle with a lot of bend but with a start and end handle that are close together. The bend handle should still be visible.

### Release Notes

- Fixed a bug where the bend handle on arrows with a large curve could sometimes be hidden.