### PR TITLE
Fix kickout helper for all rotated frames 

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -10,7 +10,7 @@ import {
 /** @internal */
 export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 	const shapes = shapeIds.map((id) => editor.getShape(id)).filter((s) => s) as TLShape[]
-	const effectedParents = shapes
+	const affectedParents = shapes
 		.map((shape) => {
 			const parent = editor.getShape(shape.parentId)
 			if (!parent) return shape
@@ -19,7 +19,7 @@ export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[]) {
 		.filter((shape) => shape.type === 'frame')
 
 	const kickedOutChildren: TLShapeId[] = []
-	for (const parent of effectedParents) {
+	for (const parent of affectedParents) {
 		const childIds = editor.getSortedChildIdsForParent(parent.id)
 
 		// Get the bounds of the parent shape


### PR DESCRIPTION
This PR fixes the kickout helper to make it work for rotated frames.

https://github.com/tldraw/tldraw/assets/15892272/2ec6f74f-9713-401c-a748-7c9d5c700fa8


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
