### PR TITLE
Stickies: duplicate controls

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1216,8 +1216,16 @@ input,
 }
 
 .tl-note__duplicate-button{
+	border: none;
+	font-weight: 600;
+	background-color: var(--color-muted-2);
 	position: absolute;
 	pointer-events: all;
+	border-radius: 8px;
+}
+
+.tl-note__duplicate-button:hover{
+	background-color: var(--color-muted-1);
 }
 
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1215,6 +1215,13 @@ input,
 	opacity: 0.28;
 }
 
+.tl-note__duplicate-button{
+	position: absolute;
+	pointer-events: all;
+}
+
+
+
 .tl-loading {
 	background-color: var(--color-background);
 	color: var(--color-text-1);

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13210,7 +13210,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        id: import(\"@tldraw/editor\")."
+                  "text": ";\n        id: "
                 },
                 {
                   "kind": "Reference",
@@ -13294,7 +13294,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        id: import(\"@tldraw/editor\")."
+                  "text": ";\n        id: "
                 },
                 {
                   "kind": "Reference",

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -6,6 +6,7 @@ import {
 	SvgExportContext,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	TLShapeId,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -63,6 +64,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const theme = useDefaultColorTheme()
 		const adjustedColor = color === 'black' ? 'yellow' : color
 
+		const isSelected = this.editor.getSelectedShapeIds().includes(id)
 		return (
 			<>
 				<div
@@ -92,6 +94,50 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							wrap
 						/>
 					</div>
+					{isSelected && (
+						<>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ top: '-30px', left: '50%', transform: 'translateX(-50%)' }}
+								onClick={() => duplicateShape(shape.id, 'up', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '-30px', right: '50%', transform: 'translateX(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'down', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '50%', right: '-30px', transform: 'translateY(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'right', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '50%', left: '-30px', transform: 'translateY(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'left', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+						</>
+					)}
 				</div>
 				{'url' in shape.props && shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
@@ -218,4 +264,43 @@ function getGrowY(editor: Editor, shape: TLNoteShape, prevGrowY = 0) {
 			},
 		}
 	}
+}
+
+function duplicateShape(
+	shapeId: TLShapeId,
+	direction: 'up' | 'down' | 'left' | 'right',
+	editor: Editor
+) {
+	const shape = editor.getShape(shapeId) as TLNoteShape
+
+	const rotationRadians = shape.rotation
+	const distance = NOTE_SIZE + 20
+
+	// Calculate offsetX and offsetY based on the direction and rotation
+	let offsetX = 0
+	let offsetY = 0
+
+	switch (direction) {
+		case 'up':
+			offsetX = distance * Math.sin(rotationRadians)
+			offsetY = distance * -Math.cos(rotationRadians)
+			break
+		case 'down':
+			offsetX = distance * -Math.sin(rotationRadians)
+			offsetY = distance * Math.cos(rotationRadians)
+			break
+		case 'left':
+			offsetX = distance * -Math.cos(rotationRadians)
+			offsetY = distance * -Math.sin(rotationRadians)
+			break
+		case 'right':
+			offsetX = distance * Math.cos(rotationRadians)
+			offsetY = distance * Math.sin(rotationRadians)
+			break
+	}
+
+	console.log(shape.rotation)
+	console.log(`OffsetX: ${offsetX}, OffsetY: ${offsetY}`)
+
+	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
 }

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -273,7 +273,7 @@ function duplicateShape(
 ) {
 	const shape = editor.getShape(shapeId) as TLNoteShape
 
-	const rotationRadians = shape.rotation
+	const rotationRadians = editor.getShapePageTransform(shapeId).rotation()
 	const distance = NOTE_SIZE + 30
 
 	// Calculate offsetX and offsetY based on the direction and rotation

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -63,8 +63,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()
 		const adjustedColor = color === 'black' ? 'yellow' : color
-
-		const isSelected = this.editor.getSelectedShapeIds().includes(id)
+		const selectedShapes = this.editor.getSelectedShapeIds()
+		const isOnlyShapeSelected = selectedShapes.length === 1 && selectedShapes[0] === shape.id
 		return (
 			<>
 				<div
@@ -94,7 +94,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							wrap
 						/>
 					</div>
-					{isSelected && (
+					{isOnlyShapeSelected && (
 						<>
 							<button
 								className="tl-note__duplicate-button"
@@ -274,7 +274,7 @@ function duplicateShape(
 	const shape = editor.getShape(shapeId) as TLNoteShape
 
 	const rotationRadians = shape.rotation
-	const distance = NOTE_SIZE + 20
+	const distance = NOTE_SIZE + 30
 
 	// Calculate offsetX and offsetY based on the direction and rotation
 	let offsetX = 0

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -271,8 +271,6 @@ function duplicateShape(
 	direction: 'up' | 'down' | 'left' | 'right',
 	editor: Editor
 ) {
-	const shape = editor.getShape(shapeId) as TLNoteShape
-
 	const rotationRadians = editor.getShapePageTransform(shapeId).rotation()
 	const distance = NOTE_SIZE + 30
 
@@ -298,9 +296,6 @@ function duplicateShape(
 			offsetY = distance * Math.sin(rotationRadians)
 			break
 	}
-
-	console.log(shape.rotation)
-	console.log(`OffsetX: ${offsetX}, OffsetY: ${offsetY}`)
 
 	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
 }


### PR DESCRIPTION
A Rough sketch of what duplication controls might look like.

For now, they only pop up when one sticky is selected.  I tried a hover interaction but that felt very annoying. I can look at duplication controls for multiple stickies next.

todo:
Try out handles instead of buttons

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add duplication controls for sticky notes
