### PR TITLE
export default ui items

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -124,6 +124,17 @@ import { VecLike } from '@tldraw/editor';
 import { VecModel } from '@tldraw/editor';
 
 // @public (undocumented)
+export function AlignMenuItems(): JSX_2.Element;
+
+// @public (undocumented)
+export function ArrangeMenuSubmenu(): JSX_2.Element | null;
+
+// @public (undocumented)
+export function ArrowheadStylePickerSet({ styles }: {
+    styles: ReadonlySharedStyleMap;
+}): JSX_2.Element | null;
+
+// @public (undocumented)
 export class ArrowShapeTool extends StateNode {
     // (undocumented)
     static children: () => (typeof Idle | typeof Pointing)[];
@@ -269,11 +280,31 @@ export function BreakPointProvider({ forceMobile, children, }: {
 // @internal (undocumented)
 export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocument): void;
 
+// @public (undocumented)
+export function ClipboardMenuGroup(): JSX_2.Element;
+
+// @public (undocumented)
+export function CommonStylePickerSet({ styles }: {
+    styles: ReadonlySharedStyleMap;
+}): JSX_2.Element;
+
 // @public
 export function containBoxSize(originalSize: BoxWidthHeight, containBoxSize: BoxWidthHeight): BoxWidthHeight;
 
+// @public (undocumented)
+export function ConversionsMenuGroup(): JSX_2.Element;
+
 // @public
 export function copyAs(editor: Editor, ids: TLShapeId[], format?: TLCopyType, opts?: Partial<TLSvgOptions>): Promise<void>;
+
+// @public (undocumented)
+export function CopyMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function CutMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function DebugFlags(): JSX_2.Element | null;
 
 // @public (undocumented)
 export const DEFAULT_ACCEPTED_IMG_TYPE: string[];
@@ -361,6 +392,12 @@ export const DefaultZoomMenu: NamedExoticComponent<TLUiZoomMenuProps>;
 // @public (undocumented)
 export function DefaultZoomMenuContent(): JSX_2.Element;
 
+// @public (undocumented)
+export function DeleteMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function DistributeMenuItems(): JSX_2.Element;
+
 // @public
 export function downsizeImage(blob: Blob, width: number, height: number, opts?: {
     type?: string | undefined;
@@ -426,7 +463,16 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 }
 
 // @public (undocumented)
+export function DuplicateMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function EditLinkMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
 export function EditSubmenu(): JSX_2.Element;
+
+// @public (undocumented)
+export function EmbedsGroup(): JSX_2.Element;
 
 // @public (undocumented)
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
@@ -480,6 +526,17 @@ export type EventsProviderProps = {
     children: any;
 };
 
+// @public (undocumented)
+export function ExampleDialog({ title, body, cancel, confirm, displayDontShowAgain, onCancel, onContinue, }: {
+    title?: string;
+    body?: string;
+    cancel?: string;
+    confirm?: string;
+    displayDontShowAgain?: boolean;
+    onCancel: () => void;
+    onContinue: () => void;
+}): JSX_2.Element;
+
 // @public
 export function exportAs(editor: Editor, ids: TLShapeId[], format: TLExportType | undefined, name: string | undefined, opts?: Partial<TLSvgOptions>): Promise<void>;
 
@@ -489,10 +546,16 @@ export function ExportFileContentSubMenu(): JSX_2.Element;
 // @public (undocumented)
 export function ExtrasGroup(): JSX_2.Element;
 
+// @public (undocumented)
+export function FeatureFlags(): JSX_2.Element | null;
+
 // @public
 export function fitFrameToContent(editor: Editor, id: TLShapeId, opts?: {
     padding: number;
 }): void;
+
+// @public (undocumented)
+export function FitFrameToContentMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
 export class FrameShapeTool extends BaseBoxShapeTool {
@@ -699,6 +762,11 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     static type: "geo";
 }
 
+// @public (undocumented)
+export function GeoStylePickerSet({ styles }: {
+    styles: ReadonlySharedStyleMap;
+}): JSX_2.Element | null;
+
 // @public
 export function getEmbedInfo(inputUrl: string): TLEmbedResult;
 
@@ -711,6 +779,12 @@ export function getSvgAsImage(svg: SVGElement, isSafari: boolean, options: {
 
 // @public (undocumented)
 export function getSvgAsString(svg: SVGElement): Promise<string>;
+
+// @public (undocumented)
+export function GroupMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function GroupOrUngroupMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
 export class HandTool extends StateNode {
@@ -825,6 +899,12 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 export function isGifAnimated(file: Blob): Promise<boolean>;
 
 // @public (undocumented)
+export function KeyboardShortcutsMenuItem(): JSX_2.Element | null;
+
+// @public (undocumented)
+export const LanguageMenu: MemoExoticComponent<() => JSX_2.Element>;
+
+// @public (undocumented)
 export class LaserTool extends StateNode {
     // (undocumented)
     static children: () => (typeof Idle_9 | typeof Lasering)[];
@@ -910,6 +990,18 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     static type: "line";
 }
+
+// @public (undocumented)
+export function LockGroup(): JSX_2.Element;
+
+// @public (undocumented)
+export function MiscMenuGroup(): JSX_2.Element;
+
+// @public (undocumented)
+export function MoveToPageMenu(): JSX_2.Element | null;
+
+// @public (undocumented)
+export function MultiShapeMenuGroup(): JSX_2.Element;
 
 // @public (undocumented)
 export class NoteShapeTool extends StateNode {
@@ -1013,6 +1105,19 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 // @public (undocumented)
 export function OfflineIndicator(): JSX_2.Element;
 
+// @public (undocumented)
+export function OpacitySlider(): JSX_2.Element | null;
+
+// @public (undocumented)
+export const PageItemInput: ({ name, id, isCurrentPage, }: {
+    name: string;
+    id: TLPageId;
+    isCurrentPage: boolean;
+}) => JSX_2.Element;
+
+// @public (undocumented)
+export const PageItemSubmenu: MemoExoticComponent<({ index, listSize, item, onRename, }: PageItemSubmenuProps) => JSX_2.Element>;
+
 // @internal (undocumented)
 export function parseAndLoadDocument(editor: Editor, document: string, msg: (id: Exclude<string, TLUiTranslationKey> | TLUiTranslationKey) => string, addToast: TLUiToastsContextType['addToast'], onV1FileLoad?: () => void, forceDarkMode?: boolean): Promise<void>;
 
@@ -1023,13 +1128,31 @@ export function parseTldrawJsonFile({ json, schema, }: {
 }): Result<TLStore, TldrawFileParseError>;
 
 // @public (undocumented)
+export function PasteMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
 export function PreferencesGroup(): JSX_2.Element;
 
 // @public (undocumented)
 export function preloadFont(id: string, font: TLTypeFace): Promise<FontFace>;
 
+// @public (undocumented)
+export function PrintItem(): JSX_2.Element;
+
 // @public
 export function removeFrame(editor: Editor, ids: TLShapeId[]): void;
+
+// @public (undocumented)
+export function RemoveFrameMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ReorderMenuItems(): JSX_2.Element;
+
+// @public (undocumented)
+export function ReorderMenuSubmenu(): JSX_2.Element | null;
+
+// @public (undocumented)
+export function RotateCWMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
 export class SelectTool extends StateNode {
@@ -1060,10 +1183,21 @@ export function setDefaultEditorAssetUrls(assetUrls: TLEditorAssetUrls): void;
 export function setDefaultUiAssetUrls(urls: TLUiAssetUrls): void;
 
 // @public (undocumented)
+export function SetSelectionGroup(): JSX_2.Element;
+
+// @public (undocumented)
 export function ShapeSubmenu(): JSX_2.Element;
 
 // @internal (undocumented)
 export function Spinner(props: React_2.SVGProps<SVGSVGElement>): JSX_2.Element;
+
+// @public (undocumented)
+export function SplineStylePickerSet({ styles }: {
+    styles: ReadonlySharedStyleMap;
+}): JSX_2.Element | null;
+
+// @public (undocumented)
+export function StackMenuItems(): JSX_2.Element;
 
 // @public (undocumented)
 export class TextShapeTool extends StateNode {
@@ -1182,6 +1316,11 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     static type: "text";
 }
+
+// @public (undocumented)
+export function TextStylePickerSet({ styles }: {
+    styles: ReadonlySharedStyleMap;
+}): JSX_2.Element | null;
 
 // @public (undocumented)
 export type TLComponents = Expand<TLEditorComponents & TLUiComponents>;
@@ -2069,6 +2208,39 @@ export type TLUiZoomMenuProps = {
 };
 
 // @public (undocumented)
+export function ToggleAutoSizeMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleDarkModeItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleDebugModeItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleEdgeScrollingItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleFocusModeItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleGridItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleLockMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleReduceMotionItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleSnapModeItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleToolLockItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ToggleTransparentBgMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
 export function toolbarItem(toolItem: TLUiToolItem): TLUiToolbarItem;
 
 // @public (undocumented)
@@ -2076,6 +2248,15 @@ export const truncateStringWithEllipsis: (str: string, maxLength: number) => str
 
 // @public (undocumented)
 export function UiEventsProvider({ onEvent, children }: EventsProviderProps): JSX_2.Element;
+
+// @public (undocumented)
+export function UndoRedoGroup(): JSX_2.Element;
+
+// @public (undocumented)
+export function UngroupMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function UnlockAllMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
 export function unwrapLabel(label?: TLUiActionItem['label'], menuType?: string): string | undefined;
@@ -2215,6 +2396,15 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 export function ViewSubmenu(): JSX_2.Element;
 
 // @public (undocumented)
+export function ZoomOrRotateMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ZoomTo100MenuItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function ZoomToFitMenuItem(): JSX_2.Element;
+
+// @public (undocumented)
 export class ZoomTool extends StateNode {
     // (undocumented)
     static children: () => (typeof Idle_12 | typeof Pointing_8 | typeof ZoomBrushing)[];
@@ -2239,6 +2429,9 @@ export class ZoomTool extends StateNode {
     // (undocumented)
     onKeyUp: TLKeyboardEvent;
 }
+
+// @public (undocumented)
+export function ZoomToSelectionMenuItem(): JSX_2.Element;
 
 
 export * from "@tldraw/editor";

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -173,6 +173,139 @@
       "preserveMemberOrder": false,
       "members": [
         {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!AlignMenuItems:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function AlignMenuItems(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "AlignMenuItems"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ArrangeMenuSubmenu:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ArrangeMenuSubmenu(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ArrangeMenuSubmenu"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ArrowheadStylePickerSet:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ArrowheadStylePickerSet({ styles }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    styles: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReadonlySharedStyleMap",
+              "canonicalReference": "@tldraw/editor!ReadonlySharedStyleMap:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 8
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ styles }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "ArrowheadStylePickerSet"
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@tldraw/tldraw!ArrowShapeTool:class",
           "docComment": "/**\n * @public\n */\n",
@@ -2111,6 +2244,98 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ClipboardMenuGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ClipboardMenuGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ClipboardMenuGroup"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!CommonStylePickerSet:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function CommonStylePickerSet({ styles }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    styles: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReadonlySharedStyleMap",
+              "canonicalReference": "@tldraw/editor!ReadonlySharedStyleMap:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 7
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ styles }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "CommonStylePickerSet"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!containBoxSize:function(1)",
           "docComment": "/**\n * Contains the size within the given box size\n *\n * @param originalSize - The size of the asset\n *\n * @param containBoxSize - The container size\n *\n * @returns Adjusted size\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -2172,6 +2397,39 @@
             }
           ],
           "name": "containBoxSize"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ConversionsMenuGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ConversionsMenuGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ConversionsMenuGroup"
         },
         {
           "kind": "Function",
@@ -2291,6 +2549,109 @@
             }
           ],
           "name": "copyAs"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!CopyMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function CopyMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "CopyMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!CutMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function CutMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "CutMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!DebugFlags:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function DebugFlags(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "DebugFlags"
         },
         {
           "kind": "Variable",
@@ -3405,6 +3766,72 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!DeleteMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function DeleteMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "DeleteMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!DistributeMenuItems:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function DistributeMenuItems(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "DistributeMenuItems"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!downsizeImage:function(1)",
           "docComment": "/**\n * Resize an image Blob to be smaller than it is currently.\n *\n * @param image - The image Blob.\n *\n * @param width - The desired width.\n *\n * @param height - The desired height.\n *\n * @param opts - Options for the image.\n *\n * @example\n * ```ts\n * const image = await (await fetch('/image.jpg')).blob()\n * const size = await getImageSize(image)\n * const resizedImage = await downsizeImage(image, size.w / 2, size.h / 2, { type: \"image/jpeg\", quality: 0.92 })\n * ```\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -4450,6 +4877,72 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!DuplicateMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function DuplicateMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "DuplicateMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!EditLinkMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function EditLinkMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "EditLinkMenuItem"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!EditSubmenu:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -4480,6 +4973,39 @@
           "overloadIndex": 1,
           "parameters": [],
           "name": "EditSubmenu"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!EmbedsGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function EmbedsGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "EmbedsGroup"
         },
         {
           "kind": "Class",
@@ -5297,6 +5823,56 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ExampleDialog:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ExampleDialog({ title, body, cancel, confirm, displayDontShowAgain, onCancel, onContinue, }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    title?: string;\n    body?: string;\n    cancel?: string;\n    confirm?: string;\n    displayDontShowAgain?: boolean;\n    onCancel: () => void;\n    onContinue: () => void;\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 5
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ title, body, cancel, confirm, displayDontShowAgain, onCancel, onContinue, }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "ExampleDialog"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!exportAs:function(1)",
           "docComment": "/**\n * Export the given shapes as files.\n *\n * @param editor - The editor instance.\n *\n * @param ids - The ids of the shapes to export.\n *\n * @param format - The format to export as.\n *\n * @param name - Name of the exported file. If undefined a predefined name, based on the selection, will be used.\n *\n * @param opts - Options for the export.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -5502,6 +6078,43 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!FeatureFlags:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function FeatureFlags(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "FeatureFlags"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!fitFrameToContent:function(1)",
           "docComment": "/**\n * Fit a frame to its content.\n *\n * @param id - Id of the frame you wish to fit to content.\n *\n * @param editor - tlraw editor instance.\n *\n * @param opts - Options for fitting the frame.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -5578,6 +6191,39 @@
             }
           ],
           "name": "fitFrameToContent"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!FitFrameToContentMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function FitFrameToContentMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "FitFrameToContentMenuItem"
         },
         {
           "kind": "Class",
@@ -7721,6 +8367,69 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!GeoStylePickerSet:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function GeoStylePickerSet({ styles }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    styles: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReadonlySharedStyleMap",
+              "canonicalReference": "@tldraw/editor!ReadonlySharedStyleMap:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 8
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ styles }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "GeoStylePickerSet"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!getEmbedInfo:function(1)",
           "docComment": "/**\n * Tests whether an URL supports embedding and returns the result. If we encounter an error, we return undefined.\n *\n * @param inputUrl - The URL to match\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -7907,6 +8616,72 @@
             }
           ],
           "name": "getSvgAsString"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!GroupMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function GroupMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "GroupMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!GroupOrUngroupMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function GroupOrUngroupMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "GroupOrUngroupMenuItem"
         },
         {
           "kind": "Class",
@@ -9754,6 +10529,84 @@
           "name": "isGifAnimated"
         },
         {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!KeyboardShortcutsMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function KeyboardShortcutsMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "KeyboardShortcutsMenuItem"
+        },
+        {
+          "kind": "Variable",
+          "canonicalReference": "@tldraw/tldraw!LanguageMenu:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "LanguageMenu: "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "MemoExoticComponent",
+              "canonicalReference": "@types/react!React.MemoExoticComponent:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<() => import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/LanguageMenu.tsx",
+          "isReadonly": true,
+          "releaseTag": "Public",
+          "name": "LanguageMenu",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 6
+          }
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@tldraw/tldraw!LaserTool:class",
           "docComment": "/**\n * @public\n */\n",
@@ -10874,6 +11727,142 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!LockGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function LockGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "LockGroup"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!MiscMenuGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function MiscMenuGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "MiscMenuGroup"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!MoveToPageMenu:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function MoveToPageMenu(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "MoveToPageMenu"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!MultiShapeMenuGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function MultiShapeMenuGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "MultiShapeMenuGroup"
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@tldraw/tldraw!NoteShapeTool:class",
           "docComment": "/**\n * @public\n */\n",
@@ -11893,6 +12882,148 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!OpacitySlider:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function OpacitySlider(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "OpacitySlider"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!PageItemInput:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "PageItemInput: ({ name, id, isCurrentPage, }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    name: string;\n    id: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLPageId",
+              "canonicalReference": "@tldraw/tlschema!TLPageId:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    isCurrentPage: boolean;\n}"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 7
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ name, id, isCurrentPage, }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "PageItemInput"
+        },
+        {
+          "kind": "Variable",
+          "canonicalReference": "@tldraw/tldraw!PageItemSubmenu:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "PageItemSubmenu: "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "MemoExoticComponent",
+              "canonicalReference": "@types/react!React.MemoExoticComponent:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<({ index, listSize, item, onRename, }: "
+            },
+            {
+              "kind": "Reference",
+              "text": "PageItemSubmenuProps",
+              "canonicalReference": "@tldraw/tldraw!~PageItemSubmenuProps:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx",
+          "isReadonly": true,
+          "releaseTag": "Public",
+          "name": "PageItemSubmenu",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 8
+          }
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!parseTldrawJsonFile:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -11967,6 +13098,39 @@
             }
           ],
           "name": "parseTldrawJsonFile"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!PasteMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function PasteMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "PasteMenuItem"
         },
         {
           "kind": "Function",
@@ -12079,6 +13243,39 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!PrintItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function PrintItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "PrintItem"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!removeFrame:function(1)",
           "docComment": "/**\n * Remove a frame.\n *\n * @param editor - tlraw editor instance.\n *\n * @param ids - Ids of the frames you wish to remove.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -12143,6 +13340,142 @@
             }
           ],
           "name": "removeFrame"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!RemoveFrameMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function RemoveFrameMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "RemoveFrameMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ReorderMenuItems:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ReorderMenuItems(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ReorderMenuItems"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ReorderMenuSubmenu:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ReorderMenuSubmenu(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ReorderMenuSubmenu"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!RotateCWMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function RotateCWMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "RotateCWMenuItem"
         },
         {
           "kind": "Class",
@@ -12677,6 +14010,39 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!SetSelectionGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function SetSelectionGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "SetSelectionGroup"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!ShapeSubmenu:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -12707,6 +14073,102 @@
           "overloadIndex": 1,
           "parameters": [],
           "name": "ShapeSubmenu"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!SplineStylePickerSet:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function SplineStylePickerSet({ styles }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    styles: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReadonlySharedStyleMap",
+              "canonicalReference": "@tldraw/editor!ReadonlySharedStyleMap:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 8
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ styles }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "SplineStylePickerSet"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!StackMenuItems:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function StackMenuItems(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "StackMenuItems"
         },
         {
           "kind": "Class",
@@ -13781,6 +15243,69 @@
             "endIndex": 5
           },
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!TextStylePickerSet:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function TextStylePickerSet({ styles }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    styles: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReadonlySharedStyleMap",
+              "canonicalReference": "@tldraw/editor!ReadonlySharedStyleMap:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 8
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ styles }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "TextStylePickerSet"
         },
         {
           "kind": "TypeAlias",
@@ -23033,6 +24558,369 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleAutoSizeMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleAutoSizeMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleAutoSizeMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleDarkModeItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleDarkModeItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleDarkModeItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleDebugModeItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleDebugModeItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleDebugModeItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleEdgeScrollingItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleEdgeScrollingItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleEdgeScrollingItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleFocusModeItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleFocusModeItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleFocusModeItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleGridItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleGridItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleGridItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleLockMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleLockMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleLockMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleReduceMotionItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleReduceMotionItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleReduceMotionItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleSnapModeItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleSnapModeItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleSnapModeItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleToolLockItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleToolLockItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleToolLockItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ToggleTransparentBgMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ToggleTransparentBgMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ToggleTransparentBgMenuItem"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!toolbarItem:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -23185,6 +25073,105 @@
             }
           ],
           "name": "UiEventsProvider"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!UndoRedoGroup:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function UndoRedoGroup(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "UndoRedoGroup"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!UngroupMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function UngroupMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "UngroupMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!UnlockAllMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function UnlockAllMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "UnlockAllMenuItem"
         },
         {
           "kind": "Function",
@@ -24865,6 +26852,105 @@
           "name": "ViewSubmenu"
         },
         {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ZoomOrRotateMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ZoomOrRotateMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ZoomOrRotateMenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ZoomTo100MenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ZoomTo100MenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ZoomTo100MenuItem"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ZoomToFitMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ZoomToFitMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ZoomToFitMenuItem"
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@tldraw/tldraw!ZoomTool:class",
           "docComment": "/**\n * @public\n */\n",
@@ -25213,6 +27299,39 @@
             "endIndex": 2
           },
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!ZoomToSelectionMenuItem:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function ZoomToSelectionMenuItem(): "
+            },
+            {
+              "kind": "Content",
+              "text": "import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/menu-items.tsx",
+          "returnTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [],
+          "name": "ZoomToSelectionMenuItem"
         }
       ]
     }

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -147,13 +147,21 @@ export {
 } from './lib/ui/context/components'
 
 export { DefaultPageMenu } from './lib/ui/components/PageMenu/DefaultPageMenu'
