### PR TITLE
fix frame style panel

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
@@ -37,7 +37,7 @@ export const DefaultStylePanel = memo(function DefaultStylePanel({
 			data-ismobile={isMobile}
 			onPointerLeave={handlePointerOut}
 		>
-			{content}
+			<div className="tlui-style-panel">{content}</div>
 		</div>
 	)
 })

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
@@ -33,11 +33,11 @@ export const DefaultStylePanel = memo(function DefaultStylePanel({
 
 	return (
 		<div
-			className={classNames('', { 'tlui-style-panel__wrapper': !isMobile })}
+			className={classNames('tlui-style-panel', { 'tlui-style-panel__wrapper': !isMobile })}
 			data-ismobile={isMobile}
 			onPointerLeave={handlePointerOut}
 		>
-			<div className="tlui-style-panel">{content}</div>
+			{content}
 		</div>
 	)
 })


### PR DESCRIPTION
Opacity slider was squished when frame tool was selected. I think it's because this PR #2847 got rid of the tlui-style-panel div. Putting it back seems to fix it.

### Change Type

- [x] `patch` — Bug fix



### Release Notes

- Fixes an issue with the opacity slider getting squished.
