### PR TITLE
handles prototype 1: no gods no handles

### DIFF
--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleHandle.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleHandle.tsx
@@ -1,0 +1,103 @@
+import { HandleControl, StateNode, Vec, track, useEditor } from '@tldraw/tldraw'
+import { useEffect } from 'react'
+import { SpeechBubbleShape } from './SpeechBubbleUtil'
+
+export const SpeechBubbleHandle = track(function SpeechBubbleHandle() {
+	const editor = useEditor()
+
+	useEffect(() => {
+		editor.root.find('select')!.addChild(DraggingSpeechBubble)
+	}, [editor])
+
+	if (!editor.isInAny('select.idle')) {
+		return null
+	}
+
+	const shape = editor.getOnlySelectedShape()
+	if (!shape || !editor.isShapeOfType<SpeechBubbleShape>(shape, 'speech-bubble')) {
+		return null
+	}
+
+	const transform = editor.getShapePageTransform(shape)
+	const localPosition = new Vec(
+		shape.props.tail.x * shape.props.w,
+		shape.props.tail.y * shape.props.h
+	)
+
+	return (
+		<HandleControl
+			position={transform.applyToPoint(localPosition)}
+			onPointerDown={(e) => {
+				e.preventDefault()
+				e.stopPropagation()
+
+				editor.root.transition('select.draggingSpeechBubble')
+			}}
+		/>
+	)
+})
+
+// missing from here:
+// - tool masks (what even is this?)
+// - snapping/modifiers
+// - triggering updates on key presses?
+//
+// drawbacks:
+// - need to manually handle cancellation, undo-redo, etc
+// - kinda funky with typescript to have properties on the state node
+// - how to pass data into this?
+// - feels pretty unfamiliar to devs - why do i have to do something special to add this to the state tree?
+class DraggingSpeechBubble extends StateNode {
+	override id = 'draggingSpeechBubble'
+
+	initialShape!: SpeechBubbleShape
+	initialPageTailPoint!: Vec
+	initialPageCursorPoint!: Vec
+	markId!: string
+
+	// you can pass stuff to this i think? but it doesn't get typed. kinda tricky imo.
+	override onEnter = () => {
+		const shape = this.editor.getOnlySelectedShape()
+		if (!shape || !this.editor.isShapeOfType<SpeechBubbleShape>(shape, 'speech-bubble')) {
+			throw new Error('wrong shape')
+		}
+
+		this.editor.mark('draggingSpeechBubbleTail')
+		this.initialShape = shape
+		const transform = this.editor.getShapePageTransform(shape)
+		this.initialPageCursorPoint = this.editor.inputs.currentPagePoint.clone()
+		this.initialPageTailPoint = transform.applyToPoint({
+			x: shape.props.tail.x * shape.props.w,
+			y: shape.props.tail.y * shape.props.h,
+		})
+	}
+
+	override onPointerMove = () => {
+		const currentShape = this.editor.getShape<SpeechBubbleShape>(this.initialShape.id)
+		if (!currentShape) return
+
+		const delta = Vec.Sub(this.editor.inputs.currentPagePoint, this.initialPageCursorPoint)
+		const pageTailPoint = Vec.Add(this.initialPageTailPoint, delta)
+		const shapeTailPoint = this.editor.getPointInShapeSpace(this.initialShape.id, pageTailPoint)
+
+		this.editor.updateShape<SpeechBubbleShape>({
+			id: this.initialShape.id,
+			type: 'speech-bubble',
+			props: {
+				tail: {
+					x: shapeTailPoint.x / currentShape.props.w,
+					y: shapeTailPoint.y / currentShape.props.h,
+				},
+			},
+		})
+	}
+
+	override onPointerUp = () => {
+		this.editor.root.transition('select.idle')
+	}
+
+	override onCancel = () => {
+		this.editor.root.transition('select.idle')
+		this.editor.bailToMark('draggingSpeechBubbleTail')
+	}
+}

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -9,7 +9,6 @@ import {
 	TLDefaultColorStyle,
 	TLDefaultSizeStyle,
 	TLOnBeforeUpdateHandler,
-	TLOnHandleDragHandler,
 	TLOnResizeHandler,
 	Vec,
 	VecModel,
@@ -83,24 +82,6 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 		return body
 	}
 
