### PR TITLE
[dx] use Biome instead of Prettier, part 2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2
 
-#      - name: Run Biome
-#        run: biome ci --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=false .
+      - name: Run Biome
+        run: biome ci --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=false .
 
       - name: Typecheck
         run: yarn build-types

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -109,7 +109,9 @@ export async function GET(req: NextRequest) {
 			}
 		})
 
-		Object.keys(results).forEach((section: string) => results[section as keyof Data['results']].sort((a, b) => b.score - a.score))
+		Object.keys(results).forEach((section: string) =>
+			results[section as keyof Data['results']].sort((a, b) => b.score - a.score)
+		)
 
 		results.articles.sort(
 			(a, b) => (b.type === 'heading' ? -1 : 1) - (a.type === 'heading' ? -1 : 1)

--- a/apps/docs/scripts/functions/generateSection.ts
+++ b/apps/docs/scripts/functions/generateSection.ts
@@ -115,8 +115,8 @@ export function generateSection(section: InputSection, articles: Articles, index
 				section.id === 'getting-started'
 					? `/${articleId}`
 					: isUncategorized
-						? `/${section.id}/${articleId}`
-						: `/${section.id}/${categoryId}/${articleId}`,
+					  ? `/${section.id}/${articleId}`
+					  : `/${section.id}/${categoryId}/${articleId}`,
 		}
 
 		if (isExamples) {

--- a/apps/docs/utils/ContentDatabase.ts
+++ b/apps/docs/utils/ContentDatabase.ts
@@ -161,8 +161,8 @@ export class ContentDatabase {
 			sectionId === 'examples'
 				? this._sidebarExamplesContentLinks
 				: sectionId === 'reference'
-					? this._sidebarReferenceContentLinks
-					: this._sidebarContentLinks
+				  ? this._sidebarReferenceContentLinks
+				  : this._sidebarContentLinks
 		if (cachedLinks && process.env.NODE_ENV !== 'development') {
 			// Use the previously cached sidebar links
 			links = cachedLinks

--- a/apps/docs/utils/ContentVectorDatabase.ts
+++ b/apps/docs/utils/ContentVectorDatabase.ts
@@ -217,8 +217,8 @@ export async function getVectorDb(
 			INCLUDE_API_CONTENT && INCLUDE_CONTENT
 				? await db.all('SELECT * FROM articles')
 				: INCLUDE_API_CONTENT
-					? await db.all('SELECT * FROM articles WHERE articles.sectionId = ?', 'reference')
-					: await db.all('SELECT * FROM articles WHERE articles.sectionId != ?', 'reference')
+				  ? await db.all('SELECT * FROM articles WHERE articles.sectionId = ?', 'reference')
+				  : await db.all('SELECT * FROM articles WHERE articles.sectionId != ?', 'reference')
 
 		nicelog(`Adding articles to index`)
 		const max = Math.min(articles.length, MAX_ARTICLES)

--- a/apps/dotcom-worker/src/lib/AlarmScheduler.test.ts
+++ b/apps/dotcom-worker/src/lib/AlarmScheduler.test.ts
@@ -3,9 +3,11 @@ import { AlarmScheduler } from './AlarmScheduler'
 
 jest.useFakeTimers()
 
-function makeMockAlarmScheduler<Key extends string>(alarms: {
-	[K in Key]: jest.Mock<Promise<void>, []>
-}) {
+function makeMockAlarmScheduler<Key extends string>(
+	alarms: {
+		[K in Key]: jest.Mock<Promise<void>, []>
+	}
+) {
 	const data = new Map<string, number>()
 	let scheduledAlarm: number | null = null
 

--- a/apps/dotcom/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
+++ b/apps/dotcom/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
@@ -38,7 +38,7 @@ export function BoardHistorySnapshot({
 				...(token
 					? {
 							Authorization: 'Bearer ' + token,
-						}
+					  }
 					: {}),
 			},
 			body: JSON.stringify({ timestamp }),

--- a/apps/dotcom/src/components/PeopleMenu/PeopleMenuItem.tsx
+++ b/apps/dotcom/src/components/PeopleMenu/PeopleMenuItem.tsx
@@ -50,8 +50,8 @@ export const PeopleMenuItem = track(function PeopleMenuItem({ userId }: { userId
 					theyAreFollowingYou
 						? msg('people-menu.leading')
 						: youAreFollowingThem
-							? msg('people-menu.following')
-							: msg('people-menu.follow')
+						  ? msg('people-menu.following')
+						  : msg('people-menu.follow')
 				}
 				icon={theyAreFollowingYou ? 'leading' : youAreFollowingThem ? 'following' : 'follow'}
 				onClick={handleFollowClick}

--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -188,8 +188,8 @@ export const ShareMenu = React.memo(function ShareMenu() {
 										shareState.state === 'offline'
 											? 'share-menu.offline-note'
 											: isReadOnlyLink
-												? 'share-menu.copy-readonly-link-note'
-												: 'share-menu.copy-link-note'
+											  ? 'share-menu.copy-readonly-link-note'
+											  : 'share-menu.copy-link-note'
 									)}
 								</p>
 							</div>

--- a/apps/dotcom/src/pages/public-snapshot.tsx
+++ b/apps/dotcom/src/pages/public-snapshot.tsx
@@ -10,7 +10,7 @@ const { loader, useData } = defineLoader(async (args) => {
 		? ((await result.json()) as {
 				schema: SerializedSchema
 				records: TLRecord[]
-			})
+		  })
 		: null
 })
 

--- a/apps/dotcom/src/utils/migration/LocalMigration.tsx
+++ b/apps/dotcom/src/utils/migration/LocalMigration.tsx
@@ -10,7 +10,6 @@ export function LocalMigration() {
 
 	useEffect(() => {
 		let didCancel = false
-
 		;(async () => {
 			if (!isEditorEmpty(editor)) return
 

--- a/apps/dotcom/src/utils/useFileSystem.tsx
+++ b/apps/dotcom/src/utils/useFileSystem.tsx
@@ -97,7 +97,7 @@ export function useFileSystem({ isMultiplayer }: { isMultiplayer: boolean }): TL
 				const newItem = menuItem(actions[NEW_PROJECT_ACTION])
 				const group = isMultiplayer
 					? // open is not currently supported in multiplayer
-						menuGroup('filesystem', saveItem)
+					  menuGroup('filesystem', saveItem)
 					: menuGroup('filesystem', newItem, openItem, saveItem)
 				fileMenu.children.unshift(group!)
 

--- a/apps/examples/src/examples/api/APIExample.tsx
+++ b/apps/examples/src/examples/api/APIExample.tsx
@@ -97,7 +97,6 @@ const InsideOfEditorContext = () => {
 	return null
 }
 
-
 /* 
 Introduction: 
 

--- a/apps/examples/src/examples/user-presence/UserPresenceExample.tsx
+++ b/apps/examples/src/examples/user-presence/UserPresenceExample.tsx
@@ -60,11 +60,11 @@ export default function UserPresenceExample() {
 									t < 1
 										? ''
 										: t > 2
-											? CURSOR_CHAT_MESSAGE
-											: CURSOR_CHAT_MESSAGE.slice(
+										  ? CURSOR_CHAT_MESSAGE
+										  : CURSOR_CHAT_MESSAGE.slice(
 													0,
 													Math.ceil((t - 1) * CURSOR_CHAT_MESSAGE.length)
-												)
+											  )
 							}
 
 							editor.store.put([

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -157,8 +157,8 @@ function getStateFromElapsedTime(elapsed: number) {
 	return elapsed > COLLABORATOR_INACTIVE_TIMEOUT
 		? 'inactive'
 		: elapsed > COLLABORATOR_IDLE_TIMEOUT
-			? 'idle'
-			: 'active'
+		  ? 'idle'
+		  : 'active'
 }
 
 function useCollaboratorState(latestPresence: TLInstancePresence | null) {

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -32,13 +32,13 @@ export function createTLStore({ initialData, defaultName = '', ...rest }: TLStor
 	const schema =
 		'schema' in rest && rest.schema
 			? // we have a schema
-				rest.schema
+			  rest.schema
 			: // we need a schema
-				createTLSchema({
+			  createTLSchema({
 					shapes: currentPageShapesToShapeMap(
 						checkShapesAndAddCore('shapeUtils' in rest && rest.shapeUtils ? rest.shapeUtils : [])
 					),
-				})
+			  })
 
 	return new Store({
 		schema,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5759,12 +5759,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 					? {
 							...translateStartChanges,
 							[val]: shape[val] + localDelta[val],
-						}
+					  }
 					: {
 							id: shape.id as any,
 							type: shape.type,
 							[val]: shape[val] + localDelta[val],
-						}
+					  }
 			)
 
 			v += pageBounds[shape.id][dim] + shapeGap
@@ -7850,16 +7850,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 					newShape.props.start = mappedId
 						? { ...newShape.props.start, boundShapeId: mappedId }
 						: // this shouldn't happen, if you copy an arrow but not it's bound shape it should
-							// convert the binding to a point at the time of copying
-							{ type: 'point', x: 0, y: 0 }
+						  // convert the binding to a point at the time of copying
+						  { type: 'point', x: 0, y: 0 }
 				}
 				if (newShape.props.end.type === 'binding') {
 					const mappedId = idMap.get(newShape.props.end.boundShapeId)
 					newShape.props.end = mappedId
 						? { ...newShape.props.end, boundShapeId: mappedId }
 						: // this shouldn't happen, if you copy an arrow but not it's bound shape it should
-							// convert the binding to a point at the time of copying
-							{ type: 'point', x: 0, y: 0 }
+						  // convert the binding to a point at the time of copying
+						  { type: 'point', x: 0, y: 0 }
 				}
 			}
 

--- a/packages/editor/src/lib/editor/managers/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager.ts
@@ -643,8 +643,8 @@ export class SnapManager {
 						? 'x'
 						: 'y'
 					: nearestSnapsX.length
-						? 'x'
-						: 'y'
+					  ? 'x'
+					  : 'y'
 
 			const ratio = initialSelectionPageBounds.aspectRatio
 
@@ -1193,7 +1193,7 @@ export class SnapManager {
 												'forward',
 												gapBreadthIntersection
 											),
-										]
+									  ]
 									: [
 											...findAdjacentGaps(
 												horizontal,
@@ -1209,7 +1209,7 @@ export class SnapManager {
 												) as [Vec, Vec],
 												endEdge: selectionSides.left,
 											},
-										],
+									  ],
 						})
 
 						break
@@ -1297,7 +1297,7 @@ export class SnapManager {
 													'forward',
 													gapBreadthIntersection
 												),
-											]
+										  ]
 										: [
 												...findAdjacentGaps(
 													vertical,
@@ -1313,7 +1313,7 @@ export class SnapManager {
 													) as [Vec, Vec],
 													endEdge: selectionSides.top,
 												},
-											],
+										  ],
 							})
 						}
 						break

--- a/packages/editor/src/lib/primitives/easings.ts
+++ b/packages/editor/src/lib/primitives/easings.ts
@@ -23,10 +23,10 @@ export const EASINGS = {
 		t <= 0
 			? 0
 			: t >= 1
-				? 1
-				: t < 0.5
-					? Math.pow(2, 20 * t - 10) / 2
-					: (2 - Math.pow(2, -20 * t + 10)) / 2,
+			  ? 1
+			  : t < 0.5
+				  ? Math.pow(2, 20 * t - 10) / 2
+				  : (2 - Math.pow(2, -20 * t + 10)) / 2,
 } as const
 
 /** @public */

--- a/packages/editor/src/lib/utils/getIncrementedName.ts
+++ b/packages/editor/src/lib/utils/getIncrementedName.ts
@@ -14,7 +14,7 @@ export function getIncrementedName(name: string, others: string[]) {
 		result = /^.*(\d+)$/.exec(result)?.[1]
 			? result.replace(/(\d+)(?=\D?)$/, (m) => {
 					return (+m + 1).toString()
-				})
+			  })
 			: `${result} 1`
 	}
 

--- a/packages/state/docs-ordering.json
+++ b/packages/state/docs-ordering.json
@@ -1,5 +1,8 @@
 [
-	["functions", ["atom-1", "computed-1", "react", "reactor-1", "transact", "transaction"]],
+	[
+		"functions",
+		["atom-1", "computed-1", "react", "reactor-1", "transact", "transaction"]
+	],
 	["classes"],
 	["interfaces", ["Signal"]]
 ]

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -121,13 +121,13 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 							migrations: ourType.migrations,
 							fromVersion: persistedVersion,
 							toVersion: ourVersion,
-						})
+					  })
 					: migrateRecord<R>({
 							record,
 							migrations: ourType.migrations,
 							fromVersion: ourVersion,
 							toVersion: persistedVersion,
-						})
+					  })
 			if (result.type === 'error') {
 				return result
 			}
@@ -174,13 +174,13 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 						migrations: ourSubTypeMigrations,
 						fromVersion: persistedSubTypeVersion,
 						toVersion: ourSubTypeMigrations.currentVersion,
-					})
+				  })
 				: migrateRecord<R>({
 						record,
 						migrations: ourSubTypeMigrations,
 						fromVersion: ourSubTypeMigrations.currentVersion,
 						toVersion: persistedSubTypeVersion,
-					})
+				  })
 
 		if (result.type === 'error') {
 			return result
@@ -258,12 +258,12 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 												k,
 												v.currentVersion,
 											])
