### PR TITLE
Stickies: bring to front

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -5,6 +5,7 @@ import {
 	TLArrowShape,
 	TLEventHandlers,
 	TLGeoShape,
+	TLNoteShape,
 	TLPointerEventInfo,
 	TLShape,
 } from '@tldraw/editor'
@@ -27,6 +28,13 @@ export class PointingShape extends StateNode {
 
 		this.hitShape = info.shape
 		const outermostSelectingShape = this.editor.getOutermostSelectableShape(info.shape)
+
+		// Bring sticky notes to front on pointer down;
+		// consider changing the logic to "move to front of any overlapping shapes"
+		// rather than move to front of all shapes in the page / parent
+		if (this.editor.isShapeOfType<TLNoteShape>(info.shape, 'note')) {
+			this.editor.bringToFront([info.shape.id])
+		}
 
 		if (
 			// If the shape has an onClick handler


### PR DESCRIPTION
This PR makes pointing a sticky note bring it to the front. Extracted from https://github.com/tldraw/tldraw/pull/3208/files.

We could consider changing the logic to "move to front of any overlapping shapes" rather than move to front of all shapes in the page / parent.

![Kapture 2024-03-20 at 12 41 08](https://github.com/tldraw/tldraw/assets/23072548/bc94fe05-f709-4b85-a5d4-493174471b69)

If we haven't landed #3204, then this would mean clicking a note would bring it in front of anything that has been placed on top of the note. Even if we did land that PR, this would only improve things going forward: any existing notes would not have the parent / child relationship with shapes that had been previously placed on top of it.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Place a sticky slightly behind another shape
2. Click on the sticky behind
3. It should be in front

- [ ] Unit Tests

### Release Notes

- When clicking a sticky, bring it to front