### PR TITLE
Remove access token logic.

### DIFF
--- a/apps/dotcom/src/hooks/useRemoteSyncClient.ts
+++ b/apps/dotcom/src/hooks/useRemoteSyncClient.ts
@@ -30,7 +30,7 @@ export function useRemoteSyncClient(opts: UseSyncClientConfig): RemoteTLStoreWit
 		readyClient?: TLSyncClient<TLRecord, TLStore>
 		error?: Error
 	} | null>(null)
-	const { uri, roomId = 'default', userPreferences: prefs, getAccessToken } = opts
+	const { uri, roomId = 'default', userPreferences: prefs } = opts
 
 	const store = useTLStore({ schema })
 
@@ -52,10 +52,6 @@ export function useRemoteSyncClient(opts: UseSyncClientConfig): RemoteTLStoreWit
 			const withParams = new URL(uri)
 			withParams.searchParams.set('sessionKey', TAB_ID)
 			withParams.searchParams.set('storeId', store.id)
-			const accessToken = await getAccessToken?.()
-			if (accessToken) {
-				withParams.searchParams.set('accessToken', accessToken)
-			}
 			return withParams.toString()
 		})
 
@@ -95,7 +91,7 @@ export function useRemoteSyncClient(opts: UseSyncClientConfig): RemoteTLStoreWit
 			client.close()
 			socket.close()
 		}
-	}, [getAccessToken, prefs, roomId, store, uri])
+	}, [prefs, roomId, store, uri])
 
 	return useValue<RemoteTLStoreWithStatus>(
 		'remote synced store',

--- a/apps/dotcom/src/utils/remote-sync/remote-sync.ts
+++ b/apps/dotcom/src/utils/remote-sync/remote-sync.ts
@@ -15,5 +15,4 @@ export type UseSyncClientConfig = {
 	roomId?: string
 	userPreferences?: Signal<TLUserPreferences>
 	snapshotForNewRoomRef?: { current: null | TLStoreSnapshot }
-	getAccessToken?: () => Promise<string | undefined | null> | string | undefined | null
 }


### PR DESCRIPTION
Looks like we had some leftover logic from pro. We removed it from workers, but not (completely) from the client.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [x] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Remove some leftover logic from pro days.
