### PR TITLE
Stickies: simplify shadows / DOM elements, add note colors to theme, new colors

### DIFF
--- a/apps/dotcom/package.json
+++ b/apps/dotcom/package.json
@@ -26,7 +26,7 @@
 		"@tldraw/tlsync": "workspace:*",
 		"@tldraw/utils": "workspace:*",
 		"@vercel/analytics": "^1.1.1",
-		"browser-fs-access": "^0.33.0",
+		"browser-fs-access": "^0.35.0",
 		"idb": "^7.1.1",
 		"nanoid": "4.0.2",
 		"qrcode": "^1.5.1",

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1138,57 +1138,23 @@ input,
 
 /* -------------------- NoteShape ------------------- */
 
-.tl-note {
-	position: relative;
-}
-
 .tl-note__container {
+	position: relative;
 	width: 100%;
 	height: 100%;
 	pointer-events: all;
 	opacity: 1;
-	opacity: 0.98;
+	z-index: 1;
+	border-radius: 1px;
 }
 
-.tl-note .tl-text-label {
+.tl-note__container > .tl-text-label {
 	text-shadow: none;
+	color: currentColor;
 	z-index: 4;
 }
 
-.tl-note__shadow {
-	position: absolute;
-	background-color: none;
-	left: 0px;
-	bottom: 0px;
-	width: 100%;
-	transform-origin: bottom center;
-	z-index: 1;
-}
-
-.tl-note__body {
-	position: absolute;
-	left: 0px;
-	bottom: 0px;
-	height: 100%;
-	width: 100%;
-	background-color: currentColor;
-	border-radius: 1px;
-	z-index: 2;
-}
-
-.tl-note__scrim {
-	position: absolute;
-	z-index: 1;
-	inset: 0px;
-	height: 100%;
-	width: 100%;
-	background-color: var(--color-background);
-	box-shadow:
-		0px 4px 8px -8px inset currentColor,
-		0px 50px 8px -10px inset rgba(0, 0, 0, 0.08);
-	opacity: 0.2;
-	z-index: 3;
-}
+/* --------------------- Loading -------------------- */
 
 .tl-loading {
 	background-color: var(--color-background);

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -84,6 +84,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			this.editor,
 		])
 
+		const showShadows = this.editor.getZoomLevel() > 0.5
+
 		// Shadow stuff
 		const oy = Math.cos(rotation)
 		const ox = Math.sin(rotation)
@@ -99,10 +101,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					height: noteHeight,
 					color: theme[color].note.text,
 					backgroundColor: theme[color].note.fill,
-					boxShadow: `
+					borderBottom: showShadows ? 'none' : `2px solid rgba(144, 144, 144, .5)`,
+					boxShadow: showShadows
+						? `
 						${ox * 3}px 4px 4px -4px rgba(0,0,0,.4),
 						${ox * 6}px ${(6 + lift * 8) * oy}px ${6 + lift * 8}px -${6 + lift * 6}px rgba(0,0,0,${0.3 + lift * 0.1}), 
-						0px 50px 8px -10px inset rgba(0,0,0,0.035)`,
+						0px 50px 8px -10px inset rgba(0,0,0,${0.0375 + 0.025 * random()})`
+						: 'none',
 				}}
 			>
 				<TextLabel

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -100,8 +100,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					color: theme[color].note.text,
 					backgroundColor: theme[color].note.fill,
 					boxShadow: `
-						${ox * 3}px 4px 4px -4px rgba(0,0,0,.3),
-						${ox * 6}px ${(6 + lift * 8) * oy}px ${6 + lift * 8}px -${6 + lift * 6}px rgba(0,0,0,${0.25 + lift * 0.1}), 
+						${ox * 3}px 4px 4px -4px rgba(0,0,0,.4),
+						${ox * 6}px ${(6 + lift * 8) * oy}px ${6 + lift * 8}px -${6 + lift * 6}px rgba(0,0,0,${0.3 + lift * 0.1}), 
 						0px 50px 8px -10px inset rgba(0,0,0,0.035)`,
 				}}
 			>

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -77,7 +77,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()
-		const adjustedColor = color === 'black' ? 'yellow' : color
 		const noteHeight = this.getHeight(shape)
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -89,55 +88,41 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const oy = Math.cos(rotation)
 		const ox = Math.sin(rotation)
 		const random = rng(id)
