### PR TITLE
Fix an issue with publishing canary

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"@types/react-dom": "^18.2.18",
 		"@typescript-eslint/eslint-plugin": "^5.57.0",
 		"@typescript-eslint/parser": "^5.57.0",
-		"auto": "^10.46.0",
+		"auto": "^11.0.7",
 		"eslint": "^8.37.0",
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-plugin-deprecation": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@auto-it/bot-list@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/bot-list@npm:11.0.7"
+  checksum: c2f4ac6022dffa4e52f600f4854bb51811c4cbc594fed7465713cfcb0716758c37ac3e335c18da0dfa46ec60c52d8d4a334edbc9f5651b796150a70762b0458c
+  languageName: node
+  linkType: hard
+
 "@auto-it/core@npm:10.46.0":
   version: 10.46.0
   resolution: "@auto-it/core@npm:10.46.0"
@@ -141,6 +148,59 @@ __metadata:
     "@types/node":
       optional: true
   checksum: f407cf3d931d57f4ec7ba1128c4fc2df1c717e93c9271fb461c67b304f1a0ad5aa45623dbe9c8c8072a0f58134a33870de42b876b95ce8d810d8b43bb16c70e0
+  languageName: node
+  linkType: hard
+
+"@auto-it/core@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/core@npm:11.0.7"
+  dependencies:
+    "@auto-it/bot-list": "npm:11.0.7"
+    "@endemolshinegroup/cosmiconfig-typescript-loader": "npm:^3.0.2"
+    "@octokit/core": "npm:^3.5.1"
+    "@octokit/plugin-enterprise-compatibility": "npm:1.3.0"
+    "@octokit/plugin-retry": "npm:^3.0.9"
+    "@octokit/plugin-throttling": "npm:^3.6.2"
+    "@octokit/rest": "npm:^18.12.0"
+    await-to-js: "npm:^3.0.0"
+    chalk: "npm:^4.0.0"
+    cosmiconfig: "npm:7.0.0"
+    deepmerge: "npm:^4.0.0"
+    dotenv: "npm:^8.0.0"
+    endent: "npm:^2.1.0"
+    enquirer: "npm:^2.3.4"
+    env-ci: "npm:^5.0.1"
+    fast-glob: "npm:^3.1.1"
+    fp-ts: "npm:^2.5.3"
+    fromentries: "npm:^1.2.0"
+    gitlog: "npm:^4.0.3"
+    https-proxy-agent: "npm:^5.0.0"
+    import-cwd: "npm:^3.0.0"
+    import-from: "npm:^3.0.0"
+    io-ts: "npm:^2.1.2"
+    lodash.chunk: "npm:^4.2.0"
+    log-symbols: "npm:^4.0.0"
+    node-fetch: "npm:2.6.7"
+    parse-author: "npm:^2.0.0"
+    parse-github-url: "npm:1.0.2"
+    pretty-ms: "npm:^7.0.0"
+    requireg: "npm:^0.2.2"
+    semver: "npm:^7.0.0"
+    signale: "npm:^1.4.0"
+    tapable: "npm:^2.2.0"
+    terminal-link: "npm:^2.1.1"
+    tinycolor2: "npm:^1.4.1"
+    ts-node: "npm:^10.9.1"
+    tslib: "npm:2.1.0"
+    type-fest: "npm:^0.21.1"
+    typescript-memoize: "npm:^1.0.0-alpha.3"
+    url-join: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 52f71d5d59dc8898745cda28d008766ccbfc399416264ca77d0579334643c2dd4a76f19615f52d1777c04bec6aa84f6e44dcd575814cb9fd2a29085eaf0bbfa3
   languageName: node
   linkType: hard
 
@@ -197,12 +257,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@auto-it/npm@npm:10.46.0":
-  version: 10.46.0
-  resolution: "@auto-it/npm@npm:10.46.0"
+"@auto-it/npm@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/npm@npm:11.0.7"
   dependencies:
-    "@auto-it/core": "npm:10.46.0"
-    "@auto-it/package-json-utils": "npm:10.46.0"
+    "@auto-it/core": "npm:11.0.7"
+    "@auto-it/package-json-utils": "npm:11.0.7"
     await-to-js: "npm:^3.0.0"
     endent: "npm:^2.1.0"
     env-ci: "npm:^5.0.1"
@@ -215,44 +275,44 @@ __metadata:
     typescript-memoize: "npm:^1.0.0-alpha.3"
     url-join: "npm:^4.0.0"
     user-home: "npm:^2.0.0"
-  checksum: 7027fc51beb7f170a79d705523622091ecdde985195f717c180ee91b8db740da6f7e4e84381fec7deecc6b15aa51e2d78df328f835945217a447d6e574068846
+  checksum: 5efc7e1db71c4fa3c400d15a67f8e1f6b0b2d946e5b2e396a770733608b7974adcbb9cff5561a633da1d993df8d62a524ef2d0c8f9f904664d0c2959d384bfc7
   languageName: node
   linkType: hard
 
