### PR TITLE
Remove pointer check for arrow labels

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -34,13 +34,6 @@ export class Idle extends StateNode {
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = () => {
 		updateHoveredId(this.editor)
-
-		const hitShape = this.editor.getHoveredShape()
-		if (this.isOverArrowLabelTest(hitShape)) {
-			this.editor.setCursor({ type: 'pointer', rotation: 0 })
-		} else {
-			this.editor.setCursor({ type: 'default', rotation: 0 })
-		}
 	}
 
 	override onPointerDown: TLEventHandlers['onPointerDown'] = (info) => {


### PR DESCRIPTION
This PR removes a check for pointer changes over arrow labels. We don't really have any other uses of the `pointer` in the canvas except for buttons, so I'd rather keep the default cursor for arrow labels.

### Change Type

- [x] `minor` — New feature