### PR TITLE
textfields: make them consistent

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
@@ -76,6 +76,7 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 						onChange={handleChange}
 						onKeyDown={handleKeyDown}
 						onBlur={handleBlur}
+						onTouchEnd={stopEventPropagation}
 						onContextMenu={stopEventPropagation}
 						onPointerDown={handleInputPointerDown}
 						onDoubleClick={handleDoubleClick}

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -120,6 +120,7 @@ export const TextLabel = React.memo(function TextLabel<
 						onChange={handleChange}
 						onKeyDown={handleKeyDown}
 						onBlur={handleBlur}
+						onTouchEnd={stopEventPropagation}
 						onContextMenu={stopEventPropagation}
 						onPointerDown={handleInputPointerDown}
 						onDoubleClick={handleDoubleClick}

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -118,11 +118,11 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 							autoCapitalize="false"
 							autoCorrect="false"
 							autoSave="false"
-							autoFocus={isEditing}
+							autoFocus
 							placeholder=""
 							spellCheck="true"
 							wrap="off"
-							dir="ltr"
+							dir="auto"
 							datatype="wysiwyg"
 							defaultValue={text}
 							onFocus={handleFocus}


### PR DESCRIPTION
as i look into textfields the places where we are using them are out-of-sync at the moment. this brings them in line with each other for further refactoring later.

### Change Type

- [x] `patch` — Bug fix

