### PR TITLE
docs: fix scroll position and theming issue for code snippets

### DIFF
--- a/apps/docs/components/mdx-components/code.tsx
+++ b/apps/docs/components/mdx-components/code.tsx
@@ -2,6 +2,7 @@
 
 import { SandpackCodeViewer, SandpackFiles, SandpackProvider } from '@codesandbox/sandpack-react'
 import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
 
 export const Code = (props: any) => {
 	if (!props.className) {
@@ -13,7 +14,14 @@ export const Code = (props: any) => {
 }
 
 export function CodeBlock({ code }: { code: SandpackFiles }) {
+	const [isClientSide, setIsClientSide] = useState(false)
 	const { theme } = useTheme()
+	useEffect(() => setIsClientSide(true), [])
+
+	// This is to avoid hydration mismatch between the server and the client because of the useTheme.
+	if (!isClientSide) {
+		return null
+	}
 
 	const trimmedCode = Object.fromEntries(
 		Object.entries(code).map(([key, value]) => [key, (value as string).trim()])

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -45,6 +45,9 @@
 
 	/* Shape */
 	--border-radius-menu: 4px;
+
+	/* Sizes */
+	--header-height: 72px;
 }
 
 [data-theme='dark'] {
@@ -90,6 +93,7 @@
 html {
 	background-color: #000;
 	border-bottom: none;
+	scroll-padding-top: var(--header-height);
 }
 
 body {
@@ -113,7 +117,7 @@ body {
 	width: 100%;
 	max-width: 1440px;
 	grid-template-columns: 250px 1fr;
-	grid-template-rows: 72px 1fr;
+	grid-template-rows: var(--header-height) 1fr;
 	column-gap: 48px;
 	row-gap: 0px;
 	padding: 0px;
@@ -770,7 +774,7 @@ body {
 .layout__headings {
 	position: sticky;
 	align-self: start;
-	top: 72px;
+	top: var(--header-height);
 	margin-left: -12px;
 	padding: 24px 28px 120px 12px;
 	max-height: calc(100vh);
@@ -804,7 +808,7 @@ body {
 .sidebar {
 	position: sticky;
 	align-self: start;
-	top: 72px;
+	top: var(--header-height);
 	margin-left: -12px;
 	padding: 0px 12px 120px 28px;
 	width: calc(100% + 24px);


### PR DESCRIPTION
- scrolling to a section was hiding the header under the top layout when clicking on the sidebar
- dark mode wasn't hydrating correctly and we only render on client, for now

### Change Type

- [x] `documentation` — Changes to the documentation only[^2]