### PR TITLE
[substantial tweak] add 4px horizontal padding to text

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -727,7 +727,7 @@ input,
 .tl-text {
 	/* remove overflow from textarea on windows */
 	margin: 0px;
-	padding: 0px;
+	padding: 0px 4px;
 	border: 0px;
 	color: inherit;
 	caret-color: var(--color-text);

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -384,6 +384,7 @@ function getTextSize(editor: Editor, props: TLTextShape['props']) {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[font],
 		fontSize: fontSize,
+		padding: '0px 4px',
 		maxWidth: cw,
 	})
 


### PR DESCRIPTION
This PR adds padding to the left and right of text, similar to arrow labels.

![Kapture 2024-02-16 at 20 41 03](https://github.com/tldraw/tldraw/assets/23072548/2a584717-4fbe-43c5-921d-b63175bcceef)

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Check out the delta on large projects
