### PR TITLE
Don't add editor / app to window.

### DIFF
--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -91,6 +91,8 @@ export function LocalEditor() {
 	const fileSystemUiOverrides = useFileSystem({ isMultiplayer: false })
 
 	const handleMount = useCallback((editor: Editor) => {
+		;(window as any).app = editor
+		;(window as any).editor = editor
 		editor.registerExternalAssetHandler('url', createAssetFromUrl)
 	}, [])
 

--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -142,6 +142,8 @@ export function MultiplayerEditor({
 
 	const handleMount = useCallback(
 		(editor: Editor) => {
+			;(window as any).app = editor
+			;(window as any).editor = editor
 			editor.updateInstanceState({ isReadonly: isReadOnly })
 			editor.registerExternalAssetHandler('file', createAssetFromFile)
 			editor.registerExternalAssetHandler('url', createAssetFromUrl)

--- a/apps/dotcom/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/src/components/SnapshotsEditor.tsx
@@ -83,6 +83,8 @@ export function SnapshotsEditor(props: SnapshotEditorProps) {
 				overrides={[sharingUiOverrides, fileSystemUiOverrides]}
 				onUiEvent={handleUiEvent}
 				onMount={(editor) => {
+					;(window as any).app = editor
+					;(window as any).editor = editor
 					editor.updateInstanceState({ isReadonly: true })
 				}}
 				components={components}

--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -4,7 +4,13 @@ import '@tldraw/tldraw/tldraw.css'
 export default function Develop() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="tldraw_example" />
+			<Tldraw
+				persistenceKey="tldraw_example"
+				onMount={(editor) => {
+					;(window as any).app = editor
+					;(window as any).editor = editor
+				}}
+			/>
 		</div>
 	)
 }

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -9,6 +9,9 @@ export default function EndToEnd() {
 		<div className="tldraw__editor">
 			<Tldraw
 				onMount={(editor) => {
+					;(window as any).app = editor
+					;(window as any).editor = editor
+
 					editor.on('event', (info) => {
 						;(window as any).__tldraw_editor_events.push(info)
 					})

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -285,8 +285,6 @@ function TldrawEditorWithReadyStore({
 			initialState,
 			inferDarkMode,
 		})
-		;(window as any).app = editor
-		;(window as any).editor = editor
 		setEditor(editor)
 
 		return () => {


### PR DESCRIPTION
This PR removes code that would add a reference to the editor to the window. This is a feature that we added very early on during testing, but which we should have moved out of the library earlier. Adding it here as one of our last PRs before release.

If you've relied on this, you'll need to update your use of the library to do it manually:

```ts
<Tldraw onMount={(editor) => {
  ;(window as any).app = editor
  ;(window as any).editor = editor
}}/>
```

### Change Type

- [x] `major` — Breaking change

### Release Notes

- Remove `window.editor` and `window.app` references to editor.
