### PR TITLE
Stickies: Duplication previews v2

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -466,7 +466,7 @@ export const DefaultErrorFallback: TLErrorFallbackComponent;
 export function DefaultGrid({ x, y, z, size }: TLGridProps): JSX_2.Element;
 
 // @public (undocumented)
-export function DefaultHandle({ handle, isCoarse, className, zoom }: TLHandleProps): JSX_2.Element;
+export function DefaultHandle({ handle, isCoarse, className, zoom }: TLHandleProps): JSX_2.Element | null;
 
 // @public (undocumented)
 export const DefaultHandles: ({ children }: TLHandlesProps) => JSX_2.Element;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -6380,13 +6380,17 @@
             },
             {
               "kind": "Content",
+              "text": " | null"
+            },
+            {
+              "kind": "Content",
               "text": ";"
             }
           ],
           "fileUrlPath": "packages/editor/src/lib/components/default-components/DefaultHandle.tsx",
           "returnTypeTokenRange": {
             "startIndex": 3,
-            "endIndex": 5
+            "endIndex": 6
           },
           "releaseTag": "Public",
           "overloadIndex": 1,

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -520,11 +520,15 @@ input,
 	pointer-events: none;
 }
 
+
 .tl-handle__create {
 	opacity: 0;
 }
 .tl-handle__create:hover {
 	opacity: 1;
+}
+.tl-handle__note-create:hover {
+	opacity: 0.1;
 }
 
 .tl-handle__bg:active {

--- a/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
@@ -16,6 +16,19 @@ export function DefaultHandle({ handle, isCoarse, className, zoom }: TLHandlePro
 	const bgRadius = (isCoarse ? COARSE_HANDLE_RADIUS : HANDLE_RADIUS) / zoom
 	const fgRadius = (handle.type === 'create' && isCoarse ? 3 : 4) / zoom
 
+	// todo: this is bad
+	// @ts-expect-error
+	if (handle.type === 'note-create') {
+		return (
+			<rect
+				className="tl-handle tl-handle__create"
+				width={200}
+				height={200}
+				fill="rgba(255,192,120,0.2)"
+			/>
+		)
+	}
+
 	return (
 		<g
 			className={classNames(

--- a/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
@@ -1,6 +1,8 @@
-import { TLHandle, TLShapeId } from '@tldraw/tlschema'
+import { TLHandle, TLShape, TLShapeId, getDefaultColorTheme } from '@tldraw/tlschema'
 import classNames from 'classnames'
 import { COARSE_HANDLE_RADIUS, HANDLE_RADIUS } from '../../constants'
+import { useEditor } from '../../hooks/useEditor'
+import { Box } from '../../primitives/Box'
 
 /** @public */
 export type TLHandleProps = {
@@ -10,23 +12,59 @@ export type TLHandleProps = {
 	isCoarse: boolean
 	className?: string
 }
-
+export type NoteHandleId =
+	| 'note-button-up'
+	| 'note-preview-up'
+	| 'note-button-down'
+	| 'note-preview-down'
+	| 'note-button-left'
+	| 'note-preview-left'
+	| 'note-button-right'
+	| 'note-preview-right'
 /** @public */
 export function DefaultHandle({ handle, isCoarse, className, zoom }: TLHandleProps) {
 	const bgRadius = (isCoarse ? COARSE_HANDLE_RADIUS : HANDLE_RADIUS) / zoom
 	const fgRadius = (handle.type === 'create' && isCoarse ? 3 : 4) / zoom
-
+	const editor = useEditor()
 	// todo: this is bad
 	// @ts-expect-error
 	if (handle.type === 'note-create') {
-		return (
-			<rect
-				className="tl-handle tl-handle__create"
-				width={200}
-				height={200}
-				fill="rgba(255,192,120,0.2)"
-			/>
-		)
+		const noteShape = editor.getSelectedShapes()
+		const getNoteBox = (id: string, shape: TLShape) => {
+			switch (id) {
+				case 'note-preview-up':
+					return new Box(shape.x, shape.y - 230, 200, 200).expandBy(20)
+				case 'note-preview-down':
+					return new Box(shape.x, shape.y + 230, 200, 200).expandBy(20)
+				case 'note-preview-left':
+					return new Box(shape.x - 230, shape.y, 200, 200).expandBy(20)
+				case 'note-preview-right':
+					return new Box(shape.x + 230, shape.y, 200, 200).expandBy(20)
+				default:
+					throw new Error('Invalid note handle id')
+			}
+		}
+		const noteBox = getNoteBox(handle.id, noteShape[0])
+		const overlappingShapes = editor.getCurrentPageShapes().map((shape) => {
+			const bounds = editor.getShapePageBounds(shape)
+			if (bounds) {
+				return noteBox.contains(bounds)
+			} else return false
+		})
+
+		const shapesOverlapping = overlappingShapes.some(Boolean)
+		const theme = getDefaultColorTheme({ isDarkMode: editor.user.getIsDarkMode() })
+		if (!shapesOverlapping) {
+			return (
+				<rect
+					className="tl-handle tl-handle__create tl-handle__note-create"
+					width={200}
+					height={200}
+					// @ts-expect-error
+					fill={`${theme[noteShape[0].props.color].solid}`}
+				/>
+			)
+		} else return null
 	}
 
 	return (

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -224,9 +224,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
+        type: "point";
         x: number;
         y: number;
-        type: "point";
         }>;
         }, never>;
         end: UnionValidator<"type", {
@@ -238,9 +238,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         isPrecise: boolean;
         }>;
         point: ObjectValidator<    {
+        type: "point";
         x: number;
         y: number;
-        type: "point";
         }>;
         }, never>;
         bend: Validator<number>;
@@ -1061,9 +1061,9 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         spline: EnumStyleProp<"cubic" | "line">;
         points: DictValidator<string, {
-        id: string;
         x: number;
         y: number;
+        id: string;
         index: IndexKey;
         }>;
     };
@@ -1105,6 +1105,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getGeometry(shape: TLNoteShape): Rectangle2d;
     // (undocumented)
+    getHandles(shape: TLNoteShape): TLHandle[];
+    // (undocumented)
     getHeight(shape: TLNoteShape): number;
     // (undocumented)
     hideResizeHandles: () => boolean;
@@ -1125,6 +1127,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            buttons: VecModel[];
+            previews: VecModel[];
         };
         type: "note";
         x: number;
@@ -1149,6 +1153,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             verticalAlign: "end" | "middle" | "start";
             url: string;
             text: string;
+            buttons: VecModel[];
+            previews: VecModel[];
         };
         type: "note";
         x: number;
@@ -1174,6 +1180,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         growY: Validator<number>;
         url: Validator<string>;
         text: Validator<string>;
+        buttons: ArrayOfValidator<VecModel>;
+        previews: ArrayOfValidator<VecModel>;
     };
     // (undocumented)
     toSvg(shape: TLNoteShape, ctx: SvgExportContext): JSX_2.Element;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1169,7 +1169,14 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         typeName: "shape";
     } | undefined;
     // (undocumented)
