### PR TITLE
[examples] Log out the 'after' values of changes in StoreEventsExample

### DIFF
--- a/apps/examples/src/examples/store-events/StoreEventsExample.tsx
+++ b/apps/examples/src/examples/store-events/StoreEventsExample.tsx
@@ -42,14 +42,16 @@ export default function StoreEventsExample() {
 					let diff = _.reduce(
 						from,
 						(result: any[], value, key: string) =>
-							_.isEqual(value, (to as any)[key]) ? result : result.concat([key, value]),
+							_.isEqual(value, (to as any)[key]) ? result : result.concat([key, (to as any)[key]]),
 						[]
 					)
 					if (diff?.[0] === 'props') {
 						diff = _.reduce(
 							(from as any).props,
 							(result: any[], value, key) =>
-								_.isEqual(value, (to as any).props[key]) ? result : result.concat([key, value]),
+								_.isEqual(value, (to as any).props[key])
+									? result
+									: result.concat([key, (to as any).props[key]]),
 							[]
 						)
 					}


### PR DESCRIPTION
The log statements in this were confusing me when I was inspecting style changes the other day because when you changed some value from A (before) to B (after) it only logged out the A value. I tried experimenting with logging both A and B but it didn't feel necessary, switching to only B feels fine.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]

