### PR TITLE
Stickies: Show indicators descendants of selected shapes

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -429,6 +429,12 @@ export class CubicSpline2d extends Geometry2d {
     _segments?: CubicBezier2d[];
 }
 
+// @internal (undocumented)
+export function DashedOutlineBox({ bounds, className }: {
+    bounds: Box;
+    className: string;
+}): JSX_2.Element;
+
 // @public (undocumented)
 export function dataUrlToFile(url: string, filename: string, mimeType: string): Promise<File>;
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -875,6 +875,12 @@ input,
 	opacity: 0.5;
 }
 
+.tl-parent-group {
+	stroke: var(--color-selected);
+	stroke-width: calc(1px * var(--tl-scale));
+	opacity: 0.5;
+}
+
 /* ------------------- Bookmark Shape ------------------- */
 
 .tl-bookmark__container {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -184,6 +184,7 @@ export {
 	type TLShapeUtilConstructor,
 	type TLShapeUtilFlag,
 } from './lib/editor/shapes/ShapeUtil'
+export { DashedOutlineBox } from './lib/editor/shapes/group/DashedOutlineBox'
 export { GroupShapeUtil } from './lib/editor/shapes/group/GroupShapeUtil'
 export {
 	type TLArcInfo,

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -384,9 +384,14 @@ function ShapesToDisplay() {
 
 function SelectedIdIndicators() {
 	const editor = useEditor()
-	const selectedShapeIds = useValue('selectedShapeIds', () => editor.getSelectedShapeIds(), [
-		editor,
-	])
+	const indicatedShapeIds = useValue(
+		'indicatedShapeIds',
+		() => {
+			const selectedShapeIds = editor.getSelectedShapeIds()
+			return [...editor.getShapeAndDescendantIds(selectedShapeIds)]
+		},
+		[editor]
+	)
 	const shouldDisplay = useValue(
 		'should display selected ids',
 		() => {
@@ -412,7 +417,7 @@ function SelectedIdIndicators() {
 
 	return (
 		<>
-			{selectedShapeIds.map((id) => (
+			{indicatedShapeIds.map((id) => (
 				<ShapeIndicator
 					key={id + '_indicator'}
 					className="tl-user-indicator__selected"

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -384,14 +384,11 @@ function ShapesToDisplay() {
 
 function SelectedIdIndicators() {
 	const editor = useEditor()
-	const indicatedShapeIds = useValue(
-		'indicatedShapeIds',
-		() => {
-			const selectedShapeIds = editor.getSelectedShapeIds()
-			return [...editor.getShapeAndDescendantIds(selectedShapeIds)]
-		},
-		[editor]
-	)
+
+	const selectedShapeIds = useValue('selectedShapeIds', () => editor.getSelectedShapeIds(), [
+		editor,
+	])
+
 	const shouldDisplay = useValue(
 		'should display selected ids',
 		() => {
@@ -417,7 +414,7 @@ function SelectedIdIndicators() {
 
 	return (
 		<>
-			{indicatedShapeIds.map((id) => (
+			{selectedShapeIds.map((id) => (
 				<ShapeIndicator
 					key={id + '_indicator'}
 					className="tl-user-indicator__selected"

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -22,6 +22,7 @@ import {
 	TLImageAsset,
 	TLInstance,
 	TLInstancePageState,
+	TLNoteShape,
 	TLPOINTER_ID,
 	TLPage,
 	TLPageId,
@@ -7473,12 +7474,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// We can have many deep levels of grouped shape
 			// Making a recursive function to look through all the levels
 			const addShapeById = (shape: TLShape) => {
-				if (this.isShapeOfType<TLGroupShape>(shape, 'group')) {
+				const isGroup = this.isShapeOfType<TLGroupShape>(shape, 'group')
+				const isNote = this.isShapeOfType<TLNoteShape>(shape, 'note')
+
+				if (isGroup || isNote) {
 					const childIds = this.getSortedChildIdsForParent(shape.id)
 					for (const childId of childIds) {
 						addShapeById(this.getShape(childId)!)
 					}
-				} else {
+				}
+
+				if (!isGroup) {
 					const util = this.getShapeUtil(shape)
 					const stylePropKey = this.styleProps[shape.type].get(style)
 					if (stylePropKey) {

--- a/packages/editor/src/lib/editor/shapes/group/DashedOutlineBox.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/DashedOutlineBox.tsx
@@ -3,6 +3,7 @@ import { useEditor } from '../../../hooks/useEditor'
 import { Box } from '../../../primitives/Box'
 import { getPerfectDashProps } from '../shared/getPerfectDashProps'
 
+/** @internal */
 export function DashedOutlineBox({ bounds, className }: { bounds: Box; className: string }) {
 	const editor = useEditor()
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -227,9 +227,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			)
 		)
 
+		const isSelected = this.editor.getSelectedShapeIds().includes(shape.id)
+
 		return (
 			<>
-				<DashedOutlineBox className="tl-parent-group" bounds={descendantsBounds} />
+				{isSelected && <DashedOutlineBox className="tl-parent-group" bounds={descendantsBounds} />}
 				<rect
 					rx="1"
 					width={toDomPrecision(NOTE_SIZE)}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -227,7 +227,12 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			)
 		)
 
-		const isSelected = this.editor.getSelectedShapeIds().includes(shape.id)
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const isSelected = useValue(
+			'is selected',
+			() => this.editor.getSelectedShapeIds().includes(shape.id),
+			[this.editor]
+		)
 
 		return (
 			<>

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -1,4 +1,6 @@
 import {
+	Box,
+	DashedOutlineBox,
 	Editor,
 	IndexKey,
 	Rectangle2d,
@@ -28,7 +30,6 @@ import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
 import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
-
 import { useForceSolid } from '../shared/useForceSolid'
 import {
 	ADJACENT_NOTE_MARGIN,
@@ -217,12 +218,24 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	}
 
 	indicator(shape: TLNoteShape) {
+		const descendantIds = [...this.editor.getShapeAndDescendantIds([shape.id])]
+
+		// todo: there's gotta be a better way of doing this
+		const descendantsBounds = Box.FromPoints(
+			Box.Common(descendantIds.map((id) => this.editor.getShapePageBounds(id)!)).corners.map(
+				(corner) => this.editor.getPointInShapeSpace(shape.id, corner)
+			)
+		)
+
 		return (
-			<rect
-				rx="1"
-				width={toDomPrecision(NOTE_SIZE)}
-				height={toDomPrecision(this.getHeight(shape))}
-			/>
+			<>
+				<DashedOutlineBox className="tl-parent-group" bounds={descendantsBounds} />
+				<rect
+					rx="1"
+					width={toDomPrecision(NOTE_SIZE)}
+					height={toDomPrecision(this.getHeight(shape))}
+				/>
+			</>
 		)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -9,7 +9,7 @@ import {
 /** @internal */
 export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 	const shapes = shapeIds.map((id) => editor.getShape(id)).filter((s) => s) as TLShape[]
-	const effectedParents = shapes
+	const effectedParents: TLShape[] = shapes
 		.map((shape) => {
 			const parent = editor.getShape(shape.parentId)
 			if (!parent) return shape

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -1,7 +1,5 @@
 import {
 	Editor,
-	TLFrameShape,
-	TLNoteShape,
 	TLShape,
 	TLShapeId,
 	polygonIntersectsPolyline,
@@ -29,7 +27,7 @@ export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 
 		// For each child, check whether its bounds overlap with the parent's bounds
 		for (const childId of childIds) {
-			if (isShapeOccluded(editor, parent as TLFrameShape | TLNoteShape, childId)) {
+			if (isShapeOccluded(editor, parent, childId)) {
 				kickedOutChildren.push(childId)
 			}
 		}
@@ -41,11 +39,7 @@ export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 }
 
 /** @internal */
-export function isShapeOccluded(
-	editor: Editor,
-	occluder: TLNoteShape | TLFrameShape,
-	shape: TLShapeId
-) {
+export function isShapeOccluded(editor: Editor, occluder: TLShape, shape: TLShapeId) {
 	const occluderPageBounds = editor.getShapePageBounds(occluder)
 	if (!occluderPageBounds) return false
 

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -46,20 +46,20 @@ export function isShapeOccluded(editor: Editor, occluder: TLShape, shape: TLShap
 	const shapePageBounds = editor.getShapePageBounds(shape)
 	if (!shapePageBounds) return true
 
+	// If the shape's bounds are completely inside the occluder, it's not occluded
+	if (occluderPageBounds.contains(shapePageBounds)) {
+		return false
+	}
+
 	// If the shape's bounds are completely outside the occluder, it's occluded
 	if (!occluderPageBounds.includes(shapePageBounds)) {
 		return true
 	}
 
-	// Otherwise, look at the shape's geometry for a more fine-grained check
+	// If we've made it this far, the shape's bounds must intersect the edge of the occluder
+	// In this case, we need to look at the shape's geometry for a more fine-grained check
 	const shapeGeometry = editor.getShapeGeometry(shape)
-	const occluderGeometry = editor.getShapeGeometry(occluder)
-	const occluderPageTransform = editor.getShapePageTransform(occluder)
-	const occluderCornersInPageSpace = occluderGeometry.vertices.map((corner) => {
-		return occluderPageTransform.applyToPoint(corner)
-	})
-
-	const occluderCornersInShapeSpace = occluderCornersInPageSpace.map((v) => {
+	const occluderCornersInShapeSpace = occluderPageBounds.corners.map((v) => {
 		return editor.getPointInShapeSpace(shape, v)
 	})
 


### PR DESCRIPTION
This PR shows a dotted line around descendants of selected notes. This came out of the QA sessions - hopefully this makes it clearer when you're selected notes with children. It also lets you style all descendants of a sticky, when you use the style panel (similar to what we do with groups).

https://github.com/tldraw/tldraw/assets/15892272/e0f1ffcb-24b9-459b-a209-7f31f1900096

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
