### PR TITLE
[example] culling

### DIFF
--- a/apps/examples/src/examples/rendering-shape-changes/README.md
+++ b/apps/examples/src/examples/rendering-shape-changes/README.md
@@ -1,0 +1,10 @@
+---
+title: Rendering shapes change
+component: ./RenderingShapesChangeExample.tsx
+category: basic
+priority: 1
+---
+
+---
+
+Do something when the rendering shapes change.

--- a/apps/examples/src/examples/rendering-shape-changes/README.md
+++ b/apps/examples/src/examples/rendering-shape-changes/README.md
@@ -2,7 +2,6 @@
 title: Rendering shapes change
 component: ./RenderingShapesChangeExample.tsx
 category: basic
-priority: 1
 ---
 
 ---

--- a/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
+++ b/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { TLShape, Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+import { useChangedShapesReactor } from './useRenderingShapesChange'
+
+const components = {
+	InFrontOfTheCanvas: () => {
+		const [state, setState] = useState<{
+			created: TLShape[]
+			deleted: TLShape[]
+			culled: TLShape[]
+			restored: TLShape[]
+		}>({
+			created: [],
+			deleted: [],
+			culled: [],
+			restored: [],
+		})
+
+		useChangedShapesReactor(setState)
+
+		return (
+			<div style={{ padding: 50 }}>
+				<pre>{JSON.stringify(state, null, 2)}</pre>
+			</div>
+		)
+	},
+}
+
+export default function RenderingShapesChangeExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="example" components={components} />
+		</div>
+	)
+}

--- a/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
+++ b/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
@@ -1,29 +1,28 @@
-import { useState } from 'react'
+import { useCallback } from 'react'
 import { TLShape, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { useChangedShapesReactor } from './useRenderingShapesChange'
 
 const components = {
 	InFrontOfTheCanvas: () => {
-		const [state, setState] = useState<{
-			created: TLShape[]
-			deleted: TLShape[]
-			culled: TLShape[]
-			restored: TLShape[]
-		}>({
-			created: [],
-			deleted: [],
-			culled: [],
-			restored: [],
-		})
-
-		useChangedShapesReactor(setState)
-
-		return (
-			<div style={{ padding: 50 }}>
-				<pre>{JSON.stringify(state, null, 2)}</pre>
-			</div>
+		const onShapesChanged = useCallback(
+			(info: {
+				created: TLShape[]
+				deleted: TLShape[]
+				culled: TLShape[]
+				restored: TLShape[]
+			}) => {
+				// eslint-disable-next-line no-console
+				for (const shape of info.culled) console.log('culled: ' + shape.id)
+				// eslint-disable-next-line no-console
+				for (const shape of info.restored) console.log('restored: ' + shape.id)
+			},
+			[]
 		)
+
+		useChangedShapesReactor(onShapesChanged)
+
+		return null
 	},
 }
 

--- a/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
+++ b/apps/examples/src/examples/rendering-shape-changes/RenderingShapesChangeExample.tsx
@@ -5,20 +5,12 @@ import { useChangedShapesReactor } from './useRenderingShapesChange'
 
 const components = {
 	InFrontOfTheCanvas: () => {
-		const onShapesChanged = useCallback(
-			(info: {
-				created: TLShape[]
-				deleted: TLShape[]
-				culled: TLShape[]
-				restored: TLShape[]
-			}) => {
-				// eslint-disable-next-line no-console
-				for (const shape of info.culled) console.log('culled: ' + shape.id)
-				// eslint-disable-next-line no-console
-				for (const shape of info.restored) console.log('restored: ' + shape.id)
-			},
-			[]
-		)
+		const onShapesChanged = useCallback((info: { culled: TLShape[]; restored: TLShape[] }) => {
+			// eslint-disable-next-line no-console
+			for (const shape of info.culled) console.log('culled: ' + shape.id)
+			// eslint-disable-next-line no-console
+			for (const shape of info.restored) console.log('restored: ' + shape.id)
+		}, [])
 
 		useChangedShapesReactor(onShapesChanged)
 

--- a/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
+++ b/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
@@ -2,12 +2,7 @@ import { useEffect, useRef } from 'react'
 import { TLShape, react, useEditor } from 'tldraw'
 
 export function useChangedShapesReactor(
-	cb: (info: {
-		created: TLShape[]
-		deleted: TLShape[]
-		culled: TLShape[]
-		restored: TLShape[]
-	}) => void
+	cb: (info: { culled: TLShape[]; restored: TLShape[] }) => void
 ) {
 	const editor = useEditor()
 	const rPrevShapes = useRef(editor.getRenderingShapes())
@@ -17,7 +12,6 @@ export function useChangedShapesReactor(
 			const after = editor.getRenderingShapes()
 			const before = rPrevShapes.current
 
-			const created: TLShape[] = []
 			const culled: TLShape[] = []
 			const restored: TLShape[] = []
 
@@ -26,7 +20,7 @@ export function useChangedShapesReactor(
 			for (const afterInfo of after) {
 				const beforeInfo = before.find((s) => s.id === afterInfo.id)
 				if (!beforeInfo) {
-					created.push(afterInfo.shape)
+					continue
 				} else {
 					if (afterInfo.isCulled && !beforeInfo.isCulled) {
 						culled.push(afterInfo.shape)
@@ -37,13 +31,9 @@ export function useChangedShapesReactor(
 				}
 			}
 
-			const deleted = Array.from(beforeToVisit).map((s) => s.shape)
-
 			rPrevShapes.current = after
 
 			cb({
-				created,
-				deleted,
 				culled,
 				restored,
 			})

--- a/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
+++ b/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+import { TLShape, react, useEditor } from 'tldraw'
+
+export function useChangedShapesReactor(
+	cb: (info: {
+		created: TLShape[]
+		deleted: TLShape[]
+		culled: TLShape[]
+		restored: TLShape[]
+	}) => void
+) {
+	const editor = useEditor()
+	const rPrevShapes = useRef(editor.getRenderingShapes())
+
+	useEffect(() => {
+		return react('when rendering shapes change', () => {
+			const after = editor.getRenderingShapes()
+			const before = rPrevShapes.current
+
+			const created: TLShape[] = []
+			const culled: TLShape[] = []
+			const restored: TLShape[] = []
+
+			const beforeToVisit = new Set(before)
+
+			for (const afterInfo of after) {
+				const beforeInfo = before.find((s) => s.id === afterInfo.id)
+				if (!beforeInfo) {
+					created.push(afterInfo.shape)
+				} else {
+					if (afterInfo.isCulled && !beforeInfo.isCulled) {
+						culled.push(afterInfo.shape)
+					} else if (!afterInfo.isCulled && beforeInfo.isCulled) {
+						restored.push(afterInfo.shape)
+					}
+					beforeToVisit.delete(beforeInfo)
+				}
+			}
+
+			const deleted = Array.from(beforeToVisit).map((s) => s.shape)
+
+			rPrevShapes.current = after
+
+			cb({
+				created,
+				deleted,
+				culled,
+				restored,
+			})
+		})
+	}, [cb, editor])
+}


### PR DESCRIPTION
An example hook for listening to when shapes were culled or unculled.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [x] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

