### PR TITLE
fix(editor): resolve zoom interactions with reduced motion

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2530,7 +2530,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			return this._setCamera({
 				x: -targetViewportPage.x,
 				y: -targetViewportPage.y,
-				z: viewportPageBounds.width / targetViewportPage.width,
+				z: this.getViewportScreenBounds().width / targetViewportPage.width,
 			})
 		}
 


### PR DESCRIPTION
Hotfix using the following PR: https://github.com/tldraw/tldraw/pull/2818

Fixes a bug with zoom interactions not working correctly when using reduce motion option.

Before:

https://github.com/tldraw/tldraw/assets/2523721/125e9aaa-681c-4242-bb9e-298dd41b7a97

After:

https://github.com/tldraw/tldraw/assets/2523721/e59b950c-2c55-4663-91cc-fdc0c1403bb0

### Change type

- [x] `bugfix`

### Test plan

1. Zooming via the minimap should now correctly go through the zoom steps.
2. Other zoom interactions should work correctly (things like zoom to selection, zoom to 100%,...).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes an issue with the camera and zooming when reduced motion is enabled.