### PR TITLE
[Examples] Add a stupid 404 page

### DIFF
--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -25,6 +25,10 @@ if (!basicExample) throw new Error('Could not find basic example')
 
 const router = createBrowserRouter([
 	{
+		path: '*',
+		element: <div>404</div>,
+	},
+	{
 		path: '/',
 		lazy: async () => {
 			const Component = await basicExample.loadComponent()


### PR DESCRIPTION
Use a 404 Page.

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]
