### PR TITLE
Revert "Fix text resizing bug (#3327)"

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -70,9 +70,6 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 		const { width, height } = this.getMinDimensions(shape)
 
-		const transformOrigin =
-			align === 'start' ? 'top left' : align === 'end' ? 'top right' : 'top center'
-
 		return (
 			<HTMLContainer id={shape.id}>
 				<TextLabel
@@ -90,7 +87,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 					textHeight={height}
 					style={{
 						transform: `scale(${scale})`,
-						transformOrigin: transformOrigin,
+						transformOrigin: 'top left',
 					}}
 					wrap
 				/>


### PR DESCRIPTION
This reverts commit 0e912fe0f259696450ef364174925ef615275203.

(The fix is more to do with a CSS regression instead of a JS fix.)


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
