### PR TITLE
put `getCurrentPageId` into a computed

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3325,7 +3325,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	getCurrentPageId(): TLPageId {
+	@computed getCurrentPageId(): TLPageId {
 		return this.getInstanceState().currentPageId
 	}
 


### PR DESCRIPTION
This PR makes the `getCurrentPageId` method use a computed. Previously, anything that referenced the current page id would pick up any change to instance state. This will help a bunch of interactions like brushing that would update the instance state on every frame.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features