### PR TITLE
[fix] Input tags

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/components/ArrowTextLabel.tsx
@@ -61,10 +61,10 @@ export const ArrowTextLabel = React.memo(function ArrowTextLabel({
 						className="tl-text tl-text-input"
 						name="text"
 						tabIndex={-1}
-						autoComplete="false"
-						autoCapitalize="false"
-						autoCorrect="false"
-						autoSave="false"
+						autoComplete="off"
+						autoCapitalize="off"
+						autoCorrect="off"
+						autoSave="off"
 						autoFocus
 						placeholder=""
 						spellCheck="true"

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -105,10 +105,10 @@ export const TextLabel = React.memo(function TextLabel<
 						className="tl-text tl-text-input"
 						name="text"
 						tabIndex={-1}
-						autoComplete="false"
-						autoCapitalize="false"
-						autoCorrect="false"
-						autoSave="false"
+						autoComplete="off"
+						autoCapitalize="off"
+						autoCorrect="off"
+						autoSave="off"
 						autoFocus
 						placeholder=""
 						spellCheck="true"

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -114,10 +114,10 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 							className="tl-text tl-text-input"
 							name="text"
 							tabIndex={-1}
-							autoComplete="false"
-							autoCapitalize="false"
-							autoCorrect="false"
-							autoSave="false"
+							autoComplete="off"
+							autoCapitalize="off"
+							autoCorrect="off"
+							autoSave="off"
 							autoFocus
 							placeholder=""
 							spellCheck="true"


### PR DESCRIPTION
This PR fixes the input tags, which were set to `false` rather than `off`, as they should be.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

1. Test autocomplete
2. Test autocapitalize
3. Test autocorrect
4. Make sure that password managers don't show up


### Release Notes

- Fixed autocomplete, autocapitalize, and autocorrect tags on text inputs.