### PR TITLE
stickies: add see more/less button

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1229,16 +1229,18 @@ input,
 .tl-note__expand-button {
 	color: var(--color-text-1);
 	border-radius: 8px;
-	background-color: var(--color-background);
-	padding: 4px;
+	background-color: var(--color-hint);
+	color: var(--color-text-1);
+	font-size: 12px;
+	padding: 3px;
 	opacity: 0;
 	border: none;
 	position: absolute;
-	bottom: -25px;
-	left: 50%;
-	transform: translateX(-50%);
+	bottom: 6px;
+	right: 6px;
+	z-index: 10000;
 }
-.tl-shape:hover .tl-note__expand-button {
+.tl-shape:hover > div .tl-note__container .tl-note__expand-button {
 	opacity: 1;
 }
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1206,13 +1206,15 @@ input,
 }
 
 .tl-note__container[data-isexpanded='false'] .tl-text-label .tl-text-label__inner {
-	max-height: 200px;
+	height: fit-content;
+	max-height: 164.5px;
 }
 
 .tl-note__container[data-isexpanded='false'] .tl-text-label .tl-text-label__inner .tl-text-content {
 	height: 100%;
-	max-height: 200px;
+	max-height: 180.5px;
 }
+
 
 .tl-note__scrim {
 	position: absolute;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1205,6 +1205,15 @@ input,
 	text-shadow: none;
 }
 
+.tl-note__container[data-isexpanded='false'] .tl-text-label .tl-text-label__inner {
+	max-height: 200px;
+}
+
+.tl-note__container[data-isexpanded='false'] .tl-text-label .tl-text-label__inner .tl-text-content {
+	height: 100%;
+	max-height: 200px;
+}
+
 .tl-note__scrim {
 	position: absolute;
 	z-index: 1;
@@ -1213,6 +1222,22 @@ input,
 	width: 100%;
 	background-color: var(--color-background);
 	opacity: 0.28;
+}
+
+.tl-note__expand-button {
+	color: var(--color-text-1);
+	border-radius: 8px;
+	background-color: var(--color-background);
+	padding: 4px;
+	opacity: 0;
+	border: none;
+	position: absolute;
+	bottom: -25px;
+	left: 50%;
+	transform: translateX(-50%);
+}
+.tl-shape:hover .tl-note__expand-button {
+	opacity: 1;
 }
 
 .tl-loading {

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1093,6 +1093,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getHeight(shape: TLNoteShape): number;
     // (undocumented)
+    getTruncatedText(text: string, shape: TLNoteShape): string;
+    // (undocumented)
     hideResizeHandles: () => boolean;
     // (undocumented)
     hideSelectionBoundsFg: () => boolean;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1111,6 +1111,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            expanded: boolean;
         };
         type: "note";
         x: number;
@@ -1135,6 +1136,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            expanded: boolean;
         };
         type: "note";
         x: number;
@@ -1160,6 +1162,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;
+        expanded: Validator<boolean>;
     };
     // (undocumented)
     toSvg(shape: TLNoteShape, ctx: SvgExportContext): SVGGElement;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13183,7 +13183,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            expanded: boolean;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13267,7 +13267,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            expanded: boolean;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13449,7 +13449,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string>;\n    }"
+                  "text": "<string>;\n        expanded: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<boolean>;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -13462,7 +13471,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 20
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13015,6 +13015,71 @@
               "name": "getHeight"
             },
             {
+              "kind": "Method",
+              "canonicalReference": "tldraw!NoteShapeUtil#getTruncatedText:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getTruncatedText(text: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "text",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getTruncatedText"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#hideResizeHandles:member",
               "docComment": "",

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -40,11 +40,16 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			verticalAlign: 'middle',
 			growY: 0,
 			url: '',
+			expanded: false,
 		}
 	}
 
 	getHeight(shape: TLNoteShape) {
-		return NOTE_SIZE + shape.props.growY
+		const height = NOTE_SIZE
+		if (shape.props.expanded) {
+			return height + shape.props.growY
+		}
+		return height
 	}
 
 	getGeometry(shape: TLNoteShape) {
@@ -70,10 +75,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						position: 'absolute',
 						width: NOTE_SIZE,
 						height: this.getHeight(shape),
+						pointerEvents: 'all',
 					}}
 				>
 					<div
 						className="tl-note__container"
+						data-isexpanded={shape.props.expanded}
 						style={{
 							color: theme[adjustedColor].solid,
 							backgroundColor: theme[adjustedColor].solid,
@@ -92,6 +99,21 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							wrap
 						/>
 					</div>
+					{shape.props.growY > 0 && (
+						<button
+							className="tl-note__expand-button"
+							onClick={() => {
+								this.editor.updateShape({
+									id: shape.id,
+									type: 'note',
+									props: { expanded: !shape.props.expanded },
+								})
+							}}
+							onPointerDown={(e) => e.stopPropagation()}
+						>
+							{shape.props.expanded ? 'see less' : 'see more'}
+						</button>
+					)}
 				</div>
 				{'url' in shape.props && shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -707,6 +707,7 @@ export const noteShapeProps: {
     growY: T.Validator<number>;
     url: T.Validator<string>;
     text: T.Validator<string>;
+    expanded: T.Validator<boolean>;
 };
 
 // @internal (undocumented)

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2954,7 +2954,16 @@
             },
             {
               "kind": "Content",
-              "text": "<string>;\n}"
+              "text": "<string>;\n    expanded: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<boolean>;\n}"
             }
           ],
           "fileUrlPath": "packages/tlschema/src/shapes/TLNoteShape.ts",
@@ -2963,7 +2972,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 20
           }
         },
         {

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -20,6 +20,7 @@ export const noteShapeProps = {
 	growY: T.positiveNumber,
 	url: T.linkUrl,
 	text: T.string,
+	expanded: T.boolean,
 }
 
 /** @public */


### PR DESCRIPTION
I've added a see more button, very minimal styling so far. Immediately the problem I've come up against is having to manage all of these expanded and unexpanded stickies. I can see that being annoying.

I can see this potentially being ok if we make them collapse on blur, but can't figure out a way to make that happen.

Related to issue [TLD-2292](https://github.com/tldraw/tldraw/issues/3085)

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan


### Release Notes

- Adds a see more to expand sticky notes
