### PR TITLE
docs: fix typo in shape-with-tldraw-styles example

### DIFF
--- a/apps/examples/src/examples/shape-with-tldraw-styles/README.md
+++ b/apps/examples/src/examples/shape-with-tldraw-styles/README.md
@@ -9,7 +9,7 @@ Using the tldraw style panel with your custom shapes
 
 ---
 
-The default tldraw UI will displaye UI for the styles of your selection or your current tool. For example, when you have two shapes selected that both have the tldraw's "size" style, the size selector will be displayed. If all of your selected shapes have the same value for this style, that value will be shown as selected in the panel. If they have different values, the panel will show the value as "mixed".
+The default tldraw UI will display UI for the styles of your selection or your current tool. For example, when you have two shapes selected that both have the tldraw's "size" style, the size selector will be displayed. If all of your selected shapes have the same value for this style, that value will be shown as selected in the panel. If they have different values, the panel will show the value as "mixed".
 
 You can use tldraw's Styles API to create your own styles that behave in the same way, though you'll also need to create a custom UI for your style.
 


### PR DESCRIPTION
Fixes a typo in the README for the shape-with-tldraw-styles example.

### Change type

- [x] `other`

### Test plan

1. Look at the revised documentation

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a typo in the shape-with-tldraw-styles example documentation.