### PR TITLE
Don't import package.json in scripts/refresh-assets.ts, just read it

### DIFF
--- a/scripts/refresh-assets.ts
+++ b/scripts/refresh-assets.ts
@@ -402,9 +402,9 @@ async function writeAssetDeclarationDTSFile() {
 }
 
 async function copyVersionToDotCom() {
-	const packageVersion = await import(join(REPO_ROOT, 'packages', 'tldraw', 'package.json')).then(
-		(pkg) => pkg.version
-	)
+	const packageJson = await readJsonIfExists(join(REPO_ROOT, 'packages', 'tldraw', 'package.json'))
+	const packageVersion = packageJson.version
+
 	const file = `export const version = '${packageVersion}'`
 	await writeCodeFile(
 		'scripts/refresh-assets.ts',


### PR DESCRIPTION
Per #3018, the `import` causes `scripts/refresh-assets.ts` to fail on Windows. This PR applies @SomeHats's suggestions cleanly on top of the current `main`. Thank you @cscxj for the original report!

Describe what your pull request does. If appropriate, add GIFs or images showing the before and after.

### Change Type

- [x] `internal` — Any other changes that don't affect the published package