### PR TITLE
fix docs not building due to typo

### DIFF
--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -24726,7 +24726,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@tldraw/editor!isSafeFloat:function(1)",
-          "docComment": "/**\n * ] Check if a float is safe to use. ie: Not too big or small.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Check if a float is safe to use. ie: Not too big or small.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -349,7 +349,7 @@ export function toFixed(v: number) {
 	return Math.round(v * 1e2) / 1e2
 }
 
-/**]
+/**
  * Check if a float is safe to use. ie: Not too big or small.
  * @public
  */


### PR DESCRIPTION
oops

### Change Type

- [x] `docs` — Changes to the documentation, examples, or templates.
- [x] `bugfix` — Bug fix

