### PR TITLE
Stickies: sticky notes as a surface (heavyweight version)

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -654,6 +654,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         }[K];
     };
     findCommonAncestor(shapes: TLShape[] | TLShapeId[], predicate?: (shape: TLShape) => boolean): TLShapeId | undefined;
+    findSelectedAncestor(shape: TLShape | TLShapeId): null | TLShape;
     findShapeAncestor(shape: TLShape | TLShapeId, predicate: (parent: TLShape) => boolean): TLShape | undefined;
     flipShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical'): this;
     getAncestorPageId(shape?: TLShape | TLShapeId): TLPageId | undefined;
@@ -722,8 +723,6 @@ export class Editor extends EventEmitter<TLEventMap> {
         isCulled: boolean;
         maskedPageBounds: Box | undefined;
     }[];
-    // (undocumented)
-    getSelectedAncestor(shape: TLShape | TLShapeId): null | TLShape;
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];
     getSelectedShapes(): TLShape[];

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -766,6 +766,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     getSharedStyles(): ReadonlySharedStyleMap;
     getSortedChildIdsForParent(parent: TLPage | TLParentId | TLShape): TLShapeId[];
     getStateDescendant<T extends StateNode>(path: string): T | undefined;
+    // (undocumented)
+    getStickingOverShape(shape: TLShape): TLUnknownShape | undefined;
     getStyleForNextShape<T>(style: StyleProp<T>): T;
     getSvg(shapes: TLShape[] | TLShapeId[], opts?: Partial<TLSvgOptions>): Promise<SVGSVGElement | undefined>;
     getViewportPageBounds(): Box;
@@ -1652,13 +1654,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onRotateEnd?: TLOnRotateEndHandler<Shape>;
     onRotateStart?: TLOnRotateStartHandler<Shape>;
     // (undocumented)
-    onStickShapes?: TLOnDragHandler<Shape>;
+    onStickShape?: (shape: Shape, other: TLShape) => void;
     // (undocumented)
-    onStickShapesOut?: TLOnDragHandler<Shape>;
+    onStickShapeOut?: (shape: Shape, other: TLShape) => void;
     // (undocumented)
-    onStickShapesOver?: TLOnDragHandler<Shape, {
+    onStickShapeOver?: (shape: Shape, other: TLShape) => {
         shouldHint: boolean;
-    }>;
+    };
     onTranslate?: TLOnTranslateHandler<Shape>;
     onTranslateEnd?: TLOnTranslateEndHandler<Shape>;
     onTranslateStart?: TLOnTranslateStartHandler<Shape>;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1607,6 +1607,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canScroll: TLShapeUtilFlag<Shape>;
     canSelectChildOnPointerDownWhileSelected(shape: Shape, child: TLShape): boolean;
     canSnap: TLShapeUtilFlag<Shape>;
+    // (undocumented)
+    canStickShape(shape: Shape, other: TLShape): boolean;
     canUnmount: TLShapeUtilFlag<Shape>;
     abstract component(shape: Shape): any;
     // (undocumented)
@@ -1649,6 +1651,14 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onRotate?: TLOnRotateHandler<Shape>;
     onRotateEnd?: TLOnRotateEndHandler<Shape>;
     onRotateStart?: TLOnRotateStartHandler<Shape>;
+    // (undocumented)
+    onStickShapes?: TLOnDragHandler<Shape>;
+    // (undocumented)
+    onStickShapesOut?: TLOnDragHandler<Shape>;
+    // (undocumented)
+    onStickShapesOver?: TLOnDragHandler<Shape, {
+        shouldHint: boolean;
+    }>;
     onTranslate?: TLOnTranslateHandler<Shape>;
     onTranslateEnd?: TLOnTranslateEndHandler<Shape>;
     onTranslateStart?: TLOnTranslateStartHandler<Shape>;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -722,6 +722,8 @@ export class Editor extends EventEmitter<TLEventMap> {
         isCulled: boolean;
         maskedPageBounds: Box | undefined;
     }[];
+    // (undocumented)
+    getSelectedAncestor(shape: TLShape | TLShapeId): null | TLShape;
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];
     getSelectedShapes(): TLShape[];
@@ -1604,6 +1606,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canReceiveNewChildrenOfType(shape: Shape, type: TLShape['type']): boolean;
     canResize: TLShapeUtilFlag<Shape>;
     canScroll: TLShapeUtilFlag<Shape>;
