### PR TITLE
Remove template references

### DIFF
--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -15,8 +15,6 @@ By the end of this guide you will have made something that looks like this:
 <Embed className="article__embed--quickstart" src="https://vite-template-five.vercel.app/" />
 
 
-Follow the steps below to make your own version of it, or [clone the repo](https://github.com/tldraw/vite-template) to skip to the end. 
-
 <hr />
 <ol className="ordered-list__quickstart">
   <li>


### PR DESCRIPTION
Removes references to the vite template

- [x] `documentation` — Changes to the documentation only[^2]
### Release Notes

- changes the doc site so it no longer references the site template
