### PR TITLE
[handles] Line shape handles -> keyed by id

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -867,7 +867,12 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     getHandles(shape: TLLineShape): TLHandle[];
     // (undocumented)
     getHandleSnapGeometry(shape: TLLineShape): {
-        points: VecModel[];
+        points: {
+            id: string;
+            index: IndexKey;
+            x: number;
+            y: number;
+        }[];
     };
     // (undocumented)
     getOutlineSegments(shape: TLLineShape): Vec[][];
@@ -893,7 +898,12 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
         dash: EnumStyleProp<"dashed" | "dotted" | "draw" | "solid">;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         spline: EnumStyleProp<"cubic" | "line">;
-        handles: DictValidator<IndexKey, VecModel>;
+        handles: DictValidator<string, {
+        id: string;
+        index: IndexKey;
+        x: number;
+        y: number;
+        }>;
     };
     // (undocumented)
     toSvg(shape: TLLineShape, ctx: SvgExportContext): SVGGElement;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -10239,16 +10239,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n        points: import(\"@tldraw/editor\")."
+                  "text": "{\n        points: {\n            id: string;\n            index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
-                  "text": "VecModel",
-                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                  "text": "IndexKey",
+                  "canonicalReference": "@tldraw/utils!IndexKey:type"
                 },
                 {
                   "kind": "Content",
-                  "text": "[];\n    }"
+                  "text": ";\n            x: number;\n            y: number;\n        }[];\n    }"
                 },
                 {
                   "kind": "Content",
@@ -10684,7 +10684,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<import(\"@tldraw/editor\")."
+                  "text": "<string, {\n            id: string;\n            index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -10693,16 +10693,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", import(\"@tldraw/editor\")."
-                },
-                {
-                  "kind": "Reference",
-                  "text": "VecModel",
-                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">;\n    }"
+                  "text": ";\n            x: number;\n            y: number;\n        }>;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -10715,7 +10706,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 16
+                "endIndex": 14
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -17,7 +17,10 @@ describe('Handle snapping', () => {
 				ref="line"
 				x={0}
 				y={0}
-				handles={{ ['a1' as IndexKey]: { x: 200, y: 0 }, ['a2' as IndexKey]: { x: 200, y: 100 } }}
+				handles={{
+					a: { id: 'a', index: 'a1' as IndexKey, x: 200, y: 0 },
+					b: { id: 'b', index: 'a2' as IndexKey, x: 200, y: 100 },
+				}}
 			/>,
 		])
 	})

--- a/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeTool.test.ts
@@ -66,8 +66,8 @@ describe('When dragging the line', () => {
 			y: 0,
 			props: {
 				handles: {
-					a1: { x: 0, y: 0 },
-					a2: { x: 10, y: 10 },
+					a: { id: 'a', index: 'a1', x: 0, y: 0 },
+					b: { id: 'b', index: 'a2', x: 10, y: 10 },
 				},
 			},
 		})

--- a/packages/tldraw/src/lib/shapes/line/__snapshots__/LineShapeUtil.test.tsx.snap
+++ b/packages/tldraw/src/lib/shapes/line/__snapshots__/LineShapeUtil.test.tsx.snap
@@ -12,11 +12,15 @@ exports[`Misc resizes: line shape after resize 1`] = `
     "color": "black",
     "dash": "draw",
     "handles": {
-      "a1": {
+      "a": {
+        "id": "a",
+        "index": "a1",
         "x": 0,
         "y": 0,
       },
-      "a2": {
+      "b": {
+        "id": "b",
+        "index": "a2",
         "x": 100,
         "y": 700,
       },

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -1,18 +1,17 @@
 import {
-	IndexKey,
 	Mat,
 	StateNode,
 	TLEventHandlers,
 	TLInterruptEvent,
 	TLLineShape,
+	TLLineShapeHandle,
 	TLShapeId,
 	Vec,
-	VecModel,
 	createShapeId,
 	getIndexAbove,
 	last,
 	sortByIndex,
-	structuredClone,
+	uniqueId,
 } from '@tldraw/editor'
 
 const MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES = 2
@@ -51,7 +50,7 @@ export class Pointing extends StateNode {
 				new Vec(this.shape.x, this.shape.y)
 			)
 
-			let nextEndHandleIndex: IndexKey, nextEndHandle: VecModel
+			let nextEndHandle: TLLineShapeHandle
 
 			const nextPoint = Vec.Sub(currentPagePoint, shapePagePoint)
 
@@ -60,30 +59,31 @@ export class Pointing extends StateNode {
 				Vec.Dist(nextPoint, endHandle) < MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES
 			) {
 				// If the end handle is too close to the previous end handle, we'll just extend the previous end handle
-				nextEndHandleIndex = endHandle.index
 				nextEndHandle = {
+					id: endHandle.id,
+					index: endHandle.index,
 					x: nextPoint.x + 0.1,
 					y: nextPoint.y + 0.1,
 				}
 			} else {
 				// Otherwise, we'll create a new end handle
-				nextEndHandleIndex = getIndexAbove(endHandle.index)
 				nextEndHandle = {
+					id: uniqueId(),
+					index: getIndexAbove(endHandle.index),
 					x: nextPoint.x + 0.1,
 					y: nextPoint.y + 0.1,
 				}
 			}
-
-			const nextHandles = structuredClone(this.shape.props.handles)
-
-			nextHandles[nextEndHandleIndex] = nextEndHandle
 
 			this.editor.updateShapes([
 				{
 					id: this.shape.id,
 					type: this.shape.type,
 					props: {
-						handles: nextHandles,
+						handles: {
+							...this.shape.props.handles,
+							[nextEndHandle.id]: nextEndHandle,
+						},
 					},
 				},
 			])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -15,6 +15,7 @@ import {
 	deepCopy,
 	snapAngle,
 	sortByIndex,
+	uniqueId,
 } from '@tldraw/editor'
 
 export class DraggingHandle extends StateNode {
@@ -54,7 +55,18 @@ export class DraggingHandle extends StateNode {
 		this.shapeId = shape.id
 		this.markId = isCreating ? `creating:${shape.id}` : 'dragging handle'
 		if (!isCreating) this.editor.mark(this.markId)
+
 		this.initialHandle = deepCopy(handle)
+
+		// Change create handles to new vertex handle?
+		if (this.initialHandle.type === 'create') {
+			this.initialHandle = {
+				...this.initialHandle,
+				id: uniqueId(),
+				type: 'vertex',
+			}
+		}
+
 		this.initialPageTransform = this.editor.getShapePageTransform(shape)!
 		this.initialPageRotation = this.initialPageTransform.rotation()
 		this.initialPagePoint = this.editor.inputs.originPagePoint.clone()
@@ -216,6 +228,7 @@ export class DraggingHandle extends StateNode {
 		} = editor
 
 		const initial = this.info.shape
+
 		const shape = editor.getShape(shapeId)
 		if (!shape) return
 		const util = editor.getShapeUtil(shape)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -8,10 +8,13 @@ export class PointingHandle extends StateNode {
 	override onEnter = (info: TLPointerEventInfo & { target: 'handle' }) => {
 		this.info = info
 
-		const initialTerminal = (info.shape as TLArrowShape).props[info.handle.id as 'start' | 'end']
+		const { shape } = info
+		if (this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')) {
+			const initialTerminal = shape.props[info.handle.id as 'start' | 'end']
 
-		if (initialTerminal?.type === 'binding') {
-			this.editor.setHintingShapes([initialTerminal.boundShapeId])
+			if (initialTerminal?.type === 'binding') {
+				this.editor.setHintingShapes([initialTerminal.boundShapeId])
+			}
 		}
 
 		this.editor.updateInstanceState(

--- a/packages/tldraw/src/test/customSnapping.test.tsx
+++ b/packages/tldraw/src/test/customSnapping.test.tsx
@@ -205,8 +205,8 @@ describe('custom handle snapping', () => {
 				x={0}
 				y={0}
 				handles={{
-					['a1' as IndexKey]: { x: 0, y: 0 },
-					['a2' as IndexKey]: { x: 100, y: 100 },
+					a: { id: 'a', index: 'a1' as IndexKey, x: 0, y: 0 },
+					b: { id: 'b', index: 'a2' as IndexKey, x: 100, y: 100 },
 				}}
 			/>,
 			<TL.test ref="test" x={200} y={200} w={100} h={100} boundsSnapPoints={null} />,

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -674,7 +674,12 @@ export const lineShapeProps: {
     dash: EnumStyleProp<"dashed" | "dotted" | "draw" | "solid">;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     spline: EnumStyleProp<"cubic" | "line">;
-    handles: T.DictValidator<IndexKey, VecModel>;
+    handles: T.DictValidator<string, {
+        id: string;
+        index: IndexKey;
+        x: number;
+        y: number;
+    }>;
 };
 
 // @public (undocumented)
@@ -1143,6 +1148,9 @@ export type TLLanguage = (typeof LANGUAGES)[number];
 
 // @public (undocumented)
 export type TLLineShape = TLBaseShape<'line', TLLineShapeProps>;
+
+// @public (undocumented)
+export type TLLineShapeHandle = T.TypeOf<typeof handleModelValidator>;
 
 // @public (undocumented)
 export type TLNoteShape = TLBaseShape<'note', TLNoteShapeProps>;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2765,7 +2765,7 @@
             },
             {
               "kind": "Content",
-              "text": "<import(\"@tldraw/utils\")."
+              "text": "<string, {\n        id: string;\n        index: import(\"@tldraw/utils\")."
             },
             {
               "kind": "Reference",
@@ -2774,16 +2774,7 @@
             },
             {
               "kind": "Content",
-              "text": ", import(\"../misc/geometry-types\")."
-            },
-            {
-              "kind": "Reference",
-              "text": "VecModel",
-              "canonicalReference": "@tldraw/tlschema!VecModel:interface"
-            },
-            {
-              "kind": "Content",
-              "text": ">;\n}"
+              "text": ";\n        x: number;\n        y: number;\n    }>;\n}"
             }
           ],
           "fileUrlPath": "packages/tlschema/src/shapes/TLLineShape.ts",
@@ -2792,7 +2783,7 @@
           "name": "lineShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 16
+            "endIndex": 14
           }
         },
         {
@@ -8192,6 +8183,46 @@
           "fileUrlPath": "packages/tlschema/src/shapes/TLLineShape.ts",
           "releaseTag": "Public",
           "name": "TLLineShape",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 5
+          }
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@tldraw/tlschema!TLLineShapeHandle:type",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type TLLineShapeHandle = "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.TypeOf",
+              "canonicalReference": "@tldraw/validate!TypeOf:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<typeof "
+            },
+            {
+              "kind": "Reference",
+              "text": "handleModelValidator",
+              "canonicalReference": "@tldraw/tlschema!~handleModelValidator:var"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tlschema/src/shapes/TLLineShape.ts",
+          "releaseTag": "Public",
+          "name": "TLLineShapeHandle",
           "typeTokenRange": {
             "startIndex": 1,
             "endIndex": 5

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -127,6 +127,7 @@ export {
 	lineShapeMigrations,
 	lineShapeProps,
 	type TLLineShape,
+	type TLLineShapeHandle,
 } from './shapes/TLLineShape'
 export { noteShapeMigrations, noteShapeProps, type TLNoteShape } from './shapes/TLNoteShape'
 export {

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -1937,6 +1937,67 @@ describe('Remove extra handle props', () => {
 	})
 })
 
+describe('Restore some handle props', () => {
+	const { up, down } = lineShapeMigrations.migrators[lineShapeVersions.RestoreSomeProps]
+	it('up works as expected', () => {
+		expect(
+			up({
+				props: {
+					handles: {
+						a1: { x: 0, y: 0 },
+						a1V: { x: 76, y: 60 },
+						a2: { x: 190, y: -62 },
+					},
+				},
+			})
+		).toEqual({
+			props: {
+				handles: {
+					'handle:a1': {
+						id: 'handle:a1',
+						index: 'a1',
+						x: 0,
+						y: 0,
+					},
+					'handle:a2': {
+						id: 'handle:a2',
+						index: 'a2',
+						x: 190,
+						y: -62,
+					},
+					'handle:a1V': {
+						id: 'handle:a1V',
+						index: 'a1V',
+						x: 76,
+						y: 60,
+					},
+				},
+			},
+		})
+	})
+	it('down works as expected', () => {
+		expect(
+			down({
+				props: {
+					handles: {
+						cat: { id: 'cat', index: 'a1', x: 0, y: 0 },
+						dog: { id: 'dog', index: 'a2', x: 190, y: -62 },
+						rat: { id: 'rat', index: 'a1V', x: 76, y: 60 },
+					},
+				},
+			})
+		).toEqual({
+			props: {
+				handles: {
+					a1: { x: 0, y: 0 },
+					a1V: { x: 76, y: 60 },
+					a2: { x: 190, y: -62 },
+				},
+			},
+		})
+	})
+})
+
 /* ---  PUT YOUR MIGRATIONS TESTS ABOVE HERE --- */
 
 for (const migrator of allMigrators) {


### PR DESCRIPTION
This PR restores id and index props to the handles of the line shapeshape, and changes the line shape's props.handles to be keyed by id rather than index. 

# Ids
Generally our dictionaries are objects with an id value, keyed by id:

```ts
dict: {
	id1: { id: "id1", ...rest },
	id2: { id: "id2", ...rest },
	id3: { id: "id3", ...rest },
}
```

Previous snapping PRs used a different pattern, keying by index:

```ts
handles: {
	a1: { x: 0, y: 0 },
	a1V: { x: 76, y: 60 },
	a2: { x: 190, y: -62 },
}
```

While this works, I'd prefer us to keep the handles dict following our pattern from elsewhere in the app.

Thus, this PR restores the id and index props to handles:

```ts
handles: {
	cat: { id: 'cat', index: 'a1', x: 0, y: 0 },
	dog: { id: 'dog', index: 'a2', x: 190, y: -62 },
	rat: { id: 'rat', index: 'a1V', x: 76, y: 60 },
}
```

### Change Type

- [x] `major` — Breaking change
