### PR TITLE
fix prune preview deployment script

### DIFF
--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     name: Prune preview deploys
     timeout-minutes: 15
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-16-cores-open
     environment: deploy-staging
 
     steps:


### PR DESCRIPTION
The script that prunes old preview deployments in cloudlfare was broken when we moved dotcom into the public repo. This fixes it.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]
