### PR TITLE
textfields: only do pointer capture when not editing

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -160,9 +160,11 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 
 			// This is important so that when dragging a shape using the text label,
 			// the shape continues to be dragged, even if the cursor is over the UI.
-			setPointerCapture(e.currentTarget, e)
+			if (!isEditing) {
+				setPointerCapture(e.currentTarget, e)
+			}
 		},
-		[editor, id]
+		[editor, id, isEditing]
 	)
 
 	const handleDoubleClick = stopEventPropagation


### PR DESCRIPTION
Fixes https://linear.app/tldraw/issue/TLD-2374/can-lose-focus-and-caret

#focus-issues #blood-moat

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

