### PR TITLE
Stickies: Use page space for sticky shadow rotation

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -156,9 +156,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const noteHeight = this.getHeight(shape)
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const rotation = useValue('shape rotation', () => this.editor.getShape(id)?.rotation ?? 0, [
-			this.editor,
-		])
+		const rotation = useValue(
+			'shape rotation',
+			() => this.editor.getShapePageTransform(id)?.rotation() ?? 0,
+			[this.editor]
+		)
 
 		// todo: consider hiding shadows on dark mode if they're invisible anyway
 		// eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -17,6 +17,7 @@ import {
 	rng,
 	toDomPrecision,
 	useEditor,
+	useValue,
 } from '@tldraw/editor'
 import { useCallback } from 'react'
 import { useCurrentTranslation } from '../../ui/hooks/useTranslation/useTranslation'
@@ -154,7 +155,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const theme = useDefaultColorTheme()
 		const noteHeight = this.getHeight(shape)
 
-		const rotation = this.editor.getShapePageTransform(shape)!.rotation()
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const rotation = useValue(
+			'shape rotation',
+			() => this.editor.getShapePageTransform(id)?.rotation() ?? 0,
+			[this.editor]
+		)
 
 		// todo: consider hiding shadows on dark mode if they're invisible anyway
 		// eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -17,7 +17,6 @@ import {
 	rng,
 	toDomPrecision,
 	useEditor,
-	useValue,
 } from '@tldraw/editor'
 import { useCallback } from 'react'
 import { useCurrentTranslation } from '../../ui/hooks/useTranslation/useTranslation'
@@ -155,12 +154,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const theme = useDefaultColorTheme()
 		const noteHeight = this.getHeight(shape)
 
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const rotation = useValue(
-			'shape rotation',
-			() => this.editor.getShapePageTransform(id)?.rotation() ?? 0,
-			[this.editor]
-		)
+		const rotation = this.editor.getShapePageTransform(shape)!.rotation()
 
 		// todo: consider hiding shadows on dark mode if they're invisible anyway
 		// eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
This PR makes sticky shadows use page space rotation, not shape space rotation. This brings it in line with what our other shapes do (eg: bookmarks)

https://github.com/tldraw/tldraw/assets/15892272/6b0ae307-7811-4a11-a29d-2c61cafd3d1d


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
