### PR TITLE
stickies: fixed aspect ratio; auto-grow as text grows

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -65,6 +65,7 @@ export class TextManager {
 			maxWidth: null | number
 			minWidth?: string
 			padding: string
+			aspectRatio?: string
 		}
 	): BoxModel => {
 		// Duplicate our base element; we don't need to clone deep
@@ -80,6 +81,7 @@ export class TextManager {
 		elm.style.setProperty('max-width', opts.maxWidth === null ? null : opts.maxWidth + 'px')
 		elm.style.setProperty('min-width', opts.minWidth ?? null)
 		elm.style.setProperty('padding', opts.padding)
+		elm.style.setProperty('aspect-ratio', opts.aspectRatio ?? null)
 
 		elm.textContent = normalizeTextForDom(textToMeasure)
 		const rect = elm.getBoundingClientRect()

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1032,7 +1032,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getGeometry(shape: TLNoteShape): Rectangle2d;
     // (undocumented)
-    getHeight(shape: TLNoteShape): number;
+    getSize(shape: TLNoteShape): number;
     // (undocumented)
     hideResizeHandles: () => boolean;
     // (undocumented)
@@ -1045,6 +1045,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onBeforeCreate: (next: TLNoteShape) => {
         props: {
             growY: number;
+            w: number | undefined;
+            h: number | undefined;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
@@ -1069,6 +1071,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onBeforeUpdate: (prev: TLNoteShape, next: TLNoteShape) => {
         props: {
             growY: number;
+            w: number | undefined;
+            h: number | undefined;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
@@ -1093,10 +1097,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
     static props: {
+        w: Validator<number | undefined>;
+        h: Validator<number | undefined>;
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
-        align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
+        align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">; /** @public */
         verticalAlign: EnumStyleProp<"end" | "middle" | "start">;
         growY: Validator<number>;
         url: Validator<string>;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12307,12 +12307,12 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "tldraw!NoteShapeUtil#getHeight:member(1)",
+              "canonicalReference": "tldraw!NoteShapeUtil#getSize:member(1)",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "getHeight(shape: "
+                  "text": "getSize(shape: "
                 },
                 {
                   "kind": "Reference",
@@ -12352,7 +12352,7 @@
               ],
               "isOptional": false,
               "isAbstract": false,
-              "name": "getHeight"
+              "name": "getSize"
             },
             {
               "kind": "Property",
@@ -12523,7 +12523,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            w: number | undefined;\n            h: number | undefined;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12607,7 +12607,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            w: number | undefined;\n            h: number | undefined;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12717,7 +12717,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n        color: import(\"@tldraw/editor\")."
+                  "text": "{\n        w: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number | undefined>;\n        h: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number | undefined>;\n        color: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12753,7 +12771,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\">;\n        verticalAlign: import(\"@tldraw/editor\")."
+                  "text": "<\"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\">; /** @public */\n        verticalAlign: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12802,7 +12820,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 22
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -699,6 +699,8 @@ export const noteShapeMigrations: Migrations;
 
 // @public (undocumented)
 export const noteShapeProps: {
+    w: T.Validator<number | undefined>;
+    h: T.Validator<number | undefined>;
     color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2882,7 +2882,25 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    color: import(\"..\")."
+              "text": "{\n    w: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<number | undefined>;\n    h: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<number | undefined>;\n    color: import(\"..\")."
             },
             {
               "kind": "Reference",
@@ -2963,7 +2981,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 22
           }
         },
         {

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -12,6 +12,8 @@ import { ShapePropsType, TLBaseShape } from './TLBaseShape'
 
 /** @public */
 export const noteShapeProps = {
+	w: T.optional(T.nonZeroNumber),
+	h: T.optional(T.nonZeroNumber),
 	color: DefaultColorStyle,
 	size: DefaultSizeStyle,
 	font: DefaultFontStyle,


### PR DESCRIPTION
Breakout from https://github.com/tldraw/tldraw/pull/2953
Note: if we go this route, I need to add a migration before landing. I didn't add it yet.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Sticky notes: fixed aspect ratio; auto-grow as text grows.
