### PR TITLE
[culling] Improve setting of display none.

### DIFF
--- a/apps/examples/src/examples/custom-renderer/CustomRenderer.tsx
+++ b/apps/examples/src/examples/custom-renderer/CustomRenderer.tsx
@@ -36,7 +36,8 @@ export function CustomRenderer() {
 			const theme = getDefaultColorTheme({ isDarkMode: editor.user.getIsDarkMode() })
 			const currentPageId = editor.getCurrentPageId()
 
-			for (const { shape, maskedPageBounds, opacity } of renderingShapes) {
+			for (const { shape, opacity } of renderingShapes) {
+				const maskedPageBounds = editor.getShapeMaskedPageBounds(shape)
 				if (!maskedPageBounds) continue
 				ctx.save()
 

--- a/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
+++ b/apps/examples/src/examples/rendering-shape-changes/useRenderingShapesChange.ts
@@ -22,9 +22,11 @@ export function useChangedShapesReactor(
 				if (!beforeInfo) {
 					continue
 				} else {
-					if (afterInfo.isCulled && !beforeInfo.isCulled) {
+					const isAfterCulled = editor.isShapeCulled(afterInfo.id)
+					const isBeforeCulled = editor.isShapeCulled(beforeInfo.id)
+					if (isAfterCulled && !isBeforeCulled) {
 						culled.push(afterInfo.shape)
-					} else if (!afterInfo.isCulled && beforeInfo.isCulled) {
+					} else if (!isAfterCulled && isBeforeCulled) {
 						restored.push(afterInfo.shape)
 					}
 					beforeToVisit.delete(beforeInfo)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -720,8 +720,6 @@ export class Editor extends EventEmitter<TLEventMap> {
         index: number;
         backgroundIndex: number;
         opacity: number;
-        isCulled: boolean;
-        maskedPageBounds: Box | undefined;
     }[];
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];
@@ -782,8 +780,6 @@ export class Editor extends EventEmitter<TLEventMap> {
         index: number;
         backgroundIndex: number;
         opacity: number;
-        isCulled: boolean;
-        maskedPageBounds: Box | undefined;
     }[];
     getViewportPageBounds(): Box;
     getViewportPageCenter(): Vec;
@@ -821,6 +817,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         margin?: number | undefined;
         hitInside?: boolean | undefined;
     }): boolean;
+    isShapeCulled(shape: TLShape | TLShapeId): boolean;
     isShapeInPage(shape: TLShape | TLShapeId, pageId?: TLPageId): boolean;
     isShapeOfType<T extends TLUnknownShape>(shape: TLUnknownShape, type: T['type']): shape is T;
     // (undocumented)

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -11955,16 +11955,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ">;\n        index: number;\n        backgroundIndex: number;\n        opacity: number;\n        isCulled: boolean;\n        maskedPageBounds: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Box",
-                  "canonicalReference": "@tldraw/editor!Box:class"
-                },
-                {
-                  "kind": "Content",
-                  "text": " | undefined;\n    }[]"
+                  "text": ">;\n        index: number;\n        backgroundIndex: number;\n        opacity: number;\n    }[]"
                 },
                 {
                   "kind": "Content",
@@ -11974,7 +11965,7 @@
               "isStatic": false,
               "returnTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 12
+                "endIndex": 10
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -14822,6 +14813,64 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "isPointInShape"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#isShapeCulled:member(1)",
+              "docComment": "/**\n * Get whether the shape is culled or not.\n *\n * @param shape - The shape (or shape id) to get the culled info for.\n *\n * @example\n * ```ts\n * editor.isShapeCulled(myShape)\n * editor.isShapeCulled(myShapeId)\n * ```\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isShapeCulled(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "isShapeCulled"
             },
             {
               "kind": "Method",

--- a/packages/editor/src/lib/components/CulledShapes.tsx
+++ b/packages/editor/src/lib/components/CulledShapes.tsx
@@ -112,8 +112,9 @@ export function CulledShapes() {
 		const shapeVertices = computed('shape vertices', function calculateCulledShapeVertices() {
 			const results: number[] = []
 
-			for (const { isCulled, maskedPageBounds } of editor.getRenderingShapes()) {
-				if (isCulled && maskedPageBounds) {
+			for (const { id } of editor.getUnorderedRenderingShapes(true)) {
+				const maskedPageBounds = editor.getShapeMaskedPageBounds(id)
+				if (editor.isShapeCulled(id) && maskedPageBounds) {
 					results.push(
 						// triangle 1
 						maskedPageBounds.minX,

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -118,30 +118,15 @@ export const Shape = memo(function Shape({
 		[opacity, index, backgroundIndex]
 	)
 
-	// This stuff changes pretty infrequently, so we can change them together
 	useQuickReactor(
 		'set display',
 		() => {
 			const shape = editor.getShape(id)
 			if (!shape) return // probably the shape was just deleted
 
-			// If renderingBoundsMargin is set to Infinity, then we won't cull offscreen shapes
-			const isCullingOffScreenShapes = Number.isFinite(editor.renderingBoundsMargin)
-			const selectedShapeIds = editor.getSelectedShapeIds()
-			const renderingBoundsExpanded = editor.getRenderingBoundsExpanded()
-			const maskedPageBounds = editor.getShapeMaskedPageBounds(id)
-			const isCulled =
-				isCullingOffScreenShapes &&
-				// never cull editing shapes
-				editor.getEditingShapeId() !== id &&
-				// if the shape is fully outside of its parent's clipping bounds...
-				(maskedPageBounds === undefined ||
-					// ...or if the shape is outside of the expanded viewport bounds...
-					(!renderingBoundsExpanded.includes(maskedPageBounds) &&
-						// ...and if it's not selected... then cull it
-						!selectedShapeIds.includes(id)))
+			// console.log(shape.id)
+			const isCulled = editor.isShapeCulled(shape)
 			setStyleProperty(containerRef.current, 'display', isCulled ? 'none' : 'block')
-			setStyleProperty(culledContainerRef.current, 'display', isCulled ? 'block' : 'none')
 			setStyleProperty(bgContainerRef.current, 'display', isCulled ? 'none' : 'block')
 		},
 		[editor]

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -124,7 +124,6 @@ export const Shape = memo(function Shape({
 			const shape = editor.getShape(id)
 			if (!shape) return // probably the shape was just deleted
 
-			// console.log(shape.id)
 			const isCulled = editor.isShapeCulled(shape)
 			setStyleProperty(containerRef.current, 'display', isCulled ? 'none' : 'block')
 			setStyleProperty(bgContainerRef.current, 'display', isCulled ? 'none' : 'block')

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -376,8 +376,8 @@ function ShapesToDisplay() {
 
 	return (
 		<>
-			{renderingShapes.map((result) => (
-				<Shape key={result.id + '_shape'} {...result} dprMultiple={dprMultiple} />
+			{renderingShapes.map(({ isCulled: _isCulled, ...rest }) => (
+				<Shape key={rest.id + '_shape'} {...rest} dprMultiple={dprMultiple} />
 			))}
 		</>
 	)

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -376,8 +376,8 @@ function ShapesToDisplay() {
 
 	return (
 		<>
-			{renderingShapes.map(({ isCulled: _isCulled, ...rest }) => (
-				<Shape key={rest.id + '_shape'} {...rest} dprMultiple={dprMultiple} />
+			{renderingShapes.map((result) => (
+				<Shape key={result.id + '_shape'} {...result} dprMultiple={dprMultiple} />
 			))}
 		</>
 	)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4624,7 +4624,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getCurrentPageShapesSorted(): TLShape[] {
-		// console.log('current pge sorted')
 		// todo: consider making into a function call that includes options for selected-only, rendering, etc.
 		// todo: consider making a derivation or something, or merging with rendering shapes
 		const shapes = new Set(this.getCurrentPageShapes().sort(sortByIndex))

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4658,7 +4658,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getCurrentPageRenderingShapesSorted(): TLShape[] {
-		return this.getRenderingShapes()
+		return this.getUnorderedRenderingShapes(true)
 			.filter(({ id }) => !this.isShapeCulled(id))
 			.sort((a, b) => a.index - b.index)
 			.map(({ shape }) => shape)

--- a/packages/editor/src/lib/editor/getSvgJsx.tsx
+++ b/packages/editor/src/lib/editor/getSvgJsx.tsx
@@ -38,7 +38,8 @@ export async function getSvgJsx(
 	if (opts.bounds) {
 		bbox = opts.bounds
 	} else {
-		for (const { maskedPageBounds } of renderingShapes) {
+		for (const { id } of renderingShapes) {
+			const maskedPageBounds = editor.getShapeMaskedPageBounds(id)
 			if (!maskedPageBounds) continue
 			if (bbox) {
 				bbox.union(maskedPageBounds)

--- a/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
@@ -19,9 +19,10 @@ export function BackToContent() {
 
 			// Rendering shapes includes all the shapes in the current page.
 			// We have to filter them down to just the shapes that are inside the renderingBounds.
-			const visibleShapes = renderingShapes.filter(
-				(s) => s.maskedPageBounds && renderingBounds.includes(s.maskedPageBounds)
-			)
+			const visibleShapes = renderingShapes.filter((s) => {
+				const maskedPageBounds = editor.getShapeMaskedPageBounds(s.id)
+				return maskedPageBounds && renderingBounds.includes(maskedPageBounds)
+			})
 			const showBackToContentNow =
 				visibleShapes.length === 0 && editor.getCurrentPageShapes().length > 0
 

--- a/packages/tldraw/src/test/renderingShapes.test.tsx
+++ b/packages/tldraw/src/test/renderingShapes.test.tsx
@@ -63,42 +63,50 @@ it('updates the rendering viewport when the camera stops moving', () => {
 it('lists shapes in viewport', () => {
 	const ids = createShapes()
 	editor.selectNone()
-	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
-		[ids.A, false], // A is within the expanded rendering bounds, so should not be culled; and it's in the regular viewport too, so it's on screen.
-		[ids.B, false],
-		[ids.C, false],
-		[ids.D, true], // D is clipped and so should always be culled / outside of viewport
-	])
+	expect(editor.getRenderingShapes().map(({ id }) => [id, editor.isShapeCulled(id)])).toStrictEqual(
+		[
+			[ids.A, false], // A is within the expanded rendering bounds, so should not be culled; and it's in the regular viewport too, so it's on screen.
+			[ids.B, false],
+			[ids.C, false],
+			[ids.D, true], // D is clipped and so should always be culled / outside of viewport
+		]
+	)
 
 	// Move the camera 201 pixels to the right and 201 pixels down
 	editor.pan({ x: -201, y: -201 })
 	jest.advanceTimersByTime(500)
 
-	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
-		[ids.A, false], // A should not be culled, even though it's no longer in the viewport (because it's still in the EXPANDED viewport)
-		[ids.B, false],
-		[ids.C, false],
-		[ids.D, true], // D is clipped and so should always be culled / outside of viewport
-	])
+	expect(editor.getRenderingShapes().map(({ id }) => [id, editor.isShapeCulled(id)])).toStrictEqual(
+		[
+			[ids.A, false], // A should not be culled, even though it's no longer in the viewport (because it's still in the EXPANDED viewport)
+			[ids.B, false],
+			[ids.C, false],
+			[ids.D, true], // D is clipped and so should always be culled / outside of viewport
+		]
+	)
 
 	editor.pan({ x: -100, y: -100 })
 	jest.advanceTimersByTime(500)
 
-	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
-		[ids.A, true], // A should be culled now that it's outside of the expanded viewport too
-		[ids.B, false],
-		[ids.C, false],
-		[ids.D, true], // D is clipped and so should always be culled, even if it's in the viewport
-	])
+	expect(editor.getRenderingShapes().map(({ id }) => [id, editor.isShapeCulled(id)])).toStrictEqual(
+		[
+			[ids.A, true], // A should be culled now that it's outside of the expanded viewport too
+			[ids.B, false],
+			[ids.C, false],
+			[ids.D, true], // D is clipped and so should always be culled, even if it's in the viewport
+		]
+	)
 
 	editor.pan({ x: -900, y: -900 })
 	jest.advanceTimersByTime(500)
-	expect(editor.getRenderingShapes().map(({ id, isCulled }) => [id, isCulled])).toStrictEqual([
-		[ids.A, true],
-		[ids.B, true],
-		[ids.C, true],
-		[ids.D, true],
-	])
+	expect(editor.getRenderingShapes().map(({ id }) => [id, editor.isShapeCulled(id)])).toStrictEqual(
+		[
+			[ids.A, true],
+			[ids.B, true],
+			[ids.C, true],
+			[ids.D, true],
+		]
+	)
 })
 
 it('lists shapes in viewport sorted by id with correct indexes & background indexes', () => {


### PR DESCRIPTION
Small improvement for culling shapes. We now use reactor to do it. .

Before:
![image](https://github.com/tldraw/tldraw/assets/2523721/7f791cdd-c0e2-4b92-84d1-8b071540de10)

After:
![image](https://github.com/tldraw/tldraw/assets/2523721/ca2e2a9e-f9f6-48a8-936f-05a402c1e7a2)


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