+    onDoubleClickHandle: (shape: TLNoteShape) => TLNoteShape;
+    // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
+    // (undocumented)
+    onHandlePointerDown: ({ shape, handleId }: {
+        shape: TLNoteShape;
+        handleId: NoteHandleId;
+    }) => void;
     // (undocumented)
     static props: {
         color: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "yellow">;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -1645,7 +1645,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
+                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        end: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -1690,7 +1690,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n                x: number;\n                y: number;\n                type: \"point\";\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
+                  "text": "<{\n                type: \"point\";\n                x: number;\n                y: number;\n            }>;\n        }, never>;\n        bend: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12394,7 +12394,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, {\n            id: string;\n            x: number;\n            y: number;\n            index: import(\"@tldraw/editor\")."
+                  "text": "<string, {\n            x: number;\n            y: number;\n            id: string;\n            index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -12996,6 +12996,60 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "tldraw!NoteShapeUtil#getHandles:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getHandles(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLHandle",
+                  "canonicalReference": "@tldraw/tlschema!TLHandle:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getHandles"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "tldraw!NoteShapeUtil#getHeight:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -13212,7 +13266,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[];\n            previews: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[];\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13261,7 +13333,7 @@
               "name": "onBeforeCreate",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 12
+                "endIndex": 16
               },
               "isStatic": false,
               "isProtected": false,
