### PR TITLE
Stickies: Emit `text-select-all` event

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2190,6 +2190,10 @@ export interface TLEventMap {
         count: number;
     }];
     // (undocumented)
+    'select-all-text': [{
+        shapeId: TLShapeId;
+    }];
+    // (undocumented)
     'stop-camera-animation': [];
     // (undocumented)
     'stop-following': [];

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -38965,6 +38965,42 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@tldraw/editor!TLEventMap#\"select-all-text\":member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "'select-all-text': "
+                },
+                {
+                  "kind": "Content",
+                  "text": "[{\n        shapeId: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLShapeId",
+                  "canonicalReference": "@tldraw/tlschema!TLShapeId:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n    }]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "\"select-all-text\"",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@tldraw/editor!TLEventMap#\"stop-camera-animation\":member",
               "docComment": "",
               "excerptTokens": [

--- a/packages/editor/src/lib/editor/types/emit-types.ts
+++ b/packages/editor/src/lib/editor/types/emit-types.ts
@@ -1,5 +1,5 @@
 import { HistoryEntry } from '@tldraw/store'
-import { TLPageId, TLRecord } from '@tldraw/tlschema'
+import { TLPageId, TLRecord, TLShapeId } from '@tldraw/tlschema'
 import { TLEventInfo } from './event-types'
 
 /** @public */
@@ -17,6 +17,7 @@ export interface TLEventMap {
 	frame: [number]
 	'change-history': [{ reason: 'undo' | 'redo' | 'push' } | { reason: 'bail'; markId?: string }]
 	'mark-history': [{ id: string }]
+	'select-all-text': [{ shapeId: TLShapeId }]
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -129,7 +129,7 @@ export function getNoteShapeForAdjacentPosition(
 	// Start from the top of the stack, and work our way down
 	const allShapesOnPage = editor.getCurrentPageShapesSorted()
 
-	const minDistance = NOTE_SIZE + ADJACENT_NOTE_MARGIN
+	const minDistance = NOTE_SIZE + ADJACENT_NOTE_MARGIN ** 2
 
 	for (let i = allShapesOnPage.length - 1; i >= 0; i--) {
 		const otherNote = allShapesOnPage[i]
@@ -137,7 +137,7 @@ export function getNoteShapeForAdjacentPosition(
 			const otherBounds = editor.getShapePageBounds(otherNote)
 			if (
 				otherBounds &&
-				otherBounds.center.dist(center) < minDistance &&
+				Vec.Dist2(otherBounds.center, center) < minDistance &&
 				editor.isPointInShape(otherNote, center)
 			) {
 				nextNote = otherNote

--- a/packages/tldraw/src/lib/shapes/shared/TextHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/shared/TextHelpers.ts
@@ -294,11 +294,7 @@ function getCaretIndex(element: HTMLElement) {
 }
 
 /** @internal */
-export function startEditingShapeWithLabel(
-	editor: Editor,
-	shape: TLShape,
-	shouldSelectAll?: boolean
-) {
+export function startEditingShapeWithLabel(editor: Editor, shape: TLShape, selectAll = false) {
 	// Finish this shape and start editing the next one
 	editor.select(shape)
 	editor.setEditingShape(shape)
@@ -306,12 +302,9 @@ export function startEditingShapeWithLabel(
 		target: 'shape',
 		shape: shape,
 	})
-
-	if (shouldSelectAll) {
-		// Select any text that's in the newly selected sticky
-		;(document.getElementById(`text-input-${shape.id}`) as HTMLTextAreaElement)?.select()
+	if (selectAll) {
+		editor.emit('select-all-text', { shapeId: shape.id })
 	}
-
 	zoomToShapeIfOffscreen(editor)
 }
 

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -110,7 +110,6 @@ export const TextLabel = React.memo(function TextLabel({
 				</div>
 				{(isEditingAnything || isSelected) && (
 					<TextArea
-						id={`text-input-${id}`}
 						ref={rInput}
 						// We need to add the initial value as the key here because we need this component to
 						// 'reset' when this state changes and grab the latest defaultValue.

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -88,7 +88,6 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 	}, [editor, id])
 
 	// When the user presses ctrl / meta enter, complete the editing state.
-	// When the user presses tab, indent or unindent the text.
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 			if (!isEditing) return

--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -19,6 +19,21 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 	const rInput = useRef<HTMLTextAreaElement>(null)
 	const rSelectionRanges = useRef<Range[] | null>()
 
+	useEffect(() => {
+		function selectAllIfEditing({ shapeId }: { shapeId: TLShapeId }) {
+			if (shapeId === id) {
+				const elm = rInput.current
+				if (elm) {
+					elm.select()
+				}
+			}
+		}
+		editor.on('select-all-text', selectAllIfEditing)
+		return () => {
+			editor.off('select-all-text', selectAllIfEditing)
+		}
+	}, [editor, id])
+
 	const isEditingAnything = useValue(
 		'isEditingAnything',
 		() => editor.getEditingShapeId() !== null,

--- a/packages/tldraw/src/lib/shapes/text/TextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextArea.tsx
@@ -2,7 +2,6 @@ import { preventDefault, stopEventPropagation } from '@tldraw/editor'
 import { forwardRef } from 'react'
 
 type TextAreaProps = {
-	id: string
 	isEditing: boolean
 	text: string
 	handleFocus: () => void
@@ -15,7 +14,6 @@ type TextAreaProps = {
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function TextArea(
 	{
-		id,
 		isEditing,
 		text,
 		handleFocus,
@@ -29,7 +27,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function 
 ) {
 	return (
 		<textarea
-			id={id}
 			ref={ref}
 			className="tl-text tl-text-input"
 			name="text"

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -163,13 +163,7 @@ export class PointingShape extends StateNode {
 										this.editor.setCurrentTool('select.editing_shape')
 
 										if (this.isDoubleClick) {
-											// XXX this is a hack to select the text in the textarea when we hit enter.
-											// Open to other ideas! I don't see how else to currently do this in the codebase.
-											;(
-												document.getElementById(
-													`text-input-${selectingShape.id}`
-												) as HTMLTextAreaElement
-											).select()
+											this.editor.emit('select-all-text', { shapeId: selectingShape.id })
 										}
 									})
 									return


### PR DESCRIPTION
This PR adds a `select-all-text` event that the editor emits when it intends for the editing shape's text to be selected. This replaces some temporary code that would query the shape's textarea element directly.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Test Plan

For geo shapes / arrows / note shapes (any shape with a label):
1. Press enter to select all of its text.
2. Double click the shape to select all of its text
3. Select a text shape and press enter
