### PR TITLE
Make shapes leave frames when dragged completely outside

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -46,22 +46,21 @@ export class DragAndDropManager {
 
 		// is the next dropping shape id same as the last one?
 		if (nextDroppingShapeId === this.prevDroppingShapeId) {
-			// Check if all shapes are outside their parents
-			const areAllShapesOutsideTheirParents = movingShapes.every((shape) => {
-				const parent = this.editor.getShape(shape.parentId)
-				if (!parent) return false
-				const parentBounds = this.editor.getShapePageBounds(parent)
-				const shapeBounds = this.editor.getShapePageBounds(shape)
-				if (!parentBounds || !shapeBounds) return false
-				return !parentBounds.includes(shapeBounds)
-			})
-
-			// If some shapes are within their parents still, don't do anything
-			if (!areAllShapesOutsideTheirParents) {
+			// if some shapes are still within their parent, do nothing
+			if (
+				movingShapes.some((shape) => {
+					const parent = this.editor.getShape(shape.parentId)
+					if (!parent) return true
+					const parentBounds = this.editor.getShapePageBounds(parent)
+					const shapeBounds = this.editor.getShapePageBounds(shape)
+					if (!parentBounds || !shapeBounds) return true
+					return parentBounds.includes(shapeBounds)
+				})
+			) {
 				return
 			}
 
-			// If all shapes are outside their parents, we'll reparent them to the next dropping shape
+			// if all shapes are outside their parents, reparent each one
 			for (const shape of movingShapes) {
 				const parent = this.editor.getShape(shape.parentId)
 				if (!parent) continue

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -61,10 +61,22 @@ export class DragAndDropManager {
 			}
 
 			// if all shapes are outside their parents, reparent each one
+
+			// group shapes by their parent
+			const parentChildGroups = new Map<TLShape, TLShape[]>()
 			for (const shape of movingShapes) {
 				const parent = this.editor.getShape(shape.parentId)
 				if (!parent) continue
-				this.editor.getShapeUtil(parent).onDragShapesOut?.(parent, [shape])
+				const group = parentChildGroups.get(parent) ?? []
+				if (!parentChildGroups.has(parent)) {
+					parentChildGroups.set(parent, group)
+				}
+				group.push(shape)
+			}
+
+			// call onDragShapesOut for each parent
+			for (const [parent, children] of parentChildGroups) {
+				this.editor.getShapeUtil(parent).onDragShapesOut?.(parent, children)
 			}
 
 			this.prevDroppingShapeId = null

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -15,15 +15,6 @@ export class DragAndDropManager {
 	first = true
 
 	updateDroppingNode(movingShapes: TLShape[], cb: () => void) {
-		// if (this.first) {
-		// 	// Find out where the shapes are being dragged from, even if that's not where the pointer starts
-		// 	const commonAncestor = this.editor.findCommonAncestor(movingShapes, (ancestor) =>
-		// 		this.editor.getShapeUtil(ancestor).canDropShapes(ancestor, movingShapes)
-		// 	)
-		// 	this.prevDroppingShapeId = commonAncestor ?? null
-		// 	this.first = false
-		// }
-
 		if (this.first) {
 			this.prevDroppingShapeId =
 				this.editor.getDroppingOverShape(this.editor.inputs.originPagePoint, movingShapes)?.id ??

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -16,9 +16,11 @@ export class DragAndDropManager {
 
 	updateDroppingNode(movingShapes: TLShape[], cb: () => void) {
 		if (this.first) {
-			this.prevDroppingShapeId =
-				this.editor.getDroppingOverShape(this.editor.inputs.originPagePoint, movingShapes)?.id ??
-				null
+			// Find out where the shapes are being dragged from, even if that's not where the pointer starts
+			const commonAncestor = this.editor.findCommonAncestor(movingShapes, (ancestor) =>
+				this.editor.getShapeUtil(ancestor).canDropShapes(ancestor, movingShapes)
+			)
+			this.prevDroppingShapeId = commonAncestor ?? null
 			this.first = false
 		}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -62,14 +62,6 @@ export class DragAndDropManager {
 			}
 
 			// If all shapes are outside their parents, we'll reparent them to the next dropping shape
-			const { prevDroppingShapeId } = this
-			const prevDroppingShape = prevDroppingShapeId && this.editor.getShape(prevDroppingShapeId)
-			if (prevDroppingShape) {
-				this.editor
-					.getShapeUtil(prevDroppingShape)
-					.onDragShapesOut?.(prevDroppingShape, movingShapes)
-			}
-
 			for (const shape of movingShapes) {
 				const parent = this.editor.getShape(shape.parentId)
 				if (!parent) continue


### PR DESCRIPTION
This PR adds an extra way for shapes to leave their frame. If a shape is dragged completely outside of a frame (so that it doesn't overlap it anymore), then it leaves the frame.

I added this so that you don't accidentally get a shape stuck 'behind the canvas' so easily. **This behaviour will also make 'stickies as a surface' work better. I think that it's a good change for frames, but if we don't want to do that, we can keep frames the way they are, and bring this behaviour only to stickies.**

![2024-03-26 at 14 37 04 - Teal Buzzard](https://github.com/tldraw/tldraw/assets/15892272/a678593d-29e6-4103-b697-48d1d5149c63)

It also deals with multiple frames.

![2024-03-26 at 14 45 43 - Violet Peafowl](https://github.com/tldraw/tldraw/assets/15892272/5af29b74-4e7d-421d-81a1-0b095f34021f)

Shapes only leave their frames if *all* dragged shapes are fully outside.

![2024-03-26 at 14 48 28 - Olive Firefly](https://github.com/tldraw/tldraw/assets/15892272/e70f6de7-6450-46e2-83aa-1d949a8060e2)

It works with nested frames too.

![2024-03-26 at 14 52 23 - Amaranth Sailfish](https://github.com/tldraw/tldraw/assets/15892272/eedb166c-e81a-489a-83b5-747c9c85a72b)

It works with groups too

![2024-03-26 at 14 50 19 - Black Egret](https://github.com/tldraw/tldraw/assets/15892272/15249838-93fd-4aa6-bc20-338ea6ca1e5b)

And it keeps grouped children together.

![2024-03-26 at 16 20 34 - Black Butterfly](https://github.com/tldraw/tldraw/assets/15892272/16d5a319-fe68-417d-b819-0769bbc7b49d)

This decision tree shows the behaviour before VS after:

![image](https://github.com/tldraw/tldraw/assets/15892272/75b60212-9a41-4130-aa43-ece509d4e63c)


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Make a frame.
2. Put a shape in the frame.
3. Drag the shape so it gets partially masked by the frame.
4. Click the masked part of the shape, and drag it completely outside of the frame, so that the shape doesn't overlap with it anymore.
5. The shape should leave the frame.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixed/improved how shapes can escape frames.