@@ -13296,7 +13368,25 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
+                  "text": ") => {\n        props: {\n            growY: number;\n            color: \"black\" | \"blue\" | \"green\" | \"grey\" | \"light-blue\" | \"light-green\" | \"light-red\" | \"light-violet\" | \"orange\" | \"red\" | \"violet\" | \"yellow\";\n            size: \"l\" | \"m\" | \"s\" | \"xl\";\n            font: \"draw\" | \"mono\" | \"sans\" | \"serif\";\n            align: \"end-legacy\" | \"end\" | \"middle-legacy\" | \"middle\" | \"start-legacy\" | \"start\";\n            verticalAlign: \"end\" | \"middle\" | \"start\";\n            url: string;\n            text: string;\n            buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[];\n            previews: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[];\n        };\n        type: \"note\";\n        x: number;\n        y: number;\n        rotation: number;\n        index: import(\"@tldraw/editor\")."
                 },
                 {
                   "kind": "Reference",
@@ -13345,7 +13435,7 @@
               "name": "onBeforeUpdate",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 14
+                "endIndex": 18
               },
               "isStatic": false,
               "isProtected": false,
@@ -13478,7 +13568,43 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<string>;\n    }"
+                  "text": "<string>;\n        buttons: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ArrayOfValidator",
+                  "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">;\n        previews: import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ArrayOfValidator",
+                  "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<import(\"@tldraw/editor\")."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecModel",
+                  "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -13491,7 +13617,7 @@
               "name": "props",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 18
