### PR TITLE
tooling: prettier ignore pr template

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ apps/examples/www
 content.json
 apps/docs/utils/vector-db/index.json
 **/gen/**/*.md
+.github/pull_request_template.md
 
 **/api-report.md
 **/CHANGELOG.md


### PR DESCRIPTION
`yarn format` was causing an update `pull_request_template` which caused an error for `update-pr-template`. seems like we should just ignore it

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

