### PR TITLE
hotfix: Fix infinite cursor chat issue by partially reverting "reactive context menu overrides (#2697)" (#2775)

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
@@ -87,8 +87,8 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 		editor.getSortedChildIdsForParent(onlySelectedShape).length > 0
 	const isShapeLocked = onlySelectedShape && editor.isShapeOrAncestorLocked(onlySelectedShape)
 
-	const contextTLUiMenuSchemaWithoutOverrides = useMemo<TLUiMenuSchema>(() => {
-		return compactMenuItems([
+	const contextTLUiMenuSchema = useMemo<TLUiMenuSchema>(() => {
+		const contextTLUiMenuSchemaWithoutOverrides: TLUiMenuSchema = compactMenuItems([
 			menuGroup(
 				'selection',
 				showAutoSizeToggle && menuItem(actions['toggle-auto-size']),
@@ -204,6 +204,17 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 				),
 			oneSelected && !isShapeLocked && menuGroup('delete-group', menuItem(actions['delete'])),
 		])
+
+		if (!overrides) return contextTLUiMenuSchemaWithoutOverrides
+		return overrides(editor, contextTLUiMenuSchemaWithoutOverrides, {
+			actions,
+			oneSelected,
+			twoSelected,
+			threeSelected,
+			showAutoSizeToggle,
+			showUngroup: allowUngroup,
+			onlyFlippableShapeSelected,
+		})
 	}, [
 		actions,
 		oneSelected,
@@ -223,35 +234,9 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 		// oneEmbeddableBookmarkSelected,
 		isTransparentBg,
 		isShapeLocked,
+		editor,
+		overrides,
 	])
-
-	const contextTLUiMenuSchema = useValue(
-		'overrides',
-		() => {
-			if (!overrides) return contextTLUiMenuSchemaWithoutOverrides
-			return overrides(editor, contextTLUiMenuSchemaWithoutOverrides, {
-				actions,
-				oneSelected,
-				twoSelected,
-				threeSelected,
-				showAutoSizeToggle,
-				showUngroup: allowUngroup,
-				onlyFlippableShapeSelected,
-			})
-		},
-		[
-			actions,
-			allowUngroup,
-			contextTLUiMenuSchemaWithoutOverrides,
-			editor,
-			oneSelected,
-			onlyFlippableShapeSelected,
-			overrides,
-			showAutoSizeToggle,
-			threeSelected,
-			twoSelected,
-		]
-	)
 
 	return (
 		<TLUiContextMenuSchemaContext.Provider value={contextTLUiMenuSchema}>


### PR DESCRIPTION
Hotfixed from f185edcb76b5da78a8d40ce129861643e3d302d0

When we made context menu overrides, we introduced two new issues:
1. the context menu on the main app now updates much more frequently than it should
2. every time it updates, it adds a new 'cursor chat' entry to the menu

This reverts the part of that change that made the context menu reactive. This is the quick fix for us to hotfix, but i'm going to follow this up by restoring that functionality without those issues.
