### PR TITLE
Remove Geometry2d.isSnappable

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -537,7 +537,6 @@ export class Edge2d extends Geometry2d {
     constructor(config: {
         start: Vec;
         end: Vec;
-        isSnappable?: boolean;
     });
     // (undocumented)
     d: Vec;
@@ -1021,8 +1020,6 @@ export abstract class Geometry2d {
     isLabel: boolean;
     // (undocumented)
     isPointInBounds(point: Vec, margin?: number): boolean;
-    // (undocumented)
-    isSnappable: boolean;
     // (undocumented)
     abstract nearestPoint(point: Vec): Vec;
     // (undocumented)

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -6442,7 +6442,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        isSnappable?: boolean;\n    }"
+                  "text": ";\n    }"
                 },
                 {
                   "kind": "Content",
@@ -20931,36 +20931,6 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "isPointInBounds"
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!Geometry2d#isSnappable:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "isSnappable: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "isSnappable",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
             },
             {
               "kind": "Method",

--- a/packages/editor/src/lib/primitives/geometry/Edge2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Edge2d.ts
@@ -10,7 +10,7 @@ export class Edge2d extends Geometry2d {
 	u: Vec
 	ul: number
 
-	constructor(config: { start: Vec; end: Vec; isSnappable?: boolean }) {
+	constructor(config: { start: Vec; end: Vec }) {
 		super({ ...config, isClosed: false, isFilled: false })
 		const { start, end } = config
 

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -6,7 +6,6 @@ export interface Geometry2dOptions {
 	isFilled: boolean
 	isClosed: boolean
 	isLabel?: boolean
-	isSnappable?: boolean
 	debugColor?: string
 	ignore?: boolean
 }
@@ -16,14 +15,12 @@ export abstract class Geometry2d {
 	isFilled = false
 	isClosed = true
 	isLabel = false
-	isSnappable = true
 	debugColor?: string
 	ignore?: boolean
 
 	constructor(opts: Geometry2dOptions) {
 		this.isFilled = opts.isFilled
 		this.isClosed = opts.isClosed
-		this.isSnappable = opts.isSnappable ?? false
 		this.isLabel = opts.isLabel ?? false
 		this.debugColor = opts.debugColor
 		this.ignore = opts.ignore

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -130,7 +130,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		return new Group2d({
 			children: [...(labelGeom ? [bodyGeom, labelGeom] : [bodyGeom]), ...debugGeom],
-			isSnappable: false,
 		})
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -299,7 +299,6 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					width: w,
 					height: h,
 					isFilled,
-					isSnappable: true,
 				})
 				break
 			}
@@ -333,12 +332,10 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					width: labelWidth,
 					height: labelHeight,
 					isFilled: true,
-					isSnappable: false,
 					isLabel: true,
 				}),
 				...edges,
 			],
-			isSnappable: false,
 		})
 	}
 


### PR DESCRIPTION
`Geometry2d.isSnappable` isn't used. There's some intended behaviour here around making it so you can't snap handles to text labels, but it's not actually working.

This is a breaking change, but given this property doesn't do anything I don't think it's likely to be heavily depended upon

### Change Type
- [x] `major` — Breaking change

