### PR TITLE
capture latency drift between client and worker

### DIFF
--- a/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
+++ b/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
@@ -289,6 +289,21 @@ export class TLDrawDurableObject extends TLServer {
 				})
 				break
 			}
+			case 'message_delivery_drift': {
+				this.writeEvent(event.type, {
+					blobs: [event.roomId],
+					doubles: [
+						event.drift.p01,
+						event.drift.p05,
+						event.drift.p25,
+						event.drift.p50,
+						event.drift.p75,
+						event.drift.p95,
+						event.drift.p99,
+					],
+				})
+				break
+			}
 			default: {
 				exhaustiveSwitchError(event)
 			}

--- a/apps/dotcom-worker/src/lib/worker.ts
+++ b/apps/dotcom-worker/src/lib/worker.ts
@@ -91,7 +91,7 @@ async function blockUnknownOrigins(request: Request) {
 	}
 
 	const origin = request.headers.get('origin')
-	if (env.IS_LOCAL !== 'true' && (!origin || !isAllowedOrigin(origin))) {
+	if (env.TLDRAW_ENV !== undefined && (!origin || !isAllowedOrigin(origin))) {
 		console.error('Attempting to connect from an invalid origin:', origin, env, request)
 		return new Response('Not allowed', { status: 403 })
 	}

--- a/packages/tlsync/src/lib/ServerSocketAdapter.ts
+++ b/packages/tlsync/src/lib/ServerSocketAdapter.ts
@@ -17,6 +17,7 @@ export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocke
 	}
 	// see TLRoomSocket for details on why this accepts a union and not just arrays
 	sendMessage(msg: TLSocketServerSentEvent<R>) {
+		msg.ts = Date.now()
 		const message = JSON.stringify(msg)
 		this.opts.logSendMessage(msg.type, message.length)
 		this.opts.ws.send(message)

--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -42,6 +42,7 @@ import {
 } from './diff'
 import { interval } from './interval'
 import {
+	DriftHistogram,
 	TLIncompatibilityReason,
 	TLSYNC_PROTOCOL_VERSION,
 	TLSocketClientSentEvent,
@@ -183,6 +184,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 	readonly events = createNanoEvents<{
 		room_became_empty: () => void
 		session_removed: (args: { sessionKey: string }) => void
+		client_time_drift: (drift: DriftHistogram) => void
 	}>()
 
 	// Values associated with each uid (must be serializable).
@@ -647,6 +649,9 @@ export class TLSyncRoom<R extends UnknownRecord> {
 			case 'ping': {
 				if (session.state === RoomSessionState.Connected) {
 					session.lastInteractionTime = Date.now()
+				}
+				if (message.drift) {
+					this.events.emit('client_time_drift', message.drift)
 				}
 				return this.sendMessage(session.sessionKey, { type: 'pong' })
 			}

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -17,7 +17,10 @@ export type TLIncompatibilityReason =
 	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
 /** @public */
-export type TLSocketServerSentEvent<R extends UnknownRecord> =
+export type TLSocketServerSentEvent<R extends UnknownRecord> = {
+	/** timestamp of when the server sent this event */
+	ts?: number
+} & (
 	| {
 			type: 'connect'
 			hydrationType: 'wipe_all' | 'wipe_presence'
@@ -40,6 +43,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	  }
 	| { type: 'data'; data: TLSocketServerSentDataEvent<R>[] }
 	| TLSocketServerSentDataEvent<R>
+)
 
 /** @public */
 export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
@@ -77,9 +81,13 @@ export type TLConnectRequest = {
 	schema: SerializedSchema
 }
 
+export type DriftHistogram = Record<'p01' | 'p05' | 'p25' | 'p50' | 'p75' | 'p95' | 'p99', number>
+
 /** @public */
 export type TLPingRequest = {
 	type: 'ping'
+	/** Difference in time between the client receiving events and the server sending them */
+	drift?: DriftHistogram
 }
 
 /** @public */


### PR DESCRIPTION
We don't have a good way to measure the speed of our multiplayer, but we might be able to measure when the client gets locked up with messages - it'll cause larger drift between how far apart the server sent two messages, and how far apart the client thinks it received them. This diff captures that drift on the client, then sends a histogram of the drift back to the server every ping when there've been more than 100 messages received in the mean time. 

Not clear on whether this will be useful or not - spikey network latency etc. is probably a pretty big factor in this.

### Change Type

- [x] `dotcom` — Changes the tldraw.com web app
- [x] `chore` — Updating dependencies, other boring stuff
