### PR TITLE
Fix the issue with shape position getting out of sync.

### DIFF
--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -1,4 +1,4 @@
-import { track, useQuickReactor, useStateTracking } from '@tldraw/state'
+import { track, useReactor, useStateTracking } from '@tldraw/state'
 import { TLShape, TLShapeId } from '@tldraw/tlschema'
 import * as React from 'react'
 import { ShapeUtil } from '../editor/shapes/ShapeUtil'
@@ -49,7 +49,7 @@ export const Shape = track(function Shape({
 		backgroundContainerRef.current?.style.setProperty(property, value)
 	}, [])
 
-	useQuickReactor(
+	useReactor(
 		'set shape container transform position',
 		() => {
 			const shape = editor.getShape(id)
@@ -62,7 +62,7 @@ export const Shape = track(function Shape({
 		[editor, setProperty]
 	)
 
-	useQuickReactor(
+	useReactor(
 		'set shape container clip path',
 		() => {
 			const shape = editor.getShape(id)
@@ -74,7 +74,7 @@ export const Shape = track(function Shape({
 		[editor, setProperty]
 	)
 
-	useQuickReactor(
+	useReactor(
 		'set shape height and width',
 		() => {
 			const shape = editor.getShape(id)

--- a/packages/state/src/lib/react/useReactor.ts
+++ b/packages/state/src/lib/react/useReactor.ts
@@ -1,10 +1,11 @@
+import { throttleToNextFrame } from '@tldraw/utils'
 import { useEffect, useMemo } from 'react'
 import { EffectScheduler } from '../core'
 
 /** @public */
 export function useReactor(name: string, reactFn: () => void, deps: undefined | any[] = []) {
 	const scheduler = useMemo(
-		() => new EffectScheduler(name, reactFn, { scheduleEffect: (cb) => requestAnimationFrame(cb) }),
+		() => new EffectScheduler(name, reactFn, { scheduleEffect: (cb) => throttleToNextFrame(cb) }),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		deps
 	)

--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -12,7 +12,7 @@ import {
 	useComputed,
 	useEditor,
 	useIsDarkMode,
-	useQuickReactor,
+	useReactor,
 } from '@tldraw/editor'
 import * as React from 'react'
 import { MinimapManager } from './MinimapManager'
@@ -151,7 +151,7 @@ export function DefaultMinimap() {
 	)
 
 	// Update the minimap's dpr when the dpr changes
-	useQuickReactor(
+	useReactor(
 		'update when dpr changes',
 		() => {
 			const dpr = devicePixelRatio.get()
@@ -172,7 +172,7 @@ export function DefaultMinimap() {
 		[devicePixelRatio, minimap]
 	)
 
-	useQuickReactor(
+	useReactor(
 		'minimap render when pagebounds or collaborators changes',
 		() => {
 			const shapeIdsOnCurrentPage = editor.getCurrentPageShapeIds()


### PR DESCRIPTION
Fixes an issue where the perf updates PR caused the shape position to be out of sync. We now also throttle things in the `useReactor` and we switch to using that one instead of `useQuickReactor` in a couple of places.

### Change Type

- [x] `patch` — Bug fix
- [ ] `minor` — New feature
- [ ] `major` — Breaking change
- [ ] `dependencies` — Changes to package dependencies[^1]
- [ ] `documentation` — Changes to the documentation only[^2]
- [ ] `tests` — Changes to any test code only[^2]
- [ ] `internal` — Any other changes that don't affect the published package[^2]
- [ ] I don't know

[^1]: publishes a `patch` release, for devDependencies use `internal`
[^2]: will not publish a new version

### Test Plan

1. Create some shapes.
2. Resize them
3. It should not be janky. The effect is even more pronounced in multiplayer.

- [ ] Unit Tests
- [ ] End to end tests

