### PR TITLE
Allow "kickout" on every shape, not just frames, and add drag-and-drop example

### DIFF
--- a/apps/examples/src/examples/drag-and-drop/DragAndDropExample.tsx
+++ b/apps/examples/src/examples/drag-and-drop/DragAndDropExample.tsx
@@ -16,8 +16,8 @@ import 'tldraw/tldraw.css'
 type MyGridShape = TLBaseShape<'my-grid-shape', Record<string, never>>
 type MyCounterShape = TLBaseShape<'my-counter-shape', Record<string, never>>
 
-const COUNTER_SIZE = 100
-
+// [2]
+const SLOT_SIZE = 100
 class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 	static override type = 'my-counter-shape' as const
 
@@ -29,7 +29,7 @@ class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 	}
 
 	getGeometry(): Geometry2d {
-		return new Circle2d({ radius: COUNTER_SIZE / 2 - 10, isFilled: true })
+		return new Circle2d({ radius: SLOT_SIZE / 2 - 10, isFilled: true })
 	}
 
 	component() {
@@ -40,17 +40,16 @@ class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 					border: '1px solid #ff8787',
 					borderRadius: '50%',
 				}}
-			></HTMLContainer>
+			/>
 		)
 	}
 
 	indicator() {
-		return (
-			<circle r={COUNTER_SIZE / 2 - 10} cx={COUNTER_SIZE / 2 - 10} cy={COUNTER_SIZE / 2 - 10} />
-		)
+		return <circle r={SLOT_SIZE / 2 - 10} cx={SLOT_SIZE / 2 - 10} cy={SLOT_SIZE / 2 - 10} />
 	}
 }
 
+// [3]
 class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 	static override type = 'my-grid-shape' as const
 
@@ -60,8 +59,8 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 
 	getGeometry(): Geometry2d {
 		return new Rectangle2d({
-			width: COUNTER_SIZE * 5,
-			height: COUNTER_SIZE * 2,
+			width: SLOT_SIZE * 5,
+			height: SLOT_SIZE * 2,
 			isFilled: true,
 		})
 	}
@@ -69,6 +68,7 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 	override canResize = () => false
 	override hideResizeHandles = () => true
 
+	// [a]
 	override canDropShapes = (shape: MyGridShape, shapes: TLShape[]) => {
 		if (shapes.every((s) => s.type === 'my-counter-shape')) {
 			return true
@@ -76,12 +76,14 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 		return false
 	}
 
+	// [b]
 	override onDragShapesOver = (shape: MyGridShape, shapes: TLShape[]) => {
 		if (!shapes.every((child) => child.parentId === shape.id)) {
 			this.editor.reparentShapes(shapes, shape.id)
 		}
 	}
 
+	// [c]
 	override onDragShapesOut = (shape: MyGridShape, shapes: TLShape[]) => {
 		this.editor.reparentShapes(shapes, this.editor.getCurrentPageId())
 	}
@@ -93,18 +95,18 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 					backgroundColor: '#efefef',
 					borderRight: '1px solid #ccc',
 					borderBottom: '1px solid #ccc',
-					backgroundSize: `${COUNTER_SIZE}px ${COUNTER_SIZE}px`,
+					backgroundSize: `${SLOT_SIZE}px ${SLOT_SIZE}px`,
 					backgroundImage: `
 						linear-gradient(to right, #ccc 1px, transparent 1px),
 						linear-gradient(to bottom, #ccc 1px, transparent 1px)
 					`,
 				}}
-			></HTMLContainer>
+			/>
 		)
 	}
 
 	indicator() {
-		return <rect width={COUNTER_SIZE * 5} height={COUNTER_SIZE * 2} />
+		return <rect width={SLOT_SIZE * 5} height={SLOT_SIZE * 2} />
 	}
 }
 
@@ -125,5 +127,25 @@ export default function DragAndDropExample() {
 }
 
 /*
+
+This example demonstrates how to use the drag-and-drop system.
+
+[1] Define some shape types. For the purposes of this example, we'll define two
+shapes: a grid and a counter.
+
+[2] Make a shape util for the first shape. For this example, we'll make a simple
+red circle that you drag and drop onto the other shape.
+
+[3] Make the other shape util. In this example, we'll make a grid that you can
+place the the circle counters onto.
+
+    [a] Use the `canDropShapes` method to specify which shapes can be dropped onto
+    the grid shape.
+
+    [b] Use the `onDragShapesOver` method to reparent counters to the grid shape
+    when they are dragged on top.
+
+    [c] Use the `onDragShapesOut` method to reparent counters back to the page
+    when they are dragged off.
 
 */

