### PR TITLE
Skip the random ID for regular history entries

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1964,7 +1964,6 @@ export type TLCollaboratorHintProps = {
 // @public (undocumented)
 export type TLCommand<Name extends string = any, Data = any> = {
     type: 'command';
-    id: string;
     data: Data;
     name: Name;
     preservesRedoStack?: boolean;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -35941,7 +35941,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    type: 'command';\n    id: string;\n    data: Data;\n    name: Name;\n    preservesRedoStack?: boolean;\n}"
+              "text": "{\n    type: 'command';\n    data: Data;\n    name: Name;\n    preservesRedoStack?: boolean;\n}"
             },
             {
               "kind": "Content",

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -82,7 +82,6 @@ export class HistoryManager<
 					this._undos.update((undos) =>
 						undos.tail.push({
 							...prev,
-							id: uniqueId(),
 							data: devFreeze(handle.squash!(prev.data, data)),
 						})
 					)
@@ -93,7 +92,6 @@ export class HistoryManager<
 							type: 'command',
 							name,
 							data: devFreeze(data),
-							id: uniqueId(),
 							preservesRedoStack: preservesRedoStack,
 						})
 					)
@@ -117,9 +115,9 @@ export class HistoryManager<
 			this._batchDepth++
 			if (this._batchDepth === 1) {
 				transact(() => {
-					const mostRecentActionId = this._undos.get().head?.id
+					const mostRecentAction = this._undos.get().head
 					fn()
-					if (mostRecentActionId !== this._undos.get().head?.id) {
+					if (mostRecentAction !== this._undos.get().head) {
 						this.onBatchComplete()
 					}
 				})

--- a/packages/editor/src/lib/editor/types/history-types.ts
+++ b/packages/editor/src/lib/editor/types/history-types.ts
@@ -25,7 +25,6 @@ export type TLHistoryMark = {
 /** @public */
 export type TLCommand<Name extends string = any, Data = any> = {
 	type: 'command'
-	id: string
 	data: Data
 	name: Name
 	/**


### PR DESCRIPTION
Non-mark history entries don't need a random id. 🤷‍♂️

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know