### PR TITLE
Fix examples / JSON protection

### DIFF
--- a/apps/dotcom/src/utils/userPreferences.ts
+++ b/apps/dotcom/src/utils/userPreferences.ts
@@ -47,5 +47,5 @@ function loadItemFromStorage<Type>(key: string, validator: T.Validator<Type>): T
 }
 
 function saveItemToStorage(key: string, value: unknown): void {
-	setInLocalStorage(`tldrawUserPreferences.${key}`, JSON.stringify(value))
+	setInLocalStorage(`tldrawUserPreferences.${key}`, value)
 }

--- a/apps/dotcom/src/utils/userPreferences.ts
+++ b/apps/dotcom/src/utils/userPreferences.ts
@@ -40,7 +40,7 @@ function loadItemFromStorage<Type>(key: string, validator: T.Validator<Type>): T
 	const item = getFromLocalStorage(`tldrawUserPreferences.${key}`, null)
 	if (item == null) return null
 	try {
-		return validator.validate(JSON.parse(item))
+		return validator.validate(item)
 	} catch (e) {
 		return null
 	}

--- a/apps/examples/src/examples/local-storage/LocalStorageExample.tsx
+++ b/apps/examples/src/examples/local-storage/LocalStorageExample.tsx
@@ -45,7 +45,7 @@ export default function PersistenceExample() {
 		const cleanupFn = store.listen(
 			throttle(() => {
 				const snapshot = store.getSnapshot()
-				setInLocalStorage(PERSISTENCE_KEY, JSON.stringify(snapshot))
+				setInLocalStorage(PERSISTENCE_KEY, snapshot)
 			}, 500)
 		)
 

--- a/apps/examples/src/examples/local-storage/LocalStorageExample.tsx
+++ b/apps/examples/src/examples/local-storage/LocalStorageExample.tsx
@@ -31,7 +31,7 @@ export default function PersistenceExample() {
 
 		if (persistedSnapshot) {
 			try {
-				const snapshot = JSON.parse(persistedSnapshot)
+				const snapshot = persistedSnapshot
 				store.loadSnapshot(snapshot)
 				setLoadingState({ status: 'ready' })
 			} catch (error: any) {

--- a/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
+++ b/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
@@ -58,7 +58,7 @@ function iOS() {
  * @public
  */
 export const TAB_ID: string = window
-	? window[tabIdKey] ?? getFromSessionStorage(tabIdKey) ?? `TLDRAW_INSTANCE_STATE_V1_` + uniqueId()
+	? window[tabIdKey] ?? getFromSessionStorage(tabIdKey, `TLDRAW_INSTANCE_STATE_V1_` + uniqueId())
 	: '<error>'
 if (window) {
 	window[tabIdKey] = TAB_ID

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -204,8 +204,7 @@ function loadUserPreferences(): TLUserPreferences {
 	const userData =
 		typeof window === 'undefined'
 			? null
-			: ((JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null') ??
-					null) as null | UserDataSnapshot)
+			: (getFromLocalStorage(USER_DATA_KEY, null) as null | UserDataSnapshot)
 
 	return migrateUserPreferences(userData)
 }

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -201,10 +201,7 @@ function migrateUserPreferences(userData: unknown) {
 }
 
 function loadUserPreferences(): TLUserPreferences {
-	const userData =
-		typeof window === 'undefined'
-			? null
-			: (getFromLocalStorage(USER_DATA_KEY, null) as null | UserDataSnapshot)
+	const userData = getFromLocalStorage(USER_DATA_KEY, null) as null | UserDataSnapshot
 
 	return migrateUserPreferences(userData)
 }

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -131,7 +131,7 @@ function createDebugValueBase<T>(def: DebugFlagDef<T>): DebugFlag<T> {
 					if (currentValue === defaultValue) {
 						deleteFromSessionStorage(`tldraw_debug:${def.name}`)
 					} else {
-						setInSessionStorage(`tldraw_debug:${def.name}`, JSON.stringify(currentValue))
+						setInSessionStorage(`tldraw_debug:${def.name}`, currentValue)
 					}
 				} catch {
 					// not a big deal

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -155,7 +155,7 @@ function createDebugValueBase<T>(def: DebugFlagDef<T>): DebugFlag<T> {
 
 function getStoredInitialValue(name: string) {
 	try {
-		return JSON.parse(getFromSessionStorage(`tldraw_debug:${name}`) ?? 'null')
+		return getFromSessionStorage(`tldraw_debug:${name}`, null)
 	} catch (err) {
 		return null
 	}

--- a/packages/editor/src/lib/utils/sync/indexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/indexedDb.ts
@@ -222,7 +222,7 @@ async function pruneSessionState({
 
 /** @internal */
 export function getAllIndexDbNames(): string[] {
-	const result = JSON.parse(getFromLocalStorage(dbNameIndexKey) || '[]') ?? []
+	const result = getFromLocalStorage(dbNameIndexKey, [])
 	if (!Array.isArray(result)) {
 		return []
 	}

--- a/packages/editor/src/lib/utils/sync/indexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/indexedDb.ts
@@ -232,5 +232,5 @@ export function getAllIndexDbNames(): string[] {
 function addDbName(name: string) {
 	const all = new Set(getAllIndexDbNames())
 	all.add(name)
-	setInLocalStorage(dbNameIndexKey, JSON.stringify([...all]))
+	setInLocalStorage(dbNameIndexKey, [...all])
 }

--- a/packages/tldraw/src/lib/ui/hooks/useLocalStorageState.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useLocalStorageState.ts
@@ -9,7 +9,7 @@ export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
 		const value = getFromLocalStorage(key)
 		if (value) {
 			try {
-				setState(JSON.parse(value))
+				setState(value)
 			} catch (e) {
 				console.error(`Could not restore value ${key} from local storage.`)
 			}
@@ -20,7 +20,7 @@ export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
 		(setter: T | ((value: T) => T)) => {
 			setState((s) => {
 				const value = typeof setter === 'function' ? (setter as any)(s) : setter
-				setInLocalStorage(key, JSON.stringify(value))
+				setInLocalStorage(key, value)
 				return value
 			})
 		},

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -81,10 +81,10 @@ export function getErrorAnnotations(error: Error): ErrorAnnotations;
 export function getFirstFromIterable<T = unknown>(set: Map<any, T> | Set<T>): T;
 
 // @public
-export function getFromLocalStorage(key: string, defaultValue?: null): any;
+export function getFromLocalStorage(key: string, defaultValue?: any): any;
 
 // @public
-export function getFromSessionStorage(key: string, defaultValue?: null): any;
+export function getFromSessionStorage(key: string, defaultValue?: any): any;
 
 // @public
 export function getHashForBuffer(buffer: ArrayBuffer): string;

--- a/packages/utils/api/api.json
+++ b/packages/utils/api/api.json
@@ -819,7 +819,7 @@
             },
             {
               "kind": "Content",
-              "text": "null"
+              "text": "any"
             },
             {
               "kind": "Content",
@@ -880,7 +880,7 @@
             },
             {
               "kind": "Content",
-              "text": "null"
+              "text": "any"
             },
             {
               "kind": "Content",

--- a/packages/utils/src/lib/local-storage.ts
+++ b/packages/utils/src/lib/local-storage.ts
@@ -8,7 +8,7 @@
  *
  * @public
  */
-export function getFromLocalStorage(key: string, defaultValue = null) {
+export function getFromLocalStorage(key: string, defaultValue: any = null) {
 	try {
 		const value = localStorage.getItem(key)
 		if (value === null) return defaultValue

--- a/packages/utils/src/lib/session-storage.ts
+++ b/packages/utils/src/lib/session-storage.ts
@@ -8,7 +8,7 @@
  *
  * @public
  */
-export function getFromSessionStorage(key: string, defaultValue = null) {
+export function getFromSessionStorage(key: string, defaultValue: any = null) {
 	try {
 		const value = sessionStorage.getItem(key)
 		if (value === null) return defaultValue


### PR DESCRIPTION
We added some helpers for local storage / session storage that broke the app in secret quiet ways.

Previously, we used `localStorage.getItem` and `localStorage.setItem`, which both work with strings.

However, our helpers accept regular values and also parse / stringify them.

As a result, we were running `JSON.parse` on the results from our helpers (`getFromLocalStorage`), which was causing a crash.

### Change Type

- [x] `patch` — Bug fix

### Test Plan

- [x] Unit Tests
