### PR TITLE
[docs] Move description out of header.

### DIFF
--- a/apps/docs/components/ExampleDocsPage.tsx
+++ b/apps/docs/components/ExampleDocsPage.tsx
@@ -28,8 +28,9 @@ export async function ExampleDocsPage({ article }: { article: Article }) {
 				<div className="page-header">
 					<Breadcrumb section={section} category={category} />
 					<h1>{article.title}</h1>
-					{article.description && <p>{article.description}</p>}
 				</div>
+				{article.description && <p>{article.description}</p>}
+				{article.content && <Mdx content={article.content} />}
 				{article.hero && <Image alt="hero" title={article.title} src={`images/${article.hero}`} />}
 				{article.componentCode && (
 					<ExampleCodeBlock
@@ -41,7 +42,6 @@ export async function ExampleDocsPage({ article }: { article: Article }) {
 						activeFile={'App.tsx'}
 					/>
 				)}
-				{article.content && <Mdx content={article.content} />}
 				{links && <ArticleNavLinks links={links} />}
 			</main>
 		</>

--- a/apps/docs/components/ExampleDocsPage.tsx
+++ b/apps/docs/components/ExampleDocsPage.tsx
@@ -31,7 +31,6 @@ export async function ExampleDocsPage({ article }: { article: Article }) {
 					{article.description && <p>{article.description}</p>}
 				</div>
 				{article.hero && <Image alt="hero" title={article.title} src={`images/${article.hero}`} />}
-				{article.content && <Mdx content={article.content} />}
 				{article.componentCode && (
 					<ExampleCodeBlock
 						articleId={article.id}
@@ -42,6 +41,7 @@ export async function ExampleDocsPage({ article }: { article: Article }) {
 						activeFile={'App.tsx'}
 					/>
 				)}
+				{article.content && <Mdx content={article.content} />}
 				{links && <ArticleNavLinks links={links} />}
 			</main>
 		</>


### PR DESCRIPTION
This PR moves the example content below the code.

## Before
<img width="613" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/edd417b9-ba1e-489e-8bb8-2bf1694a0968">

## After
<img width="604" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/cb9940dc-c002-4119-ba6b-c7769403949e">

Actually considering just removing the separation here? But there are some articles without content and other articles without descriptions.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [x] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
