### PR TITLE
menu fixes: add company links in general; add tracking to lang menu

### DIFF
--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -45,6 +45,7 @@ const components: TLComponents = {
 		<DefaultMainMenu>
 			<LocalFileMenu />
 			<DefaultMainMenuContent />
+			<Links />
 		</DefaultMainMenu>
 	),
 	KeyboardShortcutsDialog: (props) => {

--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -67,6 +67,7 @@ const components: TLComponents = {
 		<DefaultMainMenu>
 			<MultiplayerFileMenu />
 			<DefaultMainMenuContent />
+			<Links />
 		</DefaultMainMenu>
 	),
 	KeyboardShortcutsDialog: (props) => {

--- a/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
@@ -1,11 +1,11 @@
-import { useEditor } from '@tldraw/editor'
+import { track, useEditor } from '@tldraw/editor'
 import { useUiEvents } from '../context/events'
 import { useLanguages } from '../hooks/useTranslation/useLanguages'
 import { TldrawUiMenuCheckboxItem } from './primitives/menus/TldrawUiMenuCheckboxItem'
 import { TldrawUiMenuGroup } from './primitives/menus/TldrawUiMenuGroup'
 import { TldrawUiMenuSubmenu } from './primitives/menus/TldrawUiMenuSubmenu'
 
-export function LanguageMenu() {
+export const LanguageMenu = track(function LanguageMenu() {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()
 	const { languages, currentLanguage } = useLanguages()
@@ -29,4 +29,4 @@ export function LanguageMenu() {
 			</TldrawUiMenuGroup>
 		</TldrawUiMenuSubmenu>
 	)
-}
+})


### PR DESCRIPTION
- the company links appear back in the burger menu. they could be selectively shown if mobile but i'd argue they should just always be there.
- add the `track` to LanguageMenu to make the menu update. however, i'm a little annoyed that i don't understand why the Help menu already works without this :-/

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Add company menu links back in and make sure the Language menu is updated on change.
