### PR TITLE
[experiment] improve note+highlighter stickiness behavior

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1599,7 +1599,6 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canBind: <K>(_shape: Shape, _otherShape?: K | undefined) => boolean;
     canCrop: TLShapeUtilFlag<Shape>;
     canDropShapes(shape: Shape, shapes: TLShape[]): boolean;
-    canDropShapesOnlyWithinMaskedBounds: TLShapeUtilFlag<Shape>;
     canEdit: TLShapeUtilFlag<Shape>;
     canEditInReadOnly: TLShapeUtilFlag<Shape>;
     canReceiveNewChildrenOfType(shape: Shape, type: TLShape['type']): boolean;
@@ -1624,6 +1623,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     hideSelectionBoundsFg: TLShapeUtilFlag<Shape>;
     abstract indicator(shape: Shape): any;
     isAspectRatioLocked: TLShapeUtilFlag<Shape>;
+    isFrame: TLShapeUtilFlag<Shape>;
     isSticky: TLShapeUtilFlag<Shape>;
     // (undocumented)
     static migrations?: Migrations;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1599,6 +1599,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canBind: <K>(_shape: Shape, _otherShape?: K | undefined) => boolean;
     canCrop: TLShapeUtilFlag<Shape>;
     canDropShapes(shape: Shape, shapes: TLShape[]): boolean;
+    canDropShapesOnlyWithinMaskedBounds: TLShapeUtilFlag<Shape>;
     canEdit: TLShapeUtilFlag<Shape>;
     canEditInReadOnly: TLShapeUtilFlag<Shape>;
     canReceiveNewChildrenOfType(shape: Shape, type: TLShape['type']): boolean;
@@ -1623,6 +1624,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     hideSelectionBoundsFg: TLShapeUtilFlag<Shape>;
     abstract indicator(shape: Shape): any;
     isAspectRatioLocked: TLShapeUtilFlag<Shape>;
+    isSticky: TLShapeUtilFlag<Shape>;
     // (undocumented)
     static migrations?: Migrations;
     onBeforeCreate?: TLOnBeforeCreateHandler<Shape>;
@@ -1634,10 +1636,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onDoubleClick?: TLOnDoubleClickHandler<Shape>;
     onDoubleClickEdge?: TLOnDoubleClickHandler<Shape>;
     onDoubleClickHandle?: TLOnDoubleClickHandleHandler<Shape>;
-    onDragShapesOut?: TLOnDragHandler<Shape>;
-    onDragShapesOver?: TLOnDragHandler<Shape, {
+    onDragShapesOut(shape: Shape, shapes: TLShape[]): void;
+    onDragShapesOver(shape: Shape, shapes: TLShape[]): {
         shouldHint: boolean;
-    }>;
+    } | undefined;
     onDropShapesOver?: TLOnDragHandler<Shape>;
     onEditEnd?: TLOnEditEndHandler<Shape>;
     onHandleDrag?: TLOnHandleDragHandler<Shape>;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -30403,6 +30403,41 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#canDropShapesOnlyWithinMaskedBounds:member",
+              "docComment": "/**\n * Whether the dropping a shape onto another behaves like a frame (true) where one has to drop the shape within the bounds of the frame, or like a stickies (false) where the shape is considered dropped when the bounding boxes collide.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canDropShapesOnlyWithinMaskedBounds: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeUtilFlag",
+                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canDropShapesOnlyWithinMaskedBounds",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#canEdit:member",
               "docComment": "/**\n * Whether the shape can be double clicked to edit.\n *\n * @public\n */\n",
               "excerptTokens": [
@@ -31251,6 +31286,41 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#isSticky:member",
+              "docComment": "/**\n * Whether the shape should adhere to other shapes: stickers, washi tape, sticky notes, highlighters, etc.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isSticky: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeUtilFlag",
+                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isSticky",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil.migrations:member",
               "docComment": "",
               "excerptTokens": [
@@ -31526,74 +31596,142 @@
               "isAbstract": false
             },
             {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#onDragShapesOut:member",
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onDragShapesOut:member(1)",
               "docComment": "/**\n * A callback called when some other shapes are dragged out of this one.\n *\n * @param shape - The shape.\n *\n * @param shapes - The shapes that are being dragged out.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onDragShapesOut?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLOnDragHandler",
-                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                  "text": "onDragShapesOut(shape: "
                 },
                 {
                   "kind": "Content",
-                  "text": "<Shape>"
+                  "text": "Shape"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
                 },
                 {
                   "kind": "Content",
                   "text": ";"
                 }
               ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onDragShapesOut",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 3
-              },
               "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 6,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
               "isProtected": false,
