### PR TITLE
textfields: also let draw shapes not be in the way of text editing

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1102,9 +1102,11 @@ input,
 }
 /* This part of the rule helps preserve the occlusion rules for the shapes so we
  * don't click on shapes that are behind other shapes.
- * One extra nuance is arrows which have weird geometry and just gets in the way.
+ * One extra nuance is we don't use this behavior for:
+ *  - arrows which have weird geometry and just gets in the way.
+ *  - draw shapes, because it feels restrictive to have them be 'in the way' of clicking on a textfield
  */
-.tl-canvas[data-iseditinganything='true'] .tl-shape:not([data-shape-type='arrow']) {
+.tl-canvas[data-iseditinganything='true'] .tl-shape:not([data-shape-type='arrow']):not([data-shape-type='draw']) {
 	pointer-events: all;
 }
 /* But, re-disable the pointer-events rule for the svg container. */


### PR DESCRIPTION
Draw shapes shouldn't get in the way when going from EditingShape→EditingShape. They don't feel like they have the same occlusion rules. Hard to see in the gifs below but the geometry is occluding the sticky underneath like so:

<img width="588" alt="Screenshot 2024-04-08 at 16 39 51" src="https://github.com/tldraw/tldraw/assets/469604/2559725c-4706-43ae-9f7f-4961bd99471f">


before

https://github.com/tldraw/tldraw/assets/469604/04e760a6-70e7-48d8-89b0-b481193be7be




after

https://github.com/tldraw/tldraw/assets/469604/f9b2ecdd-d844-4d11-9bf2-c28d97751fbb



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
