### PR TITLE
menu: make menu items be disabled not disappear/reappear

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
@@ -176,19 +176,19 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 					),
 					menuGroup(
 						'selection',
-						showAutoSizeToggle && menuItem(actions['toggle-auto-size']),
-						showEditLink && menuItem(actions['edit-link']),
+						menuItem(actions['toggle-auto-size'], { disabled: !showAutoSizeToggle }),
+						menuItem(actions['edit-link'], { disabled: !showEditLink }),
 						menuItem(actions['duplicate'], { disabled: !oneSelected }),
-						allowGroup && menuItem(actions['group']),
-						allowUngroup && menuItem(actions['ungroup']),
+						menuItem(actions['group'], { disabled: !allowGroup }),
+						menuItem(actions['ungroup'], { disabled: !allowUngroup }),
 						menuItem(actions['unlock-all'], { disabled: emptyPage })
 					),
 					menuGroup('delete-group', menuItem(actions['delete'], { disabled: !oneSelected })),
 					menuGroup(
 						'embeds',
-						oneEmbedSelected && menuItem(actions['open-embed-link']),
-						oneEmbedSelected && menuItem(actions['convert-to-bookmark']),
-						oneEmbeddableBookmarkSelected && menuItem(actions['convert-to-embed'])
+						menuItem(actions['open-embed-link'], { disabled: !oneEmbedSelected }),
+						menuItem(actions['convert-to-bookmark'], { disabled: !oneEmbedSelected }),
+						menuItem(actions['convert-to-embed'], { disabled: !oneEmbeddableBookmarkSelected })
 					)
 				),
 				menuSubmenu(


### PR DESCRIPTION
Alternatively, we add a separate menu if we feel that this menu has too many items in it.
I'm thinking perhaps an "Object" menu, the way that Inkscape, say, has.

<img width="481" alt="Screenshot 2024-02-07 at 16 57 21" src="https://github.com/tldraw/tldraw/assets/469604/508669be-7f47-4b48-b634-275dc305f84e">


### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Menu: update Edit menu to be more consistent in its available options.
