### PR TITLE
Stickies: additive cursor icon

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -64,6 +64,7 @@
 	/* These cursor values get programmatically overridden */
 	/* They're just here to help your editor autocomplete */
 	--tl-cursor: var(--tl-cursor-default);
+	--tl-cursor-copy: copy;
 	--tl-cursor-resize-edge: ew-resize;
 	--tl-cursor-resize-corner: nesw-resize;
 	--tl-cursor-ew-resize: ew-resize;

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -36,6 +36,7 @@ function getCursorCss(
 const STATIC_CURSORS = [
 	'default',
 	'pointer',
+	'copy',
 	'cross',
 	'move',
 	'grab',

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Idle.ts
@@ -8,7 +8,7 @@ export class Idle extends StateNode {
 	}
 
 	override onEnter = () => {
-		this.editor.setCursor({ type: 'cross', rotation: 0 })
+		this.editor.setCursor({ type: 'copy', rotation: 0 })
 	}
 
 	override onCancel = () => {

--- a/packages/tlschema/src/misc/TLCursor.ts
+++ b/packages/tlschema/src/misc/TLCursor.ts
@@ -9,6 +9,7 @@ export const TL_CURSOR_TYPES = new Set([
 	'none',
 	'default',
 	'pointer',
+	'copy',
 	'cross',
 	'grab',
 	'rotate',


### PR DESCRIPTION
Breakout from https://github.com/tldraw/tldraw/pull/2953

I could very easily see an argument that this should just be a custom icon. I'm not married to this particular icon. @steveruizok feel free to add one!

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Sticky note: update insertion mouse icon.
