### PR TITLE
stickies: limit options for alignment, font size

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -207,9 +207,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
-        type: "point";
         x: number;
         y: number;
+        type: "point";
         }>;
         }, never>;
         end: UnionValidator<"type", {
@@ -221,9 +221,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
-        type: "point";
         x: number;
         y: number;
+        type: "point";
         }>;
         }, never>;
         bend: Validator<number>;
@@ -985,9 +985,9 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         spline: EnumStyleProp<"cubic" | "line">;
         points: DictValidator<string, {
+        id: string;
         x: number;
         y: number;
-        id: string;
         index: IndexKey;
         }>;
     };

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -207,9 +207,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
+        type: "point";
         x: number;
         y: number;
-        type: "point";
         }>;
         }, never>;
         end: UnionValidator<"type", {
@@ -221,9 +221,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
+        type: "point";
         x: number;
         y: number;
-        type: "point";
         }>;
         }, never>;
         bend: Validator<number>;
@@ -985,9 +985,9 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         spline: EnumStyleProp<"cubic" | "line">;
         points: DictValidator<string, {
-        id: string;
         x: number;
         y: number;
+        id: string;
         index: IndexKey;
         }>;
     };
@@ -1046,10 +1046,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         props: {
             growY: number;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
-            size: "l" | "m" | "s" | "xl";
+            size: "s";
             font: "draw" | "mono" | "sans" | "serif";
-            align: "end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start";
-            verticalAlign: "end" | "middle" | "start";
+            align: "start";
+            verticalAlign: "start";
             url: string;
             text: string;
         };
@@ -1070,10 +1070,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         props: {
             growY: number;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
-            size: "l" | "m" | "s" | "xl";
+            size: "s";
             font: "draw" | "mono" | "sans" | "serif";
-            align: "end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start";
-            verticalAlign: "end" | "middle" | "start";
+            align: "start";
+            verticalAlign: "start";
             url: string;
             text: string;
         };
@@ -1094,10 +1094,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     static props: {
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
-        size: EnumStyleProp<"l" | "m" | "s" | "xl">;
+        size: Validator<"s">;
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
-        align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
-        verticalAlign: EnumStyleProp<"end" | "middle" | "start">;
+        align: Validator<"start">;
+        verticalAlign: Validator<"start">;
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -1520,7 +1520,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
+                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -1565,7 +1565,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
+                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -11659,7 +11659,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, {\n            id: string;\n            x: number;\n            y: number;\n            index: import(\"@tldraw/editor\")."
+                  "text": "<string, {\n            x: number;\n            y: number;\n            id: string;\n            index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12523,7 +12523,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"s\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"start\";\n            verticalAlign: \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12607,7 +12607,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"s\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"start\";\n            verticalAlign: \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12730,12 +12730,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "EnumStyleProp",
-                  "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n        font: import(\"@tldraw/editor\")."
+                  "text": "<\"s\">;\n        font: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12748,21 +12748,21 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "EnumStyleProp",
-                  "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\">;\n        verticalAlign: import(\"@tldraw/editor\")."
+                  "text": "<\"start\">;\n        verticalAlign: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
-                  "text": "EnumStyleProp",
-                  "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"end\" | \"middle\" | \"start\">;\n        growY: import(\"@tldraw/editor\")."
+                  "text": "<\"start\">;\n        growY: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -1520,7 +1520,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
+                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -1565,7 +1565,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
+                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -11659,7 +11659,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, {\n            x: number;\n            y: number;\n            id: string;\n            index: import(\"@tldraw/editor\")."
+                  "text": "<string, {\n            id: string;\n            x: number;\n            y: number;\n            index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -33,11 +33,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	getDefaultProps(): TLNoteShape['props'] {
 		return {
 			color: 'black',
-			size: 'm',
+			size: 's',
 			text: '',
 			font: 'draw',
-			align: 'middle',
-			verticalAlign: 'middle',
+			align: 'start',
+			verticalAlign: 'start',
 			growY: 0,
 			url: '',
 		}
@@ -56,7 +56,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const {
 			id,
 			type,
-			props: { color, font, size, align, text, verticalAlign },
+			props: { color, font, text },
 		} = shape
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -84,9 +84,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							id={id}
 							type={type}
 							font={font}
-							size={size}
-							align={align}
-							verticalAlign={verticalAlign}
+							size="s"
+							align="start"
+							verticalAlign="start"
 							text={text}
 							labelColor="black"
 							wrap
@@ -187,7 +187,7 @@ function getGrowY(editor: Editor, shape: TLNoteShape, prevGrowY = 0) {
 	const nextTextSize = editor.textMeasure.measureText(shape.props.text, {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[shape.props.font],
-		fontSize: LABEL_FONT_SIZES[shape.props.size],
+		fontSize: LABEL_FONT_SIZES[shape.props.size || 's'],
 		maxWidth: NOTE_SIZE - PADDING * 2,
 	})
 

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -190,9 +190,9 @@ export function buildFromV1Document(editor: Editor, document: LegacyTldrawDocume
 									props: {
 										text: v1Shape.text ?? '',
 										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
+										size: 's',
 										font: getV2Font(v1Shape.style.font),
-										align: getV2Align(v1Shape.style.textAlign),
+										align: 'start',
 									},
 								},
 							])

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -47,9 +47,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
-            type: "point";
             x: number;
             y: number;
+            type: "point";
         } & {}>;
     }, never>;
     end: T.UnionValidator<"type", {
@@ -61,9 +61,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
-            type: "point";
             x: number;
             y: number;
+            type: "point";
         } & {}>;
     }, never>;
     bend: T.Validator<number>;
@@ -684,9 +684,9 @@ export const lineShapeProps: {
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     spline: EnumStyleProp<"cubic" | "line">;
     points: T.DictValidator<string, {
+        id: string;
         x: number;
         y: number;
-        id: string;
         index: IndexKey;
     } & {}>;
 };

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -47,9 +47,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
+            type: "point";
             x: number;
             y: number;
-            type: "point";
         } & {}>;
     }, never>;
     end: T.UnionValidator<"type", {
@@ -61,9 +61,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
+            type: "point";
             x: number;
             y: number;
-            type: "point";
         } & {}>;
     }, never>;
     bend: T.Validator<number>;