+                "endIndex": 26
               },
               "isStatic": true,
               "isProtected": false,

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13443,6 +13443,50 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onDoubleClickHandle:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onDoubleClickHandle: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onDoubleClickHandle",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#onEditEnd:member",
               "docComment": "",
               "excerptTokens": [
@@ -13480,6 +13524,54 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 5
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "tldraw!NoteShapeUtil#onHandlePointerDown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onHandlePointerDown: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "({ shape, handleId }: {\n        shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLNoteShape",
+                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n        handleId: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "NoteHandleId",
+                  "canonicalReference": "tldraw!~NoteHandleId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n    }) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "onHandlePointerDown",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
               },
               "isStatic": false,
               "isProtected": false,

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -5,17 +5,22 @@ import {
 	LoadingScreen,
 	StoreSnapshot,
 	TLEditorComponents,
+	TLNoteShape,
 	TLOnMountHandler,
 	TLRecord,
 	TLStore,
 	TLStoreWithStatus,
 	TldrawEditor,
 	TldrawEditorBaseProps,
+	createShapeId,
+	stopEventPropagation,
+	track,
 	useEditor,
 	useEditorComponents,
 	useEvent,
 	useShallowArrayIdentity,
 	useShallowObjectIdentity,
+	useValue,
 } from '@tldraw/editor'
 import { useLayoutEffect, useMemo } from 'react'
 import { TldrawHandles } from './canvas/TldrawHandles'
@@ -31,6 +36,7 @@ import { defaultShapeTools } from './defaultShapeTools'
 import { defaultShapeUtils } from './defaultShapeUtils'
 import { registerDefaultSideEffects } from './defaultSideEffects'
 import { defaultTools } from './defaultTools'
+import { NOTE_GRID_OFFSET } from './shapes/note/NoteShapeUtil'
 import { TldrawUi, TldrawUiProps } from './ui/TldrawUi'
 import { TLUiComponents, useTldrawUiComponents } from './ui/context/components'
 import { useToasts } from './ui/context/toasts'
@@ -91,6 +97,7 @@ export function Tldraw(props: TldrawProps) {
 			SelectionBackground: TldrawSelectionBackground,
 			Handles: TldrawHandles,
 			HoveredShapeIndicator: TldrawHoveredShapeIndicator,
+			InFrontOfTheCanvas: NoteDuplicationHandles,
 			..._components,
 		}),
 		[_components]
@@ -208,4 +215,137 @@ function InsideOfEditorAndUiContext({
 	}
 
 	return null
+}
+
+const HANDLE_SIZE = 10
+const NoteDuplicationHandles = track(() => {
+	const editor = useEditor()
+
+	const info = useValue(
+		'selection bounds',
+		() => {
+			const screenBounds = editor.getViewportScreenBounds()
+			const rotation = editor.getSelectionRotation()
+			const rotatedScreenBounds = editor.getSelectionRotatedScreenBounds()
+			const zoom = editor.getZoomLevel()
+			if (!rotatedScreenBounds) return
+			return {
+				x: rotatedScreenBounds.x - screenBounds.x,
+				y: rotatedScreenBounds.y - screenBounds.y,
+				width: rotatedScreenBounds.width,
+				height: rotatedScreenBounds.height,
+				rotation: rotation,
+				zoom,
+			}
+		},
+		[editor]
+	)
+
+	const shapes = editor.getSelectedShapes()
+	if (shapes.length === 0) return null
+	if (shapes.length > 1) return null
+	if (shapes[0].type !== 'note') return null
+	if (!info) return
+	const zoomOffsetAboveLeft = HANDLE_SIZE * 2.5 * info.zoom
+	console.log({ zoomOffsetAboveLeft, HANDLE_SIZE })
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				transformOrigin: 'top left',
+				transform: `translate(${info.x}px, ${info.y}px) rotate(${info.rotation}rad)`,
+				pointerEvents: 'all',
+			}}
+			onPointerDown={stopEventPropagation}
+		>
+			<DuplicateInDirectionButton
+				shape={shapes[0] as TLNoteShape}
+				y={-HANDLE_SIZE * 2.5}
+				x={info.width / 2 - HANDLE_SIZE / 2}
+				direction={'above'}
+				rotation={-(Math.PI / 2)}
+			/>
+			<DuplicateInDirectionButton
+				shape={shapes[0] as TLNoteShape}
+				y={info.height / 2 - HANDLE_SIZE / 2}
+				x={-HANDLE_SIZE * 2.5}
+				direction={'left'}
+				rotation={Math.PI}
+			/>
+			<DuplicateInDirectionButton
+				shape={shapes[0] as TLNoteShape}
+				y={info.height / 2 - HANDLE_SIZE / 2}
+				x={info.width + HANDLE_SIZE * 1.5}
+				direction={'right'}
+				rotation={0}
+			/>
+			<DuplicateInDirectionButton
+				shape={shapes[0] as TLNoteShape}
+				y={info.height + HANDLE_SIZE * 1.5}
+				x={info.width / 2 - HANDLE_SIZE / 2}
+				direction={'below'}
+				rotation={Math.PI / 2}
+			/>
+		</div>
+	)
+})
+
+function DuplicateInDirectionButton({
+	x,
+	y,
+	rotation,
+	shape,
+	direction,
+}: {
+	x: number
+	y: number
+	rotation: number
+	shape: TLNoteShape
+	direction: 'above' | 'below' | 'left' | 'right'
+}) {
+	const editor = useEditor()
+
+	const offsetX =
+		direction === 'left' ? -NOTE_GRID_OFFSET : direction === 'right' ? NOTE_GRID_OFFSET : 0
+	const offsetY =
+		direction === 'above' ? -NOTE_GRID_OFFSET : direction === 'below' ? NOTE_GRID_OFFSET : 0
+
+	return (
+		<button
+			style={{
+				position: 'absolute',
+				width: HANDLE_SIZE * 2,
+				height: HANDLE_SIZE * 2,
+				pointerEvents: 'all',
+				border: 'none',
+				backgroundColor: 'transparent',
+				padding: '0',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				cursor: 'pointer',
+				transform: `translate(${x}px, ${y}px) rotate(${rotation}rad)`,
+			}}
+			onPointerDown={(e) => {
+				stopEventPropagation(e)
+				const noteId = createShapeId()
+				editor.createShapes([
+					{ type: 'note', id: noteId, x: shape.x + offsetX, y: shape.y + offsetY },
+				])
+				const newNote = editor.getShape(noteId)
+			}}
+		>
+			<div
+				style={{
+					height: HANDLE_SIZE,
+					width: HANDLE_SIZE,
+					borderRadius: '10px',
+					border: '2px solid blue',
+					padding: '0',
+				}}
+			></div>
+		</button>
+	)
 }

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -6,6 +6,7 @@ import {
 	TLHandle,
 	TLNoteShape,
 	TLOnEditEndHandler,
+	createShapeId,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -20,7 +21,7 @@ import { getFontDefForExport } from '../shared/defaultStyleDefs'
 
 export const NOTE_SIZE = 200
 export const NOTE_GRID_OFFSET = 230
-type NoteHandleId =
+export type NoteHandleId =
 	| 'note-button-up'
 	| 'note-preview-up'
 	| 'note-button-down'
@@ -242,7 +243,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			}
 		}
 		const offset = getOffset(handleId, shape)
