### PR TITLE
A failed attempt to un-generify tlsync

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6627,7 +6627,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					let shapeRecordToCreate = (
 						this.store.schema.types.shape as RecordType<
 							TLShape,
-							'type' | 'props' | 'index' | 'parentId'
+							Pick<TLShape, 'type' | 'props' | 'index' | 'parentId'>
 						>
 					).create({
 						...partial,

--- a/packages/store/src/lib/BaseRecord.ts
+++ b/packages/store/src/lib/BaseRecord.ts
@@ -15,7 +15,10 @@ export interface BaseRecord<TypeName extends string, Id extends RecordId<Unknown
 }
 
 /** @public */
-export type UnknownRecord = BaseRecord<string, RecordId<UnknownRecord>>
+export type UnknownRecord = {
+	id: unknown
+	typeName: unknown
+} //BaseRecord<string, RecordId<UnknownRecord>>
 
 export type OmitMeta<R extends UnknownRecord> = R extends R ? Omit<R, 'id' | 'typeName'> : R
 

--- a/packages/tlsync/src/lib/RoomSession.ts
+++ b/packages/tlsync/src/lib/RoomSession.ts
@@ -2,11 +2,13 @@ import { SerializedSchema, UnknownRecord } from '@tldraw/store'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentDataEvent } from './protocol'
 
-export enum RoomSessionState {
-	AWAITING_CONNECT_MESSAGE = 'awaiting-connect-message',
-	AWAITING_REMOVAL = 'awaiting-removal',
-	CONNECTED = 'connected',
-}
+export const RoomSessionState = {
+	AwaitingConnectMessage: 'awaiting-connect-message',
+	AwaitingRemoval: 'awaiting-removal',
+	Connected: 'connected',
+} as const
+
+export type RoomSessionState = (typeof RoomSessionState)[keyof typeof RoomSessionState]
 
 export const SESSION_START_WAIT_TIME = 10000
 export const SESSION_REMOVAL_WAIT_TIME = 10000
@@ -14,21 +16,21 @@ export const SESSION_IDLE_TIMEOUT = 20000
 
 export type RoomSession<R extends UnknownRecord> =
 	| {
-			state: RoomSessionState.AWAITING_CONNECT_MESSAGE
+			state: typeof RoomSessionState.AwaitingConnectMessage
 			sessionKey: string
 			presenceId: string
 			socket: TLRoomSocket<R>
 			sessionStartTime: number
 	  }
 	| {
-			state: RoomSessionState.AWAITING_REMOVAL
+			state: typeof RoomSessionState.AwaitingRemoval
 			sessionKey: string
 			presenceId: string
 			socket: TLRoomSocket<R>
 			cancellationTime: number
 	  }
 	| {
-			state: RoomSessionState.CONNECTED
+			state: typeof RoomSessionState.Connected
 			sessionKey: string
 			presenceId: string
 			socket: TLRoomSocket<R>

--- a/packages/tlsync/src/lib/RoomSession.ts
+++ b/packages/tlsync/src/lib/RoomSession.ts
@@ -1,4 +1,4 @@
-import { SerializedSchema, UnknownRecord } from '@tldraw/store'
+import { RecordId, SerializedSchema, UnknownRecord } from '@tldraw/store'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentDataEvent } from './protocol'
 
@@ -14,28 +14,28 @@ export const SESSION_START_WAIT_TIME = 10000
 export const SESSION_REMOVAL_WAIT_TIME = 10000
 export const SESSION_IDLE_TIMEOUT = 20000
 
