### PR TITLE
styling: make dotcom and examples site have consistent font styling

### DIFF
--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -56,7 +56,7 @@ If you'd like to deeply change the way that tldraw looks, you can copy the `tldr
 We also use Inter as the default tldraw font. You can import this font however you like (or use a different font!) but here's the CSS import from Google fonts that we use:
 
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 ```
 
 ### HTML

--- a/apps/dotcom/styles/core.css
+++ b/apps/dotcom/styles/core.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 
 :root {
 	font-family:

--- a/apps/dotcom/styles/globals.css
+++ b/apps/dotcom/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Plus+Jakarta+Sans:wght@600;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Plus+Jakarta+Sans:wght@600;800&display=swap');
 @import url('tldraw/tldraw.css');
 @import url('./z-board.css');
 

--- a/apps/dotcom/styles/globals.css
+++ b/apps/dotcom/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Plus+Jakarta+Sans:wght@600;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 @import url('tldraw/tldraw.css');
 @import url('./z-board.css');
 

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 
 :root {
 	--gray-light: #f5f5f5;

--- a/apps/vscode/editor/public/index.css
+++ b/apps/vscode/editor/public/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 
 html,
 body {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -6,12 +6,6 @@
 	--layer-overlays: 500;
 	--layer-toasts: 650;
 	--layer-cursor: 700;
-	font-weight: 500;
-	line-height: 1.6;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	font-smooth: antialiased;
-	text-rendering: optimizeLegibility;
 }
 
 /* -------------------------------------------------- */
@@ -344,6 +338,12 @@
 	z-index: var(--layer-panels);
 	-webkit-transform: translate3d(0, 0, 0);
 	--sab: env(safe-area-inset-bottom);
+	font-weight: 500;
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-smooth: antialiased;
+	text-rendering: optimizeLegibility;
 }
 
 .tlui-layout__top {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -6,6 +6,12 @@
 	--layer-overlays: 500;
 	--layer-toasts: 650;
 	--layer-cursor: 700;
+	font-weight: 500;
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-smooth: antialiased;
+	text-rendering: optimizeLegibility;
 }
 
 /* -------------------------------------------------- */
@@ -29,6 +35,7 @@
 	pointer-events: all;
 	font-weight: inherit;
 	font-family: inherit;
+	line-height: inherit;
 	text-rendering: optimizeLegibility;
 	font-size: 12px;
 	gap: 0px;

--- a/templates/nextjs/src/app/globals.css
+++ b/templates/nextjs/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Roboto+Mono:wght@400;700&display=swap');
 @import url('tldraw/tldraw.css');
 
 body {

--- a/templates/nextjs/src/app/globals.css
+++ b/templates/nextjs/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Roboto+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
 @import url('tldraw/tldraw.css');
 
 body {

--- a/templates/vite/src/index.css
+++ b/templates/vite/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Roboto+Mono:wght@400;700&display=swap');
 @import url('tldraw/tldraw.css');
 
 body {

--- a/templates/vite/src/index.css
+++ b/templates/vite/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=Roboto+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700@400;700&display=swap');
 @import url('tldraw/tldraw.css');
 
 body {


### PR DESCRIPTION
Our font styling for dotcom vs. our examples app is _ever_ so slightly different.
- the Inter fonts weren't being consistently linked. Sometimes we grabbed 700, sometimes 800, sometimes 500 or 400
- the dotcom specified a default weight of 500 and line-height 1.6 which was not specified in the our UI. this made the UI inconsistent
- furthermore, we didn't specify `text-rendering` nor `font-smooth` and that also made things inconsistent
- finally, our buttons needed to inherit the line-height because otherwise they were reverting to the user agent default

before:
<img width="1800" alt="Screenshot 2024-03-26 at 15 23 12" src="https://github.com/tldraw/tldraw/assets/469604/ee25c79c-5b43-4501-a126-255a9b03a4b8">
after:
<img width="1800" alt="Screenshot 2024-03-26 at 15 22 53" src="https://github.com/tldraw/tldraw/assets/469604/a7a62441-e767-4919-b2bb-5c283eadd230">


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
