### PR TITLE
[experiment] Scarily blazingly faster resizing by manually creating a history entry

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -86,6 +86,9 @@ export const ANIMATION_MEDIUM_MS = 320;
 // @internal (undocumented)
 export const ANIMATION_SHORT_MS = 80;
 
+// @public (undocumented)
+export function applyPartialToShape<T extends TLShape>(prev: T, partial?: TLShapePartial<T>): T;
+
 // @internal (undocumented)
 export function applyRotationToSnapshotShapes({ delta, editor, snapshot, stage, }: {
     delta: number;
@@ -723,6 +726,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         isCulled: boolean;
         maskedPageBounds: Box | undefined;
     }[];
+    getResizedShape(shape: TLShape | TLShapeId, scale: VecLike, options?: TLResizeShapeOptions): TLShape | undefined;
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];
     getSelectedShapes(): TLShape[];
@@ -863,7 +867,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     renderingBoundsMargin: number;
     reparentShapes(shapes: TLShape[] | TLShapeId[], parentId: TLParentId, insertIndex?: IndexKey): this;
     resetZoom(point?: Vec, animation?: TLAnimationOptions): this;
-    resizeShape(shape: TLShape | TLShapeId, scale: VecLike, options?: TLResizeShapeOptions): this;
+    resizeShape(id: TLShapeId, scale: VecLike, options?: TLResizeShapeOptions): this;
     readonly root: RootState;
     rotateShapesBy(shapes: TLShape[] | TLShapeId[], delta: number): this;
     screenToPage(point: VecLike): {

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -251,6 +251,94 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/editor!applyPartialToShape:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function applyPartialToShape<T extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLShape",
+              "canonicalReference": "@tldraw/tlschema!TLShape:type"
+            },
+            {
+              "kind": "Content",
+              "text": ">(prev: "
+            },
+            {
+              "kind": "Content",
+              "text": "T"
+            },
+            {
+              "kind": "Content",
+              "text": ", partial?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLShapePartial",
+              "canonicalReference": "@tldraw/tlschema!TLShapePartial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<T>"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "T"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/utils/applyPartialToShape.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 8,
+            "endIndex": 9
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "prev",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "partial",
+              "parameterTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 7
+              },
+              "isOptional": true
+            }
+          ],
+          "typeParameters": [
+            {
+              "typeParameterName": "T",
+              "constraintTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "defaultTypeTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              }
+            }
+          ],
+          "name": "applyPartialToShape"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/editor!approximately:function(1)",
           "docComment": "/**\n * Whether two numbers numbers a and b are approximately equal.\n *\n * @param a - The first point.\n *\n * @param b - The second point.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -11986,6 +12074,103 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#getResizedShape:member(1)",
