### PR TITLE
Fix pinch zooming

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8588,11 +8588,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 							if (!inputs.isPinching) return
 
 							const {
+								point: { z = 1 },
 								delta: { x: dx, y: dy },
 							} = info
 
 							const { screenBounds } = this.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
-							const { x, y, z = 1 } = Vec.SubXY(info.point, screenBounds.x, screenBounds.y)
+							const { x, y } = Vec.SubXY(info.point, screenBounds.x, screenBounds.y)
 
 							const { x: cx, y: cy, z: cz } = this.getCamera()
 


### PR DESCRIPTION
This PR fixes pinch zooming not working on touch screens.

Tested on android chrome, windows, ipad.

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On a touch screen, try to pinch zoom in and out. Does it work?

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- None: Fixes an unreleased bug.
