### PR TITLE
[fix] fit to content shown on groups

### DIFF
--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -87,7 +87,10 @@ export function FitFrameToContentMenuItem() {
 		() => {
 			const onlySelectedShape = editor.getOnlySelectedShape()
 			if (!onlySelectedShape) return false
-			return editor.getSortedChildIdsForParent(onlySelectedShape).length > 0
+			return (
+				onlySelectedShape.type === 'frame' &&
+				editor.getSortedChildIdsForParent(onlySelectedShape).length > 0
+			)
 		},
 		[editor]
 	)

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -88,7 +88,7 @@ export function FitFrameToContentMenuItem() {
 			const onlySelectedShape = editor.getOnlySelectedShape()
 			if (!onlySelectedShape) return false
 			return (
-				onlySelectedShape.type === 'frame' &&
+				editor.isShapeOfType<TLFrameShape>(onlySelectedShape, 'frame') &&
 				editor.getSortedChildIdsForParent(onlySelectedShape).length > 0
 			)
 		},


### PR DESCRIPTION
This PR fixes a bug where "fit to content" would be shown on groups.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Fix bug where "fit frame to content" would be shown when a group is selected.