+              "docComment": "/**\n * Get a resized shape.\n *\n * @param id - The id of the shape to resize.\n *\n * @param scale - The scale factor to apply to the shape.\n *\n * @param options - Additional options.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getResizedShape(shape: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", scale: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "VecLike",
+                  "canonicalReference": "@tldraw/editor!VecLike:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", options?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLResizeShapeOptions",
+                  "canonicalReference": "@tldraw/editor!TLResizeShapeOptions:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShape",
+                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 9,
+                "endIndex": 11
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "shape",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "scale",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "options",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
+                  },
+                  "isOptional": true
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getResizedShape"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#getSelectedShapeAtPoint:member(1)",
               "docComment": "/**\n * Get the top-most selected shape at the given point, ignoring groups.\n *\n * @param point - The point to check.\n *\n * @returns The top-most selected shape at the given point, or undefined if there is no shape at the point.\n */\n",
               "excerptTokens": [
@@ -16465,16 +16650,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "resizeShape(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " | "
+                  "text": "resizeShape(id: "
                 },
                 {
                   "kind": "Reference",
@@ -16514,34 +16690,34 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 9,
-                "endIndex": 10
+                "startIndex": 7,
+                "endIndex": 8
               },
               "releaseTag": "Public",
               "isProtected": false,
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "shape",
+                  "parameterName": "id",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 4
+                    "endIndex": 2
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "scale",
                   "parameterTypeTokenRange": {
-                    "startIndex": 5,
-                    "endIndex": 6
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "options",
                   "parameterTypeTokenRange": {
-                    "startIndex": 7,
-                    "endIndex": 8
+                    "startIndex": 5,
+                    "endIndex": 6
                   },
                   "isOptional": true
                 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -339,6 +339,7 @@ export {
 	type SharedStyle,
 } from './lib/utils/SharedStylesMap'
 export { WeakMapCache } from './lib/utils/WeakMapCache'
+export { applyPartialToShape } from './lib/utils/applyPartialToShape'
 export { dataUrlToFile } from './lib/utils/assets'
 export { debugFlags, featureFlags, type DebugFlag } from './lib/utils/debug-flags'
 export {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6221,7 +6221,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	resizeShape(id: TLShapeId, scale: VecLike, options?: TLResizeShapeOptions): this {
-		this.updateShape(this.getResizedShape(id, scale, options))
+		this.updateShape(this.getResizedShape(id, scale, options), { squashing: true })
 		return this
 	}
 
@@ -6293,14 +6293,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (util.onResize && util.canResize(initialShape)) {
 			// get the model changes from the shape util
-			const newPagePoint = this._scalePagePoint(
-				Mat.applyToPoint(pageTransform, new Vec(0, 0)),
-				scaleOrigin,
-				scale,
-				scaleAxisRotation
-			)
 
-			const newLocalPoint = this.getPointInParentSpace(initialShape.id, newPagePoint)
+			// Get the point in the same coordinate space as the shape
+			const newLocalPoint = this.getPointInParentSpace(
+				initialShape.id,
+				this._scalePagePoint(pageTransform.point(), scaleOrigin, scale, scaleAxisRotation)
+			)
 
 			// resize the shape's local bounding box
 			const myScale = new Vec(scale.x, scale.y)

--- a/packages/editor/src/lib/utils/applyPartialToShape.ts
+++ b/packages/editor/src/lib/utils/applyPartialToShape.ts
@@ -1,0 +1,38 @@
+import { TLShape, TLShapePartial } from '@tldraw/tlschema'
+import { JsonObject } from '@tldraw/utils'
+
+/** @public */
+export function applyPartialToShape<T extends TLShape>(prev: T, partial?: TLShapePartial<T>): T {
+	if (!partial) return prev
+	let next = null as null | T
+	const entries = Object.entries(partial)
+	for (let i = 0, n = entries.length; i < n; i++) {
+		const [k, v] = entries[i]
+		if (v === undefined) continue
+
+		// Is the key a special key? We don't update those
+		if (k === 'id' || k === 'type' || k === 'typeName') continue
+
+		// Is the value the same as it was before?
+		if (v === (prev as any)[k]) continue
+
+		// There's a new value, so create the new shape if we haven't already (should we be cloning this?)
+		if (!next) next = { ...prev }
+
+		// for props / meta properties, we support updates with partials of this object
+		if (k === 'props' || k === 'meta') {
+			next[k] = { ...prev[k] } as JsonObject
+			for (const [nextKey, nextValue] of Object.entries(v as object)) {
+				if (nextValue !== undefined) {
+					;(next[k] as JsonObject)[nextKey] = nextValue
+				}
+			}
+			continue
+		}
+
+		// base property
+		;(next as any)[k] = v
+	}
+	if (!next) return prev
+	return next
+}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -118,7 +118,10 @@ export class Resizing extends StateNode {
 
 	private cancel() {
 		// Restore initial models
+		const shapes = Array.from(this.snapshot.shapeSnapshots.values()).map((s) => s.shape)
+		this.updateShapesInStore(shapes)
 		this.editor.bailToMark(this.markId)
+
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, {})
 		} else {


### PR DESCRIPTION
This PR improves the speed of resizing many shapes. 

![Kapture 2024-04-05 at 18 11 59](https://github.com/tldraw/tldraw/assets/23072548/cb60aef6-6426-4062-bfb3-cfc362774dd1)

Previously, the `updateShapes` command would be called multiple times each frame for each resizing shape. As part of this work, changes would be squashed into the history entry. This squashing was very slow. In this PR, we manage the history entry ourselves in the resizing interaction.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Test Plan

1. Resize lots of shapes.
2. Ensure that undo / redo / cancelling works as expected.

### Release Notes

- Improves performance of resizing.