### PR TITLE
Export history hooks

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2068,6 +2068,12 @@ export function useAssetUrls(): TLUiAssetUrls;
 export function useBreakpoint(): number;
 
 // @public (undocumented)
+export function useCanRedo(): boolean;
+
+// @public (undocumented)
+export function useCanUndo(): boolean;
+
+// @public (undocumented)
 export function useCopyAs(): (ids: TLShapeId[], format?: TLCopyType) => void;
 
 // @public (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -22981,6 +22981,62 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!useCanRedo:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function useCanRedo(): "
+            },
+            {
+              "kind": "Content",
+              "text": "boolean"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/hooks/menu-hooks.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "useCanRedo"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!useCanUndo:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function useCanUndo(): "
+            },
+            {
+              "kind": "Content",
+              "text": "boolean"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/hooks/menu-hooks.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "useCanUndo"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!useCopyAs:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -1,5 +1,7 @@
 /// <reference types="react" />
 
+export { useCanRedo, useCanUndo } from './lib/ui/hooks/menu-hooks'
+
 // eslint-disable-next-line local/no-export-star
 export * from '@tldraw/editor'
 export { Tldraw, type TldrawProps } from './lib/Tldraw'


### PR DESCRIPTION
This PR restores `useCanUndo` and `useCanRedo` to exports from tldraw.

### Change Type

- [ ] `patch` — Bug fix
- [x] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know
