### PR TITLE
[fix] Debug panel text overflow

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -591,7 +591,9 @@
 }
 
 .tlui-debug-panel__current-state {
+	overflow: hidden;
 	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .tlui-debug-panel__fps {


### PR DESCRIPTION
This PR prevents text overflow on the debug panel.

### Change Type

- [x] `patch` — Bug fix
