### PR TITLE
fix cursor update frequency

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -41,6 +41,7 @@ import {
 import {
 	JsonObject,
 	annotateError,
+	applyPartial,
 	assert,
 	compact,
 	dedupe,
@@ -1179,7 +1180,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 **/
 	updateDocumentSettings(settings: Partial<TLDocument>): this {
-		this.store.put([{ ...this.getDocumentSettings(), ...settings }])
+		this.store.put([applyPartial(this.getDocumentSettings(), settings)])
 		return this
 	}
 
@@ -1229,7 +1230,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			historyOptions?: TLCommandHistoryOptions
 		) => {
 			const prev = this.store.get(this.getInstanceState().id)!
-			const next = { ...prev, ...partial }
+			const next = applyPartial<TLInstance>(prev, partial)
 
 			return {
 				data: { prev, next },
@@ -1351,8 +1352,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setCursor = (cursor: Partial<TLCursor>): this => {
+		applyPartialToShape
 		this.updateInstanceState(
-			{ cursor: { ...this.getInstanceState().cursor, ...cursor } },
+			{ cursor: applyPartial(this.getInstanceState().cursor, cursor) },
 			{ ephemeral: true }
 		)
 		return this
@@ -1424,7 +1426,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		},
 		{
 			do: ({ prev, partial }) => {
-				this.store.update(prev.id, (state) => ({ ...state, ...partial }))
+				this.store.update(prev.id, (state) => applyPartial<TLInstancePageState>(state, partial))
 			},
 			undo: ({ prev }) => {
 				this.store.update(prev.id, () => prev)
@@ -3417,7 +3419,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		},
 		{
 			do: ({ partial }) => {
-				this.store.update(partial.id, (page) => ({ ...page, ...partial }))
+				this.store.update(partial.id, (page) => applyPartial(page, partial))
 			},
 			undo: ({ prev, partial }) => {
 				this.store.update(partial.id, () => prev)
@@ -7368,7 +7370,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const stylesForNextShape = this.getInstanceState().stylesForNextShape
 
 		this.updateInstanceState(
-			{ stylesForNextShape: { ...stylesForNextShape, [style.id]: value } },
+			{ stylesForNextShape: applyPartial(stylesForNextShape, { [style.id]: value }) },
 			historyOptions
 		)
 

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -644,3 +644,22 @@ describe('when the user prefers light UI', () => {
 		expect(editor.user.getIsDarkMode()).toBe(false)
 	})
 })
+
+describe('setCursor', () => {
+	test('setting the same cursor doesnt produce updates', () => {
+		editor.setCursor({ type: 'default' })
+		editor.store._flushHistory()
+
+		const onStoreChange = jest.fn()
+		editor.store.listen(onStoreChange)
+
+		editor.setCursor({ type: 'default' })
+		expect(onStoreChange).not.toHaveBeenCalled()
+
+		editor.setCursor({ type: 'pointer' })
+		expect(onStoreChange).toHaveBeenCalledTimes(1)
+
+		editor.setCursor({ type: 'pointer' })
+		expect(onStoreChange).toHaveBeenCalledTimes(1)
+	})
+})

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -7,6 +7,9 @@
 // @internal
 export function annotateError(error: unknown, annotations: Partial<ErrorAnnotations>): void;
 
+// @internal
+export function applyPartial<T extends object>(initialRecord: T, partial: Partial<T>): T;
+
 // @internal (undocumented)
 export function areArraysShallowEqual<T>(arr1: readonly T[], arr2: readonly T[]): boolean;
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -26,6 +26,7 @@ export type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from './lib/json
 export { MediaHelpers } from './lib/media'
 export { invLerp, lerp, modulate, rng } from './lib/number'
 export {
+	applyPartial,
 	areObjectsShallowEqual,
 	deepCopy,
 	filterEntries,

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -153,3 +153,21 @@ export function areObjectsShallowEqual<T extends Record<string, unknown>>(
 	}
 	return true
 }
+
+/**
+ * Equivalent to `{...initialRecord, ...partial}`, but if the result would shallow-equal
+ * `initialRecord`, we return `initialRecord` instead.
+ *
+ * @internal
+ */
+export function applyPartial<T extends object>(initialRecord: T, partial: Partial<T>): T {
+	let didChange = false
+	const result = { ...initialRecord }
+	for (const [key, newValue] of Object.entries(partial)) {
+		if (Object.is(getOwnProperty(initialRecord, key), newValue)) continue
+		;(result as any)[key] = newValue
+		didChange = true
+	}
+
+	return didChange ? result : initialRecord
+}


### PR DESCRIPTION
Previously, no-op changes to `setCursor` would still trigger full signia updates and network diffs. This would happen on every pointer move event even though the change wasn't actually doing anything. This is because we were using `{...original, ...update}` style updates, which produce a fresh object regardless of whether anything actually changed. This diff introduces an `applyPartial` helper which does the same thing as `{...original, ...update}`, but if the result is the same as `original` (according to `Object.is` on each key in the partial), we return the unchanged `original` instead.

See https://github.com/tldraw/tldraw/pull/2792#issuecomment-1936327594 for details

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

- [x] Unit Tests


