### PR TITLE
Blink to show pasted shapes when the pasted page bounds are equal to the copied bounds

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -330,30 +330,6 @@ input,
 	contain: size layout;
 }
 
-.tl-canvas-recent-paste-event .tl-shape-indicator path {
-	animation: puff 0.2s ease-in forwards;
-}
-
-@keyframes puff {
-  0% {
-		transform-origin: 25% 25%;
-    transform: scale(1, 1);
-    filter: blur(0px);
-  }
-
-  50% {
-		transform-origin: 25% 25%;
-    transform: scale(1.05, 1.05);
-    filter: blur(3px);
-  }
-
-  100% {
-		transform-origin: 25% 25%;
-    transform: scale(1, 1);
-    filter: blur(0px);
-  }
-}
-
 .tl-shape__culled {
 	position: relative;
 	background-color: var(--color-culled);
@@ -426,20 +402,6 @@ input,
 	z-index: 100;
 }
 
-.tl-user-indicator__hint {
-	z-index: 110;
-	stroke-width: calc(2.5px * var(--tl-scale));
-}
-
-/* behind collaborator cursor */
-.tl-collaborator__cursor-hint {
-	z-index: 120;
-}
-
-.tl-collaborator__cursor {
-	z-index: 130;
-}
-
 .tl-cursor {
 	overflow: visible;
 }
@@ -451,6 +413,25 @@ input,
 	fill: none;
 	stroke-width: calc(1.5px * var(--tl-scale));
 	contain: size;
+}
+
+.tl-user-indicator__hint {
+	z-index: 75;
+}
+
+.tl-user-indicator__hint > .tl-shape-indicator {
+	stroke-width: calc(2.5px * var(--tl-scale));
+}
+
+/* ------------------ Collaborator ------------------ */
+
+/* behind collaborator cursor */
+.tl-collaborator__cursor-hint {
+	z-index: 120;
+}
+
+.tl-collaborator__cursor {
+	z-index: 130;
 }
 
 /* ------------------ SelectionBox ------------------ */

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -416,11 +416,12 @@ input,
 }
 
 .tl-user-indicator__hint {
+	/* Above other indicators, below handles / controls */
 	z-index: 75;
 }
 
 .tl-user-indicator__hint > .tl-shape-indicator {
-	stroke-width: calc(2.5px * var(--tl-scale));
+	stroke-width: calc(3px * var(--tl-scale));
 }
 
 /* ------------------ Collaborator ------------------ */

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -25,13 +25,6 @@ import { ShapeIndicator } from './ShapeIndicator'
 /** @public */
 export function Canvas({ className }: { className?: string }) {
 	const editor = useEditor()
-	const [didPasteEventHappenRecently, setDidPasteEventHappenRecently] = React.useState(false)
-	editor.on('event', (event) => {
-		if (event.type === 'misc' && event.name === 'paste') {
-			setDidPasteEventHappenRecently(true)
-		}
-	})
-	editor.on('change-history', () => setDidPasteEventHappenRecently(false))
 
 	const { Background, SvgDefs } = useEditorComponents()
 
@@ -100,11 +93,7 @@ export function Canvas({ className }: { className?: string }) {
 		<div
 			ref={rCanvas}
 			draggable={false}
-			className={classNames(
-				'tl-canvas',
-				{ 'tl-canvas-recent-paste-event': didPasteEventHappenRecently },
-				className
-			)}
+			className={classNames('tl-canvas', className)}
 			data-testid="canvas"
 			{...events}
 		>
@@ -427,6 +416,8 @@ const HintedShapeIndicator = track(function HintedShapeIndicator() {
 	const ids = dedupe(editor.getHintingShapeIds())
 
 	if (!ids.length) return null
+
+	console.log(ids)
 
 	return (
 		<>

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -417,8 +417,6 @@ const HintedShapeIndicator = track(function HintedShapeIndicator() {
 
 	if (!ids.length) return null
 
-	console.log(ids)
-
 	return (
 		<>
 			{ids.map((id) => (

--- a/packages/editor/src/lib/components/Canvas.tsx
+++ b/packages/editor/src/lib/components/Canvas.tsx
@@ -353,11 +353,9 @@ function ShapesToDisplay() {
 
 function SelectedIdIndicators() {
 	const editor = useEditor()
-	const selectedShapeIds = useValue(
-		'selectedShapeIds',
-		() => editor.getCurrentPageState().selectedShapeIds,
-		[editor]
-	)
+	const selectedShapeIds = useValue('selectedShapeIds', () => editor.getSelectedShapeIds(), [
+		editor,
+	])
 	const shouldDisplay = useValue(
 		'should display selected ids',
 		() => {

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
@@ -11,15 +11,23 @@ import { Editor, TLContent, VecLike } from '@tldraw/editor'
 export function pasteTldrawContent(editor: Editor, clipboard: TLContent, point?: VecLike) {
 	const p = point ?? (editor.inputs.shiftKey ? editor.inputs.currentPagePoint : undefined)
 
+	const seletionBoundsBefore = editor.getSelectionPageBounds()
 	editor.mark('paste')
 	editor.putContentOntoCurrentPage(clipboard, {
 		point: p,
 		select: true,
 	})
-	const shapeIds = editor.getSelectedShapeIds()
-	editor.setHintingShapes(shapeIds)
-	setTimeout(() => {
-		editor.setHintingShapes([])
-	}, 250)
+	const selectedBoundsAfter = editor.getSelectionPageBounds()
+	if (
+		seletionBoundsBefore &&
+		selectedBoundsAfter &&
+		seletionBoundsBefore?.equals(selectedBoundsAfter)
+	) {
+		editor.updateInstanceState({ isChangingStyle: true })
+		setTimeout(() => {
+			editor.updateInstanceState({ isChangingStyle: false })
+		}, 150)
+	}
+
 	editor.emit('event', { type: 'misc', name: 'paste' })
 }

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
@@ -16,5 +16,10 @@ export function pasteTldrawContent(editor: Editor, clipboard: TLContent, point?:
 		point: p,
 		select: true,
 	})
+	const shapeIds = editor.getSelectedShapeIds()
+	editor.setHintingShapes(shapeIds)
+	setTimeout(() => {
+		editor.setHintingShapes([])
+	}, 150)
 	editor.emit('event', { type: 'misc', name: 'paste' })
 }

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
@@ -20,6 +20,6 @@ export function pasteTldrawContent(editor: Editor, clipboard: TLContent, point?:
 	editor.setHintingShapes(shapeIds)
 	setTimeout(() => {
 		editor.setHintingShapes([])
-	}, 150)
+	}, 250)
 	editor.emit('event', { type: 'misc', name: 'paste' })
 }


### PR DESCRIPTION
![Kapture 2024-02-21 at 08 27 16](https://github.com/tldraw/tldraw/assets/23072548/df84655e-308c-451b-b1a5-a18de826247f)

This PR uses the `isChangingStyle` to temporarily hide the selection UI after paste causing the selection UI to "blink". We also use the `isChangingStyle` property from the style panel to hide the selection UI when the use changes colors.

This effect only happens _when the pasted bounds are equal to the copied bounds_. 

Compared to hinting, this is much more of a visual alert that something has changed (and that the selection has changed!) even though the selection itself moves immediately to the new shapes. 


(This PR also fixes a bug with this that was preventing hinting shapes from displaying correctly, though I'll extract that into its own PR).

### Change Type

- [x] `patch` — Bug fix