### PR TITLE
[fix] VSCode keyboard shortcuts while editing text

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -101,8 +101,6 @@ export function useEditableText<T extends Extract<TLShape, { props: { text: stri
 		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 			if (!isEditing) return
 
-			if (e.ctrlKey || e.metaKey) stopEventPropagation(e)
-
 			switch (e.key) {
 				case 'Enter': {
 					if (e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
This PR fixes a bug where keyboard shortcuts weren't working in the vs code extension. We had taken some extra steps early on to prevent kbds from running while an input was focused, but we've since solved this bug in the kbd logic itself.

Closes #2717 

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Using the vs code extension, edit text and then use keyboard shortcuts, e.g. for select all or copy / paste
2. Confirm that regular tldraw shortcuts don't fire when editing text

### Release Notes

- Fixed a bug in the VS Code that prevented keyboard shortcuts from working in text labels.