### PR TITLE
Stickies: sticky notes as a surface

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1084,7 +1084,11 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
+    canDropShapes: () => boolean;
+    // (undocumented)
     canEdit: () => boolean;
+    // (undocumented)
+    canReceiveNewChildrenOfType: () => boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX_2.Element;
     // (undocumented)
@@ -1150,6 +1154,14 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         typeName: "shape";
     } | undefined;
     // (undocumented)
+    onDragShapesOut: (shape: TLNoteShape, shapes: TLShape[]) => void;
+    // (undocumented)
+    onDragShapesOver: () => {
+        shouldHint: boolean;
+    };
+    // (undocumented)
+    onDropShapesOver: (shape: TLNoteShape, shapes: TLShape[]) => void;
+    // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
     static props: {
@@ -1157,7 +1169,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
         align: EnumStyleProp<"end-legacy" | "end" | "middle-legacy" | "middle" | "start-legacy" | "start">;
-        verticalAlign: EnumStyleProp<"end" | "middle" | "start">;
+        verticalAlign: EnumStyleProp<"end" | "middle" | "start">; /** @public */
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1156,11 +1156,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     onDragShapesOut: (shape: TLNoteShape, shapes: TLShape[]) => void;
     // (undocumented)
-    onDragShapesOver: () => {
+    onDragShapesOver: (shape: TLNoteShape, shapes: TLShape[]) => {
         shouldHint: boolean;
     };
-    // (undocumented)
-    onDropShapesOver: (shape: TLNoteShape, shapes: TLShape[]) => void;
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12806,6 +12806,36 @@
           "members": [
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canDropShapes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canDropShapes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canDropShapes",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -12826,6 +12856,36 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "canEdit",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canReceiveNewChildrenOfType:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canReceiveNewChildrenOfType: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canReceiveNewChildrenOfType",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -13333,6 +13393,132 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOut:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDragShapesOut: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDragShapesOut",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOver:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDragShapesOver: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => {\n        shouldHint: boolean;\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDragShapesOver",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDropShapesOver:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDropShapesOver: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDropShapesOver",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#onEditEnd:member",
               "docComment": "",
               "excerptTokens": [
@@ -13431,7 +13617,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<\"end\" | \"middle\" | \"start\">;\n        growY: import(\"@tldraw/editor\")."
+                  "text": "<\"end\" | \"middle\" | \"start\">; /** @public */\n        growY: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13450,36 +13450,6 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "() => {\n        shouldHint: boolean;\n    }"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onDragShapesOver",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onDropShapesOver:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onDropShapesOver: "
-                },
-                {
-                  "kind": "Content",
                   "text": "(shape: "
                 },
                 {
@@ -13498,7 +13468,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "[]) => void"
+                  "text": "[]) => {\n        shouldHint: boolean;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -13508,7 +13478,7 @@
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",
-              "name": "onDropShapesOver",
+              "name": "onDragShapesOver",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 6

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -6,6 +6,7 @@ import {
 	SvgExportContext,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	TLShape,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -30,9 +31,21 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override hideResizeHandles = () => true
 	override hideSelectionBoundsFg = () => true
 
+	override canReceiveNewChildrenOfType = () => true
+	override canDropShapes = () => true
+	override onDragShapesOver = () => ({ shouldHint: true })
+	override onDropShapesOver = (shape: TLNoteShape, shapes: TLShape[]) => {
+		this.editor.reparentShapes(shapes, shape.id)
+	}
+
+	override onDragShapesOut = (shape: TLNoteShape, shapes: TLShape[]) => {
+		this.editor.reparentShapes(shapes, this.editor.getCurrentPage().id)
+	}
+
 	getDefaultProps(): TLNoteShape['props'] {
 		return {
 			color: 'black',
+
 			size: 'm',
 			text: '',
 			font: 'draw',

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -33,9 +33,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 	override canReceiveNewChildrenOfType = () => true
 	override canDropShapes = () => true
-	override onDragShapesOver = () => ({ shouldHint: true })
-	override onDropShapesOver = (shape: TLNoteShape, shapes: TLShape[]) => {
+	override onDragShapesOver = (shape: TLNoteShape, shapes: TLShape[]) => {
 		this.editor.reparentShapes(shapes, shape.id)
+		return { shouldHint: true }
 	}
 
 	override onDragShapesOut = (shape: TLNoteShape, shapes: TLShape[]) => {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -45,7 +45,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	getDefaultProps(): TLNoteShape['props'] {
 		return {
 			color: 'black',
-
 			size: 'm',
 			text: '',
 			font: 'draw',

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -35,7 +35,6 @@ export class PointingShape extends StateNode {
 			outermostSelectingShape.id === focusedGroupId ||
 			// ...or if the shape is within the selection
 			selectedShapeIds.includes(outermostSelectingShape.id) ||
-			this.editor.isAncestorSelected(outermostSelectingShape.id) ||
 			// ...or if the current point is NOT within the selection bounds
 			(selectedShapeIds.length > 1 && selectionBounds?.containsPoint(currentPagePoint))
 		) {


### PR DESCRIPTION
This PR allows the user to draw on sticky notes, and place things onto them.

As an experimental prototype, it lets you place *anything* on sticky notes, but we could filter down the list of allowed shapes if we wanted.

This PR breaks frames behaviour slightly in order to get the prototype to work. If we decide to ship this, we could fix frames. (However, hot take: Part of me wants to change the behaviour of frames to what this PR does anyway. That's another thing though).

More work to do:
- Place shapes on a sticky even if your cursor doesn't overlap the sticky.
- As a sticky grows longer/shorter, move its children with it.
- Some visual feedback that something has attached? 

https://github.com/tldraw/tldraw/assets/15892272/f5e84fe2-09bc-4cbe-8443-31d9a4df5b52

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Create a sticky note.
2. Try to draw on it.
3. Move the sticky. The drawing should move with it.
4. Drag another shape on top of the sticky note shape.
5. Move the sticky. It should move the dragged shape with it.
6. Remove the attached shape(s) from the sticky.
7. Move the sticky. Make sure the removed shape doesn't move with it.
8. With the sticky note selected, drag a shape that's on top of it.
9. The dragged shape should move - not the sticky.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Shapes can now be attached to sticky notes.
