### PR TITLE
log message size in worker analytics

### DIFF
--- a/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
+++ b/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
@@ -283,7 +283,10 @@ export class TLDrawDurableObject extends TLServer {
 				break
 			}
 			case 'send_message': {
-				this.writeEvent(event.type, { blobs: [event.roomId], doubles: [event.messageLength] })
+				this.writeEvent(event.type, {
+					blobs: [event.roomId, event.messageType],
+					doubles: [event.messageLength],
+				})
 				break
 			}
 			default: {

--- a/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
+++ b/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
@@ -261,7 +261,7 @@ export class TLDrawDurableObject extends TLServer {
 		{ blobs, indexes, doubles }: { blobs?: string[]; indexes?: [string]; doubles?: number[] }
 	) {
 		this.measure?.writeDataPoint({
-			blobs: [this.env.WORKER_NAME ?? 'development-tldraw-multiplayer', name, ...(blobs ?? [])],
+			blobs: [name, this.env.WORKER_NAME ?? 'development-tldraw-multiplayer', ...(blobs ?? [])],
 			doubles,
 			indexes,
 		})

--- a/apps/dotcom-worker/src/lib/types.ts
+++ b/apps/dotcom-worker/src/lib/types.ts
@@ -26,4 +26,5 @@ export interface Environment {
 	TLDRAW_ENV: string | undefined
 	SENTRY_DSN: string | undefined
 	IS_LOCAL: string | undefined
+	WORKER_NAME: string | undefined
 }

--- a/packages/tlsync/src/index.ts
+++ b/packages/tlsync/src/index.ts
@@ -1,4 +1,4 @@
-export { TLServer, type DBLoadResult } from './lib/TLServer'
+export { TLServer, type DBLoadResult, type TLServerEvent } from './lib/TLServer'
 export {
 	TLSyncClient,
 	type TLPersistentClientSocket,

--- a/packages/tlsync/src/lib/ServerSocketAdapter.ts
+++ b/packages/tlsync/src/lib/ServerSocketAdapter.ts
@@ -5,7 +5,7 @@ import { TLSocketServerSentEvent } from './protocol'
 
 type ServerSocketAdapterOptions = {
 	readonly ws: WebSocket | ws.WebSocket
-	readonly logSendMessage: (size: number) => void
+	readonly logSendMessage: (type: string, size: number) => void
 }
 
 /** @public */
@@ -18,7 +18,7 @@ export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocke
 	// see TLRoomSocket for details on why this accepts a union and not just arrays
 	sendMessage(msg: TLSocketServerSentEvent<R>) {
 		const message = JSON.stringify(msg)
-		this.opts.logSendMessage(message.length)
+		this.opts.logSendMessage(msg.type, message.length)
 		this.opts.ws.send(message)
 	}
 	close() {

--- a/packages/tlsync/src/lib/ServerSocketAdapter.ts
+++ b/packages/tlsync/src/lib/ServerSocketAdapter.ts
@@ -3,18 +3,25 @@ import ws from 'ws'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentEvent } from './protocol'
 
+type ServerSocketAdapterOptions = {
+	readonly ws: WebSocket | ws.WebSocket
+	readonly logSendMessage: (size: number) => void
+}
+
 /** @public */
 export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocket<R> {
-	constructor(public readonly ws: WebSocket | ws.WebSocket) {}
+	constructor(public readonly opts: ServerSocketAdapterOptions) {}
 	// eslint-disable-next-line no-restricted-syntax
 	get isOpen(): boolean {
-		return this.ws.readyState === 1 // ready state open
+		return this.opts.ws.readyState === 1 // ready state open
 	}
 	// see TLRoomSocket for details on why this accepts a union and not just arrays
 	sendMessage(msg: TLSocketServerSentEvent<R>) {
-		this.ws.send(JSON.stringify(msg))
+		const message = JSON.stringify(msg)
+		this.opts.logSendMessage(message.length)
+		this.opts.ws.send(message)
 	}
 	close() {
-		this.ws.close()
+		this.opts.ws.close()
 	}
 }

--- a/packages/tlsync/src/lib/TLServer.ts
+++ b/packages/tlsync/src/lib/TLServer.ts
@@ -20,6 +20,31 @@ export type DBLoadResult =
 			type: 'room_not_found'
 	  }
 
+export type TLServerEvent =
+	| {
+			type: 'client'
+			name: 'room_create' | 'room_reopen' | 'enter' | 'leave' | 'last_out'
+			roomId: string
+			clientId: string
+			instanceId: string
+			localClientId: string
+	  }
+	| {
+			type: 'room'
+			name:
+				| 'failed_load_from_db'
+				| 'failed_persist_to_db'
+				| 'room_empty'
+				| 'fail_persist'
+				| 'room_start'
+			roomId: string
+	  }
+	| {
+			type: 'send_message'
+			roomId: string
+			messageLength: number
+	  }
+
 /**
  * This class manages rooms for a websocket server.
  *
@@ -116,7 +141,14 @@ export abstract class TLServer {
 		const clientId = nanoid()
 		const [roomState, roomOpenKind] = await this.getInitialRoomState(persistenceKey)
 
-		roomState.room.handleNewSession(sessionKey, new ServerSocketAdapter(socket))
+		roomState.room.handleNewSession(
+			sessionKey,
+			new ServerSocketAdapter({
+				ws: socket,
+				logSendMessage: (size) =>
+					this.logEvent({ type: 'send_message', roomId: persistenceKey, messageLength: size }),
+			})
+		)
 
 		if (roomOpenKind === 'new' || roomOpenKind === 'reopen') {
 			// Record that the room is now active
@@ -223,22 +255,7 @@ export abstract class TLServer {
 	 * @param event - The event to log.
 	 * @public
 	 */
-	abstract logEvent(
-		event:
-			| {
-					type: 'client'
-					roomId: string
-					name: string
-					clientId: string
-					instanceId: string
-					localClientId: string
-			  }
-			| {
-					type: 'room'
-					roomId: string
-					name: string
-			  }
-	): void
+	abstract logEvent(event: TLServerEvent): void
 
 	/**
 	 * Get a room by its id.

--- a/packages/tlsync/src/lib/TLServer.ts
+++ b/packages/tlsync/src/lib/TLServer.ts
@@ -42,6 +42,7 @@ export type TLServerEvent =
 	| {
 			type: 'send_message'
 			roomId: string
+			messageType: string
 			messageLength: number
 	  }
 
@@ -145,8 +146,13 @@ export abstract class TLServer {
 			sessionKey,
 			new ServerSocketAdapter({
 				ws: socket,
-				logSendMessage: (size) =>
-					this.logEvent({ type: 'send_message', roomId: persistenceKey, messageLength: size }),
+				logSendMessage: (messageType, messageLength) =>
+					this.logEvent({
+						type: 'send_message',
+						roomId: persistenceKey,
+						messageType,
+						messageLength,
+					}),
 			})
 		)
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -185,7 +185,7 @@ name = "${previewId}-tldraw-assets"`
 
 let didUpdateTlsyncWorker = false
 async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
-	let workerId = `${env.TLDRAW_ENV}-tldraw-multiplayer`
+	const workerId = `${previewId ?? env.TLDRAW_ENV}-tldraw-multiplayer`
 	if (previewId && !didUpdateTlsyncWorker) {
 		appendFileSync(
 			join(worker, 'wrangler.toml'),
@@ -193,7 +193,6 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 [env.preview]
 name = "${previewId}-tldraw-multiplayer"`
 		)
-		workerId = `preview-${previewId}-tldraw-multiplayer`
 		didUpdateTlsyncWorker = true
 	}
 	await exec(

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -185,6 +185,7 @@ name = "${previewId}-tldraw-assets"`
 
 let didUpdateTlsyncWorker = false
 async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
+	let workerId = `${env.TLDRAW_ENV}-tldraw-multiplayer`
 	if (previewId && !didUpdateTlsyncWorker) {
 		appendFileSync(
 			join(worker, 'wrangler.toml'),
@@ -192,6 +193,7 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 [env.preview]
 name = "${previewId}-tldraw-multiplayer"`
 		)
+		workerId = `preview-${previewId}-tldraw-multiplayer`
 		didUpdateTlsyncWorker = true
 	}
 	await exec(
@@ -212,6 +214,8 @@ name = "${previewId}-tldraw-multiplayer"`
 			`TLDRAW_ENV:${env.TLDRAW_ENV}`,
 			'--var',
 			`APP_ORIGIN:${env.APP_ORIGIN}`,
+			'--var',
+			`WORKER_NAME:${workerId}`,
 		],
 		{
 			pwd: worker,


### PR DESCRIPTION
Adds logging of message size in worker analytics.

This also adds the environment to worker analytics as `blob2`. We need this because previously, all the analytics from all environments were going to the same place with no ability to tell them apart, which means we can't easily compare analytics on e.g. a particular PR.

This means that all the other blobs get shifted along one, so we won't be able to query across the boundary of when this gets released for those properties. I think this is fine though - it's things like `roomId` that I don't think we were querying on anyway.

You can query the analytics through grafana - [docs here](https://www.notion.so/tldraw/How-to-11fce2ed0be5480bb8e711c7ff1a0488?pvs=4#a66fae7bfcfe4ffe9d5348504598c6a0)

### Change Type
- [x] `internal` — Does not affect user-facing stuff
- [x] `chore` — Updating dependencies, other boring stuff

