### PR TITLE
fix invite others

### DIFF
--- a/apps/dotcom/src/components/PeopleMenu/PeopleMenu.tsx
+++ b/apps/dotcom/src/components/PeopleMenu/PeopleMenu.tsx
@@ -80,10 +80,8 @@ export const PeopleMenu = track(function PeopleMenu({
 									data-testid="people-menu.invite"
 									onClick={() => editor.addOpenMenu('share menu')}
 								>
-									<TldrawUiButtonLabel>
-										{msg('people-menu.invite')}
-										<TldrawUiButtonIcon icon="plus" />
-									</TldrawUiButtonLabel>
+									<TldrawUiButtonLabel>{msg('people-menu.invite')}</TldrawUiButtonLabel>
+									<TldrawUiButtonIcon icon="plus" />
 								</TldrawUiButton>
 							</div>
 						)}


### PR DESCRIPTION
"Invite others" button in the people menu looked off - icon was in the wrong place and it was messing up the layout.

### Change Type

- [x] `patch` — Bug fix

