### PR TITLE
remove duplication after entering translation

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -112,12 +112,7 @@ export class Translating extends StateNode {
 	}
 
 	override onKeyDown = () => {
-		if (this.editor.inputs.altKey && !this.isCloning) {
-			this.startCloning()
-			return
-		}
-
-		// need to update in case user pressed a different modifier key
+		// need to update in case user pressed a modifier key
 		this.updateShapes()
 	}
 


### PR DESCRIPTION
When I'm dragging a shape, if I hold down alt I don't really expect the shape to duplicate where it originally dragged from. This PR removes that behaviour. We could also consider duplicating at the current cursor position.

## Before
![2024-03-18 at 9 25 31 - Teal Whitefish](https://github.com/tldraw/tldraw/assets/98838967/0a1376cb-9929-450c-ba44-bc333c438aa7)
## After
![2024-03-18 at 9 33 00 - Gold Alligator](https://github.com/tldraw/tldraw/assets/98838967/4d66a85f-0798-44c3-b25a-1a7568226122)


<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know




### Release Notes

- Add a brief release note for your PR here.
