### PR TITLE
Configure dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,5 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
-    # Always increase the version requirement
-    # to match the new version.
-    versioning-strategy: increase
+      interval: 'daily'
+    versioning-strategy: auto

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    versioning-strategy: auto
+    versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    # Always increase the version requirement
+    # to match the new version.
+    versioning-strategy: increase

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -1,0 +1,37 @@
+name: Dedupe Dependabot PRs
+
+on:
+  push:
+    branches: ['dependabot/**']
+
+permissions:
+  contents: write
+  pull-requests: write
+  repository-projects: write
+
+jobs:
+  dedupe:
+    name: Dedupe Dependabot PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Dedupe dependencies
+        run: yarn dedupe
+
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m 'Dedupe' || true
+
+      - name: Push changes
+        run: git push

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dedupe:
     name: Dedupe Dependabot PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores-open
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Adds dependabot config. 

Seems like monthly is the least frequent update you can choose right now (there are feature request for quarterly and for chron like syntax). 

For now I used the daily interval though. I want to make sure it works, will then switch to monthly. The main thing I'd like to see is that the main `yarn.lock` file gets updated. That didn't happen in one of the previous dependabot PRs (seems like [others faced the same issue](https://github.com/dependabot/dependabot-core/issues/6346)). So 🤞  this solves it.

Also added a dedupe workflow, that should only run on dependabot branches (prefixed with `depandabot/`). Otherwise we would need to manually do it, as [seen on this PR](https://github.com/tldraw/tldraw/pull/2982) ([failure](https://github.com/tldraw/tldraw/actions/runs/8070271847/job/22047204003)). 

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version