-		this.editor.createShape({ type: 'note', x: offset.x, y: offset.y })
+		const id = createShapeId()
+		this.editor.createShape({ id, type: 'note', x: offset.x, y: offset.y })
+		this.editor.select(id)
 	}
 	override onDoubleClickHandle = (shape: TLNoteShape) => {
 		return shape

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -20,6 +20,15 @@ import { getFontDefForExport } from '../shared/defaultStyleDefs'
 
 export const NOTE_SIZE = 200
 export const NOTE_GRID_OFFSET = 230
+type NoteHandleId =
+	| 'note-button-up'
+	| 'note-preview-up'
+	| 'note-button-down'
+	| 'note-preview-down'
+	| 'note-button-left'
+	| 'note-preview-left'
+	| 'note-button-right'
+	| 'note-preview-right'
 
 /** @public */
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
@@ -47,7 +56,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 				{ x: 0.5, y: 1.1 },
 				{ x: -0.1, y: 0.5 },
 			],
-			previews: [{ x: 0, y: 0 }],
+			previews: [
+				{ x: 0, y: -1.14 },
+				{ x: 1.14, y: 0 },
+				{ x: 0, y: 1.14 },
+				{ x: -1.14, y: 0 },
+			],
 		}
 	}
 
@@ -64,10 +78,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		}))
 		const previewsArr = previews.map((preview, i) => ({
 			id: 'note-preview-' + directionArr[i],
-			type: 'create',
+			type: 'note-create',
 			index: `${i}`,
-			x: preview.x,
-			y: preview.y,
+			x: preview.x * NOTE_SIZE,
+			y: preview.y * NOTE_SIZE,
 			canSnap: true,
 		}))
 		return [...previewsArr, ...buttonsArr] as TLHandle[]
@@ -207,6 +221,31 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 				},
 			])
 		}
