### PR TITLE
[experiment] global timer

### DIFF
--- a/apps/examples/src/examples/custom-renderer/CustomRenderer.tsx
+++ b/apps/examples/src/examples/custom-renderer/CustomRenderer.tsx
@@ -19,10 +19,7 @@ export function CustomRenderer() {
 
 		const ctx = canvas.getContext('2d')!
 
-		let isCancelled = false
-
 		function render() {
-			if (isCancelled) return
 			if (!canvas) return
 
 			ctx.resetTransform()
@@ -92,14 +89,11 @@ export function CustomRenderer() {
 				}
 				ctx.restore()
 			}
-
-			requestAnimationFrame(render)
 		}
-
-		render()
+		editor.on('tick', render)
 
 		return () => {
-			isCancelled = true
+			editor.off('tick', render)
 		}
 	}, [editor])
 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -600,6 +600,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     clearOpenMenus(): this;
     // @internal
     protected _clickManager: ClickManager;
+    clock: TickManager;
     complete(): this;
     // @internal (undocumented)
     crash(error: unknown): this;
@@ -901,6 +902,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     updateDocumentSettings(settings: Partial<TLDocument>): this;
     updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, historyOptions?: TLCommandHistoryOptions): this;
     updatePage(partial: RequiredKeys<TLPage, 'id'>, historyOptions?: TLCommandHistoryOptions): this;
