### PR TITLE
Remove more note parenting code

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -38,9 +38,8 @@ export class PointingShape extends StateNode {
 			outermostSelectingShape.id === focusedGroupId ||
 			// ...or if the shape is within the selection
 			selectedShapeIds.includes(outermostSelectingShape.id) ||
-			// ...or if an ancestor of the shape is selected (except note shapes)...
-			// todo: Consider adding a flag for this hardcoded behaviour
-			(selectedAncestor && selectedAncestor.type !== 'note') ||
+			// ...or if an ancestor of the shape is selected
+			selectedAncestor ||
 			// ...or if the current point is NOT within the selection bounds
 			(selectedShapeIds.length > 1 && selectionBounds?.containsPoint(currentPagePoint))
 		) {

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -15,7 +15,7 @@ export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 			if (!parent) return shape
 			return parent
 		})
-		.filter((shape) => shape.type === 'frame' || shape.type === 'note')
+		.filter((shape) => shape.type === 'frame')
 
 	const kickedOutChildren: TLShapeId[] = []
 	for (const parent of effectedParents) {


### PR DESCRIPTION
This PR removes some extras that were used for note parenting.
 
### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
