### PR TITLE
Stickies: expanded snap bounds

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -9,6 +9,7 @@
 import { ArrayOfValidator } from '@tldraw/editor';
 import { BaseBoxShapeTool } from '@tldraw/editor';
 import { BaseBoxShapeUtil } from '@tldraw/editor';
+import { BoundsSnapGeometry } from '@tldraw/editor';
 import { BoundsSnapPoint } from '@tldraw/editor';
 import { Box } from '@tldraw/editor';
 import { Circle2d } from '@tldraw/editor';
@@ -1087,6 +1088,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     canEdit: () => boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX_2.Element;
+    // (undocumented)
+    getBoundsSnapGeometry(shape: TLNoteShape): BoundsSnapGeometry;
     // (undocumented)
     getDefaultProps(): TLNoteShape['props'];
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12890,6 +12890,56 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "tldraw!NoteShapeUtil#getBoundsSnapGeometry:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getBoundsSnapGeometry(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BoundsSnapGeometry",
+                  "canonicalReference": "@tldraw/editor!BoundsSnapGeometry:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getBoundsSnapGeometry"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "tldraw!NoteShapeUtil#getDefaultProps:member(1)",
               "docComment": "",
               "excerptTokens": [

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -1,4 +1,5 @@
 import {
+	BoundsSnapGeometry,
 	DefaultFontFamilies,
 	Editor,
 	Rectangle2d,
@@ -6,6 +7,7 @@ import {
 	SvgExportContext,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	Vec,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -19,6 +21,7 @@ import { getFontDefForExport } from '../shared/defaultStyleDefs'
 import { getTextLabelSvgElement } from '../shared/getTextLabelSvgElement'
 
 const NOTE_SIZE = 200
+const NOTE_MARGIN = 10
 
 /** @public */
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
@@ -50,6 +53,23 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	getGeometry(shape: TLNoteShape) {
 		const height = this.getHeight(shape)
 		return new Rectangle2d({ width: NOTE_SIZE, height, isFilled: true })
+	}
+
+	override getBoundsSnapGeometry(shape: TLNoteShape): BoundsSnapGeometry {
+		const height = this.getHeight(shape)
+		return {
+			points: [
+				// new Vec(0, 0),
+				// new Vec(NOTE_SIZE, 0),
+				// new Vec(NOTE_SIZE, height),
+				// new Vec(0, height),
+				new Vec(-NOTE_MARGIN, -NOTE_MARGIN),
+				new Vec(NOTE_SIZE + NOTE_MARGIN, -NOTE_MARGIN),
+				new Vec(NOTE_SIZE + NOTE_MARGIN, height + NOTE_MARGIN),
+				new Vec(-NOTE_MARGIN, height + NOTE_MARGIN),
+				new Vec(NOTE_SIZE / 2, height / 2),
+			],
+		}
 	}
 
 	component(shape: TLNoteShape) {


### PR DESCRIPTION
This PR expands the bounds snap points for the note shape.

![Kapture 2024-03-25 at 08 21 05](https://github.com/tldraw/tldraw/assets/23072548/e9cb2e68-ee8b-4a3c-8b71-9df8ee7b1494)

First thoughts are that this doesn't feel like it should be using the snap feature, it should sort of "just snap" when its center is near to where the center would be if the note was adjacent / padded out from another sticky note.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `feature` — New feature

### Test Plan

1. Drag a sticky note and snap it to other shapes / notes.

### Release Notes

- Expands the snapping bounds of sticky notes for easier grids.