-export type RoomSession<R extends UnknownRecord> =
+export type RoomSession =
 	| {
 			state: typeof RoomSessionState.AwaitingConnectMessage
 			sessionKey: string
-			presenceId: string
-			socket: TLRoomSocket<R>
+			presenceId: RecordId<UnknownRecord>
+			socket: TLRoomSocket
 			sessionStartTime: number
 	  }
 	| {
 			state: typeof RoomSessionState.AwaitingRemoval
 			sessionKey: string
-			presenceId: string
-			socket: TLRoomSocket<R>
+			presenceId: RecordId<UnknownRecord>
+			socket: TLRoomSocket
 			cancellationTime: number
 	  }
 	| {
 			state: typeof RoomSessionState.Connected
 			sessionKey: string
-			presenceId: string
-			socket: TLRoomSocket<R>
+			presenceId: RecordId<UnknownRecord>
+			socket: TLRoomSocket
 			serializedSchema: SerializedSchema
 			lastInteractionTime: number
 			debounceTimer: ReturnType<typeof setTimeout> | null
-			outstandingDataMessages: TLSocketServerSentDataEvent<R>[]
+			outstandingDataMessages: TLSocketServerSentDataEvent[]
 	  }

--- a/packages/tlsync/src/lib/ServerSocketAdapter.ts
+++ b/packages/tlsync/src/lib/ServerSocketAdapter.ts
@@ -1,17 +1,16 @@
-import { UnknownRecord } from '@tldraw/store'
 import ws from 'ws'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentEvent } from './protocol'
 
 /** @public */
