### PR TITLE
Fix count shapes and nodes

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -153,26 +153,12 @@ export function DefaultDebugMenuContent() {
 					id="count-nodes"
 					label={'Count shapes / nodes'}
 					onSelect={() => {
-						function countDescendants({ children }: HTMLElement) {
-							let count = 0
-							if (!children.length) return 0
-							for (const el of [...(children as any)]) {
-								count++
-								count += countDescendants(el)
-							}
-							return count
-						}
 						const selectedShapes = editor.getSelectedShapes()
 						const shapes =
 							selectedShapes.length === 0 ? editor.getRenderingShapes() : selectedShapes
-						const elms = shapes.map(
-							(shape) => (document.getElementById(shape.id) as HTMLElement)!.parentElement!
+						window.alert(
+							`Shapes ${shapes.length}, DOM nodes:${document.querySelector('.tl-shapes')!.querySelectorAll('*')?.length}`
 						)
-						let descendants = elms.length
-						for (const elm of elms) {
-							descendants += countDescendants(elm)
-						}
-						window.alert(`Shapes ${shapes.length}, DOM nodes:${descendants}`)
 					}}
 				/>
 				{(() => {


### PR DESCRIPTION
This PR simplifies the debug count for debugging number of elements on the page. It fixes a bug where note shapes and other shapes without shapeid ids were not correctly counted.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix
