### PR TITLE
[infra] fix canary dist tag

### DIFF
--- a/scripts/publish-canary.ts
+++ b/scripts/publish-canary.ts
@@ -1,39 +1,25 @@
 import { exec } from './lib/exec'
-import { nicelog } from './lib/nicelog'
 import { getLatestVersion, publish, setAllVersions } from './lib/publishing'
 
 async function main() {
 	const sha = (await exec('git', ['rev-parse', 'HEAD'])).trim().slice(0, 12)
 
-	async function setCanaryVersions(bump: 'major' | 'minor' | 'patch') {
+	async function setCanaryVersions() {
 		const latestVersion = await getLatestVersion()
 
 		const nextVersion = latestVersion.prerelease.length
 			? // if the package is in prerelease mode, we want to release a canary for the current version rather than bumping
 				latestVersion
-			: latestVersion?.inc(bump)
+			: latestVersion?.inc('minor')
 		const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-canary.${sha}`
 
 		await setAllVersions(versionString)
 	}
 
 	// module was called directly
-	const bumpType = (await exec('npx', ['auto', 'version'])).trim() as
-		| 'major'
-		| 'minor'
-		| 'patch'
-		| ''
 
-	nicelog('bumpType', bumpType)
-	if (bumpType === '') {
-		nicelog('nothing to do')
-	} else if (['major', 'minor', 'patch'].includes(bumpType)) {
-		nicelog('setting canary versions')
-		setCanaryVersions(bumpType)
-		publish()
-	} else {
-		throw new Error('Invalid bump type provided')
-	}
+	setCanaryVersions()
+	publish('canary')
 }
 
 main()


### PR DESCRIPTION
Some of the tooling changes we made last week made it so that canary releases were being published with the `latest` dist tag. This should prevent that from happening, and I also fixed all the current packages to set `latest` back to 2.0.0

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [x] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


