### PR TITLE
docs: fix up gen links to point to the new /reference section

### DIFF
--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -94,7 +94,7 @@ function LoadButton() {
 }
 ```
 
-A [snapshot](/gen/store/StoreSnapshot) includes both the store's [serialized records](/gen/store/SerializedStore) and its [serialized schema](/gen/store/SerializedSchema), which is used for migrations.
+A [snapshot](/reference/store/StoreSnapshot) includes both the store's [serialized records](/reference/store/SerializedStore) and its [serialized schema](/reference/store/SerializedSchema), which is used for migrations.
 
 > By default, the `getSnapshot` method returns only the editor's document data. If you want to get records from a different scope, You can pass in `session`, `document`, `presence`, or else `all` for all scopes.
 

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -21,7 +21,7 @@ We make a distinction between three types of shapes: "core", "default", and "cus
 
 ### Core shapes
 
-The editor's core shapes are shapes that are built in and always present. At the moment the only core shape is the [group shape](/gen/tlschema/TLGroupShape).
+The editor's core shapes are shapes that are built in and always present. At the moment the only core shape is the [group shape](/reference/tlschema/TLGroupShape).
 
 ### Default shapes
 
@@ -69,7 +69,7 @@ Shapes are just records (JSON objects) that sit in the [store](/docs/editor#Stor
 
 ### Base properties
 
-Every shape contains some base information. These include the shape's type, position, rotation, opacity, and more. You can find the full list of base properties [here](/gen/tlschema/TLBaseShape).
+Every shape contains some base information. These include the shape's type, position, rotation, opacity, and more. You can find the full list of base properties [here](/reference/tlschema/TLBaseShape).
 
 ### Props
 

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -23,9 +23,9 @@ For more detailed information about the state chart, and how it works, go to the
 
 ## Types of tool
 
-The tldraw editor comes with some in-built **core tools**: the [select tool](/gen/tldraw/SelectTool), the [zoom tool](/gen/tldraw/ZoomTool), and the [text tool](/gen/tldraw/TextShapeTool). These are always added to the state chart.
+The tldraw editor comes with some in-built **core tools**: the [select tool](/reference/tldraw/SelectTool), the [zoom tool](/reference/tldraw/ZoomTool), and the [text tool](/reference/tldraw/TextShapeTool). These are always added to the state chart.
 
-There are also some **default tools** available, like the [draw tool](/gen/tldraw/DrawShapeTool), the [hand tool](/gen/tldraw/HandTool), the [arrow tool](/gen/tldraw/ArrowShapeTool), and more. The `<Tldraw>` component automatically adds these tools to the state chart.
+There are also some **default tools** available, like the [draw tool](/reference/tldraw/DrawShapeTool), the [hand tool](/reference/tldraw/HandTool), the [arrow tool](/reference/tldraw/ArrowShapeTool), and more. The `<Tldraw>` component automatically adds these tools to the state chart.
 
 You can also create your own **custom tools**. You can add them to the state chart by passing an array of them to the [Tldraw](?) component's `tools` prop.
 
@@ -33,7 +33,7 @@ Note: You might also want to add a tool to the user interface in various ways, s
 
 ## Transitioning
 
-You can change the current active tool using [editor.setCurrentTool](/gen/editor/Editor#setCurrentTool).
+You can change the current active tool using [editor.setCurrentTool](/reference/editor/Editor#setCurrentTool).
 
 ```ts
 editor.setCurrentTool('select')