-										)
+									  )
 									: undefined,
-							}
+						  }
 						: {
 								version: type.migrations.currentVersion,
-							},
+						  },
 				])
 			),
 		}
@@ -286,12 +286,12 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 												k,
 												v.firstVersion,
 											])
-										)
+									  )
 									: undefined,
-							}
+						  }
 						: {
 								version: type.migrations.firstVersion,
-							},
+						  },
 				])
 			),
 		}

--- a/packages/store/src/lib/migrate.ts
+++ b/packages/store/src/lib/migrate.ts
@@ -213,105 +213,105 @@ type Range<From extends number, To extends number> = To extends From
 type Decrement<n extends number> = n extends 0
 	? never
 	: n extends 1
-		? 0
-		: n extends 2
-			? 1
-			: n extends 3
-				? 2
-				: n extends 4
-					? 3
-					: n extends 5
-						? 4
-						: n extends 6
-							? 5
-							: n extends 7
-								? 6
-								: n extends 8
-									? 7
-									: n extends 9
-										? 8
-										: n extends 10
-											? 9
-											: n extends 11
-												? 10
-												: n extends 12
-													? 11
-													: n extends 13
-														? 12
-														: n extends 14
-															? 13
-															: n extends 15
-																? 14
-																: n extends 16
-																	? 15
-																	: n extends 17
-																		? 16
-																		: n extends 18
-																			? 17
-																			: n extends 19
-																				? 18
-																				: n extends 20
-																					? 19
-																					: n extends 21
-																						? 20
-																						: n extends 22
-																							? 21
-																							: n extends 23
-																								? 22
-																								: n extends 24
-																									? 23
-																									: n extends 25
-																										? 24
-																										: n extends 26
-																											? 25
-																											: n extends 27
-																												? 26
-																												: n extends 28
-																													? 27
-																													: n extends 29
-																														? 28
-																														: n extends 30
-																															? 29
-																															: n extends 31
-																																? 30
-																																: n extends 32
-																																	? 31
-																																	: n extends 33
-																																		? 32
-																																		: n extends 34
-																																			? 33
-																																			: n extends 35
-																																				? 34
-																																				: n extends 36
-																																					? 35
-																																					: n extends 37
-																																						? 36
-																																						: n extends 38
-																																							? 37
-																																							: n extends 39
-																																								? 38
-																																								: n extends 40
-																																									? 39
-																																									: n extends 41
-																																										? 40
-																																										: n extends 42
-																																											? 41
-																																											: n extends 43
-																																												? 42
-																																												: n extends 44
-																																													? 43
-																																													: n extends 45
-																																														? 44
-																																														: n extends 46
-																																															? 45
-																																															: n extends 47
-																																																? 46
-																																																: n extends 48
-																																																	? 47
-																																																	: n extends 49
-																																																		? 48
-																																																		: n extends 50
-																																																			? 49
-																																																			: n extends 51
-																																																				? 50
-																																																				: never
+	  ? 0
+	  : n extends 2
+		  ? 1
+		  : n extends 3
+			  ? 2
+			  : n extends 4
+				  ? 3
+				  : n extends 5
+					  ? 4
+					  : n extends 6
+						  ? 5
+						  : n extends 7
+							  ? 6
+							  : n extends 8
+								  ? 7
+								  : n extends 9
+									  ? 8
+									  : n extends 10
+										  ? 9
+										  : n extends 11
+											  ? 10
+											  : n extends 12
+												  ? 11
+												  : n extends 13
+													  ? 12
+													  : n extends 14
+														  ? 13
+														  : n extends 15
+															  ? 14
+															  : n extends 16
+																  ? 15
+																  : n extends 17
+																	  ? 16
+																	  : n extends 18
+																		  ? 17
+																		  : n extends 19
+																			  ? 18
+																			  : n extends 20
+																				  ? 19
+																				  : n extends 21
+																					  ? 20
+																					  : n extends 22
+																						  ? 21
+																						  : n extends 23
+																							  ? 22
+																							  : n extends 24
+																								  ? 23
+																								  : n extends 25
+																									  ? 24
+																									  : n extends 26
+																										  ? 25
+																										  : n extends 27
+																											  ? 26
+																											  : n extends 28
+																												  ? 27
+																												  : n extends 29
+																													  ? 28
+																													  : n extends 30
+																														  ? 29
+																														  : n extends 31
+																															  ? 30
+																															  : n extends 32
+																																  ? 31
+																																  : n extends 33
+																																	  ? 32
+																																	  : n extends 34
+																																		  ? 33
+																																		  : n extends 35
+																																			  ? 34
+																																			  : n extends 36
+																																				  ? 35
+																																				  : n extends 37
+																																					  ? 36
+																																					  : n extends 38
+																																						  ? 37
+																																						  : n extends 39
+																																							  ? 38
+																																							  : n extends 40
+																																								  ? 39
+																																								  : n extends 41
+																																									  ? 40
+																																									  : n extends 42
+																																										  ? 41
+																																										  : n extends 43
+																																											  ? 42
+																																											  : n extends 44
+																																												  ? 43
+																																												  : n extends 45
+																																													  ? 44
+																																													  : n extends 46
+																																														  ? 45
+																																														  : n extends 47
+																																															  ? 46
+																																															  : n extends 48
+																																																  ? 47
+																																																  : n extends 49
+																																																	  ? 48
+																																																	  : n extends 50
+																																																		  ? 49
+																																																		  : n extends 51
+																																																			  ? 50
+																																																			  : never

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -140,7 +140,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 			shouldDisplayControls &&
 			(onlyShape
 				? editor.getShapeUtil(onlyShape).canResize(onlyShape) &&
-					!editor.getShapeUtil(onlyShape).hideResizeHandles(onlyShape)
+				  !editor.getShapeUtil(onlyShape).hideResizeHandles(onlyShape)
 				: true) &&
 			!showCropHandles &&
 			!isLockedShape

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -104,7 +104,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			? new Edge2d({
 					start: Vec.From(info.start.point),
 					end: Vec.From(info.end.point),
-				})
+			  })
 			: new Arc2d({
 					center: Vec.Cast(info.handleArc.center),
 					radius: info.handleArc.radius,
@@ -112,7 +112,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 					end: Vec.Cast(info.end.point),
 					sweepFlag: info.bodyArc.sweepFlag,
 					largeArcFlag: info.bodyArc.largeArcFlag,
-				})
+			  })
 
 		let labelGeom
 		if (shape.props.text.trim()) {
@@ -583,8 +583,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 								? shape.props.start.isExact
 									? ''
 									: shape.props.start.isPrecise
-										? 'url(#arrowhead-cross)'
-										: 'url(#arrowhead-dot)'
+									  ? 'url(#arrowhead-cross)'
+									  : 'url(#arrowhead-dot)'
 								: ''
 						}
 						markerEnd={
@@ -592,8 +592,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 								? shape.props.end.isExact
 									? ''
 									: shape.props.end.isPrecise
-										? 'url(#arrowhead-cross)'
-										: 'url(#arrowhead-dot)'
+									  ? 'url(#arrowhead-cross)'
+									  : 'url(#arrowhead-dot)'
 								: ''
 						}
 						opacity={0.16}

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -39,7 +39,7 @@ export function getArrowLabelSize(editor: Editor, shape: TLArrowShape) {
 		? new Edge2d({
 				start: Vec.From(info.start.point),
 				end: Vec.From(info.end.point),
-			})
+		  })
 		: new Arc2d({
 				center: Vec.Cast(info.handleArc.center),
 				radius: info.handleArc.radius,
@@ -47,7 +47,7 @@ export function getArrowLabelSize(editor: Editor, shape: TLArrowShape) {
 				end: Vec.Cast(info.end.point),
 				sweepFlag: info.bodyArc.sweepFlag,
 				largeArcFlag: info.bodyArc.largeArcFlag,
-			})
+		  })
 
 	if (shape.props.text.trim()) {
 		const bodyBounds = bodyGeom.bounds

--- a/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
@@ -29,8 +29,8 @@ function getArrowPoints(
 					? ints[0]
 					: ints[1]
 				: info.handleArc.sweepFlag
-					? ints[1]
-					: ints[0]
+				  ? ints[1]
+				  : ints[0]
 	}
 
 	return {

--- a/packages/tldraw/src/lib/shapes/draw/getPath.ts
+++ b/packages/tldraw/src/lib/shapes/draw/getPath.ts
@@ -72,10 +72,10 @@ export function getFreehandOptions(
 		...(forceSolid
 			? solidSettings(strokeWidth)
 			: shapeProps.dash === 'draw'
-				? shapeProps.isPen
+			  ? shapeProps.isPen
 					? realPressureSettings(strokeWidth)
 					: simulatePressureSettings(strokeWidth)
-				: solidSettings(strokeWidth)),
+			  : solidSettings(strokeWidth)),
 		last: shapeProps.isComplete || forceComplete,
 	}
 }

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -322,14 +322,14 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 						shape.props.align === 'start'
 							? 0
 							: shape.props.align === 'end'
