### PR TITLE
textfields: need to select on pointer down when in EditingShape, not later

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -96,6 +96,9 @@ export class EditingShape extends StateNode {
 						} else {
 							this.hitShapeForPointerUp = selectingShape
 
+							this.editor.mark('editing on pointer up')
+							this.editor.select(selectingShape.id)
+
 							// When clicking on a different shape's label, we need to clear the other selection
 							// proactively until the pointer up happens.
 							requestAnimationFrame(() => window.getSelection()?.removeAllRanges())
@@ -133,9 +136,6 @@ export class EditingShape extends StateNode {
 			// Stay in edit mode to maintain flow of editing.
 			this.editor.batch(() => {
 				if (!hitShape) return
-
-				this.editor.mark('editing on pointer up')
-				this.editor.select(hitShape.id)
 
 				const util = this.editor.getShapeUtil(hitShape)
 				if (this.editor.getInstanceState().isReadonly) {


### PR DESCRIPTION
A long press was causing the wrong shape to be selected on mobile. We need to set the right selection on pointer down not on up.

before

https://github.com/tldraw/tldraw/assets/469604/610f5dc8-a619-419a-9e4d-db1c3af767da

after

https://github.com/tldraw/tldraw/assets/469604/8ff16119-5850-403a-89f3-a113408d3816



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

