### PR TITLE
Fix some tests

### DIFF
--- a/packages/editor/src/lib/components/CulledShapes.tsx
+++ b/packages/editor/src/lib/components/CulledShapes.tsx
@@ -90,7 +90,7 @@ function setupWebGl(canvas: HTMLCanvasElement | null, isDarkMode: boolean) {
 	}
 }
 
-export function CulledShapes() {
+function _CulledShapes() {
 	const editor = useEditor()
 	const isDarkMode = useIsDarkMode()
 	const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -176,4 +176,11 @@ export function CulledShapes() {
 	return isCullingOffScreenShapes ? (
 		<canvas ref={canvasRef} className="tl-culled-shapes__canvas" />
 	) : null
+}
+
+export function CulledShapes() {
+	if (process.env.NODE_ENV === 'test') {
+		return null
+	}
+	return _CulledShapes()
 }

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -179,6 +179,11 @@ function usePattern() {
 	const [backgroundUrls, setBackgroundUrls] = useState<PatternDef[]>(defaultPatterns)
 
 	useEffect(() => {
+		if (process.env.NODE_ENV === 'test') {
+			setIsReady(true)
+			return
+		}
+
 		const promises: Promise<{ zoom: number; url: string; darkMode: boolean }>[] = []
 
 		for (let i = 1; i <= Math.ceil(MAX_ZOOM); i++) {


### PR DESCRIPTION
This PR fixes some jest test.

- We skip the culling shapes in test environments.
- We skip rendering patterns in test environments.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `tests` — Changes to any test code