### PR TITLE
Fix viewport params for pages.

### DIFF
--- a/apps/dotcom/src/hooks/useUrlState.ts
+++ b/apps/dotcom/src/hooks/useUrlState.ts
@@ -50,6 +50,17 @@ export function useUrlState(onChangeUrl: (params: UrlStateParams) => void) {
 
 		const url = new URL(location.href)
 
+		// We need to check the page first so that any changes to the camera will be applied to the correct page.
+		if (url.searchParams.has(PARAMS.page) || url.searchParams.has(PARAMS.p)) {
+			const newPageId =
+				url.searchParams.get(PARAMS.page) ?? 'page:' + url.searchParams.get(PARAMS.p)
+			if (newPageId) {
+				if (editor.store.has(newPageId as TLPageId)) {
+					editor.setCurrentPage(newPageId as TLPageId)
+				}
+			}
+		}
+
 		if (url.searchParams.has(PARAMS.viewport) || url.searchParams.has(PARAMS.v)) {
 			const newViewportRaw = url.searchParams.get(PARAMS.viewport) ?? url.searchParams.get(PARAMS.v)
 			if (newViewportRaw) {
@@ -67,15 +78,6 @@ export function useUrlState(onChangeUrl: (params: UrlStateParams) => void) {
 					})
 				} catch (err) {
 					console.error(err)
-				}
-			}
-		}
-		if (url.searchParams.has(PARAMS.page) || url.searchParams.has(PARAMS.p)) {
-			const newPageId =
-				url.searchParams.get(PARAMS.page) ?? 'page:' + url.searchParams.get(PARAMS.p)
-			if (newPageId) {
-				if (editor.store.has(newPageId as TLPageId)) {
-					editor.setCurrentPage(newPageId as TLPageId)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes an issue with the viewport url params only working on the first page. We first need to check the page params and possibly switch to the page referenced in the url. Only then can we look at viewport params, since those change the camera. Otherwise we might move the camera for the wrong page.

Related pr: https://github.com/tldraw/tldraw/pull/3041#issuecomment-1976662481

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Create a shared project.
2. Create a new page.
3. Move the camera around a bit so that the viewport params are not the default ones.
4. Refresh the page.
5. This should not change the camera position.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes an issue with url params in the share links. The viewport params only worked on the first page in the document.