@@ -55,7 +55,7 @@ class MyTool extends StateNode {
 }
 ```
 
-Tools can contain **children**. For example, the [hand tool](/gen/tldraw/HandTool) has three children, `Idle`, `Pointing` and `Dragging`. If a state has children, it must also have an `initial` state, so that it knows which state to start in.
+Tools can contain **children**. For example, the [hand tool](/reference/tldraw/HandTool) has three children, `Idle`, `Pointing` and `Dragging`. If a state has children, it must also have an `initial` state, so that it knows which state to start in.
 
 ```ts
 class MyIdleState extends StateNode {
@@ -75,7 +75,7 @@ class MyTool extends StateNode {
 
 ### Handling events
 
-When the editor receives an [event](/gen/editor/TLEventHandlers) via its [Editor#dispatch](?) method, the event is first processed in order to update its inputs, then passed to the editor's state chart.
+When the editor receives an [event](/reference/editor/TLEventHandlers) via its [Editor#dispatch](?) method, the event is first processed in order to update its inputs, then passed to the editor's state chart.
 
 Beginning at the root, each node will first handle the event and then pass the event to its current active child state. This continues until either: the event is handled on a state without any children; or the event is handled in a way that produces a transition.
 

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -41,7 +41,7 @@ The source for these examples are available in the [tldraw repository](https://g
 
 ## Overrides
 
-The content of tldraw's menus can be controlled via the `overrides` prop. This prop accepts a [TLUiOverrides](/gen/tldraw/TLUiOverrides) object, which has methods for each part of the user interface, such as the `toolbar` or `keyboardShortcutsMenu`.
+The content of tldraw's menus can be controlled via the `overrides` prop. This prop accepts a [TLUiOverrides](/reference/tldraw/TLUiOverrides) object, which has methods for each part of the user interface, such as the `toolbar` or `keyboardShortcutsMenu`.
 
 ### Actions
 
@@ -72,7 +72,7 @@ const myOverrides: TLUiOverrides = {
 }
 ```
 
-The `actions` object is a map of [TLUiActionItem](/gen/tldraw/TLUiActionItem)s, with each item keyed under its `id`.
+The `actions` object is a map of [TLUiActionItem](/reference/tldraw/TLUiActionItem)s, with each item keyed under its `id`.
 
 ### Tools
 
@@ -98,7 +98,7 @@ const myOverrides: TLUiOverrides = {
 }
 ```
 
-The `tools` object is a map of [TLUiToolItem](/gen/tldraw/TLUiToolItem)s, with each item keyed under its `id`.
+The `tools` object is a map of [TLUiToolItem](/reference/tldraw/TLUiToolItem)s, with each item keyed under its `id`.
 
 ### Toolbar and Menus
 
@@ -139,7 +139,7 @@ const myOverrides: TLUiOverrides = {
 }
 ```
 
-A menu schema is an array of either [submenus](/gen/tldraw/TLUiSubMenu), [groups](/gen/tldraw/TLUiMenuGroup), [items](/gen/tldraw/TLUiMenuItem), or [custom items](/gen/tldraw/TLUiCustomMenuItem). Each group or submenu may include any of the other types as its children.
+A menu schema is an array of either [submenus](/reference/tldraw/TLUiSubMenu), [groups](/reference/tldraw/TLUiMenuGroup), [items](/reference/tldraw/TLUiMenuItem), or [custom items](/reference/tldraw/TLUiCustomMenuItem). Each group or submenu may include any of the other types as its children.
 
 The menu schema is stateful. Referencing atomic properties (such as computed values in the editor) will cause the menu to update when those values change. If you wish for a menu item to disappear from the menu, you can return `null` from the menu method. You can also provide additional options for each item, `disabled` or `checked`.
 

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -47,14 +47,14 @@ const nextConfig = {
 				// For reverse compatibility with old links
 				// (This is a page that we referred people to quite often)
 				source: '/gen/editor/Editor-class',
-				destination: '/gen/editor/Editor',
+				destination: '/reference/editor/Editor',
 				permanent: true,
 			},
 			{
 				// For reverse compatibility with old links
 				// (This is a page that we referred people to quite often)
 				source: '/gen/editor/ShapeUtil-class',
-				destination: '/gen/editor/ShapeUtil',
+				destination: '/reference/editor/ShapeUtil',
 				permanent: true,
 			},
 		]

--- a/apps/docs/scripts/functions/getApiMarkdown.ts
+++ b/apps/docs/scripts/functions/getApiMarkdown.ts
@@ -409,7 +409,7 @@ function addReferences(result: Result, member: ApiItem) {
 			return
 		}
 		const apiItem = apiItemResult.resolvedApiItem!
-		const url = `/gen/${getPath(apiItem)}`
+		const url = `/reference/${getPath(apiItem)}`
 		references.add(`[${token.text}](${url})`)
 	})
 

--- a/apps/docs/scripts/utils.ts
+++ b/apps/docs/scripts/utils.ts
@@ -174,7 +174,7 @@ export class MarkdownWriter {
 				this.write(
 					'[',
 					docNode.linkText ?? getDefaultReferenceText(linkedItem),
-					'](/gen/',
+					'](/reference/',
 					path,
 					')'
 				)

--- a/apps/docs/utils/autoLinkDocs.ts
+++ b/apps/docs/utils/autoLinkDocs.ts
@@ -4,7 +4,7 @@ import { Database } from 'sqlite'
 import sqlite3 from 'sqlite3'
 
 export async function autoLinkDocs(db: Database<sqlite3.Database, sqlite3.Statement>) {
-	// replace [TLEditor](?) with [TLEditor](/gen/editor/TLEditor)?
+	// replace [TLEditor](?) with [TLEditor](/reference/editor/TLEditor)?
 	// not sure how we would get there but finding an article with the same title
 	const articles = await db.all(
 		'SELECT id, content FROM articles WHERE sectionId != ?',


### PR DESCRIPTION
### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fix up doc links with /gen links
