### PR TITLE
Managers for better property caching for InstanceState & InstancePageState

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -273,7 +273,7 @@ You can get a shape using the shape's `id` or the shape record itself.
 You can use the [Editor#updateInstanceState](?) method to turn on read only mode.
 
 ```ts
-editor.updateInstanceState({ isReadonly: true })
+editor.instanceState.update({ isReadonly: true })
 ```
 
 ### Move the camera
@@ -289,7 +289,7 @@ editor.setCamera(0, 0, 1)
 You can prevent the user from changing the camera using the [Editor#updateInstanceState](?) method.
 
 ```ts
-editor.updateInstanceState({ canMoveCamera: false })
+editor.instanceState.update({ canMoveCamera: false })
 ```
 
 ### Turn on dark mode

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -270,7 +270,7 @@ You can get a shape using the shape's `id` or the shape record itself.
 
 ### Turn on read only mode
 
-You can use the [Editor#updateInstanceState](?) method to turn on read only mode.
+You can use the [InstanceStateManager#update](?) method to turn on read only mode.
 
 ```ts
 editor.instanceState.update({ isReadonly: true })
@@ -286,7 +286,7 @@ editor.setCamera(0, 0, 1)
 
 ### Freeze the camera
 
-You can prevent the user from changing the camera using the [Editor#updateInstanceState](?) method.
+You can prevent the user from changing the camera using the [InstanceStateManager#update](?) method.
 
 ```ts
 editor.instanceState.update({ canMoveCamera: false })

--- a/apps/dotcom/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
+++ b/apps/dotcom/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
@@ -59,7 +59,7 @@ export function BoardHistorySnapshot({
 					store={store}
 					assetUrls={assetUrls}
 					onMount={(editor) => {
-						editor.updateInstanceState({ isReadonly: true })
+						editor.instanceState.update({ isReadonly: true })
 						setTimeout(() => {
 							editor.setCurrentTool('hand')
 						})

--- a/apps/dotcom/src/components/CursorChatBubble.tsx
+++ b/apps/dotcom/src/components/CursorChatBubble.tsx
@@ -19,7 +19,8 @@ const CHAT_MESSAGE_TIMEOUT_CHATTING = 5000
 export const CursorChatBubble = track(function CursorChatBubble() {
 	const editor = useEditor()
 	const container = useContainer()
-	const { isChatting, chatMessage } = editor.getInstanceState()
+	const isChatting = editor.instanceState.getIsChatting()
+	const chatMessage = editor.instanceState.getChatMessage()
 
 	const rTimeout = useRef<any>(-1)
 	const [value, setValue] = useState('')
@@ -29,7 +30,7 @@ export const CursorChatBubble = track(function CursorChatBubble() {
 		if (closingUp || isChatting) {
 			const duration = isChatting ? CHAT_MESSAGE_TIMEOUT_CHATTING : CHAT_MESSAGE_TIMEOUT_CLOSING
 			rTimeout.current = setTimeout(() => {
-				editor.updateInstanceState({ chatMessage: '', isChatting: false })
+				editor.instanceState.update({ chatMessage: '', isChatting: false })
 				setValue('')
 				container.focus()
 			}, duration)
@@ -135,7 +136,7 @@ const CursorChatInput = track(function CursorChatInput({
 	}, [editor])
 
 	const stopChatting = useCallback(() => {
-		editor.updateInstanceState({ isChatting: false })
+		editor.instanceState.update({ isChatting: false })
 		container.focus()
 	}, [editor, container])
 
@@ -144,7 +145,7 @@ const CursorChatInput = track(function CursorChatInput({
 		(e: ChangeEvent<HTMLInputElement>) => {
 			const { value } = e.target
 			setValue(value.slice(0, 64))
-			editor.updateInstanceState({ chatMessage: value })
+			editor.instanceState.update({ chatMessage: value })
 		},
 		[editor, setValue]
 	)

--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -43,7 +43,7 @@ export function MultiplayerEditor({
 
 	const handleMount = useCallback(
 		(editor: Editor) => {
-			editor.updateInstanceState({ isReadonly: isReadOnly })
+			editor.instanceState.update({ isReadonly: isReadOnly })
 			editor.registerExternalAssetHandler('file', createAssetFromFile)
 			editor.registerExternalAssetHandler('url', createAssetFromUrl)
 		},

--- a/apps/dotcom/src/components/PeopleMenu/PeopleMenuItem.tsx
+++ b/apps/dotcom/src/components/PeopleMenu/PeopleMenuItem.tsx
@@ -18,7 +18,7 @@ export const PeopleMenuItem = track(function PeopleMenuItem({ userId }: { userId
 	const presence = usePresence(userId)
 
 	const handleFollowClick = useCallback(() => {
-		if (editor.getInstanceState().followingUserId === userId) {
+		if (editor.instanceState.getFollowingUserId() === userId) {
 			editor.stopFollowingUser()
 			trackEvent('stop-following', { source: 'people-menu' })
 		} else {
@@ -28,7 +28,7 @@ export const PeopleMenuItem = track(function PeopleMenuItem({ userId }: { userId
 	}, [editor, userId, trackEvent])
 
 	const theyAreFollowingYou = presence?.followingUserId === editor.user.getId()
-	const youAreFollowingThem = editor.getInstanceState().followingUserId === userId
+	const youAreFollowingThem = editor.instanceState.getFollowingUserId() === userId
 
 	if (!presence) return null
 

--- a/apps/dotcom/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/src/components/SnapshotsEditor.tsx
@@ -30,7 +30,7 @@ export function SnapshotsEditor(props: SnapshotEditorProps) {
 				overrides={[sharingUiOverrides, fileSystemUiOverrides, linksUiOverrides]}
 				onUiEvent={handleUiEvent}
 				onMount={(editor) => {
-					editor.updateInstanceState({ isReadonly: true })
+					editor.instanceState.update({ isReadonly: true })
 				}}
 				components={{
 					ErrorFallback: ({ error }) => {

--- a/apps/dotcom/src/utils/useCursorChat.ts
+++ b/apps/dotcom/src/utils/useCursorChat.ts
@@ -18,17 +18,17 @@ export function useCursorChat(): TLUiOverrides {
 						handleUiEvent('open-cursor-chat', { source })
 
 						// Don't open cursor chat if we're on a touch device
-						if (editor.getInstanceState().isCoarsePointer) {
+						if (editor.instanceState.getIsCoarsePointer()) {
 							return
 						}
 
-						editor.updateInstanceState({ isChatting: true })
+						editor.instanceState.update({ isChatting: true })
 					},
 				}
 				return actions
 			},
 			contextMenu(editor, contextMenu, { actions }) {
-				if (editor.getSelectedShapes().length > 0 || editor.getInstanceState().isCoarsePointer) {
+				if (editor.getSelectedShapes().length > 0 || editor.instanceState.getIsCoarsePointer()) {
 					return contextMenu
 				}
 

--- a/apps/dotcom/src/utils/useFileSystem.tsx
+++ b/apps/dotcom/src/utils/useFileSystem.tsx
@@ -76,13 +76,13 @@ export function useFileSystem({ isMultiplayer }: { isMultiplayer: boolean }): TL
 						if (!shouldOverride) return
 
 						transact(() => {
-							const isFocused = editor.getInstanceState().isFocused
+							const isFocused = editor.instanceState.getIsFocused()
 							editor.store.clear()
 							editor.store.ensureStoreIsUsable()
 							editor.history.clear()
 							editor.updateViewportScreenBounds()
 							editor.updateRenderingBounds()
-							editor.updateInstanceState({ isFocused })
+							editor.instanceState.update({ isFocused })
 						})
 					},
 				}

--- a/apps/examples/e2e/tests/export-snapshots.spec.ts
+++ b/apps/examples/e2e/tests/export-snapshots.spec.ts
@@ -195,11 +195,8 @@ test.describe('Export snapshots', () => {
 			await setupPage(page)
 			await page.evaluate((shapes) => {
 				editor.user.updateUserPreferences({ isDarkMode: true })
-				editor
-					.updateInstanceState({ exportBackground: false })
-					.selectAll()
-					.deleteShapes(editor.getSelectedShapeIds())
-					.createShapes(shapes)
+				editor.instanceState.update({ exportBackground: false })
+				editor.selectAll().deleteShapes(editor.getSelectedShapeIds()).createShapes(shapes)
 			}, shapes as any)
 
 			await snapshotTest(page)

--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -43,9 +43,9 @@ test.describe('Focus', () => {
 				({ id }) => {
 					if (
 						!(
-							EDITOR_A.getInstanceState().isFocused === (id === 'A') &&
-							EDITOR_B.getInstanceState().isFocused === (id === 'B') &&
-							EDITOR_C.getInstanceState().isFocused === (id === 'C')
+							EDITOR_A.instanceState.getIsFocused() === (id === 'A') &&
+							EDITOR_B.instanceState.getIsFocused() === (id === 'B') &&
+							EDITOR_C.instanceState.getIsFocused() === (id === 'C')
 						)
 					) {
 						throw Error('isFocused is not correct')

--- a/apps/examples/src/examples/inline/InlineExample.tsx
+++ b/apps/examples/src/examples/inline/InlineExample.tsx
@@ -38,7 +38,7 @@ function InlineEditor({ width, height }: { width: number; height: number }) {
 	const title = `${width} x ${height}`
 
 	const handleMount = (editor: Editor) => {
-		editor.updateInstanceState({ isDebugMode: false })
+		editor.instanceState.update({ isDebugMode: false })
 	}
 
 	return (

--- a/apps/examples/src/examples/readonly/ReadOnlyExample.tsx
+++ b/apps/examples/src/examples/readonly/ReadOnlyExample.tsx
@@ -7,7 +7,7 @@ export default function ReadOnlyExample() {
 			<Tldraw
 				persistenceKey="example"
 				onMount={(editor) => {
-					editor.updateInstanceState({ isReadonly: true })
+					editor.instanceState.update({ isReadonly: true })
 				}}
 			/>
 		</div>

--- a/apps/examples/src/examples/screenshot-tool/ScreenshotTool/childStates/Dragging.ts
+++ b/apps/examples/src/examples/screenshot-tool/ScreenshotTool/childStates/Dragging.ts
@@ -77,7 +77,7 @@ export class ScreenshotDragging extends StateNode {
 					editor,
 					shapes.map((s) => s.id),
 					'png',
-					{ bounds: box, background: editor.getInstanceState().exportBackground }
+					{ bounds: box, background: editor.instanceState.getExportBackground() }
 				)
 			} else {
 				// Export the shapes as a png
@@ -85,7 +85,7 @@ export class ScreenshotDragging extends StateNode {
 					editor,
 					shapes.map((s) => s.id),
 					'png',
-					{ bounds: box, background: editor.getInstanceState().exportBackground }
+					{ bounds: box, background: editor.instanceState.getExportBackground() }
 				)
 			}
 		}

--- a/apps/examples/src/examples/ui-events/codeSnippets.ts
+++ b/apps/examples/src/examples/ui-events/codeSnippets.ts
@@ -99,9 +99,9 @@ export function getCodeSnippet(name: string, data: any) {
 		if (data.id === 'media') {
 			codeSnippet = 'insertMedia()'
 		} else if (data.id.startsWith('geo-')) {
-			codeSnippet = `\n  editor.updateInstanceState({
+			codeSnippet = `\n  editor.instanceState.update({
   stylesForNextShape: {
-    ...editor.getInstanceState().stylesForNextShape,
+    ...editor.instanceState.getStylesForNextShape(),
     [GeoShapeGeoStyle.id]: '${data.id.replace('geo-', '')}',
   },
 }, { ephemeral: true });
@@ -130,7 +130,7 @@ if (updates.length > 0) {
 	} else if (name === 'stop-following') {
 		codeSnippet = `editor.stopFollowingUser()`
 	} else if (name === 'exit-pen-mode') {
-		codeSnippet = `editor.updateInstanceState({ isPenMode: false })`
+		codeSnippet = `editor.instanceState.update({ isPenMode: false })`
 	} else if (name === 'remove-frame') {
 		codeSnippet = `removeFrame(editor, editor.getSelectedShapes().map((shape) => shape.id))`
 	} else if (name === 'fit-frame-to-content') {
@@ -153,7 +153,7 @@ if (updates.length > 0) {
 			const prefName = PREFS_EVENT[name as keyof typeof PREFS_EVENT]
 			codeSnippet = userPrefName
 				? `editor.user.updateUserPreferences({ ${userPrefName}: <value> })`
-				: `editor.updateInstanceState({ ${prefName}: !editor.getInstanceState().${prefName} })`
+				: `editor.instanceState.update({ ${prefName}: !editor.getInstanceState().${prefName} })`
 		}
 	}
 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -423,8 +423,6 @@ export class CubicSpline2d extends Geometry2d {
 export class CurrentPageStateManager {
     constructor(editor: Editor);
     // (undocumented)
-    get(): TLInstancePageState;
-    // (undocumented)
     getCroppingShapeId(): TLShapeId | null;
     // (undocumented)
     getErasingShapeIds(): TLShapeId[];
@@ -436,6 +434,8 @@ export class CurrentPageStateManager {
     getId(): TLInstancePageStateId;
     // (undocumented)
     getMeta(): JsonObject;
+    // (undocumented)
+    getRecord(): TLInstancePageState;
     update(partial: CurrentPageStateUpdate, historyOptions?: TLCommandHistoryOptions): void;
     // @internal (undocumented)
     _update: (partial: Partial<Omit<TLInstancePageState, 'selectedShapeIds'>>, historyOptions?: Partial<{
@@ -1245,8 +1245,6 @@ export type HTMLContainerProps = React_3.HTMLAttributes<HTMLDivElement>;
 export class InstanceStateManager {
     constructor(editor: Editor);
     // (undocumented)
-    get(): TLInstance;
-    // (undocumented)
     getBrush(): BoxModel | null;
     // (undocumented)
     getCanMoveCamera(): boolean;
@@ -1302,6 +1300,8 @@ export class InstanceStateManager {
     getOpacityForNextShape(): number;
     // (undocumented)
     getOpenMenus(): string[];
+    // (undocumented)
+    getRecord(): TLInstance;
     // (undocumented)
     getScreenBounds(): BoxModel;
     // (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -50,7 +50,7 @@ import { TLHandle } from '@tldraw/tlschema';
 import { TLImageAsset } from '@tldraw/tlschema';
 import { TLInstance } from '@tldraw/tlschema';
 import { TLInstancePageState } from '@tldraw/tlschema';
-import { TLInstancePageStateId } from '@tldraw/tlschema/.tsbuild/records/TLPageState';
+import { TLInstancePageStateId } from '@tldraw/tlschema';
 import { TLInstancePresence } from '@tldraw/tlschema';
 import { TLPage } from '@tldraw/tlschema';
 import { TLPageId } from '@tldraw/tlschema';

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -50,6 +50,7 @@ import { TLHandle } from '@tldraw/tlschema';
 import { TLImageAsset } from '@tldraw/tlschema';
 import { TLInstance } from '@tldraw/tlschema';
 import { TLInstancePageState } from '@tldraw/tlschema';
+import { TLInstancePageStateId } from '@tldraw/tlschema/.tsbuild/records/TLPageState';
 import { TLInstancePresence } from '@tldraw/tlschema';
 import { TLPage } from '@tldraw/tlschema';
 import { TLPageId } from '@tldraw/tlschema';
@@ -419,6 +420,35 @@ export class CubicSpline2d extends Geometry2d {
 }
 
 // @public (undocumented)
+export class CurrentPageStateManager {
+    constructor(editor: Editor);
+    // (undocumented)
+    get(): TLInstancePageState;
+    // (undocumented)
+    getCroppingShapeId(): TLShapeId | null;
+    // (undocumented)
+    getErasingShapeIds(): TLShapeId[];
+    // (undocumented)
+    getHintingShapeIds(): TLShapeId[];
+    // (undocumented)
+    getHoveredShapeId(): TLShapeId | null;
+    // (undocumented)
+    getId(): TLInstancePageStateId;
+    // (undocumented)
+    getMeta(): JsonObject;
+    update(partial: CurrentPageStateUpdate, historyOptions?: TLCommandHistoryOptions): void;
+    // @internal (undocumented)
+    _update: (partial: Partial<Omit<TLInstancePageState, 'selectedShapeIds'>>, historyOptions?: Partial<{
+        squashing: boolean;
+        ephemeral: boolean;
+        preservesRedoStack: boolean;
+    }> | undefined) => Editor;
+}
+
+// @public (undocumented)
+export type CurrentPageStateUpdate = Partial<Omit<TLInstancePageState, 'editingShapeId' | 'focusedGroupId' | 'pageId' | 'selectedShapeIds'>>;
+
+// @public (undocumented)
 export function dataUrlToFile(url: string, filename: string, mimeType: string): Promise<File>;
 
 // @internal (undocumented)
@@ -626,6 +656,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     createPage(page: Partial<TLPage>): this;
     createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this;
     createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this;
+    // (undocumented)
+    currentPageState: CurrentPageStateManager;
     deleteAssets(assets: TLAsset[] | TLAssetId[]): this;
     deleteOpenMenu(id: string): this;
     deletePage(page: TLPage | TLPageId): this;
@@ -687,6 +719,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getCurrentPageShapeIds(): Set<TLShapeId>;
     getCurrentPageShapes(): TLShape[];
     getCurrentPageShapesSorted(): TLShape[];
+    // @deprecated
     getCurrentPageState(): TLInstancePageState;
     getCurrentTool(): StateNode;
     getCurrentToolId(): string;
@@ -704,6 +737,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getHoveredShape(): TLShape | undefined;
     getHoveredShapeId(): null | TLShapeId;
     getInitialMetaForShape(_shape: TLShape): JsonObject;
+    // @deprecated
     getInstanceState(): TLInstance;
     getIsMenuOpen(): boolean;
     getOnlySelectedShape(): null | TLShape;
@@ -802,6 +836,8 @@ export class Editor extends EventEmitter<TLEventMap> {
         isPanning: boolean;
         pointerVelocity: Vec;
     };
+    // (undocumented)
+    readonly instanceState: InstanceStateManager;
     interrupt(): this;
     isAncestorSelected(shape: TLShape | TLShapeId): boolean;
     isIn(path: string): boolean;
@@ -904,9 +940,11 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     ungroupShapes(ids: TLShape[]): this;
     updateAssets(assets: TLAssetPartial[]): this;
-    updateCurrentPageState(partial: Partial<Omit<TLInstancePageState, 'editingShapeId' | 'focusedGroupId' | 'pageId' | 'selectedShapeIds'>>, historyOptions?: TLCommandHistoryOptions): this;
+    // @deprecated
+    updateCurrentPageState(partial: CurrentPageStateUpdate, historyOptions?: TLCommandHistoryOptions): this;
     updateDocumentSettings(settings: Partial<TLDocument>): this;
-    updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, historyOptions?: TLCommandHistoryOptions): this;
+    // @deprecated
+    updateInstanceState(partial: InstanceStateUpdate, historyOptions?: TLCommandHistoryOptions): this;
     updatePage(partial: RequiredKeys<TLPage, 'id'>, historyOptions?: TLCommandHistoryOptions): this;
     // @internal
     updateRenderingBounds(): this;
@@ -1202,6 +1240,81 @@ export function HTMLContainer({ children, className, ...rest }: HTMLContainerPro
 
 // @public (undocumented)
 export type HTMLContainerProps = React_3.HTMLAttributes<HTMLDivElement>;
+
+// @public (undocumented)
+export class InstanceStateManager {
+    constructor(editor: Editor);
+    // (undocumented)
+    get(): TLInstance;
+    // (undocumented)
+    getBrush(): BoxModel | null;
+    // (undocumented)
+    getCanMoveCamera(): boolean;
+    // (undocumented)
+    getChatMessage(): string;
+    // (undocumented)
+    getCurrentPageId(): TLPageId;
+    // (undocumented)
+    getCursor(): TLCursor;
+    // (undocumented)
+    getDevicePixelRatio(): number;
+    // (undocumented)
+    getDuplicateProps(): {
+        shapeIds: TLShapeId[];
+        offset: {
+            x: number;
+            y: number;
+        };
+    } | null;
+    // (undocumented)
+    getExportBackground(): boolean;
+    // (undocumented)
+    getFollowingUserId(): null | string;
+    // (undocumented)
+    getHighlightedUserIds(): string[];
+    // (undocumented)
+    getInsets(): boolean[];
+    // (undocumented)
+    getIsChangingStyle(): boolean;
+    // (undocumented)
+    getIsChatting(): boolean;
+    // (undocumented)
+    getIsCoarsePointer(): boolean;
+    // (undocumented)
+    getIsDebugMode(): boolean;
+    // (undocumented)
+    getIsFocused(): boolean;
+    // (undocumented)
+    getIsFocusMode(): boolean;
+    // (undocumented)
+    getIsGridMode(): boolean;
+    // (undocumented)
+    getIsHoveringCanvas(): boolean | null;
+    // (undocumented)
+    getIsPenMode(): boolean;
+    // (undocumented)
+    getIsReadonly(): boolean;
+    // (undocumented)
+    getIsToolLocked(): boolean;
+    // (undocumented)
+    getMeta(): JsonObject;
+    // (undocumented)
+    getOpacityForNextShape(): number;
+    // (undocumented)
+    getOpenMenus(): string[];
+    // (undocumented)
+    getScreenBounds(): BoxModel;
+    // (undocumented)
+    getScribbles(): TLScribble[];
+    // (undocumented)
+    getStylesForNextShape(): Record<string, unknown>;
+    // (undocumented)
+    getZoomBrush(): BoxModel | null;
+    update(partial: InstanceStateUpdate, historyOptions?: TLCommandHistoryOptions): void;
+}
+
+// @public (undocumented)
+export type InstanceStateUpdate = Partial<Omit<TLInstance, 'currentPageId'>>;
 
 // @public
 export function intersectCircleCircle(c1: VecLike, r1: number, c2: VecLike, r2: number): Vec[];

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -5964,38 +5964,6 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#get:member(1)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "get(): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLInstancePageState",
-                  "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "get"
-            },
-            {
-              "kind": "Method",
               "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getCroppingShapeId:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -6225,6 +6193,38 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "getMeta"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getRecord:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getRecord(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLInstancePageState",
+                  "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getRecord"
             },
             {
               "kind": "Method",
@@ -24202,38 +24202,6 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "@tldraw/editor!InstanceStateManager#get:member(1)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "get(): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLInstance",
-                  "canonicalReference": "@tldraw/tlschema!TLInstance:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "get"
-            },
-            {
-              "kind": "Method",
               "canonicalReference": "@tldraw/editor!InstanceStateManager#getBrush:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -25039,6 +25007,38 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "getOpenMenus"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getRecord:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getRecord(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLInstance",
+                  "canonicalReference": "@tldraw/tlschema!TLInstance:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getRecord"
             },
             {
               "kind": "Method",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -6133,7 +6133,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "import(\"@tldraw/tlschema/.tsbuild/records/TLPageState\")."
+                  "text": "import(\"@tldraw/tlschema\")."
                 },
                 {
                   "kind": "Reference",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -5923,7 +5923,7 @@
               "text": "export declare class CurrentPageStateManager "
             }
           ],
-          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstancePageStateManager.ts",
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts",
           "releaseTag": "Public",
           "isAbstract": false,
           "name": "CurrentPageStateManager",
@@ -6336,7 +6336,7 @@
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstancePageStateManager.ts",
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts",
           "releaseTag": "Public",
           "name": "CurrentPageStateUpdate",
           "typeTokenRange": {

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -5914,6 +5914,437 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "Class",
+          "canonicalReference": "@tldraw/editor!CurrentPageStateManager:class",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class CurrentPageStateManager "
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstancePageStateManager.ts",
+          "releaseTag": "Public",
+          "isAbstract": false,
+          "name": "CurrentPageStateManager",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "Constructor",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager:constructor(1)",
+              "docComment": "/**\n * Constructs a new instance of the `CurrentPageStateManager` class\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "constructor(editor: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Editor",
+                  "canonicalReference": "@tldraw/editor!Editor:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "editor",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ]
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#get:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "get(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLInstancePageState",
+                  "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "get"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getCroppingShapeId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getCroppingShapeId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getCroppingShapeId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getErasingShapeIds:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getErasingShapeIds(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getErasingShapeIds"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getHintingShapeIds:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getHintingShapeIds(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getHintingShapeIds"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getHoveredShapeId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getHoveredShapeId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getHoveredShapeId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema/.tsbuild/records/TLPageState\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLInstancePageStateId",
+                  "canonicalReference": "@tldraw/tlschema!TLInstancePageStateId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#getMeta:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getMeta(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/utils\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonObject",
+                  "canonicalReference": "@tldraw/utils!JsonObject:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getMeta"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!CurrentPageStateManager#update:member(1)",
+              "docComment": "/**\n * Update this instance's page state.\n *\n * @param partial - The partial of the page state object containing the changes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' })\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })\n * ```\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "update(partial: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CurrentPageStateUpdate",
+                  "canonicalReference": "@tldraw/editor!CurrentPageStateUpdate:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", historyOptions?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLCommandHistoryOptions",
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "partial",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "historyOptions",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": true
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "update"
+            }
+          ],
+          "implementsTokenRanges": []
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/editor!CurrentPageStateUpdate:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type CurrentPageStateUpdate = "
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Omit",
+              "canonicalReference": "!Omit:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TLInstancePageState",
+              "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ", 'editingShapeId' | 'focusedGroupId' | 'pageId' | 'selectedShapeIds'>>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstancePageStateManager.ts",
+          "releaseTag": "Public",
+          "name": "CurrentPageStateUpdate",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 7
+          }
+        },
+        {
           "kind": "Function",
           "canonicalReference": "@tldraw/editor!dataUrlToFile:function(1)",
           "docComment": "/**\n * @public\n */\n",
@@ -8169,6 +8600,37 @@
               "name": "createShapes"
             },
             {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!Editor#currentPageState:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "currentPageState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CurrentPageStateManager",
+                  "canonicalReference": "@tldraw/editor!CurrentPageStateManager:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "currentPageState",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#deleteAssets:member(1)",
               "docComment": "/**\n * Delete one or more assets.\n *\n * @param ids - The assets to delete.\n *\n * @example\n * ```ts\n * editor.deleteAssets(['asset1', 'asset2'])\n * ```\n *\n * @public\n */\n",
@@ -10119,7 +10581,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getCurrentPageState:member(1)",
-              "docComment": "/**\n * The current page state.\n *\n * @public\n */\n",
+              "docComment": "/**\n * The current page state.\n *\n * @deprecated\n *\n * Use the getters on {@link CurrentPageStateManager} instead.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10821,7 +11283,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getInstanceState:member(1)",
-              "docComment": "/**\n * The current instance's state.\n *\n * @public\n */\n",
+              "docComment": "/**\n * The current instance's state.\n *\n * @deprecated\n *\n * Use the accessors on {@link InstanceStateManager} instead.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -13996,6 +14458,37 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 20
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!Editor#instanceState:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly instanceState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "InstanceStateManager",
+                  "canonicalReference": "@tldraw/editor!InstanceStateManager:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "instanceState",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
               },
               "isStatic": false,
               "isProtected": false,
@@ -18241,7 +18734,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateCurrentPageState:member(1)",
-              "docComment": "/**\n * Update this instance's page state.\n *\n * @param partial - The partial of the page state object containing the changes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' })\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })\n * ```\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update this instance's page state.\n *\n * @deprecated\n *\n * Use {@link CurrentPageStateManager.update} instead.\n *\n * @param partial - The partial of the page state object containing the changes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' })\n * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18249,30 +18742,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Partial",
-                  "canonicalReference": "!Partial:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Omit",
-                  "canonicalReference": "!Omit:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLInstancePageState",
-                  "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", 'editingShapeId' | 'focusedGroupId' | 'pageId' | 'selectedShapeIds'>>"
+                  "text": "CurrentPageStateUpdate",
+                  "canonicalReference": "@tldraw/editor!CurrentPageStateUpdate:type"
                 },
                 {
                   "kind": "Content",
@@ -18298,8 +18769,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 10,
-                "endIndex": 11
+                "startIndex": 5,
+                "endIndex": 6
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -18309,15 +18780,15 @@
                   "parameterName": "partial",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 7
+                    "endIndex": 2
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "historyOptions",
                   "parameterTypeTokenRange": {
-                    "startIndex": 8,
-                    "endIndex": 9
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": true
                 }
@@ -18391,7 +18862,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#updateInstanceState:member(1)",
-              "docComment": "/**\n * Update the instance's state.\n *\n * @param partial - A partial object to update the instance state with.\n *\n * @param historyOptions - The history options for the change.\n *\n * @public\n */\n",
+              "docComment": "/**\n * Update the instance's state.\n *\n * @deprecated\n *\n * Use {@link InstanceStateManager.update} instead.\n *\n * @param partial - A partial object to update the instance state with.\n *\n * @param historyOptions - The history options for the change.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18399,30 +18870,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Partial",
-                  "canonicalReference": "!Partial:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Omit",
-                  "canonicalReference": "!Omit:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLInstance",
-                  "canonicalReference": "@tldraw/tlschema!TLInstance:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", 'currentPageId'>>"
+                  "text": "InstanceStateUpdate",
+                  "canonicalReference": "@tldraw/editor!InstanceStateUpdate:type"
                 },
                 {
                   "kind": "Content",
@@ -18448,8 +18897,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 10,
-                "endIndex": 11
+                "startIndex": 5,
+                "endIndex": 6
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -18459,15 +18908,15 @@
                   "parameterName": "partial",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 7
+                    "endIndex": 2
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "historyOptions",
                   "parameterTypeTokenRange": {
-                    "startIndex": 8,
-                    "endIndex": 9
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": true
                 }
@@ -23700,6 +24149,1165 @@
           "typeTokenRange": {
             "startIndex": 1,
             "endIndex": 5
+          }
+        },
+        {
+          "kind": "Class",
+          "canonicalReference": "@tldraw/editor!InstanceStateManager:class",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class InstanceStateManager "
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstanceStateManager.ts",
+          "releaseTag": "Public",
+          "isAbstract": false,
+          "name": "InstanceStateManager",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "Constructor",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager:constructor(1)",
+              "docComment": "/**\n * Constructs a new instance of the `InstanceStateManager` class\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "constructor(editor: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Editor",
+                  "canonicalReference": "@tldraw/editor!Editor:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "editor",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ]
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#get:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "get(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLInstance",
+                  "canonicalReference": "@tldraw/tlschema!TLInstance:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "get"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getBrush:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getBrush(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BoxModel",
+                  "canonicalReference": "@tldraw/tlschema!BoxModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getBrush"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getCanMoveCamera:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getCanMoveCamera(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getCanMoveCamera"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getChatMessage:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getChatMessage(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getChatMessage"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getCurrentPageId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getCurrentPageId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLPageId",
+                  "canonicalReference": "@tldraw/tlschema!TLPageId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getCurrentPageId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getCursor:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getCursor(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLCursor",
+                  "canonicalReference": "@tldraw/tlschema!TLCursor:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getCursor"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getDevicePixelRatio:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getDevicePixelRatio(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getDevicePixelRatio"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getDuplicateProps:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getDuplicateProps(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        shapeIds: import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[];\n        offset: {\n            x: number;\n            y: number;\n        };\n    } | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getDuplicateProps"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getExportBackground:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getExportBackground(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getExportBackground"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getFollowingUserId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getFollowingUserId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "null | string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getFollowingUserId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getHighlightedUserIds:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getHighlightedUserIds(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getHighlightedUserIds"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getInsets:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getInsets(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getInsets"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsChangingStyle:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsChangingStyle(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsChangingStyle"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsChatting:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsChatting(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsChatting"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsCoarsePointer:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsCoarsePointer(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsCoarsePointer"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsDebugMode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsDebugMode(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsDebugMode"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsFocused:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsFocused(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsFocused"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsFocusMode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsFocusMode(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsFocusMode"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsGridMode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsGridMode(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsGridMode"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsHoveringCanvas:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsHoveringCanvas(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsHoveringCanvas"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsPenMode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsPenMode(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsPenMode"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsReadonly:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsReadonly(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsReadonly"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getIsToolLocked:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getIsToolLocked(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getIsToolLocked"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getMeta:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getMeta(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/utils\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "JsonObject",
+                  "canonicalReference": "@tldraw/utils!JsonObject:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getMeta"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getOpacityForNextShape:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getOpacityForNextShape(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getOpacityForNextShape"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getOpenMenus:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getOpenMenus(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getOpenMenus"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getScreenBounds:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getScreenBounds(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BoxModel",
+                  "canonicalReference": "@tldraw/tlschema!BoxModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getScreenBounds"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getScribbles:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getScribbles(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLScribble",
+                  "canonicalReference": "@tldraw/tlschema!TLScribble:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getScribbles"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getStylesForNextShape:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getStylesForNextShape(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getStylesForNextShape"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#getZoomBrush:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getZoomBrush(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import(\"@tldraw/tlschema\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BoxModel",
+                  "canonicalReference": "@tldraw/tlschema!BoxModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getZoomBrush"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!InstanceStateManager#update:member(1)",
+              "docComment": "/**\n * Update the instance's state.\n *\n * @param partial - A partial object to update the instance state with.\n *\n * @param historyOptions - The history options for the change.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "update(partial: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "InstanceStateUpdate",
+                  "canonicalReference": "@tldraw/editor!InstanceStateUpdate:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", historyOptions?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLCommandHistoryOptions",
+                  "canonicalReference": "@tldraw/editor!TLCommandHistoryOptions:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "partial",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "historyOptions",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": true
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "update"
+            }
+          ],
+          "implementsTokenRanges": []
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/editor!InstanceStateUpdate:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type InstanceStateUpdate = "
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Omit",
+              "canonicalReference": "!Omit:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TLInstance",
+              "canonicalReference": "@tldraw/tlschema!TLInstance:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ", 'currentPageId'>>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/managers/InstanceStateManager.ts",
+          "releaseTag": "Public",
+          "name": "InstanceStateUpdate",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 7
           }
         },
         {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -146,6 +146,14 @@ export {
 	type TLEditorOptions,
 	type TLResizeShapeOptions,
 } from './lib/editor/Editor'
+export {
+	CurrentPageStateManager,
+	CurrentPageStateUpdate,
+} from './lib/editor/managers/InstancePageStateManager'
+export {
+	InstanceStateManager,
+	InstanceStateUpdate,
+} from './lib/editor/managers/InstanceStateManager'
 export type {
 	TLAfterChangeHandler,
 	TLAfterCreateHandler,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -149,7 +149,7 @@ export {
 export {
 	CurrentPageStateManager,
 	CurrentPageStateUpdate,
-} from './lib/editor/managers/InstancePageStateManager'
+} from './lib/editor/managers/CurrentPageStateManager'
 export {
 	InstanceStateManager,
 	InstanceStateUpdate,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -148,11 +148,11 @@ export {
 } from './lib/editor/Editor'
 export {
 	CurrentPageStateManager,
-	CurrentPageStateUpdate,
+	type CurrentPageStateUpdate,
 } from './lib/editor/managers/CurrentPageStateManager'
 export {
 	InstanceStateManager,
-	InstanceStateUpdate,
+	type InstanceStateUpdate,
 } from './lib/editor/managers/InstanceStateManager'
 export type {
 	TLAfterChangeHandler,

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -139,7 +139,7 @@ function GridWrapper() {
 	const editor = useEditor()
 	const gridSize = useValue('gridSize', () => editor.getDocumentSettings().gridSize, [editor])
 	const { x, y, z } = useValue('camera', () => editor.getCamera(), [editor])
-	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
+	const isGridMode = useValue('isGridMode', () => editor.instanceState.getIsGridMode(), [editor])
 	const { Grid } = useEditorComponents()
 
 	if (!(Grid && isGridMode)) return null
@@ -149,7 +149,7 @@ function GridWrapper() {
 
 function ScribbleWrapper() {
 	const editor = useEditor()
-	const scribbles = useValue('scribbles', () => editor.getInstanceState().scribbles, [editor])
+	const scribbles = useValue('scribbles', () => editor.instanceState.getScribbles(), [editor])
 	const zoomLevel = useValue('zoomLevel', () => editor.getZoomLevel(), [editor])
 	const { Scribble } = useEditorComponents()
 
@@ -171,7 +171,7 @@ function ScribbleWrapper() {
 
 function BrushWrapper() {
 	const editor = useEditor()
-	const brush = useValue('brush', () => editor.getInstanceState().brush, [editor])
+	const brush = useValue('brush', () => editor.instanceState.getBrush(), [editor])
 	const { Brush } = useEditorComponents()
 
 	if (!(Brush && brush)) return null
@@ -181,7 +181,7 @@ function BrushWrapper() {
 
 function ZoomBrushWrapper() {
 	const editor = useEditor()
-	const zoomBrush = useValue('zoomBrush', () => editor.getInstanceState().zoomBrush, [editor])
+	const zoomBrush = useValue('zoomBrush', () => editor.instanceState.getZoomBrush(), [editor])
 	const { ZoomBrush } = useEditorComponents()
 
 	if (!(ZoomBrush && zoomBrush)) return null
@@ -212,17 +212,17 @@ function HandlesWrapper() {
 
 	const zoomLevel = useValue('zoomLevel', () => editor.getZoomLevel(), [editor])
 
-	const isCoarse = useValue('coarse pointer', () => editor.getInstanceState().isCoarsePointer, [
+	const isCoarse = useValue('coarse pointer', () => editor.instanceState.getIsCoarsePointer(), [
 		editor,
 	])
 
-	const isReadonly = useValue('isChangingStyle', () => editor.getInstanceState().isReadonly, [
+	const isReadonly = useValue('isChangingStyle', () => editor.instanceState.getIsReadonly(), [
 		editor,
 	])
 
 	const isChangingStyle = useValue(
 		'isChangingStyle',
-		() => editor.getInstanceState().isChangingStyle,
+		() => editor.instanceState.getIsChangingStyle(),
 		[editor]
 	)
 
@@ -354,11 +354,9 @@ function ShapesToDisplay() {
 
 function SelectedIdIndicators() {
 	const editor = useEditor()
-	const selectedShapeIds = useValue(
-		'selectedShapeIds',
-		() => editor.getCurrentPageState().selectedShapeIds,
-		[editor]
-	)
+	const selectedShapeIds = useValue('selectedShapeIds', () => editor.getSelectedShapeIds(), [
+		editor,
+	])
 	const shouldDisplay = useValue(
 		'should display selected ids',
 		() => {
@@ -372,7 +370,7 @@ function SelectedIdIndicators() {
 					'select.pointing_shape',
 					'select.pointing_selection',
 					'select.pointing_handle'
-				) && !editor.getInstanceState().isChangingStyle
+				) && !editor.instanceState.getIsChangingStyle()
 			)
 		},
 		[editor]
@@ -394,17 +392,15 @@ const HoveredShapeIndicator = function HoveredShapeIndicator() {
 	const { HoveredShapeIndicator } = useEditorComponents()
 	const isCoarsePointer = useValue(
 		'coarse pointer',
-		() => editor.getInstanceState().isCoarsePointer,
+		() => editor.instanceState.getIsCoarsePointer(),
 		[editor]
 	)
 	const isHoveringCanvas = useValue(
 		'hovering canvas',
-		() => editor.getInstanceState().isHoveringCanvas,
+		() => editor.instanceState.getIsHoveringCanvas(),
 		[editor]
 	)
-	const hoveredShapeId = useValue('hovered id', () => editor.getCurrentPageState().hoveredShapeId, [
-		editor,
-	])
+	const hoveredShapeId = useValue('hovered id', () => editor.getHoveredShapeId(), [editor])
 
 	if (isCoarsePointer || !isHoveringCanvas || !hoveredShapeId || !HoveredShapeIndicator) return null
 
@@ -485,7 +481,7 @@ const DebugSvgCopy = track(function DupSvg({ id }: { id: TLShapeId }) {
 			const bb = editor.getShapePageBounds(id)
 			const el = await editor.getSvg([id], {
 				padding: 0,
-				background: editor.getInstanceState().exportBackground,
+				background: editor.instanceState.getExportBackground(),
 			})
 			if (el && bb && latest === renderId) {
 				el.style.setProperty('overflow', 'visible')

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -38,7 +38,8 @@ const CollaboratorGuard = track(function CollaboratorGuard({
 
 	switch (collaboratorState) {
 		case 'inactive': {
-			const { followingUserId, highlightedUserIds } = editor.getInstanceState()
+			const followingUserId = editor.instanceState.getFollowingUserId()
+			const highlightedUserIds = editor.instanceState.getHighlightedUserIds()
 			// If they're inactive and unless we're following them or they're highlighted, hide them
 			if (!(followingUserId === presence.userId || highlightedUserIds.includes(presence.userId))) {
 				return null
@@ -46,7 +47,7 @@ const CollaboratorGuard = track(function CollaboratorGuard({
 			break
 		}
 		case 'idle': {
-			const { highlightedUserIds } = editor.getInstanceState()
+			const highlightedUserIds = editor.instanceState.getHighlightedUserIds()
 			// If they're idle and following us and unless they have a chat message or are highlighted, hide them
 			if (
 				presence.followingUserId === editor.user.getId() &&

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -81,7 +81,7 @@ export const Shape = track(function Shape({
 			if (!shape) return null
 
 			const bounds = editor.getShapeGeometry(shape).bounds
-			const dpr = Math.floor(editor.getInstanceState().devicePixelRatio * 100) / 100
+			const dpr = Math.floor(editor.instanceState.getDevicePixelRatio() * 100) / 100
 			// dprMultiple is the smallest number we can multiply dpr by to get an integer
 			// it's usually 1, 2, or 4 (for e.g. dpr of 2, 2.5 and 2.25 respectively)
 			const dprMultiple = nearestMultiple(dpr)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -103,12 +103,9 @@ import { arrowBindingsIndex } from './derivations/arrowBindingsIndex'
 import { parentsToChildren } from './derivations/parentsToChildren'
 import { deriveShapeIdsInCurrentPage } from './derivations/shapeIdsInCurrentPage'
 import { ClickManager } from './managers/ClickManager'
+import { CurrentPageStateManager, CurrentPageStateUpdate } from './managers/CurrentPageStateManager'
 import { EnvironmentManager } from './managers/EnvironmentManager'
 import { HistoryManager } from './managers/HistoryManager'
-import {
-	CurrentPageStateManager,
-	CurrentPageStateUpdate,
-} from './managers/InstancePageStateManager'
 import { InstanceStateManager, InstanceStateUpdate } from './managers/InstanceStateManager'
 import { ScribbleManager } from './managers/ScribbleManager'
 import { SideEffectManager } from './managers/SideEffectManager'

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -490,7 +490,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			const backupPageId = this.getPages().find((p) => p.id !== record.id)?.id
 			if (!backupPageId) return
-			this.store.put([{ ...this.instanceState.get(), currentPageId: backupPageId }])
+			this.store.put([{ ...this.instanceState.getRecord(), currentPageId: backupPageId }])
 
 			// delete the camera and state for the page if necessary
 			const cameraId = CameraRecordType.createId(record.id)
@@ -1346,7 +1346,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getCurrentPageState(): TLInstancePageState {
-		return this.currentPageState.get()
+		return this.currentPageState.getRecord()
 	}
 
 	/**
@@ -1378,7 +1378,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getSelectedShapeIds() {
-		return this.currentPageState.get().selectedShapeIds
+		return this.currentPageState.getRecord().selectedShapeIds
 	}
 
 	/**
@@ -1418,7 +1418,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	private _setSelectedShapes = this.history.createCommand(
 		'setSelectedShapes',
 		(ids: TLShapeId[], historyOptions?: TLCommandHistoryOptions) => {
-			const { selectedShapeIds: prevSelectedShapeIds } = this.currentPageState.get()
+			const { selectedShapeIds: prevSelectedShapeIds } = this.currentPageState.getRecord()
 			const prevSet = new Set(prevSelectedShapeIds)
 
 			if (ids.length === prevSet.size && ids.every((id) => prevSet.has(id))) return null
@@ -1431,12 +1431,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		},
 		{
 			do: ({ selectedShapeIds }) => {
-				this.store.put([{ ...this.currentPageState.get(), selectedShapeIds }])
+				this.store.put([{ ...this.currentPageState.getRecord(), selectedShapeIds }])
 			},
 			undo: ({ prevSelectedShapeIds }) => {
 				this.store.put([
 					{
-						...this.currentPageState.get(),
+						...this.currentPageState.getRecord(),
 						selectedShapeIds: prevSelectedShapeIds,
 					},
 				])
@@ -1646,7 +1646,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getFocusedGroupId(): TLShapeId | TLPageId {
-		return this.currentPageState.get().focusedGroupId ?? this.getCurrentPageId()
+		return this.currentPageState.getRecord().focusedGroupId ?? this.getCurrentPageId()
 	}
 
 	/**
@@ -1691,7 +1691,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	private _setFocusedGroupId = this.history.createCommand(
 		'setFocusedGroupId',
 		(next: TLShapeId | null) => {
-			const prev = this.currentPageState.get().focusedGroupId
+			const prev = this.currentPageState.getRecord().focusedGroupId
 			if (prev === next) return
 			return {
 				data: {
@@ -1746,7 +1746,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getEditingShapeId(): TLShapeId | null {
-		return this.currentPageState.get().editingShapeId
+		return this.currentPageState.getRecord().editingShapeId
 	}
 
 	/**
@@ -1798,7 +1798,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getHoveredShapeId(): TLShapeId | null {
-		return this.currentPageState.get().hoveredShapeId
+		return this.currentPageState.getRecord().hoveredShapeId
 	}
 
 	/**
@@ -1838,7 +1838,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getHintingShapeIds() {
-		return this.currentPageState.get().hintingShapeIds
+		return this.currentPageState.getRecord().hintingShapeIds
 	}
 	/**
 	 * The editor's current hinting shapes.
@@ -1881,7 +1881,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getErasingShapeIds() {
-		return this.currentPageState.get().erasingShapeIds
+		return this.currentPageState.getRecord().erasingShapeIds
 	}
 
 	/**
@@ -1940,7 +1940,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	getCroppingShapeId() {
-		return this.currentPageState.get().croppingShapeId
+		return this.currentPageState.getRecord().croppingShapeId
 	}
 
 	/**
@@ -3313,7 +3313,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					])
 				}
 
-				this.store.put([{ ...this.instanceState.get(), currentPageId: toId }])
+				this.store.put([{ ...this.instanceState.getRecord(), currentPageId: toId }])
 
 				this.updateRenderingBounds()
 			},
@@ -3322,7 +3322,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					// in multiplayer contexts this page might have been deleted
 					return
 				}
-				this.store.put([{ ...this.instanceState.get(), currentPageId: fromId }])
+				this.store.put([{ ...this.instanceState.getRecord(), currentPageId: fromId }])
 
 				this.updateRenderingBounds()
 			},

--- a/packages/editor/src/lib/editor/managers/ClickManager.ts
+++ b/packages/editor/src/lib/editor/managers/ClickManager.ts
@@ -228,7 +228,7 @@ export class ClickManager {
 			this._clickState !== 'idle' &&
 			this._clickScreenPoint &&
 			this._clickScreenPoint.dist(this.editor.inputs.currentScreenPoint) >
-				(this.editor.getInstanceState().isCoarsePointer ? COARSE_DRAG_DISTANCE : DRAG_DISTANCE)
+				(this.editor.instanceState.getIsCoarsePointer() ? COARSE_DRAG_DISTANCE : DRAG_DISTANCE)
 		) {
 			this.cancelDoubleClickTimeout()
 		}

--- a/packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts
@@ -17,7 +17,7 @@ export class CurrentPageStateManager {
 				partial: Partial<Omit<TLInstancePageState, 'selectedShapeIds'>>,
 				historyOptions?: TLCommandHistoryOptions
 			) => {
-				const prev = this.get()
+				const prev = this.getRecord()
 				return { data: { prev, partial }, ...historyOptions }
 			},
 			{
@@ -34,7 +34,7 @@ export class CurrentPageStateManager {
 	getId() {
 		return InstancePageStateRecordType.createId(this.editor.getCurrentPageId())
 	}
-	@computed get() {
+	@computed getRecord() {
 		return this.editor.store.get(this.getId())!
 	}
 
@@ -65,18 +65,18 @@ export class CurrentPageStateManager {
 	}
 
 	@computed getHintingShapeIds() {
-		return this.get().hintingShapeIds
+		return this.getRecord().hintingShapeIds
 	}
 	@computed getErasingShapeIds() {
-		return this.get().erasingShapeIds
+		return this.getRecord().erasingShapeIds
 	}
 	@computed getHoveredShapeId() {
-		return this.get().hoveredShapeId
+		return this.getRecord().hoveredShapeId
 	}
 	@computed getCroppingShapeId() {
-		return this.get().croppingShapeId
+		return this.getRecord().croppingShapeId
 	}
 	@computed getMeta() {
-		return this.get().meta
+		return this.getRecord().meta
 	}
 }

--- a/packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/CurrentPageStateManager.ts
@@ -34,7 +34,7 @@ export class CurrentPageStateManager {
 	getId() {
 		return InstancePageStateRecordType.createId(this.editor.getCurrentPageId())
 	}
-	get() {
+	@computed get() {
 		return this.editor.store.get(this.getId())!
 	}
 

--- a/packages/editor/src/lib/editor/managers/InstancePageStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/InstancePageStateManager.ts
@@ -1,0 +1,82 @@
+import { computed } from '@tldraw/state'
+import { InstancePageStateRecordType, TLInstancePageState } from '@tldraw/tlschema'
+import { Editor } from '../Editor'
+import { TLCommandHistoryOptions } from '../types/history-types'
+
+/** @public */
+export type CurrentPageStateUpdate = Partial<
+	Omit<TLInstancePageState, 'selectedShapeIds' | 'editingShapeId' | 'pageId' | 'focusedGroupId'>
+>
+
+/** @public */
+export class CurrentPageStateManager {
+	constructor(private readonly editor: Editor) {
+		this._update = this.editor.history.createCommand(
+			'setInstancePageState',
+			(
+				partial: Partial<Omit<TLInstancePageState, 'selectedShapeIds'>>,
+				historyOptions?: TLCommandHistoryOptions
+			) => {
+				const prev = this.get()
+				return { data: { prev, partial }, ...historyOptions }
+			},
+			{
+				do: ({ prev, partial }) => {
+					this.editor.store.update(prev.id, (state) => ({ ...state, ...partial }))
+				},
+				undo: ({ prev }) => {
+					this.editor.store.update(prev.id, () => prev)
+				},
+			}
+		)
+	}
+
+	getId() {
+		return InstancePageStateRecordType.createId(this.editor.getCurrentPageId())
+	}
+	get() {
+		return this.editor.store.get(this.getId())!
+	}
+
+	/** @internal */
+	_update: (
+		partial: Partial<Omit<TLInstancePageState, 'selectedShapeIds'>>,
+		historyOptions?:
+			| Partial<{ squashing: boolean; ephemeral: boolean; preservesRedoStack: boolean }>
+			| undefined
+	) => Editor
+
+	/**
+	 * Update this instance's page state.
+	 *
+	 * @example
+	 * ```ts
+	 * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' })
+	 * editor.updateCurrentPageState({ id: 'page1', editingShapeId: 'shape:123' }, { ephemeral: true })
+	 * ```
+	 *
+	 * @param partial - The partial of the page state object containing the changes.
+	 * @param historyOptions - The history options for the change.
+	 *
+	 * @public
+	 */
+	update(partial: CurrentPageStateUpdate, historyOptions?: TLCommandHistoryOptions) {
+		this._update(partial, historyOptions)
+	}
+
+	@computed getHintingShapeIds() {
+		return this.get().hintingShapeIds
+	}
+	@computed getErasingShapeIds() {
+		return this.get().erasingShapeIds
+	}
+	@computed getHoveredShapeId() {
+		return this.get().hoveredShapeId
+	}
+	@computed getCroppingShapeId() {
+		return this.get().croppingShapeId
+	}
+	@computed getMeta() {
+		return this.get().meta
+	}
+}

--- a/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
@@ -12,7 +12,7 @@ export class InstanceStateManager {
 		this._update = this.editor.history.createCommand(
 			'updateInstanceState',
 			(partial: InstanceStateUpdate, historyOptions?: TLCommandHistoryOptions) => {
-				const prev = this.editor.store.get(this.get().id)!
+				const prev = this.editor.store.get(this.getRecord().id)!
 				const next = { ...prev, ...partial }
 
 				return {
@@ -36,7 +36,7 @@ export class InstanceStateManager {
 		)
 	}
 
-	@computed get(): TLInstance {
+	@computed getRecord(): TLInstance {
 		return this.editor.store.get(TLINSTANCE_ID)!
 	}
 
@@ -66,90 +66,90 @@ export class InstanceStateManager {
 	}
 
 	getCurrentPageId() {
-		return this.get().currentPageId
+		return this.getRecord().currentPageId
 	}
 	@computed getOpacityForNextShape() {
-		return this.get().opacityForNextShape
+		return this.getRecord().opacityForNextShape
 	}
 	@computed getStylesForNextShape() {
-		return this.get().stylesForNextShape
+		return this.getRecord().stylesForNextShape
 	}
 	@computed getFollowingUserId() {
-		return this.get().followingUserId
+		return this.getRecord().followingUserId
 	}
 	@computed getHighlightedUserIds() {
-		return this.get().highlightedUserIds
+		return this.getRecord().highlightedUserIds
 	}
 	@computed getBrush() {
-		return this.get().brush
+		return this.getRecord().brush
 	}
 	@computed getCursor() {
-		return this.get().cursor
+		return this.getRecord().cursor
 	}
 	@computed getScribbles() {
-		return this.get().scribbles
+		return this.getRecord().scribbles
 	}
 	@computed getIsFocusMode() {
-		return this.get().isFocusMode
+		return this.getRecord().isFocusMode
 	}
 	@computed getIsDebugMode() {
-		return this.get().isDebugMode
+		return this.getRecord().isDebugMode
 	}
 	@computed getIsToolLocked() {
-		return this.get().isToolLocked
+		return this.getRecord().isToolLocked
 	}
 	@computed getExportBackground() {
-		return this.get().exportBackground
+		return this.getRecord().exportBackground
 	}
 	@computed getScreenBounds() {
-		return this.get().screenBounds
+		return this.getRecord().screenBounds
 	}
 	@computed getInsets() {
-		return this.get().insets
+		return this.getRecord().insets
 	}
 	@computed getZoomBrush() {
-		return this.get().zoomBrush
+		return this.getRecord().zoomBrush
 	}
 	@computed getChatMessage() {
-		return this.get().chatMessage
+		return this.getRecord().chatMessage
 	}
 	@computed getIsChatting() {
-		return this.get().isChatting
+		return this.getRecord().isChatting
 	}
 	@computed getIsPenMode() {
-		return this.get().isPenMode
+		return this.getRecord().isPenMode
 	}
 	@computed getIsGridMode() {
-		return this.get().isGridMode
+		return this.getRecord().isGridMode
 	}
 	@computed getCanMoveCamera() {
-		return this.get().canMoveCamera
+		return this.getRecord().canMoveCamera
 	}
 	@computed getIsFocused() {
-		return this.get().isFocused
+		return this.getRecord().isFocused
 	}
 	@computed getDevicePixelRatio() {
-		return this.get().devicePixelRatio
+		return this.getRecord().devicePixelRatio
 	}
 	@computed getIsCoarsePointer() {
-		return this.get().isCoarsePointer
+		return this.getRecord().isCoarsePointer
 	}
 	@computed getIsHoveringCanvas() {
-		return this.get().isHoveringCanvas
+		return this.getRecord().isHoveringCanvas
 	}
 	@computed getOpenMenus() {
-		return this.get().openMenus
+		return this.getRecord().openMenus
 	}
 	@computed getIsChangingStyle() {
-		return this.get().isChangingStyle
+		return this.getRecord().isChangingStyle
 	}
 	@computed getIsReadonly() {
-		return this.get().isReadonly
+		return this.getRecord().isReadonly
 	}
 	@computed getMeta() {
-		return this.get().meta
+		return this.getRecord().meta
 	}
 	@computed getDuplicateProps() {
-		return this.get().duplicateProps
+		return this.getRecord().duplicateProps
 	}
 }

--- a/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
@@ -1,0 +1,155 @@
+import { computed } from '@tldraw/state'
+import { TLINSTANCE_ID, TLInstance } from '@tldraw/tlschema'
+import { Editor } from '../Editor'
+import { TLCommandHistoryOptions } from '../types/history-types'
+
+/** @public */
+export type InstanceStateUpdate = Partial<Omit<TLInstance, 'currentPageId'>>
+
+/** @public */
+export class InstanceStateManager {
+	constructor(private readonly editor: Editor) {
+		this._update = this.editor.history.createCommand(
+			'updateInstanceState',
+			(partial: InstanceStateUpdate, historyOptions?: TLCommandHistoryOptions) => {
+				const prev = this.editor.store.get(this.get().id)!
+				const next = { ...prev, ...partial }
+
+				return {
+					data: { prev, next },
+					ephemeral: false,
+					squashing: false,
+					...historyOptions,
+				}
+			},
+			{
+				do: ({ next }) => {
+					this.editor.store.put([next])
+				},
+				undo: ({ prev }) => {
+					this.editor.store.put([prev])
+				},
+				squash({ prev }, { next }) {
+					return { prev, next }
+				},
+			}
+		)
+	}
+
+	get(): TLInstance {
+		return this.editor.store.get(TLINSTANCE_ID)!
+	}
+
+	private _update: (partial: InstanceStateUpdate, historyOptions?: any) => Editor
+	private _isChangingStyleTimeout: ReturnType<typeof setTimeout> | undefined
+
+	/**
+	 * Update the instance's state.
+	 *
+	 * @param partial - A partial object to update the instance state with.
+	 * @param historyOptions - The history options for the change.
+	 *
+	 * @public
+	 */
+	update(partial: InstanceStateUpdate, historyOptions?: TLCommandHistoryOptions) {
+		this._update(partial, { ephemeral: true, squashing: true, ...historyOptions })
+
+		if (partial.isChangingStyle !== undefined) {
+			clearTimeout(this._isChangingStyleTimeout)
+			if (partial.isChangingStyle === true) {
+				// If we've set to true, set a new reset timeout to change the value back to false after 2 seconds
+				this._isChangingStyleTimeout = setTimeout(() => {
+					this.update({ isChangingStyle: false })
+				}, 2000)
+			}
+		}
+	}
+
+	@computed getCurrentPageId() {
+		return this.get().currentPageId
+	}
+	@computed getOpacityForNextShape() {
+		return this.get().opacityForNextShape
+	}
+	@computed getStylesForNextShape() {
+		return this.get().stylesForNextShape
+	}
+	@computed getFollowingUserId() {
+		return this.get().followingUserId
+	}
+	@computed getHighlightedUserIds() {
+		return this.get().highlightedUserIds
+	}
+	@computed getBrush() {
+		return this.get().brush
+	}
+	@computed getCursor() {
+		return this.get().cursor
+	}
+	@computed getScribbles() {
+		return this.get().scribbles
+	}
+	@computed getIsFocusMode() {
+		return this.get().isFocusMode
+	}
+	@computed getIsDebugMode() {
+		return this.get().isDebugMode
+	}
+	@computed getIsToolLocked() {
+		return this.get().isToolLocked
+	}
+	@computed getExportBackground() {
+		return this.get().exportBackground
+	}
+	@computed getScreenBounds() {
+		return this.get().screenBounds
+	}
+	@computed getInsets() {
+		return this.get().insets
+	}
+	@computed getZoomBrush() {
+		return this.get().zoomBrush
+	}
+	@computed getChatMessage() {
+		return this.get().chatMessage
+	}
+	@computed getIsChatting() {
+		return this.get().isChatting
+	}
+	@computed getIsPenMode() {
+		return this.get().isPenMode
+	}
+	@computed getIsGridMode() {
+		return this.get().isGridMode
+	}
+	@computed getCanMoveCamera() {
+		return this.get().canMoveCamera
+	}
+	@computed getIsFocused() {
+		return this.get().isFocused
+	}
+	@computed getDevicePixelRatio() {
+		return this.get().devicePixelRatio
+	}
+	@computed getIsCoarsePointer() {
+		return this.get().isCoarsePointer
+	}
+	@computed getIsHoveringCanvas() {
+		return this.get().isHoveringCanvas
+	}
+	@computed getOpenMenus() {
+		return this.get().openMenus
+	}
+	@computed getIsChangingStyle() {
+		return this.get().isChangingStyle
+	}
+	@computed getIsReadonly() {
+		return this.get().isReadonly
+	}
+	@computed getMeta() {
+		return this.get().meta
+	}
+	@computed getDuplicateProps() {
+		return this.get().duplicateProps
+	}
+}

--- a/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
+++ b/packages/editor/src/lib/editor/managers/InstanceStateManager.ts
@@ -36,7 +36,7 @@ export class InstanceStateManager {
 		)
 	}
 
-	get(): TLInstance {
+	@computed get(): TLInstance {
 		return this.editor.store.get(TLINSTANCE_ID)!
 	}
 
@@ -65,7 +65,7 @@ export class InstanceStateManager {
 		}
 	}
 
-	@computed getCurrentPageId() {
+	getCurrentPageId() {
 		return this.get().currentPageId
 	}
 	@computed getOpacityForNextShape() {

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -58,7 +58,7 @@ export class ScribbleManager {
 	}
 
 	reset() {
-		this.editor.updateInstanceState({ scribbles: [] })
+		this.editor.instanceState.update({ scribbles: [] })
 		this.scribbleItems.clear()
 		this.pause()
 	}
@@ -182,7 +182,7 @@ export class ScribbleManager {
 
 			// The object here will get frozen into the record, so we need to
 			// create a copies of the parts that what we'll be mutating later.
-			this.editor.updateInstanceState({
+			this.editor.instanceState.update({
 				scribbles: Array.from(this.scribbleItems.values())
 					.map(({ scribble }) => ({
 						...scribble,

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -51,7 +51,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	component(shape: TLGroupShape) {
 		const isErasing = this.editor.getErasingShapeIds().includes(shape.id)
 
-		const { hintingShapeIds } = this.editor.getCurrentPageState()
+		const hintingShapeIds = this.editor.getHintingShapeIds()
 		const isHintingOtherGroup =
 			hintingShapeIds.length > 0 &&
 			hintingShapeIds.some(
@@ -60,7 +60,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 					this.editor.isShapeOfType<TLGroupShape>(this.editor.getShape(id)!, 'group')
 			)
 
-		const isFocused = this.editor.getCurrentPageState().focusedGroupId !== shape.id
+		const isFocused = this.editor.getFocusedGroupId() !== shape.id
 
 		if (
 			!isErasing && // always show the outline while we're erasing the group
@@ -89,13 +89,13 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	override onChildrenChange: TLOnChildrenChangeHandler<TLGroupShape> = (group) => {
 		const children = this.editor.getSortedChildIdsForParent(group.id)
 		if (children.length === 0) {
-			if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
+			if (this.editor.getFocusedGroupId() === group.id) {
 				this.editor.popFocusedGroupId()
 			}
 			this.editor.deleteShapes([group.id])
 			return
 		} else if (children.length === 1) {
-			if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
+			if (this.editor.getFocusedGroupId() === group.id) {
 				this.editor.popFocusedGroupId()
 			}
 			this.editor.reparentShapes(children, group.parentId)

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -112,7 +112,7 @@ export class Pointing extends StateNode {
 
 		this.editor.setSelectedShapes([id])
 
-		if (this.editor.getInstanceState().isToolLocked) {
+		if (this.editor.instanceState.getIsToolLocked()) {
 			this.parent.transition('idle')
 		} else {
 			this.editor.setCurrentTool('select.idle')

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -41,7 +41,7 @@ export function useCanvasEvents() {
 				})
 
 				if (editor.getOpenMenus().length > 0) {
-					editor.updateInstanceState({
+					editor.instanceState.update({
 						openMenus: [],
 					})
 
@@ -83,16 +83,16 @@ export function useCanvasEvents() {
 
 			function onPointerEnter(e: React.PointerEvent) {
 				if ((e as any).isKilled) return
-				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
+				if (editor.instanceState.getIsPenMode() && e.pointerType !== 'pen') return
 				const canHover = e.pointerType === 'mouse' || e.pointerType === 'pen'
-				editor.updateInstanceState({ isHoveringCanvas: canHover ? true : null })
+				editor.instanceState.update({ isHoveringCanvas: canHover ? true : null })
 			}
 
 			function onPointerLeave(e: React.PointerEvent) {
 				if ((e as any).isKilled) return
-				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
+				if (editor.instanceState.getIsPenMode() && e.pointerType !== 'pen') return
 				const canHover = e.pointerType === 'mouse' || e.pointerType === 'pen'
-				editor.updateInstanceState({ isHoveringCanvas: canHover ? false : null })
+				editor.instanceState.update({ isHoveringCanvas: canHover ? false : null })
 			}
 
 			function onTouchStart(e: React.TouchEvent) {

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -13,13 +13,13 @@ export function useCoarsePointer() {
 			!editor.environment.isAndroid &&
 			!editor.environment.isIos
 		) {
-			editor.updateInstanceState({ isCoarsePointer: false })
+			editor.instanceState.update({ isCoarsePointer: false })
 			return
 		}
 		if (window.matchMedia) {
 			const mql = window.matchMedia('(pointer: coarse)')
 			const handler = () => {
-				editor.updateInstanceState({ isCoarsePointer: !!mql.matches })
+				editor.instanceState.update({ isCoarsePointer: !!mql.matches })
 			}
 			handler()
 			if (mql) {

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -72,7 +72,7 @@ export function useCursor() {
 	useQuickReactor(
 		'useCursor',
 		() => {
-			const { type, rotation } = editor.getInstanceState().cursor
+			const { type, rotation } = editor.instanceState.getCursor()
 
 			if (STATIC_CURSORS.includes(type)) {
 				container.style.setProperty('--tl-cursor', `var(--tl-cursor-${type})`)

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -9,7 +9,7 @@ export function useDocumentEvents() {
 	const editor = useEditor()
 	const container = useContainer()
 
-	const isAppFocused = useValue('isFocused', () => editor.getInstanceState().isFocused, [editor])
+	const isAppFocused = useValue('isFocused', () => editor.instanceState.getIsFocused(), [editor])
 
 	useEffect(() => {
 		if (typeof matchMedia === undefined) return
@@ -44,7 +44,7 @@ export function useDocumentEvents() {
 					media.removeListener(safariCb)
 				}
 			}
-			editor.updateInstanceState({ devicePixelRatio: window.devicePixelRatio })
+			editor.instanceState.update({ devicePixelRatio: window.devicePixelRatio })
 		}
 		updatePixelRatio()
 		return () => {

--- a/packages/editor/src/lib/hooks/useFocusEvents.ts
+++ b/packages/editor/src/lib/hooks/useFocusEvents.ts
@@ -10,8 +10,8 @@ export function useFocusEvents(autoFocus: boolean) {
 		if (autoFocus) {
 			// When autoFocus is true, update the editor state to be focused
 			// unless it's already focused
-			if (!editor.getInstanceState().isFocused) {
-				editor.updateInstanceState({ isFocused: true })
+			if (!editor.instanceState.getIsFocused()) {
+				editor.instanceState.update({ isFocused: true })
 			}
 
 			// Note: Focus is also handled by the side effect manager in tldraw.
@@ -24,8 +24,8 @@ export function useFocusEvents(autoFocus: boolean) {
 		} else {
 			// When autoFocus is false, update the editor state to be not focused
 			// unless it's already not focused
-			if (editor.getInstanceState().isFocused) {
-				editor.updateInstanceState({ isFocused: false })
+			if (editor.instanceState.getIsFocused()) {
+				editor.instanceState.update({ isFocused: false })
 			}
 		}
 	}, [editor, container, autoFocus])

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -81,7 +81,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 		let pinchState = 'not sure' as 'not sure' | 'zooming' | 'panning'
 
 		const onWheel: Handler<'wheel', WheelEvent> = ({ event }) => {
-			if (!editor.getInstanceState().isFocused) {
+			if (!editor.instanceState.getIsFocused()) {
 				return
 			}
 

--- a/packages/editor/src/lib/utils/edgeScrolling.ts
+++ b/packages/editor/src/lib/utils/edgeScrolling.ts
@@ -47,10 +47,8 @@ export function moveCameraWhenCloseToEdge(editor: Editor) {
 	const screenSizeFactorX = screenBounds.w < 1000 ? 0.612 : 1
 	const screenSizeFactorY = screenBounds.h < 1000 ? 0.612 : 1
 
-	const {
-		isCoarsePointer,
-		insets: [t, r, b, l],
-	} = editor.getInstanceState()
+	const isCoarsePointer = editor.instanceState.getIsCoarsePointer()
+	const [t, r, b, l] = editor.instanceState.getInsets()
 	const proximityFactorX = getEdgeProximityFactor(x, screenBounds.w, isCoarsePointer, l, r)
 	const proximityFactorY = getEdgeProximityFactor(y, screenBounds.h, isCoarsePointer, t, b)
 

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -34,8 +34,8 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 		const bottomLeftEvents = useSelectionEvents('bottom_left')
 
 		const isDefaultCursor =
-			!editor.getIsMenuOpen() && editor.getInstanceState().cursor.type === 'default'
-		const isCoarsePointer = editor.getInstanceState().isCoarsePointer
+			!editor.getIsMenuOpen() && editor.instanceState.getCursor().type === 'default'
+		const isCoarsePointer = editor.instanceState.getIsCoarsePointer()
 
 		const onlyShape = editor.getOnlySelectedShape()
 		const isLockedShape = onlyShape && editor.isShapeOrAncestorLocked(onlyShape)
@@ -54,7 +54,7 @@ export const TldrawSelectionForeground: TLSelectionForegroundComponent = track(
 		bounds = bounds.clone().expandBy(expandOutlineBy).zeroFix()
 
 		const zoom = editor.getZoomLevel()
-		const isChangingStyle = editor.getInstanceState().isChangingStyle
+		const isChangingStyle = editor.instanceState.getIsChangingStyle()
 
 		const width = bounds.width
 		const height = bounds.height

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
@@ -106,7 +106,7 @@ describe('When dragging the arrow', () => {
 	})
 
 	it('returns to arrow.idle, keeping shape, on pointer up when tool lock is active', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		const shapesBefore = editor.getCurrentPageShapes().length
 		editor.setCurrentTool('arrow').pointerDown(0, 0).pointerMove(10, 10).pointerUp(10, 10)
 		const shapesAfter = editor.getCurrentPageShapes().length

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -540,7 +540,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				'select.dragging_handle',
 				'select.translating',
 				'arrow.dragging'
-			) && !this.editor.getInstanceState().isReadonly
+			) && !this.editor.instanceState.getIsReadonly()
 
 		const info = this.editor.getArrowInfo(shape)
 		const bounds = Box.ZeroFix(this.editor.getShapeGeometry(shape).bounds)

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
@@ -17,7 +17,7 @@ export class Idle extends StateNode {
 
 	override onKeyUp: TLEventHandlers['onKeyUp'] = (info) => {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.instanceState.getIsReadonly()) return null
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it
 			if (

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -84,7 +84,8 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 		const isHoveringWhileEditingSameShape = useValue(
 			'is hovering',
 			() => {
-				const { editingShapeId, hoveredShapeId } = this.editor.getCurrentPageState()
+				const hoveredShapeId = this.editor.getHoveredShapeId()
+				const editingShapeId = this.editor.getEditingShapeId()
 
 				if (editingShapeId && hoveredShapeId !== editingShapeId) {
 					const editingShape = this.editor.getShape(editingShapeId)

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.test.ts
@@ -123,7 +123,7 @@ describe('When in the pointing state', () => {
 	})
 
 	it('Creates a frame and returns to frame.idle on pointer up if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 		editor.setCurrentTool('frame')
 		editor.pointerDown(50, 50)
@@ -152,7 +152,7 @@ describe('When in the resizing state', () => {
 	})
 
 	it('Returns to frame.idle on complete if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor.setCurrentTool('frame')
 		editor.pointerDown(50, 50)
 		editor.pointerMove(100, 100)

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
@@ -31,7 +31,7 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 
 		this.editor.reparentShapes(shapesToAddToFrame, shape.id)
 
-		if (this.editor.getInstanceState().isToolLocked) {
+		if (this.editor.instanceState.getIsToolLocked()) {
 			this.editor.setCurrentTool('frame')
 		} else {
 			this.editor.setCurrentTool('select.idle')

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
@@ -152,7 +152,7 @@ describe('When in the pointing state', () => {
 	})
 
 	it('Creates a geo and returns to geo.idle on pointer up if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 		editor.setCurrentTool('geo')
 		editor.pointerDown(50, 50)
@@ -181,7 +181,7 @@ describe('When in the resizing state while creating a geo shape', () => {
 	})
 
 	it('Returns to geo.idle on complete if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor.setCurrentTool('geo')
 		editor.pointerDown(50, 50)
 		editor.pointerMove(100, 100)

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -13,7 +13,7 @@ export class Idle extends StateNode {
 
 	override onKeyUp: TLEventHandlers['onKeyUp'] = (info) => {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.instanceState.getIsReadonly()) return null
 
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -116,7 +116,7 @@ export class Pointing extends StateNode {
 			},
 		])
 
-		if (this.editor.getInstanceState().isToolLocked) {
+		if (this.editor.instanceState.getIsToolLocked()) {
 			this.parent.transition('idle')
 		} else {
 			this.editor.setCurrentTool('select', {})

--- a/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
@@ -88,7 +88,7 @@ describe('When dragging the line', () => {
 	})
 
 	it('returns to line.idle, keeping shape, on pointer up if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		const shapesBefore = editor.getCurrentPageShapes().length
 		editor
 			.setCurrentTool('line')
@@ -116,7 +116,7 @@ describe('When dragging the line', () => {
 
 describe('When extending the line with the shift-key in tool-lock mode', () => {
 	it('extends a line by joining-the-dots', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor
 			.setCurrentTool('line')
 			.pointerDown(0, 0, { target: 'canvas' })
@@ -133,7 +133,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 	})
 
 	it('extends a line after a click by shift-click dragging', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor
 			.setCurrentTool('line')
 			.pointerDown(0, 0, { target: 'canvas' })
@@ -150,7 +150,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 	})
 
 	it('extends a line by shift-click dragging', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor
 			.setCurrentTool('line')
 			.pointerDown(0, 0, { target: 'canvas' })
@@ -168,7 +168,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 	})
 
 	it('extends a line by shift-clicking even after canceling a pointerdown', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor
 			.setCurrentTool('line')
 			.pointerDown(0, 0, { target: 'canvas' })
@@ -188,7 +188,7 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 	})
 
 	it('extends a line by shift-clicking even after canceling a pointermove', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor
 			.setCurrentTool('line')
 			.pointerDown(0, 0, { target: 'canvas' })
@@ -213,8 +213,8 @@ describe('When extending the line with the shift-key in tool-lock mode', () => {
 describe('tool lock bug', () => {
 	it('works as expected when tool lock is on but shift is off', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.instanceState.update({ isToolLocked: true })
 		editor
-			.updateInstanceState({ isToolLocked: true })
 			.setCurrentTool('line')
 			.pointerDown(0, 0)
 			.pointerMove(10, 10)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
@@ -110,7 +110,7 @@ describe('When in the pointing state', () => {
 	})
 
 	it('Returns to the note tool on complete from translating when tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		editor.setCurrentTool('note')
 		editor.pointerDown(50, 50)
 		editor.pointerMove(55, 55)
@@ -135,7 +135,7 @@ describe('When in the pointing state', () => {
 	})
 
 	it('Creates a frame and returns to frame.idle on pointer up if tool lock is enabled', () => {
-		editor.updateInstanceState({ isToolLocked: true })
+		editor.instanceState.update({ isToolLocked: true })
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 		editor.setCurrentTool('note')
 		editor.pointerDown(50, 50)

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -65,7 +65,7 @@ export class Pointing extends StateNode {
 
 	private complete() {
 		if (this.wasFocusedOnEnter) {
-			if (this.editor.getInstanceState().isToolLocked) {
+			if (this.editor.instanceState.getIsToolLocked()) {
 				this.parent.transition('idle')
 			} else {
 				this.editor.setEditingShape(this.shape.id)

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -184,7 +184,7 @@ const getDefaultPatterns = () => {
 
 function usePattern() {
 	const editor = useEditor()
-	const dpr = editor.getInstanceState().devicePixelRatio
+	const dpr = editor.instanceState.getDevicePixelRatio()
 	const [isReady, setIsReady] = useState(false)
 	const defaultPatterns = useMemo(() => getDefaultPatterns(), [])
 	const [backgroundUrls, setBackgroundUrls] = useState<PatternDef[]>(defaultPatterns)

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -23,7 +23,7 @@ export class Idle extends StateNode {
 
 	override onKeyDown: TLEventHandlers['onKeyDown'] = (info) => {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.instanceState.getIsReadonly()) return null
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it
 			if (

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -118,7 +118,7 @@ export class Erasing extends StateNode {
 	}
 
 	complete() {
-		this.editor.deleteShapes(this.editor.getCurrentPageState().erasingShapeIds)
+		this.editor.deleteShapes(this.editor.getErasingShapeIds())
 		this.editor.setErasingShapes([])
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/HandTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/Pointing.ts
@@ -5,7 +5,7 @@ export class Pointing extends StateNode {
 
 	override onEnter = () => {
 		this.editor.stopCameraAnimation()
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'grabbing', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -48,16 +48,16 @@ export class SelectTool extends StateNode {
 	// We want to clean up the duplicate props when the selection changes
 	private cleanUpDuplicateProps = () => {
 		const selectedShapeIds = this.editor.getSelectedShapeIds()
-		const instance = this.editor.getInstanceState()
-		if (!instance.duplicateProps) return
-		const duplicatedShapes = new Set(instance.duplicateProps.shapeIds)
+		const duplicateProps = this.editor.instanceState.getDuplicateProps()
+		if (!duplicateProps) return
+		const duplicatedShapes = new Set(duplicateProps.shapeIds)
 		if (
 			selectedShapeIds.length === duplicatedShapes.size &&
 			selectedShapeIds.every((shapeId) => duplicatedShapes.has(shapeId))
 		) {
 			return
 		}
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			duplicateProps: null,
 		})
 	}
@@ -78,7 +78,7 @@ export class SelectTool extends StateNode {
 
 	override onExit = () => {
 		this.reactor?.()
-		if (this.editor.getCurrentPageState().editingShapeId) {
+		if (this.editor.getEditingShapeId()) {
 			this.editor.setEditingShape(null)
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -59,7 +59,7 @@ export class Brushing extends StateNode {
 
 	override onExit = () => {
 		this.initialSelectedShapeIds = []
-		this.editor.updateInstanceState({ brush: null })
+		this.editor.instanceState.update({ brush: null })
 	}
 
 	override onTick: TLTickEventHandler = () => {
@@ -174,12 +174,12 @@ export class Brushing extends StateNode {
 			}
 		}
 
-		this.editor.updateInstanceState({ brush: { ...this.brush.toJson() } })
+		this.editor.instanceState.update({ brush: { ...this.brush.toJson() } })
 		this.editor.setSelectedShapes(Array.from(results), { squashing: true })
 	}
 
 	override onInterrupt: TLInterruptEvent = () => {
-		this.editor.updateInstanceState({ brush: null })
+		this.editor.instanceState.update({ brush: null })
 	}
 
 	private handleHit(

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -6,7 +6,7 @@ export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onEnter = () => {
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -25,7 +25,7 @@ export class Idle extends StateNode {
 	}
 
 	override onExit: TLExitEventHandler = () => {
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
@@ -32,7 +32,7 @@ export class TranslatingCrop extends StateNode {
 	}
 
 	override onExit = () => {
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Cropping.ts
@@ -64,7 +64,7 @@ export class Cropping extends StateNode {
 		if (!selectedShape) return
 
 		const cursorType = CursorTypeMap[this.info.handle!]
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: {
 				type: cursorType,
 				rotation: selectedShape.rotation,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.ts
@@ -59,7 +59,7 @@ export class DraggingHandle extends StateNode {
 		this.initialPageRotation = this.initialPageTransform.rotation()
 		this.initialPagePoint = this.editor.inputs.originPagePoint.clone()
 
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: isCreating ? 'cross' : 'grabbing', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -170,7 +170,7 @@ export class DraggingHandle extends StateNode {
 		this.editor.setHintingShapes([])
 		this.editor.snaps.clearIndicators()
 
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -180,7 +180,7 @@ export class DraggingHandle extends StateNode {
 		this.editor.snaps.clearIndicators()
 
 		const { onInteractionEnd } = this.info
-		if (this.editor.getInstanceState().isToolLocked && onInteractionEnd) {
+		if (this.editor.instanceState.getIsToolLocked() && onInteractionEnd) {
 			// Return to the tool that was active before this one,
 			// but only if tool lock is turned on!
 			this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -20,7 +20,7 @@ export class EditingShape extends StateNode {
 	}
 
 	override onExit = () => {
-		const { editingShapeId } = this.editor.getCurrentPageState()
+		const editingShapeId = this.editor.getEditingShapeId()
 		if (!editingShapeId) return
 
 		// Clear the editing shape

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -26,7 +26,7 @@ export class Idle extends StateNode {
 	override onEnter = () => {
 		this.parent.setCurrentToolIdMask(undefined)
 		updateHoveredId(this.editor)
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -114,7 +114,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'handle': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.instanceState.getIsReadonly()) break
 				if (this.editor.inputs.altKey) {
 					this.parent.transition('pointing_shape', info)
 				} else {
@@ -242,7 +242,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'selection': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.instanceState.getIsReadonly()) break
 
 				const onlySelectedShape = this.editor.getOnlySelectedShape()
 
@@ -291,7 +291,7 @@ export class Idle extends StateNode {
 				if (
 					shape.type !== 'video' &&
 					shape.type !== 'embed' &&
-					this.editor.getInstanceState().isReadonly
+					this.editor.instanceState.getIsReadonly()
 				)
 					break
 
@@ -322,7 +322,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'handle': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.instanceState.getIsReadonly()) break
 				const { shape, handle } = info
 
 				const util = this.editor.getShapeUtil(shape)
@@ -389,7 +389,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'shape': {
-				const { selectedShapeIds } = this.editor.getCurrentPageState()
+				const selectedShapeIds = this.editor.getSelectedShapeIds()
 				const { shape } = info
 
 				const targetShape = this.editor.getOutermostSelectableShape(
@@ -519,7 +519,7 @@ export class Idle extends StateNode {
 
 	handleDoubleClickOnCanvas(info: TLClickEventInfo) {
 		// Create text shape and transition to editing_shape
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.instanceState.getIsReadonly()) return
 
 		this.editor.mark('creating text shape')
 
@@ -544,7 +544,7 @@ export class Idle extends StateNode {
 		if (!shape) return
 
 		const util = this.editor.getShapeUtil(shape)
-		if (this.editor.getInstanceState().isReadonly) {
+		if (this.editor.instanceState.getIsReadonly()) {
 			if (!util.canEditInReadOnly(shape)) {
 				return
 			}
@@ -580,7 +580,7 @@ export class Idle extends StateNode {
 
 		const { gridSize } = this.editor.getDocumentSettings()
 
-		const step = this.editor.getInstanceState().isGridMode
+		const step = this.editor.instanceState.getIsGridMode()
 			? shiftKey
 				? gridSize * GRID_INCREMENT
 				: gridSize
@@ -592,7 +592,7 @@ export class Idle extends StateNode {
 	}
 
 	private canInteractWithShapeInReadOnly(shape: TLShape) {
-		if (!this.editor.getInstanceState().isReadonly) return true
+		if (!this.editor.instanceState.getIsReadonly()) return true
 		const util = this.editor.getShapeUtil(shape)
 		if (util.canEditInReadOnly(shape)) return true
 		return false

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -58,7 +58,7 @@ export class PointingArrowLabel extends StateNode {
 	override onExit = () => {
 		this.parent.setCurrentToolIdMask(undefined)
 
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCropHandle.ts
@@ -14,7 +14,7 @@ export class PointingCropHandle extends StateNode {
 
 	private updateCursor(shape: TLShape) {
 		const cursorType = CursorTypeMap[this.info.handle!]
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: {
 				type: cursorType,
 				rotation: shape.rotation,
@@ -33,7 +33,7 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	override onExit = () => {
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -14,7 +14,7 @@ export class PointingHandle extends StateNode {
 			this.editor.setHintingShapes([initialTerminal.boundShapeId])
 		}
 
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'grabbing', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -22,7 +22,7 @@ export class PointingHandle extends StateNode {
 
 	override onExit = () => {
 		this.editor.setHintingShapes([])
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -34,7 +34,7 @@ export class PointingResizeHandle extends StateNode {
 	private updateCursor() {
 		const selected = this.editor.getSelectedShapes()
 		const cursorType = CursorTypeMap[this.info.handle!]
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: { type: cursorType, rotation: selected.length === 1 ? selected[0].rotation : 0 },
 		})
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -12,7 +12,7 @@ export class PointingRotateHandle extends StateNode {
 
 	private updateCursor() {
 		const selectionRotation = this.editor.getSelectionRotation()
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: {
 				type: CursorTypeMap[this.info.handle as RotateCorner],
 				rotation: selectionRotation,
@@ -28,7 +28,7 @@ export class PointingRotateHandle extends StateNode {
 
 	override onExit = () => {
 		this.parent.setCurrentToolIdMask(undefined)
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
@@ -25,7 +25,7 @@ export class PointingSelection extends StateNode {
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
 		if (this.editor.inputs.isDragging) {
-			if (this.editor.getInstanceState().isReadonly) return
+			if (this.editor.instanceState.getIsReadonly()) return
 			this.parent.transition('translating', info)
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -151,7 +151,7 @@ export class PointingShape extends StateNode {
 										this.editor.select(selectingShape.id)
 
 										const util = this.editor.getShapeUtil(selectingShape)
-										if (this.editor.getInstanceState().isReadonly) {
+										if (this.editor.instanceState.getIsReadonly()) {
 											if (!util.canEditInReadOnly(selectingShape)) {
 												return
 											}
@@ -195,7 +195,7 @@ export class PointingShape extends StateNode {
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
 		if (this.editor.inputs.isDragging) {
-			if (this.editor.getInstanceState().isReadonly) return
+			if (this.editor.instanceState.getIsReadonly()) return
 			this.parent.transition('translating', info)
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -61,7 +61,7 @@ export class Resizing extends StateNode {
 		if (isCreating) {
 			this.markId = `creating:${this.editor.getOnlySelectedShape()!.id}`
 
-			this.editor.updateInstanceState(
+			this.editor.instanceState.update(
 				{ cursor: { type: 'cross', rotation: 0 } },
 				{ ephemeral: true }
 			)
@@ -119,7 +119,7 @@ export class Resizing extends StateNode {
 			return
 		}
 
-		if (this.editor.getInstanceState().isToolLocked && this.info.onInteractionEnd) {
+		if (this.editor.instanceState.getIsToolLocked() && this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, {})
 			return
 		}
@@ -219,7 +219,7 @@ export class Resizing extends StateNode {
 			.sub(this.creationCursorOffset)
 		const originPagePoint = this.editor.inputs.originPagePoint.clone().sub(cursorHandleOffset)
 
-		if (this.editor.getInstanceState().isGridMode && !ctrlKey) {
+		if (this.editor.instanceState.getIsGridMode() && !ctrlKey) {
 			const { gridSize } = this.editor.getDocumentSettings()
 			currentPagePoint.snapToGrid(gridSize)
 		}
@@ -377,7 +377,7 @@ export class Resizing extends StateNode {
 		isFlippedY: boolean
 		rotation: number
 	}) {
-		const nextCursor = { ...this.editor.getInstanceState().cursor }
+		const nextCursor = { ...this.editor.instanceState.getCursor() }
 
 		switch (dragHandle) {
 			case 'top_left':
@@ -405,7 +405,7 @@ export class Resizing extends StateNode {
 
 	override onExit = () => {
 		this.parent.setCurrentToolIdMask(undefined)
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -87,7 +87,7 @@ export class Rotating extends StateNode {
 		})
 
 		// Update cursor
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: {
 				type: CursorTypeMap[this.info.handle as RotateCorner],
 				rotation: newSelectionRotation + this.snapshot.initialSelectionRotation,
@@ -131,7 +131,7 @@ export class Rotating extends StateNode {
 		})
 
 		// Update cursor
-		this.editor.updateInstanceState({
+		this.editor.instanceState.update({
 			cursor: {
 				type: CursorTypeMap[this.info.handle as RotateCorner],
 				rotation: newSelectionRotation + this.snapshot.initialSelectionRotation,
@@ -162,7 +162,7 @@ export class Rotating extends StateNode {
 		} else if (snapToNearestDegree) {
 			newSelectionRotation = Math.round(newSelectionRotation / ONE_DEGREE) * ONE_DEGREE
 
-			if (this.editor.getInstanceState().isCoarsePointer) {
+			if (this.editor.instanceState.getIsCoarsePointer()) {
 				const snappedToRightAngle = snapAngle(newSelectionRotation, 4)
 				const angleToRightAngle = shortAngleDist(newSelectionRotation, snappedToRightAngle)
 				if (Math.abs(angleToRightAngle) < degreesToRadians(5)) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -43,7 +43,7 @@ export class ScribbleBrushing extends StateNode {
 		this.updateScribbleSelection(true)
 
 		requestAnimationFrame(() => {
-			this.editor.updateInstanceState({ brush: null })
+			this.editor.instanceState.update({ brush: null })
 		})
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -86,7 +86,7 @@ export class Translating extends StateNode {
 		this.selectionSnapshot = {} as any
 		this.snapshot = {} as any
 		this.editor.snaps.clearIndicators()
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -170,7 +170,7 @@ export class Translating extends StateNode {
 		this.dragAndDropManager.dropShapes(this.snapshot.movingShapes)
 		this.handleEnd()
 
-		if (this.editor.getInstanceState().isToolLocked && this.info.onInteractionEnd) {
+		if (this.editor.instanceState.getIsToolLocked() && this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd)
 		} else {
 			if (this.isCreating) {
@@ -218,7 +218,7 @@ export class Translating extends StateNode {
 				movingShapes.map((s) => this.editor.getShapePageTransform(s.id)!.point())
 			)
 			const offset = Vec.Sub(currentAveragePagePoint, this.selectionSnapshot.averagePagePoint)
-			this.editor.updateInstanceState({
+			this.editor.instanceState.update({
 				duplicateProps: {
 					shapeIds: movingShapes.map((s) => s.id),
 					offset: { x: offset.x, y: offset.y },
@@ -369,7 +369,7 @@ export function moveShapesToPoint({
 }) {
 	const { inputs } = editor
 
-	const isGridMode = editor.getInstanceState().isGridMode
+	const isGridMode = editor.instanceState.getIsGridMode()
 
 	const gridSize = editor.getDocumentSettings().gridSize
 

--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -19,7 +19,7 @@ export class ZoomTool extends StateNode {
 
 	override onExit = () => {
 		this.parent.setCurrentToolIdMask(undefined)
-		this.editor.updateInstanceState(
+		this.editor.instanceState.update(
 			{ zoomBrush: null, cursor: { type: 'default', rotation: 0 } },
 			{ ephemeral: true }
 		)
@@ -53,12 +53,12 @@ export class ZoomTool extends StateNode {
 
 	private updateCursor() {
 		if (this.editor.inputs.altKey) {
-			this.editor.updateInstanceState(
+			this.editor.instanceState.update(
 				{ cursor: { type: 'zoom-out', rotation: 0 } },
 				{ ephemeral: true }
 			)
 		} else {
-			this.editor.updateInstanceState(
+			this.editor.instanceState.update(
 				{ cursor: { type: 'zoom-in', rotation: 0 } },
 				{ ephemeral: true }
 			)

--- a/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomBrushing.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomBrushing.ts
@@ -13,7 +13,7 @@ export class ZoomBrushing extends StateNode {
 	}
 
 	override onExit = () => {
-		this.editor.updateInstanceState({ zoomBrush: null })
+		this.editor.instanceState.update({ zoomBrush: null })
 	}
 
 	override onPointerMove = () => {
@@ -34,7 +34,7 @@ export class ZoomBrushing extends StateNode {
 		} = this.editor
 
 		this.zoomBrush.setTo(Box.FromPoints([originPagePoint, currentPagePoint]))
-		this.editor.updateInstanceState({ zoomBrush: this.zoomBrush.toJson() })
+		this.editor.instanceState.update({ zoomBrush: this.zoomBrush.toJson() })
 	}
 
 	private cancel() {

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -124,11 +124,11 @@ const TldrawUiContent = React.memo(function TldrawUI({
 	const editor = useEditor()
 	const msg = useTranslation()
 	const breakpoint = useBreakpoint()
-	const isReadonlyMode = useValue('isReadonlyMode', () => editor.getInstanceState().isReadonly, [
+	const isReadonlyMode = useValue('isReadonlyMode', () => editor.instanceState.getIsReadonly(), [
 		editor,
 	])
-	const isFocusMode = useValue('focus', () => editor.getInstanceState().isFocusMode, [editor])
-	const isDebugMode = useValue('debug', () => editor.getInstanceState().isDebugMode, [editor])
+	const isFocusMode = useValue('focus', () => editor.instanceState.getIsFocusMode(), [editor])
+	const isDebugMode = useValue('debug', () => editor.instanceState.getIsDebugMode(), [editor])
 
 	useKeyboardShortcuts()
 	useNativeClipboardEvents()

--- a/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu.tsx
@@ -36,7 +36,7 @@ export const ContextMenu = function ContextMenu({ children }: { children: any })
 				}
 			} else {
 				// Weird route: selecting locked shapes on long press
-				if (editor.getInstanceState().isCoarsePointer) {
+				if (editor.instanceState.getIsCoarsePointer()) {
 					const selectedShapes = editor.getSelectedShapes()
 					const {
 						inputs: { currentPagePoint },

--- a/packages/tldraw/src/lib/ui/components/FollowingIndicator.tsx
+++ b/packages/tldraw/src/lib/ui/components/FollowingIndicator.tsx
@@ -2,7 +2,7 @@ import { useEditor, usePresence, useValue } from '@tldraw/editor'
 
 export function FollowingIndicator() {
 	const editor = useEditor()
-	const followingUserId = useValue('follow', () => editor.getInstanceState().followingUserId, [
+	const followingUserId = useValue('follow', () => editor.instanceState.getFollowingUserId(), [
 		editor,
 	])
 	if (!followingUserId) return null

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -33,7 +33,7 @@ export function MobileStylePanel() {
 	const handleStylesOpenChange = useCallback(
 		(isOpen: boolean) => {
 			if (!isOpen) {
-				editor.updateInstanceState({ isChangingStyle: false })
+				editor.instanceState.update({ isChangingStyle: false })
 			}
 		},
 		[editor]

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/Minimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/Minimap.tsx
@@ -30,7 +30,7 @@ export function Minimap({ shapeFill, selectFill, viewportFill }: MinimapProps) {
 	const rPointing = React.useRef(false)
 
 	const isDarkMode = useIsDarkMode()
-	const devicePixelRatio = useComputed('dpr', () => editor.getInstanceState().devicePixelRatio, [
+	const devicePixelRatio = useComputed('dpr', () => editor.instanceState.getDevicePixelRatio(), [
 		editor,
 	])
 	const presences = React.useMemo(() => editor.store.query.records('instance_presence'), [editor])
@@ -137,7 +137,7 @@ export function Minimap({ shapeFill, selectFill, viewportFill }: MinimapProps) {
 				name: 'pointer_move',
 				...getPointerInfo(e),
 				point: screenPoint,
-				isPen: editor.getInstanceState().isPenMode,
+				isPen: editor.instanceState.getIsPenMode(),
 			}
 
 			editor.dispatch(info)

--- a/packages/tldraw/src/lib/ui/components/NavigationZone/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/NavigationZone/MinimapManager.ts
@@ -257,7 +257,7 @@ export class MinimapManager {
 
 		// Brush
 		{
-			const { brush } = editor.getInstanceState()
+			const brush = editor.instanceState.getBrush()
 			if (brush) {
 				const { x, y, w, h } = brush
 				ctx.beginPath()

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageMenu.tsx
@@ -48,7 +48,7 @@ export const PageMenu = function PageMenu() {
 
 	const isCoarsePointer = useValue(
 		'isCoarsePointer',
-		() => editor.getInstanceState().isCoarsePointer,
+		() => editor.instanceState.getIsCoarsePointer(),
 		[editor]
 	)
 

--- a/packages/tldraw/src/lib/ui/components/PenModeToggle.tsx
+++ b/packages/tldraw/src/lib/ui/components/PenModeToggle.tsx
@@ -5,7 +5,7 @@ import { Button } from './primitives/Button'
 export const ExitPenMode = track(function ExitPenMode() {
 	const editor = useEditor()
 
-	const isPenMode = editor.getInstanceState().isPenMode
+	const isPenMode = editor.instanceState.getIsPenMode()
 
 	const actions = useActions()
 

--- a/packages/tldraw/src/lib/ui/components/StopFollowing.tsx
+++ b/packages/tldraw/src/lib/ui/components/StopFollowing.tsx
@@ -6,7 +6,7 @@ export const StopFollowing = track(function StopFollowing() {
 	const editor = useEditor()
 	const actions = useActions()
 
-	if (!editor.getInstanceState().followingUserId) {
+	if (!editor.instanceState.getFollowingUserId()) {
 		return null
 	}
 

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanel.tsx
@@ -39,7 +39,7 @@ export const StylePanel = function StylePanel({ isMobile }: StylePanelProps) {
 
 	const handlePointerOut = useCallback(() => {
 		if (!isMobile) {
-			editor.updateInstanceState({ isChangingStyle: false })
+			editor.instanceState.update({ isChangingStyle: false })
 		}
 	}, [editor, isMobile])
 
@@ -83,7 +83,7 @@ function useStyleChangeCallback() {
 					editor.setStyleForSelectedShapes(style, value, { squashing })
 				}
 				editor.setStyleForNextShapes(style, value, { squashing })
-				editor.updateInstanceState({ isChangingStyle: true })
+				editor.instanceState.update({ isChangingStyle: true })
 			})
 
 			trackEvent('set-style', { source: 'style-panel', id: style.id, value: value as string })
@@ -114,7 +114,7 @@ function CommonStylePickerSet({
 					editor.setOpacityForSelectedShapes(item, { ephemeral })
 				}
 				editor.setOpacityForNextShapes(item, { ephemeral })
-				editor.updateInstanceState({ isChangingStyle: true })
+				editor.instanceState.update({ isChangingStyle: true })
 			})
 
 			trackEvent('set-style', { source: 'style-panel', id: 'opacity', value })

--- a/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
@@ -24,7 +24,7 @@ export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonP
 	const breakpoint = useBreakpoint()
 	const msg = useTranslation()
 
-	const isToolLocked = useValue('is tool locked', () => editor.getInstanceState().isToolLocked, [
+	const isToolLocked = useValue('is tool locked', () => editor.instanceState.getIsToolLocked(), [
 		editor,
 	])
 
@@ -38,7 +38,7 @@ export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonP
 				'tlui-toolbar__lock-button__mobile': breakpoint < 5,
 			})}
 			icon={isToolLocked ? 'lock' : 'unlock'}
-			onClick={() => editor.updateInstanceState({ isToolLocked: !isToolLocked })}
+			onClick={() => editor.instanceState.update({ isToolLocked: !isToolLocked })}
 			smallIcon
 		/>
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useActions.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useActions.tsx
@@ -406,17 +406,18 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('duplicate-shapes', { source })
-					const instanceState = editor.getInstanceState()
+					const duplicateProps = editor.instanceState.getDuplicateProps()
+					const canMoveCamera = editor.instanceState.getCanMoveCamera()
 					let ids: TLShapeId[]
 					let offset: { x: number; y: number }
 
-					if (instanceState.duplicateProps) {
-						ids = instanceState.duplicateProps.shapeIds
-						offset = instanceState.duplicateProps.offset
+					if (duplicateProps) {
+						ids = duplicateProps.shapeIds
+						offset = duplicateProps.offset
 					} else {
 						ids = editor.getSelectedShapeIds()
 						const commonBounds = Box.Common(compact(ids.map((id) => editor.getShapePageBounds(id))))
-						offset = instanceState.canMoveCamera
+						offset = canMoveCamera
 							? {
 									x: commonBounds.width + 10,
 									y: 0,
@@ -429,12 +430,12 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					editor.mark('duplicate shapes')
 					editor.duplicateShapes(ids, offset)
-					if (instanceState.duplicateProps) {
+					if (duplicateProps) {
 						// If we are using duplicate props then we update the shape ids to the
 						// ids of the newly created shapes to keep the duplication going
-						editor.updateInstanceState({
+						editor.instanceState.update({
 							duplicateProps: {
-								...instanceState.duplicateProps,
+								...duplicateProps,
 								shapeIds: editor.getSelectedShapeIds(),
 							},
 						})
@@ -1035,9 +1036,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('toggle-transparent', { source })
-					editor.updateInstanceState(
+					editor.instanceState.update(
 						{
-							exportBackground: !editor.getInstanceState().exportBackground,
+							exportBackground: !editor.instanceState.getExportBackground(),
 						},
 						{ ephemeral: true }
 					)
@@ -1052,7 +1053,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: 'q',
 				onSelect(source) {
 					trackEvent('toggle-tool-lock', { source })
-					editor.updateInstanceState({ isToolLocked: !editor.getInstanceState().isToolLocked })
+					editor.instanceState.update({ isToolLocked: !editor.instanceState.getIsToolLocked() })
 				},
 				checkbox: true,
 			},
@@ -1088,7 +1089,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							trackEvent('toggle-focus-mode', { source })
 							clearDialogs()
 							clearToasts()
-							editor.updateInstanceState({ isFocusMode: !editor.getInstanceState().isFocusMode })
+							editor.instanceState.update({ isFocusMode: !editor.instanceState.getIsFocusMode() })
 						})
 					})
 				},
@@ -1101,7 +1102,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: "$'",
 				onSelect(source) {
 					trackEvent('toggle-grid-mode', { source })
-					editor.updateInstanceState({ isGridMode: !editor.getInstanceState().isGridMode })
+					editor.instanceState.update({ isGridMode: !editor.instanceState.getIsGridMode() })
 				},
 				checkbox: true,
 			},
@@ -1112,8 +1113,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('toggle-debug-mode', { source })
-					editor.updateInstanceState({
-						isDebugMode: !editor.getInstanceState().isDebugMode,
+					editor.instanceState.update({
+						isDebugMode: !editor.instanceState.getIsDebugMode(),
 					})
 				},
 				checkbox: true,
@@ -1135,7 +1136,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('exit-pen-mode', { source })
-					editor.updateInstanceState({ isPenMode: false })
+					editor.instanceState.update({ isPenMode: false })
 				},
 			},
 			{

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -625,7 +625,7 @@ export function useNativeClipboardEvents() {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()
 
-	const appIsFocused = useValue('editor.isFocused', () => editor.getInstanceState().isFocused, [
+	const appIsFocused = useValue('editor.isFocused', () => editor.instanceState.getIsFocused(), [
 		editor,
 	])
 

--- a/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useContextMenuSchema.tsx
@@ -70,7 +70,7 @@ export const TLUiContextMenuSchemaProvider = track(function TLUiContextMenuSchem
 	)
 	const isTransparentBg = useValue(
 		'isTransparentBg',
-		() => editor.getInstanceState().exportBackground,
+		() => editor.instanceState.getExportBackground(),
 		[]
 	)
 	const allowGroup = useAllowGroup()

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -14,7 +14,7 @@ export function useExportAs() {
 		(ids: TLShapeId[], format: TLExportType = 'png') => {
 			exportAs(editor, ids, format, {
 				scale: 1,
-				background: editor.getInstanceState().exportBackground,
+				background: editor.instanceState.getExportBackground(),
 			}).catch((e) => {
 				console.error(e.message)
 				addToast({

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -22,7 +22,7 @@ export function useKeyboardShortcuts() {
 	const isReadonly = useReadonly()
 	const actions = useActions()
 	const tools = useTools()
-	const isFocused = useValue('is focused', () => editor.getInstanceState().isFocused, [editor])
+	const isFocused = useValue('is focused', () => editor.instanceState.getIsFocused(), [editor])
 	const { itemsInPanel: toolbarItemsInPanel } = useToolbarItems()
 
 	useEffect(() => {
@@ -59,7 +59,7 @@ export function useKeyboardShortcuts() {
 		}
 
 		for (const tool of Object.values(tools)) {
-			if (!tool.kbd || (!tool.readonlyOk && editor.getInstanceState().isReadonly)) {
+			if (!tool.kbd || (!tool.readonlyOk && editor.instanceState.getIsReadonly())) {
 				continue
 			}
 
@@ -94,7 +94,7 @@ export function useKeyboardShortcuts() {
 				ctrlKey: e.metaKey || e.ctrlKey,
 				pointerId: 0,
 				button: 0,
-				isPen: editor.getInstanceState().isPenMode,
+				isPen: editor.instanceState.getIsPenMode(),
 				target: 'canvas',
 			}
 
@@ -117,7 +117,7 @@ export function useKeyboardShortcuts() {
 				ctrlKey: e.metaKey || e.ctrlKey,
 				pointerId: 0,
 				button: 0,
-				isPen: editor.getInstanceState().isPenMode,
+				isPen: editor.instanceState.getIsPenMode(),
 				target: 'canvas',
 			}
 

--- a/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
@@ -17,7 +17,7 @@ export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void) {
 					editor.complete()
 					editor.addOpenMenu(id)
 				} else {
-					editor.updateInstanceState({
+					editor.instanceState.update({
 						openMenus: editor.getOpenMenus().filter((m) => !m.startsWith(id)),
 					})
 				}

--- a/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuSchema.tsx
@@ -54,14 +54,14 @@ export function TLUiMenuSchemaProvider({ overrides, children }: TLUiMenuSchemaPr
 	const edgeScrollSpeed = useValue('edgeScrollSpeed', () => editor.user.getEdgeScrollSpeed(), [
 		editor,
 	])
-	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
+	const isGridMode = useValue('isGridMode', () => editor.instanceState.getIsGridMode(), [editor])
 	const isSnapMode = useValue('isSnapMode', () => editor.user.getIsSnapMode(), [editor])
-	const isToolLock = useValue('isToolLock', () => editor.getInstanceState().isToolLocked, [editor])
-	const isFocusMode = useValue('isFocusMode', () => editor.getInstanceState().isFocusMode, [editor])
-	const isDebugMode = useValue('isDebugMode', () => editor.getInstanceState().isDebugMode, [editor])
+	const isToolLock = useValue('isToolLock', () => editor.instanceState.getIsToolLocked(), [editor])
+	const isFocusMode = useValue('isFocusMode', () => editor.instanceState.getIsFocusMode(), [editor])
+	const isDebugMode = useValue('isDebugMode', () => editor.instanceState.getIsDebugMode(), [editor])
 	const exportBackground = useValue(
 		'exportBackground',
-		() => editor.getInstanceState().exportBackground,
+		() => editor.instanceState.getExportBackground(),
 		[editor]
 	)
 

--- a/packages/tldraw/src/lib/ui/hooks/useReadonly.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useReadonly.ts
@@ -3,5 +3,5 @@ import { useEditor, useValue } from '@tldraw/editor'
 /** @public */
 export function useReadonly() {
 	const editor = useEditor()
-	return useValue('isReadonlyMode', () => editor.getInstanceState().isReadonly, [editor])
+	return useValue('isReadonlyMode', () => editor.instanceState.getIsReadonly(), [editor])
 }

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -105,10 +105,10 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				icon: ('geo-' + id) as TLUiIconType,
 				onSelect(source: TLUiEventSource) {
 					editor.batch(() => {
-						editor.updateInstanceState(
+						editor.instanceState.update(
 							{
 								stylesForNextShape: {
-									...editor.getInstanceState().stylesForNextShape,
+									...editor.instanceState.getStylesForNextShape(),
 									[GeoShapeGeoStyle.id]: id,
 								},
 							},

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -126,7 +126,7 @@ async function getSvgAsString(svg: SVGElement) {
 async function getSvg(editor: Editor, ids: TLShapeId[], opts: Partial<TLSvgOptions>) {
 	const svg = await editor.getSvg(ids?.length ? ids : [...editor.getCurrentPageShapeIds()], {
 		scale: 1,
-		background: editor.getInstanceState().exportBackground,
+		background: editor.instanceState.getExportBackground(),
 		...opts,
 	})
 	if (!svg) {

--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -279,7 +279,7 @@ export async function parseAndLoadDocument(
 	// this file before they'll get their camera etc.
 	// restored. we could change this in the future.
 	transact(() => {
-		const isFocused = editor.getInstanceState().isFocused
+		const isFocused = editor.instanceState.getIsFocused()
 		editor.store.clear()
 		const [shapes, nonShapes] = partition(
 			parseFileResult.value.allRecords(),
@@ -296,7 +296,7 @@ export async function parseAndLoadDocument(
 		if (bounds) {
 			editor.zoomToBounds(bounds, 1)
 		}
-		editor.updateInstanceState({ isFocused })
+		editor.instanceState.update({ isFocused })
 	})
 
 	if (forceDarkMode) editor.user.updateUserPreferences({ isDarkMode: true })

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -244,10 +244,10 @@ describe('Editor.setOpacity', () => {
 	it('stores opacity on opacityForNextShape', () => {
 		editor.setOpacityForSelectedShapes(0.5)
 		editor.setOpacityForNextShapes(0.5)
-		expect(editor.getInstanceState().opacityForNextShape).toBe(0.5)
+		expect(editor.instanceState.getOpacityForNextShape()).toBe(0.5)
 		editor.setOpacityForSelectedShapes(0.6)
 		editor.setOpacityForNextShapes(0.6)
-		expect(editor.getInstanceState().opacityForNextShape).toBe(0.6)
+		expect(editor.instanceState.getOpacityForNextShape()).toBe(0.6)
 	})
 })
 
@@ -297,7 +297,7 @@ describe("App's default tool", () => {
 	})
 	it('Is hand for readonly mode', () => {
 		editor = new TestEditor()
-		editor.updateInstanceState({ isReadonly: true })
+		editor.instanceState.update({ isReadonly: true })
 		editor.setCurrentTool('hand')
 		expect(editor.getCurrentToolId()).toBe('hand')
 	})
@@ -363,12 +363,12 @@ describe('isFocused', () => {
 
 		const updateFocus = debounce(() => {
 			const { activeElement } = document
-			const { isFocused: wasFocused } = editor.getInstanceState()
+			const wasFocused = editor.instanceState.getIsFocused()
 			const isFocused =
 				document.hasFocus() && (container === activeElement || container.contains(activeElement))
 
 			if (wasFocused !== isFocused) {
-				editor.updateInstanceState({ isFocused })
+				editor.instanceState.update({ isFocused })
 				editor.updateViewportScreenBounds()
 
 				if (!isFocused) {
@@ -385,48 +385,48 @@ describe('isFocused', () => {
 	})
 
 	it('is false by default', () => {
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 
 	it('becomes true when you call .focus()', () => {
-		editor.updateInstanceState({ isFocused: true })
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		editor.instanceState.update({ isFocused: true })
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 	})
 
 	it('becomes false when you call .blur()', () => {
-		editor.updateInstanceState({ isFocused: true })
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		editor.instanceState.update({ isFocused: true })
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 
-		editor.updateInstanceState({ isFocused: false })
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		editor.instanceState.update({ isFocused: false })
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 
 	it('remains false when you call .blur()', () => {
-		expect(editor.getInstanceState().isFocused).toBe(false)
-		editor.updateInstanceState({ isFocused: false })
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
+		editor.instanceState.update({ isFocused: false })
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 
 	it('becomes true when the container div receives a focus event', () => {
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 
 		editor.elm.focus()
 
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 	})
 
 	it('becomes false when the container div receives a blur event', () => {
 		editor.elm.focus()
 
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 
 		editor.elm.blur()
 
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 
 	it.skip('becomes true when a child of the app container div receives a focusin event', () => {
@@ -438,27 +438,27 @@ describe('isFocused', () => {
 		const child = document.createElement('div')
 		editor.elm.appendChild(child)
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 		child.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 		child.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 
 	it('becomes false when a child of the app container div receives a focusout event', () => {
 		const child = document.createElement('div')
 		editor.elm.appendChild(child)
 
-		editor.updateInstanceState({ isFocused: true })
+		editor.instanceState.update({ isFocused: true })
 
-		expect(editor.getInstanceState().isFocused).toBe(true)
+		expect(editor.instanceState.getIsFocused()).toBe(true)
 
 		child.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
 
 		jest.advanceTimersByTime(100)
-		expect(editor.getInstanceState().isFocused).toBe(false)
+		expect(editor.instanceState.getIsFocused()).toBe(false)
 	})
 })
 

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -298,14 +298,14 @@ describe('When clicking and dragging', () => {
 		editor.pointerDown(-100, -100) // outside of any shapes
 
 		editor.expectToBeIn('eraser.pointing')
-		expect(editor.getInstanceState().scribbles.length).toBe(0)
+		expect(editor.instanceState.getScribbles().length).toBe(0)
 
 		editor.pointerMove(50, 50) // inside of box1
 
 		editor.expectToBeIn('eraser.erasing')
 
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 
 		expect(editor.getErasingShapeIds()).toEqual([ids.box1])
 
@@ -331,7 +331,7 @@ describe('When clicking and dragging', () => {
 		editor.pointerDown(-100, -100) // outside of any shapes
 		editor.pointerMove(50, 50) // inside of box1
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		expect(editor.getErasingShapeIds()).toEqual([ids.box1])
 		editor.cancel()
 		editor.expectToBeIn('eraser.idle')
@@ -346,7 +346,7 @@ describe('When clicking and dragging', () => {
 		editor.pointerDown(275, 275) // in between box2 AND box3, so over of the new group
 		editor.pointerMove(280, 280) // still outside of the new group
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		expect(editor.getErasingShapeIds()).toEqual([])
 		editor.pointerMove(0, 0)
 		expect(editor.getErasingShapeIds()).toEqual([ids.box1])
@@ -361,7 +361,7 @@ describe('When clicking and dragging', () => {
 		editor.pointerDown(325, 25) // directly on frame1, not its children
 		editor.pointerMove(350, 375) // still in the frame, passing through box3
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		expect(editor.getErasingShapeIds()).toEqual([ids.box3])
 		editor.pointerUp()
 		expect(editor.getShape(ids.frame1)).toBeDefined()
@@ -375,7 +375,7 @@ describe('When clicking and dragging', () => {
 		expect(editor.getErasingShapeIds()).toEqual([])
 		editor.pointerMove(425, 500) // Through the masked part of box3
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		expect(editor.getErasingShapeIds()).toEqual([])
 		editor.pointerUp()
 		expect(editor.getShape(ids.box3)).toBeDefined()
@@ -383,7 +383,7 @@ describe('When clicking and dragging', () => {
 		editor.pointerMove(375, 0)
 		editor.pointerDown() // Above the not-masked part of box3
 		editor.pointerMove(375, 500) // Through the masked part of box3
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		expect(editor.getErasingShapeIds()).toEqual([ids.box3])
 		editor.pointerUp()
 		expect(editor.getShape(ids.box3)).not.toBeDefined()
@@ -400,16 +400,16 @@ describe('When clicking and dragging', () => {
 	it('Starts a scribble on pointer down, updates it on pointer move, stops it on exit', () => {
 		editor.setCurrentTool('eraser')
 		editor.pointerDown(-100, -100)
-		expect(editor.getInstanceState().scribbles.length).toBe(0)
+		expect(editor.instanceState.getScribbles().length).toBe(0)
 		editor.pointerMove(50, 50)
 		jest.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 		editor.pointerMove(50, 50)
 		editor.pointerMove(51, 50)
 		editor.pointerMove(52, 50)
 		editor.pointerMove(53, 50)
 		editor.pointerUp()
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
+		expect(editor.instanceState.getScribbles().length).toBe(1)
 	})
 })
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -467,7 +467,7 @@ describe('When in readonly mode', () => {
 				props: { w: 100, h: 100, url: 'https://tldraw.com' },
 			},
 		])
-		editor.updateInstanceState({ isReadonly: true })
+		editor.instanceState.update({ isReadonly: true })
 		editor.setCurrentTool('hand')
 		editor.setCurrentTool('select')
 	})
@@ -475,7 +475,7 @@ describe('When in readonly mode', () => {
 	it('Begins editing embed when double clicked', () => {
 		expect(editor.getEditingShapeId()).toBe(null)
 		expect(editor.getSelectedShapeIds().length).toBe(0)
-		expect(editor.getInstanceState().isReadonly).toBe(true)
+		expect(editor.instanceState.getIsReadonly()).toBe(true)
 
 		const shape = editor.getShape(ids.embed1)
 		editor.doubleClick(100, 100, { target: 'shape', shape })
@@ -485,7 +485,7 @@ describe('When in readonly mode', () => {
 	it('Begins editing embed when pressing Enter on a selected embed', () => {
 		expect(editor.getEditingShapeId()).toBe(null)
 		expect(editor.getSelectedShapeIds().length).toBe(0)
-		expect(editor.getInstanceState().isReadonly).toBe(true)
+		expect(editor.instanceState.getIsReadonly()).toBe(true)
 
 		editor.setSelectedShapes([ids.embed1])
 		expect(editor.getSelectedShapeIds().length).toBe(1)

--- a/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
+++ b/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
@@ -52,7 +52,7 @@ describe('createSessionStateSnapshotSignal', () => {
 		expect(isGridMode).toBe(false)
 		expect(numPages).toBe(1)
 
-		editor.updateInstanceState({ isGridMode: true })
+		editor.instanceState.update({ isGridMode: true })
 
 		expect(isGridMode).toBe(true)
 		expect(numPages).toBe(1)
@@ -70,7 +70,7 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 		let snapshot = createSessionStateSnapshotSignal(editor.store).get()
 		if (!snapshot) throw new Error('snapshot is null')
 
-		expect(editor.getInstanceState().isGridMode).toBe(false)
+		expect(editor.instanceState.getIsGridMode()).toBe(false)
 		expect(editor.getCamera().x).toBe(0)
 		expect(editor.getCamera().y).toBe(0)
 
@@ -82,7 +82,7 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 
 		loadSessionStateSnapshotIntoStore(editor.store, snapshot)
 
-		expect(editor.getInstanceState().isGridMode).toBe(true)
+		expect(editor.instanceState.getIsGridMode()).toBe(true)
 		expect(editor.getCamera().x).toBe(1)
 		expect(editor.getCamera().y).toBe(2)
 	})

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -210,7 +210,7 @@ describe('<TldrawEditor />', () => {
 
 		expect(editor).toBeTruthy()
 		await act(async () => {
-			editor.updateInstanceState(
+			editor.instanceState.update(
 				{ screenBounds: { x: 0, y: 0, w: 1080, h: 720 } },
 				{ ephemeral: true, squashing: true }
 			)
@@ -335,7 +335,7 @@ describe('Custom shapes', () => {
 
 		expect(editor).toBeTruthy()
 		await act(async () => {
-			editor.updateInstanceState(
+			editor.instanceState.update(
 				{ screenBounds: { x: 0, y: 0, w: 1080, h: 720 } },
 				{ ephemeral: true, squashing: true }
 			)

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -149,7 +149,7 @@ describe('TLSelectTool.Zooming', () => {
 		editor.expectToBeIn('zoom.idle')
 		editor.pointerDown(newBoundsX, newBoundsY)
 		editor.pointerMove(newBoundsX + newBoundsWidth, newBoundsY + newBoundsHeight)
-		expect(editor.getInstanceState().zoomBrush).toMatchObject({
+		expect(editor.instanceState.getZoomBrush()).toMatchObject({
 			x: newBoundsX,
 			y: newBoundsY,
 			w: newBoundsWidth,
@@ -186,7 +186,7 @@ describe('TLSelectTool.Zooming', () => {
 		editor.keyDown('Alt')
 		editor.pointerDown(newBoundsX, newBoundsY)
 		editor.pointerMove(newBoundsX + newBoundsWidth, newBoundsY + newBoundsHeight)
-		expect(editor.getInstanceState().zoomBrush).toMatchObject({
+		expect(editor.instanceState.getZoomBrush()).toMatchObject({
 			x: newBoundsX,
 			y: newBoundsY,
 			w: newBoundsWidth,

--- a/packages/tldraw/src/test/commands/createShapes.test.ts
+++ b/packages/tldraw/src/test/commands/createShapes.test.ts
@@ -88,13 +88,13 @@ it('Parents shapes to the current page if the parent is not found', () => {
 })
 
 it('Creates shapes with the current style', () => {
-	expect(editor.getInstanceState().stylesForNextShape[DefaultColorStyle.id]).toBe(undefined)
+	expect(editor.instanceState.getStylesForNextShape()[DefaultColorStyle.id]).toBe(undefined)
 	editor.createShapes([{ id: ids.box1, type: 'geo' }])
 	expect(editor.getShape<TLGeoShape>(ids.box1)!.props.color).toEqual('black')
 
 	editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')
 	editor.setStyleForNextShapes(DefaultColorStyle, 'red')
-	expect(editor.getInstanceState().stylesForNextShape[DefaultColorStyle.id]).toBe('red')
+	expect(editor.instanceState.getStylesForNextShape()[DefaultColorStyle.id]).toBe('red')
 	editor.createShapes([{ id: ids.box2, type: 'geo' }])
 	expect(editor.getShape<TLGeoShape>(ids.box2)!.props.color).toEqual('red')
 })

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 })
 
 function nudgeAndGet(ids: TLShapeId[], key: string, shiftKey: boolean) {
-	const step = editor.getInstanceState().isGridMode ? (shiftKey ? 50 : 10) : shiftKey ? 10 : 1
+	const step = editor.instanceState.getIsGridMode() ? (shiftKey ? 50 : 10) : shiftKey ? 10 : 1
 	switch (key) {
 		case 'ArrowLeft': {
 			editor.mark('nudge')
@@ -177,7 +177,7 @@ describe('When a shape is selected...', () => {
 
 describe('When grid is enabled...', () => {
 	it('nudges a shape correctly', () => {
-		editor.updateInstanceState({ isGridMode: true })
+		editor.instanceState.update({ isGridMode: true })
 		editor.setSelectedShapes([ids.boxA])
 
 		expect(nudgeAndGet([ids.boxA], 'ArrowUp', false)).toMatchObject([{ x: 10, y: 0 }])
@@ -187,7 +187,7 @@ describe('When grid is enabled...', () => {
 	})
 
 	it('nudges a shape with shift key pressed', () => {
-		editor.updateInstanceState({ isGridMode: true })
+		editor.instanceState.update({ isGridMode: true })
 		editor.setSelectedShapes([ids.boxA])
 
 		expect(nudgeAndGet([ids.boxA], 'ArrowUp', true)).toMatchObject([{ x: 10, y: -40 }])

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 
 it('ignores touch events while in pen mode', async () => {
 	editor.setCurrentTool('draw')
-	editor.updateInstanceState({ isPenMode: true })
+	editor.instanceState.update({ isPenMode: true })
 	editor.dispatch({
 		type: 'pointer',
 		name: 'pointer_down',

--- a/packages/tldraw/src/test/commands/screenToPage.test.ts
+++ b/packages/tldraw/src/test/commands/screenToPage.test.ts
@@ -47,7 +47,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when offset', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 100, y: 100 },
 		})
 
@@ -59,7 +59,7 @@ describe('viewport.screenToPage', () => {
 	it('converts correctly when zoomed out', () => {
 		// camera at zero, screenbounds at zero, but zoom at .5
 		editor.setCamera({ x: 0, y: 0, z: 0.5 })
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 
@@ -70,7 +70,7 @@ describe('viewport.screenToPage', () => {
 
 	it('converts correctly when zoomed in', () => {
 		editor.setCamera({ x: 0, y: 0, z: 2 })
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 
@@ -81,7 +81,7 @@ describe('viewport.screenToPage', () => {
 
 	it('converts correctly when zoomed', () => {
 		// camera at zero, screenbounds at zero, but zoom at .5
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 		editor.setCamera({ x: 0, y: 0, z: 0.5 })
@@ -93,7 +93,7 @@ describe('viewport.screenToPage', () => {
 
 	it('converts correctly when offset and zoomed', () => {
 		editor.setCamera({ x: 0, y: 0, z: 0.5 })
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 100, y: 100 },
 		})
 
@@ -103,7 +103,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when zoomed and panned', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 0.5 })
@@ -114,7 +114,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when offset', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 100, y: 100 },
 		})
 		editor.setCamera({ x: 0, y: 0, z: 0.5 })
@@ -125,7 +125,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when panned', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 1 })
@@ -136,7 +136,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when panned and zoomed', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 0.5 })
@@ -147,7 +147,7 @@ describe('viewport.screenToPage', () => {
 	})
 
 	it('converts correctly when panned and zoomed and offset', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 100, y: 100 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 0.5 })
@@ -160,7 +160,7 @@ describe('viewport.screenToPage', () => {
 
 describe('viewportPageBounds', () => {
 	it('sets the page bounds', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0, w: 1000, h: 1000 },
 		})
 		editor.setCamera({ x: 0, y: 0, z: 1 })
@@ -174,7 +174,7 @@ describe('viewportPageBounds', () => {
 	})
 
 	it('sets the page bounds when camera is zoomed', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0, w: 1000, h: 1000 },
 		})
 		editor.setCamera({ x: 0, y: 0, z: 2 })
@@ -196,7 +196,7 @@ describe('viewportPageBounds', () => {
 	})
 
 	it('sets the page bounds when camera is panned', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0, w: 1000, h: 1000 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 1 })
@@ -212,7 +212,7 @@ describe('viewportPageBounds', () => {
 	})
 
 	it('sets the page bounds when camera is panned and zoomed', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 0, y: 0, w: 1000, h: 1000 },
 		})
 		editor.setCamera({ x: 100, y: 100, z: 2 })
@@ -228,7 +228,7 @@ describe('viewportPageBounds', () => {
 	})
 
 	it('sets the page bounds when viewport is offset', () => {
-		editor.updateInstanceState({
+		editor.instanceState.update({
 			screenBounds: { ...editor.getViewportScreenBounds(), x: 100, y: 100, w: 1000, h: 1000 },
 		})
 		editor.setCamera({ x: 0, y: 0, z: 2 })

--- a/packages/tldraw/src/test/commands/setBrush.test.ts
+++ b/packages/tldraw/src/test/commands/setBrush.test.ts
@@ -7,11 +7,11 @@ beforeEach(() => {
 })
 
 it('Sets the brush', () => {
-	expect(editor.getInstanceState().brush).toEqual(null)
+	expect(editor.instanceState.getBrush()).toEqual(null)
 
-	editor.updateInstanceState({ brush: { x: 0, y: 0, w: 100, h: 100 } })
+	editor.instanceState.update({ brush: { x: 0, y: 0, w: 100, h: 100 } })
 
-	expect(editor.getInstanceState().brush).toMatchObject({
+	expect(editor.instanceState.getBrush()).toMatchObject({
 		x: 0,
 		y: 0,
 		w: 100,
@@ -20,7 +20,7 @@ it('Sets the brush', () => {
 
 	editor.undo()
 
-	expect(editor.getInstanceState().brush).toEqual({
+	expect(editor.instanceState.getBrush()).toEqual({
 		x: 0,
 		y: 0,
 		w: 100,
@@ -29,7 +29,7 @@ it('Sets the brush', () => {
 
 	editor.redo()
 
-	expect(editor.getInstanceState().brush).toEqual({
+	expect(editor.instanceState.getBrush()).toEqual({
 		x: 0,
 		y: 0,
 		w: 100,

--- a/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
+++ b/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
@@ -115,9 +115,9 @@ describe('When center is true', () => {
 })
 
 test("if nothing changes it doesn't update the store", () => {
-	const originalScreenBounds = editor.getInstanceState().screenBounds
+	const originalScreenBounds = editor.instanceState.getScreenBounds()
 	editor.setScreenBounds(originalScreenBounds, true)
-	expect(editor.getInstanceState().screenBounds).toBe(originalScreenBounds)
+	expect(editor.instanceState.getScreenBounds()).toBe(originalScreenBounds)
 	editor.setScreenBounds({ ...originalScreenBounds }, true)
-	expect(editor.getInstanceState().screenBounds).toBe(originalScreenBounds)
+	expect(editor.instanceState.getScreenBounds()).toBe(originalScreenBounds)
 })

--- a/packages/tldraw/src/test/commands/zoomIn.test.ts
+++ b/packages/tldraw/src/test/commands/zoomIn.test.ts
@@ -59,7 +59,7 @@ it('zooms to from B to D when B >= (C - A)/2, else zooms from B to C', () => {
 it('does not zoom when camera is frozen', () => {
 	editor.setCamera({ x: 0, y: 0, z: 1 })
 	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
-	editor.updateInstanceState({ canMoveCamera: false })
+	editor.instanceState.update({ canMoveCamera: false })
 	editor.zoomIn()
 	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 })

--- a/packages/tldraw/src/test/commands/zoomOut.test.ts
+++ b/packages/tldraw/src/test/commands/zoomOut.test.ts
@@ -25,7 +25,7 @@ it('zooms by increments', () => {
 it('does not zoom out when camera is frozen', () => {
 	editor.setCamera({ x: 0, y: 0, z: 1 })
 	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
-	editor.updateInstanceState({ canMoveCamera: false })
+	editor.instanceState.update({ canMoveCamera: false })
 	editor.zoomOut()
 	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 })

--- a/packages/tldraw/src/test/commands/zoomToBounds.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToBounds.test.ts
@@ -44,7 +44,7 @@ it('does not zoom past min', () => {
 it('does not zoom to bounds when camera is frozen', () => {
 	editor.setScreenBounds({ x: 0, y: 0, w: 1000, h: 1000 })
 	expect(editor.getViewportPageCenter().toJson()).toCloselyMatchObject({ x: 500, y: 500 })
-	editor.updateInstanceState({ canMoveCamera: false })
+	editor.instanceState.update({ canMoveCamera: false })
 	editor.zoomToBounds(new Box(200, 300, 300, 300))
 	expect(editor.getViewportPageCenter().toJson()).toCloselyMatchObject({ x: 500, y: 500 })
 })

--- a/packages/tldraw/src/test/commands/zoomToFit.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToFit.test.ts
@@ -14,7 +14,7 @@ it('converts correctly', () => {
 
 it('does not zoom to bounds when camera is frozen', () => {
 	const cameraBefore = { ...editor.getCamera() }
-	editor.updateInstanceState({ canMoveCamera: false })
+	editor.instanceState.update({ canMoveCamera: false })
 	editor.zoomToFit()
 	expect(editor.getCamera()).toMatchObject(cameraBefore)
 })

--- a/packages/tldraw/src/test/commands/zoomToSelection.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToSelection.test.ts
@@ -35,7 +35,7 @@ it('does not zoom past min', () => {
 
 it('does not zoom to selection when camera is frozen', () => {
 	const cameraBefore = { ...editor.getCamera() }
-	editor.updateInstanceState({ canMoveCamera: false })
+	editor.instanceState.update({ canMoveCamera: false })
 	editor.setSelectedShapes([ids.box1, ids.box2])
 	editor.zoomToSelection()
 	expect(editor.getCamera()).toMatchObject(cameraBefore)

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -237,7 +237,7 @@ describe('When duplicating shapes after cloning', () => {
 		expect(shape.y).toBe(-10)
 
 		// Make sure the duplicate props are set
-		let instance = editor.instanceState.get()
+		let instance = editor.instanceState.getRecord()
 		let duplicateProps = instance?.duplicateProps
 		if (!duplicateProps) throw new Error('duplicateProps should be set')
 		expect(duplicateProps.shapeIds).toEqual([shape.id])
@@ -252,7 +252,7 @@ describe('When duplicating shapes after cloning', () => {
 
 		// Make sure the duplicate props are cleared when we select a different shape
 		editor.select(ids.box1)
-		instance = editor.instanceState.get()
+		instance = editor.instanceState.getRecord()
 		duplicateProps = instance?.duplicateProps
 		expect(duplicateProps).toBe(null)
 	})

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -237,7 +237,7 @@ describe('When duplicating shapes after cloning', () => {
 		expect(shape.y).toBe(-10)
 
 		// Make sure the duplicate props are set
-		let instance = editor.getInstanceState()
+		let instance = editor.instanceState.get()
 		let duplicateProps = instance?.duplicateProps
 		if (!duplicateProps) throw new Error('duplicateProps should be set')
 		expect(duplicateProps.shapeIds).toEqual([shape.id])
@@ -252,7 +252,7 @@ describe('When duplicating shapes after cloning', () => {
 
 		// Make sure the duplicate props are cleared when we select a different shape
 		editor.select(ids.box1)
-		instance = editor.getInstanceState()
+		instance = editor.instanceState.get()
 		duplicateProps = instance?.duplicateProps
 		expect(duplicateProps).toBe(null)
 	})

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -600,14 +600,14 @@ describe('frame shapes', () => {
 		const frameId = editor.getOnlySelectedShape()!.id
 
 		expect(editor.getSelectedShapeIds()[0]).toBe(frameId)
-		expect(editor.getCurrentPageState().editingShapeId).toBe(null)
+		expect(editor.getEditingShapeId()).toBe(null)
 
 		editor.setCurrentTool('select')
 
 		editor.keyDown('Enter')
 		editor.keyUp('Enter')
 
-		expect(editor.getCurrentPageState().editingShapeId).toBe(frameId)
+		expect(editor.getEditingShapeId()).toBe(frameId)
 	})
 
 	it('can be selected with box brushing only if the whole frame is selected', () => {

--- a/packages/tldraw/src/test/groups.test.ts
+++ b/packages/tldraw/src/test/groups.test.ts
@@ -291,7 +291,7 @@ describe('creating groups', () => {
 		// │ A │   │ B │   │ C │
 		// └───┘   └───┘   └───┘
 		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0), box(ids.boxC, 40, 0)])
-		editor.updateInstanceState({ isReadonly: true })
+		editor.instanceState.update({ isReadonly: true })
 		editor.setCurrentTool('hand')
 		editor.selectAll()
 		expect(editor.getSelectedShapeIds().length).toBe(3)
@@ -505,7 +505,7 @@ describe('ungrouping shapes', () => {
 		expect(editor.getSelectedShapeIds().length).toBe(3)
 		editor.groupShapes(editor.getSelectedShapeIds())
 		expect(editor.getSelectedShapeIds().length).toBe(1)
-		editor.updateInstanceState({ isReadonly: true })
+		editor.instanceState.update({ isReadonly: true })
 		editor.setCurrentTool('hand')
 
 		editor.ungroupShapes(editor.getSelectedShapeIds())
@@ -1502,8 +1502,8 @@ describe('erasing', () => {
 
 		// erase D
 		editor.pointerDown(65, 5, ids.boxD)
-		expect(editor.getCurrentPageState().erasingShapeIds.length).toBe(1)
-		expect(editor.getCurrentPageState().erasingShapeIds[0]).toBe(groupCId)
+		expect(editor.getErasingShapeIds().length).toBe(1)
+		expect(editor.getErasingShapeIds()[0]).toBe(groupCId)
 		editor.pointerUp()
 		expect(editor.getShape(groupCId)).toBeFalsy()
 	})
@@ -1523,8 +1523,8 @@ describe('erasing', () => {
 
 		// erase B
 		editor.pointerDown(25, 5, ids.boxB)
-		expect(editor.getCurrentPageState().erasingShapeIds.length).toBe(1)
-		expect(editor.getCurrentPageState().erasingShapeIds[0]).toBe(ids.boxB)
+		expect(editor.getErasingShapeIds().length).toBe(1)
+		expect(editor.getErasingShapeIds()[0]).toBe(ids.boxB)
 		editor.pointerUp()
 
 		// group A disappears
@@ -1539,8 +1539,8 @@ describe('erasing', () => {
 
 		// erase E
 		editor.pointerDown(5, 25, ids.boxE)
-		expect(editor.getCurrentPageState().erasingShapeIds.length).toBe(1)
-		expect(editor.getCurrentPageState().erasingShapeIds[0]).toBe(ids.boxE)
+		expect(editor.getErasingShapeIds().length).toBe(1)
+		expect(editor.getErasingShapeIds()[0]).toBe(ids.boxE)
 
 		// move to group B
 		editor.pointerMove(65, 5)

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -2953,7 +2953,7 @@ describe('snapping while the grid is enabled', () => {
 
 		editor.createShapes([box(ids.boxA, 0, 0, 20, 20), box(ids.boxB, 60, 0, 20, 20)])
 
-		editor.updateInstanceState({ isGridMode: true })
+		editor.instanceState.update({ isGridMode: true })
 
 		// try to move right side of A to left side of B
 		// doesn't work because of the grid
@@ -3831,16 +3831,16 @@ it('uses the cross cursor when create resizing', () => {
 	editor.pointerDown(0, 0)
 	editor.pointerMove(100, 100)
 	editor.expectToBeIn('select.resizing')
-	expect(editor.getInstanceState().cursor.type).toBe('cross')
-	expect(editor.getInstanceState().cursor.rotation).toBe(0)
+	expect(editor.instanceState.getCursor().type).toBe('cross')
+	expect(editor.instanceState.getCursor().rotation).toBe(0)
 
 	editor.pointerMove(120, 120)
-	expect(editor.getInstanceState().cursor.type).toBe('cross')
-	expect(editor.getInstanceState().cursor.rotation).toBe(0)
+	expect(editor.instanceState.getCursor().type).toBe('cross')
+	expect(editor.instanceState.getCursor().rotation).toBe(0)
 
 	editor.pointerMove(-120, -120)
-	expect(editor.getInstanceState().cursor.type).toBe('cross')
-	expect(editor.getInstanceState().cursor.rotation).toBe(0)
+	expect(editor.instanceState.getCursor().type).toBe('cross')
+	expect(editor.instanceState.getCursor().rotation).toBe(0)
 })
 
 describe('Resizing text from the right edge', () => {
@@ -3853,7 +3853,7 @@ describe('Resizing text from the right edge', () => {
 
 		const bounds = editor.getShapeGeometry(id).bounds
 
-		editor.updateInstanceState({ isCoarsePointer: false })
+		editor.instanceState.update({ isCoarsePointer: false })
 
 		// Resize from the right edge
 		editor.pointerDown(bounds.maxX, bounds.midY, { target: 'selection', handle: 'right' }) // right edge
@@ -3870,7 +3870,7 @@ describe('Resizing text from the right edge', () => {
 	})
 
 	it('Resizes text from the right edge when pointer is coarse', () => {
-		editor.updateInstanceState({ isCoarsePointer: true })
+		editor.instanceState.update({ isCoarsePointer: true })
 
 		const id = createShapeId()
 		editor.createShapes([{ id, type: 'text', props: { text: 'H' } }])

--- a/packages/tldraw/src/test/select.test.tsx
+++ b/packages/tldraw/src/test/select.test.tsx
@@ -22,7 +22,7 @@ describe(SelectTool, () => {
 			editor.expectToBeIn('select.idle')
 			editor.doubleClick(50, 50, shapeId)
 
-			expect(editor.getCurrentPageState().editingShapeId).toBe(shapeId)
+			expect(editor.getEditingShapeId()).toBe(shapeId)
 
 			// note: this behavior has moved to the React hook useEditableText.
 			// clicking on the input will preserve selection, however you can
@@ -36,7 +36,7 @@ describe(SelectTool, () => {
 			jest.advanceTimersByTime(1000)
 
 			editor.pointerDown(150, 150).pointerUp()
-			expect(editor.getCurrentPageState().editingShapeId).toBe(null)
+			expect(editor.getEditingShapeId()).toBe(null)
 			editor.expectToBeIn('select.idle')
 		})
 	})
@@ -48,18 +48,18 @@ describe(SelectTool, () => {
 		editor.setCurrentTool('select')
 		editor.doubleClick(50, 50, shapeId)
 
-		expect(editor.getCurrentPageState().editingShapeId).toBe(shapeId)
+		expect(editor.getEditingShapeId()).toBe(shapeId)
 
 		// clicking outside the shape should end editing
 		jest.advanceTimersByTime(1000)
 
 		editor.pointerDown(150, 150).pointerUp()
-		expect(editor.getCurrentPageState().editingShapeId).toBe(null)
+		expect(editor.getEditingShapeId()).toBe(null)
 		editor.expectToBeIn('select.idle')
 
 		editor.undo()
 
-		expect(editor.getCurrentPageState().editingShapeId).toBe(null)
+		expect(editor.getEditingShapeId()).toBe(null)
 	})
 })
 

--- a/packages/tldraw/src/test/spacebarPanning.test.ts
+++ b/packages/tldraw/src/test/spacebarPanning.test.ts
@@ -15,18 +15,18 @@ beforeEach(() => {
 })
 
 it('Sets cursor and state correctly', () => {
-	expect(editor.getInstanceState().cursor.type).toBe('default')
+	expect(editor.instanceState.getCursor().type).toBe('default')
 	expect(editor.inputs.isPanning).toBe(false)
 	editor.keyDown(' ')
 	expect(editor.inputs.isPanning).toBe(true)
-	expect(editor.getInstanceState().cursor.type).toBe('grab')
+	expect(editor.instanceState.getCursor().type).toBe('grab')
 	editor.pointerDown(0, 0)
-	expect(editor.getInstanceState().cursor.type).toBe('grabbing')
+	expect(editor.instanceState.getCursor().type).toBe('grabbing')
 	editor.pointerUp(0, 0)
-	expect(editor.getInstanceState().cursor.type).toBe('grab')
+	expect(editor.instanceState.getCursor().type).toBe('grab')
 	editor.keyUp(' ')
 	expect(editor.inputs.isPanning).toBe(false)
-	expect(editor.getInstanceState().cursor.type).toBe('default')
+	expect(editor.instanceState.getCursor().type).toBe('default')
 })
 
 it('When holding spacebar and clicking and dragging, it pans the camera', () => {

--- a/packages/tldraw/src/test/styles2.test.tsx
+++ b/packages/tldraw/src/test/styles2.test.tsx
@@ -191,9 +191,9 @@ describe('Editor.setStyle', () => {
 	it('stores styles on stylesForNextShape', () => {
 		editor.setStyleForSelectedShapes(DefaultColorStyle, 'red')
 		editor.setStyleForNextShapes(DefaultColorStyle, 'red')
-		expect(editor.getInstanceState().stylesForNextShape[DefaultColorStyle.id]).toBe('red')
+		expect(editor.instanceState.getStylesForNextShape()[DefaultColorStyle.id]).toBe('red')
 		editor.setStyleForSelectedShapes(DefaultColorStyle, 'green')
 		editor.setStyleForNextShapes(DefaultColorStyle, 'green')
-		expect(editor.getInstanceState().stylesForNextShape[DefaultColorStyle.id]).toBe('green')
+		expect(editor.instanceState.getStylesForNextShape()[DefaultColorStyle.id]).toBe('green')
 	})
 })

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -1454,7 +1454,7 @@ describe('translating while the grid is enabled', () => {
 		//  └───┘       └───┘
 		editor.createShapes([box(ids.box1, 0, 0, 20, 20), box(ids.box2, 50, 0, 20, 20)])
 
-		editor.updateInstanceState({ isGridMode: true })
+		editor.instanceState.update({ isGridMode: true })
 
 		// try to snap A to B
 		// doesn't work because of the grid

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1094,6 +1094,9 @@ export interface TLInstancePageState extends BaseRecord<'instance_page_state', T
 }
 
 // @public (undocumented)
+export type TLInstancePageStateId = RecordId<TLInstancePageState>;
+
+// @public (undocumented)
 export interface TLInstancePresence extends BaseRecord<'instance_presence', TLInstancePresenceID> {
     // (undocumented)
     brush: BoxModel | null;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -7344,7 +7344,7 @@
             {
               "kind": "Reference",
               "text": "TLInstancePageStateId",
-              "canonicalReference": "@tldraw/tlschema!~TLInstancePageStateId:type"
+              "canonicalReference": "@tldraw/tlschema!TLInstancePageStateId:type"
             },
             {
               "kind": "Content",
@@ -7660,6 +7660,46 @@
               "endIndex": 5
             }
           ]
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/tlschema!TLInstancePageStateId:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type TLInstancePageStateId = "
+            },
+            {
+              "kind": "Reference",
+              "text": "RecordId",
+              "canonicalReference": "@tldraw/store!RecordId:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TLInstancePageState",
+              "canonicalReference": "@tldraw/tlschema!TLInstancePageState:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tlschema/src/records/TLPageState.ts",
+          "releaseTag": "Public",
+          "name": "TLInstancePageStateId",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 5
+          }
         },
         {
           "kind": "Interface",

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -46,7 +46,11 @@ export {
 	type TLPage,
 	type TLPageId,
 } from './records/TLPage'
-export { InstancePageStateRecordType, type TLInstancePageState } from './records/TLPageState'
+export {
+	InstancePageStateRecordType,
+	type TLInstancePageState,
+	type TLInstancePageStateId,
+} from './records/TLPageState'
 export { PointerRecordType, TLPOINTER_ID } from './records/TLPointer'
 export { InstancePresenceRecordType, type TLInstancePresence } from './records/TLPresence'
 export { type TLRecord } from './records/TLRecord'

--- a/packages/tlsync/src/test/syncFuzz.test.ts
+++ b/packages/tlsync/src/test/syncFuzz.test.ts
@@ -136,7 +136,7 @@ function runTest(seed: number) {
 		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.getCurrentPage())) {
 			throw new Error(`not all peer editors have current page (${when})`)
 		}
-		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.getCurrentPageState())) {
+		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.currentPageState.get())) {
 			throw new Error(`not all peer editors have page states (${when})`)
 		}
 		if (

--- a/packages/tlsync/src/test/syncFuzz.test.ts
+++ b/packages/tlsync/src/test/syncFuzz.test.ts
@@ -136,7 +136,7 @@ function runTest(seed: number) {
 		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.getCurrentPage())) {
 			throw new Error(`not all peer editors have current page (${when})`)
 		}
-		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.currentPageState.get())) {
+		if (peers.some((p) => p.editor?.editor && !p.editor?.editor.currentPageState.getRecord())) {
 			throw new Error(`not all peer editors have page states (${when})`)
 		}
 		if (


### PR DESCRIPTION
Big diff, sorry!

This diff deprecates `getInstanceState`, `getCurrentPageState`, and their related updaters in favour of managers that handle caching on the properties of those records.

These records are both bags of largely unrelated data, some of which updates very frequently. These frequent updates cause calls to the deprecated methods to trigger a lot of unneeded signia updates & react renders. By encouraging reads of those values to instead go through `@computed`, we cut down drastically on those extra updates/renders:

![Kapture 2024-02-08 at 15 52 37](https://github.com/tldraw/tldraw/assets/1489520/f4c6753c-486e-40e5-b1d7-f25c8bf3a6c4)

Running these two through managers mirrors `editor.userPreferences`, which has per-property getters, and a single top-level updater command. This diff mostly follows that pattern, with one deviation: accessors that already existed on `editor` are still there rather than in the manager (e.g. we do `editor.getSelectedShapeIds()`, not `editor.currentPageState.getSelectedShapeIds()`).

This has resulted in things being a bit inconsistent. We could also deprecate the editor versions of those getters and move them all to the manager, but i think this is probably fine for now.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Largely relying on existing unit & end to end tests for this one :/

### Release Notes

- `editor.getInstanceState()` is deprecated in favour of getters on `editor.instanceState` e.g. `editor.instanceState.getIsCoarsePointer()`
- `editor.getCurrentPageState()` is deprecated in favour of getters on `editor.currentPageState` e.g. `editor.currentPageState.getCroppingShapeId()`
- `editor.updateInstanceState` is deprecated in favour of `editor.instanceState.update`
- `editor.updateCurrentPageState` is deprecated in favour of `editor.currentPageState.update`
