### PR TITLE
stickies: try out auto-sizing text instead of auto-sizing the shape

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -63,8 +63,9 @@ export class TextManager {
 			 * space are preserved.
 			 */
 			maxWidth: null | number
-			minWidth?: string
+			minWidth?: null | number
 			padding: string
+			aspectRatio?: string
 		}
 	): BoxModel => {
 		// Duplicate our base element; we don't need to clone deep
@@ -78,8 +79,9 @@ export class TextManager {
 		elm.style.setProperty('font-size', opts.fontSize + 'px')
 		elm.style.setProperty('line-height', opts.lineHeight * opts.fontSize + 'px')
 		elm.style.setProperty('max-width', opts.maxWidth === null ? null : opts.maxWidth + 'px')
-		elm.style.setProperty('min-width', opts.minWidth ?? null)
+		elm.style.setProperty('min-width', opts.minWidth === null ? null : opts.minWidth + 'px')
 		elm.style.setProperty('padding', opts.padding)
+		elm.style.setProperty('aspect-ratio', opts.aspectRatio ?? null)
 
 		elm.textContent = normalizeTextForDom(textToMeasure)
 		const rect = elm.getBoundingClientRect()

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1030,26 +1030,27 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getDefaultProps(): TLNoteShape['props'];
     // (undocumented)
-    getGeometry(shape: TLNoteShape): Rectangle2d;
+    getGeometry(): Rectangle2d;
     // (undocumented)
-    getHeight(shape: TLNoteShape): number;
+    getHeight(): number;
     // (undocumented)
     hideResizeHandles: () => boolean;
     // (undocumented)
     hideSelectionBoundsFg: () => boolean;
     // (undocumented)
-    indicator(shape: TLNoteShape): JSX_2.Element;
+    indicator(): JSX_2.Element;
     // (undocumented)
     static migrations: Migrations;
     // (undocumented)
     onBeforeCreate: (next: TLNoteShape) => {
         props: {
-            growY: number;
+            fontSize: number;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
             align: "end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start";
             verticalAlign: "end" | "middle" | "start";
+            growY: number;
             url: string;
             text: string;
         };
@@ -1064,16 +1065,17 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         meta: JsonObject;
         id: TLShapeId;
         typeName: "shape";
-    } | undefined;
+    };
     // (undocumented)
     onBeforeUpdate: (prev: TLNoteShape, next: TLNoteShape) => {
         props: {
-            growY: number;
+            fontSize: number;
             color: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow";
             size: "l" | "m" | "s" | "xl";
             font: "draw" | "mono" | "sans" | "serif";
             align: "end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start";
             verticalAlign: "end" | "middle" | "start";
+            growY: number;
             url: string;
             text: string;
         };
@@ -1095,6 +1097,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     static props: {
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
+        fontSize: Validator<number | undefined>;
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
         align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
         verticalAlign: EnumStyleProp<"end" | "middle" | "start">;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12282,16 +12282,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "getGeometry(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
+                  "text": "getGeometry(): "
                 },
                 {
                   "kind": "Reference",
@@ -12305,22 +12296,13 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
+                "startIndex": 1,
+                "endIndex": 2
               },
               "releaseTag": "Public",
               "isProtected": false,
               "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "shape",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
+              "parameters": [],
               "isOptional": false,
               "isAbstract": false,
               "name": "getGeometry"
@@ -12332,16 +12314,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "getHeight(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
+                  "text": "getHeight(): "
                 },
                 {
                   "kind": "Content",
@@ -12354,22 +12327,13 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
+                "startIndex": 1,
+                "endIndex": 2
               },
               "releaseTag": "Public",
               "isProtected": false,
               "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "shape",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
+              "parameters": [],
               "isOptional": false,
               "isAbstract": false,
               "name": "getHeight"
@@ -12441,16 +12405,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "indicator(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
+                  "text": "indicator(): "
                 },
                 {
                   "kind": "Content",
@@ -12468,22 +12423,13 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 5
+                "startIndex": 1,
+                "endIndex": 3
               },
               "releaseTag": "Public",
               "isProtected": false,
               "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "shape",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
