### PR TITLE
Make Vercel URL rewrites precise

### DIFF
--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -1,10 +1,12 @@
 import glob from 'fast-glob'
 import { mkdirSync, writeFileSync } from 'fs'
 import { exec } from '../../../scripts/lib/exec'
+import { SPA_ROUTE_FILTER } from '../spaRouteFilter'
 import { Config } from './vercel-output-config'
 
 import { config } from 'dotenv'
 import { nicelog } from '../../../scripts/lib/nicelog'
+
 config({
 	path: './.env.local',
 })
@@ -45,7 +47,7 @@ async function build() {
 					// finally handle SPA routing
 					{
 						check: true,
-						src: '.*',
+						src: SPA_ROUTE_FILTER,
 						dest: '/index.html',
 					},
 				],

--- a/apps/dotcom/spaRouteFilter.ts
+++ b/apps/dotcom/spaRouteFilter.ts
@@ -1,0 +1,19 @@
+// This value is used to configure Vercel routing to rewrite dotcom SPA routes to /index.html.
+// It is also tested in routes.test.ts to make sure it matches all React Router routes.
+//
+// It is a string and not a regular expression as it's substituted
+// into a string in Vercel's "build output spec" in scripts/build.ts.
+//
+// Make sure it's not overly broad, because otherwise we won't give correct 404 responses.
+export const SPA_ROUTE_FILTER =
+	'^\\/new.*' +
+	'|' +
+	'^\\/r' +
+	'|' +
+	'^\\/r\\/.*' +
+	'|' +
+	'^\\/s\\/.*' +
+	'|' +
+	'^\\/v\\/.*' +
+	'|' +
+	'^\\/$'

--- a/apps/dotcom/src/components/DefaultErrorFallback/DefaultErrorFallback.tsx
+++ b/apps/dotcom/src/components/DefaultErrorFallback/DefaultErrorFallback.tsx
@@ -2,7 +2,6 @@ import { captureException } from '@sentry/react'
 import { DefaultErrorFallback as ErrorFallback } from '@tldraw/tldraw'
 import { useEffect } from 'react'
 import { useRouteError } from 'react-router-dom'