-								? w - labelWidth
-								: (w - labelWidth) / 2,
+							  ? w - labelWidth
+							  : (w - labelWidth) / 2,
 					y:
 						shape.props.verticalAlign === 'start'
 							? 0
 							: shape.props.verticalAlign === 'end'
-								? h - labelHeight
-								: (h - labelHeight) / 2,
+							  ? h - labelHeight
+							  : (h - labelHeight) / 2,
 					width: labelWidth,
 					height: labelHeight,
 					isFilled: true,

--- a/packages/tldraw/src/lib/shapes/geo/cloudOutline.ts
+++ b/packages/tldraw/src/lib/shapes/geo/cloudOutline.ts
@@ -59,7 +59,7 @@ export function getPillPoints(width: number, height: number, numPoints: number) 
 						center: new Vec(radius, radius),
 						startAngle: PI / 2,
 					},
-				]
+			  ]
 			: [
 					{
 						type: 'straight',
@@ -81,7 +81,7 @@ export function getPillPoints(width: number, height: number, numPoints: number) 
 						center: new Vec(radius, radius),
 						startAngle: PI,
 					},
-				]
+			  ]
 
 	let sectionOffset = 0
 

--- a/packages/tldraw/src/lib/shapes/geo/components/DashStyleCloud.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/components/DashStyleCloud.tsx
@@ -39,10 +39,10 @@ export const DashStyleCloud = React.memo(function DashStylePolygon({
 				{arcs.map(({ leftPoint, rightPoint, center, radius }, i) => {
 					const arcLength = center
 						? radius *
-							canonicalizeRotation(
+						  canonicalizeRotation(
 								canonicalizeRotation(Vec.Angle(center, rightPoint)) -
 									canonicalizeRotation(Vec.Angle(center, leftPoint))
-							)
+						  )
 						: Vec.Dist(leftPoint, rightPoint)
 
 					const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
@@ -99,10 +99,10 @@ export function DashStyleCloudSvg({
 	for (const { leftPoint, rightPoint, center, radius } of arcs) {
 		const arcLength = center
 			? radius *
-				canonicalizeRotation(
+			  canonicalizeRotation(
 					canonicalizeRotation(Vec.Angle(center, rightPoint)) -
 						canonicalizeRotation(Vec.Angle(center, leftPoint))
-				)
+			  )
 			: Vec.Dist(leftPoint, rightPoint)
 
 		const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(arcLength, strokeWidth, {

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -94,8 +94,8 @@ export class Pointing extends StateNode {
 			shape.props.geo === 'star'
 				? new Box(0, 0, 200, 190)
 				: shape.props.geo === 'cloud'
-					? new Box(0, 0, 300, 180)
-					: new Box(0, 0, 200, 200)
+				  ? new Box(0, 0, 300, 180)
+				  : new Box(0, 0, 200, 200)
 
 		const delta = bounds.center
 		const parentTransform = this.editor.getShapeParentTransform(shape)

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -82,7 +82,7 @@ export const TextLabel = React.memo(function TextLabel<
 							width: bounds.width,
 							height: bounds.height,
 							position: 'absolute',
-						}
+					  }
 					: {}),
 			}}
 		>

--- a/packages/tldraw/src/lib/shapes/shared/createTextSvgElementFromSpans.ts
+++ b/packages/tldraw/src/lib/shapes/shared/createTextSvgElementFromSpans.ts
@@ -59,8 +59,8 @@ export function createTextSvgElementFromSpans(
 		(opts.verticalTextAlign === 'start'
 			? padding
 			: opts.verticalTextAlign === 'end'
-				? opts.height - padding - bounds.height
-				: (Math.ceil(opts.height) - bounds.height) / 2)
+			  ? opts.height - padding - bounds.height
+			  : (Math.ceil(opts.height) - bounds.height) / 2)
 
 	// Create text span elements for each word
 	let currentLineTop = null

--- a/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
@@ -207,15 +207,15 @@ export function getStrokeOutlinePoints(
 		start.taper === false
 			? 0
 			: start.taper === true
-				? Math.max(size, totalLength)
-				: (start.taper as number)
+			  ? Math.max(size, totalLength)
+			  : (start.taper as number)
 
 	const taperEnd =
 		end.taper === false
 			? 0
 			: end.taper === true
-				? Math.max(size, totalLength)
-				: (end.taper as number)
+			  ? Math.max(size, totalLength)
+			  : (end.taper as number)
 
 	// The minimum allowed distance between points (squared)
 	// Our collected left and right points

--- a/packages/tldraw/src/lib/shapes/shared/freehand/setStrokePointRadii.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/setStrokePointRadii.ts
@@ -89,15 +89,15 @@ export function setStrokePointRadii(strokePoints: StrokePoint[], options: Stroke
 		start.taper === false
 			? 0
 			: start.taper === true
-				? Math.max(size, totalLength)
-				: (start.taper as number)
+			  ? Math.max(size, totalLength)
+			  : (start.taper as number)
 
 	const taperEnd =
 		end.taper === false
 			? 0
 			: end.taper === true
-				? Math.max(size, totalLength)
-				: (end.taper as number)
+			  ? Math.max(size, totalLength)
+			  : (end.taper as number)
 
 	if (taperStart || taperEnd) {
 		for (let i = 0; i < strokePoints.length; i++) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -378,7 +378,7 @@ function getTextSize(editor: Editor, props: TLTextShape['props']) {
 	const cw = autoSize
 		? null
 		: // `measureText` floors the number so we need to do the same here to avoid issues.
-			Math.floor(Math.max(minWidth, w))
+		  Math.floor(Math.max(minWidth, w))
 
 	const result = editor.textMeasure.measureText(text, {
 		...TEXT_PROPS,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -199,10 +199,10 @@ export class Idle extends StateNode {
 					hoveredShape && !this.editor.isShapeOfType<TLGroupShape>(hoveredShape, 'group')
 						? hoveredShape
 						: this.editor.getSelectedShapeAtPoint(this.editor.inputs.currentPagePoint) ??
-							this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
+						  this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
 								margin: HIT_TEST_MARGIN / this.editor.getZoomLevel(),
 								hitInside: false,
-							})
+						  })
 
 				const focusedGroupId = this.editor.getFocusedGroupId()
 
@@ -358,7 +358,7 @@ export class Idle extends StateNode {
 								hitLabels: true,
 								hitFrameInside: false,
 								renderingOnly: true,
-							})
+						  })
 
 				if (hitShape) {
 					this.onRightClick({
@@ -567,8 +567,8 @@ export class Idle extends StateNode {
 				? gridSize * GRID_INCREMENT
 				: gridSize
 			: shiftKey
-				? MAJOR_NUDGE_FACTOR
-				: MINOR_NUDGE_FACTOR
+			  ? MAJOR_NUDGE_FACTOR
+			  : MINOR_NUDGE_FACTOR
 
 		this.editor.nudgeShapes(this.editor.getSelectedShapeIds(), delta.mul(step))
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
@@ -39,7 +39,7 @@ export class PointingSelection extends StateNode {
 						hitInside: true,
 						margin: 0,
 						renderingOnly: true,
-					})
+				  })
 
 		if (hitShape) {
 			// todo: extract the double click shape logic from idle so that we can share it here

--- a/packages/tldraw/src/lib/ui/components/ActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu.tsx
@@ -35,8 +35,8 @@ export const ActionsMenu = memo(function ActionsMenu() {
 									? `${msg(label)} ${kbdStr(kbd)}`
 									: `${msg(label)}`
 								: kbd
-									? `${kbdStr(kbd)}`
-									: ''
+								  ? `${kbdStr(kbd)}`
+								  : ''
 						}
 						onClick={() => onSelect('actions-menu')}
 						disabled={item.disabled}

--- a/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugPanel.tsx
@@ -91,11 +91,16 @@ const CurrentState = track(function CurrentState() {
 	const shape = path === 'select.idle' || !path.includes('select.') ? hoverShape : selectedShape
 	const shapeInfo =
 		shape && path.includes('select.')
-			? ` / ${shape.type || ''}${'geo' in shape.props ? ' / ' + shape.props.geo : ''} / [${Vec.ToFixed(editor.getPointInShapeSpace(shape, editor.inputs.currentPagePoint), 0)}]`
+			? ` / ${shape.type || ''}${
+					'geo' in shape.props ? ' / ' + shape.props.geo : ''
+			  } / [${Vec.ToFixed(editor.getPointInShapeSpace(shape, editor.inputs.currentPagePoint), 0)}]`
 			: ''
 	const ruler =
 		path.startsWith('select.') && !path.includes('.idle')
-			? ` / [${Vec.ToFixed(editor.inputs.originPagePoint, 0)}] → [${Vec.ToFixed(editor.inputs.currentPagePoint, 0)}] = ${Vec.Dist(editor.inputs.originPagePoint, editor.inputs.currentPagePoint).toFixed(0)}`
+			? ` / [${Vec.ToFixed(editor.inputs.originPagePoint, 0)}] → [${Vec.ToFixed(
+					editor.inputs.currentPagePoint,
+					0
+			  )}] = ${Vec.Dist(editor.inputs.originPagePoint, editor.inputs.currentPagePoint).toFixed(0)}`
 			: ''
 
 	return <div className="tlui-debug-panel__current-state">{`${path}${shapeInfo}${ruler}`}</div>

--- a/packages/tldraw/src/lib/ui/components/Menu.tsx
+++ b/packages/tldraw/src/lib/ui/components/Menu.tsx
@@ -65,8 +65,8 @@ function MenuContent() {
 							depth <= 1
 								? 'medium'
 								: breakpoint < 3 || (parent?.type === 'submenu' && depth > 2)
-									? 'tiny'
-									: 'medium'
+								  ? 'tiny'
+								  : 'medium'
 						}
 						key={item.id}
 					>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
@@ -129,7 +129,7 @@ function CommonStylePickerSet({
 					minBy(tldrawSupportedOpacities, (supportedOpacity) =>
 						Math.abs(supportedOpacity - opacity.value)
 					)!
-				)
+			  )
 
 	return (
 		<>

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteExcalidrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteExcalidrawContent.ts
@@ -244,12 +244,12 @@ export async function pasteExcalidrawContent(editor: Editor, clipboard: any, poi
 									normalizedAnchor: { x: 0.5, y: 0.5 },
 									isPrecise: false,
 									isExact: false,
-								}
+							  }
 							: {
 									type: 'point',
 									x: start[0],
 									y: start[1],
-								},
+							  },
 						end: endTargetId
 							? {
 									type: 'binding',
@@ -257,12 +257,12 @@ export async function pasteExcalidrawContent(editor: Editor, clipboard: any, poi
 									normalizedAnchor: { x: 0.5, y: 0.5 },
 									isPrecise: false,
 									isExact: false,
-								}
+							  }
 							: {
 									type: 'point',
 									x: end[0],
 									y: end[1],
-								},
+							  },
 						arrowheadEnd: arrowheadsToArrowheadTypes[element.endArrowhead] ?? 'none',
 						arrowheadStart: arrowheadsToArrowheadTypes[element.startArrowhead] ?? 'none',
 					},

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -420,11 +420,11 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							? {
 									x: commonBounds.width + 10,
 									y: 0,
-								}
+							  }
 							: {
 									x: 16 / editor.getZoomLevel(),
 									y: 16 / editor.getZoomLevel(),
-								}
+							  }
 					}
 
 					editor.mark('duplicate shapes')

--- a/packages/tldraw/src/lib/ui/hooks/useActionsMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActionsMenuSchema.tsx
@@ -80,8 +80,8 @@ export const ActionsMenuSchemaProvider = ({
 			allowGroup
 				? menuItem(actions['group'], { disabled: !twoSelected })
 				: allowUngroup
-					? menuItem(actions['ungroup'])
-					: menuItem(actions['group'], { disabled: !twoSelected }),
+				  ? menuItem(actions['ungroup'])
+				  : menuItem(actions['group'], { disabled: !twoSelected }),
 		]
 
 		if (overrides) {

--- a/packages/tldraw/src/lib/ui/overrides.ts
+++ b/packages/tldraw/src/lib/ui/overrides.ts
@@ -50,10 +50,12 @@ type DefaultHelpers = ReturnType<typeof useDefaultHelpers>
 
 export type TLUiOverride<Type, Helpers> = (editor: Editor, schema: Type, helpers: Helpers) => Type
 
-type WithDefaultHelpers<T extends TLUiOverride<any, any>> =
-	T extends TLUiOverride<infer Type, infer Helpers>
-		? TLUiOverride<Type, Helpers extends undefined ? DefaultHelpers : Helpers & DefaultHelpers>
-		: never
+type WithDefaultHelpers<T extends TLUiOverride<any, any>> = T extends TLUiOverride<
+	infer Type,
+	infer Helpers
+>
+	? TLUiOverride<Type, Helpers extends undefined ? DefaultHelpers : Helpers & DefaultHelpers>
+	: never
 
 /** @public */
 export type TLUiOverrides = Partial<{

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -222,7 +222,7 @@ export class TestEditor extends Editor {
 			? ({
 					target: 'shape',
 					shape: this.getShape(info as any),
-				} as T)
+			  } as T)
 			: info
 	}
 
@@ -267,18 +267,18 @@ export class TestEditor extends Editor {
 				key === 'Shift'
 					? 'ShiftLeft'
 					: key === 'Alt'
-						? 'AltLeft'
-						: key === 'Control' || key === 'Meta'
-							? 'CtrlLeft'
-							: key === ' '
-								? 'Space'
-								: key === 'Enter' ||
+					  ? 'AltLeft'
+					  : key === 'Control' || key === 'Meta'
+						  ? 'CtrlLeft'
+						  : key === ' '
+							  ? 'Space'
+							  : key === 'Enter' ||
 									  key === 'ArrowRight' ||
 									  key === 'ArrowLeft' ||
 									  key === 'ArrowUp' ||
 									  key === 'ArrowDown'
-									? key
-									: 'Key' + key[0].toUpperCase() + key.slice(1),
+								  ? key
+								  : 'Key' + key[0].toUpperCase() + key.slice(1),
 			type: 'keyboard',
 			key,
 		}

--- a/packages/tlschema/src/records/TLAsset.ts
+++ b/packages/tlschema/src/records/TLAsset.ts
@@ -61,7 +61,7 @@ export type TLAssetPartial<T extends TLAsset = TLAsset> = T extends T
 			type: T['type']
 			props?: Partial<T['props']>
 			meta?: Partial<T['meta']>
-		} & Partial<Omit<T, 'type' | 'id' | 'props' | 'meta'>>
+	  } & Partial<Omit<T, 'type' | 'id' | 'props' | 'meta'>>
 	: never
 
 /** @public */

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -364,12 +364,12 @@ export const instanceMigrations = defineMigrations({
 							opacity < 0.175
 								? '0.1'
 								: opacity < 0.375
-									? '0.25'
-									: opacity < 0.625
-										? '0.5'
-										: opacity < 0.875
-											? '0.75'
-											: '1',
+								  ? '0.25'
+								  : opacity < 0.625
+									  ? '0.5'
+									  : opacity < 0.875
+										  ? '0.75'
+										  : '1',
 					},
 				}
 			},

--- a/packages/tlschema/src/records/TLShape.ts
+++ b/packages/tlschema/src/records/TLShape.ts
@@ -60,7 +60,7 @@ export type TLShapePartial<T extends TLShape = TLShape> = T extends T
 			type: T['type']
 			props?: Partial<T['props']>
 			meta?: Partial<T['meta']>
-		} & Partial<Omit<T, 'type' | 'id' | 'props' | 'meta'>>
+	  } & Partial<Omit<T, 'type' | 'id' | 'props' | 'meta'>>
 	: never
 
 /** @public */
@@ -124,12 +124,12 @@ export const rootShapeMigrations = defineMigrations({
 							opacity < 0.175
 								? '0.1'
 								: opacity < 0.375
-									? '0.25'
-									: opacity < 0.625
-										? '0.5'
-										: opacity < 0.875
-											? '0.75'
-											: '1',
+								  ? '0.25'
+								  : opacity < 0.625
+									  ? '0.5'
+									  : opacity < 0.875
+										  ? '0.75'
+										  : '1',
 					},
 				}
 			},

--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -121,14 +121,14 @@ export const arrowShapeMigrations = defineMigrations({
 										isPrecise: !(
 											start.normalizedAnchor.x === 0.5 && start.normalizedAnchor.y === 0.5
 										),
-									}
+								  }
 								: start,
 						end:
 							(end as TLArrowShapeTerminal).type === 'binding'
 								? {
 										...end,
 										isPrecise: !(end.normalizedAnchor.x === 0.5 && end.normalizedAnchor.y === 0.5),
-									}
+								  }
 								: end,
 					},
 				}

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -58,9 +58,11 @@ export function deepCopy<T = unknown>(obj: T): T {
  *
  * @internal
  */
-export function objectMapKeys<Key extends string>(object: {
-	readonly [K in Key]: unknown
-}): Array<Key> {
+export function objectMapKeys<Key extends string>(
+	object: {
+		readonly [K in Key]: unknown
+	}
+): Array<Key> {
 	return Object.keys(object) as Key[]
 }
 
@@ -70,9 +72,11 @@ export function objectMapKeys<Key extends string>(object: {
  *
  * @internal
  */
-export function objectMapValues<Key extends string, Value>(object: {
-	[K in Key]: Value
-}): Array<Value> {
+export function objectMapValues<Key extends string, Value>(
+	object: {
+		[K in Key]: Value
+	}
+): Array<Value> {
 	return Object.values(object) as Value[]
 }
 
@@ -82,9 +86,11 @@ export function objectMapValues<Key extends string, Value>(object: {
  *
  * @internal
  */
-export function objectMapEntries<Key extends string, Value>(object: {
-	[K in Key]: Value
-}): Array<[Key, Value]> {
+export function objectMapEntries<Key extends string, Value>(
+	object: {
+		[K in Key]: Value
+	}
+): Array<[Key, Value]> {
 	return Object.entries(object) as [Key, Value][]
 }
 

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -242,9 +242,11 @@ export class ObjectValidator<Shape extends object> extends Validator<Shape> {
 	 * })
 	 * ```
 	 */
-	extend<Extension extends Record<string, unknown>>(extension: {
-		readonly [K in keyof Extension]: Validatable<Extension[K]>
-	}): ObjectValidator<Shape & Extension> {
+	extend<Extension extends Record<string, unknown>>(
+		extension: {
+			readonly [K in keyof Extension]: Validatable<Extension[K]>
+		}
+	): ObjectValidator<Shape & Extension> {
 		return new ObjectValidator({ ...this.config, ...extension }) as ObjectValidator<
 			Shape & Extension
 		>
@@ -470,9 +472,11 @@ export const unknownObject = new Validator<Record<string, unknown>>((value) => {
  *
  * @public
  */
-export function object<Shape extends object>(config: {
-	readonly [K in keyof Shape]: Validatable<Shape[K]>
-}): ObjectValidator<Shape> {
+export function object<Shape extends object>(
+	config: {
+		readonly [K in keyof Shape]: Validatable<Shape[K]>
+	}
+): ObjectValidator<Shape> {
 	return new ObjectValidator(config)
 }
 

--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -10,7 +10,7 @@ async function main() {
 
 		const nextVersion = latestVersion.prerelease.length
 			? // if the package is in prerelease mode, we want to release a canary for the current version rather than bumping
-				latestVersion
+			  latestVersion
 			: latestVersion?.inc(bump)
 		const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-canary.${sha}`
 

--- a/scripts/publish-new.ts
+++ b/scripts/publish-new.ts
@@ -46,7 +46,7 @@ async function main() {
 	const nextVersion = prereleaseTag
 		? `${latestVersion.major}.${latestVersion.minor}.${latestVersion.patch}-${prereleaseTag}.${
 				Number(prereleaseNumber) + 1
-			}`
+		  }`
 		: latestVersion.inc(bump).format()
 
 	setAllVersions(nextVersion)


### PR DESCRIPTION
Biome seems to be MUCH faster than Prettier. Unfortunately, it introduces some formatting changes around the ternary operator, so we have to update files in the repo. To make revert easier if we need it, the change is split into two PRs. This PR introduces a Biome CI check and reformats all files accordingly.

## Change Type
- [x] `minor` — New feature