### PR TITLE
Add tests for Vec.Average

### DIFF
--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -375,3 +375,14 @@ describe('Vec.snapToGrid', () => {
 		expect(Vec.SnapToGrid(new Vec(12, 49), 10)).toMatchObject(new Vec(10, 50))
 	})
 })
+
+describe('Vec.Average', () => {
+	it('correctly calcuates the average of an array of vectors', () => {
+		const vecs = [new Vec(2, 4), new Vec(8, 16)]
+		expect(Vec.Average(vecs)).toMatchObject(new Vec(5, 10))
+	})
+
+	it('returns a 0,0 vector when passing any empty array', () => {
+		expect(Vec.Average([])).toMatchObject(new Vec(0, 0))
+	})
+})

--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -377,12 +377,12 @@ describe('Vec.snapToGrid', () => {
 })
 
 describe('Vec.Average', () => {
-	it('correctly calcuates the average of an array of vectors', () => {
+	it('correctly calculates the average of an array of vectors', () => {
 		const vecs = [new Vec(2, 4), new Vec(8, 16)]
 		expect(Vec.Average(vecs)).toMatchObject(new Vec(5, 10))
 	})
 
-	it('returns a 0,0 vector when passing any empty array', () => {
+	it('returns a (0,0) vector when passing any empty array', () => {
 		expect(Vec.Average([])).toMatchObject(new Vec(0, 0))
 	})
 })


### PR DESCRIPTION
Adds tests for the Vec.Average. [My previous PR](https://github.com/tldraw/tldraw/pull/3065) added a check that prevented returning vectors with NaNs, this adds a test for that.

### Change Type

- [ ] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [x] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version


