### PR TITLE
Add yarn immutable check to pre-commit.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+yarn install --immutable
 npx lazy run build-api
 git add packages/*/api-report.md
 git add packages/*/api/api.json


### PR DESCRIPTION
Right now if you add some dependencies in one of the `package.json` files, but forget to install them, your [build will fail](https://github.com/tldraw/tldraw/actions/runs/8346008840/job/22842259795?pr=3217#step:3:82) since we have a check for that in CI. Might be nice to have an early warning for that in the `pre-commit`?

Adds around 1s to pre-commit.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [x] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

