### PR TITLE
bump typescript / api-extractor

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -82,7 +82,7 @@
 		"sqlite": "^5.0.1",
 		"sqlite3": "^5.1.6",
 		"tsx": "^4.0.0",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"unist-util-is": "^6.0.0",
 		"unist-util-visit": "^5.0.0",
 		"vectra": "^0.4.4",

--- a/apps/dotcom-bookmark-extractor/package.json
+++ b/apps/dotcom-bookmark-extractor/package.json
@@ -18,6 +18,6 @@
 	},
 	"devDependencies": {
 		"lazyrepo": "0.0.0-alpha.27",
-		"typescript": "^5.2.2"
+		"typescript": "^5.3.3"
 	}
 }

--- a/apps/dotcom-worker/package.json
+++ b/apps/dotcom-worker/package.json
@@ -40,7 +40,7 @@
 		"concurrently": "^8.2.2",
 		"lazyrepo": "0.0.0-alpha.27",
 		"picocolors": "^1.0.0",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"wrangler": "3.16.0"
 	},
 	"jest": {

--- a/apps/health-worker/package.json
+++ b/apps/health-worker/package.json
@@ -15,7 +15,7 @@
 		"@cloudflare/workers-types": "^4.20230821.0",
 		"@types/node": "~20.11",
 		"discord-api-types": "^0.37.67",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"wrangler": "3.16.0"
 	}
 }

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -147,7 +147,7 @@
 		"ts-loader": "^9.2.5",
 		"tslib": "^2.6.2",
 		"tsx": "^4.0.0",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"vsce": "^2.15.0",
 		"webpack": "^5.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"prettier-plugin-organize-imports": "^3.2.3",
 		"rimraf": "^4.4.0",
 		"tsx": "^4.0.0",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"vercel": "^28.16.15"
 	},
 	"resolutions": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		]
 	},
 	"devDependencies": {
-		"@microsoft/api-extractor": "^7.35.4",
+		"@microsoft/api-extractor": "^7.41.0",
 		"@next/eslint-plugin-next": "^13.3.0",
 		"@swc/core": "^1.3.55",
 		"@swc/jest": "^0.2.34",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"lazyrepo": "0.0.0-alpha.27",
 		"ts-node-dev": "^1.1.8",
-		"typescript": "^5.2.2"
+		"typescript": "^5.3.3"
 	},
 	"jest": {
 		"preset": "config/jest/node",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -6087,17 +6087,13 @@
           "name": "DefaultBackground"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!DefaultBrush:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!DefaultBrush:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "DefaultBrush: "
-            },
-            {
-              "kind": "Content",
-              "text": "({ brush, color, opacity, className }: "
+              "text": "DefaultBrush: ({ brush, color, opacity, className }: "
             },
             {
               "kind": "Reference",
@@ -6106,7 +6102,11 @@
             },
             {
               "kind": "Content",
-              "text": ") => import(\"react/jsx-runtime\")."
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
             },
             {
               "kind": "Reference",
@@ -6115,13 +6115,23 @@
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultBrush.tsx",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "DefaultBrush",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
             "endIndex": 5
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ brush, color, opacity, className }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "DefaultBrush"
         },
         {
           "kind": "Function",
@@ -6393,17 +6403,13 @@
           "name": "DefaultHandle"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!DefaultHandles:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!DefaultHandles:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "DefaultHandles: "
-            },
-            {
-              "kind": "Content",
-              "text": "({ children }: "
+              "text": "DefaultHandles: ({ children }: "
             },
             {
               "kind": "Reference",
@@ -6412,7 +6418,11 @@
             },
             {
               "kind": "Content",
-              "text": ") => import(\"react/jsx-runtime\")."
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
             },
             {
               "kind": "Reference",
@@ -6421,13 +6431,23 @@
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultHandles.tsx",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "DefaultHandles",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
             "endIndex": 5
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ children }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "DefaultHandles"
         },
         {
           "kind": "Function",
@@ -6767,27 +6787,28 @@
           "name": "DefaultSpinner"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!DefaultSvgDefs:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!DefaultSvgDefs:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "DefaultSvgDefs: "
+              "text": "DefaultSvgDefs: () => "
             },
             {
               "kind": "Content",
-              "text": "() => null"
+              "text": "null"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultSvgDefs.tsx",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "DefaultSvgDefs",
-          "variableTypeTokenRange": {
+          "returnTypeTokenRange": {
             "startIndex": 1,
             "endIndex": 2
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "DefaultSvgDefs"
         },
         {
           "kind": "Variable",
@@ -24446,27 +24467,45 @@
           "name": "intersectPolygonPolygon"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!isSafeFloat:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!isSafeFloat:function(1)",
           "docComment": "/**\n * Check if a float is safe to use. ie: Not too big or small.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "isSafeFloat: "
+              "text": "isSafeFloat: (n: "
             },
             {
               "kind": "Content",
-              "text": "(n: number) => boolean"
+              "text": "number"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "boolean"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/primitives/utils.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 4
+          },
           "releaseTag": "Public",
-          "name": "isSafeFloat",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "n",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "isSafeFloat"
         },
         {
           "kind": "Function",
@@ -32157,27 +32196,45 @@
           "name": "shortAngleDist"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!SIN:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!SIN:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "SIN: "
+              "text": "SIN: (x: "
             },
             {
               "kind": "Content",
-              "text": "(x: number) => number"
+              "text": "number"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "number"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/primitives/utils.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 4
+          },
           "releaseTag": "Public",
-          "name": "SIN",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "x",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "SIN"
         },
         {
           "kind": "Function",
@@ -34246,27 +34303,45 @@
           ]
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/editor!stopEventPropagation:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/editor!stopEventPropagation:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "stopEventPropagation: "
+              "text": "stopEventPropagation: (e: "
             },
             {
               "kind": "Content",
-              "text": "(e: any) => any"
+              "text": "any"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "any"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/utils/dom.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 4
+          },
           "releaseTag": "Public",
