### PR TITLE
Remove note parenting

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1097,11 +1097,7 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canDropShapes: (shape: TLNoteShape, _shapes: TLShape[]) => boolean;
-    // (undocumented)
     canEdit: () => boolean;
-    // (undocumented)
-    canReceiveNewChildrenOfType: (shape: TLNoteShape, type: string) => boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX_2.Element;
     // (undocumented)
@@ -1168,10 +1164,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         id: TLShapeId;
         typeName: "shape";
     } | undefined;
-    // (undocumented)
-    onDragShapesOut: (note: TLNoteShape, shapes: TLShape[]) => void;
-    // (undocumented)
-    onDragShapesOver: (note: TLNoteShape, shapes: TLShape[]) => void;
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLNoteShape>;
     // (undocumented)

--- a/packages/tldraw/api/api.json
+++ b/packages/tldraw/api/api.json
@@ -12782,54 +12782,6 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#canDropShapes:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "canDropShapes: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", _shapes: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]) => boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "canDropShapes",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "tldraw!NoteShapeUtil#canEdit:member",
               "docComment": "",
               "excerptTokens": [
@@ -12853,45 +12805,6 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#canReceiveNewChildrenOfType:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "canReceiveNewChildrenOfType: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(shape: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", type: string) => boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "canReceiveNewChildrenOfType",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
               },
               "isStatic": false,
               "isProtected": false,
@@ -13394,102 +13307,6 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 14
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOut:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onDragShapesOut: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(note: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", shapes: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]) => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onDragShapesOut",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "tldraw!NoteShapeUtil#onDragShapesOver:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onDragShapesOver: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(note: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLNoteShape",
-                  "canonicalReference": "@tldraw/tlschema!TLNoteShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", shapes: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLShape",
-                  "canonicalReference": "@tldraw/tlschema!TLShape:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]) => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onDragShapesOver",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
               },
               "isStatic": false,
               "isProtected": false,

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -5,7 +5,6 @@ import {
 	Rectangle2d,
 	ShapeUtil,
 	SvgExportContext,
-	TLGroupShape,
 	TLHandle,
 	TLNoteShape,
 	TLOnEditEndHandler,
@@ -55,36 +54,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	override canEdit = () => true
 	override hideResizeHandles = () => true
 	override hideSelectionBoundsFg = () => false
-
-	override canReceiveNewChildrenOfType = (shape: TLNoteShape, type: string) => {
-		return !shape.isLocked && type !== 'frame'
-	}
-
-	override canDropShapes = (shape: TLNoteShape, _shapes: TLShape[]): boolean => {
-		return !shape.isLocked
-	}
-
-	override onDragShapesOver = (note: TLNoteShape, shapes: TLShape[]) => {
-		if (!shapes.every((child) => child.parentId === note.id)) {
-			const shapesWithoutFrames = shapes.filter(
-				(shape) => !this.editor.isShapeOfType(shape, 'frame')
-			)
-			this.editor.reparentShapes(shapesWithoutFrames, note.id)
-		}
-	}
-
-	override onDragShapesOut = (note: TLNoteShape, shapes: TLShape[]) => {
-		const parent = this.editor.getShape(note.parentId)
-		const isInGroup = parent && this.editor.isShapeOfType<TLGroupShape>(parent, 'group')
-
-		// If sticky is in a group, keep the shape in that group
-
-		if (isInGroup) {
-			this.editor.reparentShapes(shapes, parent.id)
-		} else {
-			this.editor.reparentShapes(shapes, this.editor.getCurrentPageId())
-		}
-	}
 
 	getDefaultProps(): TLNoteShape['props'] {
 		return {


### PR DESCRIPTION
This PR removes the ability for notes to accept children. It keeps all of the other improvements to dragging / dropping / etc.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `feature` — New feature