@@ -684,9 +684,9 @@ export const lineShapeProps: {
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     spline: EnumStyleProp<"cubic" | "line">;
     points: T.DictValidator<string, {
-        id: string;
         x: number;
         y: number;
+        id: string;
         index: IndexKey;
     } & {}>;
 };
@@ -700,10 +700,10 @@ export const noteShapeMigrations: Migrations;
 // @public (undocumented)
 export const noteShapeProps: {
     color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
-    size: EnumStyleProp<"l" | "m" | "s" | "xl">;
+    size: T.Validator<"s">;
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
-    align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
-    verticalAlign: EnumStyleProp<"end" | "middle" | "start">;
+    align: T.Validator<"start">;
+    verticalAlign: T.Validator<"start">;
     growY: T.Validator<number>;
     url: T.Validator<string>;
     text: T.Validator<string>;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -364,7 +364,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    end: "
+              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    end: "
             },
             {
               "kind": "Reference",
@@ -409,7 +409,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    bend: "
+              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    bend: "
             },
             {
               "kind": "Reference",
@@ -2818,7 +2818,7 @@
             },
             {
               "kind": "Content",
-              "text": "<string, {\n        x: number;\n        y: number;\n        id: string;\n        index: "
+              "text": "<string, {\n        id: string;\n        x: number;\n        y: number;\n        index: "
             },
             {
               "kind": "Reference",

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -364,7 +364,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    end: "
+              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    end: "
             },
             {
               "kind": "Reference",
@@ -409,7 +409,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    bend: "
+              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    bend: "
             },
             {
               "kind": "Reference",
@@ -2818,7 +2818,7 @@
             },
             {
               "kind": "Content",
-              "text": "<string, {\n        id: string;\n        x: number;\n        y: number;\n        index: "
+              "text": "<string, {\n        x: number;\n        y: number;\n        id: string;\n        index: "
             },
             {
               "kind": "Reference",
@@ -2891,7 +2891,16 @@
             },
             {
               "kind": "Content",
-              "text": "<\"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\">;\n    size: import(\"..\")."
+              "text": "<\"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\">;\n    size: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<\"s\">;\n    font: import(\"..\")."
             },
             {
               "kind": "Reference",
@@ -2900,34 +2909,25 @@
             },
             {
               "kind": "Content",
-              "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n    font: import(\"..\")."
+              "text": "<\"draw\" | \"mono\" | \"sans\" | \"serif\">;\n    align: "
             },
             {
               "kind": "Reference",
-              "text": "EnumStyleProp",
-              "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
             },
             {
               "kind": "Content",
-              "text": "<\"draw\" | \"mono\" | \"sans\" | \"serif\">;\n    align: import(\"..\")."
+              "text": "<\"start\">;\n    verticalAlign: "
             },
             {
               "kind": "Reference",
-              "text": "EnumStyleProp",
-              "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
             },
             {
               "kind": "Content",
-              "text": "<\"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\">;\n    verticalAlign: import(\"..\")."
-            },
-            {
-              "kind": "Reference",
-              "text": "EnumStyleProp",
-              "canonicalReference": "@tldraw/tlschema!EnumStyleProp:class"
-            },
-            {
-              "kind": "Content",
-              "text": "<\"end\" | \"middle\" | \"start\">;\n    growY: "
+              "text": "<\"start\">;\n    growY: "
             },
             {
               "kind": "Reference",

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -2,21 +2,16 @@ import { defineMigrations } from '@tldraw/store'
 import { T } from '@tldraw/validate'
 import { DefaultColorStyle } from '../styles/TLColorStyle'
 import { DefaultFontStyle } from '../styles/TLFontStyle'
-import {
-	DefaultHorizontalAlignStyle,
-	TLDefaultHorizontalAlignStyle,
-} from '../styles/TLHorizontalAlignStyle'
-import { DefaultSizeStyle } from '../styles/TLSizeStyle'
-import { DefaultVerticalAlignStyle } from '../styles/TLVerticalAlignStyle'
+import { TLDefaultHorizontalAlignStyle } from '../styles/TLHorizontalAlignStyle'
 import { ShapePropsType, TLBaseShape } from './TLBaseShape'
 
 /** @public */
 export const noteShapeProps = {
 	color: DefaultColorStyle,
-	size: DefaultSizeStyle,
+	size: T.literal('s'),
 	font: DefaultFontStyle,
-	align: DefaultHorizontalAlignStyle,
-	verticalAlign: DefaultVerticalAlignStyle,
+	align: T.literal('start'),
+	verticalAlign: T.literal('start'),
 	growY: T.positiveNumber,
 	url: T.linkUrl,
 	text: T.string,


### PR DESCRIPTION
Breakout from https://github.com/tldraw/tldraw/pull/2953

Note: this would require a migration added to this PR before landing, I'll add that if we decide to move forward on this.

### Change Type

- [x] `patch` — Bug fix

### Release Notes

- Sticky note: limit alignment and font size options.