-	// override getHandles(shape: SpeechBubbleShape) {
-	// 	const {
-	// 		handles: { handle },
-	// 		w,
-	// 		h,
-	// 	} = shape.props
-
-	// 	return [
-	// 		{
-	// 			...handle,
-	// 			// props.handles.handle coordinates are normalized
-	// 			// but here we need them in shape space
-	// 			x: handle.x * w,
-	// 			y: handle.y * h,
-	// 		},
-	// 	]
-	// }
-
 	// [4]
 	override onBeforeUpdate: TLOnBeforeUpdateHandler<SpeechBubbleShape> | undefined = (
 		_: SpeechBubbleShape,
@@ -135,13 +116,6 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 		const next = deepCopy(shape)
 		next.props.tail.x = newPoint.x / w
 		next.props.tail.y = newPoint.y / h
-
-		return next
-	}
-
-	override onHandleDrag: TLOnHandleDragHandler<SpeechBubbleShape> = (_, { handle, initial }) => {
-		const next = deepCopy(initial!)
-		next.props.tail = { x: handle.x / initial!.props.w, y: handle.y / initial!.props.h }
 
 		return next
 	}

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/helpers.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/helpers.tsx
@@ -2,9 +2,9 @@ import { Vec, VecLike, lerp, pointInPolygon } from '@tldraw/tldraw'
 import { SpeechBubbleShape } from './SpeechBubbleUtil'
 
 export const getSpeechBubbleVertices = (shape: SpeechBubbleShape): Vec[] => {
-	const { w, h, handles } = shape.props
+	const { w, h, tail } = shape.props
 
-	const handleInShapeSpace = new Vec(handles.handle.x * w, handles.handle.y * h)
+	const handleInShapeSpace = new Vec(tail.x * w, tail.y * h)
 
 	const [tl, tr, br, bl] = [new Vec(0, 0), new Vec(w, 0), new Vec(w, h), new Vec(0, h)]
 
@@ -73,8 +73,8 @@ export const getSpeechBubbleVertices = (shape: SpeechBubbleShape): Vec[] => {
 }
 
 export function getHandleIntersectionPoint(shape: SpeechBubbleShape) {
-	const { w, h, handles } = shape.props
-	const handleInShapeSpace = new Vec(handles.handle.x * w, handles.handle.y * h)
+	const { w, h, tail } = shape.props
+	const handleInShapeSpace = new Vec(tail.x * w, tail.y * h)
 
 	const center = new Vec(w / 2, h / 2)
 	const corners = [new Vec(0, 0), new Vec(w, 0), new Vec(w, h), new Vec(0, h)]

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/ui-overrides.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/ui-overrides.tsx
@@ -8,6 +8,7 @@ import {
 	toolbarItem,
 	useTools,
 } from '@tldraw/tldraw'
+import { SpeechBubbleHandle } from './SpeechBubbleHandle'
 
 // There's a guide at the bottom of this file!
 
@@ -49,6 +50,7 @@ export const components: TLComponents = {
 			</DefaultKeyboardShortcutsDialog>
 		)
 	},
+	InFrontOfTheCanvas: () => <SpeechBubbleHandle />,
 }
 
 /* 

--- a/apps/examples/src/examples/things-on-the-canvas/OnTheCanvas.tsx
+++ b/apps/examples/src/examples/things-on-the-canvas/OnTheCanvas.tsx
@@ -1,11 +1,4 @@
-import {
-	stopEventPropagation,
-	Tldraw,
-	TLEditorComponents,
-	track,
-	useEditor,
-	Vec,
-} from '@tldraw/tldraw'
+import { stopEventPropagation, Tldraw, TLEditorComponents, track, useEditor } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 import { useState } from 'react'
 
@@ -67,10 +60,7 @@ const MyComponentInFront = track(() => {
 	const selectionRotatedPageBounds = editor.getSelectionRotatedPageBounds()
 	if (!selectionRotatedPageBounds) return null
 
-	const pageCoordinates = Vec.Sub(
-		editor.pageToScreen(selectionRotatedPageBounds.point),
-		editor.getViewportScreenBounds()
-	)
+	const pageCoordinates = editor.pageToViewport(selectionRotatedPageBounds.point)
 
 	return (
 		<div

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -19,8 +19,10 @@ import { HistoryEntry } from '@tldraw/store';
 import { IndexKey } from '@tldraw/utils';
 import { JsonObject } from '@tldraw/utils';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
+import { MemoExoticComponent } from 'react';
 import { Migrations } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
+import { PointerEvent as PointerEvent_2 } from 'react';
 import { PointerEventHandler } from 'react';
 import { react } from '@tldraw/state';
 import { default as React_2 } from 'react';
@@ -816,6 +818,8 @@ export class Editor extends EventEmitter<TLEventMap> {
         y: number;
         z: number;
     };
+    // (undocumented)
+    pageToViewport(point: VecLike): Vec;
     pan(offset: VecLike, animation?: TLAnimationOptions): this;
     panZoomIntoView(ids: TLShapeId[], animation?: TLAnimationOptions): this;
     popFocusedGroupId(): this;
@@ -1145,6 +1149,9 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 
 // @public (undocumented)
 export const HALF_PI: number;
+
+// @internal (undocumented)
+export const HandleControl: MemoExoticComponent<({ position, onPointerDown, }: HandleControlProps) => JSX_2.Element>;
 
 // @public
 export interface HandleSnapGeometry {
@@ -1723,6 +1730,8 @@ export class Stadium2d extends Ellipse2d {
 export abstract class StateNode implements Partial<TLEventHandlers> {
     constructor(editor: Editor, parent?: StateNode);
     // (undocumented)
+    addChild(NodeCtor: TLStateNodeConstructor): void;
+    // (undocumented)
     static children?: () => TLStateNodeConstructor[];
     // (undocumented)
     children?: Record<string, StateNode>;
@@ -1733,6 +1742,10 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     enter: (info: any, from: string) => void;
     // (undocumented)
     exit: (info: any, from: string) => void;
+    // (undocumented)
+    find(path: string | string[]): StateNode | undefined;
+    // (undocumented)
+    getActiveChild(): StateNode | undefined;
     getCurrent(): StateNode | undefined;
     // (undocumented)
     getCurrentToolIdMask(): string | undefined;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -15348,6 +15348,56 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#pageToViewport:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "pageToViewport(point: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecLike",
+                  "canonicalReference": "@tldraw/editor!VecLike:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Vec",
+                  "canonicalReference": "@tldraw/editor!Vec:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "point",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "pageToViewport"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#pan:member(1)",
               "docComment": "/**\n * Pan the camera.\n *\n * @param offset - The offset in the current page space.\n *\n * @param animation - The animation options.\n *\n * @example\n * ```ts\n * editor.pan({ x: 100, y: 100 })\n * editor.pan({ x: 100, y: 100 }, { duration: 1000 })\n * ```\n *\n */\n",
               "excerptTokens": [
@@ -32970,6 +33020,55 @@
               ]
             },
             {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!StateNode#addChild:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "addChild(NodeCtor: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLStateNodeConstructor",
+                  "canonicalReference": "@tldraw/editor!TLStateNodeConstructor:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "NodeCtor",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "addChild"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "@tldraw/editor!StateNode#children:member",
               "docComment": "",
@@ -33142,6 +33241,95 @@
               "isStatic": false,
               "isProtected": false,
               "isAbstract": false
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!StateNode#find:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "find(path: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "StateNode",
+                  "canonicalReference": "@tldraw/editor!StateNode:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "path",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "find"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!StateNode#getActiveChild:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getActiveChild(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "StateNode",
+                  "canonicalReference": "@tldraw/editor!StateNode:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getActiveChild"
             },
             {
               "kind": "Method",

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -40,6 +40,7 @@ export {
 	type TLErrorBoundaryProps,
 } from './lib/components/ErrorBoundary'
 export { HTMLContainer, type HTMLContainerProps } from './lib/components/HTMLContainer'
+export { HandleControl } from './lib/components/Interaction'
 export { SVGContainer, type SVGContainerProps } from './lib/components/SVGContainer'
 export { DefaultBackground } from './lib/components/default-components/DefaultBackground'
 export { DefaultBrush, type TLBrushProps } from './lib/components/default-components/DefaultBrush'

--- a/packages/editor/src/lib/components/Interaction.tsx
+++ b/packages/editor/src/lib/components/Interaction.tsx
@@ -11,6 +11,7 @@ interface HandleControlProps {
 	onPointerDown: (event: PointerEvent) => void
 }
 
+/** @internal */
 export const HandleControl = track(function HandleControl({
 	position,
 	onPointerDown,

--- a/packages/editor/src/lib/components/Interaction.tsx
+++ b/packages/editor/src/lib/components/Interaction.tsx
@@ -1,0 +1,43 @@
+import { track, useValue } from '@tldraw/state'
+import classNames from 'classnames'
+import { PointerEvent } from 'react'
+import { COARSE_HANDLE_RADIUS, HANDLE_RADIUS } from '../constants'
+import { useEditor } from '../hooks/useEditor'
+import { Vec } from '../primitives/Vec'
+import { SVGContainer } from './SVGContainer'
+
+interface HandleControlProps {
+	position: Vec
+	onPointerDown: (event: PointerEvent) => void
+}
+
+export const HandleControl = track(function HandleControl({
+	position,
+	onPointerDown,
+}: HandleControlProps) {
+	const editor = useEditor()
+	const isCoarse = useValue('coarse pointer', () => editor.getInstanceState().isCoarsePointer, [
+		editor,
+	])
+
+	const bgRadius = isCoarse ? COARSE_HANDLE_RADIUS : HANDLE_RADIUS
+	const fgRadius = 4
+
+	const viewportPosition = editor.pageToViewport(position)
+
+	return (
+		<SVGContainer
+			style={{ transform: `translate(${viewportPosition.x}px, ${viewportPosition.y}px)` }}
+		>
+			<g
+				className={classNames('tl-handle')}
+				onPointerDown={(e) => {
+					onPointerDown(e)
+				}}
+			>
+				<circle className="tl-handle__bg" r={bgRadius} />
+				<circle className="tl-handle__fg" r={fgRadius} />
+			</g>
+		</SVGContainer>
+	)
+})

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -144,7 +144,6 @@ function GridWrapper() {
 	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	const { Grid } = useEditorComponents()
 
-	console.log({ Grid, isGridMode })
 	if (!(Grid && isGridMode)) return null
 
 	return <Grid x={x} y={y} z={z} size={gridSize} />

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -144,6 +144,7 @@ function GridWrapper() {
 	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	const { Grid } = useEditorComponents()
 
+	console.log({ Grid, isGridMode })
 	if (!(Grid && isGridMode)) return null
 
 	return <Grid x={x} y={y} z={z} size={gridSize} />

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2857,6 +2857,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 	}
 
+	pageToViewport(point: VecLike) {
+		return Vec.Sub(this.pageToScreen(point), this.getViewportScreenBounds())
+	}
+
 	// Following
 
 	/**


### PR DESCRIPTION
(i've not actually removed the handles code in this pr - just take a look at the speech bubble example for what a new API might look like)

in this version, I've added a couple of very light-weight additions to the library:
- A couple of utilities for mutating the state chart (`.find`, `.addChild`)
- A `<HandleControl position onPointerDown />` component designed to be rendered with `InFrontOfTheCanvas`

Then, in the example i've implemented what is effectively a handle on top of that:
- the `<SpeechBubbleHandle />` component adds its node to the state chart on mount
- it renders the handle when a speech bubble (and only a speech bubble) is selected
- when someone interacts with the speech bubble, we block the event from reaching tldraw's normal state chart, and instead add our own transition into the new state node

This works pretty well! There are some big drawbacks though:
- blocking the event from reaching our state chart means we don't get things like pointer capture, updates to `inputs`, gesture recognition, etc
- requiring users to pass this in to `OnTopOfCanvas` is a pain, and wouldn't scale to doing this for every single shape
- the state tree is conditional on react - so we can't test easily
- imo our state tree is pretty cumbersome to work with - it's one of the oldest parts of this codebase, has a bunch of weird quirks where the abstraction doesn't quite fit the use case (e.g. gesture recognition and tool masks), and I think could do with the same treatment that selection & ui composition have received