### PR TITLE
textfields: paste text content onto selected shape

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -272,6 +272,22 @@ export function registerDefaultExternalContentHandlers(
 
 		const textToPaste = cleanupText(text)
 
+		// If we're pasting into a text shape, update the text.
+		const onlySelectedShape = editor.getOnlySelectedShape()
+		if (onlySelectedShape && 'text' in onlySelectedShape.props) {
+			editor.updateShapes([
+				{
+					id: onlySelectedShape.id,
+					type: onlySelectedShape.type,
+					props: {
+						text: textToPaste,
+					},
+				},
+			])
+
+			return
+		}
+
 		// Measure the text with default values
 		let w: number
 		let h: number


### PR DESCRIPTION
If there's a text on the clipboard, we now would allow that text to go into the shape itself instead of creating a new shape.

before:

https://github.com/tldraw/tldraw/assets/469604/6b8db088-f640-4527-8730-e7e176894e8f


after:

https://github.com/tldraw/tldraw/assets/469604/96c854e0-a11b-4a31-837b-5bef48e10dcd



Linear issue: TLD-2365

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

