### PR TITLE
children: any -> children: ReactNode

### DIFF
--- a/apps/docs/app/providers.tsx
+++ b/apps/docs/app/providers.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { ThemeProvider } from 'next-themes'
+import { ReactNode } from 'react'
 
-export function Providers({ children }: { children: any }) {
+export function Providers({ children }: { children: ReactNode }) {
 	return <ThemeProvider enableSystem>{children}</ThemeProvider>
 }

--- a/apps/docs/components/AutoRefresh.tsx
+++ b/apps/docs/components/AutoRefresh.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { ReactNode, useEffect } from 'react'
 
-let AutoRefresh = ({ children }: { children: any }) => {
+let AutoRefresh = ({ children }: { children: ReactNode }) => {
 	return children
 }
 

--- a/apps/dotcom/src/components/IFrameProtector.tsx
+++ b/apps/dotcom/src/components/IFrameProtector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, version } from 'react'
+import { ReactNode, useEffect, useState, version } from 'react'
 import { LoadingScreen } from 'tldraw'
 import { useUrl } from '../hooks/useUrl'
 import { trackAnalyticsEvent } from '../utils/trackAnalyticsEvent'
@@ -47,7 +47,7 @@ export function IFrameProtector({
 		| 'history-snapshot'
 		| 'history'
 		| 'local'
-	children: any
+	children: ReactNode
 }) {
 	const [embeddedState, setEmbeddedState] = useState<
 		'iframe-unknown' | 'iframe-not-allowed' | 'not-iframe' | 'iframe-ok'

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -26,6 +26,7 @@ import { PointerEventHandler } from 'react';
 import { react } from '@tldraw/state';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
+import { ReactNode } from 'react';
 import { SerializedSchema } from '@tldraw/store';
 import { SerializedStore } from '@tldraw/store';
 import { ShapeProps } from '@tldraw/tlschema';
@@ -968,7 +969,7 @@ export class ErrorBoundary extends React_3.Component<React_3.PropsWithRef<React_
 
 // @public (undocumented)
 export function ErrorScreen({ children }: {
-    children: any;
+    children: ReactNode;
 }): JSX_2.Element;
 
 // @public (undocumented)
@@ -1211,7 +1212,7 @@ export function linesIntersect(A: VecLike, B: VecLike, C: VecLike, D: VecLike): 
 
 // @public (undocumented)
 export function LoadingScreen({ children }: {
-    children: any;
+    children: ReactNode;
 }): JSX_2.Element;
 
 // @public
@@ -2021,7 +2022,7 @@ export const TldrawEditor: React_2.NamedExoticComponent<TldrawEditorProps>;
 // @public
 export interface TldrawEditorBaseProps {
     autoFocus?: boolean;
-    children?: any;
+    children?: ReactNode;
     className?: string;
     components?: TLEditorComponents;
     inferDarkMode?: boolean;
@@ -2228,7 +2229,7 @@ export type TLHandleProps = {
 
 // @public (undocumented)
 export type TLHandlesProps = {
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -20461,7 +20461,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children: any;\n}"
+              "text": "{\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20483,8 +20492,8 @@
           ],
           "fileUrlPath": "packages/editor/src/lib/TldrawEditor.tsx",
           "returnTypeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 5
+            "startIndex": 5,
+            "endIndex": 7
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -20493,7 +20502,7 @@
               "parameterName": "{ children }",
               "parameterTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 2
+                "endIndex": 4
               },
               "isOptional": false
             }
@@ -24717,7 +24726,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children: any;\n}"
+              "text": "{\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -24739,8 +24757,8 @@
           ],
           "fileUrlPath": "packages/editor/src/lib/TldrawEditor.tsx",
           "returnTypeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 5
+            "startIndex": 5,
+            "endIndex": 7
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -24749,7 +24767,7 @@
               "parameterName": "{ children }",
               "parameterTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 2
+                "endIndex": 4
               },
               "isOptional": false
             }
