### PR TITLE
Enable document name

### DIFF
--- a/apps/dotcom/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/src/components/MultiplayerEditor.tsx
@@ -11,7 +11,6 @@ import {
 	Editor,
 	ExportFileContentSubMenu,
 	ExtrasGroup,
-	OfflineIndicator,
 	PreferencesGroup,
 	TLComponents,
 	Tldraw,
@@ -19,7 +18,6 @@ import {
 	TldrawUiMenuItem,
 	ViewSubmenu,
 	atom,
-	debugFlags,
 	lns,
 	useActions,
 	useValue,
@@ -93,15 +91,6 @@ const components: TLComponents = {
 	},
 	TopPanel: () => {
 		const isOffline = useValue('offline', () => shittyOfflineAtom.get(), [])
-		const showDocumentName = useValue('documentName ', () => debugFlags.documentName.get(), [
-			debugFlags,
-		])
-		if (!showDocumentName) {
-			if (isOffline) {
-				return <OfflineIndicator />
-			}
-			return null
-		}
 		return <DocumentTopZone isOffline={isOffline} />
 	},
 	SharePanel: () => {

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -53,7 +53,6 @@ export const debugFlags: Record<string, DebugFlag<boolean>> = {
 	forceSrgb: createDebugValue('forceSrgbColors', { defaults: { all: false } }),
 	debugGeometry: createDebugValue('debugGeometry', { defaults: { all: false } }),
 	hideShapes: createDebugValue('hideShapes', { defaults: { all: false } }),
-	documentName: createDebugValue('documentName', { defaults: { all: false } }),
 }
 
 declare global {


### PR DESCRIPTION
Apparently we were supposed to do this for the previous release, and the release notes mentioned the document title, so I'm doing a quick hotfix for dotcom.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `dotcom` — Changes the tldraw.com web app

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `feature` — New feature



