### PR TITLE
[experiment] stickies: new look and feel

### DIFF
--- a/assets/icons/icon/tool-note-new.svg
+++ b/assets/icons/icon/tool-note-new.svg
@@ -1,0 +1,4 @@
+<!-- MIT License: Icons8 https://github.com/icons8/windows-10-icons?ref=svgrepo.com -->
+<svg fill="black" viewBox="2 2 28 28" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 5 5 L 5 27 L 20.40625 27 L 20.71875 26.71875 L 26.71875 20.71875 L 27 20.40625 L 27 5 Z M 7 7 L 25 7 L 25 19 L 19 19 L 19 25 L 7 25 Z M 21 21 L 23.5625 21 L 21 23.5625 Z" />
+</svg>

--- a/packages/assets/imports.js
+++ b/packages/assets/imports.js
@@ -171,6 +171,7 @@ import iconsToolHighlight from './icons/icon/tool-highlight.svg'
 import iconsToolLaser from './icons/icon/tool-laser.svg'
 import iconsToolLine from './icons/icon/tool-line.svg'
 import iconsToolMedia from './icons/icon/tool-media.svg'
+import iconsToolNoteNew from './icons/icon/tool-note-new.svg'
 import iconsToolNote from './icons/icon/tool-note.svg'
 import iconsToolPencil from './icons/icon/tool-pencil.svg'
 import iconsToolPointer from './icons/icon/tool-pointer.svg'
