### PR TITLE
fix: defineEnum and literalEnum typescript

### DIFF
--- a/packages/tlschema/src/styles/StyleProp.ts
+++ b/packages/tlschema/src/styles/StyleProp.ts
@@ -72,7 +72,7 @@ export class StyleProp<Type> implements T.Validatable<Type> {
 	 * })
 	 * ```
 	 */
-	static defineEnum<const Values extends readonly unknown[]>(
+	static defineEnum<Values extends readonly unknown[]>(
 		uniqueId: string,
 		options: { defaultValue: Values[number]; values: Values }
 	) {

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -607,7 +607,7 @@ export function nullable<T>(validator: Validatable<T>): Validator<T | null> {
 }
 
 /** @public */
-export function literalEnum<const Values extends readonly unknown[]>(
+export function literalEnum<Values extends readonly unknown[]>(
 	...values: Values
 ): Validator<Values[number]> {
 	return setEnum(new Set(values))


### PR DESCRIPTION
When trying to use tldraw in my app, I get a bunch of Typesccript errors coming out of schema and validation

![image](https://github.com/tldraw/tldraw/assets/2216153/ce05b55e-41ea-43fd-a17a-908836bed251)

These all stem from the same pattern of using "const" when defining a generic type, which I don't think is valid Typescript? Please correct me if I'm missing something here, but it looks like a typo

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan
There is no functionality change here, just types fix

### Release Notes

- Fix enum types 
