### PR TITLE
Allocate memory only once

### DIFF
--- a/packages/editor/src/lib/components/CulledShapes.tsx
+++ b/packages/editor/src/lib/components/CulledShapes.tsx
@@ -1,5 +1,6 @@
 import { computed, react } from '@tldraw/state'
 import { useEffect, useRef } from 'react'
+import { MAX_SHAPES_PER_PAGE } from '../constants'
 import { useEditor } from '../hooks/useEditor'
 import { useIsDarkMode } from '../hooks/useIsDarkMode'
 
@@ -109,6 +110,9 @@ export function CulledShapes() {
 			viewportEndUniformLocation,
 		} = webGl
 
+		// Each shape requires 12 numbers: 2 triangles * 3 vertices per triangle * 2 positions (x, y) per vertex
+		const triangleGeoCpuBuffer = new Float32Array(12 * MAX_SHAPES_PER_PAGE)
+
 		const shapeVertices = computed('shape vertices', function calculateCulledShapeVertices() {
 			const results: number[] = []
 
@@ -156,7 +160,7 @@ export function CulledShapes() {
 				const viewport = editor.getViewportPageBounds() // when the viewport changes...
 				context.uniform2f(viewportStartUniformLocation, viewport.minX, viewport.minY)
 				context.uniform2f(viewportEndUniformLocation, viewport.maxX, viewport.maxY)
-				const triangleGeoCpuBuffer = new Float32Array(verticesArray)
+				triangleGeoCpuBuffer.set(verticesArray)
 				const triangleGeoBuffer = context.createBuffer()
 				context.bindBuffer(context.ARRAY_BUFFER, triangleGeoBuffer)
 				context.bufferData(context.ARRAY_BUFFER, triangleGeoCpuBuffer, context.STATIC_DRAW)

--- a/packages/store/api/api.json
+++ b/packages/store/api/api.json
@@ -4231,7 +4231,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@tldraw/store!Store#onBeforeChange:member",
-              "docComment": "/**\n * A callback before after each record's change.\n *\n * @param prev - The previous value, if any.\n *\n * @param next - The next value.\n */\n",
+              "docComment": "/**\n * A callback fired before each record's change.\n *\n * @param prev - The previous value, if any.\n *\n * @param next - The next value.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",


### PR DESCRIPTION
Allocate the memory only once. This does mean we use more memory on average, but we only allocate it once instead of doing it on every change to shape / camera ....

A bit [more info](https://github.com/tldraw/tldraw/pull/3377#discussion_r1555513083).


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
