### PR TITLE
Restore export menu content

### DIFF
--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -9,6 +9,7 @@ import {
 	DefaultMainMenu,
 	EditSubmenu,
 	Editor,
+	ExportFileContentSubMenu,
 	ExtrasGroup,
 	PreferencesGroup,
 	TLComponents,
@@ -49,6 +50,7 @@ const components: TLComponents = {
 			<LocalFileMenu />
 			<EditSubmenu />
 			<ViewSubmenu />
+			<ExportFileContentSubMenu />
 			<ExtrasGroup />
 			<PreferencesGroup />
 			<Links />

--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -9,6 +9,7 @@ import {
 	DefaultMainMenu,
 	EditSubmenu,
 	Editor,
+	ExportFileContentSubMenu,
 	ExtrasGroup,
 	OfflineIndicator,
 	PreferencesGroup,
@@ -69,6 +70,7 @@ const components: TLComponents = {
 			<MultiplayerFileMenu />
 			<EditSubmenu />
 			<ViewSubmenu />
+			<ExportFileContentSubMenu />
 			<ExtrasGroup />
 			<PreferencesGroup />
 			<Links />


### PR DESCRIPTION
This PR restores the export menu on dotcom.

Before:
<img width="545" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/7377c9ae-7644-4889-a01f-7e304fbc8c68">

After:
<img width="824" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/4f634d53-06ed-42a7-b8bb-f92e183ce5dd">


### Change Type

- [x] `internal` — Any other changes that don't affect the published package[^2]

### Test Plan

1. Check the menu on tldraw.com / readonly / shared room / snapshot
