### PR TITLE
Readonly defaults to the hand tool

### DIFF
--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -67,6 +67,7 @@ export function MultiplayerEditor({
 				store={storeWithStatus}
 				assetUrls={assetUrls}
 				onMount={handleMount}
+				initialState={isReadOnly ? 'hand' : 'select'}
 				overrides={[
 					sharingUiOverrides,
 					fileSystemUiOverrides,


### PR DESCRIPTION
#2720 
This PR makes it so that the editor defaults to the hand tool in read only mode

### Change Type

- [x] `minor` — New feature


### Test Plan

1. Open the editor in readonly mode
2. It should default to the hand tool

### Release Notes

- Shared projects in  read only mode now default to the hand tool