+export { PageItemInput } from './lib/ui/components/PageMenu/PageItemInput'
+export { PageItemSubmenu } from './lib/ui/components/PageMenu/PageItemSubmenu'
 
 export {
 	DefaultStylePanel,
 	type TLUiStylePanelProps,
 } from './lib/ui/components/StylePanel/DefaultStylePanel'
 export {
+	ArrowheadStylePickerSet,
+	CommonStylePickerSet,
 	DefaultStylePanelContent,
+	GeoStylePickerSet,
+	OpacitySlider,
+	SplineStylePickerSet,
+	TextStylePickerSet,
 	type TLUiStylePanelContentProps,
 } from './lib/ui/components/StylePanel/DefaultStylePanelContent'
 
@@ -161,7 +169,16 @@ export {
 	DefaultActionsMenu,
 	type TLUiActionsMenuProps,
 } from './lib/ui/components/ActionsMenu/DefaultActionsMenu'
-export { DefaultActionsMenuContent } from './lib/ui/components/ActionsMenu/DefaultActionsMenuContent'
+export {
+	AlignMenuItems,
+	DefaultActionsMenuContent,
+	DistributeMenuItems,
+	GroupOrUngroupMenuItem,
+	ReorderMenuItems,
+	RotateCWMenuItem,
+	StackMenuItems,
+	ZoomOrRotateMenuItem,
+} from './lib/ui/components/ActionsMenu/DefaultActionsMenuContent'
 
 export {
 	DefaultContextMenu as ContextMenu,
@@ -174,7 +191,47 @@ export {
 	DefaultHelpMenu,
 	type TLUiHelpMenuProps,
 } from './lib/ui/components/HelpMenu/DefaultHelpMenu'
-export { DefaultHelpMenuContent } from './lib/ui/components/HelpMenu/DefaultHelpMenuContent'
+export {
+	DefaultHelpMenuContent,
+	KeyboardShortcutsMenuItem,
+} from './lib/ui/components/HelpMenu/DefaultHelpMenuContent'
+export { LanguageMenu } from './lib/ui/components/LanguageMenu'
+
+export {
+	ArrangeMenuSubmenu,
+	ClipboardMenuGroup,
+	ConversionsMenuGroup,
+	CopyMenuItem,
+	CutMenuItem,
+	DeleteMenuItem,
+	DuplicateMenuItem,
+	EditLinkMenuItem,
+	EmbedsGroup,
+	FitFrameToContentMenuItem,
+	GroupMenuItem,
+	MoveToPageMenu,
+	PasteMenuItem,
+	PrintItem,
+	RemoveFrameMenuItem,
+	ReorderMenuSubmenu,
+	SetSelectionGroup,
+	ToggleAutoSizeMenuItem,
+	ToggleDarkModeItem,
+	ToggleDebugModeItem,
+	ToggleEdgeScrollingItem,
+	ToggleFocusModeItem,
+	ToggleGridItem,
+	ToggleLockMenuItem,
+	ToggleReduceMotionItem,
+	ToggleSnapModeItem,
+	ToggleToolLockItem,
+	ToggleTransparentBgMenuItem,
+	UngroupMenuItem,
+	UnlockAllMenuItem,
+	ZoomTo100MenuItem,
+	ZoomToFitMenuItem,
+	ZoomToSelectionMenuItem,
+} from './lib/ui/components/menu-items'
 
 export {
 	DefaultMainMenu,
@@ -185,8 +242,12 @@ export {
 	EditSubmenu,
 	ExportFileContentSubMenu,
 	ExtrasGroup,
+	LockGroup,
+	MiscMenuGroup,
+	MultiShapeMenuGroup,
 	PreferencesGroup,
 	ShapeSubmenu,
+	UndoRedoGroup,
 	ViewSubmenu,
 } from './lib/ui/components/MainMenu/DefaultMainMenuContent'
 
@@ -218,7 +279,12 @@ export {
 	DefaultDebugMenu,
 	type TLUiDebugMenuProps,
 } from './lib/ui/components/DebugMenu/DefaultDebugMenu'
-export { DefaultDebugMenuContent } from './lib/ui/components/DebugMenu/DefaultDebugMenuContent'
+export {
+	DebugFlags,
+	DefaultDebugMenuContent,
+	ExampleDialog,
+	FeatureFlags,
+} from './lib/ui/components/DebugMenu/DefaultDebugMenuContent'
 
 export { DefaultToolbar } from './lib/ui/components/Toolbar/DefaultToolbar'
 

--- a/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenuContent.tsx
@@ -27,7 +27,8 @@ export function DefaultActionsMenuContent() {
 	)
 }
 
-function AlignMenuItems() {
+/** @public */
+export function AlignMenuItems() {
 	const actions = useActions()
 	const twoSelected = useUnlockedSelectedShapesCount(2)
 
@@ -45,7 +46,8 @@ function AlignMenuItems() {
 	)
 }
 
-function DistributeMenuItems() {
+/** @public */
+export function DistributeMenuItems() {
 	const actions = useActions()
 	const threeSelected = useUnlockedSelectedShapesCount(3)
 
@@ -57,7 +59,8 @@ function DistributeMenuItems() {
 	)
 }
 
-function StackMenuItems() {
+/** @public */
+export function StackMenuItems() {
 	const actions = useActions()
 	const threeStackableItems = useThreeStackableItems()
 
@@ -69,7 +72,8 @@ function StackMenuItems() {
 	)
 }
 
-function ReorderMenuItems() {
+/** @public */
+export function ReorderMenuItems() {
 	const actions = useActions()
 	const oneSelected = useUnlockedSelectedShapesCount(1)
 
@@ -83,54 +87,63 @@ function ReorderMenuItems() {
 	)
 }
 
-function ZoomOrRotateMenuItem() {
+/** @public */
+
+export function ZoomOrRotateMenuItem() {
 	const breakpoint = useBreakpoint()
 	return breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM ? <ZoomTo100MenuItem /> : <RotateCCWMenuItem />
 }
+/** @public */
 
-function ZoomTo100MenuItem() {
+export function ZoomTo100MenuItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isZoomedTo100 = useValue('zoom is 1', () => editor.getZoomLevel() === 1, [editor])
 
 	return <TldrawUiMenuItem {...actions['zoom-to-100']} disabled={isZoomedTo100} />
 }
+/** @public */
 
-function RotateCCWMenuItem() {
+export function RotateCCWMenuItem() {
 	const actions = useActions()
 	const oneSelected = useUnlockedSelectedShapesCount(1)
 
 	return <TldrawUiMenuItem {...actions['rotate-ccw']} disabled={!oneSelected} />
 }
+/** @public */
 
-function RotateCWMenuItem() {
+export function RotateCWMenuItem() {
 	const actions = useActions()
 	const oneSelected = useUnlockedSelectedShapesCount(1)
 
 	return <TldrawUiMenuItem {...actions['rotate-cw']} disabled={!oneSelected} />
 }
+/** @public */
 
-function EditLinkMenuItem() {
+export function EditLinkMenuItem() {
 	const actions = useActions()
 	const showEditLink = useHasLinkShapeSelected()
 
 	return <TldrawUiMenuItem {...actions['edit-link']} disabled={!showEditLink} />
 }
+/** @public */
 
-function GroupOrUngroupMenuItem() {
+export function GroupOrUngroupMenuItem() {
 	const allowGroup = useAllowGroup()
 	const allowUngroup = useAllowUngroup()
 	return allowGroup ? <GroupMenuItem /> : allowUngroup ? <UngroupMenuItem /> : <GroupMenuItem />
 }
+/** @public */
 
-function GroupMenuItem() {
+export function GroupMenuItem() {
 	const actions = useActions()
 	const twoSelected = useUnlockedSelectedShapesCount(2)
 
 	return <TldrawUiMenuItem {...actions['group']} disabled={!twoSelected} />
 }
+/** @public */
 
-function UngroupMenuItem() {
+export function UngroupMenuItem() {
 	const actions = useActions()
 	return <TldrawUiMenuItem {...actions['ungroup']} />
 }

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -182,8 +182,8 @@ export function DefaultDebugMenuContent() {
 		</>
 	)
 }
-
-function DebugFlags() {
+/** @public */
+export function DebugFlags() {
 	const items = Object.values(debugFlags)
 	if (!items.length) return null
 	return (
@@ -196,8 +196,8 @@ function DebugFlags() {
 		</TldrawUiMenuSubmenu>
 	)
 }
-
-function FeatureFlags() {
+/** @public */
+export function FeatureFlags() {
 	const items = Object.values(featureFlags)
 	if (!items.length) return null
 	return (
@@ -210,8 +210,8 @@ function FeatureFlags() {
 		</TldrawUiMenuSubmenu>
 	)
 }
-
-function ExampleDialog({
+/** @public */
+export function ExampleDialog({
 	title = 'title',
 	body = 'hello hello hello',
 	cancel = 'Cancel',

--- a/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenuContent.tsx
@@ -12,8 +12,8 @@ export function DefaultHelpMenuContent() {
 		</>
 	)
 }
-
-function KeyboardShortcutsMenuItem() {
+/** @public */
+export function KeyboardShortcutsMenuItem() {
 	const { KeyboardShortcutsDialog } = useTldrawUiComponents()
 	const { addDialog } = useDialogs()
 

--- a/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
@@ -5,6 +5,7 @@ import { TldrawUiMenuCheckboxItem } from './primitives/menus/TldrawUiMenuCheckbo
 import { TldrawUiMenuGroup } from './primitives/menus/TldrawUiMenuGroup'
 import { TldrawUiMenuSubmenu } from './primitives/menus/TldrawUiMenuSubmenu'
 
+/** @public */
 export const LanguageMenu = track(function LanguageMenu() {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
@@ -1,7 +1,7 @@
 import { TLPageId, useEditor } from '@tldraw/editor'
 import { useCallback, useRef } from 'react'
 import { TldrawUiInput } from '../primitives/TldrawUiInput'
-
+/** @public */
 export const PageItemInput = function PageItemInput({
 	name,
 	id,

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -12,14 +12,14 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { TldrawUiMenuGroup } from '../primitives/menus/TldrawUiMenuGroup'
 import { TldrawUiMenuItem } from '../primitives/menus/TldrawUiMenuItem'
 import { onMovePage } from './edit-pages-shared'
-
+/** @public */
 export interface PageItemSubmenuProps {
 	index: number
 	item: { id: string; name: string }
 	listSize: number
 	onRename?: () => void
 }
-
+/** @public */
 export const PageItemSubmenu = track(function PageItemSubmenu({
 	index,
 	listSize,

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -85,7 +85,8 @@ function useStyleChangeCallback() {
 	)
 }
 
-function CommonStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
+/** @public */
+export function CommonStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	const msg = useTranslation()
 
 	const handleValueChange = useStyleChangeCallback()
@@ -155,7 +156,8 @@ function CommonStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	)
 }
 
-function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
+/** @public */
+export function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	const msg = useTranslation()
 	const handleValueChange = useStyleChangeCallback()
 
@@ -216,8 +218,8 @@ function TextStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 		</div>
 	)
 }
-
-function GeoStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
+/** @public */
+export function GeoStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	const handleValueChange = useStyleChangeCallback()
 
 	const geo = styles.get(GeoShapeGeoStyle)
@@ -238,8 +240,8 @@ function GeoStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 		/>
 	)
 }
-
-function SplineStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
+/** @public */
+export function SplineStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	const handleValueChange = useStyleChangeCallback()
 
 	const spline = styles.get(LineShapeSplineStyle)
@@ -261,7 +263,8 @@ function SplineStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	)
 }
 
-function ArrowheadStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
+/** @public */
+export function ArrowheadStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap }) {
 	const handleValueChange = useStyleChangeCallback()
 
 	const arrowheadEnd = styles.get(ArrowShapeArrowheadEndStyle)
@@ -289,8 +292,8 @@ function ArrowheadStylePickerSet({ styles }: { styles: ReadonlySharedStyleMap })
 }
 
 const tldrawSupportedOpacities = [0.1, 0.25, 0.5, 0.75, 1] as const
-
-function OpacitySlider() {
+/** @public */
+export function OpacitySlider() {
 	const editor = useEditor()
 	const opacity = useValue('opacity', () => editor.getSharedOpacity(), [editor])
 	const trackEvent = useUiEvents()

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -27,42 +27,42 @@ import { TldrawUiMenuItem } from './primitives/menus/TldrawUiMenuItem'
 import { TldrawUiMenuSubmenu } from './primitives/menus/TldrawUiMenuSubmenu'
 
 /* -------------------- Selection ------------------- */
-
+/** @public */
 export function ToggleAutoSizeMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useShowAutoSizeToggle()
 
 	return <TldrawUiMenuItem {...actions['toggle-auto-size']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function EditLinkMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useHasLinkShapeSelected()
 
 	return <TldrawUiMenuItem {...actions['edit-link']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function DuplicateMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useUnlockedSelectedShapesCount(1)
 
 	return <TldrawUiMenuItem {...actions['duplicate']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function GroupMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useAllowGroup()
 
 	return <TldrawUiMenuItem {...actions['group']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function UngroupMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useAllowUngroup()
 
 	return <TldrawUiMenuItem {...actions['ungroup']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function RemoveFrameMenuItem() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -78,7 +78,7 @@ export function RemoveFrameMenuItem() {
 
 	return <TldrawUiMenuItem {...actions['remove-frame']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function FitFrameToContentMenuItem() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -97,7 +97,7 @@ export function FitFrameToContentMenuItem() {
 
 	return <TldrawUiMenuItem {...actions['fit-frame-to-content']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function ToggleLockMenuItem() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -107,7 +107,7 @@ export function ToggleLockMenuItem() {
 
 	return <TldrawUiMenuItem {...actions['toggle-lock']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function ToggleTransparentBgMenuItem() {
 	const actions = useActions()
 	const editor = useEditor()
@@ -118,7 +118,7 @@ export function ToggleTransparentBgMenuItem() {
 	)
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-transparent']} checked={isTransparentBg} />
 }
-
+/** @public */
 export function UnlockAllMenuItem() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -130,7 +130,7 @@ export function UnlockAllMenuItem() {
 }
 
 /* ---------------------- Zoom ---------------------- */
-
+/** @public */
 export function ZoomTo100MenuItem() {
 	const editor = useEditor()
 	const isZoomedTo100 = useValue('zoomed to 100', () => editor.getZoomLevel() === 1, [editor])
@@ -138,7 +138,7 @@ export function ZoomTo100MenuItem() {
 
 	return <TldrawUiMenuItem {...actions['zoom-to-100']} noClose disabled={isZoomedTo100} />
 }
-
+/** @public */
 export function ZoomToFitMenuItem() {
 	const editor = useEditor()
 	const hasShapes = useValue('has shapes', () => editor.getCurrentPageShapeIds().size > 0, [editor])
@@ -153,7 +153,7 @@ export function ZoomToFitMenuItem() {
 		/>
 	)
 }
-
+/** @public */
 export function ZoomToSelectionMenuItem() {
 	const editor = useEditor()
 	const hasSelected = useValue('has shapes', () => editor.getSelectedShapeIds().length > 0, [
@@ -172,7 +172,7 @@ export function ZoomToSelectionMenuItem() {
 }
 
 /* -------------------- Clipboard ------------------- */
-
+/** @public */
 export function ClipboardMenuGroup() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -209,21 +209,21 @@ export function ClipboardMenuGroup() {
 		</TldrawUiMenuGroup>
 	)
 }
-
+/** @public */
 export function CutMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useUnlockedSelectedShapesCount(1)
 
 	return <TldrawUiMenuItem {...actions['cut']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function CopyMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = useAnySelectedShapesCount(1)
 
 	return <TldrawUiMenuItem {...actions['copy']} disabled={!shouldDisplay} />
 }
-
+/** @public */
 export function PasteMenuItem() {
 	const actions = useActions()
 	const shouldDisplay = showMenuPaste
@@ -232,7 +232,7 @@ export function PasteMenuItem() {
 }
 
 /* ------------------- Conversions ------------------ */
-
+/** @public */
 export function ConversionsMenuGroup() {
 	const actions = useActions()
 	const shouldDisplay = useUnlockedSelectedShapesCount(1)
@@ -259,7 +259,7 @@ export function ConversionsMenuGroup() {
 }
 
 /* ------------------ Set Selection ----------------- */
-
+/** @public */
 export function SetSelectionGroup() {
 	const actions = useActions()
 	const editor = useEditor()
@@ -277,7 +277,7 @@ export function SetSelectionGroup() {
 }
 
 /* ------------------ Delete Group ------------------ */
-
+/** @public */
 export function DeleteMenuItem() {
 	const actions = useActions()
 	const oneSelected = useUnlockedSelectedShapesCount(1)
@@ -286,7 +286,7 @@ export function DeleteMenuItem() {
 }
 
 /* --------------------- Modify --------------------- */
-
+/** @public */
 export function ArrangeMenuSubmenu() {
 	const twoSelected = useUnlockedSelectedShapesCount(2)
 	const onlyFlippableShapeSelected = useOnlyFlippableShape()
@@ -351,7 +351,7 @@ function OrderMenuGroup() {
 		</TldrawUiMenuGroup>
 	)
 }
-
+/** @public */
 export function ReorderMenuSubmenu() {
 	const actions = useActions()
 	const oneSelected = useUnlockedSelectedShapesCount(1)
@@ -368,7 +368,7 @@ export function ReorderMenuSubmenu() {
 		</TldrawUiMenuSubmenu>
 	)
 }
-
+/** @public */
 export function MoveToPageMenu() {
 	const editor = useEditor()
 	const pages = useValue('pages', () => editor.getPages(), [editor])
@@ -423,7 +423,7 @@ export function MoveToPageMenu() {
 		</TldrawUiMenuSubmenu>
 	)
 }
-
+/** @public */
 export function EmbedsGroup() {
 	const editor = useEditor()
 	const actions = useActions()
@@ -471,42 +471,42 @@ export function EmbedsGroup() {
 }
 
 /* ------------------- Preferences ------------------ */
-
+/** @public */
 export function ToggleSnapModeItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isSnapMode = useValue('isSnapMode', () => editor.user.getIsSnapMode(), [editor])
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-snap-mode']} checked={isSnapMode} />
 }
-
+/** @public */
 export function ToggleToolLockItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isToolLock = useValue('isToolLock', () => editor.getInstanceState().isToolLocked, [editor])
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-tool-lock']} checked={isToolLock} />
 }
-
+/** @public */
 export function ToggleGridItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-grid']} checked={isGridMode} />
 }
-
+/** @public */
 export function ToggleDarkModeItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isDarkMode = useValue('isDarkMode', () => editor.user.getIsDarkMode(), [editor])
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-dark-mode']} checked={isDarkMode} />
 }
-
+/** @public */
 export function ToggleFocusModeItem() {
 	const actions = useActions()
 	const editor = useEditor()
 	const isFocusMode = useValue('isFocusMode', () => editor.getInstanceState().isFocusMode, [editor])
 	return <TldrawUiMenuCheckboxItem {...actions['toggle-focus-mode']} checked={isFocusMode} />
 }
-
+/** @public */
 export function ToggleEdgeScrollingItem() {
 	const actions = useActions()
 	const editor = useEditor()
@@ -520,7 +520,7 @@ export function ToggleEdgeScrollingItem() {
 		/>
 	)
 }
-
+/** @public */
 export function ToggleReduceMotionItem() {
 	const actions = useActions()
 	const editor = useEditor()
@@ -529,7 +529,7 @@ export function ToggleReduceMotionItem() {
 		<TldrawUiMenuCheckboxItem {...actions['toggle-reduce-motion']} checked={animationSpeed === 0} />
 	)
 }
-
+/** @public */
 export function ToggleDebugModeItem() {
 	const actions = useActions()
 	const editor = useEditor()
@@ -538,7 +538,7 @@ export function ToggleDebugModeItem() {
 }
 
 /* ---------------------- Print --------------------- */
-
+/** @public */
 export function PrintItem() {
 	const editor = useEditor()
 	const actions = useActions()


### PR DESCRIPTION
This PR exports all the components within each of the default menu content components. Should make it easier to customise the default UI.


- [x] `minor` — New feature


### Release Notes

- Components within default menu content components are now exported.
