### PR TITLE
Don't allow edge scrolling when camera is frozen.

### DIFF
--- a/packages/editor/src/lib/utils/edgeScrolling.ts
+++ b/packages/editor/src/lib/utils/edgeScrolling.ts
@@ -33,7 +33,12 @@ function getEdgeProximityFactor(
  * @public
  */
 export function moveCameraWhenCloseToEdge(editor: Editor) {
-	if (!editor.inputs.isDragging || editor.inputs.isPanning) return
+	if (
+		!editor.inputs.isDragging ||
+		editor.inputs.isPanning ||
+		!editor.getInstanceState().canMoveCamera
+	)
+		return
 
 	const {
 		inputs: {


### PR DESCRIPTION
Don't allow edge scrolling when camera is frozen.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Testing
It's a bit hard to test this, you actually need to change the code a bit.
1. Add an `onMount` handler to the `Tldraw` component in `develop.tsx`
2. In the `onMount` handler add: `editor.updateInstanceState({canMoveCamera: false})` to freeze the camera.
3. Make sure edge scrolling is turned on in the preferences.
4. Use brush selections / resizing / translating close to the edges.
5. The camera should not move.

### Release Notes

- Don't allow edge scrolling when camera is frozen.