@@ -36359,8 +36377,9 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -38400,7 +38419,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children: any;\n}"
+              "text": "{\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -38412,7 +38440,7 @@
           "name": "TLHandlesProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -2,6 +2,7 @@ import { SerializedStore, Store, StoreSnapshot } from '@tldraw/store'
 import { TLRecord, TLStore } from '@tldraw/tlschema'
 import { Expand, Required, annotateError } from '@tldraw/utils'
 import React, {
+	ReactNode,
 	memo,
 	useCallback,
 	useLayoutEffect,
@@ -66,7 +67,7 @@ export interface TldrawEditorBaseProps {
 	/**
 	 * The component's children.
 	 */
-	children?: any
+	children?: ReactNode
 
 	/**
 	 * An array of shape utils to use in the editor.
@@ -345,7 +346,7 @@ function Layout({
 	onMount,
 	autoFocus,
 }: {
-	children: any
+	children: ReactNode
 	autoFocus: boolean
 	onMount?: TLOnMountHandler
 }) {
@@ -365,12 +366,12 @@ function Crash({ crashingError }: { crashingError: unknown }): null {
 }
 
 /** @public */
-export function LoadingScreen({ children }: { children: any }) {
+export function LoadingScreen({ children }: { children: ReactNode }) {
 	return <div className="tl-loading">{children}</div>
 }
 
 /** @public */
-export function ErrorScreen({ children }: { children: any }) {
+export function ErrorScreen({ children }: { children: ReactNode }) {
 	return <div className="tl-loading">{children}</div>
 }
 

--- a/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
@@ -1,6 +1,8 @@
+import { ReactNode } from 'react'
+
 /** @public */
 export type TLHandlesProps = {
-	children: any
+	children: ReactNode
 }
 
 /** @public */

--- a/packages/editor/src/lib/hooks/useEditorComponents.tsx
+++ b/packages/editor/src/lib/hooks/useEditorComponents.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, createContext, useContext, useMemo } from 'react'
+import { ComponentType, ReactNode, createContext, useContext, useMemo } from 'react'
 import { DefaultBackground } from '../components/default-components/DefaultBackground'
 import { DefaultBrush, TLBrushProps } from '../components/default-components/DefaultBrush'
 import {
@@ -95,7 +95,7 @@ const EditorComponentsContext = createContext({} as TLEditorComponents & ErrorCo
 
 type ComponentsContextProviderProps = {
 	overrides?: TLEditorComponents
-	children: any
+	children: ReactNode
 }
 
 export function EditorComponentsProvider({

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -274,7 +274,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 // @public (undocumented)
 export function BreakPointProvider({ forceMobile, children, }: {
     forceMobile?: boolean;
-    children: any;
+    children: ReactNode;
 }): JSX_2.Element;
 
 // @internal (undocumented)
@@ -523,7 +523,7 @@ export class EraserTool extends StateNode {
 // @public (undocumented)
 export type EventsProviderProps = {
     onEvent?: TLUiEventHandler;
-    children: any;
+    children: React_3.ReactNode;
 };
 
 // @public (undocumented)
@@ -1399,7 +1399,7 @@ export const TldrawSelectionForeground: MemoExoticComponent<({ bounds, rotation,
 
 // @public (undocumented)
 export const TldrawUi: React_2.NamedExoticComponent<{
-    children?: any;
+    children?: ReactNode;
     hideUi?: boolean | undefined;
     components?: Partial<{
         ContextMenu: null | React_2.ComponentType<TLUiContextMenuProps>;
@@ -1562,7 +1562,7 @@ export function TldrawUiContextProvider({ overrides, components, assetUrls, onUi
 // @public
 export interface TldrawUiContextProviderProps {
     assetUrls?: RecursivePartial<TLUiAssetUrls>;
-    children?: any;
+    children?: ReactNode;
     components?: TLUiComponents;
     forceMobile?: boolean;
     onUiEvent?: TLUiEventHandler;
@@ -1627,13 +1627,13 @@ export function TldrawUiMenuCheckboxItem<TranslationKey extends string = string,
 export function TldrawUiMenuContextProvider({ type, sourceId, children, }: TLUiMenuContextProviderProps): JSX_2.Element;
 
 // @public (undocumented)
-export function TldrawUiMenuGroup({ id, label, children }: TLUiMenuGroupProps): any;
+export function TldrawUiMenuGroup({ id, label, children }: TLUiMenuGroupProps): boolean | JSX_2.Element | Iterable<ReactNode> | null | number | string | undefined;
 
 // @public (undocumented)
 export function TldrawUiMenuItem<TranslationKey extends string = string, IconType extends string = string>({ disabled, spinner, readonlyOk, id, kbd, label, icon, onSelect, noClose, }: TLUiMenuItemProps<TranslationKey, IconType>): JSX_2.Element | null;
 
 // @public (undocumented)
-export function TldrawUiMenuSubmenu<Translation extends string = string>({ id, disabled, label, size, children, }: TLUiMenuSubmenuProps<Translation>): any;
+export function TldrawUiMenuSubmenu<Translation extends string = string>({ id, disabled, label, size, children, }: TLUiMenuSubmenuProps<Translation>): boolean | JSX_2.Element | Iterable<ReactNode> | null | number | string | undefined;
 
 // @public (undocumented)
 export function TldrawUiPopover({ id, children, onOpenChange, open }: TLUiPopoverProps): JSX_2.Element;
@@ -1677,7 +1677,7 @@ export type TLUiActionsContextType = Record<string, TLUiActionItem>;
 
 // @public (undocumented)
 export type TLUiActionsMenuProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -1697,7 +1697,7 @@ export type TLUiButtonIconProps = {
 
 // @public (undocumented)
 export type TLUiButtonLabelProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -1732,18 +1732,18 @@ export type TLUiComponents = Partial<{
 // @public (undocumented)
 export type TLUiComponentsProviderProps = {
     overrides?: TLUiComponents;
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
 export interface TLUiContextMenuProps {
     // (undocumented)
-    children?: any;
+    children?: ReactNode;
 }
 
 // @public (undocumented)
 export type TLUiDebugMenuProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -1759,20 +1759,20 @@ export interface TLUiDialog {
 // @public (undocumented)
 export type TLUiDialogBodyProps = {
     className?: string;
-    children: any;
+    children: ReactNode;
     style?: React.CSSProperties;
 };
 
 // @public (undocumented)
 export type TLUiDialogFooterProps = {
     className?: string;
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
 export type TLUiDialogHeaderProps = {
     className?: string;
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
@@ -1795,7 +1795,7 @@ export type TLUiDialogsContextType = {
 // @public (undocumented)
 export type TLUiDialogTitleProps = {
     className?: string;
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
@@ -1803,7 +1803,7 @@ export interface TLUiDropdownMenuCheckboxItemProps {
     // (undocumented)
     checked?: boolean;
     // (undocumented)
-    children: any;
+    children: ReactNode;
     // (undocumented)
     disabled?: boolean;
     // (undocumented)
@@ -1815,7 +1815,7 @@ export interface TLUiDropdownMenuCheckboxItemProps {
 // @public (undocumented)
 export type TLUiDropdownMenuContentProps = {
     id?: string;
-    children: any;
+    children: ReactNode;
     alignOffset?: number;
     sideOffset?: number;
     align?: 'center' | 'end' | 'start';
@@ -1824,13 +1824,13 @@ export type TLUiDropdownMenuContentProps = {
 
 // @public (undocumented)
 export type TLUiDropdownMenuGroupProps = {
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
 export interface TLUiDropdownMenuItemProps {
     // (undocumented)
-    children: any;
+    children: ReactNode;
     // (undocumented)
     noClose?: boolean;
 }
@@ -1838,7 +1838,7 @@ export interface TLUiDropdownMenuItemProps {
 // @public (undocumented)
 export type TLUiDropdownMenuRootProps = {
     id: string;
-    children: any;
+    children: ReactNode;
     modal?: boolean;
     debugOpen?: boolean;
 };
@@ -1846,7 +1846,7 @@ export type TLUiDropdownMenuRootProps = {
 // @public (undocumented)
 export type TLUiDropdownMenuSubProps = {
     id: string;
-    children: any;
+    children: ReactNode;
 };
 
 // @public (undocumented)
@@ -1860,7 +1860,7 @@ export type TLUiDropdownMenuSubTriggerProps = {
 // @public (undocumented)
 export interface TLUiDropdownMenuTriggerProps {
     // (undocumented)
-    children?: any;
+    children?: ReactNode;
 }
 
 // @public (undocumented)
@@ -2041,12 +2041,12 @@ export type TLUiEventSource = 'actions-menu' | 'context-menu' | 'debug-panel' | 
 
 // @public (undocumented)
 export type TLUiHelperButtonsProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
 export type TLUiHelpMenuProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -2075,7 +2075,7 @@ export interface TLUiInputProps {
     // (undocumented)
     autoselect?: boolean;
     // (undocumented)
-    children?: any;
+    children?: React_3.ReactNode;
     // (undocumented)
     className?: string;
     // (undocumented)
@@ -2113,12 +2113,12 @@ export interface TLUiKbdProps {
 
 // @public (undocumented)
 export type TLUiKeyboardShortcutsDialogProps = TLUiDialogProps & {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
 export type TLUiMainMenuProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -2149,7 +2149,7 @@ export type TLUiMenuGroupProps<TranslationKey extends string = string> = {
     label?: {
         [key: string]: TranslationKey;
     } | TranslationKey;
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)
@@ -2175,7 +2175,7 @@ export type TLUiMenuSubmenuProps<Translation extends string = string> = {
         [key: string]: Translation;
     } | Translation;
     disabled?: boolean;
-    children: any;
+    children: ReactNode;
     size?: 'medium' | 'small' | 'tiny' | 'wide';
 };
 
@@ -2212,7 +2212,7 @@ export interface TLUiPopoverTriggerProps {
 
 // @public (undocumented)
 export type TLUiQuickActionsProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @internal (undocumented)
@@ -2239,7 +2239,7 @@ export type TLUiStylePanelContentProps = {
 // @public (undocumented)
 export interface TLUiStylePanelProps {
     // (undocumented)
-    children?: any;
+    children?: ReactNode;
     // (undocumented)
     isMobile?: boolean;
 }
@@ -2323,7 +2323,7 @@ export type TLUiToolsProviderProps = {
     overrides?: (editor: Editor, tools: TLUiToolsContextType, helpers: {
         insertMedia: () => void;
     }) => TLUiToolsContextType;
-    children: any;
+    children: React_3.ReactNode;
 };
 
 // @public (undocumented)
@@ -2341,7 +2341,7 @@ export type TLUiTranslationKey = 'action.align-bottom' | 'action.align-center-ho
 
 // @public (undocumented)
 export type TLUiZoomMenuProps = {
-    children?: any;
+    children?: ReactNode;
 };
 
 // @public (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -2203,7 +2203,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    forceMobile?: boolean;\n    children: any;\n}"
+              "text": "{\n    forceMobile?: boolean;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -2225,8 +2234,8 @@
           ],
           "fileUrlPath": "packages/tldraw/src/lib/ui/context/breakpoints.tsx",
           "returnTypeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 5
+            "startIndex": 5,
+            "endIndex": 7
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -2235,7 +2244,7 @@
               "parameterName": "{ forceMobile, children, }",
               "parameterTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 2
+                "endIndex": 4
               },
               "isOptional": false
             }
@@ -5806,7 +5815,16 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    children: any;\n}"
+              "text": ";\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "React.ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -5818,7 +5836,7 @@
           "name": "EventsProviderProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 4
+            "endIndex": 6
           }
         },
         {
@@ -16156,7 +16174,16 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n    children?: any;\n    hideUi?: boolean | undefined;\n    components?: "
+              "text": "<{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    hideUi?: boolean | undefined;\n    components?: "
             },
             {
               "kind": "Reference",
@@ -16966,7 +16993,7 @@
           "name": "TldrawUi",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 181
+            "endIndex": 183
           }
         },
         {
@@ -17534,8 +17561,9 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -18693,7 +18721,34 @@
             },
             {
               "kind": "Content",
-              "text": "any"
+              "text": "boolean | import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "Iterable",
+              "canonicalReference": "!Iterable:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": "> | null | number | string | undefined"
             },
             {
               "kind": "Content",
@@ -18703,7 +18758,7 @@
           "fileUrlPath": "packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx",
           "returnTypeTokenRange": {
             "startIndex": 3,
-            "endIndex": 4
+            "endIndex": 10
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -18874,7 +18929,34 @@
             },
             {
               "kind": "Content",
-              "text": "any"
+              "text": "boolean | import(\"react/jsx-runtime\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "JSX.Element",
+              "canonicalReference": "@types/react!JSX.Element:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "Iterable",
+              "canonicalReference": "!Iterable:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": "> | null | number | string | undefined"
             },
             {
               "kind": "Content",
@@ -18884,7 +18966,7 @@
           "fileUrlPath": "packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx",
           "returnTypeTokenRange": {
             "startIndex": 8,
-            "endIndex": 9
+            "endIndex": 15
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -19474,19 +19556,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ActionsMenu/DefaultActionsMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiActionsMenuProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -19592,7 +19683,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -19604,7 +19704,7 @@
           "name": "TLUiButtonLabelProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20000,7 +20100,16 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    children: any;\n}"
+              "text": ";\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20012,7 +20121,7 @@
           "name": "TLUiComponentsProviderProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 4
+            "endIndex": 6
           }
         },
         {
@@ -20025,7 +20134,7 @@
               "text": "export interface TLUiContextMenuProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ContextMenu/DefaultContextMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiContextMenuProps",
           "preserveMemberOrder": false,
@@ -20040,15 +20149,15 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx",
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
@@ -20072,7 +20181,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20084,7 +20202,7 @@
           "name": "TLUiDebugMenuProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20211,7 +20329,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    className?: string;\n    children: any;\n    style?: "
+              "text": "{\n    className?: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    style?: "
             },
             {
               "kind": "Reference",
@@ -20232,7 +20359,7 @@
           "name": "TLUiDialogBodyProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 4
+            "endIndex": 6
           }
         },
         {
@@ -20246,7 +20373,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    className?: string;\n    children: any;\n}"
+              "text": "{\n    className?: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20258,7 +20394,7 @@
           "name": "TLUiDialogFooterProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20272,19 +20408,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    className?: string;\n    children: any;\n}"
+              "text": "{\n    className?: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/primitives/TldrawUiDialog.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx",
           "releaseTag": "Public",
           "name": "TLUiDialogHeaderProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20414,7 +20559,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    className?: string;\n    children: any;\n}"
+              "text": "{\n    className?: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20426,7 +20580,7 @@
           "name": "TLUiDialogTitleProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20481,8 +20635,9 @@
                   "text": "children: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -20602,7 +20757,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    id?: string;\n    children: any;\n    alignOffset?: number;\n    sideOffset?: number;\n    align?: 'center' | 'end' | 'start';\n    side?: 'bottom' | 'left' | 'right' | 'top';\n}"
+              "text": "{\n    id?: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    alignOffset?: number;\n    sideOffset?: number;\n    align?: 'center' | 'end' | 'start';\n    side?: 'bottom' | 'left' | 'right' | 'top';\n}"
             },
             {
               "kind": "Content",
@@ -20614,7 +20778,7 @@
           "name": "TLUiDropdownMenuContentProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20628,7 +20792,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children: any;\n}"
+              "text": "{\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20640,7 +20813,7 @@
           "name": "TLUiDropdownMenuGroupProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20668,8 +20841,9 @@
                   "text": "children: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -20726,7 +20900,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    id: string;\n    children: any;\n    modal?: boolean;\n    debugOpen?: boolean;\n}"
+              "text": "{\n    id: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    modal?: boolean;\n    debugOpen?: boolean;\n}"
             },
             {
               "kind": "Content",
@@ -20738,7 +20921,7 @@
           "name": "TLUiDropdownMenuRootProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20752,7 +20935,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    id: string;\n    children: any;\n}"
+              "text": "{\n    id: string;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -20764,7 +20956,7 @@
           "name": "TLUiDropdownMenuSubProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -20818,8 +21010,9 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -22807,7 +23000,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -22819,7 +23021,7 @@
           "name": "TLUiHelperButtonsProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -22833,19 +23035,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/HelpMenu/DefaultHelpMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiHelpMenuProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -23179,8 +23390,9 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "React.ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
@@ -23695,7 +23907,16 @@
             },
             {
               "kind": "Content",
-              "text": " & {\n    children?: any;\n}"
+              "text": " & {\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -23707,7 +23928,7 @@
           "name": "TLUiKeyboardShortcutsDialogProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 3
+            "endIndex": 5
           }
         },
         {
@@ -23721,19 +23942,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/MainMenu/DefaultMainMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiMainMenuProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -23916,7 +24146,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    id: string;\n    label?: {\n        [key: string]: TranslationKey;\n    } | TranslationKey;\n    children?: any;\n}"
+              "text": "{\n    id: string;\n    label?: {\n        [key: string]: TranslationKey;\n    } | TranslationKey;\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -23941,7 +24180,7 @@
           ],
           "typeTokenRange": {
             "startIndex": 5,
-            "endIndex": 6
+            "endIndex": 8
           }
         },
         {
@@ -24071,7 +24310,16 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    id: string;\n    label?: {\n        [key: string]: Translation;\n    } | Translation;\n    disabled?: boolean;\n    children: any;\n    size?: 'medium' | 'small' | 'tiny' | 'wide';\n}"
+              "text": "{\n    id: string;\n    label?: {\n        [key: string]: Translation;\n    } | Translation;\n    disabled?: boolean;\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    size?: 'medium' | 'small' | 'tiny' | 'wide';\n}"
             },
             {
               "kind": "Content",
@@ -24096,7 +24344,7 @@
           ],
           "typeTokenRange": {
             "startIndex": 5,
-            "endIndex": 6
+            "endIndex": 8
           }
         },
         {
@@ -24347,19 +24595,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/QuickActions/DefaultQuickActions.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActions.tsx",
           "releaseTag": "Public",
           "name": "TLUiQuickActionsProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {
@@ -24416,7 +24673,7 @@
               "text": "export interface TLUiStylePanelProps "
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/StylePanel/DefaultStylePanel.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx",
           "releaseTag": "Public",
           "name": "TLUiStylePanelProps",
           "preserveMemberOrder": false,
@@ -24431,15 +24688,15 @@
                   "text": "children?: "
                 },
                 {
-                  "kind": "Content",
-                  "text": "any"
+                  "kind": "Reference",
+                  "text": "ReactNode",
+                  "canonicalReference": "@types/react!React.ReactNode:type"
                 },
                 {
                   "kind": "Content",
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx",
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
@@ -24467,7 +24724,6 @@
                   "text": ";"
                 }
               ],
-              "fileUrlPath": "packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx",
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
@@ -25297,7 +25553,16 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    children: any;\n}"
+              "text": ";\n    children: "
+            },
+            {
+              "kind": "Reference",
+              "text": "React.ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -25309,7 +25574,7 @@
           "name": "TLUiToolsProviderProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 8
+            "endIndex": 10
           }
         },
         {
@@ -25420,19 +25685,28 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    children?: any;\n}"
+              "text": "{\n    children?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ReactNode",
+              "canonicalReference": "@types/react!React.ReactNode:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
               "text": ";"
             }
           ],
-          "fileUrlPath": "packages/tldraw/.tsbuild-api/lib/ui/components/ZoomMenu/DefaultZoomMenu.d.ts",
+          "fileUrlPath": "packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx",
           "releaseTag": "Public",
           "name": "TLUiZoomMenuProps",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 4
           }
         },
         {

--- a/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
@@ -1,5 +1,5 @@
 import { useEditor, useValue } from '@tldraw/editor'
-import { memo } from 'react'
+import { ReactNode, memo } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useReadonly } from '../../hooks/useReadonly'
@@ -16,7 +16,7 @@ import { DefaultActionsMenuContent } from './DefaultActionsMenuContent'
 
 /** @public */
 export type TLUiActionsMenuProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
@@ -1,13 +1,13 @@
 import * as _ContextMenu from '@radix-ui/react-context-menu'
 import { preventDefault, useContainer, useEditor, useEditorComponents } from '@tldraw/editor'
-import { memo, useCallback } from 'react'
+import { ReactNode, memo, useCallback } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { DefaultContextMenuContent } from './DefaultContextMenuContent'
 
 /** @public */
 export interface TLUiContextMenuProps {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import {
@@ -10,7 +11,7 @@ import { DefaultDebugMenuContent } from './DefaultDebugMenuContent'
 
 /** @public */
 export type TLUiDebugMenuProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -169,6 +169,7 @@ export function DefaultDebugMenuContent() {
 				/>
 				{(() => {
 					if (error) throw Error('oh no!')
+					return null
 				})()}
 				<TldrawUiMenuItem id="throw-error" onSelect={() => setError(true)} label={'Throw error'} />
 				<TldrawUiMenuItem id="hard-reset" onSelect={hardResetEditor} label={'Hard reset'} />

--- a/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenu.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { ReactNode, memo } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -14,7 +14,7 @@ import { DefaultHelpMenuContent } from './DefaultHelpMenuContent'
 
 /** @public */
 export type TLUiHelpMenuProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/HelperButtons/DefaultHelperButtons.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/DefaultHelperButtons.tsx
@@ -1,9 +1,10 @@
+import { ReactNode } from 'react'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { DefaultHelperButtonsContent } from './DefaultHelperButtonsContent'
 
 /** @public */
 export type TLUiHelperButtonsProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialog.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { memo } from 'react'
+import { ReactNode, memo } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { TLUiDialogProps } from '../../context/dialogs'
@@ -15,7 +15,7 @@ import { DefaultKeyboardShortcutsDialogContent } from './DefaultKeyboardShortcut
 
 /** @public */
 export type TLUiKeyboardShortcutsDialogProps = TLUiDialogProps & {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
@@ -1,6 +1,6 @@
 import * as _Dropdown from '@radix-ui/react-dropdown-menu'
 import { useContainer } from '@tldraw/editor'
-import { memo } from 'react'
+import { ReactNode, memo } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
@@ -10,7 +10,7 @@ import { DefaultMainMenuContent } from './DefaultMainMenuContent'
 
 /** @public */
 export type TLUiMainMenuProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActions.tsx
+++ b/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActions.tsx
@@ -1,10 +1,10 @@
-import { memo } from 'react'
+import { ReactNode, memo } from 'react'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { DefaultQuickActionsContent } from './DefaultQuickActionsContent'
 
 /** @public */
 export type TLUiQuickActionsProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
@@ -1,13 +1,13 @@
 import { useEditor } from '@tldraw/editor'
 import classNames from 'classnames'
-import { memo, useCallback } from 'react'
+import { ReactNode, memo, useCallback } from 'react'
 import { useRelevantStyles } from '../../hooks/useRelevantStyles'
 import { DefaultStylePanelContent } from './DefaultStylePanelContent'
 
 /** @public */
 export interface TLUiStylePanelProps {
 	isMobile?: boolean
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
@@ -1,6 +1,6 @@
 import * as _Dropdown from '@radix-ui/react-dropdown-menu'
 import { ANIMATION_MEDIUM_MS, useContainer, useEditor, useValue } from '@tldraw/editor'
-import { forwardRef, memo, useCallback } from 'react'
+import { ReactNode, forwardRef, memo, useCallback } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
@@ -11,7 +11,7 @@ import { DefaultZoomMenuContent } from './DefaultZoomMenuContent'
 
 /** @public */
 export type TLUiZoomMenuProps = {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonLabel.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonLabel.tsx
@@ -1,5 +1,7 @@
+import { ReactNode } from 'react'
+
 /** @public */
-export type TLUiButtonLabelProps = { children?: any }
+export type TLUiButtonLabelProps = { children?: ReactNode }
 
 /** @public */
 export function TldrawUiButtonLabel({ children }: TLUiButtonLabelProps) {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
@@ -1,12 +1,13 @@
 import * as _Dialog from '@radix-ui/react-dialog'
 import classNames from 'classnames'
+import { ReactNode } from 'react'
 import { TldrawUiButton } from './Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from './Button/TldrawUiButtonIcon'
 
 /** @public */
 export type TLUiDialogHeaderProps = {
 	className?: string
-	children: any
+	children: ReactNode
 }
 
 /** @public */
@@ -17,7 +18,7 @@ export function TldrawUiDialogHeader({ className, children }: TLUiDialogHeaderPr
 /** @public */
 export type TLUiDialogTitleProps = {
 	className?: string
-	children: any
+	children: ReactNode
 }
 
 /** @public */
@@ -49,7 +50,7 @@ export function TldrawUiDialogCloseButton() {
 /** @public */
 export type TLUiDialogBodyProps = {
 	className?: string
-	children: any
+	children: ReactNode
 	style?: React.CSSProperties
 }
 
@@ -65,7 +66,7 @@ export function TldrawUiDialogBody({ className, children, style }: TLUiDialogBod
 /** @public */
 export type TLUiDialogFooterProps = {
 	className?: string
-	children: any
+	children: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import * as _DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { preventDefault, useContainer } from '@tldraw/editor'
+import { ReactNode } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { TldrawUiButton } from './Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from './Button/TldrawUiButtonIcon'
@@ -9,7 +10,7 @@ import { TldrawUiIcon } from './TldrawUiIcon'
 /** @public */
 export type TLUiDropdownMenuRootProps = {
 	id: string
-	children: any
+	children: ReactNode
 	modal?: boolean
 	debugOpen?: boolean
 }
@@ -37,7 +38,7 @@ export function TldrawUiDropdownMenuRoot({
 
 /** @public */
 export interface TLUiDropdownMenuTriggerProps {
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */
@@ -58,7 +59,7 @@ export function TldrawUiDropdownMenuTrigger({ children, ...rest }: TLUiDropdownM
 /** @public */
 export type TLUiDropdownMenuContentProps = {
 	id?: string
-	children: any
+	children: ReactNode
 	alignOffset?: number
 	sideOffset?: number
 	align?: 'start' | 'center' | 'end'
@@ -92,7 +93,7 @@ export function TldrawUiDropdownMenuContent({
 }
 
 /** @public */
-export type TLUiDropdownMenuSubProps = { id: string; children: any }
+export type TLUiDropdownMenuSubProps = { id: string; children: ReactNode }
 
 /** @public */
 export function TldrawUiDropdownMenuSub({ id, children }: TLUiDropdownMenuSubProps) {
@@ -142,7 +143,7 @@ export type TLUiDropdownMenuSubContentProps = {
 	alignOffset?: number
 	sideOffset?: number
 	size?: 'tiny' | 'small' | 'medium' | 'wide'
-	children: any
+	children: ReactNode
 }
 
 /** @public */
@@ -172,7 +173,7 @@ export function TldrawUiDropdownMenuSubContent({
 
 /** @public */
 export type TLUiDropdownMenuGroupProps = {
-	children: any
+	children: ReactNode
 }
 
 /** @public */
@@ -196,7 +197,7 @@ export function TldrawUiDropdownMenuIndicator() {
 /** @public */
 export interface TLUiDropdownMenuItemProps {
 	noClose?: boolean
-	children: any
+	children: ReactNode
 }
 
 /** @public */
@@ -214,7 +215,7 @@ export interface TLUiDropdownMenuCheckboxItemProps {
 	onSelect?: (e: Event) => void
 	disabled?: boolean
 	title: string
-	children: any
+	children: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
@@ -14,7 +14,7 @@ export interface TLUiInputProps {
 	iconLeft?: TLUiIconType | Exclude<string, TLUiIconType>
 	autofocus?: boolean
 	autoselect?: boolean
-	children?: any
+	children?: React.ReactNode
 	defaultValue?: string
 	placeholder?: string
 	onComplete?: (value: string) => void

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
@@ -1,4 +1,5 @@
 import { ContextMenuGroup } from '@radix-ui/react-context-menu'
+import { ReactNode } from 'react'
 import { unwrapLabel } from '../../../context/actions'
 import { TLUiTranslationKey } from '../../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../../hooks/useTranslation/useTranslation'
@@ -12,7 +13,7 @@ export type TLUiMenuGroupProps<TranslationKey extends string = string> = {
 	 * The label to display on the item. If it's a string, it will be translated. If it's an object, the keys will be used as the language keys and the values will be translated.
 	 */
 	label?: TranslationKey | { [key: string]: TranslationKey }
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
@@ -5,6 +5,7 @@ import {
 	ContextMenuSubTrigger,
 } from '@radix-ui/react-context-menu'
 import { useContainer } from '@tldraw/editor'
+import { ReactNode } from 'react'
 import { useMenuIsOpen } from '../../../hooks/useMenuIsOpen'
 import { TLUiTranslationKey } from '../../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../../hooks/useTranslation/useTranslation'
@@ -23,7 +24,7 @@ export type TLUiMenuSubmenuProps<Translation extends string = string> = {
 	id: string
 	label?: Translation | { [key: string]: Translation }
 	disabled?: boolean
-	children: any
+	children: ReactNode
 	size?: 'tiny' | 'small' | 'medium' | 'wide'
 }
 
@@ -102,7 +103,7 @@ export function TldrawUiMenuSubmenu<Translation extends string = string>({
 }
 
 /** @private */
-export type TLUiContextMenuSubProps = { id: string; children: any }
+export type TLUiContextMenuSubProps = { id: string; children: ReactNode }
 
 /** @private */
 export function ContextMenuSubWithMenu({ id, children }: TLUiContextMenuSubProps) {

--- a/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
+++ b/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
@@ -1,4 +1,5 @@
 import { RecursivePartial } from '@tldraw/editor'
+import { ReactNode } from 'react'
 import { TLUiAssetUrls, useDefaultUiAssetUrlsWithOverrides } from '../assetUrls'
 import { ToolbarSchemaProvider } from '../hooks/useToolbarSchema'
 import { ToolsProvider } from '../hooks/useTools'
@@ -46,7 +47,7 @@ export interface TldrawUiContextProviderProps {
 	/**
 	 * The component's children.
 	 */
-	children?: any
+	children?: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -63,7 +63,7 @@ export type ActionsProviderProps = {
 		actions: TLUiActionsContextType,
 		helpers: undefined
 	) => TLUiActionsContextType
-	children: any
+	children: React.ReactNode
 }
 
 function makeActions(actions: TLUiActionItem[]) {

--- a/packages/tldraw/src/lib/ui/context/breakpoints.tsx
+++ b/packages/tldraw/src/lib/ui/context/breakpoints.tsx
@@ -1,5 +1,5 @@
 import { useEditor, useValue } from '@tldraw/editor'
-import React, { useContext } from 'react'
+import React, { ReactNode, useContext } from 'react'
 import { PORTRAIT_BREAKPOINT, PORTRAIT_BREAKPOINTS } from '../constants'
 
 const BreakpointContext = React.createContext(0)
@@ -10,7 +10,7 @@ export function BreakPointProvider({
 	children,
 }: {
 	forceMobile?: boolean
-	children: any
+	children: ReactNode
 }) {
 	const editor = useEditor()
 

--- a/packages/tldraw/src/lib/ui/context/components.tsx
+++ b/packages/tldraw/src/lib/ui/context/components.tsx
@@ -1,5 +1,5 @@
 import { useShallowObjectIdentity } from '@tldraw/editor'
-import { ComponentType, createContext, useContext, useMemo } from 'react'
+import { ComponentType, ReactNode, createContext, useContext, useMemo } from 'react'
 import {
 	DefaultActionsMenu,
 	TLUiActionsMenuProps,
@@ -61,7 +61,7 @@ const TldrawUiComponentsContext = createContext({} as TLUiComponents)
 /** @public */
 export type TLUiComponentsProviderProps = {
 	overrides?: TLUiComponents
-	children: any
+	children: ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/context/dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/context/dialogs.tsx
@@ -1,5 +1,5 @@
 import { Editor, uniqueId, useEditor } from '@tldraw/editor'
-import { ComponentType, createContext, useCallback, useContext, useState } from 'react'
+import { ComponentType, ReactNode, createContext, useCallback, useContext, useState } from 'react'
 import { useUiEvents } from './events'
 
 /** @public */
@@ -29,7 +29,7 @@ export const DialogsContext = createContext({} as TLUiDialogsContextType)
 /** @internal */
 export type DialogsProviderProps = {
 	overrides?: (editor: Editor) => TLUiDialogsContextType
-	children: any
+	children: ReactNode
 }
 
 /** @internal */

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -120,7 +120,7 @@ export const EventsContext = React.createContext<TLUiEventContextType>({} as TLU
 /** @public */
 export type EventsProviderProps = {
 	onEvent?: TLUiEventHandler
-	children: any
+	children: React.ReactNode
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/context/toasts.tsx
+++ b/packages/tldraw/src/lib/ui/context/toasts.tsx
@@ -1,5 +1,5 @@
 import { Editor, uniqueId } from '@tldraw/editor'
-import { createContext, useCallback, useContext, useState } from 'react'
+import { ReactNode, createContext, useCallback, useContext, useState } from 'react'
 import { TLUiIconType } from '../icon-types'
 
 /** @public */
@@ -34,7 +34,7 @@ export const ToastsContext = createContext({} as TLUiToastsContextType)
 /** @internal */
 export type ToastsProviderProps = {
 	overrides?: (editor: Editor) => TLUiToastsContextType
-	children: any
+	children: ReactNode
 }
 
 /** @internal */

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -37,7 +37,7 @@ export type TLUiToolsProviderProps = {
 		tools: TLUiToolsContextType,
 		helpers: { insertMedia: () => void }
 	) => TLUiToolsContextType
-	children: any
+	children: React.ReactNode
 }
 
 /** @internal */

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -7,7 +7,7 @@ import { TLUiTranslation, fetchTranslation } from './translations'
 
 /** @public */
 export interface TLUiTranslationProviderProps {
-	children: any
+	children: React.ReactNode
 	/**
 	 * A collection of overrides different locales.
 	 *


### PR DESCRIPTION
We use `children: any` in a bunch of places, but the proper type for these is `ReactNode`. This diff fixes those.

### Change Type

- [x] `patch` — Bug fix