+	}
+	onHandlePointerDown = ({ shape, handleId }: { shape: TLNoteShape; handleId: NoteHandleId }) => {
+		const getOffset = (handleId: NoteHandleId, shape: TLNoteShape) => {
+			switch (handleId) {
+				case 'note-button-right':
+				case 'note-preview-right':
+					return { x: shape.x + NOTE_GRID_OFFSET, y: shape.y }
+				case 'note-button-left':
+				case 'note-preview-left':
+					return { x: shape.x - NOTE_GRID_OFFSET, y: shape.y }
+				case 'note-button-up':
+				case 'note-preview-up':
+					return { x: shape.x, y: shape.y - NOTE_GRID_OFFSET }
+				case 'note-button-down':
+				case 'note-preview-down':
+					return { x: shape.x, y: shape.y + NOTE_GRID_OFFSET }
+				default:
+					throw new Error('this should not happen')
+			}
+		}
+		const offset = getOffset(handleId, shape)
+		this.editor.createShape({ type: 'note', x: offset.x, y: offset.y })
+	}
+	override onDoubleClickHandle = (shape: TLNoteShape) => {
+		return shape
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -3,6 +3,7 @@ import {
 	Rectangle2d,
 	ShapeUtil,
 	SvgExportContext,
+	TLHandle,
 	TLNoteShape,
 	TLOnEditEndHandler,
 	getDefaultColorTheme,
@@ -40,7 +41,36 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			verticalAlign: 'middle',
 			growY: 0,
 			url: '',
+			buttons: [
+				{ x: 0.5, y: -0.1 },
+				{ x: 1.1, y: 0.5 },
+				{ x: 0.5, y: 1.1 },
+				{ x: -0.1, y: 0.5 },
+			],
+			previews: [{ x: 0, y: 0 }],
 		}
+	}
+
+	override getHandles(shape: TLNoteShape): TLHandle[] {
+		const { buttons, previews } = shape.props
+		const directionArr = ['up', 'right', 'down', 'left']
+		const buttonsArr = buttons.map((button, i) => ({
+			id: 'note-button-' + directionArr[i],
+			type: 'vertex',
+			index: `${i}`,
+			x: button.x * NOTE_SIZE,
+			y: button.y * this.getHeight(shape),
+			canSnap: true,
+		}))
+		const previewsArr = previews.map((preview, i) => ({
+			id: 'note-preview-' + directionArr[i],
+			type: 'create',
+			index: `${i}`,
+			x: preview.x,
+			y: preview.y,
+			canSnap: true,
+		}))
+		return [...previewsArr, ...buttonsArr] as TLHandle[]
 	}
 
 	getHeight(shape: TLNoteShape) {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -17,7 +17,7 @@ import { TextLabel } from '../shared/TextLabel'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
 
-const NOTE_SIZE = 200
+export const NOTE_SIZE = 200
 
 /** @public */
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -18,6 +18,7 @@ import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-s
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
 
 export const NOTE_SIZE = 200
+export const NOTE_GRID_OFFSET = 230
 
 /** @public */
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -1,4 +1,10 @@
-import { StateNode, TLArrowShape, TLEventHandlers, TLPointerEventInfo } from '@tldraw/editor'
+import {
+	StateNode,
+	TLArrowShape,
+	TLEventHandlers,
+	TLNoteShape,
+	TLPointerEventInfo,
+} from '@tldraw/editor'
 
 export class PointingHandle extends StateNode {
 	static override id = 'pointing_handle'
@@ -15,6 +21,13 @@ export class PointingHandle extends StateNode {
 			if (initialTerminal?.type === 'binding') {
 				this.editor.setHintingShapes([initialTerminal.boundShapeId])
 			}
+		}
+		if (this.editor.isShapeOfType<TLNoteShape>(shape, 'note')) {
+			this.editor
+				.getShapeUtil<TLNoteShape>(shape)
+				// todo: fix this
+				// @ts-expect-error
+				.onHandlePointerDown({ shape, handleId: this.info.handle.id })
 		}
 
 		this.editor.updateInstanceState(

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -300,7 +300,7 @@ export class Translating extends StateNode {
 			checkForStickyPit: this.checkForStickyPit,
 		})
 		if (info) {
-			console.log(info)
+			// console.log({ info })
 			this.checkForStickyPit = info.checkForStickyPit
 		}
 
@@ -548,20 +548,19 @@ export function moveShapesToPoint({
 	if (stickyPit) {
 		const noteShape = editor.getShape(snapshots[0].shape.id)
 		const distance = Vec.Dist({ x: noteShape!.x + 100, y: noteShape!.y + 100 }, stickyPit)
-		console.log({ distance, firstCheck, checkForStickyPit })
+		// console.log({ distance, firstCheck, checkForStickyPit })
 		if (!checkForStickyPit && distance > 20) {
 			return { checkForStickyPit: true }
 		}
 		if (distance < 20 && firstCheck) {
-			// here
 			return { checkForStickyPit: false }
-		} else if (distance < 20) {
+		} else if (distance < 20 && checkForStickyPit) {
 			editor.updateShape({
 				...snapshots[0].shape,
 				x: stickyPit.x - 100,
 				y: stickyPit.y - 100,
 			})
-			return { checkForStickyPit: false }
+			return { checkForStickyPit: true }
 		}
 	}
 }

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ArrayOfValidator } from '@tldraw/validate';
 import { BaseRecord } from '@tldraw/store';
 import { Expand } from '@tldraw/utils';
 import { IndexKey } from '@tldraw/utils';
@@ -47,9 +48,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
+            type: "point";
             x: number;
             y: number;
-            type: "point";
         } & {}>;
     }, never>;
     end: T.UnionValidator<"type", {
@@ -61,9 +62,9 @@ export const arrowShapeProps: {
             isPrecise: boolean;
         } & {}>;
         point: T.ObjectValidator<{
+            type: "point";
             x: number;
             y: number;
-            type: "point";
         } & {}>;
     }, never>;
     bend: T.Validator<number>;
