### PR TITLE
Stickies: Duplication via handles

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1216,8 +1216,16 @@ input,
 }
 
 .tl-note__duplicate-button{
+	border: none;
+	font-weight: 600;
+	background-color: var(--color-muted-2);
 	position: absolute;
 	pointer-events: all;
+	border-radius: 8px;
+}
+
+.tl-note__duplicate-button:hover{
+	background-color: var(--color-muted-1);
 }
 
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1215,6 +1215,13 @@ input,
 	opacity: 0.28;
 }
 
+.tl-note__duplicate-button{
+	position: absolute;
+	pointer-events: all;
+}
+
+
+
 .tl-loading {
 	background-color: var(--color-background);
 	color: var(--color-text-1);

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1091,6 +1091,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getGeometry(shape: TLNoteShape): Rectangle2d;
     // (undocumented)
+    getHandles(shape: TLNoteShape): TLHandle[];
+    // (undocumented)
     getHeight(shape: TLNoteShape): number;
     // (undocumented)
     hideResizeHandles: () => boolean;
@@ -1111,6 +1113,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            buttons: VecModel;
         };
         type: "note";
         x: number;
@@ -1135,6 +1138,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            buttons: VecModel;
         };
         type: "note";
         x: number;
@@ -1160,6 +1164,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;
+        buttons: Validator<VecModel>;
     };
     // (undocumented)
     toSvg(shape: TLNoteShape, ctx: SvgExportContext): SVGGElement;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1113,7 +1113,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
-            buttons: VecModel;
+            buttons: VecModel[];
         };
         type: "note";
         x: number;
@@ -1138,7 +1138,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
-            buttons: VecModel;
+            buttons: VecModel[];
         };
         type: "note";
         x: number;
@@ -1155,6 +1155,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
+    onHandlePointerUp(info: {
+        shape: TLNoteShape;
+        handleId: 'down' | 'left' | 'right' | 'up';
+    }): void;
+    // (undocumented)
     static props: {
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
@@ -1164,7 +1169,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;
-        buttons: Validator<VecModel>;
+        buttons: ArrayOfValidator<VecModel>;
     };
     // (undocumented)
     toSvg(shape: TLNoteShape, ctx: SvgExportContext): SVGGElement;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13210,7 +13210,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        id: import(\"@tldraw/editor\")."
+                  "text": ";\n        id: "
                 },
                 {
                   "kind": "Reference",
@@ -13294,7 +13294,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        id: import(\"@tldraw/editor\")."
+                  "text": ";\n        id: "
                 },
                 {
                   "kind": "Reference",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13246,7 +13246,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": "[];\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13339,7 +13339,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": "[];\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13439,6 +13439,63 @@
               "isAbstract": false
             },
             {
+              "kind": "Method",
+              "canonicalReference": "tldraw!NoteShapeUtil#onHandlePointerUp:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onHandlePointerUp(info: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n        handleId: 'down' | 'left' | 'right' | 'up';\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "info",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "onHandlePointerUp"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil.props:member",
               "docComment": "",
@@ -13525,8 +13582,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Validator",
-                  "canonicalReference": "@tldraw/validate!Validator:class"
+                  "text": "ArrayOfValidator",
+                  "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
                 },
                 {
                   "kind": "Content",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12967,6 +12967,60 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "tldraw!NoteShapeUtil#getHandles:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getHandles(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLHandle",
+                  "canonicalReference": "@tldraw/tlschema!TLHandle:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getHandles"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "tldraw!NoteShapeUtil#getHeight:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -13183,7 +13237,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13232,7 +13295,7 @@
               "name": "onBeforeCreate",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 12
+                "endIndex": 14
               },
               "isStatic": false,
               "isProtected": false,
@@ -13267,7 +13330,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13316,7 +13388,7 @@
               "name": "onBeforeUpdate",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 14
+                "endIndex": 16
               },
               "isStatic": false,
               "isProtected": false,
