### PR TITLE
[Fix] Note shape border radius

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -103,7 +103,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	indicator(shape: TLNoteShape) {
 		return (
 			<rect
-				rx="7"
+				rx="6"
 				width={toDomPrecision(NOTE_SIZE)}
 				height={toDomPrecision(this.getHeight(shape))}
 			/>


### PR DESCRIPTION
This PR fixes a border radius on the note shape.

Before
<img width="382" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/5cb95dbd-c935-4f1f-901c-eca294836c96">

After
<img width="436" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/0cce7ccf-2f7b-40dd-a27c-08c251cb4715">


### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes a bad border radius