### PR TITLE
repair Huppy's handling of LICENCE

### DIFF
--- a/apps/huppy/src/flows/standaloneExamplesBranch.tsx
+++ b/apps/huppy/src/flows/standaloneExamplesBranch.tsx
@@ -5,7 +5,7 @@ import { Flow } from '../flow'
 import { withWorkingRepo } from '../repo'
 import { readJsonIfExists } from '../utils'
 
-const filesToCopyFromRoot = ['.gitignore', '.prettierrc', 'LICENSE']
+const filesToCopyFromRoot = ['.gitignore', '.prettierrc', 'LICENSE.md']
 const packageDepsToSyncFromRoot = ['typescript', '@types/react', '@types/react-dom']
 
 export const standaloneExamplesBranch = {


### PR DESCRIPTION
Huppy was expecting `LICENCE`, while the actual filename is now `LICENCE.md`. This PR fixes the oversight.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package