-          "name": "stopEventPropagation",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "e",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "stopEventPropagation"
         },
         {
           "kind": "Function",

--- a/packages/state/api/api.json
+++ b/packages/state/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -1448,17 +1448,21 @@
           "name": "isSignal"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/state!isUninitialized:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/state!isUninitialized:function(1)",
           "docComment": "/**\n * Call this inside a computed signal function to determine whether it is the first time the function is being called.\n *\n * Mainly useful for incremental signal computation.\n *\n * @param value - The value to check.\n *\n * @example\n * ```ts\n * const count = atom('count', 0)\n * const double = computed('double', (prevValue) => {\n *   if (isUninitialized(prevValue)) {\n *     print('First time!')\n *   }\n *   return count.get() * 2\n * })\n * ```\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "isUninitialized: "
+              "text": "isUninitialized: (value: "
             },
             {
               "kind": "Content",
-              "text": "(value: any) => "
+              "text": "any"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
             },
             {
               "kind": "Reference",
@@ -1476,13 +1480,23 @@
             }
           ],
           "fileUrlPath": "packages/state/src/lib/core/Computed.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 6
+          },
           "releaseTag": "Public",
-          "name": "isUninitialized",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 5
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "value",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "isUninitialized"
         },
         {
           "kind": "Function",

--- a/packages/store/api/api.json
+++ b/packages/store/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -591,17 +591,13 @@
           "name": "compareRecordVersions"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/store!compareSchemas:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/store!compareSchemas:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "compareSchemas: "
-            },
-            {
-              "kind": "Content",
-              "text": "(a: "
+              "text": "compareSchemas: (a: "
             },
             {
               "kind": "Reference",
@@ -619,17 +615,39 @@
             },
             {
               "kind": "Content",
-              "text": ") => -1 | 0 | 1"
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "-1 | 0 | 1"
             }
           ],
           "fileUrlPath": "packages/store/src/lib/compareSchemas.ts",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "compareSchemas",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
+          "returnTypeTokenRange": {
+            "startIndex": 5,
             "endIndex": 6
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "a",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "b",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "compareSchemas"
         },
         {
           "kind": "TypeAlias",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -14285,17 +14285,13 @@
           "name": "TldrawScribble"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/tldraw!TldrawSelectionBackground:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!TldrawSelectionBackground:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "TldrawSelectionBackground: "
-            },
-            {
-              "kind": "Content",
-              "text": "({ bounds, rotation }: "
+              "text": "TldrawSelectionBackground: ({ bounds, rotation }: "
             },
             {
               "kind": "Reference",
@@ -14304,7 +14300,11 @@
             },
             {
               "kind": "Content",
-              "text": ") => import(\"react/jsx-runtime\")."
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
             },
             {
               "kind": "Reference",
@@ -14317,13 +14317,23 @@
             }
           ],
           "fileUrlPath": "packages/tldraw/src/lib/canvas/TldrawSelectionBackground.tsx",
