### PR TITLE
textfields: prevent selection drag on Firefox

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextArea.tsx
@@ -1,4 +1,4 @@
-import { stopEventPropagation } from '@tldraw/editor'
+import { preventDefault, stopEventPropagation } from '@tldraw/editor'
 import { forwardRef } from 'react'
 
 type TextAreaProps = {
@@ -55,6 +55,11 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function 
 			onContextMenu={isEditing ? stopEventPropagation : undefined}
 			onPointerDown={handleInputPointerDown}
 			onDoubleClick={handleDoubleClick}
+			// On FF, there's a behavior where dragging a selection will grab that selection into
+			// the drag event. However, once the drag is over, and you select away from the textarea,
+			// starting a drag over the textarea will restart a selection drag instead of a shape drag.
+			// This prevents that default behavior in FF.
+			onDragStart={preventDefault}
 		/>
 	)
 })


### PR DESCRIPTION
This is a minor edge case but worth accounting for: in Firefox, there's a behavior where dragging a selection will grab that selection into the drag event. However, once the drag is over, and you select away from the textarea, starting a drag over the textarea will restart a selection drag, instead of a shape drag. And also then your cursor will get 'stuck' because it missed some pointer event somewhere. This prevents that default behavior in FF.

Before:

https://github.com/tldraw/tldraw/assets/469604/21416a61-e439-4245-bf4b-c41b170bfb05


After:

https://github.com/tldraw/tldraw/assets/469604/6b372fd6-c1dd-4d5f-b959-ce961b188d1f



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