-		const randomizedRotation = random() * 4
-		const shadowBlur = 20 + random() * 2
-		const shadowWidth = NOTE_SIZE - shadowBlur * 2 //(3 + Math.abs(ox))
-		const heightRatio = noteHeight / NOTE_SIZE
+		const lift = 1 + random() * 0.5
 
 		return (
-			<>
-				<div
-					className="tl-note"
-					style={{
-						width: NOTE_SIZE,
-						height: noteHeight,
-					}}
-				>
-					<div
-						className="tl-note__container"
-						style={{
-							color: theme[adjustedColor].solid,
-						}}
-					>
-						<div
-							className="tl-note__shadow"
-							style={{
-								height: noteHeight,
-								boxShadow: `${ox * shadowBlur}px ${oy * 0.75 * shadowBlur}px ${shadowBlur}px rgba(0,0,0,.72), ${ox * shadowBlur}px ${oy * 0.75 * shadowBlur}px ${shadowBlur * 2}px ${shadowBlur / 2}px rgba(0,0,0,.55)`,
-								transform: `scaleX(${shadowWidth / NOTE_SIZE}) translateY(${-shadowBlur}px) perspective(${noteHeight / heightRatio}px) rotateX(${shadowBlur}deg) rotateY(${ox * -2}deg) rotateZ(${randomizedRotation + -ox}deg) `,
-							}}
-						/>
-						<div className="tl-note__body" />
-						<div className="tl-note__scrim" />
-					</div>
-					<TextLabel
-						id={id}
-						type={type}
-						font={font}
-						fontSize={fontSizeAdjustment || LABEL_FONT_SIZES[size]}
-						lineHeight={TEXT_PROPS.lineHeight}
-						align={align}
-						verticalAlign={verticalAlign}
-						text={text}
-						labelColor="black"
-						wrap
-						onKeyDown={handleKeyDown}
-					/>
-				</div>
+			<div
+				id={id}
+				className="tl-note__container"
+				style={{
+					width: NOTE_SIZE,
+					height: noteHeight,
+					color: theme[color].note.text,
+					backgroundColor: theme[color].note.fill,
+					boxShadow: `
+						${ox * 3}px 4px 4px -4px rgba(0,0,0,.3),
+						${ox * 6}px ${(6 + lift * 8) * oy}px ${6 + lift * 8}px -${6 + lift * 6}px rgba(0,0,0,${0.25 + lift * 0.1}), 
+						0px 50px 8px -10px inset rgba(0,0,0,0.035)`,
+				}}
+			>
+				<TextLabel
+					id={id}
+					type={type}
+					font={font}
+					fontSize={fontSizeAdjustment || LABEL_FONT_SIZES[size]}
+					lineHeight={TEXT_PROPS.lineHeight}
+					align={align}
+					verticalAlign={verticalAlign}
+					text={text}
+					isNote
+					labelColor={color}
+					wrap
+					onKeyDown={handleKeyDown}
+				/>
 				{'url' in shape.props && shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
 				)}
-			</>
+			</div>
 		)
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -27,6 +27,7 @@ import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
+import { useForceSolid } from '../shared/useForceSolid'
 
 const NOTE_SIZE = 200
 const NEW_NOTE_MARGIN = 20
@@ -84,7 +85,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			this.editor,
 		])
 
-		const showShadows = this.editor.getZoomLevel() > 0.5
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const hideShadows = useForceSolid()
 
 		// Shadow stuff
 		const oy = Math.cos(rotation)
@@ -101,13 +103,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					height: noteHeight,
 					color: theme[color].note.text,
 					backgroundColor: theme[color].note.fill,
-					borderBottom: showShadows ? 'none' : `2px solid rgba(144, 144, 144, .5)`,
-					boxShadow: showShadows
-						? `
-						${ox * 3}px 4px 4px -4px rgba(0,0,0,.4),
+					borderBottom: hideShadows ? `3px solid rgb(144, 144, 144)` : 'none',
+					boxShadow: hideShadows
+						? 'none'
+						: `${ox * 3}px 4px 4px -4px rgba(0,0,0,.4),
 						${ox * 6}px ${(6 + lift * 8) * oy}px ${6 + lift * 8}px -${6 + lift * 6}px rgba(0,0,0,${0.3 + lift * 0.1}), 
-						0px 50px 8px -10px inset rgba(0,0,0,${0.0375 + 0.025 * random()})`
-						: 'none',
+						0px 50px 8px -10px inset rgba(0,0,0,${0.0375 + 0.025 * random()})`,
 				}}
 			>
 				<TextLabel

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -28,6 +28,7 @@ type TextLabelProps = {
 	text: string
 	labelColor: TLDefaultColorStyle
 	bounds?: Box
+	isNote?: boolean
 	onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
 	classNamePrefix?: string
 	style?: React.CSSProperties
@@ -48,6 +49,7 @@ export const TextLabel = React.memo(function TextLabel({
 	verticalAlign,
 	wrap,
 	bounds,
+	isNote,
 	onKeyDown: handleKeyDownCustom,
 	classNamePrefix,
 	style,
@@ -105,7 +107,7 @@ export const TextLabel = React.memo(function TextLabel({
 					lineHeight: fontSize * lineHeight + 'px',
 					minHeight: lineHeight + 32,
 					minWidth: textWidth || 0,
-					color: theme[labelColor].solid,
+					color: isNote ? theme[labelColor].note.text : 'solid',
 					width: textWidth,
 					height: textHeight,
 				}}

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -153,26 +153,12 @@ export function DefaultDebugMenuContent() {
 					id="count-nodes"
 					label={'Count shapes / nodes'}
 					onSelect={() => {
-						function countDescendants({ children }: HTMLElement) {
-							let count = 0
-							if (!children.length) return 0
-							for (const el of [...(children as any)]) {
-								count++
-								count += countDescendants(el)
-							}
-							return count
-						}
 						const selectedShapes = editor.getSelectedShapes()
 						const shapes =
 							selectedShapes.length === 0 ? editor.getRenderingShapes() : selectedShapes
-						const elms = shapes.map(
-							(shape) => (document.getElementById(shape.id) as HTMLElement)!.parentElement!
+						window.alert(
+							`Shapes ${shapes.length}, DOM nodes:${document.querySelector('.tl-shapes')!.querySelectorAll('*')?.length}`
 						)
-						let descendants = elms.length
-						for (const elm of elms) {
-							descendants += countDescendants(elm)
-						}
-						window.alert(`Shapes ${shapes.length}, DOM nodes:${descendants}`)
 					}}
 				/>
 				{(() => {

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -918,6 +918,10 @@ export type TLDefaultColorThemeColor = {
     solid: string;
     semi: string;
     pattern: string;
+    note: {
+        fill: string;
+        text: string;
+    };
     highlight: {
         srgb: string;
         p3: string;

--- a/packages/tlschema/api/api.json
+++ b/packages/tlschema/api/api.json
@@ -5326,7 +5326,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    solid: string;\n    semi: string;\n    pattern: string;\n    highlight: {\n        srgb: string;\n        p3: string;\n    };\n}"
+              "text": "{\n    solid: string;\n    semi: string;\n    pattern: string;\n    note: {\n        fill: string;\n        text: string;\n    };\n    highlight: {\n        srgb: string;\n        p3: string;\n    };\n}"
             },
             {
               "kind": "Content",

--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -55,7 +55,7 @@ export const DefaultColorThemePalette: {
 		black: {
 			solid: '#1d1d1d',
 			note: {
-				fill: '#fcd977',
+				fill: '#FCE8AE',
 				text: '#000000',
 			},
 			semi: '#e8e8e8',
@@ -68,7 +68,7 @@ export const DefaultColorThemePalette: {
 		blue: {
 			solid: '#4263eb',
 			note: {
-				fill: '#4263eb',
+				fill: '#B3BFFF',
 				text: '#000000',
 			},
 			semi: '#dce1f8',
@@ -81,7 +81,7 @@ export const DefaultColorThemePalette: {
 		green: {
 			solid: '#099268',
 			note: {
-				fill: '#099268',
+				fill: '#8FDEB9',
 				text: '#000000',
 			},
 			semi: '#d3e9e3',
@@ -94,7 +94,7 @@ export const DefaultColorThemePalette: {
 		grey: {
 			solid: '#adb5bd',
 			note: {
-				fill: '#efefef',
+				fill: '#E3E6E8',
 				text: '#000000',
 			},
 			semi: '#eceef0',
@@ -107,7 +107,7 @@ export const DefaultColorThemePalette: {
 		'light-blue': {
 			solid: '#4dabf7',
 			note: {
-				fill: '#4dabf7',
+				fill: '#C1DFFF',
 				text: '#000000',
 			},
 			semi: '#ddedfa',
@@ -120,7 +120,7 @@ export const DefaultColorThemePalette: {
 		'light-green': {
 			solid: '#40c057',
 			note: {
-				fill: '#40c057',
+				fill: '#BEEEC6',
 				text: '#000000',
 			},
 			semi: '#dbf0e0',
@@ -133,7 +133,7 @@ export const DefaultColorThemePalette: {
 		'light-red': {
 			solid: '#ff8787',
 			note: {
-				fill: '#ff8787',
+				fill: '#FFCAC2',
 				text: '#000000',
 			},
 			semi: '#f4dadb',
@@ -146,7 +146,7 @@ export const DefaultColorThemePalette: {
 		'light-violet': {
 			solid: '#e599f7',
 			note: {
-				fill: '#e599f7',
+				fill: '#F0CEFD',
 				text: '#000000',
 			},
 			semi: '#f5eafa',
@@ -159,7 +159,7 @@ export const DefaultColorThemePalette: {
 		orange: {
 			solid: '#f76707',
 			note: {
-				fill: '#f76707',
+				fill: '#FFB185',
 				text: '#000000',
 			},
 			semi: '#f8e2d4',
@@ -172,7 +172,7 @@ export const DefaultColorThemePalette: {
 		red: {
 			solid: '#e03131',
 			note: {
-				fill: '#e03131',
+				fill: '#FF9C96',
 				text: '#000000',
 			},
 			semi: '#f4dadb',
@@ -185,7 +185,7 @@ export const DefaultColorThemePalette: {
 		violet: {
 			solid: '#ae3ec9',
 			note: {
-				fill: '#ae3ec9',
+				fill: '#E6A6FD',
 				text: '#000000',
 			},
 			semi: '#ecdcf2',
@@ -198,7 +198,7 @@ export const DefaultColorThemePalette: {
 		yellow: {
 			solid: '#ffc078',
 			note: {
-				fill: '#ffc078',
+				fill: '#FFDCAF',
 				text: '#000000',
 			},
 			semi: '#f9f0e6',
@@ -218,7 +218,7 @@ export const DefaultColorThemePalette: {
 		black: {
 			solid: '#e1e1e1',
 			note: {
-				fill: '#ffc034',
+				fill: '#FBE4A4',
 				text: '#000000',
 			},
 			semi: '#2c3036',
@@ -231,7 +231,7 @@ export const DefaultColorThemePalette: {
 		blue: {
 			solid: '#4263eb',
 			note: {
-				fill: '#4263eb',
+				fill: '#A3B2FF',
 				text: '#000000',
 			},
 			semi: '#262d40',
@@ -244,7 +244,7 @@ export const DefaultColorThemePalette: {
 		green: {
 			solid: '#099268',
 			note: {
-				fill: '#099268',
+				fill: '#64CE9C',
 				text: '#000000',
 			},
 			semi: '#253231',
@@ -257,7 +257,7 @@ export const DefaultColorThemePalette: {
 		grey: {
 			solid: '#9398b0',
 			note: {
-				fill: '#9398b0',
+				fill: '#E3E6E8',
 				text: '#000000',
 			},
 			semi: '#33373c',
@@ -270,7 +270,7 @@ export const DefaultColorThemePalette: {
 		'light-blue': {
 			solid: '#4dabf7',
 			note: {
-				fill: '#4dabf7',
+				fill: '#C1DFFF',
 				text: '#000000',
 			},
 			semi: '#2a3642',
@@ -283,7 +283,7 @@ export const DefaultColorThemePalette: {
 		'light-green': {
 			solid: '#40c057',
 			note: {
-				fill: '#40c057',
+				fill: '#B1ECB0',
 				text: '#000000',
 			},
 			semi: '#2a3830',
@@ -296,7 +296,7 @@ export const DefaultColorThemePalette: {
 		'light-red': {
 			solid: '#ff8787',
 			note: {
-				fill: '#ff8787',
+				fill: '#FFCAC2',
 				text: '#000000',
 			},
 			semi: '#3b3235',
@@ -309,7 +309,7 @@ export const DefaultColorThemePalette: {
 		'light-violet': {
 			solid: '#e599f7',
 			note: {
-				fill: '#e599f7',
+				fill: '#F0CEFD',
 				text: '#000000',
 			},
 			semi: '#383442',
@@ -322,7 +322,7 @@ export const DefaultColorThemePalette: {
 		orange: {
 			solid: '#f76707',
 			note: {
-				fill: '#f76707',
+				fill: '#FFB185',
 				text: '#000000',
 			},
 			semi: '#3a2e2a',
@@ -335,7 +335,7 @@ export const DefaultColorThemePalette: {
 		red: {
 			solid: '#e03131',
 			note: {
-				fill: '#e03131',
+				fill: '#FF9C96',
 				text: '#000000',
 			},
 			semi: '#36292b',
@@ -348,7 +348,7 @@ export const DefaultColorThemePalette: {
 		violet: {
 			solid: '#ae3ec9',
 			note: {
-				fill: '#ae3ec9',
+				fill: '#E6A6FD',
 				text: '#000000',
 			},
 			semi: '#31293c',
@@ -361,7 +361,7 @@ export const DefaultColorThemePalette: {
 		yellow: {
 			solid: '#ffc034',
 			note: {
-				fill: '#ffc034',
+				fill: '#FFDCAF',
 				text: '#000000',
 			},
 			semi: '#3c3934',

--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -22,6 +22,10 @@ export type TLDefaultColorThemeColor = {
 	solid: string
 	semi: string
 	pattern: string
+	note: {
+		fill: string
+		text: string
+	}
 	highlight: {
 		srgb: string
 		p3: string
@@ -48,9 +52,12 @@ export const DefaultColorThemePalette: {
 		text: '#000000',
 		background: 'rgb(249, 250, 251)',
 		solid: '#fcfffe',
-
 		black: {
 			solid: '#1d1d1d',
+			note: {
+				fill: '#fcd977',
+				text: '#000000',
+			},
 			semi: '#e8e8e8',
 			pattern: '#494949',
 			highlight: {
@@ -60,6 +67,10 @@ export const DefaultColorThemePalette: {
 		},
 		blue: {
 			solid: '#4263eb',
+			note: {
+				fill: '#4263eb',
+				text: '#000000',
+			},
 			semi: '#dce1f8',
 			pattern: '#6681ee',
 			highlight: {
@@ -69,6 +80,10 @@ export const DefaultColorThemePalette: {
 		},
 		green: {
 			solid: '#099268',
+			note: {
+				fill: '#099268',
+				text: '#000000',
+			},
 			semi: '#d3e9e3',
 			pattern: '#39a785',
 			highlight: {
@@ -78,6 +93,10 @@ export const DefaultColorThemePalette: {
 		},
 		grey: {
 			solid: '#adb5bd',
+			note: {
+				fill: '#efefef',
+				text: '#000000',
+			},
 			semi: '#eceef0',
 			pattern: '#bcc3c9',
 			highlight: {
@@ -87,6 +106,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-blue': {
 			solid: '#4dabf7',
+			note: {
+				fill: '#4dabf7',
+				text: '#000000',
+			},
 			semi: '#ddedfa',
 			pattern: '#6fbbf8',
 			highlight: {
@@ -96,6 +119,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-green': {
 			solid: '#40c057',
+			note: {
+				fill: '#40c057',
+				text: '#000000',
+			},
 			semi: '#dbf0e0',
 			pattern: '#65cb78',
 			highlight: {
@@ -105,6 +132,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-red': {
 			solid: '#ff8787',
+			note: {
+				fill: '#ff8787',
+				text: '#000000',
+			},
 			semi: '#f4dadb',
 			pattern: '#fe9e9e',
 			highlight: {
@@ -114,6 +145,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-violet': {
 			solid: '#e599f7',
+			note: {
+				fill: '#e599f7',
+				text: '#000000',
+			},
 			semi: '#f5eafa',
 			pattern: '#e9acf8',
 			highlight: {
@@ -123,6 +158,10 @@ export const DefaultColorThemePalette: {
 		},
 		orange: {
 			solid: '#f76707',
+			note: {
+				fill: '#f76707',
+				text: '#000000',
+			},
 			semi: '#f8e2d4',
 			pattern: '#f78438',
 			highlight: {
@@ -132,6 +171,10 @@ export const DefaultColorThemePalette: {
 		},
 		red: {
 			solid: '#e03131',
+			note: {
+				fill: '#e03131',
+				text: '#000000',
+			},
 			semi: '#f4dadb',
 			pattern: '#e55959',
 			highlight: {
@@ -141,6 +184,10 @@ export const DefaultColorThemePalette: {
 		},
 		violet: {
 			solid: '#ae3ec9',
+			note: {
+				fill: '#ae3ec9',
+				text: '#000000',
+			},
 			semi: '#ecdcf2',
 			pattern: '#bd63d3',
 			highlight: {
@@ -150,6 +197,10 @@ export const DefaultColorThemePalette: {
 		},
 		yellow: {
 			solid: '#ffc078',
+			note: {
+				fill: '#ffc078',
+				text: '#000000',
+			},
 			semi: '#f9f0e6',
 			pattern: '#fecb92',
 			highlight: {
@@ -166,6 +217,10 @@ export const DefaultColorThemePalette: {
 
 		black: {
 			solid: '#e1e1e1',
+			note: {
+				fill: '#ffc034',
+				text: '#000000',
+			},
 			semi: '#2c3036',
 			pattern: '#989898',
 			highlight: {
@@ -175,6 +230,10 @@ export const DefaultColorThemePalette: {
 		},
 		blue: {
 			solid: '#4263eb',
+			note: {
+				fill: '#4263eb',
+				text: '#000000',
+			},
 			semi: '#262d40',
 			pattern: '#3a4b9e',
 			highlight: {
@@ -184,6 +243,10 @@ export const DefaultColorThemePalette: {
 		},
 		green: {
 			solid: '#099268',
+			note: {
+				fill: '#099268',
+				text: '#000000',
+			},
 			semi: '#253231',
 			pattern: '#366a53',
 			highlight: {
@@ -193,6 +256,10 @@ export const DefaultColorThemePalette: {
 		},
 		grey: {
 			solid: '#9398b0',
+			note: {
+				fill: '#9398b0',
+				text: '#000000',
+			},
 			semi: '#33373c',
 			pattern: '#7c8187',
 			highlight: {
@@ -202,6 +269,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-blue': {
 			solid: '#4dabf7',
+			note: {
+				fill: '#4dabf7',
+				text: '#000000',
+			},
 			semi: '#2a3642',
 			pattern: '#4d7aa9',
 			highlight: {
@@ -211,6 +282,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-green': {
 			solid: '#40c057',
+			note: {
+				fill: '#40c057',
+				text: '#000000',
+			},
 			semi: '#2a3830',
 			pattern: '#4e874e',
 			highlight: {
@@ -220,6 +295,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-red': {
 			solid: '#ff8787',
+			note: {
+				fill: '#ff8787',
+				text: '#000000',
+			},
 			semi: '#3b3235',
 			pattern: '#a56767',
 			highlight: {
@@ -229,6 +308,10 @@ export const DefaultColorThemePalette: {
 		},
 		'light-violet': {
 			solid: '#e599f7',
+			note: {
+				fill: '#e599f7',
+				text: '#000000',
+			},
 			semi: '#383442',
 			pattern: '#9770a9',
 			highlight: {
@@ -238,6 +321,10 @@ export const DefaultColorThemePalette: {
 		},
 		orange: {
 			solid: '#f76707',
+			note: {
+				fill: '#f76707',
+				text: '#000000',
+			},
 			semi: '#3a2e2a',
 			pattern: '#9f552d',
 			highlight: {
@@ -247,6 +334,10 @@ export const DefaultColorThemePalette: {
 		},
 		red: {
 			solid: '#e03131',
+			note: {
+				fill: '#e03131',
+				text: '#000000',
+			},
 			semi: '#36292b',
 			pattern: '#8f3734',
 			highlight: {
@@ -256,6 +347,10 @@ export const DefaultColorThemePalette: {
 		},
 		violet: {
 			solid: '#ae3ec9',
+			note: {
+				fill: '#ae3ec9',
+				text: '#000000',
+			},
 			semi: '#31293c',
 			pattern: '#763a8b',
 			highlight: {
@@ -265,6 +360,10 @@ export const DefaultColorThemePalette: {
 		},
 		yellow: {
 			solid: '#ffc034',
+			note: {
+				fill: '#ffc034',
+				text: '#000000',
+			},
 			semi: '#3c3934',
 			pattern: '#fecb92',
 			highlight: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10043,10 +10043,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-fs-access@npm:^0.33.0":
-  version: 0.33.1
-  resolution: "browser-fs-access@npm:0.33.1"
-  checksum: 1843c6d1190ed448d3f17e767cd6508ef408b0e40530ceb2de37088f0a1bdbd503e05d4d949934d7c9491d550e255c4a214b25781625b57a6724a35a7cdd8b4c
+"browser-fs-access@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "browser-fs-access@npm:0.35.0"
+  checksum: 5fa9876cc10499bfc8e1a3d83261f8966c5687c2d31c1abefed35ecc5a8e1ab8b12a51aed638b48ee4e2109ec48c2cba3bfcd162b9de270a5b5ca08740024eda
   languageName: node
   linkType: hard
 
@@ -11688,7 +11688,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:^5.59.0"
     "@vercel/analytics": "npm:^1.1.1"
     "@vitejs/plugin-react-swc": "npm:^3.5.0"
-    browser-fs-access: "npm:^0.33.0"
+    browser-fs-access: "npm:^0.35.0"
     dotenv: "npm:^16.3.1"
     eslint: "npm:^8.37.0"
     fast-glob: "npm:^3.3.1"


### PR DESCRIPTION
<img width="1247" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/c958f51c-3221-4ba6-95f9-7f9be96d8540">

<img width="1001" alt="image" src="https://github.com/tldraw/tldraw/assets/23072548/cfb1bbf1-57d1-4cc8-95e4-06f64e7feecb">

<img width="858" alt="Screenshot 2024-03-31 at 21 40 45" src="https://github.com/tldraw/tldraw/assets/23072548/c60025d9-a959-4469-a3e8-5f67bdf0594f">

This PR:
- removes the cool 3D shadows for sticky notes
- removes the scrim element
- adds simplified shadows
- hides shadows below 35% zoom
- extends the theme object to include `note: { fill: string, text: string }`

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features
