### PR TITLE
Fix keyboard shortcuts bugs

### DIFF
--- a/apps/examples/src/examples/multiple/MultipleExample.tsx
+++ b/apps/examples/src/examples/multiple/MultipleExample.tsx
@@ -31,11 +31,19 @@ export default function MultipleExample() {
 				backgroundColor: '#fff',
 				padding: 32,
 			}}
+			// Sorry you need to do this yourself
+			onPointerDown={() => setFocusedEditor(null)}
 		>
 			<focusedEditorContext.Provider value={{ focusedEditor, setFocusedEditor }}>
 				<h1>Focusing: {focusedEditor ?? 'none'}</h1>
 				<EditorA />
-				<textarea data-testid="textarea" placeholder="type in me" style={{ margin: 10 }} />
+				<textarea
+					data-testid="textarea"
+					placeholder="type in me"
+					style={{ margin: 10 }}
+					// Just to keep the current editor focused—shortcuts don't work when a textarea is focused
+					onPointerDown={(e) => e.stopPropagation()}
+				/>
 				<div
 					style={{
 						width: '100%',

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -33,13 +33,13 @@ export function useKeyboardShortcuts() {
 		hotkeys.setScope(editor.store.id)
 
 		const hot = (keys: string, callback: (event: KeyboardEvent) => void) => {
-			hotkeys(keys, { element: container, scope: editor.store.id }, callback)
+			hotkeys(keys, { element: document.body, scope: editor.store.id }, callback)
 		}
 
 		const hotUp = (keys: string, callback: (event: KeyboardEvent) => void) => {
 			hotkeys(
 				keys,
-				{ element: container, keyup: true, keydown: false, scope: editor.store.id },
+				{ element: document.body, keyup: true, keydown: false, scope: editor.store.id },
 				callback
 			)
 		}


### PR DESCRIPTION
This PR moves the focus 

### Change Type

- [x] `minor` 

### Test Plan

1. Select an element.
2. Press the delete quick action menu button.
3. Undo the delete with a keyboard shortcut.

1. Create a geo shape
2. Use the style panel to change the geo type
3. Undo so that it deletes
4. Try to redo

### Release Notes

- [Fix] Keyboard shortcut focus bug