### PR TITLE
ui events: prevent sending 2nd event unnecessarily

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -78,6 +78,8 @@ function _TldrawUiButtonPicker<T extends string>(props: TLUiButtonPickerProps<T>
 
 		const handleButtonPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
 			const { id } = e.currentTarget.dataset
+			if (value.type === 'shared' && value.value === id) return
+
 			onValueChange(style, id as T, false)
 		}
 


### PR DESCRIPTION
Noticed that we were sending two events (one for pointerDown, and one for pointerUp). The click event handler adds this same check to prevent this, so this adds it in the pointerUp event as well.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Some cleanup on duplicate UI events being sent.
