### PR TITLE
fix docs slugs

### DIFF
--- a/apps/docs/scripts/utils.ts
+++ b/apps/docs/scripts/utils.ts
@@ -11,9 +11,7 @@ import {
 	DocSoftBreak,
 } from '@microsoft/tsdoc'
 import assert from 'assert'
-import GithubSlugger from 'github-slugger'
-
-const slugs = new GithubSlugger()
+import { slug as githubSlug } from 'github-slugger'
 
 import path from 'path'
 import prettier from 'prettier'
@@ -50,7 +48,7 @@ function isOnParentPage(itemKind: ApiItemKind) {
 }
 
 export function getSlug(item: ApiItem): string {
-	return slugs.slug(item.displayName, true)
+	return githubSlug(item.displayName, true)
 }
 
 export function getPath(item: ApiItem): string {


### PR DESCRIPTION
Our slug generation code uses the stateful version of github slugger which assigns different names to different slugs e.g. `thing`, `thing-1`, `thing-2` each time it's called. This means that our links across pages are broken because the slugs get generated with a suffix. This replaces it with the non-stateful version instead.
