### PR TITLE
Fix dialog title styles

### DIFF
--- a/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from '@radix-ui/react-dialog'
 import { T, TLBaseShape, track, useEditor } from '@tldraw/editor'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { TLUiDialogProps } from '../context/dialogs'
@@ -10,6 +9,7 @@ import {
 	TldrawUiDialogCloseButton,
 	TldrawUiDialogFooter,
 	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
 } from './primitives/TldrawUiDialog'
 import { TldrawUiInput } from './primitives/TldrawUiInput'
 
@@ -141,7 +141,7 @@ export const EditLinkDialogInner = track(function EditLinkDialogInner({
 	return (
 		<>
 			<TldrawUiDialogHeader>
-				<DialogTitle>{msg('edit-link-dialog.title')}</DialogTitle>
+				<TldrawUiDialogTitle>{msg('edit-link-dialog.title')}</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody>

--- a/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EmbedDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from '@radix-ui/react-dialog'
 import { EMBED_DEFINITIONS, EmbedDefinition, track, useEditor } from '@tldraw/editor'
 import { useRef, useState } from 'react'
 import { TLEmbedResult, getEmbedInfo } from '../../utils/embeds/embeds'
@@ -12,6 +11,7 @@ import {
 	TldrawUiDialogCloseButton,
 	TldrawUiDialogFooter,
 	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
 } from './primitives/TldrawUiDialog'
 import { TldrawUiIcon } from './primitives/TldrawUiIcon'
 import { TldrawUiInput } from './primitives/TldrawUiInput'
@@ -37,11 +37,11 @@ export const EmbedDialog = track(function EmbedDialog({ onClose }: TLUiDialogPro
 	return (
 		<>
 			<TldrawUiDialogHeader>
-				<DialogTitle>
+				<TldrawUiDialogTitle>
 					{embedDefinition
 						? `${msg('embed-dialog.title')} — ${embedDefinition.title}`
 						: msg('embed-dialog.title')}
-				</DialogTitle>
+				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			{embedDefinition ? (

--- a/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from '@radix-ui/react-dialog'
 import { memo } from 'react'
 import { TLUiDialogProps } from '../../context/dialogs'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -6,6 +5,7 @@ import {
 	TldrawUiDialogBody,
 	TldrawUiDialogCloseButton,
 	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
 } from '../primitives/TldrawUiDialog'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { DefaultKeyboardShortcutsDialogContent } from './DefaultKeyboardShortcutsDialogContent'
@@ -26,7 +26,7 @@ export const DefaultKeyboardShortcutsDialog = memo(function DefaultKeyboardShort
 	return (
 		<>
 			<TldrawUiDialogHeader className="tlui-shortcuts-dialog__header">
-				<DialogTitle>{msg('shortcuts-dialog.title')}</DialogTitle>
+				<TldrawUiDialogTitle>{msg('shortcuts-dialog.title')}</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody className="tlui-shortcuts-dialog__body">


### PR DESCRIPTION
This PR fixes default dialog styles being wrong.

![image](https://github.com/tldraw/tldraw/assets/15892272/0f541111-f9b1-4ae4-9019-aaf725ab2cd2)


### Change Type

- [x] `patch` — Bug fix
[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

Try opening the following dialogs to check their titles look correct:
1. Keyboard shortcuts.
2. Edit link.
3. Insert embed.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Unreleased bug: Fixed dialog titles appearance.
