### PR TITLE
textfields: fix Safari cursor rendering bug

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2526,7 +2526,7 @@ export function useDialogs(): TLUiDialogsContextType;
 export function useEditableText(id: TLShapeId, type: string, text: string): {
     rInput: React_2.RefObject<HTMLTextAreaElement>;
     isEditing: boolean;
-    handleFocus: typeof noop;
+    handleFocus: () => void;
     handleBlur: () => void;
     handleKeyDown: (e: React_2.KeyboardEvent<HTMLTextAreaElement>) => void;
     handleChange: (e: React_2.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -27778,16 +27778,7 @@
             },
             {
               "kind": "Content",
-              "text": ">;\n    isEditing: boolean;\n    handleFocus: typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "noop",
-              "canonicalReference": "tldraw!~noop:function"
-            },
-            {
-              "kind": "Content",
-              "text": ";\n    handleBlur: () => void;\n    handleKeyDown: (e: "
+              "text": ">;\n    isEditing: boolean;\n    handleFocus: () => void;\n    handleBlur: () => void;\n    handleKeyDown: (e: "
             },
             {
               "kind": "Reference",
@@ -27842,7 +27833,7 @@
           "fileUrlPath": "packages/tldraw/src/lib/shapes/shared/useEditableText.ts",
           "returnTypeTokenRange": {
             "startIndex": 7,
-            "endIndex": 24
+            "endIndex": 22
           },
           "releaseTag": "Public",
           "overloadIndex": 1,

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -165,12 +165,25 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 		[editor, id]
 	)
 
+	const handleFocus = useCallback(() => {
+		const elm = rInput.current
+		if (elm && isEditing) {
+			// XXX: argh, this is a hack to make sure the cursor is _visible_
+			// in Safari/WebKit. When first loading tldraw, and clicking into an
+			// editable area, sometimes, the cursor is present but not visible.
+			// After a while it will always be visible after it has 'warmed up'.
+			// This tricks forces it to shake it awake and make it visible always.
+			elm.blur()
+			elm.focus()
+		}
+	}, [isEditing])
+
 	const handleDoubleClick = stopEventPropagation
 
 	return {
 		rInput,
 		isEditing,
-		handleFocus: noop,
+		handleFocus,
 		handleBlur,
 		handleKeyDown,
 		handleChange,
@@ -179,8 +192,4 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 		isEmpty,
 		isEditingAnything,
 	}
-}
-
-function noop() {
-	return
 }


### PR DESCRIPTION
There seems to be a Webkit bug with the cursor not initially being visible sometimes, especially when the page first loads.
This ain't pretty but it's a not-too-hacky way of "shaking" the cursor awake.

Before:

https://github.com/tldraw/tldraw/assets/469604/ca66c7d1-8b34-498a-a827-4f7725ab85dd


After:

https://github.com/tldraw/tldraw/assets/469604/93d0f190-b586-496c-a416-0c726ac51858




### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