-              "isAbstract": false
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "shapes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 5
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "onDragShapesOut"
             },
             {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#onDragShapesOver:member",
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onDragShapesOver:member(1)",
               "docComment": "/**\n * A callback called when some other shapes are dragged over this one.\n *\n * @param shape - The shape.\n *\n * @param shapes - The shapes that are being dragged over this one.\n *\n * @returns An object specifying whether the shape should hint that it can receive the dragged shapes.\n *\n * @example\n * ```ts\n * onDragShapesOver = (shape, shapes) => {\n * \treturn { shouldHint: true }\n * }\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onDragShapesOver?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLOnDragHandler",
-                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                  "text": "onDragShapesOver(shape: "
                 },
                 {
                   "kind": "Content",
-                  "text": "<Shape, {\n        shouldHint: boolean;\n    }>"
+                  "text": "Shape"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        shouldHint: boolean;\n    } | undefined"
                 },
                 {
                   "kind": "Content",
                   "text": ";"
                 }
               ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onDragShapesOver",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 3
-              },
               "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 6,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
               "isProtected": false,
-              "isAbstract": false
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "shapes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 5
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "onDragShapesOver"
             },
             {
               "kind": "Property",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -30403,41 +30403,6 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#canDropShapesOnlyWithinMaskedBounds:member",
-              "docComment": "/**\n * Whether the dropping a shape onto another behaves like a frame (true) where one has to drop the shape within the bounds of the frame, or like a stickies (false) where the shape is considered dropped when the bounding boxes collide.\n *\n * @public\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "canDropShapesOnlyWithinMaskedBounds: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShapeUtilFlag",
-                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<Shape>"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "canDropShapesOnlyWithinMaskedBounds",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 3
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#canEdit:member",
               "docComment": "/**\n * Whether the shape can be double clicked to edit.\n *\n * @public\n */\n",
               "excerptTokens": [
@@ -31276,6 +31241,41 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "isAspectRatioLocked",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#isFrame:member",
+              "docComment": "/**\n * Whether the shape is a frame and carries the behaviors that go along with frames. Frames are shapes that can contain other shapes, in a portal-like fashion.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isFrame: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeUtilFlag",
+                  "canonicalReference": "@tldraw/editor!TLShapeUtilFlag:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isFrame",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5026,7 +5026,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// partially clipped by its own parent frame.
 			const maskedPageBounds = this.getShapeMaskedPageBounds(shape.id)
 			if (
-				this.getShapeUtil(shape).canDropShapesOnlyWithinMaskedBounds(shape) &&
+				this.getShapeUtil(shape).isFrame(shape) &&
 				maskedPageBounds &&
 				maskedPageBounds.containsPoint(point) &&
 				this.getShapeGeometry(shape).hitTestPoint(this.getPointInShapeSpace(shape, point), 0, true)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5023,13 +5023,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			// Only allow dropping into the masked page bounds of the shape, e.g. when a frame is
-			// partially clipped by its own parent frame
+			// partially clipped by its own parent frame.
 			const maskedPageBounds = this.getShapeMaskedPageBounds(shape.id)
-
 			if (
+				this.getShapeUtil(shape).canDropShapesOnlyWithinMaskedBounds(shape) &&
 				maskedPageBounds &&
 				maskedPageBounds.containsPoint(point) &&
 				this.getShapeGeometry(shape).hitTestPoint(this.getPointInShapeSpace(shape, point), 0, true)
+			) {
+				return shape
+			}
+
+			// Non-frames have different logic when dropping. They look at collisions between the bounding boxes.
+			const shapeBounds = this.getShapePageBounds(shape)
+			if (
+				shapeBounds &&
+				droppingShapes.some((droppingShape) =>
+					this.getShapePageBounds(droppingShape)?.collides(shapeBounds)
+				)
 			) {
 				return shape
 			}

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -225,13 +225,12 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
-	 * Whether the dropping a shape onto another behaves like a frame (true) where one
-	 * has to drop the shape within the bounds of the frame, or like a stickies (false) where
-	 * the shape is considered dropped when the bounding boxes collide.
+	 * Whether the shape is a frame and carries the behaviors that go along with frames.
+	 * Frames are shapes that can contain other shapes, in a portal-like fashion.
 	 *
 	 * @public
 	 */
-	canDropShapesOnlyWithinMaskedBounds: TLShapeUtilFlag<Shape> = () => true
+	isFrame: TLShapeUtilFlag<Shape> = () => true
 
 	/**
 	 * Whether the shape should adhere to other shapes:

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -632,6 +632,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canDropShapes: (shape: TLFrameShape, _shapes: TLShape[]) => boolean;
     // (undocumented)
+    canDropShapesOnlyWithinMaskedBounds: () => boolean;
+    // (undocumented)
     canEdit: () => boolean;
     // (undocumented)
     canReceiveNewChildrenOfType: (shape: TLShape, _type: TLShape['type']) => boolean;
@@ -900,6 +902,8 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
     // (undocumented)
     indicator(shape: TLHighlightShape): JSX_2.Element;
     // (undocumented)
+    isSticky: () => boolean;
+    // (undocumented)
     static migrations: Migrations;
     // (undocumented)
     onResize: TLOnResizeHandler<TLHighlightShape>;
@@ -1099,6 +1103,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     hideSelectionBoundsFg: () => boolean;
     // (undocumented)
     indicator(shape: TLNoteShape): JSX_2.Element;
+    // (undocumented)
+    isSticky: () => boolean;
     // (undocumented)
     static migrations: Migrations;
     // (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -632,8 +632,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canDropShapes: (shape: TLFrameShape, _shapes: TLShape[]) => boolean;
     // (undocumented)
-    canDropShapesOnlyWithinMaskedBounds: () => boolean;
-    // (undocumented)
     canEdit: () => boolean;
     // (undocumented)
     canReceiveNewChildrenOfType: (shape: TLShape, _type: TLShape['type']) => boolean;
@@ -645,6 +643,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     getGeometry(shape: TLFrameShape): Geometry2d;
     // (undocumented)
     indicator(shape: TLFrameShape): JSX_2.Element;
+    // (undocumented)
+    isFrame: () => boolean;
     // (undocumented)
     static migrations: Migrations;
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -7158,6 +7158,36 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!FrameShapeUtil#canDropShapesOnlyWithinMaskedBounds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canDropShapesOnlyWithinMaskedBounds: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canDropShapesOnlyWithinMaskedBounds",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!FrameShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -10296,6 +10326,36 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!HighlightShapeUtil#isSticky:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isSticky: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isSticky",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!HighlightShapeUtil.migrations:member",
               "docComment": "",
               "excerptTokens": [
@@ -13136,6 +13196,36 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "indicator"
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#isSticky:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isSticky: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isSticky",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -7158,36 +7158,6 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!FrameShapeUtil#canDropShapesOnlyWithinMaskedBounds:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "canDropShapesOnlyWithinMaskedBounds: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "canDropShapesOnlyWithinMaskedBounds",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "tldraw!FrameShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -7457,6 +7427,36 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "indicator"
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!FrameShapeUtil#isFrame:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isFrame: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "isFrame",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -42,6 +42,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 
 	override canEdit = () => true
 
+	override canDropShapesOnlyWithinMaskedBounds = () => true
+
 	override getDefaultProps(): TLFrameShape['props'] {
 		return { w: 160 * 2, h: 90 * 2, name: '' }
 	}

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -42,7 +42,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 
 	override canEdit = () => true
 
-	override canDropShapesOnlyWithinMaskedBounds = () => true
+	override isFrame = () => true
 
 	override getDefaultProps(): TLFrameShape['props'] {
 		return { w: 160 * 2, h: 90 * 2, name: '' }

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -38,6 +38,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	override hideResizeHandles = (shape: TLHighlightShape) => getIsDot(shape)
 	override hideRotateHandle = (shape: TLHighlightShape) => getIsDot(shape)
 	override hideSelectionBoundsFg = (shape: TLHighlightShape) => getIsDot(shape)
+	override isSticky = () => true
 
 	override getDefaultProps(): TLHighlightShape['props'] {
 		return {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -29,6 +29,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override canEdit = () => true
 	override hideResizeHandles = () => true
 	override hideSelectionBoundsFg = () => true
+	override isSticky = () => true
 
 	getDefaultProps(): TLNoteShape['props'] {
 		return {

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -16,8 +16,13 @@ export class DragAndDropManager {
 
 	updateDroppingNode(movingShapes: TLShape[], cb: () => void) {
 		if (this.first) {
+			const ancestorsFromSingleMovingShape =
+				movingShapes.length === 1 ? this.editor.getShapeAncestors(movingShapes[0]) : null
+			const singleAncestorFromSingleMovingShape =
+				ancestorsFromSingleMovingShape?.length === 1 ? ancestorsFromSingleMovingShape[0] : null
 			this.prevDroppingShapeId =
 				this.editor.getDroppingOverShape(this.editor.inputs.originPagePoint, movingShapes)?.id ??
+				singleAncestorFromSingleMovingShape?.id ??
 				null
 			this.first = false
 		}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -35,7 +35,6 @@ export class PointingShape extends StateNode {
 			outermostSelectingShape.id === focusedGroupId ||
 			// ...or if the shape is within the selection
 			selectedShapeIds.includes(outermostSelectingShape.id) ||
-			this.editor.isAncestorSelected(outermostSelectingShape.id) ||
 			// ...or if the current point is NOT within the selection bounds
 			(selectedShapeIds.length > 1 && selectionBounds?.containsPoint(currentPagePoint))
 		) {


### PR DESCRIPTION
This updates the highlighter + note drag&drop behavior. 
- adds an `isSticky` property to ShapeUtil's to demarcate tools as having sticky (parenting) behavior
- improves the drop (parenting) behavior to not rely on the pointer position but the bounding box collision behavior (for non-frames)
- also improves the unparenting behavior to not rely on the pointer as well being within the bounding box


https://github.com/tldraw/tldraw/assets/469604/e066bce3-85dd-40de-bbf2-7b1aab538afb



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