+              "parameters": [],
               "isOptional": false,
               "isAbstract": false,
               "name": "indicator"
@@ -12543,7 +12489,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            fontSize: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            growY: number;\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12579,7 +12525,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        typeName: \"shape\";\n    } | undefined"
+                  "text": ";\n        typeName: \"shape\";\n    }"
                 },
                 {
                   "kind": "Content",
@@ -12627,7 +12573,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            fontSize: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            growY: number;\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12755,7 +12701,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n        font: import(\"@tldraw/editor\")."
+                  "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n        fontSize: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number | undefined>;\n        font: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12822,7 +12777,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 20
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -1094,7 +1094,7 @@ function getLabelSize(editor: Editor, shape: TLGeoShape) {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[shape.props.font],
 		fontSize: LABEL_FONT_SIZES[shape.props.size],
-		minWidth: minSize.w + 'px',
+		minWidth: minSize.w,
 		maxWidth: Math.max(
 			// Guard because a DOM nodes can't be less 0
 			0,

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -23,6 +23,7 @@ export const TextLabel = React.memo(function TextLabel<
 	type,
 	text,
 	size,
+	fontSize,
 	labelColor,
 	font,
 	align,
@@ -33,6 +34,7 @@ export const TextLabel = React.memo(function TextLabel<
 	id: T['id']
 	type: T['type']
 	size: TLDefaultSizeStyle
+	fontSize?: number
 	font: TLDefaultFontStyle
 	fill?: TLDefaultFillStyle
 	align: TLDefaultHorizontalAlignStyle
@@ -89,8 +91,8 @@ export const TextLabel = React.memo(function TextLabel<
 			<div
 				className="tl-text-label__inner"
 				style={{
-					fontSize: LABEL_FONT_SIZES[size],
-					lineHeight: LABEL_FONT_SIZES[size] * TEXT_PROPS.lineHeight + 'px',
+					fontSize: fontSize ?? LABEL_FONT_SIZES[size],
+					lineHeight: (fontSize ?? LABEL_FONT_SIZES[size]) * TEXT_PROPS.lineHeight + 'px',
 					minHeight: TEXT_PROPS.lineHeight + 32,
 					minWidth: 0,
 					color: theme[labelColor].solid,

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -701,6 +701,7 @@ export const noteShapeMigrations: Migrations;
 export const noteShapeProps: {
     color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
+    fontSize: T.Validator<number | undefined>;
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
     align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
     verticalAlign: EnumStyleProp<"end" | "middle" | "start">;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2900,7 +2900,16 @@
             },
             {
               "kind": "Content",
-              "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n    font: import(\"..\")."
+              "text": "<\"l\" | \"m\" | \"s\" | \"xl\">;\n    fontSize: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<number | undefined>;\n    font: import(\"..\")."
             },
             {
               "kind": "Reference",
@@ -2963,7 +2972,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 20
           }
         },
         {

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -13,7 +13,9 @@ import { ShapePropsType, TLBaseShape } from './TLBaseShape'
 /** @public */
 export const noteShapeProps = {
 	color: DefaultColorStyle,
+	// TODO: Would have to migrate away from this property.
 	size: DefaultSizeStyle,
+	fontSize: T.optional(T.positiveNumber),
 	font: DefaultFontStyle,
 	align: DefaultHorizontalAlignStyle,
 	verticalAlign: DefaultVerticalAlignStyle,


### PR DESCRIPTION
I don't think we should go this route after playing with it for a while, but maybe combined with @Taha-Hassan-Git 's exploration on "see more" this could play more nicely when it gets too small. Btw, @Taha-Hassan-Git if you wanna base your work off of this PR, it might be interesting, but it's up to you!


https://github.com/tldraw/tldraw/assets/469604/ca01a20e-31a8-46fa-84a5-6641d911e6bc






### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Stickies: auto-size font on stickies when reaching the limits of the height.
