### PR TITLE
stickies: always on top experiment

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1617,6 +1617,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     hideSelectionBoundsBg: TLShapeUtilFlag<Shape>;
     hideSelectionBoundsFg: TLShapeUtilFlag<Shape>;
     abstract indicator(shape: Shape): any;
+    isAlwaysOnTop: TLShapeUtilFlag<Shape>;
     isAspectRatioLocked: TLShapeUtilFlag<Shape>;
     // (undocumented)
     static migrations?: Migrations;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -31167,6 +31167,41 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#isAlwaysOnTop:member",
+              "docComment": "/**\n * Whether the shape is always on top of other shape types.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isAlwaysOnTop: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeUtilFlag",
+                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isAlwaysOnTop",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#isAspectRatioLocked:member",
               "docComment": "/**\n * Whether the shape's aspect ratio is locked.\n *\n * @public\n */\n",
               "excerptTokens": [

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3091,6 +3091,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let nextIndex = MAX_SHAPES_PER_PAGE * 2
 		let nextBackgroundIndex = MAX_SHAPES_PER_PAGE
+		const TOP_LEVEL_SHAPES_BASELINE = MAX_SHAPES_PER_PAGE * 2 * 10
 
 		// We only really need these if we're using editor state, but that's ok
 		const editingShapeId = this.getEditingShapeId()
@@ -3135,8 +3136,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				id,
 				shape,
 				util,
-				index: nextIndex,
-				backgroundIndex: nextBackgroundIndex,
+				index: util.isAlwaysOnTop(shape) ? TOP_LEVEL_SHAPES_BASELINE + nextIndex : nextIndex,
+				backgroundIndex: util.isAlwaysOnTop(shape)
+					? TOP_LEVEL_SHAPES_BASELINE + nextBackgroundIndex
+					: nextBackgroundIndex,
 				opacity,
 				isCulled,
 				maskedPageBounds,
@@ -8255,11 +8258,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 					}
 
 					const elements = []
+					const TOP_LEVEL_SHAPES_BASELINE = MAX_SHAPES_PER_PAGE * 2 * 10
 					if (shapeSvgElement) {
-						elements.push({ zIndex: index, element: shapeSvgElement })
+						elements.push({
+							zIndex: util.isAlwaysOnTop(shape) ? TOP_LEVEL_SHAPES_BASELINE + index : index,
+							element: shapeSvgElement,
+						})
 					}
 					if (backgroundSvgElement) {
-						elements.push({ zIndex: backgroundIndex, element: backgroundSvgElement })
+						elements.push({
+							zIndex: util.isAlwaysOnTop(shape)
+								? TOP_LEVEL_SHAPES_BASELINE + backgroundIndex
+								: backgroundIndex,
+							element: backgroundSvgElement,
+						})
 					}
 
 					return elements

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -132,6 +132,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	canCrop: TLShapeUtilFlag<Shape> = () => false
 
 	/**
+	 * Whether the shape is always on top of other shape types.
+	 *
+	 * @public
+	 */
+	isAlwaysOnTop: TLShapeUtilFlag<Shape> = () => false
+
+	/**
 	 * Does this shape provide a background for its children? If this is true,
 	 * then any children with a `renderBackground` method will have their
 	 * backgrounds rendered _above_ this shape. Otherwise, the children's

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1040,6 +1040,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     indicator(shape: TLNoteShape): JSX_2.Element;
     // (undocumented)
+    isAlwaysOnTop: () => boolean;
+    // (undocumented)
     static migrations: Migrations;
     // (undocumented)
     onBeforeCreate: (next: TLNoteShape) => {

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12490,6 +12490,36 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#isAlwaysOnTop:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isAlwaysOnTop: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isAlwaysOnTop",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil.migrations:member",
               "docComment": "",
               "excerptTokens": [

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -29,6 +29,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override canEdit = () => true
 	override hideResizeHandles = () => true
 	override hideSelectionBoundsFg = () => true
+	override isAlwaysOnTop = () => true
 
 	getDefaultProps(): TLNoteShape['props'] {
 		return {


### PR DESCRIPTION
This makes shape's have a property where a shape can specify that it's always on top.
We talked about this briefly — impetus being that stickies are annotations that should go on top of something, esp. in the real-life parallel, they're meant to go on top of a surface. I think this paradigm feels right (especially, as an example, of Evan's confusion in the retro of why a sticky was accidentally behind a shape)

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Sticky notes: always on top.
