### PR TITLE
fix docs build

### DIFF
--- a/apps/docs/components/Search.tsx
+++ b/apps/docs/components/Search.tsx
@@ -7,10 +7,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Autocomplete, DropdownOption } from './Autocomplete'
 
-const HOST_URL =
-	process.env.NODE_ENV === 'development'
-		? 'http://localhost:3001'
-		: process.env.NEXT_PUBLIC_SITE_URL ?? 'https://tldraw.dev'
+const HOST_URL = typeof location !== 'undefined' ? location.origin : 'https://tldraw.dev'
 
 export function Search() {
 	const [searchType, setSearchType] = useState<SEARCH_TYPE>(SEARCH_TYPE.NORMAL)

--- a/apps/docs/scripts/functions/fetchApiSource.ts
+++ b/apps/docs/scripts/functions/fetchApiSource.ts
@@ -1,17 +1,13 @@
 import fs from 'fs'
-import { Octokit } from 'octokit'
 import path from 'path'
 import { TLDRAW_PACKAGES_TO_INCLUDE_IN_DOCS } from './package-list'
-
-const octokit = new Octokit({
-	auth: process.env.ACCESS_TOKEN,
-})
 
 const { log: nicelog } = console
 
 export async function fetchApiSource() {
 	try {
 		const API_DIRECTORY = path.join(process.cwd(), 'api')
+		const REPO_ROOT = path.normalize(path.join(process.cwd(), '../../'))
 
 		if (fs.existsSync(API_DIRECTORY)) {
 			fs.rmSync(API_DIRECTORY, { recursive: true })
@@ -20,27 +16,9 @@ export async function fetchApiSource() {
 		fs.mkdirSync(API_DIRECTORY)
 
 		for (const folderName of TLDRAW_PACKAGES_TO_INCLUDE_IN_DOCS) {
-			const filePath = path.join(API_DIRECTORY, folderName + '.api.json')
-
-			nicelog(`• Fetching API for ${folderName}...`)
-
-			const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
-				owner: 'tldraw',
-				repo: 'tldraw',
-				path: `packages/${folderName}/api/api.json`,
-				branch: process.env.SOURCE_SHA || 'main',
-				headers: {
-					'X-GitHub-Api-Version': '2022-11-28',
-					accept: 'application/vnd.github.VERSION.raw',
-				},
-			})
-
-			if (res.status === 200) {
-				nicelog(`• Writing ${filePath}...`)
-				fs.writeFileSync(filePath, (res as any).data)
-			} else {
-				throw Error(`x Could not get API for ${folderName}.`)
-			}
+			const fromPath = path.join(REPO_ROOT, 'packages', folderName, 'api', 'api.json')
+			const toPath = path.join(API_DIRECTORY, folderName + '.api.json')
+			fs.copyFileSync(fromPath, toPath)
 		}
 
 		nicelog('✔ Complete!')

--- a/apps/docs/scripts/functions/fetchReleases.ts
+++ b/apps/docs/scripts/functions/fetchReleases.ts
@@ -2,9 +2,7 @@ import fs from 'fs'
 import { Octokit } from 'octokit'
 import path from 'path'
 
-const octokit = new Octokit({
-	auth: process.env.ACCESS_TOKEN,
-})
+const octokit = new Octokit({})
 
 const { log: nicelog } = console
 

--- a/scripts/vercel/build-docs.sh
+++ b/scripts/vercel/build-docs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -eux
 
+yarn run -T lazy refresh-everything  --filter=apps/docs
 yarn run -T lazy build --filter=apps/docs


### PR DESCRIPTION
- always refresh docs content when building on CI
- use local api.json files now since we don't want to use SOURCE_SHA
- @steveruizok it feels kinda problematic that we check in a bunch of derived files that the docs build requires. Things can get out of sync easily, and whose responsibility is it to update them? In the future I reckon we should explore ways to remove these files from the git index as much as possible.

closes #3200 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [x] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
