### PR TITLE
Fix validation errors for `duplicateProps`

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -213,17 +213,19 @@ export class Translating extends StateNode {
 	protected handleEnd() {
 		const { movingShapes } = this.snapshot
 
-		if (this.isCloning) {
+		if (this.isCloning && movingShapes.length > 0) {
 			const currentAveragePagePoint = Vec.Average(
 				movingShapes.map((s) => this.editor.getShapePageTransform(s.id)!.point())
 			)
 			const offset = Vec.Sub(currentAveragePagePoint, this.selectionSnapshot.averagePagePoint)
-			this.editor.updateInstanceState({
-				duplicateProps: {
-					shapeIds: movingShapes.map((s) => s.id),
-					offset: { x: offset.x, y: offset.y },
-				},
-			})
+			if (!Vec.IsNaN(offset)) {
+				this.editor.updateInstanceState({
+					duplicateProps: {
+						shapeIds: movingShapes.map((s) => s.id),
+						offset: { x: offset.x, y: offset.y },
+					},
+				})
+			}
 		}
 
 		const changes: TLShapePartial[] = []
@@ -338,7 +340,7 @@ function getTranslatingSnapshot(editor: Editor) {
 	}
 
 	return {
-		averagePagePoint: Vec.Average(pagePoints),
+		averagePagePoint: pagePoints.length ? Vec.Average(pagePoints) : new Vec(0, 0),
 		movingShapes,
 		shapeSnapshots,
 		initialPageBounds: editor.getSelectionPageBounds()!,


### PR DESCRIPTION
Should fix `At instance.duplicateProps.offset.x: Expected a number, got NaN` validation errors.

Wasn't able to reproduce. We only assign the offset here, so `Vec.Averge` is the most likely offender here and for that to happen I guess `movingShapes` might not contain any shapes.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
