### PR TITLE
license: make them not be scrubbed out in code munging

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/TextHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/shared/TextHelpers.ts
@@ -1,5 +1,8 @@
-// Adapted (mostly copied) the work of https://github.com/fregante
-// Copyright (c) Federico Brigante <opensource@bfred.it> (bfred.it)
+/*!
+ * MIT License
+ * Adapted (mostly copied) the work of https://github.com/fregante/text-field-edit
+ * Copyright (c) Federico Brigante <opensource@bfred.it> (bfred.it)
+ */
 
 // TODO: Most of this file can be moved into a DOM utils library.
 

--- a/packages/tldraw/src/lib/utils/assets/is-gif-animated.ts
+++ b/packages/tldraw/src/lib/utils/assets/is-gif-animated.ts
@@ -1,16 +1,8 @@
-// =========================
-// Modified code originally from <https://github.com/qzb/is-animated>
-//
-// # [MIT License](https://spdx.org/licenses/MIT)
-//
-// Copyright (c) 2016 Józef Sokołowski <j.k.sokolowski@gmail.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// =========================
+/*!
+ * MIT License
+ * Modified code originally from <https://github.com/qzb/is-animated>
+ * Copyright (c) 2016 Józef Sokołowski <j.k.sokolowski@gmail.com>
+ */
 
 /** Returns total length of data blocks sequence */
 function getDataBlocksLength(buffer: Uint8Array, offset: number): number {


### PR DESCRIPTION
Add the `/*!` to prevent stripping in compilation, also make the MIT part explicit.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]