### PR TITLE
Update the document title to include the document name.

### DIFF
--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -241,7 +241,7 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 
 	useEffect(() => {
 		if (documentSettings.name) {
-			document.title = `tldraw - ${documentSettings.name}`
+			document.title = `${documentSettings.name} · tldraw`
 		} else {
 			document.title = 'tldraw'
 		}

--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -230,11 +230,6 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 				if (!state.isEditing) setState((prev) => ({ ...prev, name: null }))
 				return
 			}
-			if (trimmed.length) {
-				document.title = `tldraw - ${trimmed}`
-			} else {
-				document.title = `tldraw`
-			}
 
 			editor.updateDocumentSettings({ name: trimmed })
 		}
@@ -243,6 +238,14 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 			save()
 		}
 	}, [documentSettings.name, editor, state.isEditing, state.name, setState])
+
+	useEffect(() => {
+		if (documentSettings.name) {
+			document.title = `tldraw - ${documentSettings.name}`
+		} else {
+			document.title = 'tldraw'
+		}
+	}, [documentSettings.name])
 
 	const handleChange = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {

--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -230,6 +230,11 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 				if (!state.isEditing) setState((prev) => ({ ...prev, name: null }))
 				return
 			}
+			if (trimmed.length) {
+				document.title = `tldraw - ${trimmed}`
+			} else {
+				document.title = `tldraw`
+			}
 
 			editor.updateDocumentSettings({ name: trimmed })
 		}


### PR DESCRIPTION
We now update the `document.title` with the document name. For empty rooms we default back to `tldraw`, just as we have it in `index.html`.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Use the document name in the `document.title`.