-import '../../../styles/globals.css'
 
 export function DefaultErrorFallback() {
 	const error = useRouteError()

--- a/apps/dotcom/src/main.tsx
+++ b/apps/dotcom/src/main.tsx
@@ -1,82 +1,19 @@
-import { captureException } from '@sentry/react'
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react'
-import { nanoid } from 'nanoid'
-import { useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
-import {
-	Outlet,
-	Route,
-	RouterProvider,
-	createBrowserRouter,
-	createRoutesFromElements,
-	redirect,
-	useRouteError,
-} from 'react-router-dom'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import '../sentry.client.config'
 import '../styles/core.css'
-import { DefaultErrorFallback } from './components/DefaultErrorFallback/DefaultErrorFallback'
-import { ErrorPage } from './components/ErrorPage/ErrorPage'
+import '../styles/globals.css'
 import { Head } from './components/Head/Head'
+import { router } from './routes'
 
-const router = createBrowserRouter(
-	createRoutesFromElements(
-		<Route
-			element={
-				// Add all top level providers that require the router here
-
-				<Outlet />
-			}
-			ErrorBoundary={() => {
-				const error = useRouteError()
-				useEffect(() => {
-					captureException(error)
-				}, [error])
-				return (
-					<ErrorPage
-						messages={{
-							header: 'Something went wrong',
-							para1:
-								'Please try refreshing the page. Still having trouble? Let us know at hello@tldraw.com.',
-						}}
-					/>
-				)
-			}}
-		>
-			<Route errorElement={<DefaultErrorFallback />}>
-				<Route path="/" lazy={() => import('./pages/root')} />
-				<Route
-					path="/r"
-					loader={() => {
-						const id = 'v2' + nanoid()
-						return redirect(`/r/${id}`)
-					}}
-				/>
-				<Route
-					path="/new"
-					loader={() => {
-						const id = 'v2' + nanoid()
-						return redirect(`/r/${id}`)
-					}}
-				/>
-				<Route path="/r/:roomId" lazy={() => import('./pages/public-multiplayer')} />
-				<Route path="/r/:boardId/history" lazy={() => import('./pages/history')} />
-				<Route
-					path="/r/:boardId/history/:timestamp"
-					lazy={() => import('./pages/history-snapshot')}
-				/>
-				<Route path="/s/:roomId" lazy={() => import('./pages/public-snapshot')} />
-				<Route path="/v/:roomId" lazy={() => import('./pages/public-readonly')} />
-			</Route>
-			<Route path="*" lazy={() => import('./pages/not-found')} />
-		</Route>
-	)
-)
+const browserRouter = createBrowserRouter(router)
 
 createRoot(document.getElementById('root')!).render(
 	<HelmetProvider>
 		<Head />
-		<RouterProvider router={router} />
+		<RouterProvider router={browserRouter} />
 		<VercelAnalytics debug={false} />
 	</HelmetProvider>
 )

--- a/apps/dotcom/src/routes.test.ts
+++ b/apps/dotcom/src/routes.test.ts
@@ -1,0 +1,26 @@
+import { RouteObject } from 'react-router-dom'
+import { SPA_ROUTE_FILTER } from '../spaRouteFilter'
+import { router } from './routes'
+
+test('SPA_ROUTE_FILTER matches all React routes', () => {
+	const paths: string[] = []
+
+	function walk(routeObject: RouteObject) {
+		if (routeObject.path && routeObject.path !== '*') {
+			paths.push(routeObject.path)
+		}
+		if (routeObject.children) {
+			routeObject.children.forEach(walk)
+		}
+	}
+
+	router.forEach(walk)
+
+	console.log(paths)
+
+	const regex = new RegExp(SPA_ROUTE_FILTER)
+	console.log(regex)
+	paths.forEach((path) => {
+		expect(path).toMatch(regex)
+	})
+})

--- a/apps/dotcom/src/routes.tsx
+++ b/apps/dotcom/src/routes.tsx
@@ -1,0 +1,58 @@
+import { captureException } from '@sentry/react'
+import { nanoid } from 'nanoid'
+import { useEffect } from 'react'
+import { createRoutesFromElements, Outlet, redirect, Route, useRouteError } from 'react-router-dom'
+import { DefaultErrorFallback } from './components/DefaultErrorFallback/DefaultErrorFallback'
+import { ErrorPage } from './components/ErrorPage/ErrorPage'
+
+export const router = createRoutesFromElements(
+	<Route
+		element={
+			// Add all top level providers that require the router here
+
+			<Outlet />
+		}
+		ErrorBoundary={() => {
+			const error = useRouteError()
+			useEffect(() => {
+				captureException(error)
+			}, [error])
+			return (
+				<ErrorPage
+					messages={{
+						header: 'Something went wrong',
+						para1:
+							'Please try refreshing the page. Still having trouble? Let us know at hello@tldraw.com.',
+					}}
+				/>
+			)
+		}}
+	>
+		<Route errorElement={<DefaultErrorFallback />}>
+			<Route path="/" lazy={() => import('./pages/root')} />
+			<Route
+				path="/r"
+				loader={() => {
+					const id = 'v2' + nanoid()
+					return redirect(`/r/${id}`)
+				}}
+			/>
+			<Route
+				path="/new"
+				loader={() => {
+					const id = 'v2' + nanoid()
+					return redirect(`/r/${id}`)
+				}}
+			/>
+			<Route path="/r/:roomId" lazy={() => import('./pages/public-multiplayer')} />
+			<Route path="/r/:boardId/history" lazy={() => import('./pages/history')} />
+			<Route
+				path="/r/:boardId/history/:timestamp"
+				lazy={() => import('./pages/history-snapshot')}
+			/>
+			<Route path="/s/:roomId" lazy={() => import('./pages/public-snapshot')} />
+			<Route path="/v/:roomId" lazy={() => import('./pages/public-readonly')} />
+		</Route>
+		<Route path="*" lazy={() => import('./pages/not-found')} />
+	</Route>
+)


### PR DESCRIPTION
### The problem

Right now we use a catchall path in Vercel routing config to rewrite all requests that don't match existing assets to `/index.html`, which is needed for client side routing to work. This, however, messes up 404 errors for truly non-existing files which won't be handled by the SPA, because they get redirected to index.html.

Even worse, this interacts very poorly with caching. Normally if we request a non-existent file, then put the file in place, and request the file again, we'll get 404 the first time and the actual file the second time. However, in our case we instead return `/index.html` after the first attempt and cache that response, making it impossible to correct a missing file without cache flush.

### The solution

One way to fix this is to make the regex in Vercel config precise, so that they only match our SPA routes. However, it can be dangerous, because this means we'll need to manually update the config with new SPA routes every time we add any. This PR tests that the regex we're using in Vercel matches all routes that we set in the SPA router.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]

### Test Plan

1. Might need a light smoke test after deployment to dotcom.

- [x] End to end tests