### PR TITLE
[experiment] Accoutrements

### DIFF
--- a/apps/examples/src/examples/speech-bubble/CustomShapeWithHandles.tsx
+++ b/apps/examples/src/examples/speech-bubble/CustomShapeWithHandles.tsx
@@ -1,23 +1,17 @@
 import { Tldraw } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
-import { SpeechBubbleTool } from './SpeechBubble/SpeechBubbleTool'
-import { SpeechBubbleUtil } from './SpeechBubble/SpeechBubbleUtil'
+import { SpeechBubbleAccoutrement } from './SpeechBubble/SpeechBubbleAccoutrement'
 import { components, customAssetUrls, uiOverrides } from './SpeechBubble/ui-overrides'
 import './customhandles.css'
 
 // There's a guide at the bottom of this file!
-
-// [1]
-const shapeUtils = [SpeechBubbleUtil]
-const tools = [SpeechBubbleTool]
 
 // [2]
 export default function CustomShapeWithHandles() {
 	return (
 		<div style={{ position: 'absolute', inset: 0 }}>
 			<Tldraw
-				shapeUtils={shapeUtils}
-				tools={tools}
+				accoutrements={[SpeechBubbleAccoutrement]}
 				overrides={uiOverrides}
 				assetUrls={customAssetUrls}
 				components={components}

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleAccoutrement.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleAccoutrement.tsx
@@ -1,0 +1,16 @@
+import { Accoutrement } from '@tldraw/tldraw'
+import { DraggingSpeechBubble, SpeechBubbleHandle } from './SpeechBubbleHandle'
+import { SpeechBubbleTool } from './SpeechBubbleTool'
+import { SpeechBubbleUtil } from './SpeechBubbleUtil'
+
+export const SpeechBubbleAccoutrement: Accoutrement = {
+	id: 'speechBubble',
+	onMount: (editor) => {
+		editor.root.find('select')?.addChild(DraggingSpeechBubble)
+	},
+	shapeUtils: [SpeechBubbleUtil],
+	tools: [SpeechBubbleTool],
+	components: {
+		InFrontOfTheCanvas: () => <SpeechBubbleHandle />,
+	},
+}

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleHandle.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleHandle.tsx
@@ -1,13 +1,8 @@
 import { HandleControl, StateNode, Vec, track, useEditor } from '@tldraw/tldraw'
-import { useEffect } from 'react'
 import { SpeechBubbleShape } from './SpeechBubbleUtil'
 
 export const SpeechBubbleHandle = track(function SpeechBubbleHandle() {
 	const editor = useEditor()
-
-	useEffect(() => {
-		editor.root.find('select')!.addChild(DraggingSpeechBubble)
-	}, [editor])
 
 	if (!editor.isInAny('select.idle')) {
 		return null
@@ -41,13 +36,15 @@ export const SpeechBubbleHandle = track(function SpeechBubbleHandle() {
 // - tool masks (what even is this?)
 // - snapping/modifiers
 // - triggering updates on key presses?
+// - pointer capture
 //
 // drawbacks:
 // - need to manually handle cancellation, undo-redo, etc
 // - kinda funky with typescript to have properties on the state node
 // - how to pass data into this?
 // - feels pretty unfamiliar to devs - why do i have to do something special to add this to the state tree?
-class DraggingSpeechBubble extends StateNode {
+// - gesture recognition (can't transition this into a pinch because it never reached our state chart)
+export class DraggingSpeechBubble extends StateNode {
 	override id = 'draggingSpeechBubble'
 
 	initialShape!: SpeechBubbleShape

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/ui-overrides.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/ui-overrides.tsx
@@ -8,7 +8,6 @@ import {
 	toolbarItem,
 	useTools,
 } from '@tldraw/tldraw'
-import { SpeechBubbleHandle } from './SpeechBubbleHandle'
 
 // There's a guide at the bottom of this file!
 
@@ -50,7 +49,6 @@ export const components: TLComponents = {
 			</DefaultKeyboardShortcutsDialog>
 		)
 	},
-	InFrontOfTheCanvas: () => <SpeechBubbleHandle />,
 }
 
 /* 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -76,6 +76,20 @@ import { useValue } from '@tldraw/state';
 import { VecModel } from '@tldraw/tlschema';
 import { whyAmIRunning } from '@tldraw/state';
 
+// @public (undocumented)
+export interface Accoutrement {
+    // (undocumented)
+    components?: Pick<TLEditorComponents, 'InFrontOfTheCanvas' | 'OnTheCanvas'>;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    onMount?: TLOnMountHandler;
+    // (undocumented)
+    shapeUtils?: readonly TLAnyShapeUtilConstructor[];
+    // (undocumented)
+    tools?: readonly TLStateNodeConstructor[];
+}
+
 // @public
 export function angleDistance(fromAngle: number, toAngle: number, direction: number): number;
 
@@ -2031,6 +2045,8 @@ export const TldrawEditor: React_2.NamedExoticComponent<TldrawEditorProps>;
 
 // @public
 export interface TldrawEditorBaseProps {
+    // (undocumented)
+    accoutrements?: Accoutrement[];
     autoFocus?: boolean;
     children?: any;
     className?: string;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -173,6 +173,192 @@
       "preserveMemberOrder": false,
       "members": [
         {
+          "kind": "Interface",
+          "canonicalReference": "@tldraw/editor!Accoutrement:interface",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface Accoutrement "
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/config/Accotrements.ts",
+          "releaseTag": "Public",
+          "name": "Accoutrement",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!Accoutrement#components:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "components?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Pick",
+                  "canonicalReference": "!Pick:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLEditorComponents",
+                  "canonicalReference": "@tldraw/editor!TLEditorComponents:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", 'InFrontOfTheCanvas' | 'OnTheCanvas'>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "components",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!Accoutrement#id:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "id: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "id",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!Accoutrement#onMount:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onMount?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLOnMountHandler",
+                  "canonicalReference": "@tldraw/editor!TLOnMountHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onMount",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!Accoutrement#shapeUtils:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "shapeUtils?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "readonly "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLAnyShapeUtilConstructor",
+                  "canonicalReference": "@tldraw/editor!TLAnyShapeUtilConstructor:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "shapeUtils",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!Accoutrement#tools:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "tools?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "readonly "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLStateNodeConstructor",
+                  "canonicalReference": "@tldraw/editor!TLStateNodeConstructor:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "tools",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
           "kind": "Function",
           "canonicalReference": "@tldraw/editor!angleDistance:function(1)",
           "docComment": "/**\n * Get the angle of a point on an arc.\n *\n * @param fromAngle - The angle from center to arc's start point (A) on the circle\n *\n * @param toAngle - The angle from center to arc's end point (B) on the circle\n *\n * @param direction - The direction of the arc (1 = counter-clockwise, -1 = clockwise)\n *\n * @returns The distance in radians between the two angles according to the direction\n *\n * @public\n */\n",
@@ -36333,6 +36519,38 @@
           "name": "TldrawEditorBaseProps",
           "preserveMemberOrder": false,
           "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!TldrawEditorBaseProps#accoutrements:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "accoutrements?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Accoutrement",
+                  "canonicalReference": "@tldraw/editor!Accoutrement:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "accoutrements",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
             {
               "kind": "PropertySignature",
               "canonicalReference": "@tldraw/editor!TldrawEditorBaseProps#autoFocus:member",

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -89,6 +89,7 @@ export {
 } from './lib/components/default-components/DefaultSnapIndictor'
 export { DefaultSpinner } from './lib/components/default-components/DefaultSpinner'
 export { DefaultSvgDefs } from './lib/components/default-components/DefaultSvgDefs'
+export { type Accoutrement } from './lib/config/Accotrements'
 export {
 	TAB_ID,
 	createSessionStateSnapshotSignal,

--- a/packages/editor/src/lib/config/Accotrements.ts
+++ b/packages/editor/src/lib/config/Accotrements.ts
@@ -1,0 +1,13 @@
+import { TLOnMountHandler } from '../TldrawEditor'
+import { TLStateNodeConstructor } from '../editor/tools/StateNode'
+import { TLEditorComponents } from '../hooks/useEditorComponents'
+import { TLAnyShapeUtilConstructor } from './defaultShapes'
+
+/** @public */
+export interface Accoutrement {
+	id: string
+	shapeUtils?: readonly TLAnyShapeUtilConstructor[]
+	tools?: readonly TLStateNodeConstructor[]
+	onMount?: TLOnMountHandler
+	components?: Pick<TLEditorComponents, 'OnTheCanvas' | 'InFrontOfTheCanvas'>
+}


### PR DESCRIPTION
In #2957, we implemented some of the functionality of the speech bubble shape as a separate react component that needs to be passed in as a top-level `OnTopOfCanvas` component. This works well, but it means that if you're using this shape (or e.g. our own shapes were built in this way) you'd need to bring in both the shape and the `OnTopOfCanvas` component. It makes it very hard to distribute something like a custom shape as its own npm package.

One solution here would be a way to bundle together related customisations that make up a coherent feature into a single package that could then be plugged-in to the editor. These plug-in-able things are called "accoutrements".

Accoutrements are a purely additive change - they work with our existing extension methods, but let you bundle things up into a single object if they don't make sense on their own. They're fully backwards-compatible with our existing extension methods. You could still pull out individual parts if you wanted e.g. the shape definition, but wanted to supply your own interactions on top of it. 

(the exact API of defining and using these is up for debate! i just did the most minimal thing i could for this diff to illustrate the concept)