### PR TITLE
Allow tldraw.com embeds in notion

### DIFF
--- a/apps/dotcom/src/components/IFrameProtector.tsx
+++ b/apps/dotcom/src/components/IFrameProtector.tsx
@@ -80,10 +80,13 @@ export function IFrameProtector({
 	const url = useUrl()
 
 	useEffect(() => {
-		console.log({ embeddedState, isInIframe: isInIframe(), parentOrigin: getParentOrigin() })
 		switch (embeddedState) {
 			case 'iframe-not-allowed':
-				trackAnalyticsEvent('iframe_not_allowed', { slug, context })
+				trackAnalyticsEvent('iframe_not_allowed', {
+					slug,
+					context,
+					parentOrigin: getParentOrigin(),
+				})
 				break
 			case 'iframe-ok':
 				trackAnalyticsEvent('connect_to_room_in_iframe', {


### PR DESCRIPTION
I recently tried to embed a tldraw room in a notion document. Notion supports this by iframing us in, but we block them. This diff allows embeds in notion, but also simplifies the iframe checking code in a big way - instead of doing all the message passing stuff to check if we're in a valid context, we just look at the origin of the parent (using `document.ancestorOrigins`, which isn't blocked by cross-origin iframe rules). If we're being iframe'd in by tldraw.com (or its subdomain) or notion.so (or its subdomain), we allow it. If we're being iframe'd in by something we don't recognise, it's not allowed. 

This also adds the parent origin to our logging, so we can see which sites are trying to embed tldraw in an iframe.

### Change Type

- [x] `dotcom` — Changes the tldraw.com web app
- [x] `improvement` — Improving existing features


### Test Plan

1. Tested locally by messing with devtools to insert localhost iframes. tldraw and notion.so embed are allowed, but others are prevented

### Release Notes

- You can now embed tldraw rooms in notion documents (again)
