### PR TITLE
Fix iframe warning

### DIFF
--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -190,9 +190,7 @@ export function UrlStateSync() {
 
 function useIsEmbedded(slug: string) {
 	const isEmbedded =
-		typeof window !== 'undefined' &&
-		window.self !== window.top &&
-		window.location.host !== 'www.tldraw.com'
+		typeof window !== 'undefined' && (window !== window.top || window.self !== window.parent)
 
 	useEffect(() => {
 		if (isEmbedded) {


### PR DESCRIPTION
This PR fixes a check on whether the multiplayer editor has been loaded in an iframe.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Load me in an iframe
