### PR TITLE
textfields: allow edit→edit to persist in empty geo; also increase hit target area

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -294,9 +294,12 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		const labelSize = getLabelSize(this.editor, shape)
-		const minWidth = 100
+		const minWidth = Math.min(100, w / 2)
 		const labelWidth = Math.min(w, Math.max(labelSize.w, Math.min(minWidth, Math.max(1, w - 8))))
-		const minHeight = LABEL_FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight + LABEL_PADDING * 2
+		const minHeight = Math.min(
+			LABEL_FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight + LABEL_PADDING * 2,
+			h / 2
+		)
 		const labelHeight = Math.min(h, Math.max(labelSize.h, Math.min(minHeight, Math.max(1, w - 8)))) // not sure if bug
 
 		const lines = getLines(shape.props, strokeWidth)

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -294,8 +294,10 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		const labelSize = getLabelSize(this.editor, shape)
-		const labelWidth = Math.min(w, Math.max(labelSize.w, Math.min(32, Math.max(1, w - 8))))
-		const labelHeight = Math.min(h, Math.max(labelSize.h, Math.min(32, Math.max(1, w - 8)))) // not sure if bug
+		const minWidth = 100
+		const labelWidth = Math.min(w, Math.max(labelSize.w, Math.min(minWidth, Math.max(1, w - 8))))
+		const minHeight = LABEL_FONT_SIZES[shape.props.size] * TEXT_PROPS.lineHeight + LABEL_PADDING * 2
+		const labelHeight = Math.min(h, Math.max(labelSize.h, Math.min(minHeight, Math.max(1, w - 8)))) // not sure if bug
 
 		const lines = getLines(shape.props, strokeWidth)
 		const edges = lines ? lines.map((line) => new Polyline2d({ points: line })) : []
@@ -386,8 +388,8 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const { fill, font, align, verticalAlign, size, text } = props
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 		const theme = useDefaultColorTheme()
-		const isEditing = this.editor.getEditingShapeId() === id
-		const showHtmlContainer = isEditing || shape.props.text
+		const isEditingAnything = this.editor.getEditingShapeId() !== null
+		const showHtmlContainer = isEditingAnything || shape.props.text
 
 		return (
 			<>

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -253,7 +253,7 @@ describe('when shape is hollow', () => {
 	})
 
 	it('misses on pointer down over shape, misses on pointer up', () => {
-		editor.pointerMove(75, 75)
+		editor.pointerMove(10, 10)
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([])
@@ -548,7 +548,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('misses on pointer down over shape, misses on pointer up', () => {
-		editor.pointerMove(50, 50)
+		editor.pointerMove(35, 35)
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown() // inside of box1 (which is empty)
 		expect(editor.getSelectedShapeIds()).toEqual([])
@@ -1235,7 +1235,7 @@ describe('when shift+selecting', () => {
 	it('does not add hollow shape to selection on pointer up when in empty space', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		editor.keyDown('Shift')
-		editor.pointerMove(275, 75) // above box 2
+		editor.pointerMove(215, 75) // above box 2
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -1256,7 +1256,7 @@ describe('when shift+selecting', () => {
 
 	it('does not add and remove hollow shape from selection on pointer up (without causing an edit by double clicks)', () => {
 		editor.keyDown('Shift')
-		editor.pointerMove(275, 75) // above box 2, empty space
+		editor.pointerMove(215, 75) // above box 2, empty space
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -1270,7 +1270,7 @@ describe('when shift+selecting', () => {
 
 	it('does not add and remove hollow shape from selection on double clicks (without causing an edit by double clicks)', () => {
 		editor.keyDown('Shift')
-		editor.pointerMove(275, 75) // above box 2, empty space
+		editor.pointerMove(215, 75) // above box 2, empty space
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.doubleClick()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -1304,7 +1304,7 @@ describe('when shift+selecting a group', () => {
 
 	it('does not add to selection on shift + on pointer up when clicking in hollow shape', () => {
 		editor.keyDown('Shift')
-		editor.pointerMove(275, 75)
+		editor.pointerMove(215, 75)
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown() // inside of box 2, inside of group 1
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -1333,7 +1333,7 @@ describe('when shift+selecting a group', () => {
 	})
 
 	it('does not select when shift+clicking into hollow shape inside of a group', () => {
-		editor.pointerMove(275, 75)
+		editor.pointerMove(215, 75)
 		editor.keyDown('Shift')
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown() // inside of box 2, empty space, inside of group 1
@@ -1344,7 +1344,7 @@ describe('when shift+selecting a group', () => {
 
 	it('does not deselect on pointer up when clicking into empty space in hollow shape', () => {
 		editor.keyDown('Shift')
-		editor.pointerMove(275, 75)
+		editor.pointerMove(215, 75)
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerDown() // inside of box 2, empty space, inside of group 1
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])


### PR DESCRIPTION
two things this PR does to enable better text editing on Geo shapes:
- when a geo shape is empty (no text), allow edit→edit to continue (simple change of isEditing→isEditingAnything)
- relatedly, increase the geometry size of an empty text label on geo shapes. This brings it inline with the text geometry of the new stickies so that they're consistent.

before:
<img width="605" alt="Screenshot 2024-04-09 at 09 58 50" src="https://github.com/tldraw/tldraw/assets/469604/a31aed14-4c55-41e0-9706-98ff8b74252e">


after:
<img width="581" alt="Screenshot 2024-04-09 at 09 58 39" src="https://github.com/tldraw/tldraw/assets/469604/d8812900-3f6d-4188-80b3-fda0f33ac340">


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
