### PR TITLE
arrows: account for another NaN

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2866,6 +2866,8 @@ export class Vec {
     // (undocumented)
     static FromArray(v: number[]): Vec;
     // (undocumented)
+    static IsNaN(A: VecLike): boolean;
+    // (undocumented)
     static Len(A: VecLike): number;
     // (undocumented)
     len(): number;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -45751,6 +45751,55 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Vec.IsNaN:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static IsNaN(A: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecLike",
+                  "canonicalReference": "@tldraw/editor!VecLike:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "A",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "IsNaN"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Vec#len:member(1)",
               "docComment": "",
               "excerptTokens": [

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -452,6 +452,10 @@ export class Vec {
 		return (A.y - B.y) / (A.x - B.x)
 	}
 
+	static IsNaN(A: VecLike): boolean {
+		return isNaN(A.x) || isNaN(A.y)
+	}
+
 	static Angle(A: VecLike, B: VecLike): number {
 		return Math.atan2(B.y - A.y, B.x - A.x)
 	}

--- a/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
@@ -33,7 +33,7 @@ function getArrowPoints(
 				  : ints[0]
 	}
 
-	if (isNaN(P0.x) || isNaN(P0.y)) {
+	if (Vec.IsNaN(P0)) {
 		P0 = info.start.point
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -96,6 +96,10 @@ export class PointingArrowLabel extends StateNode {
 			nextLabelPosition = getPointInArcT(measure, angleStart, angleEnd, _center.angle(nearestPoint))
 		}
 
+		if (isNaN(nextLabelPosition)) {
+			nextLabelPosition = 0.5
+		}
+
 		this.editor.updateShape<TLArrowShape>(
 			{ id: shape.id, type: shape.type, props: { labelPosition: nextLabelPosition } },
 			{ squashing: true }


### PR DESCRIPTION
This would happen when trying to translate a zero-width bound arrow.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes zero-width arrow NaN computation when moving the label.