-          "isReadonly": true,
-          "releaseTag": "Public",
-          "name": "TldrawSelectionBackground",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
             "endIndex": 6
-          }
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ bounds, rotation }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "TldrawSelectionBackground"
         },
         {
           "kind": "Variable",
@@ -22859,27 +22869,61 @@
           "name": "toolbarItem"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/tldraw!truncateStringWithEllipsis:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!truncateStringWithEllipsis:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "truncateStringWithEllipsis: "
+              "text": "truncateStringWithEllipsis: (str: "
             },
             {
               "kind": "Content",
-              "text": "(str: string, maxLength: number) => string"
+              "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": ", maxLength: "
+            },
+            {
+              "kind": "Content",
+              "text": "number"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
             }
           ],
           "fileUrlPath": "packages/tldraw/src/lib/utils/text/text.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 6
+          },
           "releaseTag": "Public",
-          "name": "truncateStringWithEllipsis",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "str",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "maxLength",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "truncateStringWithEllipsis"
         },
         {
           "kind": "Function",

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -975,17 +975,13 @@
           "name": "createAssetValidator"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/tlschema!createPresenceStateDerivation:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tlschema!createPresenceStateDerivation:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "createPresenceStateDerivation: "
-            },
-            {
-              "kind": "Content",
-              "text": "($user: "
+              "text": "createPresenceStateDerivation: ($user: "
             },
             {
               "kind": "Reference",
@@ -994,7 +990,11 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n    id: string;\n    color: string;\n    name: string;\n}>, instanceId?: "
+              "text": "<{\n    id: string;\n    color: string;\n    name: string;\n}>"
+            },
+            {
+              "kind": "Content",
+              "text": ", instanceId?: "
             },
             {
               "kind": "Reference",
@@ -1003,7 +1003,15 @@
             },
             {
               "kind": "Content",
-              "text": "['id']) => (store: "
+              "text": "['id']"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "(store: "
             },
             {
               "kind": "Reference",
@@ -1034,13 +1042,31 @@
             }
           ],
           "fileUrlPath": "packages/tlschema/src/createPresenceStateDerivation.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 7,
+            "endIndex": 14
+          },
           "releaseTag": "Public",
-          "name": "createPresenceStateDerivation",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 12
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "$user",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "instanceId",
+              "parameterTypeTokenRange": {
+                "startIndex": 4,
+                "endIndex": 6
+              },
+              "isOptional": true
+            }
+          ],
+          "name": "createPresenceStateDerivation"
         },
         {
           "kind": "Function",

--- a/packages/tlsync/package.json
+++ b/packages/tlsync/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@tldraw/tldraw": "workspace:*",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"uuid-by-string": "^4.0.0",
 		"uuid-readable": "^0.0.2"
 	},

--- a/packages/utils/api/api.json
+++ b/packages/utils/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -3235,27 +3235,58 @@
           "name": "sortByIndex"
         },
         {
-          "kind": "Variable",
-          "canonicalReference": "@tldraw/utils!structuredClone_2:var",
+          "kind": "Function",
+          "canonicalReference": "@tldraw/utils!structuredClone_2:function(1)",
           "docComment": "/**\n * Create a deep copy of a value. Uses the structuredClone API if available, otherwise uses JSON.parse(JSON.stringify()).\n *\n * @param i - The value to clone.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "structuredClone: "
+              "text": "structuredClone: <T>(i: "
             },
             {
               "kind": "Content",
-              "text": "<T>(i: T) => T"
+              "text": "T"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "T"
             }
           ],
           "fileUrlPath": "packages/utils/src/lib/value.ts",
-          "isReadonly": true,
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 4
+          },
           "releaseTag": "Public",
