### PR TITLE
Slow rotated notes

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1126,7 +1126,7 @@ input,
 	position: relative;
 	width: 100%;
 	height: 100%;
-	border-radius: var(--radius-2);
+	/* border-radius: var(--radius-2); */
 	box-shadow: var(--shadow-1);
 	overflow: hidden;
 	border-color: currentColor;


### PR DESCRIPTION
Seems like the slow rendering of rotated notes (and possibly other shapes) is a combination of rotation, border radius, and box shadow. Comment out one of them and it seems to work as it should.

Only in Chrome. Seems a bug or just an edge case it can't handle. I guess we should report it?

https://github.com/tldraw/tldraw/assets/2523721/90dbce4b-4ac7-4843-b5d3-e1e35328ae2d

@mimecuvalo 

Related to TLD-2366

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
