### PR TITLE
Make exportToBlob public

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -543,6 +543,14 @@ export function exportAs(editor: Editor, ids: TLShapeId[], format: TLExportType 
 // @public (undocumented)
 export function ExportFileContentSubMenu(): JSX_2.Element;
 
+// @public
+export function exportToBlob({ editor, ids, format, opts, }: {
+    editor: Editor;
+    ids: TLShapeId[];
+    format: 'jpeg' | 'json' | 'png' | 'svg' | 'webp';
+    opts?: Partial<TLSvgOptions>;
+}): Promise<Blob>;
+
 // @public (undocumented)
 export function ExtrasGroup(): JSX_2.Element;
 

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -6045,6 +6045,101 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/tldraw!exportToBlob:function(1)",
+          "docComment": "/**\n * Export the given shapes as a blob.\n *\n * @param editor - The editor instance.\n *\n * @param ids - The ids of the shapes to export.\n *\n * @param format - The format to export as.\n *\n * @param opts - Rendering options.\n *\n * @returns A promise that resolves to a blob.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function exportToBlob({ editor, ids, format, opts, }: "
+            },
+            {
+              "kind": "Content",
+              "text": "{\n    editor: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Editor",
+              "canonicalReference": "@tldraw/editor!Editor:class"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    ids: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLShapeId",
+              "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+            },
+            {
+              "kind": "Content",
+              "text": "[];\n    format: 'jpeg' | 'json' | 'png' | 'svg' | 'webp';\n    opts?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TLSvgOptions",
+              "canonicalReference": "@tldraw/editor!TLSvgOptions:type"
+            },
+            {
+              "kind": "Content",
+              "text": ">;\n}"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Reference",
+              "text": "Promise",
+              "canonicalReference": "!Promise:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Blob",
+              "canonicalReference": "!Blob:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/tldraw/src/lib/utils/export/export.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 11,
+            "endIndex": 15
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "{ editor, ids, format, opts, }",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 10
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "exportToBlob"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/tldraw!ExtrasGroup:function(1)",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -115,7 +115,7 @@ export {
 } from './lib/utils/assets/assets'
 export { getEmbedInfo } from './lib/utils/embeds/embeds'
 export { copyAs } from './lib/utils/export/copyAs'
-export { getSvgAsImage, getSvgAsString } from './lib/utils/export/export'
+export { exportToBlob, getSvgAsImage, getSvgAsString } from './lib/utils/export/export'
 export { exportAs } from './lib/utils/export/exportAs'
 export { fitFrameToContent, removeFrame } from './lib/utils/frames/frames'
 export { setDefaultEditorAssetUrls } from './lib/utils/static-assets/assetUrls'

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -156,12 +156,26 @@ export async function exportToString(
 	}
 }
 
-export async function exportToBlob(
-	editor: Editor,
-	ids: TLShapeId[],
-	format: 'svg' | 'png' | 'jpeg' | 'webp' | 'json',
-	opts = {} as Partial<TLSvgOptions>
-): Promise<Blob> {
+/**
+ * Export the given shapes as a blob.
+ * @param editor - The editor instance.
+ * @param ids - The ids of the shapes to export.
+ * @param format - The format to export as.
+ * @param opts - Rendering options.
+ * @returns A promise that resolves to a blob.
+ * @public
+ */
+export async function exportToBlob({
+	editor,
+	ids,
+	format,
+	opts = {} as Partial<TLSvgOptions>,
+}: {
+	editor: Editor
+	ids: TLShapeId[]
+	format: 'svg' | 'png' | 'jpeg' | 'webp' | 'json'
+	opts?: Partial<TLSvgOptions>
+}): Promise<Blob> {
 	switch (format) {
 		case 'svg':
 			return new Blob([await exportToString(editor, ids, 'svg', opts)], { type: 'text/plain' })
@@ -205,7 +219,7 @@ export function exportToBlobPromise(
 	opts = {} as Partial<TLSvgOptions>
 ): { blobPromise: Promise<Blob>; mimeType: string } {
 	return {
-		blobPromise: exportToBlob(editor, ids, format, opts),
+		blobPromise: exportToBlob({ editor, ids, format, opts }),
 		mimeType: mimeTypeByFormat[format],
 	}
 }

--- a/packages/tldraw/src/lib/utils/export/exportAs.ts
+++ b/packages/tldraw/src/lib/utils/export/exportAs.ts
@@ -36,7 +36,7 @@ export async function exportAs(
 	}
 	name += `.${format}`
 
-	const blob = await exportToBlob(editor, ids, format, opts)
+	const blob = await exportToBlob({ editor, ids, format, opts })
 	const file = new File([blob], name, { type: blob.type })
 	downloadFile(file)
 }


### PR DESCRIPTION
Solves #2939

Also converts to named arguments to make it easier to add arguments in the future. We should be doing this everywhere from now on.

### Change Type


- [x] `minor` — New feature


[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Release Notes

- Exposes the exportToBlob function for library users
