### PR TITLE
textfields: fix dragging when staying in EditingShape state and use pointer capture for down event

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -536,6 +536,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		const labelPosition = getArrowLabelPosition(this.editor, shape)
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
+		const isEditing = this.editor.getEditingShapeId() === shape.id
+		const showArrowLabel = isEditing || shape.props.text
 
 		return (
 			<>
@@ -545,16 +547,18 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 						shouldDisplayHandles={shouldDisplayHandles && onlySelectedShape === shape}
 					/>
 				</SVGContainer>
-				<ArrowTextLabel
-					id={shape.id}
-					text={shape.props.text}
-					font={shape.props.font}
-					size={shape.props.size}
-					position={labelPosition.box.center}
-					width={labelPosition.box.w}
-					isSelected={isSelected}
-					labelColor={shape.props.labelColor}
-				/>
+				{showArrowLabel && (
+					<ArrowTextLabel
+						id={shape.id}
+						text={shape.props.text}
+						font={shape.props.font}
+						size={shape.props.size}
+						position={labelPosition.box.center}
+						width={labelPosition.box.w}
+						isSelected={isSelected}
+						labelColor={shape.props.labelColor}
+					/>
+				)}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -386,31 +386,39 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const { fill, font, align, verticalAlign, size, text } = props
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 		const theme = useDefaultColorTheme()
+		const isEditing = this.editor.getEditingShapeId() === id
+		const showHtmlContainer = isEditing || shape.props.text
 
 		return (
 			<>
 				<SVGContainer id={id}>
 					<GeoShapeBody shape={shape} />
 				</SVGContainer>
-				<HTMLContainer
-					id={shape.id}
-					style={{ overflow: 'hidden', width: shape.props.w, height: shape.props.h + props.growY }}
-				>
-					<TextLabel
-						id={id}
-						type={type}
-						font={font}
-						fontSize={LABEL_FONT_SIZES[size]}
-						lineHeight={TEXT_PROPS.lineHeight}
-						fill={fill}
-						align={align}
-						verticalAlign={verticalAlign}
-						text={text}
-						isSelected={isSelected}
-						labelColor={theme[props.labelColor].solid}
-						wrap
-					/>
-				</HTMLContainer>
+				{showHtmlContainer && (
+					<HTMLContainer
+						id={shape.id}
+						style={{
+							overflow: 'hidden',
+							width: shape.props.w,
+							height: shape.props.h + props.growY,
+						}}
+					>
+						<TextLabel
+							id={id}
+							type={type}
+							font={font}
+							fontSize={LABEL_FONT_SIZES[size]}
+							lineHeight={TEXT_PROPS.lineHeight}
+							fill={fill}
+							align={align}
+							verticalAlign={verticalAlign}
+							text={text}
+							isSelected={isSelected}
+							labelColor={theme[props.labelColor].solid}
+							wrap
+						/>
+					</HTMLContainer>
+				)}
 				{shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
 				)}

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -4,6 +4,7 @@ import {
 	TLShapeId,
 	TLUnknownShape,
 	getPointerInfo,
+	setPointerCapture,
 	stopEventPropagation,
 	useEditor,
 	useValue,
@@ -147,8 +148,6 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 
 	const handleInputPointerDown = useCallback(
 		(e: React.PointerEvent) => {
-			if (!isEditing) return
-
 			editor.dispatch({
 				...getPointerInfo(e),
 				type: 'pointer',
@@ -158,8 +157,12 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 			})
 
 			stopEventPropagation(e) // we need to prevent blurring the input
+
+			// This is important so that when dragging a shape using the text label,
+			// the shape continues to be dragged, even if the cursor is over the UI.
+			setPointerCapture(e.currentTarget, e)
 		},
-		[editor, id, isEditing]
+		[editor, id]
 	)
 
 	const handleDoubleClick = stopEventPropagation


### PR DESCRIPTION
This mainly fixes the issue where going from EditingShape → EditingShape but intending a drag didn't feel right.  

Also, side fixes:
- [x] bring back mitja's change - I missed your comment @steveruizok on the other PR https://github.com/tldraw/tldraw/pull/3328 before it was merged. you're right - it didn't need to be reverted anymore.
- [x] undo a change from https://github.com/tldraw/tldraw/pull/3328 that was trying to fix the UI collision when dragging (see https://linear.app/tldraw/issue/TLD-2355/bug-dragging-note-labels-does-not-turn-on-pointer-capture ). It was causing weird flakiness when selecting. This now uses pointer capture instead as originally suggested.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