-          "name": "structuredClone_2",
-          "variableTypeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "i",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "typeParameters": [
+            {
+              "typeParameterName": "T",
+              "constraintTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              },
+              "defaultTypeTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              }
+            }
+          ],
+          "name": "structuredClone_2"
         },
         {
           "kind": "Function",

--- a/packages/validate/api/api.json
+++ b/packages/validate/api/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.4",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -48,7 +48,7 @@
 		"rimraf": "^4.4.0",
 		"semver": "^7.3.8",
 		"svgo": "^3.0.2",
-		"typescript": "^5.2.2"
+		"typescript": "^5.3.3"
 	},
 	"scripts": {
 		"lint": "yarn run -T tsx lint.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4125,7 +4125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor-model@npm:7.28.13":
+"@microsoft/api-extractor-model@npm:7.28.13, @microsoft/api-extractor-model@npm:^7.26.4":
   version: 7.28.13
   resolution: "@microsoft/api-extractor-model@npm:7.28.13"
   dependencies:
@@ -4133,17 +4133,6 @@ __metadata:
     "@microsoft/tsdoc-config": "npm:~0.16.1"
     "@rushstack/node-core-library": "npm:4.0.2"
   checksum: af1d0457d76b909ac870c7c895caf773a3348312d8c308f73bf160c8b85ab6c0be6ed6c5568a5ee5ccedf29ee1b6826af0bb241264b02ed9f5f5bba49981e631
-  languageName: node
-  linkType: hard
-
-"@microsoft/api-extractor-model@npm:^7.26.4":
-  version: 7.28.4
-  resolution: "@microsoft/api-extractor-model@npm:7.28.4"
-  dependencies:
-    "@microsoft/tsdoc": "npm:0.14.2"
-    "@microsoft/tsdoc-config": "npm:~0.16.1"
-    "@rushstack/node-core-library": "npm:3.63.0"
-  checksum: ecabfab1a816a31fb6bb6fef26661dd200417c38687c9efdb0755e3347be0618377ce871146fb780d4e8b0a09ba5763f6825dd9e66d7a6c16177594c0d5cce6a
   languageName: node
   linkType: hard
 
@@ -6014,26 +6003,6 @@ __metadata:
   version: 1.6.1
   resolution: "@rushstack/eslint-patch@npm:1.6.1"
   checksum: 4c57775785718c6665bee8daea204bf2fe59c2fec6cabf0d126f01c6c170e11605b7453a089dfd5bf3fb758832b2aa7964d6b9f29007d708a3571e8ff7bcf391
-  languageName: node
-  linkType: hard
-
-"@rushstack/node-core-library@npm:3.63.0":
-  version: 3.63.0
-  resolution: "@rushstack/node-core-library@npm:3.63.0"
-  dependencies:
-    colors: "npm:~1.2.1"
-    fs-extra: "npm:~7.0.1"
-    import-lazy: "npm:~4.0.0"
-    jju: "npm:~1.4.0"
-    resolve: "npm:~1.22.1"
-    semver: "npm:~7.5.4"
-    z-schema: "npm:~5.0.2"
-  peerDependencies:
-    "@types/node": "*"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: 14e635884bac94b7d2a73a2e5793389c0a770c9d8cc9a4f6b13975318d4e7361af5169cd7084d00ac883bf7623c5ea74581c5cfb0a4c6a5590d72b0ce6cbef83
   languageName: node
   linkType: hard
 
@@ -10976,13 +10945,6 @@ __metadata:
   version: 1.0.3
   resolution: "colors@npm:1.0.3"
   checksum: 8d81835f217ffca6de6665c8dd9ed132c562d108d4ba842d638c7cb5f8127cff47cb1b54c6bbea49e22eaa7b56caee6b85278dde9c2564f8a0eaef161e028ae0
-  languageName: node
-  linkType: hard
-
-"colors@npm:~1.2.1":
-  version: 1.2.5
-  resolution: "colors@npm:1.2.5"
-  checksum: fe30007df0f62abedc2726990d0951f19292d85686dffcc76fa96ee9dc4e1a987d50b34aa02796e88627709c54a52f07c057bf1da4b7302c06eda8e1afd2f09a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7465,7 +7465,7 @@ __metadata:
     rimraf: "npm:^4.4.0"
     svgo: "npm:^3.0.2"
     tsx: "npm:^4.0.0"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     vercel: "npm:^28.16.15"
   languageName: unknown
   linkType: soft
@@ -24204,7 +24204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2":
+"typescript@npm:^5.2.2, typescript@npm:^5.3.3":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
   bin:
@@ -24234,7 +24234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4125,14 +4125,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor-model@npm:7.27.3":
-  version: 7.27.3
-  resolution: "@microsoft/api-extractor-model@npm:7.27.3"
+"@microsoft/api-extractor-model@npm:7.28.13":
+  version: 7.28.13
+  resolution: "@microsoft/api-extractor-model@npm:7.28.13"
   dependencies:
     "@microsoft/tsdoc": "npm:0.14.2"
     "@microsoft/tsdoc-config": "npm:~0.16.1"
-    "@rushstack/node-core-library": "npm:3.59.4"
-  checksum: 9ed92235c52fa548274af016fb729f1739c808925ee27162aa1a6e9d8028f8ea588964ae25b8c9c678b884e11aa899581aba1fce54e9b13645763d889c89573a
+    "@rushstack/node-core-library": "npm:4.0.2"
+  checksum: af1d0457d76b909ac870c7c895caf773a3348312d8c308f73bf160c8b85ab6c0be6ed6c5568a5ee5ccedf29ee1b6826af0bb241264b02ed9f5f5bba49981e631
   languageName: node
   linkType: hard
 
@@ -4147,47 +4147,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor@npm:7.35.4":
-  version: 7.35.4
-  resolution: "@microsoft/api-extractor@npm:7.35.4"
+"@microsoft/api-extractor@npm:^7.41.0":
+  version: 7.41.0
+  resolution: "@microsoft/api-extractor@npm:7.41.0"
   dependencies:
-    "@microsoft/api-extractor-model": "npm:7.27.3"
+    "@microsoft/api-extractor-model": "npm:7.28.13"
     "@microsoft/tsdoc": "npm:0.14.2"
     "@microsoft/tsdoc-config": "npm:~0.16.1"
-    "@rushstack/node-core-library": "npm:3.59.4"
-    "@rushstack/rig-package": "npm:0.3.21"
-    "@rushstack/ts-command-line": "npm:4.15.1"
-    colors: "npm:~1.2.1"
+    "@rushstack/node-core-library": "npm:4.0.2"
+    "@rushstack/rig-package": "npm:0.5.2"
+    "@rushstack/terminal": "npm:0.10.0"
+    "@rushstack/ts-command-line": "npm:4.17.4"
     lodash: "npm:~4.17.15"
     resolve: "npm:~1.22.1"
-    semver: "npm:~7.3.0"
+    semver: "npm:~7.5.4"
     source-map: "npm:~0.6.1"
-    typescript: "npm:~5.0.4"
+    typescript: "npm:5.3.3"
   bin:
     api-extractor: bin/api-extractor
-  checksum: 104f889bd9dce621381f45ff1f6b4f4c377e913eb6361d365088a0ab2dfd3aca80295f146fb57a8e1adaff9a134151304724e28f0a5f756f9ca28ddbddce8816
-  languageName: node
-  linkType: hard
-
-"@microsoft/api-extractor@patch:@microsoft/api-extractor@npm%3A7.35.4#./.yarn/patches/@microsoft-api-extractor-npm-7.35.4-5f4f0357b4.patch::locator=%40tldraw%2Fmonorepo%40workspace%3A.":
-  version: 7.35.4
-  resolution: "@microsoft/api-extractor@patch:@microsoft/api-extractor@npm%3A7.35.4#./.yarn/patches/@microsoft-api-extractor-npm-7.35.4-5f4f0357b4.patch::version=7.35.4&hash=290713&locator=%40tldraw%2Fmonorepo%40workspace%3A."
-  dependencies:
-    "@microsoft/api-extractor-model": "npm:7.27.3"
-    "@microsoft/tsdoc": "npm:0.14.2"
-    "@microsoft/tsdoc-config": "npm:~0.16.1"
-    "@rushstack/node-core-library": "npm:3.59.4"
-    "@rushstack/rig-package": "npm:0.3.21"
-    "@rushstack/ts-command-line": "npm:4.15.1"
-    colors: "npm:~1.2.1"
-    lodash: "npm:~4.17.15"
-    resolve: "npm:~1.22.1"
-    semver: "npm:~7.3.0"
-    source-map: "npm:~0.6.1"
-    typescript: "npm:~5.0.4"
-  bin:
-    api-extractor: bin/api-extractor
-  checksum: d2d43c541d8da63443a9404069d804a25eabb8acc096a4a1272c6b6047736aac66fa3587b1b46ffb9014808e1daaec473c994b6babb8880c8a3e7f060001df12
+  checksum: 494feabecec7f1e0993255c9f74d3bebf7d129e5fecc9742f1c4d64d11fd772bd8d993b4e78518993afadb17bf15c9a24f3d5b0eee34bd919fd714a759c83881
   languageName: node
   linkType: hard
 
@@ -6039,26 +6017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/node-core-library@npm:3.59.4":
-  version: 3.59.4
-  resolution: "@rushstack/node-core-library@npm:3.59.4"
-  dependencies:
-    colors: "npm:~1.2.1"
-    fs-extra: "npm:~7.0.1"
-    import-lazy: "npm:~4.0.0"
-    jju: "npm:~1.4.0"
-    resolve: "npm:~1.22.1"
-    semver: "npm:~7.3.0"
-    z-schema: "npm:~5.0.2"
-  peerDependencies:
-    "@types/node": "*"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-  checksum: d0335e2135223caabfc87e04bef57cf3833e7e183b473547da6e585f1c4a457e24193159ab59bafa77e3370d87bbae816547ca3116c66442a431ed9c9aa8c3bf
-  languageName: node
-  linkType: hard
-
 "@rushstack/node-core-library@npm:3.63.0":
   version: 3.63.0
   resolution: "@rushstack/node-core-library@npm:3.63.0"
@@ -6079,25 +6037,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/rig-package@npm:0.3.21":
-  version: 0.3.21
-  resolution: "@rushstack/rig-package@npm:0.3.21"
+"@rushstack/node-core-library@npm:4.0.2":
+  version: 4.0.2
+  resolution: "@rushstack/node-core-library@npm:4.0.2"
   dependencies:
+    fs-extra: "npm:~7.0.1"
+    import-lazy: "npm:~4.0.0"
+    jju: "npm:~1.4.0"
     resolve: "npm:~1.22.1"
-    strip-json-comments: "npm:~3.1.1"
-  checksum: 5cb9f6f0063d09d7132b86fce39c6789a389a3af6ea6540922fd6b4838a2c27a8ec62f7761afa1c02776a4aa1bdecafdee034fdb49c40d1feb034a798e8ecd9a
+    semver: "npm:~7.5.4"
+    z-schema: "npm:~5.0.2"
+  peerDependencies:
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: d28ba48e4cb755f39ccc9050f0bbc2cdabe7e706b2e7ee2f7dd2c851129f2198e024c2b1f3b5932a0689c9b86d07ae72e58a6bd62f9349f398dbbcf85d399b85
   languageName: node
   linkType: hard
 
-"@rushstack/ts-command-line@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@rushstack/ts-command-line@npm:4.15.1"
+"@rushstack/rig-package@npm:0.5.2":
+  version: 0.5.2
+  resolution: "@rushstack/rig-package@npm:0.5.2"
   dependencies:
+    resolve: "npm:~1.22.1"
+    strip-json-comments: "npm:~3.1.1"
+  checksum: 2fd178a46c1662f110d06bcc7771898cc4316db62735f9b76281995b86263c1b248c60aead5c2f7ac6be023eb23f7ed28cff78ef813df7fb2b68a945e416814d
+  languageName: node
+  linkType: hard
+
+"@rushstack/terminal@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@rushstack/terminal@npm:0.10.0"
+  dependencies:
+    "@rushstack/node-core-library": "npm:4.0.2"
+    supports-color: "npm:~8.1.1"
+  peerDependencies:
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 4fb496558f4bf03235a6716fac3bbdefa92209c8ba05838b34b8986eaec59961938cb7b3ae5e7dfa4d96b692696291894b0cb7090d76ff29753e8c54624e5343
+  languageName: node
+  linkType: hard
+
+"@rushstack/ts-command-line@npm:4.17.4":
+  version: 4.17.4
+  resolution: "@rushstack/ts-command-line@npm:4.17.4"
+  dependencies:
+    "@rushstack/terminal": "npm:0.10.0"
     "@types/argparse": "npm:1.0.38"
     argparse: "npm:~1.0.9"
-    colors: "npm:~1.2.1"
     string-argv: "npm:~0.3.1"
-  checksum: 7d1cedc2d48d18bdb6f676a74dac9040b47521b0ebf3696ed595325859d4949573df733ff084185687c9a6bebf92a83a329e19ce31ad501cd302114c20eaaae9
+  checksum: 32bfc274bf41bce3eba72e3c950e392cb636ea39b2e830e9247da163d7f46077b74373743b383833cbb95cd0322a17fe78a87b2d32af8aa87d793cd276ac2888
   languageName: node
   linkType: hard
 
@@ -7292,7 +7284,7 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     lazyrepo: "npm:0.0.0-alpha.27"
     ts-node-dev: "npm:^1.1.8"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 
@@ -7305,7 +7297,7 @@ __metadata:
     grabity: "npm:^1.0.5"
     lazyrepo: "npm:0.0.0-alpha.27"
     tslib: "npm:^2.6.2"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 
@@ -7352,7 +7344,7 @@ __metadata:
     sqlite: "npm:^5.0.1"
     sqlite3: "npm:^5.1.6"
     tsx: "npm:^4.0.0"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     unist-util-is: "npm:^6.0.0"
     unist-util-visit: "npm:^5.0.0"
     vectra: "npm:^0.4.4"
@@ -7381,7 +7373,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     strip-ansi: "npm:^7.1.0"
     toucan-js: "npm:^2.7.0"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     wrangler: "npm:3.16.0"
   languageName: unknown
   linkType: soft
@@ -7430,7 +7422,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/monorepo@workspace:."
   dependencies:
-    "@microsoft/api-extractor": "npm:^7.35.4"
+    "@microsoft/api-extractor": "npm:^7.41.0"
     "@next/eslint-plugin-next": "npm:^13.3.0"
     "@sentry/cli": "npm:^2.25.0"
     "@swc/core": "npm:^1.3.55"
@@ -7498,7 +7490,7 @@ __metadata:
     semver: "npm:^7.3.8"
     svgo: "npm:^3.0.2"
     tar: "npm:^6.2.0"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 
@@ -7595,7 +7587,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     nanoevents: "npm:^7.0.1"
     nanoid: "npm:4.0.2"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     uuid-by-string: "npm:^4.0.0"
     uuid-readable: "npm:^0.0.2"
     ws: "npm:^8.16.0"
@@ -15200,7 +15192,7 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     "@types/node": "npm:~20.11"
     discord-api-types: "npm:^0.37.67"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     wrangler: "npm:3.16.0"
   languageName: unknown
   linkType: soft
@@ -22335,7 +22327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.8, semver@npm:~7.3.0":
+"semver@npm:7.3.8":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -23297,7 +23289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
+"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1, supports-color@npm:~8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -23599,7 +23591,7 @@ __metadata:
     ts-loader: "npm:^9.2.5"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.0.0"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     vsce: "npm:^2.15.0"
     webpack: "npm:^5.0.0"
   peerDependencies:
@@ -24204,23 +24196,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2, typescript@npm:^5.3.3":
+"typescript@npm:5.3.3, typescript@npm:^5.3.3":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 6e4e6a14a50c222b3d14d4ea2f729e79f972fa536ac1522b91202a9a65af3605c2928c4a790a4a50aa13694d461c479ba92cedaeb1e7b190aadaa4e4b96b8e18
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.0.4":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e5c3adff09a138c0e27d13b5bb2b106ca17a162ffa945d66161669c265c65436309c5817358a2af1abb69d07440d358f8c1ed7cbb63a2c8680e19b9c268fe4ef
   languageName: node
   linkType: hard
 
@@ -24234,23 +24216,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: c93786fcc9a70718ba1e3819bab56064ead5817004d1b8186f8ca66165f3a2d0100fee91fa64c840dcd45f994ca5d615d8e1f566d39a7470fc1e014dbb4cf15d
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.0.4#optional!builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#optional!builtin<compat/typescript>::version=5.0.4&hash=b5f058"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: b1b62606c7ec75efe9edc61e195d9e69f0440cac1bcd111dfa864f839255f0d9a7b79869f2823559c608826fc0c9894d2917ae4063e0aa06f5d0784a35170497
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR bumps TypeScript to 5.3.3 and API extractor. We started getting some weird behavior in CI due to different versions of the two libraries, ie where the CI api.jsons would differ from those built locally.

### Change Type

- [x] `dependencies` — Changes to package dependencies[^1]