+    canSelectChildOnPointerDownWhileSelected(shape: Shape, child: TLShape): boolean;
     canSnap: TLShapeUtilFlag<Shape>;
     canUnmount: TLShapeUtilFlag<Shape>;
     abstract component(shape: Shape): any;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -30774,6 +30774,71 @@
               "isAbstract": false
             },
             {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#canStickShape:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canStickShape(shape: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "Shape"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", other: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "other",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "canStickShape"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "@tldraw/editor!ShapeUtil#canUnmount:member",
               "docComment": "/**\n * Whether the shape should unmount when not visible in the editor. Consider keeping this to false if the shape's `component` has local state.\n *\n * @public\n */\n",
@@ -32030,6 +32095,111 @@
               "isOptional": true,
               "releaseTag": "Public",
               "name": "onRotateStart",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onStickShapes?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLOnDragHandler",
+                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onStickShapes",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapesOut:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onStickShapesOut?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLOnDragHandler",
+                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onStickShapesOut",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapesOver:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onStickShapesOver?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLOnDragHandler",
+                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<Shape, {\n        shouldHint: boolean;\n    }>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onStickShapesOver",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -9485,6 +9485,69 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#findSelectedAncestor:member(1)",
+              "docComment": "/**\n * Find the first selected ancestor of a shape.\n *\n * @param shape - The shape to find the selected ancestor of.\n *\n * @returns \n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "findSelectedAncestor(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "null | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "findSelectedAncestor"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#findShapeAncestor:member(1)",
               "docComment": "/**\n * Find the first ancestor matching the given predicate\n *\n * @param shape - The shape to check the ancestors for.\n *\n * @example\n * ```ts\n * const ancestor = editor.findShapeAncestor(myShape)\n * const ancestor = editor.findShapeAncestor(myShape.id)\n * const ancestor = editor.findShapeAncestor(myShape.id, (shape) => shape.type === 'frame')\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
@@ -11986,69 +12049,6 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "@tldraw/editor!Editor#getSelectedAncestor:member(1)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "getSelectedAncestor(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " | "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShapeId",
-                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "null | "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "shape",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 4
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "getSelectedAncestor"
-            },
-            {
-              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getSelectedShapeAtPoint:member(1)",
               "docComment": "/**\n * Get the top-most selected shape at the given point, ignoring groups.\n *\n * @param point - The point to check.\n *\n * @returns The top-most selected shape at the given point, or undefined if there is no shape at the point.\n */\n",
               "excerptTokens": [
@@ -14547,7 +14547,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#isAncestorSelected:member(1)",
-              "docComment": "/**\n * Determine whether or not any of a shape's ancestors are selected.\n *\n * @param id - The id of the shape to check.\n *\n * @public\n */\n",
+              "docComment": "/**\n * Determine whether or not any of a shape's ancestors are selected.\n *\n * @param shape - The shape to check.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -11986,6 +11986,69 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#getSelectedAncestor:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getSelectedAncestor(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "null | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getSelectedAncestor"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getSelectedShapeAtPoint:member(1)",
               "docComment": "/**\n * Get the top-most selected shape at the given point, ignoring groups.\n *\n * @param point - The point to check.\n *\n * @returns The top-most selected shape at the given point, or undefined if there is no shape at the point.\n */\n",
               "excerptTokens": [
@@ -30609,6 +30672,71 @@
               "isStatic": false,
               "isProtected": false,
               "isAbstract": false
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#canSelectChildOnPointerDownWhileSelected:member(1)",
+              "docComment": "/**\n * Get whether a shape's child can be immediately selected by clicking on it, while the current shape is selected.\n *\n * @param shape - The shape.\n *\n * @param child - The child shape.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canSelectChildOnPointerDownWhileSelected(shape: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "Shape"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", child: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "child",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "canSelectChildOnPointerDownWhileSelected"
             },
             {
               "kind": "Property",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -9486,7 +9486,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#findSelectedAncestor:member(1)",
-              "docComment": "/**\n * Find the first selected ancestor of a shape.\n *\n * @param shape - The shape to find the selected ancestor of.\n *\n * @returns \n */\n",
+              "docComment": "/**\n * Find the first selected ancestor of a shape.\n *\n * @param shape - The shape to find the selected ancestor of.\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -13880,6 +13880,60 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#getStickingOverShape:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getStickingOverShape(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLUnknownShape",
+                  "canonicalReference": "@tldraw/tlschema!TLUnknownShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getStickingOverShape"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getStyleForNextShape:member(1)",
               "docComment": "/**\n * Get the style for the next shape.\n *\n * @param style - The style to get.\n *\n * @example\n * ```ts\n * const color = editor.getStyleForNextShape(DefaultColorStyle)\n * ```\n *\n * @public\n */\n",
               "excerptTokens": [
@@ -32105,21 +32159,25 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapes:member",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShape:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onStickShapes?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLOnDragHandler",
-                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                  "text": "onStickShape?: "
                 },
                 {
                   "kind": "Content",
-                  "text": "<Shape>"
+                  "text": "(shape: Shape, other: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
                 },
                 {
                   "kind": "Content",
@@ -32129,10 +32187,10 @@
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
-              "name": "onStickShapes",
+              "name": "onStickShape",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 3
+                "endIndex": 4
               },
               "isStatic": false,
               "isProtected": false,
@@ -32140,21 +32198,25 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapesOut:member",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapeOut:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onStickShapesOut?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLOnDragHandler",
-                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                  "text": "onStickShapeOut?: "
                 },
                 {
                   "kind": "Content",
-                  "text": "<Shape>"
+                  "text": "(shape: Shape, other: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
                 },
                 {
                   "kind": "Content",
@@ -32164,10 +32226,10 @@
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
-              "name": "onStickShapesOut",
+              "name": "onStickShapeOut",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 3
+                "endIndex": 4
               },
               "isStatic": false,
               "isProtected": false,
@@ -32175,21 +32237,25 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapesOver:member",
+              "canonicalReference": "@tldraw/editor!ShapeUtil#onStickShapeOver:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onStickShapesOver?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLOnDragHandler",
-                  "canonicalReference": "@tldraw/editor!TLOnDragHandler:type"
+                  "text": "onStickShapeOver?: "
                 },
                 {
                   "kind": "Content",
-                  "text": "<Shape, {\n        shouldHint: boolean;\n    }>"
+                  "text": "(shape: Shape, other: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => {\n        shouldHint: boolean;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -32199,10 +32265,10 @@
               "isReadonly": false,
               "isOptional": true,
               "releaseTag": "Public",
-              "name": "onStickShapesOver",
+              "name": "onStickShapeOver",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 3
+                "endIndex": 4
               },
               "isStatic": false,
               "isProtected": false,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5031,7 +5031,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const otherBounds = this.getShapePageBounds(other)
 			if (!shapeBounds || !otherBounds || !otherBounds.includes(shapeBounds)) continue
 
+			// don't stick if you completely contain the other shape
 			if (shapeBounds.contains(otherBounds)) continue
+
+			// don't stick if you're more than two times the size of the other shape
+			if (shapeBounds.w * shapeBounds.h > otherBounds.w * otherBounds.h * 2) continue
 
 			// don't stick if your geometry doesn't intersect the other shape's geometry
 			const shapeGeometry = this.getShapeGeometry(shape)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1518,15 +1518,21 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Determine whether or not any of a shape's ancestors are selected.
 	 *
-	 * @param id - The id of the shape to check.
+	 * @param shape - The shape to check.
 	 *
 	 * @public
 	 */
 	isAncestorSelected(shape: TLShape | TLShapeId): boolean {
-		return this.getSelectedAncestor(shape) !== null
+		return this.findSelectedAncestor(shape) !== null
 	}
 
-	getSelectedAncestor(shape: TLShape | TLShapeId): TLShape | null {
+	/**
+	 * Find the first selected ancestor of a shape.
+	 *
+	 * @param shape - The shape to find the selected ancestor of.
+	 * @returns
+	 */
+	findSelectedAncestor(shape: TLShape | TLShapeId): TLShape | null {
 		const id = typeof shape === 'string' ? shape : shape?.id ?? null
 		const _shape = this.getShape(id)
 		if (!_shape) return null

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5038,6 +5038,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (shapeBounds.w * shapeBounds.h > otherBounds.w * otherBounds.h * 2) continue
 
 			// don't stick if your geometry doesn't intersect the other shape's geometry
+			// TODO: make this actually work!
 			const shapeGeometry = this.getShapeGeometry(shape)
 			const otherGeometry = this.getShapeGeometry(other)
 			if (!shapeGeometry.vertices.some((v) => otherGeometry.hitTestPoint(v, 0, true))) continue

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1523,11 +1523,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	isAncestorSelected(shape: TLShape | TLShapeId): boolean {
+		return this.getSelectedAncestor(shape) !== null
+	}
+
+	getSelectedAncestor(shape: TLShape | TLShapeId): TLShape | null {
 		const id = typeof shape === 'string' ? shape : shape?.id ?? null
 		const _shape = this.getShape(id)
-		if (!_shape) return false
+		if (!_shape) return null
 		const selectedShapeIds = this.getSelectedShapeIds()
-		return !!this.findShapeAncestor(_shape, (parent) => selectedShapeIds.includes(parent.id))
+		return this.findShapeAncestor(_shape, (parent) => selectedShapeIds.includes(parent.id)) ?? null
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1530,7 +1530,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Find the first selected ancestor of a shape.
 	 *
 	 * @param shape - The shape to find the selected ancestor of.
-	 * @returns
+	 *
+	 * @public
 	 */
 	findSelectedAncestor(shape: TLShape | TLShapeId): TLShape | null {
 		const id = typeof shape === 'string' ? shape : shape?.id ?? null

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5031,6 +5031,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const otherBounds = this.getShapePageBounds(other)
 			if (!shapeBounds || !otherBounds || !otherBounds.includes(shapeBounds)) continue
 
+			if (shapeBounds.contains(otherBounds)) continue
+
 			// don't stick if your geometry doesn't intersect the other shape's geometry
 			const shapeGeometry = this.getShapeGeometry(shape)
 			const otherGeometry = this.getShapeGeometry(other)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5040,8 +5040,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// don't stick if your geometry doesn't intersect the other shape's geometry
 			// TODO: make this actually work!
 			const shapeGeometry = this.getShapeGeometry(shape)
-			const otherGeometry = this.getShapeGeometry(other)
-			if (!shapeGeometry.vertices.some((v) => otherGeometry.hitTestPoint(v, 0, true))) continue
+			const shapePageTransform = this.getShapePageTransform(shape)
+			if (
+				!shapeGeometry.vertices.some((v) => {
+					const point = shapePageTransform.applyToPoint(v)
+					return otherBounds.containsPoint(point)
+				})
+			) {
+				continue
+			}
 
 			return other
 		}

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -212,6 +212,18 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
+	 * Get whether a shape's child can be immediately selected by clicking on
+	 * it, while the current shape is selected.
+	 *
+	 * @param shape - The shape.
+	 * @param child - The child shape.
+	 * @public
+	 */
+	canSelectChildOnPointerDownWhileSelected(shape: Shape, child: TLShape) {
+		return false
+	}
+
+	/**
 	 * Get whether the shape can receive children of a given type.
 	 *
 	 * @param shape - The shape type.

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -234,6 +234,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 		return false
 	}
 
+	canStickShape(shape: Shape, other: TLShape) {
+		return false
+	}
+
 	/**
 	 * Get the shape as an SVG object.
 	 *
@@ -346,6 +350,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 */
 	onDragShapesOver?: TLOnDragHandler<Shape, { shouldHint: boolean }>
 
+	onStickShapesOver?: TLOnDragHandler<Shape, { shouldHint: boolean }>
+
 	/**
 	 * A callback called when some other shapes are dragged out of this one.
 	 *
@@ -355,6 +361,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 */
 	onDragShapesOut?: TLOnDragHandler<Shape>
 
+	onStickShapesOut?: TLOnDragHandler<Shape>
+
 	/**
 	 * A callback called when some other shapes are dropped over this one.
 	 *
@@ -363,6 +371,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @public
 	 */
 	onDropShapesOver?: TLOnDragHandler<Shape>
+
+	onStickShapes?: TLOnDragHandler<Shape>
 
 	/**
 	 * A callback called when a shape starts being resized.

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -350,7 +350,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 */
 	onDragShapesOver?: TLOnDragHandler<Shape, { shouldHint: boolean }>
 
-	onStickShapesOver?: TLOnDragHandler<Shape, { shouldHint: boolean }>
+	onStickShapeOver?: (shape: Shape, other: TLShape) => { shouldHint: boolean }
 
 	/**
 	 * A callback called when some other shapes are dragged out of this one.
@@ -361,7 +361,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 */
 	onDragShapesOut?: TLOnDragHandler<Shape>
 
-	onStickShapesOut?: TLOnDragHandler<Shape>
+	onStickShapeOut?: (shape: Shape, other: TLShape) => void
 
 	/**
 	 * A callback called when some other shapes are dropped over this one.
@@ -372,7 +372,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 */
 	onDropShapesOver?: TLOnDragHandler<Shape>
 
-	onStickShapes?: TLOnDragHandler<Shape>
+	onStickShape?: (shape: Shape, other: TLShape) => void
 
 	/**
 	 * A callback called when a shape starts being resized.

--- a/packages/editor/src/lib/primitives/intersect.ts
+++ b/packages/editor/src/lib/primitives/intersect.ts
@@ -223,6 +223,25 @@ export function intersectPolygonBounds(points: VecLike[], bounds: Box) {
 	return result
 }
 
+/**
+ * Find the intersections between a polyline and a bounding box.
+ *
+ * @public
+ */
+export function intersectPolylineBounds(points: VecLike[], bounds: Box) {
+	const result: VecLike[] = []
+	let segmentIntersection: VecLike[] | null
+
+	for (const side of bounds.sides) {
+		segmentIntersection = intersectLineSegmentPolyline(side[0], side[1], points)
+		if (segmentIntersection) result.push(...segmentIntersection)
+	}
+
+	if (result.length === 0) return null // no intersection
+
+	return result
+}
+
 function ccw(A: VecLike, B: VecLike, C: VecLike) {
 	return (C.y - A.y) * (B.x - A.x) > (B.y - A.y) * (C.x - A.x)
 }

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1158,9 +1158,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
-    onStickShapesOut: (note: TLNoteShape, shapes: TLShape[]) => void;
+    onStickShape: (note: TLNoteShape, shape: TLShape) => void;
     // (undocumented)
-    onStickShapesOver: (note: TLNoteShape, shapes: TLShape[]) => {
+    onStickShapeOver: (note: TLNoteShape, shape: TLShape) => {
         shouldHint: boolean;
     };
     // (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1084,13 +1084,13 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canDropShapes: () => boolean;
-    // (undocumented)
     canEdit: () => boolean;
     // (undocumented)
     canReceiveNewChildrenOfType: () => boolean;
     // (undocumented)
     canSelectChildOnPointerDownWhileSelected: () => boolean;
+    // (undocumented)
+    canStickShape: () => boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX_2.Element;
     // (undocumented)
@@ -1156,13 +1156,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         typeName: "shape";
     } | undefined;
     // (undocumented)
-    onDragShapesOut: (note: TLNoteShape, shapes: TLShape[]) => void;
+    onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
-    onDragShapesOver: (note: TLNoteShape, shapes: TLShape[]) => {
+    onStickShapesOut: (note: TLNoteShape, shapes: TLShape[]) => void;
+    // (undocumented)
+    onStickShapesOver: (note: TLNoteShape, shapes: TLShape[]) => {
         shouldHint: boolean;
     };
-    // (undocumented)
-    onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)
     static props: {
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1084,7 +1084,13 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
+    canDropShapes: () => boolean;
+    // (undocumented)
     canEdit: () => boolean;
+    // (undocumented)
+    canReceiveNewChildrenOfType: () => boolean;
+    // (undocumented)
+    canSelectChildOnPointerDownWhileSelected: () => boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX_2.Element;
     // (undocumented)
@@ -1149,6 +1155,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         id: TLShapeId;
         typeName: "shape";
     } | undefined;
+    // (undocumented)
+    onDragShapesOut: (note: TLNoteShape, shapes: TLShape[]) => void;
+    // (undocumented)
+    onDragShapesOver: (note: TLNoteShape, shapes: TLShape[]) => {
+        shouldHint: boolean;
+    };
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12806,36 +12806,6 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#canDropShapes:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "canDropShapes: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "canDropShapes",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -12916,6 +12886,36 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "canSelectChildOnPointerDownWhileSelected",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canStickShape:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canStickShape: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canStickShape",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -13423,102 +13423,6 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOut:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onDragShapesOut: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(note: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", shapes: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]) => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onDragShapesOut",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOver:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onDragShapesOver: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(note: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", shapes: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]) => {\n        shouldHint: boolean;\n    }"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onDragShapesOver",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#onEditEnd:member",
               "docComment": "",
               "excerptTokens": [
@@ -13556,6 +13460,102 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 5
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onStickShapesOut:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onStickShapesOut: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(note: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onStickShapesOut",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onStickShapesOver:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onStickShapesOver: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(note: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => {\n        shouldHint: boolean;\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onStickShapesOver",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
               },
               "isStatic": false,
               "isProtected": false,

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12806,6 +12806,36 @@
           "members": [
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canDropShapes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canDropShapes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canDropShapes",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -12826,6 +12856,66 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "canEdit",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canReceiveNewChildrenOfType:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canReceiveNewChildrenOfType: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canReceiveNewChildrenOfType",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#canSelectChildOnPointerDownWhileSelected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "canSelectChildOnPointerDownWhileSelected: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "canSelectChildOnPointerDownWhileSelected",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -13326,6 +13416,102 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 14
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOut:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDragShapesOut: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(note: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDragShapesOut",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOver:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDragShapesOver: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(note: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", shapes: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]) => {\n        shouldHint: boolean;\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDragShapesOver",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
               },
               "isStatic": false,
               "isProtected": false,

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13467,12 +13467,12 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onStickShapesOut:member",
+              "canonicalReference": "tldraw!NoteShapeUtil#onStickShape:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onStickShapesOut: "
+                  "text": "onStickShape: "
                 },
                 {
                   "kind": "Content",
@@ -13485,7 +13485,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", shapes: "
+                  "text": ", shape: "
                 },
                 {
                   "kind": "Reference",
@@ -13494,7 +13494,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "[]) => void"
+                  "text": ") => void"
                 },
                 {
                   "kind": "Content",
@@ -13504,7 +13504,7 @@
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",
-              "name": "onStickShapesOut",
+              "name": "onStickShape",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 6
@@ -13515,12 +13515,12 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onStickShapesOver:member",
+              "canonicalReference": "tldraw!NoteShapeUtil#onStickShapeOver:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onStickShapesOver: "
+                  "text": "onStickShapeOver: "
                 },
                 {
                   "kind": "Content",
@@ -13533,7 +13533,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", shapes: "
+                  "text": ", shape: "
                 },
                 {
                   "kind": "Reference",
@@ -13542,7 +13542,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "[]) => {\n        shouldHint: boolean;\n    }"
+                  "text": ") => {\n        shouldHint: boolean;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -13552,7 +13552,7 @@
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",
-              "name": "onStickShapesOver",
+              "name": "onStickShapeOver",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 6

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -4,8 +4,10 @@ import {
 	Rectangle2d,
 	ShapeUtil,
 	SvgExportContext,
+	TLGroupShape,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	TLShape,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -30,6 +32,35 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override canEdit = () => true
 	override hideResizeHandles = () => true
 	override hideSelectionBoundsFg = () => true
+
+	override canReceiveNewChildrenOfType = () => true
+	override canDropShapes = () => true
+	override canSelectChildOnPointerDownWhileSelected = () => true
+
+	override onDragShapesOver = (note: TLNoteShape, shapes: TLShape[]) => {
+		if (!shapes.every((child) => child.parentId === note.id)) {
+			this.editor.reparentShapes(
+				shapes.map((shape) => shape.id),
+				note.id
+			)
+			return { shouldHint: true }
+		}
+		return { shouldHint: false }
+	}
+
+	override onDragShapesOut = (note: TLNoteShape, shapes: TLShape[]) => {
+		const parent = this.editor.getShape(note.parentId)
+		const isInGroup = parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')
+
+		// If frame is in a group, keep the shape
+		// moved out in that group
+
+		if (isInGroup) {
+			this.editor.reparentShapes(shapes, parent.id)
+		} else {
+			this.editor.reparentShapes(shapes, this.editor.getCurrentPageId())
+		}
+	}
 
 	getDefaultProps(): TLNoteShape['props'] {
 		return {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -34,10 +34,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override hideSelectionBoundsFg = () => true
 
 	override canReceiveNewChildrenOfType = () => true
-	override canDropShapes = () => true
+	override canStickShape = () => true
 	override canSelectChildOnPointerDownWhileSelected = () => true
 
-	override onDragShapesOver = (note: TLNoteShape, shapes: TLShape[]) => {
+	override onStickShapesOver = (note: TLNoteShape, shapes: TLShape[]) => {
 		if (!shapes.every((child) => child.parentId === note.id)) {
 			this.editor.reparentShapes(
 				shapes.map((shape) => shape.id),
@@ -48,7 +48,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		return { shouldHint: false }
 	}
 
-	override onDragShapesOut = (note: TLNoteShape, shapes: TLShape[]) => {
+	override onStickShapesOut = (note: TLNoteShape, shapes: TLShape[]) => {
 		const parent = this.editor.getShape(note.parentId)
 		const isInGroup = parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -4,7 +4,6 @@ import {
 	Rectangle2d,
 	ShapeUtil,
 	SvgExportContext,
-	TLGroupShape,
 	TLNoteShape,
 	TLOnEditEndHandler,
 	TLShape,
@@ -37,29 +36,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override canStickShape = () => true
 	override canSelectChildOnPointerDownWhileSelected = () => true
 
-	override onStickShapesOver = (note: TLNoteShape, shapes: TLShape[]) => {
-		if (!shapes.every((child) => child.parentId === note.id)) {
-			this.editor.reparentShapes(
-				shapes.map((shape) => shape.id),
-				note.id
-			)
-			return { shouldHint: true }
-		}
-		return { shouldHint: false }
+	override onStickShapeOver = (note: TLNoteShape, shape: TLShape) => {
+		this.editor.reparentShapes([shape], note.id)
+		return { shouldHint: true }
 	}
 
-	override onStickShapesOut = (note: TLNoteShape, shapes: TLShape[]) => {
-		const parent = this.editor.getShape(note.parentId)
-		const isInGroup = parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')
-
-		// If frame is in a group, keep the shape
-		// moved out in that group
-
-		if (isInGroup) {
-			this.editor.reparentShapes(shapes, parent.id)
-		} else {
-			this.editor.reparentShapes(shapes, this.editor.getCurrentPageId())
-		}
+	override onStickShape = (note: TLNoteShape, shape: TLShape) => {
+		this.editor.reparentShapes([shape], note.id)
 	}
 
 	getDefaultProps(): TLNoteShape['props'] {

--- a/packages/tldraw/src/lib/tools/SelectTool/StickingManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/StickingManager.ts
@@ -57,7 +57,7 @@ export class StickingManager {
 					this.editor.getShapeUtil(stickingOverShape).onStickShape?.(stickingOverShape, shape)
 				}
 			} else {
-				if (adhesive) {
+				if (adhesive && this.editor.getShape(shape.parentId)) {
 					const page = this.editor.getCurrentPage()
 					if (page) {
 						this.editor.reparentShapes([shape], page.id)

--- a/packages/tldraw/src/lib/tools/SelectTool/StickingManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/StickingManager.ts
@@ -1,0 +1,88 @@
+import { Editor, TLShape, compact } from '@tldraw/editor'
+
+const LAG_DURATION = 20
+
+/** @public */
+export class StickingManager {
+	constructor(public editor: Editor) {
+		editor.disposables.add(this.dispose)
+	}
+
+	stickingNodeTimer: ReturnType<typeof setTimeout> | null = null
+
+	updateStickingNode(movingShapes: TLShape[], cb: () => void) {
+		if (this.stickingNodeTimer === null) {
+			this.setDragTimer(movingShapes, LAG_DURATION * 10, cb)
+		}
+	}
+
+	private setDragTimer(movingShapes: TLShape[], duration: number, cb: () => void) {
+		this.stickingNodeTimer = setTimeout(() => {
+			this.editor.batch(() => {
+				this.handleStick(movingShapes, false, cb)
+			})
+			this.stickingNodeTimer = null
+		}, duration)
+	}
+
+	private handleStick(shapes: TLShape[], adhesive: boolean, cb?: () => void) {
+		shapes = compact(shapes.map((shape) => this.editor.getShape(shape.id)))
+
+		// TODO: fix this competing with dropping shapes and stuff
+		this.editor.setHintingShapes([])
+
+		for (const shape of shapes) {
+			const stickingOverShape = this.editor.getStickingOverShape(shape)
+			const prevParent = this.editor.getShape(shape.parentId)
+
+			// if (stickingOverShape === prevParent) {
+			// 	continue
+			// }
+
+			if (prevParent) {
+				this.editor.getShapeUtil(prevParent).onStickShapeOut?.(prevParent, shape)
+			}
+
+			if (stickingOverShape) {
+				const res = this.editor
+					.getShapeUtil(stickingOverShape)
+					.onStickShapeOver?.(stickingOverShape, shape)
+
+				if (!adhesive && res && res.shouldHint) {
+					const hintingShapeIds = this.editor.getHintingShapeIds()
+					this.editor.setHintingShapes([...hintingShapeIds, stickingOverShape.id])
+				}
+
+				if (adhesive) {
+					this.editor.getShapeUtil(stickingOverShape).onStickShape?.(stickingOverShape, shape)
+				}
+			} else {
+				if (adhesive) {
+					const page = this.editor.getCurrentPage()
+					if (page) {
+						this.editor.reparentShapes([shape], page.id)
+					}
+				}
+			}
+		}
+
+		cb?.()
+	}
+
+	stickShapes(shapes: TLShape[]) {
+		this.handleStick(shapes, true)
+	}
+
+	clear() {
+		if (this.stickingNodeTimer !== null) {
+			clearTimeout(this.stickingNodeTimer)
+		}
+
+		this.stickingNodeTimer = null
+		this.editor.setHintingShapes([])
+	}
+
+	dispose() {
+		this.clear()
+	}
+}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -27,6 +27,7 @@ export class PointingShape extends StateNode {
 
 		this.hitShape = info.shape
 		const outermostSelectingShape = this.editor.getOutermostSelectableShape(info.shape)
+		const selectedAncestor = this.editor.getSelectedAncestor(outermostSelectingShape.id)
 
 		if (
 			// If the shape has an onClick handler
@@ -35,8 +36,11 @@ export class PointingShape extends StateNode {
 			outermostSelectingShape.id === focusedGroupId ||
 			// ...or if the shape is within the selection
 			selectedShapeIds.includes(outermostSelectingShape.id) ||
-			this.editor.isAncestorSelected(outermostSelectingShape.id) ||
-			// ...or if the current point is NOT within the selection bounds
+			// ...or if the selected ancestor doesn't allow select on enter
+			(selectedAncestor &&
+				!this.editor
+					.getShapeUtil(selectedAncestor)
+					.canSelectChildOnPointerDownWhileSelected(selectedAncestor, outermostSelectingShape)) || // ...or if the current point is NOT within the selection bounds
 			(selectedShapeIds.length > 1 && selectionBounds?.containsPoint(currentPagePoint))
 		) {
 			// We won't select the shape on enter, though we might select it on pointer up!

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -27,7 +27,7 @@ export class PointingShape extends StateNode {
 
 		this.hitShape = info.shape
 		const outermostSelectingShape = this.editor.getOutermostSelectableShape(info.shape)
-		const selectedAncestor = this.editor.getSelectedAncestor(outermostSelectingShape.id)
+		const selectedAncestor = this.editor.findSelectedAncestor(outermostSelectingShape.id)
 
 		if (
 			// If the shape has an onClick handler

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -16,6 +16,7 @@ import {
 	moveCameraWhenCloseToEdge,
 } from '@tldraw/editor'
 import { DragAndDropManager } from '../DragAndDropManager'
+import { StickingManager } from '../StickingManager'
 
 export class Translating extends StateNode {
 	static override id = 'translating'
@@ -38,6 +39,7 @@ export class Translating extends StateNode {
 	onCreate: (shape: TLShape | null) => void = () => void null
 
 	dragAndDropManager = new DragAndDropManager(this.editor)
+	stickingManager = new StickingManager(this.editor)
 
 	override onEnter = (
 		info: TLPointerEventInfo & {
@@ -90,9 +92,11 @@ export class Translating extends StateNode {
 			{ ephemeral: true }
 		)
 		this.dragAndDropManager.clear()
+		this.stickingManager.clear()
 	}
 
 	override onTick = () => {
+		this.stickingManager.updateStickingNode(this.snapshot.movingShapes, this.updateParentTransforms)
 		this.dragAndDropManager.updateDroppingNode(
 			this.snapshot.movingShapes,
 			this.updateParentTransforms
@@ -167,6 +171,7 @@ export class Translating extends StateNode {
 	protected complete() {
 		this.updateShapes()
 		this.dragAndDropManager.dropShapes(this.snapshot.movingShapes)
+		this.stickingManager.stickShapes(this.snapshot.movingShapes)
 		this.handleEnd()
 
 		if (this.editor.getInstanceState().isToolLocked && this.info.onInteractionEnd) {
@@ -265,6 +270,7 @@ export class Translating extends StateNode {
 	protected updateShapes() {
 		const { snapshot } = this
 		this.dragAndDropManager.updateDroppingNode(snapshot.movingShapes, this.updateParentTransforms)
+		this.stickingManager.updateStickingNode(snapshot.movingShapes, this.updateParentTransforms)
 
 		moveShapesToPoint({
 			editor: this.editor,


### PR DESCRIPTION
This PR implements sticky notes as a surface in a more heavyweight way. It adds a new `StickingManager` that lets us handle sticking on a shape-by-shape basis. The code is messy and work-in-progress.


https://github.com/tldraw/tldraw/assets/15892272/fb715b20-ad2b-4df2-b77e-9588423a7463


https://github.com/tldraw/tldraw/assets/15892272/cbca0c27-a894-4c16-a864-48a497902842


https://github.com/tldraw/tldraw/assets/15892272/e53555df-f453-4827-8d35-09d44dbc22f8


https://github.com/tldraw/tldraw/assets/15892272/69c4c9c6-2c87-4e3c-8f58-f6f31a7a343a

https://github.com/tldraw/tldraw/assets/15892272/88d69b17-4638-4218-bf67-971b9c582ea1


https://github.com/tldraw/tldraw/assets/15892272/12df023b-33e7-4142-9acf-04df871cea6b




### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