@@ -387,6 +388,7 @@ export function getAssetUrlsByImport(opts) {
 			'tool-laser': formatAssetUrl(iconsToolLaser, opts),
 			'tool-line': formatAssetUrl(iconsToolLine, opts),
 			'tool-media': formatAssetUrl(iconsToolMedia, opts),
+			'tool-note-new': formatAssetUrl(iconsToolNoteNew, opts),
 			'tool-note': formatAssetUrl(iconsToolNote, opts),
 			'tool-pencil': formatAssetUrl(iconsToolPencil, opts),
 			'tool-pointer': formatAssetUrl(iconsToolPointer, opts),

--- a/packages/assets/imports.vite.js
+++ b/packages/assets/imports.vite.js
@@ -171,6 +171,7 @@ import iconsToolHighlight from './icons/icon/tool-highlight.svg?url'
 import iconsToolLaser from './icons/icon/tool-laser.svg?url'
 import iconsToolLine from './icons/icon/tool-line.svg?url'
 import iconsToolMedia from './icons/icon/tool-media.svg?url'
+import iconsToolNoteNew from './icons/icon/tool-note-new.svg?url'
 import iconsToolNote from './icons/icon/tool-note.svg?url'
 import iconsToolPencil from './icons/icon/tool-pencil.svg?url'
 import iconsToolPointer from './icons/icon/tool-pointer.svg?url'
@@ -387,6 +388,7 @@ export function getAssetUrlsByImport(opts) {
 			'tool-laser': formatAssetUrl(iconsToolLaser, opts),
 			'tool-line': formatAssetUrl(iconsToolLine, opts),
 			'tool-media': formatAssetUrl(iconsToolMedia, opts),
+			'tool-note-new': formatAssetUrl(iconsToolNoteNew, opts),
 			'tool-note': formatAssetUrl(iconsToolNote, opts),
 			'tool-pencil': formatAssetUrl(iconsToolPencil, opts),
 			'tool-pointer': formatAssetUrl(iconsToolPointer, opts),

--- a/packages/assets/selfHosted.js
+++ b/packages/assets/selfHosted.js
@@ -166,6 +166,7 @@ export function getAssetUrls(opts) {
 			'tool-laser': formatAssetUrl('./icons/icon/tool-laser.svg', opts),
 			'tool-line': formatAssetUrl('./icons/icon/tool-line.svg', opts),
 			'tool-media': formatAssetUrl('./icons/icon/tool-media.svg', opts),
+			'tool-note-new': formatAssetUrl('./icons/icon/tool-note-new.svg', opts),
 			'tool-note': formatAssetUrl('./icons/icon/tool-note.svg', opts),
 			'tool-pencil': formatAssetUrl('./icons/icon/tool-pencil.svg', opts),
 			'tool-pointer': formatAssetUrl('./icons/icon/tool-pointer.svg', opts),

--- a/packages/assets/types.d.ts
+++ b/packages/assets/types.d.ts
@@ -156,6 +156,7 @@ export type AssetUrls = {
 		'tool-laser': string
 		'tool-line': string
 		'tool-media': string
+		'tool-note-new': string
 		'tool-note': string
 		'tool-pencil': string
 		'tool-pointer': string

--- a/packages/assets/urls.js
+++ b/packages/assets/urls.js
@@ -502,6 +502,10 @@ export function getAssetUrlsByMetaUrl(opts) {
 				new URL('./icons/icon/tool-media.svg', import.meta.url).href,
 				opts
 			),
+			'tool-note-new': formatAssetUrl(
+				new URL('./icons/icon/tool-note-new.svg', import.meta.url).href,
+				opts
+			),
 			'tool-note': formatAssetUrl(
 				new URL('./icons/icon/tool-note.svg', import.meta.url).href,
 				opts

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1599,6 +1599,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canSnap: TLShapeUtilFlag<Shape>;
     canUnmount: TLShapeUtilFlag<Shape>;
     abstract component(shape: Shape): any;
+    // @internal
     doesAutoEditOnKeyStroke: TLShapeUtilFlag<Shape>;
     // (undocumented)
     editor: Editor;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1599,6 +1599,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canSnap: TLShapeUtilFlag<Shape>;
     canUnmount: TLShapeUtilFlag<Shape>;
     abstract component(shape: Shape): any;
+    doesAutoEditOnKeyStroke: TLShapeUtilFlag<Shape>;
     // (undocumented)
     editor: Editor;
     // @internal (undocumented)

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -30522,41 +30522,6 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#doesAutoEditOnKeyStroke:member",
-              "docComment": "/**\n * Whether the shape goes into edit mode when non-control keystrokes are pressed.\n *\n * @public\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "doesAutoEditOnKeyStroke: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShapeUtilFlag",
-                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<Shape>"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "doesAutoEditOnKeyStroke",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 3
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#editor:member",
               "docComment": "",
               "excerptTokens": [

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -30522,6 +30522,41 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#doesAutoEditOnKeyStroke:member",
+              "docComment": "/**\n * Whether the shape goes into edit mode when non-control keystrokes are pressed.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "doesAutoEditOnKeyStroke: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeUtilFlag",
+                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "doesAutoEditOnKeyStroke",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#editor:member",
               "docComment": "",
               "excerptTokens": [

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -64,6 +64,7 @@
 	/* These cursor values get programmatically overridden */
 	/* They're just here to help your editor autocomplete */
 	--tl-cursor: var(--tl-cursor-default);
+	--tl-cursor-copy: copy;
 	--tl-cursor-resize-edge: ew-resize;
 	--tl-cursor-resize-corner: nesw-resize;
 	--tl-cursor-ew-resize: ew-resize;
@@ -1198,6 +1199,37 @@ input,
 	border-color: currentColor;
 	border-style: solid;
 	border-width: 1px;
+}
+
+.tl-sticky__container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	box-shadow: var(--shadow-1);
+}
+
+.tl-sticky__container:before,
+.tl-sticky__container:after {
+  z-index: -1;
+  position: absolute;
+  content: '';
+  bottom: 15px;
+  left: 10px;
+  width: calc(50% - 10px);
+  top: 80%;
+  background: #777;
+  box-shadow: 0 15px 10px #777;
+  transform: rotate(-3deg);
+}
+
+.tl-sticky__container:after {
+  transform: rotate(3deg);
+  right: 10px;
+  left: auto;
+}
+
+.tl-sticky__container .tl-text-label {
+	text-shadow: none;
 }
 
 .tl-note__container .tl-text-label {

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -16,7 +16,7 @@ import { useScreenBounds } from '../../hooks/useScreenBounds'
 import { Mat } from '../../primitives/Mat'
 import { Vec } from '../../primitives/Vec'
 import { toDomPrecision } from '../../primitives/utils'
-import { debugFlags } from '../../utils/debug-flags'
+import { debugFlags, featureFlags } from '../../utils/debug-flags'
 import { GeometryDebuggingView } from '../GeometryDebuggingView'
 import { LiveCollaborators } from '../LiveCollaborators'
 import { Shape } from '../Shape'
@@ -364,14 +364,16 @@ function SelectedIdIndicators() {
 		() => {
 			// todo: move to tldraw selected ids wrapper
 			return (
-				editor.isInAny(
+				(editor.isInAny(
 					'select.idle',
 					'select.brushing',
 					'select.scribble_brushing',
 					'select.pointing_shape',
 					'select.pointing_selection',
 					'select.pointing_handle'
-				) && !editor.getInstanceState().isChangingStyle
+				) ||
+					(!featureFlags.newStickies.get() && editor.isInAny('select.editing_shape'))) &&
+				!editor.getInstanceState().isChangingStyle
 			)
 		},
 		[editor]

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -368,7 +368,6 @@ function SelectedIdIndicators() {
 					'select.idle',
 					'select.brushing',
 					'select.scribble_brushing',
-					'select.editing_shape',
 					'select.pointing_shape',
 					'select.pointing_selection',
 					'select.pointing_handle'

--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -65,6 +65,7 @@ export class TextManager {
 			maxWidth: null | number
 			minWidth?: string
 			padding: string
+			aspectRatio?: string
 		}
 	): BoxModel => {
 		// Duplicate our base element; we don't need to clone deep
@@ -80,6 +81,7 @@ export class TextManager {
 		elm.style.setProperty('max-width', opts.maxWidth === null ? null : opts.maxWidth + 'px')
 		elm.style.setProperty('min-width', opts.minWidth ?? null)
 		elm.style.setProperty('padding', opts.padding)
+		elm.style.setProperty('aspect-ratio', opts.aspectRatio ?? null)
 
 		elm.textContent = normalizeTextForDom(textToMeasure)
 		const rect = elm.getBoundingClientRect()

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -113,7 +113,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	/**
 	 * Whether the shape goes into edit mode when non-control keystrokes are pressed.
 	 *
-	 * @public
+	 * @internal
 	 */
 	doesAutoEditOnKeyStroke: TLShapeUtilFlag<Shape> = () => false
 

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -111,6 +111,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	canEdit: TLShapeUtilFlag<Shape> = () => false
 
 	/**
+	 * Whether the shape goes into edit mode when non-control keystrokes are pressed.
+	 *
+	 * @public
+	 */
+	doesAutoEditOnKeyStroke: TLShapeUtilFlag<Shape> = () => false
+
+	/**
 	 * Whether the shape can be resized.
 	 *
 	 * @public

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -36,6 +36,7 @@ function getCursorCss(
 const STATIC_CURSORS = [
 	'default',
 	'pointer',
+	'copy',
 	'cross',
 	'move',
 	'grab',

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -8,7 +8,7 @@ import { Atom, atom, react } from '@tldraw/state'
 // `true` by default in development and staging, and `false` in production.
 /** @internal */
 export const featureFlags: Record<string, DebugFlag<boolean>> = {
-	// canMoveArrowLabel: createFeatureFlag('canMoveArrowLabel'),
+	newStickies: createFeatureFlag('newStickies'),
 }
 
 /** @internal */
@@ -104,16 +104,16 @@ function createDebugValue<T>(
 	})
 }
 
-// function createFeatureFlag(
-// 	name: string,
-// 	defaults: Defaults<boolean> = { all: true, production: false }
-// ) {
-// 	return createDebugValueBase({
-// 		name,
-// 		defaults,
-// 		shouldStoreForSession: true,
-// 	})
-// }
+function createFeatureFlag(
+	name: string,
+	defaults: Defaults<boolean> = { all: true, production: false }
+) {
+	return createDebugValueBase({
+		name,
+		defaults,
+		shouldStoreForSession: true,
+	})
+}
 
 function createDebugValueBase<T>(def: DebugFlagDef<T>): DebugFlag<T> {
 	const defaultValue = getDefaultValue(def)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -938,6 +938,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onBeforeCreate: (next: TLNoteShape) => {
         props: {
             growY: number;
+            w: number | undefined;
+            h: number | undefined;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
@@ -962,6 +964,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onBeforeUpdate: (prev: TLNoteShape, next: TLNoteShape) => {
         props: {
             growY: number;
+            w: number | undefined;
+            h: number | undefined;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
@@ -986,6 +990,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
     static props: {
+        w: Validator<number | undefined>;
+        h: Validator<number | undefined>;
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
@@ -1768,7 +1774,7 @@ export interface TLUiIconProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 // @public (undocumented)
-export type TLUiIconType = 'align-bottom-center' | 'align-bottom-left' | 'align-bottom-right' | 'align-bottom' | 'align-center-center' | 'align-center-horizontal' | 'align-center-left' | 'align-center-right' | 'align-center-vertical' | 'align-left' | 'align-right' | 'align-top-center' | 'align-top-left' | 'align-top-right' | 'align-top' | 'arrow-left' | 'arrowhead-arrow' | 'arrowhead-bar' | 'arrowhead-diamond' | 'arrowhead-dot' | 'arrowhead-none' | 'arrowhead-square' | 'arrowhead-triangle-inverted' | 'arrowhead-triangle' | 'aspect-ratio' | 'avatar' | 'blob' | 'bring-forward' | 'bring-to-front' | 'check' | 'checkbox-checked' | 'checkbox-empty' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'chevrons-ne' | 'chevrons-sw' | 'clipboard-copied' | 'clipboard-copy' | 'code' | 'collab' | 'color' | 'comment' | 'cross-2' | 'cross' | 'dash-dashed' | 'dash-dotted' | 'dash-draw' | 'dash-solid' | 'discord' | 'distribute-horizontal' | 'distribute-vertical' | 'dot' | 'dots-horizontal' | 'dots-vertical' | 'drag-handle-dots' | 'duplicate' | 'edit' | 'external-link' | 'file' | 'fill-none' | 'fill-pattern' | 'fill-semi' | 'fill-solid' | 'follow' | 'following' | 'font-draw' | 'font-mono' | 'font-sans' | 'font-serif' | 'geo-arrow-down' | 'geo-arrow-left' | 'geo-arrow-right' | 'geo-arrow-up' | 'geo-check-box' | 'geo-cloud' | 'geo-diamond' | 'geo-ellipse' | 'geo-hexagon' | 'geo-octagon' | 'geo-oval' | 'geo-pentagon' | 'geo-rectangle' | 'geo-rhombus-2' | 'geo-rhombus' | 'geo-star' | 'geo-trapezoid' | 'geo-triangle' | 'geo-x-box' | 'github' | 'group' | 'hidden' | 'image' | 'info-circle' | 'leading' | 'link' | 'lock-small' | 'lock' | 'menu' | 'minus' | 'mixed' | 'pack' | 'page' | 'plus' | 'question-mark-circle' | 'question-mark' | 'redo' | 'reset-zoom' | 'rotate-ccw' | 'rotate-cw' | 'ruler' | 'search' | 'send-backward' | 'send-to-back' | 'settings-horizontal' | 'settings-vertical-1' | 'settings-vertical' | 'share-1' | 'share-2' | 'size-extra-large' | 'size-large' | 'size-medium' | 'size-small' | 'spline-cubic' | 'spline-line' | 'stack-horizontal' | 'stack-vertical' | 'status-offline' | 'status-online' | 'stretch-horizontal' | 'stretch-vertical' | 'text-align-center' | 'text-align-justify' | 'text-align-left' | 'text-align-right' | 'tool-arrow' | 'tool-embed' | 'tool-eraser' | 'tool-frame' | 'tool-hand' | 'tool-highlight' | 'tool-laser' | 'tool-line' | 'tool-media' | 'tool-note' | 'tool-pencil' | 'tool-pointer' | 'tool-text' | 'trash' | 'triangle-down' | 'triangle-up' | 'twitter' | 'undo' | 'ungroup' | 'unlock-small' | 'unlock' | 'vertical-align-center' | 'vertical-align-end' | 'vertical-align-start' | 'visible' | 'warning-triangle' | 'zoom-in' | 'zoom-out';
+export type TLUiIconType = 'align-bottom-center' | 'align-bottom-left' | 'align-bottom-right' | 'align-bottom' | 'align-center-center' | 'align-center-horizontal' | 'align-center-left' | 'align-center-right' | 'align-center-vertical' | 'align-left' | 'align-right' | 'align-top-center' | 'align-top-left' | 'align-top-right' | 'align-top' | 'arrow-left' | 'arrowhead-arrow' | 'arrowhead-bar' | 'arrowhead-diamond' | 'arrowhead-dot' | 'arrowhead-none' | 'arrowhead-square' | 'arrowhead-triangle-inverted' | 'arrowhead-triangle' | 'aspect-ratio' | 'avatar' | 'blob' | 'bring-forward' | 'bring-to-front' | 'check' | 'checkbox-checked' | 'checkbox-empty' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'chevrons-ne' | 'chevrons-sw' | 'clipboard-copied' | 'clipboard-copy' | 'code' | 'collab' | 'color' | 'comment' | 'cross-2' | 'cross' | 'dash-dashed' | 'dash-dotted' | 'dash-draw' | 'dash-solid' | 'discord' | 'distribute-horizontal' | 'distribute-vertical' | 'dot' | 'dots-horizontal' | 'dots-vertical' | 'drag-handle-dots' | 'duplicate' | 'edit' | 'external-link' | 'file' | 'fill-none' | 'fill-pattern' | 'fill-semi' | 'fill-solid' | 'follow' | 'following' | 'font-draw' | 'font-mono' | 'font-sans' | 'font-serif' | 'geo-arrow-down' | 'geo-arrow-left' | 'geo-arrow-right' | 'geo-arrow-up' | 'geo-check-box' | 'geo-cloud' | 'geo-diamond' | 'geo-ellipse' | 'geo-hexagon' | 'geo-octagon' | 'geo-oval' | 'geo-pentagon' | 'geo-rectangle' | 'geo-rhombus-2' | 'geo-rhombus' | 'geo-star' | 'geo-trapezoid' | 'geo-triangle' | 'geo-x-box' | 'github' | 'group' | 'hidden' | 'image' | 'info-circle' | 'leading' | 'link' | 'lock-small' | 'lock' | 'menu' | 'minus' | 'mixed' | 'pack' | 'page' | 'plus' | 'question-mark-circle' | 'question-mark' | 'redo' | 'reset-zoom' | 'rotate-ccw' | 'rotate-cw' | 'ruler' | 'search' | 'send-backward' | 'send-to-back' | 'settings-horizontal' | 'settings-vertical-1' | 'settings-vertical' | 'share-1' | 'share-2' | 'size-extra-large' | 'size-large' | 'size-medium' | 'size-small' | 'spline-cubic' | 'spline-line' | 'stack-horizontal' | 'stack-vertical' | 'status-offline' | 'status-online' | 'stretch-horizontal' | 'stretch-vertical' | 'text-align-center' | 'text-align-justify' | 'text-align-left' | 'text-align-right' | 'tool-arrow' | 'tool-embed' | 'tool-eraser' | 'tool-frame' | 'tool-hand' | 'tool-highlight' | 'tool-laser' | 'tool-line' | 'tool-media' | 'tool-note-new' | 'tool-note' | 'tool-pencil' | 'tool-pointer' | 'tool-text' | 'trash' | 'triangle-down' | 'triangle-up' | 'twitter' | 'undo' | 'ungroup' | 'unlock-small' | 'unlock' | 'vertical-align-center' | 'vertical-align-end' | 'vertical-align-start' | 'visible' | 'warning-triangle' | 'zoom-in' | 'zoom-out';
 
 // @public (undocumented)
 export interface TLUiInputProps {

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -11370,7 +11370,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            w: number | undefined;\n            h: number | undefined;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -11454,7 +11454,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            w: number | undefined;\n            h: number | undefined;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -11564,7 +11564,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n        color: import(\"@tldraw/editor\")."
+                  "text": "{\n        w: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number | undefined>;\n        h: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number | undefined>;\n        color: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -11649,7 +11667,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 22
               },
               "isStatic": true,
               "isProtected": false,
@@ -20385,7 +20403,7 @@
             },
             {
               "kind": "Content",
-              "text": "'align-bottom-center' | 'align-bottom-left' | 'align-bottom-right' | 'align-bottom' | 'align-center-center' | 'align-center-horizontal' | 'align-center-left' | 'align-center-right' | 'align-center-vertical' | 'align-left' | 'align-right' | 'align-top-center' | 'align-top-left' | 'align-top-right' | 'align-top' | 'arrow-left' | 'arrowhead-arrow' | 'arrowhead-bar' | 'arrowhead-diamond' | 'arrowhead-dot' | 'arrowhead-none' | 'arrowhead-square' | 'arrowhead-triangle-inverted' | 'arrowhead-triangle' | 'aspect-ratio' | 'avatar' | 'blob' | 'bring-forward' | 'bring-to-front' | 'check' | 'checkbox-checked' | 'checkbox-empty' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'chevrons-ne' | 'chevrons-sw' | 'clipboard-copied' | 'clipboard-copy' | 'code' | 'collab' | 'color' | 'comment' | 'cross-2' | 'cross' | 'dash-dashed' | 'dash-dotted' | 'dash-draw' | 'dash-solid' | 'discord' | 'distribute-horizontal' | 'distribute-vertical' | 'dot' | 'dots-horizontal' | 'dots-vertical' | 'drag-handle-dots' | 'duplicate' | 'edit' | 'external-link' | 'file' | 'fill-none' | 'fill-pattern' | 'fill-semi' | 'fill-solid' | 'follow' | 'following' | 'font-draw' | 'font-mono' | 'font-sans' | 'font-serif' | 'geo-arrow-down' | 'geo-arrow-left' | 'geo-arrow-right' | 'geo-arrow-up' | 'geo-check-box' | 'geo-cloud' | 'geo-diamond' | 'geo-ellipse' | 'geo-hexagon' | 'geo-octagon' | 'geo-oval' | 'geo-pentagon' | 'geo-rectangle' | 'geo-rhombus-2' | 'geo-rhombus' | 'geo-star' | 'geo-trapezoid' | 'geo-triangle' | 'geo-x-box' | 'github' | 'group' | 'hidden' | 'image' | 'info-circle' | 'leading' | 'link' | 'lock-small' | 'lock' | 'menu' | 'minus' | 'mixed' | 'pack' | 'page' | 'plus' | 'question-mark-circle' | 'question-mark' | 'redo' | 'reset-zoom' | 'rotate-ccw' | 'rotate-cw' | 'ruler' | 'search' | 'send-backward' | 'send-to-back' | 'settings-horizontal' | 'settings-vertical-1' | 'settings-vertical' | 'share-1' | 'share-2' | 'size-extra-large' | 'size-large' | 'size-medium' | 'size-small' | 'spline-cubic' | 'spline-line' | 'stack-horizontal' | 'stack-vertical' | 'status-offline' | 'status-online' | 'stretch-horizontal' | 'stretch-vertical' | 'text-align-center' | 'text-align-justify' | 'text-align-left' | 'text-align-right' | 'tool-arrow' | 'tool-embed' | 'tool-eraser' | 'tool-frame' | 'tool-hand' | 'tool-highlight' | 'tool-laser' | 'tool-line' | 'tool-media' | 'tool-note' | 'tool-pencil' | 'tool-pointer' | 'tool-text' | 'trash' | 'triangle-down' | 'triangle-up' | 'twitter' | 'undo' | 'ungroup' | 'unlock-small' | 'unlock' | 'vertical-align-center' | 'vertical-align-end' | 'vertical-align-start' | 'visible' | 'warning-triangle' | 'zoom-in' | 'zoom-out'"
+              "text": "'align-bottom-center' | 'align-bottom-left' | 'align-bottom-right' | 'align-bottom' | 'align-center-center' | 'align-center-horizontal' | 'align-center-left' | 'align-center-right' | 'align-center-vertical' | 'align-left' | 'align-right' | 'align-top-center' | 'align-top-left' | 'align-top-right' | 'align-top' | 'arrow-left' | 'arrowhead-arrow' | 'arrowhead-bar' | 'arrowhead-diamond' | 'arrowhead-dot' | 'arrowhead-none' | 'arrowhead-square' | 'arrowhead-triangle-inverted' | 'arrowhead-triangle' | 'aspect-ratio' | 'avatar' | 'blob' | 'bring-forward' | 'bring-to-front' | 'check' | 'checkbox-checked' | 'checkbox-empty' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'chevrons-ne' | 'chevrons-sw' | 'clipboard-copied' | 'clipboard-copy' | 'code' | 'collab' | 'color' | 'comment' | 'cross-2' | 'cross' | 'dash-dashed' | 'dash-dotted' | 'dash-draw' | 'dash-solid' | 'discord' | 'distribute-horizontal' | 'distribute-vertical' | 'dot' | 'dots-horizontal' | 'dots-vertical' | 'drag-handle-dots' | 'duplicate' | 'edit' | 'external-link' | 'file' | 'fill-none' | 'fill-pattern' | 'fill-semi' | 'fill-solid' | 'follow' | 'following' | 'font-draw' | 'font-mono' | 'font-sans' | 'font-serif' | 'geo-arrow-down' | 'geo-arrow-left' | 'geo-arrow-right' | 'geo-arrow-up' | 'geo-check-box' | 'geo-cloud' | 'geo-diamond' | 'geo-ellipse' | 'geo-hexagon' | 'geo-octagon' | 'geo-oval' | 'geo-pentagon' | 'geo-rectangle' | 'geo-rhombus-2' | 'geo-rhombus' | 'geo-star' | 'geo-trapezoid' | 'geo-triangle' | 'geo-x-box' | 'github' | 'group' | 'hidden' | 'image' | 'info-circle' | 'leading' | 'link' | 'lock-small' | 'lock' | 'menu' | 'minus' | 'mixed' | 'pack' | 'page' | 'plus' | 'question-mark-circle' | 'question-mark' | 'redo' | 'reset-zoom' | 'rotate-ccw' | 'rotate-cw' | 'ruler' | 'search' | 'send-backward' | 'send-to-back' | 'settings-horizontal' | 'settings-vertical-1' | 'settings-vertical' | 'share-1' | 'share-2' | 'size-extra-large' | 'size-large' | 'size-medium' | 'size-small' | 'spline-cubic' | 'spline-line' | 'stack-horizontal' | 'stack-vertical' | 'status-offline' | 'status-online' | 'stretch-horizontal' | 'stretch-vertical' | 'text-align-center' | 'text-align-justify' | 'text-align-left' | 'text-align-right' | 'tool-arrow' | 'tool-embed' | 'tool-eraser' | 'tool-frame' | 'tool-hand' | 'tool-highlight' | 'tool-laser' | 'tool-line' | 'tool-media' | 'tool-note-new' | 'tool-note' | 'tool-pencil' | 'tool-pointer' | 'tool-text' | 'trash' | 'triangle-down' | 'triangle-up' | 'twitter' | 'undo' | 'ungroup' | 'unlock-small' | 'unlock' | 'vertical-align-center' | 'vertical-align-end' | 'vertical-align-start' | 'visible' | 'warning-triangle' | 'zoom-in' | 'zoom-out'"
             },
             {
               "kind": "Content",

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -11,6 +11,7 @@ import {
 	TldrawEditor,
 	TldrawEditorBaseProps,
 	assert,
+	featureFlags,
 	useEditor,
 	useEditorComponents,
 	useShallowArrayIdentity,
@@ -30,6 +31,8 @@ import { defaultShapeTools } from './defaultShapeTools'
 import { defaultShapeUtils } from './defaultShapeUtils'
 import { registerDefaultSideEffects } from './defaultSideEffects'
 import { defaultTools } from './defaultTools'
+import { NoteShapeTool } from './shapes/sticky/NoteShapeTool'
+import { NoteShapeUtil } from './shapes/sticky/NoteShapeUtil'
 import { TldrawUi, TldrawUiProps } from './ui/TldrawUi'
 import { TLUiComponents, useTldrawUiComponents } from './ui/context/components'
 import { usePreloadAssets } from './ui/hooks/usePreloadAssets'
@@ -93,15 +96,27 @@ export function Tldraw(props: TldrawProps) {
 	)
 
 	const _shapeUtils = useShallowArrayIdentity(shapeUtils)
+	const isStickyExperiment = featureFlags.newStickies.get()
 	const shapeUtilsWithDefaults = useMemo(
-		() => [...defaultShapeUtils, ..._shapeUtils],
-		[_shapeUtils]
+		() => [
+			...defaultShapeUtils.map((util) =>
+				isStickyExperiment && util.type === 'note' ? NoteShapeUtil : util
+			),
+			..._shapeUtils,
+		],
+		[_shapeUtils, isStickyExperiment]
 	)
 
 	const _tools = useShallowArrayIdentity(tools)
 	const toolsWithDefaults = useMemo(
-		() => [...defaultTools, ...defaultShapeTools, ..._tools],
-		[_tools]
+		() => [
+			...defaultTools,
+			...defaultShapeTools.map((tool) =>
+				isStickyExperiment && tool.id === 'note' ? NoteShapeTool : tool
+			),
+			..._tools,
+		],
+		[_tools, isStickyExperiment]
 	)
 
 	const assets = useDefaultEditorAssetsWithOverrides(rest.assetUrls)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -32,6 +32,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 	getDefaultProps(): TLNoteShape['props'] {
 		return {
+			w: undefined,
+			h: undefined,
 			color: 'black',
 			size: 'm',
 			text: '',

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -29,6 +29,7 @@ export const TextLabel = React.memo(function TextLabel<
 	verticalAlign,
 	wrap,
 	bounds,
+	onKeyDown: handleKeyDownCustom,
 }: {
 	id: T['id']
 	type: T['type']
@@ -41,6 +42,7 @@ export const TextLabel = React.memo(function TextLabel<
 	text: string
 	labelColor: TLDefaultColorStyle
 	bounds?: Box
+	onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
 }) {
 	const {
 		rInput,
@@ -118,7 +120,7 @@ export const TextLabel = React.memo(function TextLabel<
 						defaultValue={text}
 						onFocus={handleFocus}
 						onChange={handleChange}
-						onKeyDown={handleKeyDown}
+						onKeyDown={handleKeyDownCustom ?? handleKeyDown}
 						onBlur={handleBlur}
 						onContextMenu={stopEventPropagation}
 						onPointerDown={handleInputPointerDown}

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -3,6 +3,7 @@
 import {
 	TLShape,
 	TLUnknownShape,
+	featureFlags,
 	getPointerInfo,
 	preventDefault,
 	stopEventPropagation,
@@ -39,20 +40,22 @@ export function useEditableText<T extends Extract<TLShape, { props: { text: stri
 		const skipSelect = rSkipSelectOnFocus.current
 		rSkipSelectOnFocus.current = false
 
-		// On the next frame, if we're not skipping select AND we have text in the element, then focus the text
-		requestAnimationFrame(() => {
-			const elm = rInput.current
-			if (!elm) return
+		if (!featureFlags.newStickies.get()) {
+			// On the next frame, if we're not skipping select AND we have text in the element, then focus the text
+			requestAnimationFrame(() => {
+				const elm = rInput.current
+				if (!elm) return
 
-			const shape = editor.getShape<TLShape & { props: { text: string } }>(id)
+				const shape = editor.getShape<TLShape & { props: { text: string } }>(id)
 
-			if (shape) {
-				elm.value = shape.props.text
-				if (elm.value.length && !skipSelect) {
-					elm.select()
+				if (shape) {
+					elm.value = shape.props.text
+					if (elm.value.length && !skipSelect) {
+						elm.select()
+					}
 				}
-			}
-		})
+			})
+		}
 	}, [editor, id])
 
 	// When the label blurs, deselect all of the text and complete.

--- a/packages/tldraw/src/lib/shapes/sticky/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/sticky/NoteShapeTool.test.ts
@@ -1,0 +1,146 @@
+import { TestEditor } from '../../../test/TestEditor'
+import { NoteShapeTool } from './NoteShapeTool'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+afterEach(() => {
+	editor?.dispose()
+})
+
+describe(NoteShapeTool, () => {
+	it('Creates note shapes on click-and-drag, supports undo and redo', () => {
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(100, 100)
+		editor.pointerUp(100, 100)
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		expect(editor.getCurrentPageShapes()[0]?.type).toBe('note')
+		expect(editor.getSelectedShapeIds()[0]).toBe(editor.getCurrentPageShapes()[0]?.id)
+
+		editor.cancel() // leave edit mode
+
+		editor.undo() // undoes the selection change
+		editor.undo()
+
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		editor.redo()
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+	})
+
+	it('Creates note shapes on click, supports undo and redo', () => {
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerUp(50, 50)
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		expect(editor.getCurrentPageShapes()[0]?.type).toBe('note')
+		expect(editor.getSelectedShapeIds()[0]).toBe(editor.getCurrentPageShapes()[0]?.id)
+
+		editor.undo()
+
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		editor.redo()
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+	})
+})
+
+describe('When selecting the tool', () => {
+	it('selects the tool and enters the idle state', () => {
+		editor.setCurrentTool('note')
+		editor.expectToBeIn('note.idle')
+	})
+})
+
+describe('When in the idle state', () => {
+	it('Enters pointing state on pointer down', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(100, 100)
+		editor.expectToBeIn('note.pointing')
+	})
+
+	it('Switches back to select tool on cancel', () => {
+		editor.setCurrentTool('note')
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('Does nothing on interrupt', () => {
+		editor.setCurrentTool('note')
+		editor.interrupt()
+		editor.expectToBeIn('note.idle')
+	})
+})
+
+describe('When in the pointing state', () => {
+	it('Switches back to idle on cancel', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.expectToBeIn('note.pointing')
+		editor.cancel()
+		editor.expectToBeIn('note.idle')
+	})
+
+	it('Enters the select.translating state on drag start', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(51, 51) // not far enough!
+		editor.expectToBeIn('note.pointing')
+		editor.pointerMove(55, 55)
+		editor.expectToBeIn('select.translating')
+	})
+
+	it('Returns to the note tool on cancel from translating', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(55, 55)
+		editor.cancel()
+		editor.expectToBeIn('note.idle')
+	})
+
+	it('Returns to the note tool on complete from translating when tool lock is enabled', () => {
+		editor.updateInstanceState({ isToolLocked: true })
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(55, 55)
+		editor.pointerUp()
+		editor.expectToBeIn('note.idle')
+	})
+
+	it('Returns to the idle state on interrupt', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.interrupt()
+		editor.expectToBeIn('note.idle')
+	})
+
+	it('Creates a note and begins editing on pointer up', () => {
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerUp(50, 50)
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+	})
+
+	it('Creates a frame and returns to frame.idle on pointer up if tool lock is enabled', () => {
+		editor.updateInstanceState({ isToolLocked: true })
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.setCurrentTool('note')
+		editor.pointerDown(50, 50)
+		editor.pointerUp(50, 50)
+		editor.expectToBeIn('note.idle')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+	})
+})

--- a/packages/tldraw/src/lib/shapes/sticky/NoteShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/sticky/NoteShapeTool.ts
@@ -1,0 +1,11 @@
+import { StateNode } from '@tldraw/editor'
+import { Idle } from './toolStates/Idle'
+import { Pointing } from './toolStates/Pointing'
+
+/** @public */
+export class NoteShapeTool extends StateNode {
+	static override id = 'note'
+	static override initial = 'idle'
+	static override children = () => [Idle, Pointing]
+	override shapeType = 'note'
+}

--- a/packages/tldraw/src/lib/shapes/sticky/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/sticky/NoteShapeUtil.tsx
@@ -1,0 +1,300 @@
+import {
+	ANIMATION_MEDIUM_MS,
+	BaseBoxShapeUtil,
+	DefaultColorStyle,
+	DefaultFontFamilies,
+	DefaultFontStyle,
+	DefaultHorizontalAlignStyle,
+	DefaultSizeStyle,
+	DefaultVerticalAlignStyle,
+	Editor,
+	Rectangle2d,
+	SvgExportContext,
+	T,
+	TLNoteShape,
+	TLOnEditEndHandler,
+	TLShapeId,
+	Vec,
+	getDefaultColorTheme,
+	noteShapeMigrations,
+	toDomPrecision,
+} from '@tldraw/editor'
+import { HyperlinkButton } from '../shared/HyperlinkButton'
+import { useDefaultColorTheme } from '../shared/ShapeFill'
+import { TextLabel } from '../shared/TextLabel'
+import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
+import { getFontDefForExport } from '../shared/defaultStyleDefs'
+import { getTextLabelSvgElement } from '../shared/getTextLabelSvgElement'
+import { createSticky } from './toolStates/Pointing'
+
+export const INITIAL_NOTE_SIZE = 200
+
+/** @public */
+// @ts-ignore TODO hush, this is fine for now
+export class NoteShapeUtil extends BaseBoxShapeUtil<TLNoteShape> {
+	static override type = 'note' as const
+
+	// TODO: overriding here for now so that size/align/verticalAlign can be optional
+	static override props = {
+		w: T.optional(T.nonZeroNumber),
+		h: T.optional(T.nonZeroNumber),
+		color: DefaultColorStyle,
+		size: T.optional(DefaultSizeStyle),
+		font: DefaultFontStyle,
+		align: T.optional(DefaultHorizontalAlignStyle),
+		verticalAlign: T.optional(DefaultVerticalAlignStyle),
+		growY: T.positiveNumber,
+		url: T.linkUrl,
+		text: T.string,
+	}
+	static override migrations = noteShapeMigrations
+
+	override canEdit = () => true
+	override doesAutoEditOnKeyStroke = () => true
+	override hideResizeHandles = () => true
+
+	getDefaultProps(): TLNoteShape['props'] {
+		// @ts-ignore TODO hush, this is fine for now
+		return {
+			w: INITIAL_NOTE_SIZE,
+			h: INITIAL_NOTE_SIZE,
+			color: 'black',
+			size: 's',
+			text: '',
+			font: 'draw',
+			align: 'start',
+			verticalAlign: 'start',
+			growY: 0,
+			url: '',
+		}
+	}
+
+	getSize(shape: TLNoteShape) {
+		// TODO: This fallback is only for old notes as I experiment for now.
+		return Math.max(
+			INITIAL_NOTE_SIZE,
+			((shape.props.w as number) || INITIAL_NOTE_SIZE) + shape.props.growY
+		)
+	}
+
+	override getGeometry(shape: TLNoteShape) {
+		const w = Math.max(1, this.getSize(shape) as number)
+		return new Rectangle2d({ width: w, height: w, isFilled: true })
+	}
+
+	component(shape: TLNoteShape) {
+		const {
+			id,
+			type,
+			props: { color, font, text },
+		} = shape
+
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const theme = useDefaultColorTheme()
+		const adjustedColor = color === 'black' ? 'yellow' : color
+
+		return (
+			<>
+				<div
+					style={{
+						position: 'absolute',
+						width: this.getSize(shape),
+						height: this.getSize(shape),
+					}}
+				>
+					<div
+						className="tl-sticky__container"
+						style={{
+							color: theme[adjustedColor].solid,
+							backgroundColor: theme[adjustedColor].solid,
+						}}
+					>
+						<div className="tl-note__scrim" />
+						<TextLabel
+							id={id}
+							type={type}
+							font={font}
+							size="s"
+							align="start"
+							verticalAlign="start"
+							text={text}
+							labelColor="black"
+							wrap
+							onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => this.handleKeyDown(e, id)}
+						/>
+					</div>
+				</div>
+				{'url' in shape.props && shape.props.url && (
+					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
+				)}
+			</>
+		)
+	}
+
+	private handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>, id: TLShapeId) => {
+		const shape = this.editor.getShape<TLNoteShape>(id)!
+		const isCmdOrCtrlEnter = (e.metaKey || e.ctrlKey) && e.key === 'Enter'
+		if (isCmdOrCtrlEnter || e.key === 'Tab') {
+			this.editor.complete()
+
+			// Create a new sticky
+			const size = this.getSize(shape)
+			const offset = new Vec(shape.x + size * 1.5 + 10, shape.y + size / 2)
+			const newSticky = createSticky(this.editor, undefined, offset)
+
+			// Go into edit mode on the new sticky
+			this.editor.setEditingShape(newSticky.id)
+			this.editor.setCurrentTool('select.editing_shape', {
+				target: 'shape',
+				shape: newSticky,
+			})
+
+			// Animate to the new sticky, if necessary.
+			const selectionPageBounds = this.editor.getSelectionPageBounds()
+			const viewportPageBounds = this.editor.getViewportPageBounds()
+			if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {
+				this.editor.centerOnPoint(selectionPageBounds.center, {
+					duration: ANIMATION_MEDIUM_MS,
+				})
+			}
+		}
+	}
+
+	indicator(shape: TLNoteShape) {
+		return (
+			<rect
+				width={toDomPrecision(this.getSize(shape) as number)}
+				height={toDomPrecision(this.getSize(shape) as number)}
+			/>
+		)
+	}
+
+	override toSvg(shape: TLNoteShape, ctx: SvgExportContext) {
+		ctx.addExportDef(getFontDefForExport(shape.props.font))
+		const theme = getDefaultColorTheme({ isDarkMode: ctx.isDarkMode })
+		const bounds = this.editor.getShapeGeometry(shape).bounds
+
+		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+
+		const adjustedColor = shape.props.color === 'black' ? 'yellow' : shape.props.color
+
+		const rect1 = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+		rect1.setAttribute('width', this.getSize(shape).toString())
+		rect1.setAttribute('height', this.getSize(shape).toString())
+		rect1.setAttribute('fill', theme[adjustedColor].solid)
+		rect1.setAttribute('stroke', theme[adjustedColor].solid)
+		rect1.setAttribute('stroke-width', '1')
+		g.appendChild(rect1)
+
+		const rect2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+		rect2.setAttribute('width', this.getSize(shape).toString())
+		rect2.setAttribute('height', this.getSize(shape).toString())
+		rect2.setAttribute('fill', theme.background)
+		rect2.setAttribute('opacity', '.28')
+		g.appendChild(rect2)
+
+		const textElm = getTextLabelSvgElement({
+			editor: this.editor,
+			shape,
+			font: DefaultFontFamilies[shape.props.font],
+			bounds,
+		})
+
+		textElm.setAttribute('fill', theme.text)
+		textElm.setAttribute('stroke', 'none')
+		g.appendChild(textElm)
+
+		return g
+	}
+
+	override onBeforeCreate = (next: TLNoteShape) => {
+		return getGrowY(this.editor, next, next.props.growY)
+	}
+
+	override onBeforeUpdate = (prev: TLNoteShape, next: TLNoteShape) => {
+		if (
+			prev.props.text === next.props.text &&
+			prev.props.font === next.props.font &&
+			prev.props.size === next.props.size
+		) {
+			return
+		}
+
+		return getGrowY(this.editor, next, prev.props.growY)
+	}
+
+	override onEditEnd: TLOnEditEndHandler<TLNoteShape> = (shape) => {
+		const {
+			id,
+			type,
+			props: { text },
+		} = shape
+
+		if (text.trimEnd() !== shape.props.text) {
+			this.editor.updateShapes([
+				{
+					id,
+					type,
+					props: {
+						text: text.trimEnd(),
+					},
+				},
+			])
+		}
+	}
+}
+
+function getGrowY(editor: Editor, shape: TLNoteShape, prevGrowY = 0) {
+	const PADDING = 16
+
+	let nextTextSize
+	let iterations = 0
+
+	// Auto-fit text to the right aspect-ratio.
+	do {
+		const textLen = shape.props.text.length
+		// The formula is a power law of the text as it grows longer.
+		// It then goes backwards a bit to make sure we don't get too big.
+		const lineHeightPx = LABEL_FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight
+		const closeEnoughSizeBasedOnTextLength = 16 * Math.pow(textLen, 0.5) - lineHeightPx
+		const remainder = closeEnoughSizeBasedOnTextLength % lineHeightPx
+		nextTextSize = editor.textMeasure.measureText(shape.props.text, {
+			...TEXT_PROPS,
+			fontFamily: FONT_FAMILIES[shape.props.font],
+			fontSize: LABEL_FONT_SIZES[shape.props.size],
+			minWidth: INITIAL_NOTE_SIZE.toString(),
+			// We go in smaller chunks of 1/4 of the line height to make sure we don't miss the right size.
+			maxWidth: Math.max(
+				INITIAL_NOTE_SIZE - PADDING * 2,
+				Math.floor(closeEnoughSizeBasedOnTextLength - remainder + (iterations * lineHeightPx) / 4)
+			),
+			aspectRatio: '1',
+		})
+
+		if (nextTextSize.h === nextTextSize.w) {
+			break
+		}
+	} while (iterations++ < 50)
+
+	const nextSize = nextTextSize.h + PADDING * 2
+
+	let growY: number | null = null
+
+	if (nextSize > INITIAL_NOTE_SIZE) {
+		growY = nextSize - INITIAL_NOTE_SIZE
+	} else {
+		if (prevGrowY) {
+			growY = 0
+		}
+	}
+
+	if (growY !== null) {
+		return {
+			...shape,
+			props: {
+				...shape.props,
+				growY,
+			},
+		}
+	}
+}

--- a/packages/tldraw/src/lib/shapes/sticky/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/sticky/toolStates/Idle.ts
@@ -1,0 +1,17 @@
+import { StateNode, TLEventHandlers } from '@tldraw/editor'
+
+export class Idle extends StateNode {
+	static override id = 'idle'
+
+	override onPointerDown: TLEventHandlers['onPointerDown'] = (info) => {
+		this.parent.transition('pointing', info)
+	}
+
+	override onEnter = () => {
+		this.editor.setCursor({ type: 'copy', rotation: 0 })
+	}
+
+	override onCancel = () => {
+		this.editor.setCurrentTool('select')
+	}
+}

--- a/packages/tldraw/src/lib/shapes/sticky/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/sticky/toolStates/Pointing.ts
@@ -1,0 +1,143 @@
+import {
+	Editor,
+	StateNode,
+	TLEventHandlers,
+	TLInterruptEvent,
+	TLNoteShape,
+	TLPointerEventInfo,
+	TLShapeId,
+	Vec,
+	createShapeId,
+} from '@tldraw/editor'
+import { INITIAL_NOTE_SIZE } from '../NoteShapeUtil'
+
+export class Pointing extends StateNode {
+	static override id = 'pointing'
+
+	dragged = false
+
+	info = {} as TLPointerEventInfo
+
+	wasFocusedOnEnter = false
+
+	markId = ''
+
+	shape = {} as TLNoteShape
+	shapes = [] as TLNoteShape[]
+	startingPoint = {} as Vec
+
+	override onEnter = () => {
+		this.wasFocusedOnEnter = !this.editor.getIsMenuOpen()
+
+		if (this.wasFocusedOnEnter) {
+			const id = createShapeId()
+			this.markId = `creating:${id}`
+			this.editor.mark(this.markId)
+			this.shape = createSticky(this.editor, id)
+			this.shapes = [this.shape]
+		}
+
+		this.startingPoint = this.editor.inputs.currentPagePoint.clone()
+	}
+
+	override onPointerMove: TLEventHandlers['onPointerMove'] = () => {
+		if (this.editor.inputs.isDragging) {
+			const distance =
+				Math.abs(this.startingPoint.dist(this.editor.inputs.currentPagePoint)) +
+				INITIAL_NOTE_SIZE * 1.1
+			const numberOfNotesToCreate = Math.max(1, Math.floor(distance / (INITIAL_NOTE_SIZE / 0.9)))
+			const prevNumberOfNotesToCreate = this.shapes.length
+			if (numberOfNotesToCreate > prevNumberOfNotesToCreate) {
+				const newShapes = new Array(numberOfNotesToCreate - prevNumberOfNotesToCreate).fill(
+					createSticky(this.editor, undefined /* id */, this.editor.inputs.currentPagePoint)
+				)
+				this.shapes = this.shapes.concat(newShapes)
+				this.shape = this.shapes[this.shapes.length - 1]
+			} else if (numberOfNotesToCreate < prevNumberOfNotesToCreate) {
+				const shapesToDelete = this.shapes.slice(numberOfNotesToCreate)
+				this.editor.deleteShapes(shapesToDelete.map((s) => s.id))
+				this.shapes = this.shapes.slice(0, numberOfNotesToCreate)
+				this.shape = this.shapes[this.shapes.length - 1]
+			}
+		}
+	}
+
+	override onPointerUp: TLEventHandlers['onPointerUp'] = () => {
+		this.complete()
+	}
+
+	override onInterrupt: TLInterruptEvent = () => {
+		this.cancel()
+	}
+
+	override onComplete: TLEventHandlers['onComplete'] = () => {
+		this.complete()
+	}
+
+	override onCancel: TLEventHandlers['onCancel'] = () => {
+		this.cancel()
+	}
+
+	private complete() {
+		if (this.wasFocusedOnEnter) {
+			if (this.editor.getInstanceState().isToolLocked) {
+				this.parent.transition('idle')
+			} else {
+				this.editor.setEditingShape(this.shape.id)
+				this.editor.setCurrentTool('select.editing_shape', {
+					...this.info,
+					target: 'shape',
+					shape: this.shape,
+				})
+			}
+		}
+
+		this.shapes = []
+	}
+
+	private cancel() {
+		this.shapes = []
+		this.editor.bailToMark(this.markId)
+		this.parent.transition('idle', this.info)
+	}
+}
+
+function getRandomArbitrary(min: number, max: number) {
+	return Math.random() * (max - min) + min
+}
+
+export function createSticky(editor: Editor, id?: TLShapeId, creationPoint?: Vec) {
+	const {
+		inputs: { originPagePoint },
+	} = editor
+
+	creationPoint = creationPoint || originPagePoint
+	id = id || createShapeId()
+
+	editor
+		.createShapes([
+			{
+				id,
+				type: 'note',
+				x: creationPoint.x,
+				y: creationPoint.y,
+			},
+		])
+		.select(id)
+
+	const shape = editor.getShape<TLNoteShape>(id)!
+	const bounds = editor.getShapeGeometry(shape).bounds
+
+	// Center the text around the created point
+	editor.updateShapes([
+		{
+			id,
+			type: 'note',
+			x: shape.x - bounds.width / 2,
+			y: shape.y - bounds.height / 2,
+			rotation: getRandomArbitrary(-0.066, 0.066),
+		},
+	])
+
+	return editor.getShape<TLNoteShape>(id)!
+}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -13,6 +13,7 @@ import {
 	Vec,
 	VecLike,
 	createShapeId,
+	featureFlags,
 	pointInPolygon,
 } from '@tldraw/editor'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
@@ -418,7 +419,30 @@ export class Idle extends StateNode {
 			case 'ArrowUp':
 			case 'ArrowDown': {
 				this.nudgeSelectedShapes(false)
-				break
+				return
+			}
+		}
+
+		// For shapes that specify `doesAutoEditOnKeyStroke`, we start editing when a key is pressed.
+		if (
+			featureFlags.newStickies.get() &&
+			!['Delete', 'Backspace'].includes(info.code) &&
+			!info.altKey &&
+			!info.ctrlKey
+		) {
+			// If the only selected shape is editable, then begin editing it
+			const onlySelectedShape = this.editor.getOnlySelectedShape()
+			if (
+				onlySelectedShape &&
+				this.shouldStartEditingShape(onlySelectedShape) &&
+				this.editor.getShapeUtil(onlySelectedShape).doesAutoEditOnKeyStroke(onlySelectedShape)
+			) {
+				this.startEditingShape(onlySelectedShape, {
+					...info,
+					target: 'shape',
+					shape: onlySelectedShape,
+				})
+				return
 			}
 		}
 	}

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -1,4 +1,4 @@
-import { Editor, GeoShapeGeoStyle, useEditor } from '@tldraw/editor'
+import { Editor, GeoShapeGeoStyle, featureFlags, useEditor } from '@tldraw/editor'
 import * as React from 'react'
 import { EmbedDialog } from '../components/EmbedDialog'
 import { useDialogs } from '../context/dialogs'
@@ -169,7 +169,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 			{
 				id: 'note',
 				label: 'tool.note',
-				icon: 'tool-note',
+				icon: featureFlags.newStickies.get() ? 'tool-note-new' : 'tool-note',
 				kbd: 'n',
 				onSelect(source) {
 					editor.setCurrentTool('note')

--- a/packages/tldraw/src/lib/ui/icon-types.ts
+++ b/packages/tldraw/src/lib/ui/icon-types.ts
@@ -148,6 +148,7 @@ export type TLUiIconType =
 	| 'tool-laser'
 	| 'tool-line'
 	| 'tool-media'
+	| 'tool-note-new'
 	| 'tool-note'
 	| 'tool-pencil'
 	| 'tool-pointer'
@@ -315,6 +316,7 @@ export const iconTypes = [
 	'tool-laser',
 	'tool-line',
 	'tool-media',
+	'tool-note-new',
 	'tool-note',
 	'tool-pencil',
 	'tool-pointer',

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -696,6 +696,8 @@ export const noteShapeMigrations: Migrations;
 
 // @public (undocumented)
 export const noteShapeProps: {
+    w: T.Validator<number | undefined>;
+    h: T.Validator<number | undefined>;
     color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2856,7 +2856,25 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    color: import(\"..\")."
+              "text": "{\n    w: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<number | undefined>;\n    h: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<number | undefined>;\n    color: import(\"..\")."
             },
             {
               "kind": "Reference",
@@ -2937,7 +2955,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 22
           }
         },
         {

--- a/packages/tlschema/src/misc/TLCursor.ts
+++ b/packages/tlschema/src/misc/TLCursor.ts
@@ -9,6 +9,7 @@ export const TL_CURSOR_TYPES = new Set([
 	'none',
 	'default',
 	'pointer',
+	'copy',
 	'cross',
 	'grab',
 	'rotate',

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -12,6 +12,8 @@ import { ShapePropsType, TLBaseShape } from './TLBaseShape'
 
 /** @public */
 export const noteShapeProps = {
+	w: T.optional(T.nonZeroNumber),
+	h: T.optional(T.nonZeroNumber),
 	color: DefaultColorStyle,
 	size: DefaultSizeStyle,
 	font: DefaultFontStyle,


### PR DESCRIPTION
https://github.com/tldraw/tldraw/assets/469604/498430d8-5be4-4ee9-a4d4-7c97411828fc

This is behind a feature flag and I'll land this as is and we can iterate on it / live with it for a while / develop it further!
- [x] tool: update iconography which didn't suggest a sticky note
- [x] mouse: new sticky 'create' mouse cursor
- [x] size: slightly bigger default notes
- [x] indicator: hide ShapeIndicator when editing text. it's distracting
- [x] styling: clean rectangle, no border radius, add box-shadow to suggest bent paper
- [x] sizing: maintain square aspect ratio feels better than the rectangular one
- [x] text: start position at top-left
- [x] style panel: lock down size, alignment and see if being locked in bothers us
- [x] rotation: place sticky slightly rotated randomly
- [x] multiple notes on creation; can scrub back-and-forth to change amount easily
- [x] text: should input on keystroke, not wait for double-click
- [x] keyboard shortcuts - tab & cmd-enter create new sticky next to them
- [x] text: don’t auto-resize font-size, but auto-resize note with aspect ratio, min-size
- [x] svg check
- [-] nixed for now: handle/control to create duplicate - this feels not right at the moment. since this is mimicking real life shapes i don't go to a real life post-it note to create a duplicate. i go to my pad of post-it notes, i.e. the tool. the ability to create multiple using the tool using scrubbing i think solves for this case more elegantly and intuitively.
    none of our other shapes have auto-duplicate handles and it feels like this shouldn't either. 
- [-] nixed for now: handle/control for resizing, for now. i'm not sure if we need it yet.

For future PRs:
- [ ] sizing: maybe snapped sizes only?
- [ ] sizing: sticky tabs?
- [ ] collab: be able to do reacji
- [ ] collab: add attribution via auto-color multiplayer?
- [ ] collab: add attribution via name

### Change Type

- [x] `minor` — New feature

### Test Plan

1. This is under a feature flag and will be dogfooded for a while.

- [x] Dogfood!

### Release Notes

- Refreshes the sticky look, feel, and mechanics.
