### PR TITLE
stickies: update geometry to differentiate between shape and text label

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1113,8 +1113,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getHandles(shape: TLNoteShape): TLHandle[];
     // (undocumented)
-    getHeight(shape: TLNoteShape): number;
-    // (undocumented)
     hideResizeHandles: () => boolean;
     // (undocumented)
     hideSelectionBoundsFg: () => boolean;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1109,7 +1109,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getDefaultProps(): TLNoteShape['props'];
     // (undocumented)
-    getGeometry(shape: TLNoteShape): Rectangle2d;
+    getGeometry(shape: TLNoteShape): Group2d;
     // (undocumented)
     getHandles(shape: TLNoteShape): TLHandle[];
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13037,8 +13037,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Rectangle2d",
-                  "canonicalReference": "@tldraw/editor!Rectangle2d:class"
+                  "text": "Group2d",
+                  "canonicalReference": "@tldraw/editor!Group2d:class"
                 },
                 {
                   "kind": "Content",

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -13122,55 +13122,6 @@
               "name": "getHandles"
             },
             {
-              "kind": "Method",
-              "canonicalReference": "tldraw!NoteShapeUtil#getHeight:member(1)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "getHeight(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "number"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "shape",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "getHeight"
-            },
-            {
               "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#hideResizeHandles:member",
               "docComment": "",

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -536,6 +536,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		const labelPosition = getArrowLabelPosition(this.editor, shape)
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
+		const isEditing = this.editor.getEditingShapeId() === shape.id
+		const showArrowLabel = isEditing || shape.props.text
 
 		return (
 			<>
@@ -545,16 +547,18 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 						shouldDisplayHandles={shouldDisplayHandles && onlySelectedShape === shape}
 					/>
 				</SVGContainer>
-				<ArrowTextLabel
-					id={shape.id}
-					text={shape.props.text}
-					font={shape.props.font}
-					size={shape.props.size}
-					position={labelPosition.box.center}
-					width={labelPosition.box.w}
-					isSelected={isSelected}
-					labelColor={shape.props.labelColor}
-				/>
+				{showArrowLabel && (
+					<ArrowTextLabel
+						id={shape.id}
+						text={shape.props.text}
+						font={shape.props.font}
+						size={shape.props.size}
+						position={labelPosition.box.center}
+						width={labelPosition.box.w}
+						isSelected={isSelected}
+						labelColor={shape.props.labelColor}
+					/>
+				)}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -386,31 +386,39 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const { fill, font, align, verticalAlign, size, text } = props
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 		const theme = useDefaultColorTheme()
+		const isEditing = this.editor.getEditingShapeId() === id
+		const showHtmlContainer = isEditing || shape.props.text
 
 		return (
 			<>
 				<SVGContainer id={id}>
 					<GeoShapeBody shape={shape} />
 				</SVGContainer>
-				<HTMLContainer
-					id={shape.id}
-					style={{ overflow: 'hidden', width: shape.props.w, height: shape.props.h + props.growY }}
-				>
-					<TextLabel
-						id={id}
-						type={type}
-						font={font}
-						fontSize={LABEL_FONT_SIZES[size]}
-						lineHeight={TEXT_PROPS.lineHeight}
-						fill={fill}
-						align={align}
-						verticalAlign={verticalAlign}
-						text={text}
-						isSelected={isSelected}
-						labelColor={theme[props.labelColor].solid}
-						wrap
-					/>
-				</HTMLContainer>
+				{showHtmlContainer && (
+					<HTMLContainer
+						id={shape.id}
+						style={{
+							overflow: 'hidden',
+							width: shape.props.w,
+							height: shape.props.h + props.growY,
+						}}
+					>
+						<TextLabel
+							id={id}
+							type={type}
+							font={font}
+							fontSize={LABEL_FONT_SIZES[size]}
+							lineHeight={TEXT_PROPS.lineHeight}
+							fill={fill}
+							align={align}
+							verticalAlign={verticalAlign}
+							text={text}
+							isSelected={isSelected}
+							labelColor={theme[props.labelColor].solid}
+							wrap
+						/>
+					</HTMLContainer>
+				)}
 				{shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
 				)}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -39,8 +39,8 @@ import { getFontDefForExport } from '../shared/defaultStyleDefs'
 import { useForceSolid } from '../shared/useForceSolid'
 import {
 	ADJACENT_NOTE_MARGIN,
-	CENTER_OFFSET,
 	CLONE_HANDLE_MARGIN,
+	NOTE_CENTER_OFFSET,
 	NOTE_SIZE,
 	getNoteShapeForAdjacentPosition,
 	startEditingNoteShape,
@@ -439,7 +439,7 @@ function useNoteKeydownHandler(id: TLShapeId) {
 					isCmdEnter ? (e.shiftKey ? -1 : 1) : 0
 				)
 					.mul(offsetLength)
-					.add(CENTER_OFFSET)
+					.add(NOTE_CENTER_OFFSET)
 					.rot(pageRotation)
 					.add(pageTransform.point())
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -128,6 +128,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override getHandles(shape: TLNoteShape): TLHandle[] {
 		const zoom = this.editor.getZoomLevel()
 		const offset = CLONE_HANDLE_MARGIN / zoom
+		const noteHeight = getNoteHeight(shape)
 
 		if (zoom < 0.25) return []
 
@@ -144,21 +145,21 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 				index: 'a2' as IndexKey,
 				type: 'clone',
 				x: NOTE_SIZE + offset,
-				y: getNoteHeight(shape) / 2,
+				y: noteHeight / 2,
 			},
 			{
 				id: 'bottom',
 				index: 'a3' as IndexKey,
 				type: 'clone',
 				x: NOTE_SIZE / 2,
-				y: getNoteHeight(shape) + offset,
+				y: noteHeight + offset,
 			},
 			{
 				id: 'left',
 				index: 'a4' as IndexKey,
 				type: 'clone',
 				x: -offset,
-				y: getNoteHeight(shape) / 2,
+				y: noteHeight / 2,
 			},
 		]
 	}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -28,7 +28,12 @@ import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { useDefaultColorTheme } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
-import { FONT_FAMILIES, LABEL_FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
+import {
+	FONT_FAMILIES,
+	LABEL_FONT_SIZES,
+	LABEL_PADDING,
+	TEXT_PROPS,
+} from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
 
 import { useForceSolid } from '../shared/useForceSolid'
@@ -348,7 +353,6 @@ function _getLabelSize(editor: Editor, shape: TLNoteShape) {
 		return { labelHeight: 0, labelWidth: 0, fontSizeAdjustment: 0 }
 	}
 
-	const PADDING = 16
 	const unadjustedFontSize = LABEL_FONT_SIZES[shape.props.size]
 
 	let fontSizeAdjustment = 0
@@ -363,12 +367,12 @@ function _getLabelSize(editor: Editor, shape: TLNoteShape) {
 			...TEXT_PROPS,
 			fontFamily: FONT_FAMILIES[shape.props.font],
 			fontSize: fontSizeAdjustment,
-			maxWidth: NOTE_SIZE - PADDING * 2,
+			maxWidth: NOTE_SIZE - LABEL_PADDING * 2,
 			disableOverflowWrapBreaking: true,
 		})
 
-		labelHeight = nextTextSize.h + PADDING * 2
-		labelWidth = nextTextSize.w + PADDING * 2
+		labelHeight = nextTextSize.h + LABEL_PADDING * 2
+		labelWidth = nextTextSize.w + LABEL_PADDING * 2
 
 		if (fontSizeAdjustment <= 14) {
 			// Too small, just rely now on CSS `overflow-wrap: break-word`
@@ -377,10 +381,10 @@ function _getLabelSize(editor: Editor, shape: TLNoteShape) {
 				...TEXT_PROPS,
 				fontFamily: FONT_FAMILIES[shape.props.font],
 				fontSize: fontSizeAdjustment,
-				maxWidth: NOTE_SIZE - PADDING * 2,
+				maxWidth: NOTE_SIZE - LABEL_PADDING * 2,
 			})
-			labelHeight = nextTextSizeWithOverflowBreak.h + PADDING * 2
-			labelWidth = nextTextSizeWithOverflowBreak.w + PADDING * 2
+			labelHeight = nextTextSizeWithOverflowBreak.h + LABEL_PADDING * 2
+			labelWidth = nextTextSizeWithOverflowBreak.w + LABEL_PADDING * 2
 			break
 		}
 

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -15,13 +15,11 @@ export const CLONE_HANDLE_MARGIN = 0
 /** @internal */
 export const NOTE_SIZE = 200
 /** @internal */
-export const CENTER_OFFSET = { x: NOTE_SIZE / 2, y: NOTE_SIZE / 2 }
+export const NOTE_CENTER_OFFSET = { x: NOTE_SIZE / 2, y: NOTE_SIZE / 2 }
 /** @internal */
 export const NOTE_PIT_RADIUS = 10
-/** @internal */
-export type NotePit = Vec
 
-const DEFAULT_PITS: NotePit[] = [
+const DEFAULT_PITS = [
 	new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * -0.5 - ADJACENT_NOTE_MARGIN), // t
 	new Vec(NOTE_SIZE * 1.5 + ADJACENT_NOTE_MARGIN, NOTE_SIZE * 0.5), // r
 	new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * 1.5 + ADJACENT_NOTE_MARGIN), // b
@@ -159,7 +157,7 @@ export function getNoteShapeForAdjacentPosition(
 		// space as the newly created shape (i.e its parent's space)
 		const topLeft = editor.getPointInParentSpace(
 			createdShape,
-			Vec.Sub(center, Vec.Rot(CENTER_OFFSET, pageRotation))
+			Vec.Sub(center, Vec.Rot(NOTE_CENTER_OFFSET, pageRotation))
 		)
 
 		editor.updateShape({

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -4,6 +4,7 @@ import {
 	TLShapeId,
 	TLUnknownShape,
 	getPointerInfo,
+	setPointerCapture,
 	stopEventPropagation,
 	useEditor,
 	useValue,
@@ -147,8 +148,6 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 
 	const handleInputPointerDown = useCallback(
 		(e: React.PointerEvent) => {
-			if (!isEditing) return
-
 			editor.dispatch({
 				...getPointerInfo(e),
 				type: 'pointer',
@@ -158,8 +157,12 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 			})
 
 			stopEventPropagation(e) // we need to prevent blurring the input
+
+			// This is important so that when dragging a shape using the text label,
+			// the shape continues to be dragged, even if the cursor is over the UI.
+			setPointerCapture(e.currentTarget, e)
 		},
-		[editor, id, isEditing]
+		[editor, id]
 	)
 
 	const handleDoubleClick = stopEventPropagation

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -71,7 +71,6 @@ export class EditingShape extends StateNode {
 						selectingShape,
 						this.editor.inputs.currentPagePoint
 					)
-					console.log('editing', textLabel.bounds)
 					if (
 						textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 						textLabel.hitTestPoint(pointInShapeSpace)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -71,6 +71,7 @@ export class EditingShape extends StateNode {
 						selectingShape,
 						this.editor.inputs.currentPagePoint
 					)
+					console.log('editing', textLabel.bounds)
 					if (
 						textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 						textLabel.hitTestPoint(pointInShapeSpace)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -9,7 +9,7 @@ import {
 	Vec,
 } from '@tldraw/editor'
 import {
-	CENTER_OFFSET,
+	NOTE_CENTER_OFFSET,
 	getNoteAdjacentPositions,
 	getNoteShapeForAdjacentPosition,
 	startEditingNoteShape,
@@ -72,7 +72,7 @@ export class PointingHandle extends StateNode {
 					// Center the shape on the current pointer
 					const centeredOnPointer = editor
 						.getPointInParentSpace(nextNote, editor.inputs.originPagePoint)
-						.sub(Vec.Rot(CENTER_OFFSET, nextNote.rotation))
+						.sub(Vec.Rot(NOTE_CENTER_OFFSET, nextNote.rotation))
 					editor.updateShape({ ...nextNote, x: centeredOnPointer.x, y: centeredOnPointer.y })
 
 					// Then select and begin translating the shape

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -145,6 +145,7 @@ export class PointingShape extends StateNode {
 									currentPagePoint
 								)
 
+								console.log('pointing', textLabel.bounds)
 								if (
 									textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 									textLabel.hitTestPoint(pointInShapeSpace)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -145,7 +145,6 @@ export class PointingShape extends StateNode {
 									currentPagePoint
 								)
 
-								console.log('pointing', textLabel.bounds)
 								if (
 									textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 									textLabel.hitTestPoint(pointInShapeSpace)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -18,7 +18,6 @@ import {
 import {
 	NOTE_PIT_RADIUS,
 	NOTE_SIZE,
-	NotePit,
 	getAvailableNoteAdjacentPositions,
 } from '../../../shapes/note/noteHelpers'
 import { DragAndDropManager } from '../DragAndDropManager'
@@ -354,7 +353,7 @@ function getTranslatingSnapshot(editor: Editor) {
 		}
 	}
 
-	let noteAdjacentPositions: NotePit[] | undefined
+	let noteAdjacentPositions: Vec[] | undefined
 	let noteSnapshot: MovingShapeSnapshot | undefined
 
 	const { originPagePoint } = editor.inputs

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -359,7 +359,10 @@ function getTranslatingSnapshot(editor: Editor) {
 
 	const { originPagePoint } = editor.inputs
 
-	if (shapeSnapshots.length === 1) {
+	if (
+		shapeSnapshots.length === 1 &&
+		editor.isShapeOfType<TLNoteShape>(shapeSnapshots[0].shape, 'note')
+	) {
 		noteSnapshot = shapeSnapshots[0]
 	} else {
 		const allHoveredNotes = shapeSnapshots.filter(


### PR DESCRIPTION
Separates out the geometry - we want clicking in the negative space to not have the text editing mechanics. This definitely feels better without the sticky note textfield assuming it takes up the whole note.

Before:
<img width="614" alt="Screenshot 2024-04-04 at 15 35 58" src="https://github.com/tldraw/tldraw/assets/469604/f4673fc5-5b9a-4ab9-a169-a91ba7f49d17">
After:
<img width="636" alt="Screenshot 2024-04-04 at 15 35 42" src="https://github.com/tldraw/tldraw/assets/469604/645c439a-662b-4244-af7f-6c718e5c5fc2">


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

