### PR TITLE
Refactor tab / cmd interactions

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -351,7 +351,7 @@ function useNoteKeydownHandler(id: TLShapeId) {
 						.createShape({
 							id,
 							type: 'note',
-							x: point.x, // remove offsets
+							x: point.x,
 							y: point.y,
 							rotation: shape.rotation,
 						})

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -9,6 +9,7 @@ import {
 	TLShape,
 	TLShapeId,
 	Vec,
+	createShapeId,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -26,7 +27,6 @@ import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
-import { createSticky } from './toolStates/Pointing'
 
 const NOTE_SIZE = 200
 const NEW_NOTE_MARGIN = 20
@@ -331,13 +331,27 @@ function useNoteKeydownHandler(id: TLShapeId) {
 					}
 				}
 
-				// If we didn't find any, then create a new one
+				editor.complete()
+				editor.mark()
+
+				// If we didn't find any in that position, then create a new one
 				if (!nextSticky) {
-					nextSticky = createSticky(editor, undefined, point, shape.rotation)
+					// Remove the offset from the center to get the top left corner
+					point.subXY(NOTE_SIZE / 2, NOTE_SIZE / 2)
+					const id = createShapeId()
+					editor
+						.createShape({
+							id,
+							type: 'note',
+							x: point.x,
+							y: point.y,
+							rotation: shape.rotation,
+						})
+						.select(id)
+					nextSticky = editor.getShape(id)!
 				}
 
 				// Finish this sticky and start editing the next one
-				editor.complete()
 				editor.select(nextSticky)
 				editor.setEditingShape(nextSticky)
 				editor.setCurrentTool('select.editing_shape', {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -336,15 +336,13 @@ function useNoteKeydownHandler(id: TLShapeId) {
 
 				// If we didn't find any in that position, then create a new one
 				if (!nextSticky) {
-					// Remove the offset from the center to get the top left corner
-					point.subXY(NOTE_SIZE / 2, NOTE_SIZE / 2)
 					const id = createShapeId()
 					editor
 						.createShape({
 							id,
 							type: 'note',
-							x: point.x,
-							y: point.y,
+							x: point.x - NOTE_SIZE / 2, // remove offsets
+							y: point.y - NOTE_SIZE / 2,
 							rotation: shape.rotation,
 						})
 						.select(id)

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -30,14 +30,15 @@ export class Pointing extends StateNode {
 			const id = createShapeId()
 			this.markId = `creating:${id}`
 			this.editor.mark(this.markId)
-			this.shape = createSticky(this.editor, id)
+			this.shape = createSticky(this.editor, id, this.editor.inputs.originPagePoint)
 		}
 	}
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
 		if (this.editor.inputs.isDragging) {
 			if (!this.wasFocusedOnEnter) {
-				this.shape = createSticky(this.editor, createShapeId())
+				const id = createShapeId()
+				this.shape = createSticky(this.editor, id, this.editor.inputs.originPagePoint)
 			}
 
 			this.editor.setCurrentTool('select.translating', {
@@ -91,29 +92,14 @@ export class Pointing extends StateNode {
 	}
 }
 
-export function createSticky(
-	editor: Editor,
-	id?: TLShapeId,
-	creationPoint?: Vec,
-	rotation?: number
-) {
-	const {
-		inputs: { originPagePoint },
-	} = editor
-
-	creationPoint = creationPoint || originPagePoint
-	id = id || createShapeId()
-
+export function createSticky(editor: Editor, id: TLShapeId, center: Vec) {
 	editor
-		.createShapes([
-			{
-				id,
-				type: 'note',
-				x: creationPoint.x,
-				y: creationPoint.y,
-				rotation,
-			},
-		])
+		.createShape({
+			id,
+			type: 'note',
+			x: center.x,
+			y: center.y,
+		})
 		.select(id)
 
 	const shape = editor.getShape<TLNoteShape>(id)!

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -91,7 +91,12 @@ export class Pointing extends StateNode {
 	}
 }
 
-export function createSticky(editor: Editor, id?: TLShapeId, creationPoint?: Vec) {
+export function createSticky(
+	editor: Editor,
+	id?: TLShapeId,
+	creationPoint?: Vec,
+	rotation?: number
+) {
 	const {
 		inputs: { originPagePoint },
 	} = editor
@@ -106,6 +111,7 @@ export function createSticky(editor: Editor, id?: TLShapeId, creationPoint?: Vec
 				type: 'note',
 				x: creationPoint.x,
 				y: creationPoint.y,
+				rotation,
 			},
 		])
 		.select(id)


### PR DESCRIPTION
This PR updates the tab / cmd interactions for stickies.

New notes now follow the position / rotation of the note that's being tabbed out of.

![Kapture 2024-03-30 at 14 56 41](https://github.com/tldraw/tldraw/assets/23072548/82a0d8a9-6117-4b37-9b20-186dd8998c42)

The new note's position is now correct when the shape is inside of parents / frames.

![Kapture 2024-03-30 at 14 58 35](https://github.com/tldraw/tldraw/assets/23072548/430a12ed-196d-4019-98e2-7222e6ea840d)

New shapes are no longer created when another note is in that position. Instead, focus moves to the new note.

![Kapture 2024-03-30 at 15 01 45](https://github.com/tldraw/tldraw/assets/23072548/aefb50ee-fe89-44cb-afbc-554012281cfc)

Pressing Cmd+Enter to place a note below the current sticky note now accounts for the height of the current note.

![Kapture 2024-03-30 at 15 03 38](https://github.com/tldraw/tldraw/assets/23072548/4b6a3c11-867c-4310-b9f4-b9e4c540be11)

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Test Plan

1. Use the "tab" / "shift-tab" / "cmd+enter" / "shift-cmd-enter" feature while editing sticky notes.

- [ ] Unit Tests
- [ ] End to end tests
