### PR TITLE
Fix transparency toggle

### DIFF
--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -113,7 +113,7 @@ export function ToggleTransparentBgMenuItem() {
 	const editor = useEditor()
 	const isTransparentBg = useValue(
 		'isTransparentBg',
-		() => editor.getInstanceState().exportBackground,
+		() => !editor.getInstanceState().exportBackground,
 		[editor]
 	)
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-transparent']} checked={isTransparentBg} />


### PR DESCRIPTION
We recently changed the export checkbox `✅ Export Background` to `✅ Transparent` which are logically opposite, but we didn't flip the `checked` state of the checkbox so it was exporting the background when `Transparent` was checked!

Fixes #2941 

### Change Type

- [x] `patch` — Bug fix

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Fixes the Transparent toggle. The condition was accidentally flipped.