### PR TITLE
Allow blob src urls

### DIFF
--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -948,7 +948,7 @@ export const linkUrl = string.check((value) => {
 	}
 })
 
-const validSrcProtocols = new Set(['http:', 'https:', 'data:'])
+const validSrcProtocols = new Set(['http:', 'https:', 'data:', 'blob:'])
 
 /**
  * Validates that a valid is a url safe to load as an asset.


### PR DESCRIPTION
Allows blob URLs for image sources. This enables a workflow where you can immediately render an asset on paste using a temporary blob URL, then replace it with an uploaded one.

data URLs are already supported, but they can be quite large. Blob URLs are very short, which allows for using tldraw in cases where the overall data size needs t obe small.

### Change Type

- [ ] `patch` — Bug fix
- [x] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Enable blob URLs for image sources
