### PR TITLE
Add two simple perf helpers.

### DIFF
--- a/packages/store/api/api.json
+++ b/packages/store/api/api.json
@@ -4231,7 +4231,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@tldraw/store!Store#onBeforeChange:member",
-              "docComment": "/**\n * A callback before after each record's change.\n *\n * @param prev - The previous value, if any.\n *\n * @param next - The next value.\n */\n",
+              "docComment": "/**\n * A callback fired before each record's change.\n *\n * @param prev - The previous value, if any.\n *\n * @param next - The next value.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -176,6 +176,12 @@ export function mapObjectMapValues<Key extends string, ValueBefore, ValueAfter>(
     [K in Key]: ValueAfter;
 };
 
+// @internal (undocumented)
+export function measureCbDuration(name: string, cb: () => any): any;
+
+// @internal (undocumented)
+export function measureDuration(_target: any, propertyKey: string, descriptor: PropertyDescriptor): PropertyDescriptor;
+
 // @public
 export class MediaHelpers {
     static getImageSize(blob: Blob): Promise<{

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -36,6 +36,7 @@ export {
 	objectMapKeys,
 	objectMapValues,
 } from './lib/object'
+export { measureCbDuration, measureDuration } from './lib/perf'
 export { PngHelpers } from './lib/png'
 export { type IndexKey } from './lib/reordering/IndexKey'
 export {

--- a/packages/utils/src/lib/perf.ts
+++ b/packages/utils/src/lib/perf.ts
@@ -1,0 +1,22 @@
+/** @internal */
+export function measureCbDuration(name: string, cb: () => any) {
+	const now = performance.now()
+	const result = cb()
+	// eslint-disable-next-line no-console
+	console.log(`${name} took`, performance.now() - now, 'ms')
+	return result
+}
+
+/** @internal */
+export function measureDuration(_target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+	const originalMethod = descriptor.value
+	descriptor.value = function (...args: any[]) {
+		const start = performance.now()
+		const result = originalMethod.apply(this, args)
+		const end = performance.now()
+		// eslint-disable-next-line no-console
+		console.log(`${propertyKey} took ${end - start}ms `)
+		return result
+	}
+	return descriptor
+}


### PR DESCRIPTION
Can be useful for ad-hoc measuring of performance. One is a method decorator, which can be use on methods like so:

```typescript
  @measureDuration
  someLongRunningProccess() {
  // ....
  }
```

And the other offer more granular control. It also returns what the callback returns, so it can be use in assignments / return statements.

```typescript
return measureCbDuration('sorting took', () =>  renderingShapes.sort(sortById))
```


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [x] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

