### PR TITLE
[dotcom] `TLSyncRoom` tidy

### DIFF
--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -750,7 +750,123 @@ export class TLSyncRoom<R extends UnknownRecord> {
 		this.clock++
 
 		transaction((rollback) => {
-			const pushRequest = new PushRequest<R>(this, session, message, rollback)
+			let mergedChanges: NetworkDiff<R> | null = null
+
+			const propagateOp = (id: string, op: RecordOp<R>) => {
+				if (!mergedChanges) mergedChanges = {}
+				mergedChanges[id] = op
+			}
+
+			const fail = (reason: TLIncompatibilityReason): Result<void, void> => {
+				rollback()
+				this.rejectSession(session, reason)
+				if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') {
+					console.error('failed to apply push', reason, message)
+				}
+				return Result.err(undefined)
+			}
+
+			const addDocument = (id: string, _state: R): Result<void, void> => {
+				const res = this.schema.migratePersistedRecord(_state, session.serializedSchema, 'up')
+				if (res.type === 'error') {
+					return fail(
+						res.reason === MigrationFailureReason.TargetVersionTooOld // target version is our version
+							? TLIncompatibilityReason.ServerTooOld
+							: TLIncompatibilityReason.ClientTooOld
+					)
+				}
+				const { value: state } = res
+
+				// Get the existing document, if any
+				const doc = this.getDocument(id)
+
+				if (doc) {
+					// If there's an existing document, replace it with the new state
+					// but propagate a diff rather than the entire value
+					const diff = doc.replaceState(state, this.clock)
+					if (!diff.ok) {
+						return fail(TLIncompatibilityReason.InvalidRecord)
+					}
+					if (diff.value) {
+						propagateOp(id, [RecordOpType.Patch, diff.value])
+					}
+				} else {
+					// Otherwise, if we don't already have a document with this id
+					// create the document and propagate the put op
+					const result = this.addDocument(id, state, this.clock)
+					if (!result.ok) {
+						return fail(TLIncompatibilityReason.InvalidRecord)
+					}
+					propagateOp(id, [RecordOpType.Put, state])
+				}
+
+				return Result.ok(undefined)
+			}
+
+			const patchDocument = (id: string, patch: ObjectDiff): Result<void, void> => {
+				// if it was already deleted, there's no need to apply the patch
+				const doc = this.getDocument(id)
+				if (!doc) return Result.ok(undefined)
+
+				// Compare versions of the record
+				const theirVersion = getRecordVersion(doc.state, session.serializedSchema)
+				const ourVersion = getRecordVersion(doc.state, this.serializedSchema)
+				const comparison = compareRecordVersions(ourVersion, theirVersion)
+
+				switch (comparison) {
+					case 0: {
+						// If the versions are compatible, apply the patch and propagate the patch op
+						const diff = doc.mergeDiff(patch, this.clock)
+						if (!diff.ok) {
+							return fail(TLIncompatibilityReason.InvalidRecord)
+						}
+						if (diff.value) {
+							propagateOp(id, [RecordOpType.Patch, diff.value])
+						}
+						break
+					}
+					case -1: {
+						// If the client's version of the record is newer than ours, we can't apply the patch
+						return fail(TLIncompatibilityReason.ServerTooOld)
+					}
+					case 1: {
+						// If the client's version of the record is older than ours,
+						// we apply the patch to the downgraded version of the record
+						const downgraded = this.schema.migratePersistedRecord(
+							doc.state,
+							session.serializedSchema,
+							'down'
+						)
+						if (downgraded.type === 'error') {
+							return fail(TLIncompatibilityReason.ClientTooOld)
+						}
+
+						// apply the patch to the downgraded version
+						const patched = applyObjectDiff(downgraded.value, patch)
+						// then upgrade the patched version and use that as the new state
+						const upgraded = this.schema.migratePersistedRecord(
+							patched,
+							session.serializedSchema,
+							'up'
+						)
+						// If the client's version is too old, we'll hit an error
+						if (upgraded.type === 'error') {
+							return fail(TLIncompatibilityReason.ClientTooOld)
+						}
+						// replace the state with the upgraded version and propagate the patch op
+						const diff = doc.replaceState(upgraded.value, this.clock)
+						if (!diff.ok) {
+							return fail(TLIncompatibilityReason.InvalidRecord)
+						}
+						if (diff.value) {
+							propagateOp(id, [RecordOpType.Patch, diff.value])
+						}
+						break
+					}
+				}
+
+				return Result.ok(undefined)
+			}
 
 			const { clientClock } = message
 
@@ -762,13 +878,13 @@ export class TLSyncRoom<R extends UnknownRecord> {
 				switch (type) {
 					case RecordOpType.Put: {
 						// Try to put the document. If it fails, stop here.
-						const res = pushRequest.addDocument(id, { ...val, id, typeName })
+						const res = addDocument(id, { ...val, id, typeName })
 						if (!res.ok) return
 						break
 					}
 					case RecordOpType.Patch: {
 						// Try to patch the document. If it fails, stop here.
-						const res = pushRequest.patchDocument(id, {
+						const res = patchDocument(id, {
 							...val,
 							id: [ValueOpType.Put, id],
 							typeName: [ValueOpType.Put, typeName],
@@ -791,15 +907,15 @@ export class TLSyncRoom<R extends UnknownRecord> {
 							// Try to add the document.
 							// If we're putting a record with a type that we don't recognize, fail
 							if (!this.documentTypes.has(op[1].typeName)) {
-								return pushRequest.fail(TLIncompatibilityReason.InvalidRecord)
+								return fail(TLIncompatibilityReason.InvalidRecord)
 							}
-							const res = pushRequest.addDocument(id, op[1])
+							const res = addDocument(id, op[1])
 							if (!res.ok) return
 							break
 						}
 						case RecordOpType.Patch: {
 							// Try to patch the document. If it fails, stop here.
-							const res = pushRequest.patchDocument(id, op[1])
+							const res = patchDocument(id, op[1])
 							if (!res.ok) return
 							break
 						}
@@ -812,21 +928,21 @@ export class TLSyncRoom<R extends UnknownRecord> {
 
 							// If the doc is not a type that we recognize, fail
 							if (!this.documentTypes.has(doc.state.typeName)) {
-								return pushRequest.fail(TLIncompatibilityReason.InvalidOperation)
+								return fail(TLIncompatibilityReason.InvalidOperation)
 							}
 
 							// Delete the document and propagate the delete op
 							this.removeDocument(id, this.clock)
 							// Schedule a pruneTombstones call to happen on the next call stack
 							setTimeout(this.pruneTombstones, 0)
-							pushRequest.propagateOp(id, op)
+							propagateOp(id, op)
 							break
 						}
 					}
 				}
 
 				// Let the client know what action to take based on the results of the push
-				if (!pushRequest.mergedChanges) {
+				if (!mergedChanges) {
 					// DISCARD
 					// Applying the client's changes had no effect, so the client should drop the diff
 					this.sendMessage(session.sessionKey, {
@@ -835,7 +951,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 						clientClock,
 						action: 'discard',
 					})
-				} else if (isEqual(pushRequest.mergedChanges, message.diff)) {
+				} else if (isEqual(mergedChanges, message.diff)) {
 					// COMMIT
 					// Applying the client's changes had the exact same effect on the server as
 					// they had on the client, so the client should keep the diff
@@ -850,12 +966,9 @@ export class TLSyncRoom<R extends UnknownRecord> {
 					// Applying the client's changes had a different non-empty effect on the server,
 					// so the client should rebase with our gold-standard / authoritative diff.
 					// First we need to migrate the diff to the client's version
-					const migrateResult = this.migrateDiffForSession(
-						session.serializedSchema,
-						pushRequest.mergedChanges
-					)
+					const migrateResult = this.migrateDiffForSession(session.serializedSchema, mergedChanges)
 					if (!migrateResult.ok) {
-						return pushRequest.fail(
+						return fail(
 							migrateResult.error === MigrationFailureReason.TargetVersionTooNew
 								? TLIncompatibilityReason.ServerTooOld
 								: TLIncompatibilityReason.ClientTooOld
@@ -872,10 +985,10 @@ export class TLSyncRoom<R extends UnknownRecord> {
 			}
 
 			// If there are merged changes, broadcast them to all other clients
-			if (pushRequest.mergedChanges !== null) {
+			if (mergedChanges !== null) {
 				this.broadcastPatch({
 					sourceSessionKey: session.sessionKey,
-					diff: pushRequest.mergedChanges,
+					diff: mergedChanges,
 				})
 			}
 
@@ -890,134 +1003,5 @@ export class TLSyncRoom<R extends UnknownRecord> {
 	 */
 	handleClose = (sessionKey: string) => {
 		this.cancelSession(sessionKey)
-	}
-}
-
-class PushRequest<R extends UnknownRecord> {
-	// collect actual ops that resulted from the push
-	// these will be broadcast to other users
-	mergedChanges: NetworkDiff<R> | null = null
-
-	propagateOp(id: string, op: RecordOp<R>) {
-		if (!this.mergedChanges) this.mergedChanges = {}
-		this.mergedChanges[id] = op
-	}
-
-	constructor(
-		public room: TLSyncRoom<R>,
-		public session: RoomSession<R> & { state: RoomSessionState.CONNECTED },
-		public message: Extract<TLSocketClientSentEvent<R>, { type: 'push' }>,
-		public rollback: () => void
-	) {}
-
-	fail(reason: TLIncompatibilityReason): Result<void, void> {
-		this.rollback()
-		this.room.rejectSession(this.session, reason)
-		if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') {
-			console.error('failed to apply push', reason, this.message)
-		}
-		return Result.err(undefined)
-	}
-
-	addDocument(id: string, _state: R): Result<void, void> {
-		const res = this.room.schema.migratePersistedRecord(_state, this.session.serializedSchema, 'up')
-		if (res.type === 'error') {
-			return this.fail(
-				res.reason === MigrationFailureReason.TargetVersionTooOld // target version is our version
-					? TLIncompatibilityReason.ServerTooOld
-					: TLIncompatibilityReason.ClientTooOld
-			)
-		}
-		const { value: state } = res
-
-		// Get the existing document, if any
-		const doc = this.room.getDocument(id)
-
-		if (doc) {
-			// If there's an existing document, replace it with the new state
-			// but propagate a diff rather than the entire value
-			const diff = doc.replaceState(state, this.room.clock)
-			if (!diff.ok) {
-				return this.fail(TLIncompatibilityReason.InvalidRecord)
-			}
-			if (diff.value) {
-				this.propagateOp(id, [RecordOpType.Patch, diff.value])
-			}
-		} else {
-			// Otherwise, if we don't already have a document with this id
-			// create the document and propagate the put op
-			const result = this.room.addDocument(id, state, this.room.clock)
-			if (!result.ok) {
-				return this.fail(TLIncompatibilityReason.InvalidRecord)
-			}
-			this.propagateOp(id, [RecordOpType.Put, state])
-		}
-
-		return Result.ok(undefined)
-	}
-
-	patchDocument(id: string, patch: ObjectDiff): Result<void, void> {
-		// if it was already deleted, there's no need to apply the patch
-		const doc = this.room.getDocument(id)
-		if (!doc) return Result.ok(undefined)
-
-		// Compare versions of the record
-		const theirVersion = getRecordVersion(doc.state, this.session.serializedSchema)
-		const ourVersion = getRecordVersion(doc.state, this.room.serializedSchema)
-		const comparison = compareRecordVersions(ourVersion, theirVersion)
-
-		switch (comparison) {
-			case 0: {
-				// If the versions are compatible, apply the patch and propagate the patch op
-				const diff = doc.mergeDiff(patch, this.room.clock)
-				if (!diff.ok) {
-					return this.fail(TLIncompatibilityReason.InvalidRecord)
-				}
-				if (diff.value) {
-					this.propagateOp(id, [RecordOpType.Patch, diff.value])
-				}
-				break
-			}
-			case -1: {
-				// If the client's version of the record is newer than ours, we can't apply the patch
-				return this.fail(TLIncompatibilityReason.ServerTooOld)
-			}
-			case 1: {
-				// If the client's version of the record is older than ours,
-				// we apply the patch to the downgraded version of the record
-				const downgraded = this.room.schema.migratePersistedRecord(
-					doc.state,
-					this.session.serializedSchema,
-					'down'
-				)
-				if (downgraded.type === 'error') {
-					return this.fail(TLIncompatibilityReason.ClientTooOld)
-				}
-
-				// apply the patch to the downgraded version
-				const patched = applyObjectDiff(downgraded.value, patch)
-				// then upgrade the patched version and use that as the new state
-				const upgraded = this.room.schema.migratePersistedRecord(
-					patched,
-					this.session.serializedSchema,
-					'up'
-				)
-				// If the client's version is too old, we'll hit an error
-				if (upgraded.type === 'error') {
-					return this.fail(TLIncompatibilityReason.ClientTooOld)
-				}
-				// replace the state with the upgraded version and propagate the patch op
-				const diff = doc.replaceState(upgraded.value, this.room.clock)
-				if (!diff.ok) {
-					return this.fail(TLIncompatibilityReason.InvalidRecord)
-				}
-				if (diff.value) {
-					this.propagateOp(id, [RecordOpType.Patch, diff.value])
-				}
-				break
-			}
-		}
-
-		return Result.ok(undefined)
 	}
 }

--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -592,8 +592,6 @@ export class TLSyncRoom<R extends UnknownRecord> {
 				exhaustiveSwitchError(message)
 			}
 		}
-
-		return this
 	}
 
 	/** If the client is out of date or we are out of date, we need to let them know */

--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -333,11 +333,11 @@ export class TLSyncRoom<R extends UnknownRecord> {
 		})
 	}
 
-	getDocument(id: string) {
+	private getDocument(id: string) {
 		return this.state.get().documents[id]
 	}
 
-	addDocument(id: string, state: R, clock: number): Result<void, Error> {
+	private addDocument(id: string, state: R, clock: number): Result<void, Error> {
 		let { documents, tombstones } = this.state.get()
 		if (hasOwnProperty(tombstones, id)) {
 			tombstones = { ...tombstones }
@@ -384,7 +384,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 	 * @param client - The client to send the message to.
 	 * @param message - The message to send.
 	 */
-	sendMessage(sessionKey: string, message: TLSocketServerSentEvent<R>) {
+	private sendMessage(sessionKey: string, message: TLSocketServerSentEvent<R>) {
 		const session = this.sessions.get(sessionKey)
 		if (!session) {
 			console.warn('Tried to send message to unknown session', message.type)
@@ -595,7 +595,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 	}
 
 	/** If the client is out of date or we are out of date, we need to let them know */
-	rejectSession(session: RoomSession<R>, reason: TLIncompatibilityReason) {
+	private rejectSession(session: RoomSession<R>, reason: TLIncompatibilityReason) {
 		try {
 			if (session.socket.isOpen) {
 				session.socket.sendMessage({
@@ -750,6 +750,8 @@ export class TLSyncRoom<R extends UnknownRecord> {
 		this.clock++
 
 		transaction((rollback) => {
+			// collect actual ops that resulted from the push
+			// these will be broadcast to other users
 			let mergedChanges: NetworkDiff<R> | null = null
 
 			const propagateOp = (id: string, op: RecordOp<R>) => {


### PR DESCRIPTION
I went through the sync room code today while thinking about syncing. As I worked through it, I added some comments etc for my own readability. There is no change in how the code works.

There are a few functions declared in the body of `handlePushRequest`. We might want to re-arrange things so that we're not re-declaring those on each push (there are a LOT of pushes, basically every mouse move from every client). I did try that but reverted that change; it feels like a proper solution would be bigger than what I wanted to do here.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]