+    // (undocumented)
+    updatePointerVelocity: (elapsed: number) => void;
     // @internal
     updateRenderingBounds(): this;
     updateShape<T extends TLUnknownShape>(partial: null | TLShapePartial<T> | undefined, historyOptions?: TLCommandHistoryOptions): this;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -8276,6 +8276,37 @@
               "name": "clearOpenMenus"
             },
             {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!Editor#clock:member",
+              "docComment": "/**\n * A clock for the app's tick events.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "clock: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TickManager",
+                  "canonicalReference": "@tldraw/editor!~TickManager:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "clock",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#complete:member(1)",
               "docComment": "/**\n * Dispatch a complete event.\n *\n * @example\n * ```ts\n * editor.complete()\n * ```\n *\n * @public\n */\n",
@@ -19017,6 +19048,36 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "updatePage"
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!Editor#updatePointerVelocity:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "updatePointerVelocity: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(elapsed: number) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "updatePointerVelocity",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",

--- a/packages/editor/src/lib/editor/managers/ClickManager.ts
+++ b/packages/editor/src/lib/editor/managers/ClickManager.ts
@@ -33,7 +33,7 @@ export class ClickManager {
 	private _getClickTimeout = (state: TLClickState, id = uniqueId()) => {
 		this._clickId = id
 		clearTimeout(this._clickTimeout)
-		this._clickTimeout = setTimeout(
+		this._clickTimeout = this.editor.clock.setTimeout(
 			() => {
 				if (this._clickState === state && this._clickId === id) {
 					switch (this._clickState) {

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -272,7 +272,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 
 			pinchState = 'not sure'
 
-			requestAnimationFrame(() => {
+			editor.once('tick', () => {
 				editor.dispatch({
 					type: 'pinch',
 					name: 'pinch_end',

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -20,14 +20,6 @@ const ids = {
 
 jest.useFakeTimers()
 
-window.requestAnimationFrame = function requestAnimationFrame(cb) {
-	return setTimeout(cb, 1000 / 60)
-}
-
-window.cancelAnimationFrame = function cancelAnimationFrame(id) {
-	clearTimeout(id)
-}
-
 beforeEach(() => {
 	editor = new TestEditor()
 	editor

--- a/packages/tldraw/src/test/ClickManager.test.ts
+++ b/packages/tldraw/src/test/ClickManager.test.ts
@@ -23,7 +23,7 @@ describe('Handles events', () => {
 		const eventsBeforeSettle = [{ name: 'pointer_down' }, { name: 'pointer_up' }]
 
 		// allow time for settle
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		// nothing should have settled
 		expect(events).toMatchObject(eventsBeforeSettle)
@@ -64,7 +64,7 @@ describe('Handles events', () => {
 		}
 
 		// allow double click to settle
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		expect(events).toMatchObject([
 			...eventsBeforeSettle,
@@ -110,7 +110,7 @@ describe('Handles events', () => {
 		expect(eventsBeforeSettle).toMatchObject(eventsBeforeSettle)
 
 		// allow double click to settle
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		expect(events).toMatchObject([
 			...eventsBeforeSettle,
@@ -162,7 +162,7 @@ describe('Handles events', () => {
 		expect(events).toMatchObject(eventsBeforeSettle)
 
 		// allow double click to settle
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		expect(events).toMatchObject([
 			...eventsBeforeSettle,
@@ -218,7 +218,7 @@ describe('Handles events', () => {
 		expect(events).toMatchObject(eventsBeforeSettle)
 
 		// allow double click to settle
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		expect(events).toMatchObject(eventsBeforeSettle)
 

--- a/packages/tldraw/src/test/HandTool.test.ts
+++ b/packages/tldraw/src/test/HandTool.test.ts
@@ -22,9 +22,10 @@ describe(HandTool, () => {
 		expect(editor.getZoomLevel()).toBe(1)
 		editor.click()
 		editor.click() // double click!
-		jest.advanceTimersByTime(300)
+		expect(editor.getZoomLevel()).toBe(1) // waiting to settle...
+		editor.forceTick(14) // wait for the settle
 		expect(editor.getZoomLevel()).not.toBe(1) // animating
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(2) // all done
 	})
 
@@ -34,9 +35,9 @@ describe(HandTool, () => {
 		editor.click()
 		editor.click()
 		editor.click() // triple click!
-		jest.advanceTimersByTime(300)
+		editor.forceTick(14) // wait for the settle
 		expect(editor.getZoomLevel()).not.toBe(1) // animating
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(0.5) // all done
 	})
 
@@ -48,9 +49,9 @@ describe(HandTool, () => {
 		editor.click()
 		editor.click()
 		editor.click() // quad click!
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).not.toBe(2) // animating
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(1) // all done
 	})
 
@@ -62,9 +63,9 @@ describe(HandTool, () => {
 		editor.click()
 		editor.click()
 		editor.click() // quad click!
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).not.toBe(1) // animating
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		const z = editor.getZoomLevel()
 		editor.zoomToFit() // call zoom to fit manually to compare
 		expect(editor.getZoomLevel()).toBe(z) // zoom should not have changed

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -60,7 +60,7 @@ describe('TLSelectTool.Translating', () => {
 		// There's a timer here! We shouldn't end the clone until the timer is done
 		expect(editor.getCurrentPageShapes().length).toBe(2)
 
-		jest.advanceTimersByTime(250) // tick tock
+		editor.forceTick(100) // tick tock
 
 		// Timer is done! We should have ended the clone.
 		expect(editor.getCurrentPageShapes().length).toBe(1)

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -295,7 +295,7 @@ export class TestEditor extends Editor {
 	*/
 	forceTick = (count = 1) => {
 		for (let i = 0; i < count; i++) {
-			this.emit('tick', 16)
+			this.clock.tick(16)
 		}
 		return this
 	}

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -44,7 +44,7 @@ describe('TLSelectTool.Zooming', () => {
 		expect(editor.getViewportPageCenter()).toMatchObject({ x: 540, y: 360 })
 		editor.click()
 		editor.expectToBeIn('zoom.idle')
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(2)
 	})
 
@@ -55,7 +55,7 @@ describe('TLSelectTool.Zooming', () => {
 		expect(editor.getViewportPageBounds()).toMatchObject({ x: -0, y: -0, w: 1080, h: 720 })
 		expect(editor.getViewportPageCenter()).toMatchObject({ x: 540, y: 360 })
 		editor.click()
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(0.5)
 	})
 
@@ -122,7 +122,7 @@ describe('TLSelectTool.Zooming', () => {
 		editor.expectToBeIn('zoom.zoom_brushing')
 		editor.pointerUp(change, change)
 		editor.expectToBeIn('zoom.idle')
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBe(2)
 		expect(editor.getViewportPageBounds()).toMatchObject({
 			x: change / 2,
@@ -156,7 +156,7 @@ describe('TLSelectTool.Zooming', () => {
 			h: newBoundsHeight,
 		})
 		editor.pointerUp(newBoundsX + newBoundsWidth, newBoundsY + newBoundsHeight)
-		jest.advanceTimersByTime(300)
+		editor.forceTick(19)
 		expect(editor.getZoomLevel()).toBeCloseTo(1.2888)
 		expect(editor.getViewportPageBounds()).toMatchObject({
 			x: -48.9655172413793,
@@ -193,7 +193,7 @@ describe('TLSelectTool.Zooming', () => {
 			h: newBoundsHeight,
 		})
 		editor.pointerUp()
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 		expect(editor.getZoomLevel()).toBeCloseTo(originalZoomLevel / 2)
 		expect(editor.getViewportPageBounds()).toMatchObject({
 			x: -440,

--- a/packages/tldraw/src/test/arrows-megabus.test.tsx
+++ b/packages/tldraw/src/test/arrows-megabus.test.tsx
@@ -191,7 +191,7 @@ describe('When binding an arrow to a shape', () => {
 
 		editor.keyUp('Control')
 		expect(arrow().props.end.type).toBe('point') // there's a short delay here, it should still be a point
-		jest.advanceTimersByTime(1000) // once the timer runs out...
+		editor.forceTick(65) // once the timer runs out...
 		expect(arrow().props.end.type).toBe('binding')
 
 		editor.keyDown('Control') // no delay when pressing control again though
@@ -199,7 +199,7 @@ describe('When binding an arrow to a shape', () => {
 
 		editor.keyUp('Control')
 		editor.pointerUp()
-		jest.advanceTimersByTime(1000) // once the timer runs out...
+		editor.forceTick(65) // once the timer runs out...
 		expect(arrow().props.end.type).toBe('point') // still a point because interaction ended before timer ended
 	})
 })

--- a/packages/tldraw/src/test/commands/centerOnPoint.test.ts
+++ b/packages/tldraw/src/test/commands/centerOnPoint.test.ts
@@ -14,8 +14,8 @@ it('centers on the point', () => {
 it('centers on the point with animation', () => {
 	editor.centerOnPoint({ x: 400, y: 400 }, { duration: 200 })
 	expect(editor.getViewportPageCenter()).not.toMatchObject({ x: 400, y: 400 })
-	jest.advanceTimersByTime(100)
+	editor.forceTick(10) // still animating...
 	expect(editor.getViewportPageCenter()).not.toMatchObject({ x: 400, y: 400 })
-	jest.advanceTimersByTime(200)
+	editor.forceTick(10) // should be complete now
 	expect(editor.getViewportPageCenter()).toMatchObject({ x: 400, y: 400 })
 })

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -467,7 +467,7 @@ describe('When in the select.crop.translating_crop state', () => {
 		})
 
 		editor.keyUp('Shift')
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		const afterShiftUp = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
 

--- a/packages/tldraw/src/test/customSnapping.test.tsx
+++ b/packages/tldraw/src/test/customSnapping.test.tsx
@@ -60,7 +60,9 @@ describe('custom shape bounds snapping - translate', () => {
 			expect(editor.getOnlySelectedShape()?.x).toBe(100)
 
 			// move the left edge of the test shape to the center of the box shape - it should snap
-			editor.pointerMove(105, 250, undefined, { ctrlKey: true })
+			editor.pointerMove(105, 250, undefined)
+			editor.forceTick(16)
+			editor.keyDown('Control')
 			expect(editor.snaps.getIndicators()).toHaveLength(2)
 			expect(editor.getOnlySelectedShape()?.x).toBe(50)
 		})
@@ -75,7 +77,9 @@ describe('custom shape bounds snapping - translate', () => {
 			expect(editor.getOnlySelectedShape()?.x).toBe(100)
 
 			// move the left edge of the box shape to the center of the test shape - it should snap
-			editor.pointerMove(205, 50, undefined, { ctrlKey: true })
+			editor.pointerMove(205, 50)
+			editor.forceTick(16)
+			editor.keyDown('Control')
 			expect(editor.snaps.getIndicators()).toHaveLength(2)
 			expect(editor.getOnlySelectedShape()?.x).toBe(150)
 		})

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -328,18 +328,20 @@ describe('frame shapes', () => {
 		editor.setCurrentTool('select')
 		editor.pointerDown(275, 275).pointerMove(150, 150)
 
-		jest.advanceTimersByTime(300)
+		editor.forceTick(100)
 
 		expect(editor.getOnlySelectedShape()!.id).toBe(ids.boxA)
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(frameId)
 
 		editor.pointerMove(275, 275)
-		jest.advanceTimersByTime(250)
+
+		editor.forceTick(100)
 
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(editor.getCurrentPageId())
 
 		editor.pointerMove(150, 150)
-		jest.advanceTimersByTime(250)
+
+		editor.forceTick(100)
 
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(frameId)
 
@@ -422,6 +424,8 @@ describe('frame shapes', () => {
 		editor.select(ids.boxA)
 		editor.pointerDown(275, 275, ids.boxA).pointerMove(275, 74)
 		expect(editor.getShapePageBounds(ids.boxA)).toMatchObject({ y: 49 })
+
+		editor.forceTick(16) // wait for pointer velocity decay
 		editor.keyDown('Control')
 		expect(editor.getShapePageBounds(ids.boxA)).toMatchObject({ y: 50 })
 		expect(editor.snaps.getIndicators()).toHaveLength(1)
@@ -451,9 +455,8 @@ describe('frame shapes', () => {
 			.pointerDown(277.5, 127.5, editor.getOnlySelectedShape()!.id)
 			.pointerMove(287.5, 126.5)
 			.pointerMove(277.5, 126.5)
-
+		// wait for pointer velocity decay
 		// now try to snap
-		editor.keyDown('Control')
 		expect(editor.getShapePageBounds(editor.getOnlySelectedShape()!)).toMatchObject({
 			x: 275,
 			y: 124,
@@ -465,6 +468,8 @@ describe('frame shapes', () => {
 		editor.reparentShapes([innerBoxId], editor.getCurrentPageId())
 
 		editor.pointerMove(287.5, 126.5).pointerMove(277.5, 126.5)
+		editor.forceTick(16) // wait for pointer velocity decay
+		editor.keyDown('Control')
 		expect(editor.snaps.getIndicators()).toHaveLength(1)
 		expect(editor.getShapePageBounds(editor.getOnlySelectedShape()!)).toMatchObject({
 			x: 275,
@@ -930,7 +935,7 @@ describe('When dragging a shape inside a group inside a frame', () => {
 
 		editor.pointerMove(150, 150).pointerDown().pointerMove(140, 140)
 
-		jest.advanceTimersByTime(300)
+		editor.forceTick(13)
 
 		expect(editor.getShape(ids.box1)!.parentId).toBe(ids.group1)
 	})
@@ -956,7 +961,7 @@ describe('When dragging a shape inside a group inside a frame', () => {
 			.pointerMove(-200, -200)
 			.pointerUp()
 
-		jest.advanceTimersByTime(300)
+		editor.forceTick(13)
 
 		expect(editor.getShape(ids.box1)!.parentId).toBe(editor.getCurrentPageId())
 	})

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -13,7 +13,7 @@ it('Shift Key', () => {
 	editor.pointerMove(100, 100, { shiftKey: true })
 	editor.pointerMove(100, 100, { shiftKey: false })
 	expect(editor.inputs.shiftKey).toBe(true)
-	jest.advanceTimersByTime(200)
+	editor.forceTick(13)
 	expect(editor.inputs.shiftKey).toBe(false)
 })
 
@@ -22,7 +22,7 @@ it('Alt Key', () => {
 	editor.pointerMove(100, 100, { altKey: true })
 	editor.pointerMove(100, 100, { altKey: false })
 	expect(editor.inputs.altKey).toBe(true)
-	jest.advanceTimersByTime(200)
+	editor.forceTick(13)
 	expect(editor.inputs.altKey).toBe(false)
 })
 
@@ -31,6 +31,6 @@ it('Ctrl Key', () => {
 	editor.pointerMove(100, 100, { ctrlKey: true })
 	editor.pointerMove(100, 100, { ctrlKey: false })
 	expect(editor.inputs.ctrlKey).toBe(true)
-	jest.advanceTimersByTime(200)
+	editor.forceTick(13)
 	expect(editor.inputs.ctrlKey).toBe(false)
 })

--- a/packages/tldraw/src/test/renderingShapes.test.tsx
+++ b/packages/tldraw/src/test/renderingShapes.test.tsx
@@ -53,7 +53,7 @@ it('updates the rendering viewport when the camera stops moving', () => {
 
 	editor.updateRenderingBounds = jest.fn(editor.updateRenderingBounds)
 	editor.pan({ x: -201, y: -201 })
-	jest.advanceTimersByTime(500)
+	editor.forceTick(32)
 
 	expect(editor.updateRenderingBounds).toHaveBeenCalledTimes(1)
 	expect(editor.getRenderingBounds()).toMatchObject({ x: 201, y: 201, w: 1800, h: 900 })
@@ -72,7 +72,7 @@ it('lists shapes in viewport', () => {
 
 	// Move the camera 201 pixels to the right and 201 pixels down
 	editor.pan({ x: -201, y: -201 })
-	jest.advanceTimersByTime(500)
+	editor.forceTick(32)
 
 	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
 		[ids.A, false], // A should not be culled, even though it's no longer in the viewport (because it's still in the EXPANDED viewport)
@@ -82,7 +82,7 @@ it('lists shapes in viewport', () => {
 	])
 
 	editor.pan({ x: -100, y: -100 })
-	jest.advanceTimersByTime(500)
+	editor.forceTick(32)
 
 	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
 		[ids.A, true], // A should be culled now that it's outside of the expanded viewport too
@@ -92,7 +92,7 @@ it('lists shapes in viewport', () => {
 	])
 
 	editor.pan({ x: -900, y: -900 })
-	jest.advanceTimersByTime(500)
+	editor.forceTick(32)
 	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
 		[ids.A, true],
 		[ids.B, true],

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -541,7 +541,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		// └──────────────────O
 
 		editor.pointerMove(15, 8, { altKey: false, shiftKey: true })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(roundedBox(editor.getSelectionPageBounds()!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
@@ -590,7 +590,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		editor.pointerDown(30, 20, { target: 'selection', handle: 'top_left_rotate' })
 		editor.pointerMove(20, 20, { shiftKey: true })
 		editor.pointerUp(20, 20, { shiftKey: false })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(editor.getShape(ids.boxB)!.rotation).toBeCloseTo(canonicalizeRotation(-PI / 2))
 
@@ -737,7 +737,7 @@ describe('Reisizing a selection of multiple shapes', () => {
 		// └──────────────────O
 
 		editor.pointerMove(15, 8, { altKey: false, shiftKey: true })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(roundedBox(editor.getSelectionPageBounds()!)).toMatchObject({ w: 15, h: 15 })
 		expect(roundedPageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 5, h: 5 })
@@ -2361,7 +2361,7 @@ describe('snapping while resizing a shape that has been rotated by multiples of 
 			.select(ids.boxX)
 			.pointerDown(100, 70, { target: 'selection', handle: 'top' })
 			.pointerMove(121, 70, { ctrlKey: true, shiftKey: false })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(editor.getShapePageBounds(ids.boxX)!).toMatchObject({
 			x: 40,
@@ -2429,7 +2429,7 @@ describe('snapping while resizing a shape that has been rotated by multiples of 
 			.select(ids.boxX)
 			.pointerDown(70, 40, { target: 'selection', handle: 'bottom' })
 			.pointerMove(70, 18, { ctrlKey: true, shiftKey: false })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(editor.getShapePageBounds(ids.boxX)!.x).toBeCloseTo(40)
 		expect(editor.getShapePageBounds(ids.boxX)!.y).toBeCloseTo(20)
@@ -2561,7 +2561,7 @@ describe('snapping while resizing a shape that has been rotated by multiples of 
 			.select(ids.boxX)
 			.pointerDown(100, 70, { target: 'selection', handle: 'right' })
 			.pointerMove(121, 70, { ctrlKey: true, shiftKey: false })
-		jest.advanceTimersByTime(200)
+		editor.forceTick(13)
 
 		expect(editor.getShapePageBounds(ids.boxX)!.x).toBeCloseTo(40)
 		expect(editor.getShapePageBounds(ids.boxX)!.y).toBeCloseTo(40)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1616,7 +1616,7 @@ describe('shift brushes to add to the selection', () => {
 		editor.keyUp('Shift')
 		// there's a timer here—we should keep the shift mode until the timer expires
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box2, ids.box1])
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 		// once the timer expires, we should be back in regular mode
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		editor.keyDown('Shift')
@@ -1686,7 +1686,7 @@ describe('scribble brushes to add to the selection', () => {
 		editor.pointerMove(50, 50)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
 		editor.keyUp('Shift')
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		editor.keyDown('Shift')
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
@@ -1703,7 +1703,7 @@ describe('scribble brushes to add to the selection', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box4])
 		editor.keyUp('Alt') // scribble
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box4]) // still in timer
-		jest.advanceTimersByTime(1000) // let timer expire
+		editor.forceTick(300) // let timer expire
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box3, ids.box4]) // brushed!
 		editor.keyDown('Alt') // scribble
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box4]) // back to brushed only
@@ -1846,7 +1846,7 @@ describe('When brushing close to the edges of the screen', () => {
 		editor.pointerMove(0, 0)
 		// still only box 1...
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		jest.advanceTimersByTime(100)
+		editor.forceTick(10)
 		// ...but now viewport will have moved to select box2 as well
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
 		editor.pointerUp()

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -239,7 +239,7 @@ describe('When cloning...', () => {
 
 		// Stop cloning!
 		editor.keyUp('Alt')
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		editor.expectShapeToMatch({ id: ids.box1, x: 20, y: 0 }) // A should be at the translated position...
 		expect(editor.getShape(newShape.id)).toBeUndefined() // And the new node should be gone!
@@ -274,7 +274,7 @@ describe('When cloning...', () => {
 		editor.keyUp('Alt')
 
 		// wait 500ms
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 		editor
 			.expectShapeToMatch({ id: ids.box1, x: 20, y: 0 }) // A should be at the translated position...
 			.expectShapeToMatch({ id: ids.box2, x: 210, y: 190 }) // B should be at the translated position...
@@ -311,8 +311,8 @@ describe('When cloning...', () => {
 
 		// Stop cloning!
 		editor.keyUp('Alt')
-		// wait 500ms
-		jest.advanceTimersByTime(500)
+		// wait ~500ms
+		editor.forceTick(32)
 
 		editor.expectShapeToMatch({ id: ids.box2, x: 210, y: 190 }) // B should be at the translated position...
 		expect(editor.getShape(cloneB.id)).toBeUndefined() // And the new node A should be gone!
@@ -337,7 +337,7 @@ describe('When cloning...', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(count1 + 3) // 2 new box and group
 
 		editor.keyUp('Alt')
-		jest.advanceTimersByTime(500)
+		editor.forceTick(32)
 
 		expect(editor.getCurrentPageShapes().length).toBe(count1) // 2 new box and group
 
@@ -480,12 +480,13 @@ describe('snapping with single shapes', () => {
 		expect(editor.getShape(ids.box2)!).toMatchObject({ x: 11, y: 0 })
 
 		// press ctrl key and it snaps to 10, 0
+		editor.forceTick(16) // wait for pointer velocity to decay
 		editor.keyDown('Control')
 		expect(editor.getShape(ids.box2)!).toMatchObject({ x: 10, y: 0 })
 
 		// release ctrl key and it unsnaps
 		editor.keyUp('Control')
-		jest.advanceTimersByTime(200)
+		editor.forceTick(100)
 
 		expect(editor.getShape(ids.box2)!).toMatchObject({ x: 11, y: 0 })
 
@@ -514,6 +515,9 @@ describe('snapping with single shapes', () => {
 		// │  A   │
 		// └──────┘
 		editor.pointerMove(16, -6, { ctrlKey: true })
+		editor.forceTick(16) // wait for pointer velocity to decay
+		// snapping only happens on pointer move, so we do need to trigger another
+		editor.pointerMove(16, -6, { ctrlKey: true })
 		expect(editor.getShape(ids.box2)!).toMatchObject({ x: 10, y: -10 })
 
 		// ┌──────┐
@@ -531,6 +535,9 @@ describe('snapping with single shapes', () => {
 		// ┌──────┐
 		// │  B   │
 		// └──────┘
+		editor.pointerMove(-6, 16, { ctrlKey: true })
+		editor.forceTick(16) // wait for pointer velocity to decay
+		// snapping only happens on pointer move, so we do need to trigger another
 		editor.pointerMove(-6, 16, { ctrlKey: true })
 		expect(editor.getShape(ids.box2)!).toMatchObject({ x: -10, y: 10 })
 
@@ -652,6 +659,9 @@ describe('snapping with single shapes', () => {
 		// should still snap to things on the X axis
 		editor.createShapes([{ type: 'geo', id: ids.line1, x: 100, y: 0, props: { w: 10, h: 10 } }])
 		editor.pointerMove(106, 5, { ctrlKey: true, shiftKey: true })
+		editor.forceTick(16) // wait for pointer velocity to decay
+		// snapping only happens on pointer move, so we do need to trigger another
+		editor.pointerMove(106, 5, { ctrlKey: true, shiftKey: true })
 		expect(editor.getShape(ids.box2)).toMatchObject({ x: 100, y: -1 })
 	})
 
@@ -682,6 +692,10 @@ describe('snapping with single shapes', () => {
 		// should still snap to things on the Y axis
 		editor.createShapes([{ type: 'geo', id: ids.line1, x: 20, y: 100, props: { w: 10, h: 10 } }])
 		editor.pointerMove(6, 106, { ctrlKey: true, shiftKey: true })
+		editor.forceTick(16) // wait for pointer velocity to decay
+		// snapping only happens on pointer move, so we do need to trigger another
+		editor.pointerMove(6, 106, { ctrlKey: true, shiftKey: true })
+
 		expect(editor.getShape(ids.box2)).toMatchObject({ x: 1, y: 100 })
 	})
 })
@@ -1469,7 +1483,7 @@ describe('translating while the grid is enabled', () => {
 
 		editor.select(ids.box1).pointerDown(10, 10, ids.box1).pointerMove(39, 10)
 
-		// rounds to nearest 10
+		// rounds to nearest 10 because grid is on
 		expect(editor.getShapePageBounds(ids.box1)!.x).toEqual(30)
 
 		// engage snap mode and it should indeed snap to B
@@ -1479,6 +1493,8 @@ describe('translating while the grid is enabled', () => {
 		//          │ A │ B │
 		//          └───┴───┘
 		editor.keyDown('Control')
+		editor.forceTick(16) // wait for pointer velocity to decay
+		editor.pointerMove(39, 10) // snapping only happens on pointer move, so we do need to trigger another
 		expect(editor.getShapePageBounds(ids.box1)!.x).toEqual(30)
 
 		// and we can move the box anywhere if there are no snaps nearby

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -126,6 +126,9 @@ export function getOwnProperty<K extends string, V>(obj: Partial<Record<K, V>>, 
 // @internal (undocumented)
 export function getOwnProperty(obj: object, key: string): unknown;
 
+// @public (undocumented)
+export const globalTick: GlobalTick;
+
 // @internal (undocumented)
 export function hasOwnProperty(obj: object, key: string): boolean;
 

--- a/packages/utils/api/api.json
+++ b/packages/utils/api/api.json
@@ -1358,6 +1358,30 @@
           "name": "getIndicesBetween"
         },
         {
+          "kind": "Variable",
+          "canonicalReference": "@tldraw/utils!globalTick:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "globalTick: "
+            },
+            {
+              "kind": "Reference",
+              "text": "GlobalTick",
+              "canonicalReference": "@tldraw/utils!~GlobalTick:class"
+            }
+          ],
+          "fileUrlPath": "packages/utils/src/lib/global-tick.ts",
+          "isReadonly": true,
+          "releaseTag": "Public",
+          "name": "globalTick",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "@tldraw/utils!IndexKey:type",
           "docComment": "/**\n * A string made up of an integer part followed by a fraction part. The fraction point consists of zero or more digits with no trailing zeros. Based on {@link https://observablehq.com/@dgreensp/implementing-fractional-indexing}.\n *\n * @public\n */\n",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -66,3 +66,5 @@ export { fpsThrottle, throttleToNextFrame } from './lib/throttle'
 export type { Expand, RecursivePartial, Required } from './lib/types'
 export { isDefined, isNonNull, isNonNullish, structuredClone } from './lib/value'
 export { warnDeprecatedGetter } from './lib/warnDeprecatedGetter'
+
+export { globalTick } from './lib/global-tick'

--- a/packages/utils/src/lib/global-tick.ts
+++ b/packages/utils/src/lib/global-tick.ts
@@ -1,0 +1,68 @@
+/** @public */
+export class GlobalTick {
+	prev = 0
+	tickLength = 1000 / 60
+	frame = -1
+	listeners = new Set<(elapsed: number) => void>()
+
+	tick = () => {
+		const now = Date.now()
+		const elapsed = now - this.prev
+		if (elapsed >= this.tickLength) {
+			this.prev = now
+			this.listeners.forEach((listener) => listener(elapsed))
+		}
+		this.frame = requestAnimationFrame(this.tick)
+	}
+
+	addListener = (listener: (elapsed: number) => void) => {
+		this.listeners.add(listener)
+		return () => this.removeListener(listener)
+	}
+
+	once = (listener: (elapsed: number) => void) => {
+		const cancel = (elapsed: number) => {
+			listener(elapsed)
+			this.listeners.delete(cancel)
+		}
+		this.listeners.add(cancel)
+		return () => this.listeners.delete(cancel)
+	}
+
+	removeListener = (listener: (elapsed: number) => void) => {
+		this.listeners.delete(listener)
+	}
+
+	removeListeners = () => {
+		this.listeners.clear()
+	}
+
+	start = (fps = 60) => {
+		if (typeof window !== 'undefined') {
+			if ((window as any).GLOBAL_TICK_FRAME) {
+				;(window as any).GLOBAL_TICK_FRAME.dispose()
+				delete (window as any).GLOBAL_TICK_FRAME
+			}
+			;(window as any).GLOBAL_TICK_FRAME = this
+		}
+		this.tickLength = 1000 / fps
+		this.prev = Date.now()
+		this.tick()
+		return () => this.stop()
+	}
+
+	stop() {
+		cancelAnimationFrame(this.frame)
+	}
+
+	dispose() {
+		this.removeListeners()
+		this.stop()
+	}
+}
+
+/** @public */
+const globalTick = new GlobalTick()
+globalTick.start()
+
+export { globalTick }

--- a/packages/utils/src/lib/global-tick.ts
+++ b/packages/utils/src/lib/global-tick.ts
@@ -1,4 +1,4 @@
-/** @public */
+/** @internal */
 export class GlobalTick {
 	prev = 0
 	tickLength = 1000 / 60

--- a/packages/utils/src/lib/throttle.ts
+++ b/packages/utils/src/lib/throttle.ts
@@ -1,48 +1,10 @@
+import { globalTick } from './global-tick'
+
 const isTest = () =>
 	typeof process !== 'undefined' &&
 	process.env.NODE_ENV === 'test' &&
 	// @ts-expect-error
 	!globalThis.__FORCE_RAF_IN_TESTS__
-
-const fpsQueue: Array<() => void> = []
-const targetFps = 60
-const targetTimePerFrame = 1000 / targetFps
-let frame: number | undefined
-let time = 0
-let last = 0
-
-const flush = () => {
-	const queue = fpsQueue.splice(0, fpsQueue.length)
-	for (const fn of queue) {
-		fn()
-	}
-}
-
-function tick() {
-	if (frame) {
-		return
-	}
-	const now = Date.now()
-	const elapsed = now - last
-
-	if (time + elapsed < targetTimePerFrame) {
-		frame = requestAnimationFrame(() => {
-			frame = undefined
-			tick()
-		})
-		return
-	}
-	frame = requestAnimationFrame(() => {
-		frame = undefined
-		last = now
-		// If we fall behind more than 10 frames, we'll just reset the time so we don't try to update a number of times
-		// This can happen if we don't interact with the page for a while
-		time = Math.min(time + elapsed - targetTimePerFrame, targetTimePerFrame * 10)
-		flush()
-	})
-}
-
-let started = false
 
 /**
  * Returns a throttled version of the function that will only be called max once per frame.
@@ -57,16 +19,7 @@ export function fpsThrottle(fn: () => void) {
 	}
 
 	return () => {
-		if (fpsQueue.includes(fn)) {
-			return
-		}
-		fpsQueue.push(fn)
-		if (!started) {
-			started = true
-			// We set last to Date.now() - targetTimePerFrame - 1 so that the first run will happen immediately
-			last = Date.now() - targetTimePerFrame - 1
-		}
-		tick()
+		globalTick.addListener(fn)
 	}
 }
 
@@ -82,15 +35,5 @@ export function throttleToNextFrame(fn: () => void) {
 		return fn()
 	}
 
-	if (fpsQueue.includes(fn)) {
-		return
-	}
-
-	fpsQueue.push(fn)
-	if (!started) {
-		started = true
-		// We set last to Date.now() - targetTimePerFrame - 1 so that the first run will happen immediately
-		last = Date.now() - targetTimePerFrame - 1
-	}
-	tick()
+	globalTick.addListener(fn)
 }


### PR DESCRIPTION
This PR introduces a global timer, exported from utils as `globalTick`.

The main change visible when using the trackpad to scroll while dragging a shape:

![Kapture 2024-03-17 at 11 42 05](https://github.com/tldraw/tldraw/assets/23072548/c80691e6-2a62-4622-ad0c-77016ad8d2b7)

This would be a good pairing with tick-based interactions in sessions / #3092.

This single RAF drives:
- throttling
- editor ticks
- pointer velocity
- all timers / timeouts

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Test Plan

1. Try everything.

- [x] Unit Tests

### Release Notes

- Replaces timeouts and timers with a global clock.
- Exposes the editor's `clock`.