### PR TITLE
fix document name overflow

### DIFF
--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -276,7 +276,7 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 		setState((prev) => ({ ...prev, isEditing: false }))
 	}, [setState])
 
-	const name = state.name || documentSettings.name || defaultDocumentName
+	const name = state.name ?? (documentSettings.name || defaultDocumentName)
 
 	return (
 		<div className="tlui-document-name__input__wrapper">

--- a/apps/dotcom/styles/z-board.css
+++ b/apps/dotcom/styles/z-board.css
@@ -339,7 +339,7 @@
 
 .tlui-document-name__input__wrapper {
 	position: relative;
-	max-width: calc(100% - 40px);
+	max-width: calc(100% - 36px);
 	display: flex;
 	flex: auto;
 }


### PR DESCRIPTION
Fix the document name getting truncated as I forgot to update a measurement in the CSS. Also fixes an issue where if you had a long title which you then cleared, the input width wouldn't update until you entered your first character of the new name.

### Change Type
- [x] `dotcom` — Changes the tldraw.com web app
- [x] `bugfix` — Bug fix