@@ -684,9 +685,9 @@ export const lineShapeProps: {
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     spline: EnumStyleProp<"cubic" | "line">;
     points: T.DictValidator<string, {
-        id: string;
         x: number;
         y: number;
+        id: string;
         index: IndexKey;
     } & {}>;
 };
@@ -707,6 +708,8 @@ export const noteShapeProps: {
     growY: T.Validator<number>;
     url: T.Validator<string>;
     text: T.Validator<string>;
+    buttons: ArrayOfValidator<VecModel>;
+    previews: ArrayOfValidator<VecModel>;
 };
 
 // @internal (undocumented)

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -364,7 +364,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    end: "
+              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    end: "
             },
             {
               "kind": "Reference",
@@ -409,7 +409,7 @@
             },
             {
               "kind": "Content",
-              "text": "<{\n            x: number;\n            y: number;\n            type: \"point\";\n        } & {}>;\n    }, never>;\n    bend: "
+              "text": "<{\n            type: \"point\";\n            x: number;\n            y: number;\n        } & {}>;\n    }, never>;\n    bend: "
             },
             {
               "kind": "Reference",
@@ -2818,7 +2818,7 @@
             },
             {
               "kind": "Content",
-              "text": "<string, {\n        id: string;\n        x: number;\n        y: number;\n        index: "
+              "text": "<string, {\n        x: number;\n        y: number;\n        id: string;\n        index: "
             },
             {
               "kind": "Reference",
@@ -2954,7 +2954,43 @@
             },
             {
               "kind": "Content",
-              "text": "<string>;\n}"
+              "text": "<string>;\n    buttons: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ArrayOfValidator",
+              "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<import(\"../misc/geometry-types\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "VecModel",
+              "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">;\n    previews: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ArrayOfValidator",
+              "canonicalReference": "@tldraw/validate!ArrayOfValidator:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<import(\"../misc/geometry-types\")."
+            },
+            {
+              "kind": "Reference",
+              "text": "VecModel",
+              "canonicalReference": "@tldraw/tlschema!VecModel:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ">;\n}"
             }
           ],
           "fileUrlPath": "packages/tlschema/src/shapes/TLNoteShape.ts",
@@ -2963,7 +2999,7 @@
           "name": "noteShapeProps",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 18
+            "endIndex": 26
           }
         },
         {

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -1,5 +1,6 @@
 import { defineMigrations } from '@tldraw/store'
-import { T } from '@tldraw/validate'
+import { ArrayOfValidator, T } from '@tldraw/validate'
+import { vecModelValidator } from '../misc/geometry-types'
 import { DefaultColorStyle } from '../styles/TLColorStyle'
 import { DefaultFontStyle } from '../styles/TLFontStyle'
 import {
@@ -20,6 +21,8 @@ export const noteShapeProps = {
 	growY: T.positiveNumber,
 	url: T.linkUrl,
 	text: T.string,
+	buttons: new ArrayOfValidator(vecModelValidator),
+	previews: new ArrayOfValidator(vecModelValidator),
 }
 
 /** @public */


### PR DESCRIPTION
Rough look at duplication previews, stacked on top of the translation snapping, gif below.

<img width="737" alt="Screenshot 2024-03-28 at 17 35 54" src="https://github.com/tldraw/tldraw/assets/98838967/e263bece-e375-4729-9c58-5c1aebe1c15f">

## Some questions that came up for me:

### Snapping
<img width="475" alt="Screenshot 2024-03-28 at 17 36 39" src="https://github.com/tldraw/tldraw/assets/98838967/e45b40d6-94f3-42e5-ac90-6d2579b4c4a0">

### Previews

<img width="2968" alt="shapes at 24-03-28 17 37 27" src="https://github.com/tldraw/tldraw/assets/98838967/bcd6416c-b197-47d8-94e0-d1a51b312b03">

![2024-03-28 at 17 40 24 - Peach Cicada](https://github.com/tldraw/tldraw/assets/98838967/f5e3d26a-4b31-4ec4-9b35-aa7d9bb0d347)



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