@@ -13449,7 +13521,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string>;\n    }"
+                  "text": "<string>;\n        buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Validator",
+                  "canonicalReference": "@tldraw/validate!Validator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -13462,7 +13552,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 22
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -9,6 +9,7 @@ import {
 	TLOnEditEndHandler,
 	TLShapeId,
 	ZERO_INDEX_KEY,
+	createShapeId,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -274,7 +275,7 @@ function duplicateShape(
 			break
 	}
 
-	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
-	const newShape = editor.getSelectedShapeIds()[0]
-	editor.setEditingShape(newShape)
+	const id = createShapeId()
+	editor.createShape({ type: 'note', id, x: shape.x + offsetX, y: shape.y + offsetY })
+	editor.setEditingShape(id)
 }

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -6,6 +6,7 @@ import {
 	SvgExportContext,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	TLShapeId,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -63,6 +64,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const theme = useDefaultColorTheme()
 		const adjustedColor = color === 'black' ? 'yellow' : color
 
+		const isSelected = this.editor.getSelectedShapeIds().includes(id)
 		return (
 			<>
 				<div
@@ -92,6 +94,50 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							wrap
 						/>
 					</div>
+					{isSelected && (
+						<>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ top: '-30px', left: '50%', transform: 'translateX(-50%)' }}
+								onClick={() => duplicateShape(shape.id, 'up', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '-30px', right: '50%', transform: 'translateX(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'down', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '50%', right: '-30px', transform: 'translateY(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'right', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+							<button
+								className="tl-note__duplicate-button"
+								style={{ bottom: '50%', left: '-30px', transform: 'translateY(50%)' }}
+								onClick={() => duplicateShape(shape.id, 'left', this.editor)}
+								onPointerDown={(e) => {
+									e.stopPropagation()
+								}}
+							>
+								+
+							</button>
+						</>
+					)}
 				</div>
 				{'url' in shape.props && shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
@@ -218,4 +264,43 @@ function getGrowY(editor: Editor, shape: TLNoteShape, prevGrowY = 0) {
 			},
 		}
 	}
+}
+
+function duplicateShape(
+	shapeId: TLShapeId,
+	direction: 'up' | 'down' | 'left' | 'right',
+	editor: Editor
+) {
+	const shape = editor.getShape(shapeId) as TLNoteShape
+
+	const rotationRadians = shape.rotation
+	const distance = NOTE_SIZE + 20
+
+	// Calculate offsetX and offsetY based on the direction and rotation
+	let offsetX = 0
+	let offsetY = 0
+
+	switch (direction) {
+		case 'up':
+			offsetX = distance * Math.sin(rotationRadians)
+			offsetY = distance * -Math.cos(rotationRadians)
+			break
+		case 'down':
+			offsetX = distance * -Math.sin(rotationRadians)
+			offsetY = distance * Math.cos(rotationRadians)
+			break
+		case 'left':
+			offsetX = distance * -Math.cos(rotationRadians)
+			offsetY = distance * -Math.sin(rotationRadians)
+			break
+		case 'right':
+			offsetX = distance * Math.cos(rotationRadians)
+			offsetY = distance * Math.sin(rotationRadians)
+			break
+	}
+
+	console.log(shape.rotation)
+	console.log(`OffsetX: ${offsetX}, OffsetY: ${offsetY}`)
+
+	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
 }

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -81,9 +81,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()
 		const adjustedColor = color === 'black' ? 'yellow' : color
-		const selectedShapes = this.editor.getSelectedShapeIds()
-		const isOnlyShapeSelected = selectedShapes.length === 1 && selectedShapes[0] === shape.id
-
 		return (
 			<>
 				<div
@@ -278,5 +275,6 @@ function duplicateShape(
 	}
 
 	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
-	editor.setEditingShape(editor.getSelectedShapes()[0])
+	const newShape = editor.getSelectedShapeIds()[0]
+	editor.setEditingShape(newShape)
 }

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -63,8 +63,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()
 		const adjustedColor = color === 'black' ? 'yellow' : color
-
-		const isSelected = this.editor.getSelectedShapeIds().includes(id)
+		const selectedShapes = this.editor.getSelectedShapeIds()
+		const isOnlyShapeSelected = selectedShapes.length === 1 && selectedShapes[0] === shape.id
 		return (
 			<>
 				<div
@@ -94,7 +94,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							wrap
 						/>
 					</div>
-					{isSelected && (
+					{isOnlyShapeSelected && (
 						<>
 							<button
 								className="tl-note__duplicate-button"
@@ -274,7 +274,7 @@ function duplicateShape(
 	const shape = editor.getShape(shapeId) as TLNoteShape
 
 	const rotationRadians = shape.rotation
-	const distance = NOTE_SIZE + 20
+	const distance = NOTE_SIZE + 30
 
 	// Calculate offsetX and offsetY based on the direction and rotation
 	let offsetX = 0

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -43,7 +43,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			verticalAlign: 'middle',
 			growY: 0,
 			url: '',
-			buttons: { x: 0.5, y: -0.1 },
+			buttons: [
+				{ x: 0.5, y: -0.1 },
+				{ x: 1.1, y: 0.5 },
+				{ x: 0.5, y: 1.1 },
+				{ x: -0.1, y: 0.5 },
+			],
 		}
 	}
 
@@ -55,21 +60,17 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const height = this.getHeight(shape)
 		return new Rectangle2d({ width: NOTE_SIZE, height, isFilled: true })
 	}
-
 	override getHandles(shape: TLNoteShape): TLHandle[] {
 		const { buttons } = shape.props
-		console.log(buttons)
-		return [
-			{
-				id: 'buttons',
-				type: 'vertex',
-				index: ZERO_INDEX_KEY,
-				x: buttons.x * NOTE_SIZE,
-				y: buttons.y * this.getHeight(shape),
-			},
-		]
+		const directionArr = ['up', 'right', 'down', 'left']
+		return buttons.map((button, i) => ({
+			id: directionArr[i],
+			type: 'vertex',
+			index: ZERO_INDEX_KEY,
+			x: button.x * NOTE_SIZE,
+			y: button.y * this.getHeight(shape),
+		}))
 	}
-
 	component(shape: TLNoteShape) {
 		const {
 			id,
@@ -205,6 +206,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			])
 		}
 	}
+	onHandlePointerUp(info: { shape: TLNoteShape; handleId: 'up' | 'down' | 'left' | 'right' }) {
+		duplicateShape(info.shape.id, info.handleId, this.editor)
+	}
 }
 
 function getGrowY(editor: Editor, shape: TLNoteShape, prevGrowY = 0) {
@@ -272,9 +276,6 @@ function duplicateShape(
 			offsetY = distance * Math.sin(rotationRadians)
 			break
 	}
-
-	console.log(shape.rotation)
-	console.log(`OffsetX: ${offsetX}, OffsetY: ${offsetY}`)
 
 	editor.duplicateShapes([shapeId], { x: offsetX, y: offsetY })
 	editor.setEditingShape(editor.getSelectedShapes()[0])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -8,10 +8,12 @@ import {
 	TLHandle,
 	TLKeyboardEvent,
 	TLLineShape,
+	TLNoteShape,
 	TLPointerEventInfo,
 	TLShapeId,
 	TLShapePartial,
 	Vec,
+	createShapeId,
 	snapAngle,
 	sortByIndex,
 	structuredClone,
@@ -30,7 +32,7 @@ export class DraggingHandle extends StateNode {
 	initialPageRotation: any
 
 	info = {} as TLPointerEventInfo & {
-		shape: TLArrowShape | TLLineShape
+		shape: TLArrowShape | TLLineShape | TLNoteShape
 		target: 'handle'
 		onInteractionEnd?: string
 		isCreating: boolean
@@ -58,6 +60,19 @@ export class DraggingHandle extends StateNode {
 		if (!isCreating) this.editor.mark(this.markId)
 
 		this.initialHandle = structuredClone(handle)
+
+		if (this.editor.isShapeOfType<TLNoteShape>(shape, 'note')) {
+			const shapeId = createShapeId()
+			const pagePoint = this.editor.inputs.originPagePoint
+			this.editor.createShape({
+				type: 'note',
+				id: shapeId,
+				x: pagePoint.x - 100,
+				y: pagePoint.y - 50,
+			})
+			this.editor.select(shapeId)
+			this.parent.transition('translating', { shapeId })
+		}
 
 		if (this.editor.isShapeOfType<TLLineShape>(shape, 'line')) {
 			// For line shapes, if we're dragging a "create" handle, then

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -40,9 +40,10 @@ export class PointingHandle extends StateNode {
 
 	override onPointerUp: TLEventHandlers['onPointerUp'] = () => {
 		if (this.editor.isShapeOfType<TLNoteShape>(this.shape, 'note')) {
-			console.log(this.info)
 			this.editor
 				.getShapeUtil<TLNoteShape>(this.shape)
+				// todo: fix this
+				// @ts-expect-error
 				.onHandlePointerUp({ shape: this.shape, handleId: this.info.handle.id })
 		}
 		this.parent.transition('idle', this.info)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -1,16 +1,23 @@
-import { StateNode, TLArrowShape, TLEventHandlers, TLPointerEventInfo } from '@tldraw/editor'
+import {
+	StateNode,
+	TLArrowShape,
+	TLEventHandlers,
+	TLNoteShape,
+	TLPointerEventInfo,
+	TLShape,
+} from '@tldraw/editor'
 
 export class PointingHandle extends StateNode {
 	static override id = 'pointing_handle'
+	shape = {} as TLShape
 
 	info = {} as TLPointerEventInfo & { target: 'handle' }
 
 	override onEnter = (info: TLPointerEventInfo & { target: 'handle' }) => {
 		this.info = info
-
-		const { shape } = info
-		if (this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')) {
-			const initialTerminal = shape.props[info.handle.id as 'start' | 'end']
+		this.shape = info.shape
+		if (this.editor.isShapeOfType<TLArrowShape>(this.shape, 'arrow')) {
+			const initialTerminal = this.shape.props[info.handle.id as 'start' | 'end']
 
 			if (initialTerminal?.type === 'binding') {
 				this.editor.setHintingShapes([initialTerminal.boundShapeId])
@@ -32,6 +39,12 @@ export class PointingHandle extends StateNode {
 	}
 
 	override onPointerUp: TLEventHandlers['onPointerUp'] = () => {
+		if (this.editor.isShapeOfType<TLNoteShape>(this.shape, 'note')) {
+			console.log(this.info)
+			this.editor
+				.getShapeUtil<TLNoteShape>(this.shape)
+				.onHandlePointerUp({ shape: this.shape, handleId: this.info.handle.id })
+		}
 		this.parent.transition('idle', this.info)
 	}
 

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ArrayOfValidator } from '@tldraw/validate';
 import { BaseRecord } from '@tldraw/store';
 import { Expand } from '@tldraw/utils';
 import { IndexKey } from '@tldraw/utils';
@@ -707,7 +708,7 @@ export const noteShapeProps: {
     growY: T.Validator<number>;
     url: T.Validator<string>;
     text: T.Validator<string>;
-    buttons: T.Validator<VecModel>;
+    buttons: ArrayOfValidator<VecModel>;
 };
 
 // @internal (undocumented)

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -707,6 +707,7 @@ export const noteShapeProps: {
     growY: T.Validator<number>;
     url: T.Validator<string>;
     text: T.Validator<string>;
+    buttons: T.Validator<VecModel>;
 };
 
 // @internal (undocumented)

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2954,7 +2954,25 @@
             },
             {
               "kind": "Content",
-              "text": "<string>;\n}"
+              "text": "<string>;\n    buttons: "
+            },
+            {
+              "kind": "Reference",
+              "text": "T.Validator",
+              "canonicalReference": "@tldraw/validate!Validator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<import(\"..\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "VecModel",
+              "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">;\n}"
             }
           ],
           "fileUrlPath": "packages/tlschema/src/shapes/TLNoteShape.ts",
@@ -2963,7 +2981,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 22
           }
         },
         {

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -2958,8 +2958,8 @@
             },
             {
               "kind": "Reference",
-              "text": "T.Validator",
-              "canonicalReference": "@tldraw/validate!Validator:class"
+              "text": "ArrayOfValidator",
+              "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
             },
             {
               "kind": "Content",

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -1,5 +1,5 @@
 import { defineMigrations } from '@tldraw/store'
-import { T } from '@tldraw/validate'
+import { ArrayOfValidator, T } from '@tldraw/validate'
 import { vecModelValidator } from '..'
 import { DefaultColorStyle } from '../styles/TLColorStyle'
 import { DefaultFontStyle } from '../styles/TLFontStyle'
@@ -21,7 +21,7 @@ export const noteShapeProps = {
 	growY: T.positiveNumber,
 	url: T.linkUrl,
 	text: T.string,
-	buttons: vecModelValidator,
+	buttons: new ArrayOfValidator(vecModelValidator),
 }
 
 /** @public */

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -1,5 +1,6 @@
 import { defineMigrations } from '@tldraw/store'
 import { T } from '@tldraw/validate'
+import { vecModelValidator } from '..'
 import { DefaultColorStyle } from '../styles/TLColorStyle'
 import { DefaultFontStyle } from '../styles/TLFontStyle'
 import {
@@ -20,6 +21,7 @@ export const noteShapeProps = {
 	growY: T.positiveNumber,
 	url: T.linkUrl,
 	text: T.string,
+	buttons: vecModelValidator,
 }
 
 /** @public */


### PR DESCRIPTION
Using handles for duplication controls. Can't seem to set the editing state yet. Not sure why.
![2024-03-15 at 15 32 53 - Fuchsia Locust](https://github.com/tldraw/tldraw/assets/98838967/7da9f749-a852-474c-ba48-355d5516d15d)


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
