### PR TITLE
Fix cursor chat bubble position.

### DIFF
--- a/apps/dotcom/src/components/CursorChatBubble.tsx
+++ b/apps/dotcom/src/components/CursorChatBubble.tsx
@@ -188,12 +188,9 @@ const CursorChatInput = track(function CursorChatInput({
 		[stopChatting, setValue]
 	)
 
-	const handlePaste = useCallback(
-		(e: ClipboardEvent) => {
-			e.stopPropagation()
-		},
-		[setValue]
-	)
+	const handlePaste = useCallback((e: ClipboardEvent) => {
+		e.stopPropagation()
+	}, [])
 
 	return (
 		<input

--- a/apps/dotcom/src/components/CursorChatBubble.tsx
+++ b/apps/dotcom/src/components/CursorChatBubble.tsx
@@ -190,8 +190,6 @@ const CursorChatInput = track(function CursorChatInput({
 
 	const handlePaste = useCallback(
 		(e: ClipboardEvent) => {
-			const text = e.clipboardData.getData('text/plain')
-			setValue(text)
 			e.stopPropagation()
 		},
 		[setValue]

--- a/apps/dotcom/src/components/CursorChatBubble.tsx
+++ b/apps/dotcom/src/components/CursorChatBubble.tsx
@@ -58,7 +58,11 @@ function usePositionBubble(ref: RefObject<HTMLInputElement>) {
 
 		// Positioning the chat bubble
 		function positionChatBubble(e: PointerEvent) {
-			ref.current?.style.setProperty('transform', `translate(${e.clientX}px, ${e.clientY}px)`)
+			const { minX, minY } = editor.getViewportScreenBounds()
+			ref.current?.style.setProperty(
+				'transform',
+				`translate(${e.clientX - minX}px, ${e.clientY - minY}px)`
+			)
 		}
 
 		window.addEventListener('pointermove', positionChatBubble)
@@ -184,11 +188,14 @@ const CursorChatInput = track(function CursorChatInput({
 		[stopChatting, setValue]
 	)
 
-	const handlePaste = useCallback((e: ClipboardEvent) => {
-		// todo: figure out what's an acceptable / sanitized paste
-		preventDefault(e)
-		e.stopPropagation()
-	}, [])
+	const handlePaste = useCallback(
+		(e: ClipboardEvent) => {
+			const text = e.clipboardData.getData('text/plain')
+			setValue(text)
+			e.stopPropagation()
+		},
+		[setValue]
+	)
 
 	return (
 		<input


### PR DESCRIPTION
This PR fixes the position of the cursor chat bubble when the canvas is not positioned at the top left.

### Change Type

- [x] `internal`

### Test Plan

1. Using CSS, add a margin left to the tldraw component on a multiplayer route.
2. Use cursor chat.

### Release Notes

- Fixed a bug where cursor chat bubble position could be wrong when a sidebar was open.