-export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocket<R> {
+export class ServerSocketAdapter implements TLRoomSocket {
 	constructor(public readonly ws: WebSocket | ws.WebSocket) {}
 	// eslint-disable-next-line no-restricted-syntax
 	get isOpen(): boolean {
 		return this.ws.readyState === 1 // ready state open
 	}
 	// see TLRoomSocket for details on why this accepts a union and not just arrays
-	sendMessage(msg: TLSocketServerSentEvent<R>) {
+	sendMessage(msg: TLSocketServerSentEvent) {
 		this.ws.send(JSON.stringify(msg))
 	}
 	close() {

--- a/packages/tlsync/src/lib/diff.ts
+++ b/packages/tlsync/src/lib/diff.ts
@@ -3,17 +3,20 @@ import { objectMapEntries, objectMapValues } from '@tldraw/utils'
 import isEqual from 'lodash.isequal'
 
 /** @public */
-export enum RecordOpType {
-	Put = 'put',
-	Patch = 'patch',
-	Remove = 'remove',
-}
+export const RecordOpType = {
+	Put: 'put',
+	Patch: 'patch',
+	Remove: 'remove',
+} as const
+
+/** @public */
+export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType]
 
 /** @public */
 export type RecordOp<R extends UnknownRecord> =
-	| [RecordOpType.Put, R]
-	| [RecordOpType.Patch, ObjectDiff]
-	| [RecordOpType.Remove]
+	| [typeof RecordOpType.Put, R]
+	| [typeof RecordOpType.Patch, ObjectDiff]
+	| [typeof RecordOpType.Remove]
 
 /**
  * A one-way (non-reversible) diff designed for small json footprint. These are mainly intended to
@@ -60,20 +63,22 @@ export const getNetworkDiff = <R extends UnknownRecord>(
 }
 
 /** @public */
-export enum ValueOpType {
-	Put = 'put',
-	Delete = 'delete',
-	Append = 'append',
-	Patch = 'patch',
-}
+export const ValueOpType = {
+	Put: 'put',
+	Delete: 'delete',
+	Append: 'append',
+	Patch: 'patch',
+} as const
+export type ValueOpType = (typeof ValueOpType)[keyof typeof ValueOpType]
+
 /** @public */
-export type PutOp = [type: ValueOpType.Put, value: unknown]
+export type PutOp = [type: typeof ValueOpType.Put, value: unknown]
 /** @public */
-export type AppendOp = [type: ValueOpType.Append, values: unknown[], offset: number]
+export type AppendOp = [type: typeof ValueOpType.Append, values: unknown[], offset: number]
 /** @public */
-export type PatchOp = [type: ValueOpType.Patch, diff: ObjectDiff]
+export type PatchOp = [type: typeof ValueOpType.Patch, diff: ObjectDiff]
 /** @public */
-export type DeleteOp = [type: ValueOpType.Delete]
+export type DeleteOp = [type: typeof ValueOpType.Delete]
 
 /** @public */
 export type ValueOp = PutOp | AppendOp | PatchOp | DeleteOp

--- a/packages/tlsync/src/lib/diff.ts
+++ b/packages/tlsync/src/lib/diff.ts
@@ -13,8 +13,8 @@ export const RecordOpType = {
 export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType]
 
 /** @public */
-export type RecordOp<R extends UnknownRecord> =
-	| [typeof RecordOpType.Put, R]
+export type RecordOp =
+	| [typeof RecordOpType.Put, UnknownRecord]
 	| [typeof RecordOpType.Patch, ObjectDiff]
 	| [typeof RecordOpType.Remove]
 
@@ -27,8 +27,8 @@ export type RecordOp<R extends UnknownRecord> =
  *
  * @public
  */
-export type NetworkDiff<R extends UnknownRecord> = {
-	[id: string]: RecordOp<R>
+export type NetworkDiff = {
+	[id: string]: RecordOp
 }
 
 /**
@@ -36,10 +36,8 @@ export type NetworkDiff<R extends UnknownRecord> = {
  *
  * @public
  */
-export const getNetworkDiff = <R extends UnknownRecord>(
-	diff: RecordsDiff<R>
-): NetworkDiff<R> | null => {
-	let res: NetworkDiff<R> | null = null
+export const getNetworkDiff = (diff: RecordsDiff<UnknownRecord>): NetworkDiff | null => {
+	let res: NetworkDiff | null = null
 
 	for (const [k, v] of objectMapEntries(diff.added)) {
 		if (!res) res = {}

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -17,14 +17,14 @@ export type TLIncompatibilityReason =
 	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
 /** @public */
-export type TLSocketServerSentEvent<R extends UnknownRecord> =
+export type TLSocketServerSentEvent =
 	| {
 			type: 'connect'
 			hydrationType: 'wipe_all' | 'wipe_presence'
 			connectRequestId: string
 			protocolVersion: number
 			schema: SerializedSchema
-			diff: NetworkDiff<R>
+			diff: NetworkDiff
 			serverClock: number
 	  }
 	| {
@@ -38,33 +38,33 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	| {
 			type: 'pong'
 	  }
-	| { type: 'data'; data: TLSocketServerSentDataEvent<R>[] }
+	| { type: 'data'; data: TLSocketServerSentDataEvent[] }
 
 /** @public */
-export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
+export type TLSocketServerSentDataEvent =
 	| {
 			type: 'patch'
-			diff: NetworkDiff<R>
+			diff: NetworkDiff
 			serverClock: number
 	  }
 	| {
 			type: 'push_result'
 			clientClock: number
 			serverClock: number
-			action: 'discard' | 'commit' | { rebaseWithDiff: NetworkDiff<R> }
+			action: 'discard' | 'commit' | { rebaseWithDiff: NetworkDiff }
 	  }
 
 /** @public */
-export type TLPushRequest<R extends UnknownRecord> =
+export type TLPushRequest =
 	| {
 			type: 'push'
 			clientClock: number
-			presence: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
+			presence: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, UnknownRecord]
 	  }
 	| {
 			type: 'push'
 			clientClock: number
-			diff: NetworkDiff<R>
+			diff: NetworkDiff
 	  }
 
 /** @public */
@@ -82,7 +82,4 @@ export type TLPingRequest = {
 }
 
 /** @public */
-export type TLSocketClientSentEvent<R extends UnknownRecord> =
-	| TLPushRequest<R>
-	| TLConnectRequest
-	| TLPingRequest
+export type TLSocketClientSentEvent = TLPushRequest | TLConnectRequest | TLPingRequest

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -5,12 +5,16 @@ import { NetworkDiff, ObjectDiff, RecordOpType } from './diff'
 export const TLSYNC_PROTOCOL_VERSION = 5
 
 /** @public */
-export enum TLIncompatibilityReason {
-	ClientTooOld = 'clientTooOld',
-	ServerTooOld = 'serverTooOld',
-	InvalidRecord = 'invalidRecord',
-	InvalidOperation = 'invalidOperation',
-}
+export const TLIncompatibilityReason = {
+	ClientTooOld: 'clientTooOld',
+	ServerTooOld: 'serverTooOld',
+	InvalidRecord: 'invalidRecord',
+	InvalidOperation: 'invalidOperation',
+} as const
+
+/** @public */
+export type TLIncompatibilityReason =
+	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
 /** @public */
 export type TLSocketServerSentEvent<R extends UnknownRecord> =
@@ -55,7 +59,7 @@ export type TLPushRequest<R extends UnknownRecord> =
 	| {
 			type: 'push'
 			clientClock: number
-			presence: [RecordOpType.Patch, ObjectDiff] | [RecordOpType.Put, R]
+			presence: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
 	  }
 	| {
 			type: 'push'

--- a/packages/tlsync/src/lib/server-types.ts
+++ b/packages/tlsync/src/lib/server-types.ts
@@ -5,7 +5,7 @@ export type RoomState = {
 	// the slug of the room
 	persistenceKey: string
 	// the room
-	room: TLSyncRoom<any>
+	room: TLSyncRoom
 }
 
 /** @public */

--- a/packages/tlsync/src/test/TLServer.test.ts
+++ b/packages/tlsync/src/test/TLServer.test.ts
@@ -1,4 +1,4 @@
-import { TLRecord, createTLStore, defaultShapeUtils } from 'tldraw'
+import { createTLStore, defaultShapeUtils } from 'tldraw'
 import { type WebSocket } from 'ws'
 import { RoomSessionState } from '../lib/RoomSession'
 import { DBLoadResult, TLServer } from '../lib/TLServer'
@@ -116,7 +116,7 @@ describe('TLServer', () => {
 	it('allows requests to be chunked', async () => {
 		await openConnection()
 
-		const connectMsg: TLSocketClientSentEvent<TLRecord> = {
+		const connectMsg: TLSocketClientSentEvent = {
 			type: 'connect',
 			lastServerClock: 0,
 			connectRequestId: 'test-connect-request-id',

--- a/packages/tlsync/src/test/TLServer.test.ts
+++ b/packages/tlsync/src/test/TLServer.test.ts
@@ -109,7 +109,7 @@ describe('TLServer', () => {
 		expect(server.roomState?.persistenceKey).toBe('test-persistence-key')
 		expect(server.roomState?.room.sessions.size).toBe(1)
 		expect(server.roomState?.room.sessions.get('test-session-key')?.state).toBe(
-			RoomSessionState.AWAITING_CONNECT_MESSAGE
+			RoomSessionState.AwaitingConnectMessage
 		)
 	})
 
@@ -135,7 +135,7 @@ describe('TLServer', () => {
 		sockets.client.on('message', onClientMessage)
 
 		expect(server.roomState?.room.sessions.get('test-session-key')?.state).toBe(
-			RoomSessionState.AWAITING_CONNECT_MESSAGE
+			RoomSessionState.AwaitingConnectMessage
 		)
 
 		for (const chunk of chunks) {
@@ -145,7 +145,7 @@ describe('TLServer', () => {
 		await receivedPromise
 
 		expect(server.roomState?.room.sessions.get('test-session-key')?.state).toBe(
-			RoomSessionState.CONNECTED
+			RoomSessionState.Connected
 		)
 
 		expect(onClientMessage).toHaveBeenCalledTimes(1)

--- a/packages/tlsync/src/test/TLSyncRoom.test.ts
+++ b/packages/tlsync/src/test/TLSyncRoom.test.ts
@@ -63,14 +63,14 @@ const oldArrow: TLBaseShape<'arrow', Omit<TLArrowShapeProps, 'labelColor'>> = {
 
 describe('TLSyncRoom', () => {
 	it('can be constructed with a schema alone', () => {
-		const room = new TLSyncRoom<any>(schema)
+		const room = new TLSyncRoom(schema)
 
 		// we populate the store with a default document if none is given
 		expect(room.getSnapshot().documents.length).toBeGreaterThan(0)
 	})
 
 	it('can be constructed with a snapshot', () => {
-		const room = new TLSyncRoom<TLRecord>(schema, makeSnapshot(records))
+		const room = new TLSyncRoom(schema, makeSnapshot(records))
 
 		expect(
 			room

--- a/packages/tlsync/src/test/TestSocketPair.ts
+++ b/packages/tlsync/src/test/TestSocketPair.ts
@@ -6,8 +6,8 @@ import { TLSocketClientSentEvent, TLSocketServerSentEvent } from '../lib/protoco
 import { TestServer } from './TestServer'
 
 export class TestSocketPair<R extends UnknownRecord> {
-	clientSentEventQueue: TLSocketClientSentEvent<R>[] = []
-	serverSentEventQueue: TLSocketServerSentEvent<R>[] = []
+	clientSentEventQueue: TLSocketClientSentEvent[] = []
+	serverSentEventQueue: TLSocketServerSentEvent[] = []
 	flushServerSentEvents() {
 		const queue = this.serverSentEventQueue
 		this.serverSentEventQueue = []
@@ -27,7 +27,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 		return this.serverSentEventQueue.length > 0 || this.clientSentEventQueue.length > 0
 	}
 
-	roomSocket: TLRoomSocket<R> = {
+	roomSocket: TLRoomSocket = {
 		close: () => {
 			this.flushServerSentEvents()
 			this.disconnect()
@@ -35,7 +35,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 		get isOpen() {
 			return true
 		},
-		sendMessage: (msg: TLSocketServerSentEvent<R>) => {
+		sendMessage: (msg: TLSocketServerSentEvent) => {
 			if (!this.callbacks.onReceiveMessage) {
 				throw new Error('Socket is closed')
 			}
@@ -47,9 +47,9 @@ export class TestSocketPair<R extends UnknownRecord> {
 			this.serverSentEventQueue.push(structuredClone(msg))
 		},
 	}
-	didReceiveFromClient?: (msg: TLSocketClientSentEvent<R>) => void = undefined
+	didReceiveFromClient?: (msg: TLSocketClientSentEvent) => void = undefined
 	clientDisconnected?: () => void = undefined
-	clientSocket: TLPersistentClientSocket<R> = {
+	clientSocket: TLPersistentClientSocket = {
 		connectionStatus: 'offline',
 		onStatusChange: (cb) => {
 			this.callbacks.onStatusChange = cb
@@ -63,7 +63,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 				this.callbacks.onReceiveMessage = null
 			}
 		},
-		sendMessage: (msg: TLSocketClientSentEvent<R>) => {
+		sendMessage: (msg: TLSocketClientSentEvent) => {
 			if (this.clientSocket.connectionStatus !== 'online') {
 				throw new Error('trying to send before open')
 			}
@@ -77,7 +77,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 	}
 
 	callbacks = {
-		onReceiveMessage: null as null | ((msg: TLSocketServerSentEvent<R>) => void),
+		onReceiveMessage: null as null | ((msg: TLSocketServerSentEvent) => void),
 		onStatusChange: null as null | ((status: TLPersistentClientSocketStatus) => void),
 	}
 

--- a/packages/tlsync/src/test/validation.test.ts
+++ b/packages/tlsync/src/test/validation.test.ts
@@ -83,9 +83,9 @@ async function makeTestInstance() {
 		}
 	}
 	const onSyncError = jest.fn()
-	const client = await new Promise<TLSyncClient<Book | Presence>>((resolve, reject) => {
+	const client = await new Promise<TLSyncClient>((resolve, reject) => {
 		const client = new TLSyncClient({
-			store: new Store<Book | Presence, unknown>({ schema: schemaWithoutValidator, props: {} }),
+			store: new Store({ schema: schemaWithoutValidator, props: {} }),
 			socket: socketPair.clientSocket as any,
 			onLoad: resolve,
 			onLoadError: reject,


### PR DESCRIPTION
The issue that can't be fixed easily seems to boil down to `UnknownRecord` not being a true bottom type for records

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [x] `dunno` — I don't know
