### PR TITLE
doc: fix typo in examples

### DIFF
--- a/apps/examples/src/examples/custom-actions-menu/README.md
+++ b/apps/examples/src/examples/custom-actions-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's actions menu.
 
 ---
 
-The actions menu can be customized by providing a `ActionsMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The actions menu can be customized by providing a `ActionsMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-context-menu/README.md
+++ b/apps/examples/src/examples/custom-context-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's context menu.
 
 ---
 
-The context menu can be customized by providing a `ContextMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The context menu can be customized by providing a `ContextMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/custom-debug-menu/README.md
+++ b/apps/examples/src/examples/custom-debug-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's debug menu.
 
 ---
 
-The help menu can be customized by providing a `DebugMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The help menu can be customized by providing a `DebugMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-help-menu/README.md
+++ b/apps/examples/src/examples/custom-help-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's help menu.
 
 ---
 
-The help menu can be customized by providing a `HelpMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The help menu can be customized by providing a `HelpMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-keyboard-shortcuts-dialog/README.md
+++ b/apps/examples/src/examples/custom-keyboard-shortcuts-dialog/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's keyboard shortcuts dialog.
 
 ---
 
-The keyboard shortcuts dialog can be customized by providing a `KeyboardShortcutsDialog` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The keyboard shortcuts dialog can be customized by providing a `KeyboardShortcutsDialog` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/custom-main-menu/README.md
+++ b/apps/examples/src/examples/custom-main-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's main menu.
 
 ---
 
-The actions menu can be customized by providing a `MainMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The actions menu can be customized by providing a `MainMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-navigation-panel/README.md
+++ b/apps/examples/src/examples/custom-navigation-panel/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's navigation panel or remove it entirely.
 
 ---
 
-The navigation panel can be customized by providing a `NavigationPanel` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The navigation panel can be customized by providing a `NavigationPanel` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/custom-page-menu/README.md
+++ b/apps/examples/src/examples/custom-page-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's page menu, or remove it entirely.
 
 ---
 
-The page menu can be customized by providing a `PageMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The page menu can be customized by providing a `PageMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-quick-actions/README.md
+++ b/apps/examples/src/examples/custom-quick-actions/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's quick actions, a collection of components that appear
 
 ---
 
-The quick actions component can be customized by providing a `QuickActionsContent` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden.
+The quick actions component can be customized by providing a `QuickActionsContent` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden.

--- a/apps/examples/src/examples/custom-style-panel/README.md
+++ b/apps/examples/src/examples/custom-style-panel/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's style panel or remove it entirely.
 
 ---
 
-The style panel can be customized by providing a `StylePanel` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The style panel can be customized by providing a `StylePanel` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/custom-toolbar/README.md
+++ b/apps/examples/src/examples/custom-toolbar/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's toolbar or remove it entirely.
 
 ---
 
-The toolbar can be customized by providing a `Toolbar` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The toolbar can be customized by providing a `Toolbar` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/custom-zoom-menu/README.md
+++ b/apps/examples/src/examples/custom-zoom-menu/README.md
@@ -8,4 +8,4 @@ You can customize tldraw's zoom menu.
 
 ---
 
-The zoom menu can be customized by providing a `ZoomMenu` component to the `Tldraw` component's `uiComponents` prop. If you provide `null`, then that component will be hidden instead.
+The zoom menu can be customized by providing a `ZoomMenu` component to the `Tldraw` component's `components` prop. If you provide `null`, then that component will be hidden instead.

--- a/apps/examples/src/examples/ui-components-hidden/README.md
+++ b/apps/examples/src/examples/ui-components-hidden/README.md
@@ -8,4 +8,4 @@ You can hide tldraw's UI components.
 
 ---
 
-Custom UI components can be hidden providing a `null` as the value for a component in `uiComponents`. In this case, all configurable UI components are hidden.
+Custom UI components can be hidden providing a `null` as the value for a component in `components In this case, all configurable UI components are hidden.


### PR DESCRIPTION
fix typo in examples

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [x] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- fix typo in examples
