### PR TITLE
Fix jpg export and tests

### DIFF
--- a/apps/examples/e2e/playwright.config.ts
+++ b/apps/examples/e2e/playwright.config.ts
@@ -35,7 +35,9 @@ const config: PlaywrightTestConfig = {
 	/* Retry on CI only */
 	retries: process.env.CI ? 1 : 0,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: process.env.CI ? [['list'], ['github'], ['html', { open: 'never' }]] : 'list',
+	reporter: process.env.CI
+		? [['list'], ['github'], ['html', { open: 'never' }]]
+		: [['list'], ['html', { open: 'always' }]],
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/apps/examples/e2e/playwright.config.ts
+++ b/apps/examples/e2e/playwright.config.ts
@@ -35,9 +35,7 @@ const config: PlaywrightTestConfig = {
 	/* Retry on CI only */
 	retries: process.env.CI ? 1 : 0,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: process.env.CI
-		? [['list'], ['github'], ['html', { open: 'never' }]]
-		: [['list'], ['html', { open: 'always' }]],
+	reporter: process.env.CI ? [['list'], ['github'], ['html', { open: 'never' }]] : 'list',
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/apps/examples/e2e/tests/fixtures/fixtures.ts
+++ b/apps/examples/e2e/tests/fixtures/fixtures.ts
@@ -1,4 +1,5 @@
-import { test as base } from '@playwright/test'
+import { Page, test as base } from '@playwright/test'
+import { EndToEndApi } from '../../../src/misc/EndToEndApi'
 import { ActionsMenu } from './menus/ActionsMenu'
 import { HelpMenu } from './menus/HelpMenu'
 import { MainMenu } from './menus/MainMenu'
@@ -15,6 +16,30 @@ type Fixtures = {
 	mainMenu: MainMenu
 	pageMenu: PageMenu
 	navigationPanel: NavigationPanel
+	api: ReturnType<typeof makeApiFixture>
+}
+
+export type ApiFixture = {
+	[K in keyof EndToEndApi]: (
+		...args: Parameters<EndToEndApi[K]>
+	) => Promise<ReturnType<EndToEndApi[K]>>
+}
+
+function makeApiFixture(keys: { [K in keyof EndToEndApi]: true }, page: Page): ApiFixture {
+	const result = {} as any
+
+	for (const key of Object.keys(keys)) {
+		result[key] = (...args: any[]) => {
+			return page.evaluate(
+				([key, ...args]) => {
+					return (window as any).tldrawApi[key](...args)
+				},
+				[key, ...args]
+			)
+		}
+	}
+
+	return result
 }
 
 const test = base.extend<Fixtures>({
@@ -45,6 +70,16 @@ const test = base.extend<Fixtures>({
 	navigationPanel: async ({ page }, use) => {
 		const navigationPanel = new NavigationPanel(page)
 		await use(navigationPanel)
+	},
+	api: async ({ page }, use) => {
+		const api = makeApiFixture(
+			{
+				exportAsSvg: true,
+				exportAsFormat: true,
+			},
+			page
+		)
+		await use(api)
 	},
 })
 

--- a/apps/examples/e2e/tests/test-api.spec.ts
+++ b/apps/examples/e2e/tests/test-api.spec.ts
@@ -1,0 +1,14 @@
+import { setupWithShapes } from '../shared-e2e'
+import test from './fixtures/fixtures'
+
+test.beforeEach(setupWithShapes)
+
+test.describe('api', () => {
+	for (const format of ['svg', 'png', 'jpeg', 'webp', 'json'] as const) {
+		test(`export as ${format}`, async ({ page, api }) => {
+			const downloadEvent = page.waitForEvent('download')
+			await api.exportAsFormat(format)
+			await downloadEvent
+		})
+	}
+})

--- a/apps/examples/src/misc/EndToEndApi.tsx
+++ b/apps/examples/src/misc/EndToEndApi.tsx
@@ -1,0 +1,6 @@
+import { TLExportType } from 'tldraw/src/lib/utils/export/exportAs'
+
+export interface EndToEndApi {
+	exportAsSvg: () => void
+	exportAsFormat: (format: TLExportType) => void
+}

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
-import { Tldraw, useActions } from 'tldraw'
+import { Tldraw, exportAs, useActions, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { EndToEndApi } from './EndToEndApi'
 ;(window as any).__tldraw_ui_event = { id: 'NOTHING_YET' }
 ;(window as any).__tldraw_editor_events = []
 
@@ -27,11 +28,17 @@ export default function EndToEnd() {
 }
 
 function SneakyExportButton() {
+	const editor = useEditor()
 	const actions = useActions()
 
 	useEffect(() => {
-		;(window as any)['tldraw-export'] = () => actions['export-as-svg'].onSelect('unknown')
-	}, [actions])
+		const api: EndToEndApi = {
+			exportAsSvg: () => actions['export-as-svg'].onSelect('unknown'),
+			exportAsFormat: (format) =>
+				exportAs(editor, editor.selectAll().getSelectedShapeIds(), format, 'test'),
+		}
+		;(window as any).tldrawApi = api
+	}, [actions, editor])
 
 	return null
 }

--- a/packages/tldraw/src/lib/Tldraw.test.tsx
+++ b/packages/tldraw/src/lib/Tldraw.test.tsx
@@ -10,7 +10,7 @@ describe('<Tldraw />', () => {
 			<Tldraw>
 				<div data-testid="canvas-1" />
 			</Tldraw>,
-			{ waitForPatterns: false }
+			{ waitForPatterns: true }
 		)
 
 		await screen.findByTestId('canvas-1')
@@ -27,7 +27,7 @@ describe('<Tldraw />', () => {
 			)
 		}
 
-		await renderTldrawComponent(<TestComponent />, { waitForPatterns: false })
+		await renderTldrawComponent(<TestComponent />, { waitForPatterns: true })
 		await screen.findByTestId('canvas-1')
 	})
 

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -86,10 +86,14 @@ export async function getSvgAsImage(
 
 	if (!blob) return null
 
-	const view = new DataView(await blob.arrayBuffer())
-	return PngHelpers.setPhysChunk(view, effectiveScale, {
-		type: 'image/' + type,
-	})
+	if (type === 'png') {
+		const view = new DataView(await blob.arrayBuffer())
+		return PngHelpers.setPhysChunk(view, effectiveScale, {
+			type: 'image/' + type,
+		})
+	} else {
+		return blob
+	}
 }
 
 /** @public */


### PR DESCRIPTION
Fix a bug that was preventing JPG and webp exports from working. Also:
- Re-enable our export snapshot tests which got commented out again
- Fix some react act errors when running tests

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

