### PR TITLE
fix structured clone reference in drawing

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -14,6 +14,7 @@ import {
 	createShapeId,
 	last,
 	snapAngle,
+	structuredClone,
 	toFixed,
 	uniqueId,
 } from '@tldraw/editor'

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -1,4 +1,5 @@
 import { Migrations, Store, createRecordType } from '@tldraw/store'
+import { structuredClone } from '@tldraw/utils'
 import fs from 'fs'
 import { bookmarkAssetMigrations } from './assets/TLBookmarkAsset'
 import { imageAssetMigrations } from './assets/TLImageAsset'

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -283,7 +283,7 @@ export function sortByIndex<T extends {
     index: IndexKey;
 }>(a: T, b: T): -1 | 0 | 1;
 
-// @public (undocumented)
+// @public
 const structuredClone_2: <T>(i: T) => T;
 export { structuredClone_2 as structuredClone }
 

--- a/packages/utils/api/api.json
+++ b/packages/utils/api/api.json
@@ -3237,7 +3237,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@tldraw/utils!structuredClone_2:var",
-          "docComment": "/**\n * @public\n */\n",
+          "docComment": "/**\n * Create a deep copy of a value. Uses the structuredClone API if available, otherwise uses JSON.parse(JSON.stringify()).\n *\n * @param i - The value to clone.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/packages/utils/src/lib/value.ts
+++ b/packages/utils/src/lib/value.ts
@@ -30,7 +30,11 @@ export function isNonNullish<T>(
 	return value !== null && value !== undefined
 }
 
-/** @public */
+/**
+ * Create a deep copy of a value. Uses the structuredClone API if available, otherwise uses JSON.parse(JSON.stringify()).
+ *
+ * @param i - The value to clone.
+ * @public */
 export const structuredClone =
 	typeof window !== 'undefined' && (window as any).structuredClone
 		? (window.structuredClone as <T>(i: T) => T)


### PR DESCRIPTION
This PR fixes a rogue structuredClone reference in the drawing state.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fixes a reference to structuredClone that caused a crash on older browsers.