### PR TITLE
textfields: fix cursor position on mobile in EditingShape

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -107,7 +107,12 @@ export function useCanvasEvents() {
 				;(e as any).isKilled = true
 				if (
 					(e.target as HTMLElement).tagName !== 'A' &&
-					(e.target as HTMLElement).tagName !== 'TEXTAREA'
+					(e.target as HTMLElement).tagName !== 'TEXTAREA' &&
+					// When in EditingShape state, we are actually clicking on a 'DIV'
+					// not A/TEXTAREA element yet. So, to preserve cursor position
+					// for edit mode on mobile we need to not preventDefault.
+					// TODO: Find out if we still need this preventDefault in general though.
+					!editor.getEditingShape()
 				) {
 					preventDefault(e)
 				}

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -112,7 +112,10 @@ export function useCanvasEvents() {
 					// not A/TEXTAREA element yet. So, to preserve cursor position
 					// for edit mode on mobile we need to not preventDefault.
 					// TODO: Find out if we still need this preventDefault in general though.
-					!editor.getEditingShape()
+					!(
+						editor.getEditingShape() &&
+						(e.target as HTMLElement).className.includes('tl-text-content')
+					)
 				) {
 					preventDefault(e)
 				}


### PR DESCRIPTION
On mobile, cursor position wasn't going to the right place when using the EditingShape→EditingShape transition.

Before

https://github.com/tldraw/tldraw/assets/469604/9487d741-684b-4562-b1c2-7ea8f89a3a56

After

https://github.com/tldraw/tldraw/assets/469604/f828e1ce-0315-4393-be50-c31888e25f3a



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