--- a/apps/examples/src/examples/drag-and-drop/DragAndDropExample.tsx
+++ b/apps/examples/src/examples/drag-and-drop/DragAndDropExample.tsx
@@ -1,0 +1,129 @@
+import {
+	Circle2d,
+	Geometry2d,
+	HTMLContainer,
+	Rectangle2d,
+	ShapeUtil,
+	TLBaseShape,
+	TLShape,
+	Tldraw,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// There's a guide at the bottom of this file!
+
+// [1]
+type MyGridShape = TLBaseShape<'my-grid-shape', Record<string, never>>
+type MyCounterShape = TLBaseShape<'my-counter-shape', Record<string, never>>
+
+const COUNTER_SIZE = 100
+
+class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
+	static override type = 'my-counter-shape' as const
+
+	override canResize = () => false
+	override hideResizeHandles = () => true
+
+	getDefaultProps(): MyCounterShape['props'] {
+		return {}
+	}
+
+	getGeometry(): Geometry2d {
+		return new Circle2d({ radius: COUNTER_SIZE / 2 - 10, isFilled: true })
+	}
+
+	component() {
+		return (
+			<HTMLContainer
+				style={{
+					backgroundColor: '#e03131',
+					border: '1px solid #ff8787',
+					borderRadius: '50%',
+				}}
+			></HTMLContainer>
+		)
+	}
+
+	indicator() {
+		return (
+			<circle r={COUNTER_SIZE / 2 - 10} cx={COUNTER_SIZE / 2 - 10} cy={COUNTER_SIZE / 2 - 10} />
+		)
+	}
+}
+
+class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
+	static override type = 'my-grid-shape' as const
+
+	getDefaultProps(): MyGridShape['props'] {
+		return {}
+	}
+
+	getGeometry(): Geometry2d {
+		return new Rectangle2d({
+			width: COUNTER_SIZE * 5,
+			height: COUNTER_SIZE * 2,
+			isFilled: true,
+		})
+	}
+
+	override canResize = () => false
+	override hideResizeHandles = () => true
+
+	override canDropShapes = (shape: MyGridShape, shapes: TLShape[]) => {
+		if (shapes.every((s) => s.type === 'my-counter-shape')) {
+			return true
+		}
+		return false
+	}
+
+	override onDragShapesOver = (shape: MyGridShape, shapes: TLShape[]) => {
+		if (!shapes.every((child) => child.parentId === shape.id)) {
+			this.editor.reparentShapes(shapes, shape.id)
+		}
+	}
+
+	override onDragShapesOut = (shape: MyGridShape, shapes: TLShape[]) => {
+		this.editor.reparentShapes(shapes, this.editor.getCurrentPageId())
+	}
+
+	component() {
+		return (
+			<HTMLContainer
+				style={{
+					backgroundColor: '#efefef',
+					borderRight: '1px solid #ccc',
+					borderBottom: '1px solid #ccc',
+					backgroundSize: `${COUNTER_SIZE}px ${COUNTER_SIZE}px`,
+					backgroundImage: `
+						linear-gradient(to right, #ccc 1px, transparent 1px),
+						linear-gradient(to bottom, #ccc 1px, transparent 1px)
+					`,
+				}}
+			></HTMLContainer>
+		)
+	}
+
+	indicator() {
+		return <rect width={COUNTER_SIZE * 5} height={COUNTER_SIZE * 2} />
+	}
+}
+
+export default function DragAndDropExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={[MyGridShapeUtil, MyCounterShapeUtil]}
+				onMount={(editor) => {
+					editor.createShape({ type: 'my-grid-shape', x: 100, y: 100 })
+					editor.createShape({ type: 'my-counter-shape', x: 700, y: 100 })
+					editor.createShape({ type: 'my-counter-shape', x: 750, y: 200 })
+					editor.createShape({ type: 'my-counter-shape', x: 770, y: 300 })
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+
+*/

--- a/apps/examples/src/examples/drag-and-drop/README.md
+++ b/apps/examples/src/examples/drag-and-drop/README.md
@@ -1,0 +1,12 @@
+---
+title: Drag and drop
+component: ./DragAndDropExample.tsx
+category: shapes/tools
+priority: 1
+---
+
+Shapes that can be dragged and dropped onto each other.
+
+---
+
+You can create custom shapes that can be dragged and dropped onto each other.


### PR DESCRIPTION
> Stacked on top of https://github.com/tldraw/tldraw/pull/3405

This PR makes `kickoutOccludedShapes` shape-agnostic. It now runs on any shape that opts-in to the drag and drop manager by having an `onDragShapesOut` method. This is more of a bug fix than a feature.

This PR also adds an example for drag and drop.

https://github.com/tldraw/tldraw/assets/15892272/15b66be4-75bd-4c30-a594-340415bc5896


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
