### PR TITLE
tooling: notify team members if package.json/yarn has been updated

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -10,6 +10,6 @@ CHANGED=$(git diff "$1" "$2" --stat -- ./yarn.lock | wc -l)
 if (( CHANGED > 0 )); then
     echo
     echo "🚨 🚨 🚨 yarn.lock has changed! 🚨 🚨 🚨 "
-    echo "run 'yarn' in the client directory to get the latest!"
+    echo "run 'yarn' to get the latest!"
     echo
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -3,10 +3,8 @@
 
 set -e
 
-rm -rf *.tsbuildinfo */*.tsbuildinfo */*/*.tsbuildinfo */*/*/*.tsbuildinfo */*/*/*/*.tsbuildinfo
-
 # This notifies the user if the yarn.lock file has changed.
-CHANGED=$(git diff "$1" "$2" --stat -- ./yarn.lock | wc -l)
+CHANGED=$(git diff HEAD@{1} --stat -- ./yarn.lock | wc -l)
 if (( CHANGED > 0 )); then
     echo
     echo "🚨 🚨 🚨 yarn.lock has changed! 🚨 🚨 🚨 "

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -8,6 +8,6 @@ CHANGED=$(git diff HEAD@{1} --stat -- ./yarn.lock | wc -l)
 if (( CHANGED > 0 )); then
     echo
     echo "🚨 🚨 🚨 yarn.lock has changed! 🚨 🚨 🚨 "
-    echo "run 'yarn' in the client directory to get the latest!"
+    echo "run 'yarn' to get the latest!"
     echo
 fi


### PR DESCRIPTION
This is a team tooling thing to let each other know if `yarn` needs to be run upon checkout of a branch.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]