### PR TITLE
Fix some menu issues on mobile

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1349,6 +1349,12 @@
 	opacity: 0;
 }
 
+@media (any-pointer: coarse) {
+	.tlui-page_menu__item__submenu > .tlui-button {
+		opacity: 1;
+	}
+}
+
 .tlui-page-menu__item__button .tlui-button__icon {
 	margin-right: 4px;
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -974,7 +974,7 @@
 }
 
 .tlui-menu[data-size='small'] > .tlui-menu__group {
-	min-width: 0px;
+	min-width: 96px;
 }
 
 .tlui-menu[data-size='tiny'] > .tlui-menu__group {


### PR DESCRIPTION
This PR fixes some issues with menus on mobile.

- Adds the missing submenu button on the pages menu.
- Re-adds the min-width for the main menu. Looks like it was accidentally copy-pasted over?

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. On mobile...
2. In an empty board...
3. Open the Edit menu.
4. Make sure the buttons are not tenny tiny.
5. Open the pages menu.
6. Press the pencil button in the pages menu.
7. Make sure you can see the submenu button on each page (icon is three dots).

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
