### PR TITLE
Fix: li touch not working on mobile

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -107,6 +107,7 @@ export function useCanvasEvents() {
 				;(e as any).isKilled = true
 				if (
 					(e.target as HTMLElement).tagName !== 'A' &&
+					(e.target as HTMLElement).tagName !== 'LI' &&
 					(e.target as HTMLElement).tagName !== 'TEXTAREA'
 				) {
 					preventDefault(e)


### PR DESCRIPTION
Autocomplete of textarea (or input by default, but here only allows textarea) created using lib like https://github.com/downshift-js/downshift will use li for dropdown item.

This PR allows them to be clicked.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. I tested by patch it in pnpm and tested on my site locally
1. or create custom shape with a li inside, with a onTouch callback

### Release Notes

- Allow touch li element on mobile