-"@auto-it/package-json-utils@npm:10.46.0":
-  version: 10.46.0
-  resolution: "@auto-it/package-json-utils@npm:10.46.0"
+"@auto-it/package-json-utils@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/package-json-utils@npm:11.0.7"
   dependencies:
     parse-author: "npm:^2.0.0"
     parse-github-url: "npm:1.0.2"
-  checksum: a6cade0027a4e724056b7d9371ff46766cebab9b5a77fe0f44f6e7651bd2a1899986aac44e75f0d73a021840bb561ca877c9ccd7be9f544584c5984cd3873cba
+  checksum: c563fe98c77096eed48cf3127acb35bd6a0f383ee589f18678f738e24720f49f0c01fb24cd3795e8d7e7b7682ada802a095b43c65dff4ed1702ce9b4e6441d7d
   languageName: node
   linkType: hard
 
-"@auto-it/released@npm:10.46.0":
-  version: 10.46.0
-  resolution: "@auto-it/released@npm:10.46.0"
+"@auto-it/released@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/released@npm:11.0.7"
   dependencies:
-    "@auto-it/bot-list": "npm:10.46.0"
-    "@auto-it/core": "npm:10.46.0"
+    "@auto-it/bot-list": "npm:11.0.7"
+    "@auto-it/core": "npm:11.0.7"
     deepmerge: "npm:^4.0.0"
     fp-ts: "npm:^2.5.3"
     io-ts: "npm:^2.1.2"
     tslib: "npm:2.1.0"
-  checksum: 7bae6500164458db57d268bcbc47593d3fd7d77a230d0627b80ccd1830b4ad49d7b265b8fe06a8ca23fea18a696a557401669cc1db8c7065a5dc30043d712643
+  checksum: 22382c2234c8270aeb04414b2f85bb7258aeeeb8f527913d9f87c0d02c1a733a3161aa2ac433121f2881f92d02dd175156f3b878ecbad6f12f870ff965760721
   languageName: node
   linkType: hard
 
-"@auto-it/version-file@npm:10.46.0":
-  version: 10.46.0
-  resolution: "@auto-it/version-file@npm:10.46.0"
+"@auto-it/version-file@npm:11.0.7":
+  version: 11.0.7
+  resolution: "@auto-it/version-file@npm:11.0.7"
   dependencies:
-    "@auto-it/core": "npm:10.46.0"
+    "@auto-it/core": "npm:11.0.7"
     fp-ts: "npm:^2.5.3"
     io-ts: "npm:^2.1.2"
     semver: "npm:^7.0.0"
     tslib: "npm:1.10.0"
-  checksum: 22c28a346afef375e160d9f0368d7de01e5da460f48bb13bfdc7756ad9c93f0fe9e3476c06d3290dc5e4949c636faf2ecec494e0b09805b3c39176bdb15aa9e9
+  checksum: ff34bfa2dce1b752211b3953c9b77cfcdd4fc07684cd460ac85ad1d0c0d9a94bace08197f9c5c6acdd78135c2e96cbd776aa5a0b5f4df6fd392955e60f626ad1
   languageName: node
   linkType: hard
 
@@ -7383,7 +7443,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.57.0"
     "@typescript-eslint/parser": "npm:^5.57.0"
     "@yarnpkg/types": "npm:^4.0.0"
-    auto: "npm:^10.46.0"
+    auto: "npm:^11.0.7"
     cross-env: "npm:^7.0.3"
     eslint: "npm:^8.37.0"
     eslint-config-prettier: "npm:^8.8.0"
@@ -9745,14 +9805,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"auto@npm:^10.46.0":
-  version: 10.46.0
-  resolution: "auto@npm:10.46.0"
+"auto@npm:^11.0.7":
+  version: 11.0.7
+  resolution: "auto@npm:11.0.7"
   dependencies:
-    "@auto-it/core": "npm:10.46.0"
-    "@auto-it/npm": "npm:10.46.0"
-    "@auto-it/released": "npm:10.46.0"
-    "@auto-it/version-file": "npm:10.46.0"
+    "@auto-it/core": "npm:11.0.7"
+    "@auto-it/npm": "npm:11.0.7"
+    "@auto-it/released": "npm:11.0.7"
+    "@auto-it/version-file": "npm:11.0.7"
     await-to-js: "npm:^3.0.0"
     chalk: "npm:^4.0.0"
     command-line-application: "npm:^0.10.1"
@@ -9763,7 +9823,7 @@ __metadata:
     tslib: "npm:2.1.0"
   bin:
     auto: dist/bin/auto.js
-  checksum: 2340137e2cf86d28c4c7dd975f75ecee4763cb0c25a853f9a2200bc57d6cb6907305f3348fb4e7f406d5c329fe569d35358a157c37d2149a71d31eb214859934
+  checksum: bb336d19f114cf6c4ab5b4a0bb7f0559ceaa5f2395158eb4aa74befdd8bb8f7dcbaf04d1246a8b7379f376385e3a7743741fa161c2b1f44f1cd9195d3b55b141
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Our canary builds are broken right now, see https://github.com/tldraw/tldraw/actions/runs/8018554530/job/21904677162#step:4:13

Looks like `auto@11.0.5` solves this https://github.com/intuit/auto/issues/2425

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know
