### PR TITLE
Fix selected button styles.

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -90,6 +90,20 @@
 	}
 }
 
+/* Hinted */
+
+.tlui-button__icon[data-state='hinted']::after {
+	background: var(--color-hint);
+	opacity: 1;
+	/* box-shadow: inset 0 0 0 1px var(--color-muted-1); */
+}
+
+.tlui-button__icon[data-state='hinted']:not(:disabled, :focus-visible):active::after {
+	background: var(--color-hint);
+	opacity: 1;
+	/* box-shadow: inset 0 0 0 1px var(--color-text-3); */
+}
+
 /* Low button  */
 
 .tlui-button__low {


### PR DESCRIPTION
Looks like we lost hinted styles for selected buttons in the style panel. Restoring the styles we had before.

Before:
![image](https://github.com/tldraw/tldraw/assets/2523721/9e3bf886-ede6-4eea-99a3-1644f7097f95)

After:
![image](https://github.com/tldraw/tldraw/assets/2523721/d8274429-6e12-4abd-bf93-afd72a00b62a)


### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

