### PR TITLE
Perf: block hit tests while moving camera

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -29,6 +29,7 @@
 	--layer-shapes: 300;
 	--layer-overlays: 400;
 	--layer-following-indicator: 1000;
+	--layer-blocker: 10000;
 	/* Misc */
 	--tl-zoom: 1;
 
@@ -1500,4 +1501,19 @@ it from receiving any pointer events or affecting the cursor. */
 	color: #555;
 	font-size: 12px;
 	font-family: monospace;
+}
+
+/* ---------------- Hit test blocker ---------------- */
+
+.tl-hit-test-blocker {
+	position: absolute;
+	z-index: var(--layer-blocker);
+	inset: 0px;
+	width: 100%;
+	height: 100%;
+	pointer-events: all;
+}
+
+.tl-hit-test-blocker__hidden {
+	display: none;
 }

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -17,7 +17,7 @@ import { Box } from '../../primitives/Box'
 import { Mat } from '../../primitives/Mat'
 import { Vec } from '../../primitives/Vec'
 import { toDomPrecision } from '../../primitives/utils'
-import { debugFlags } from '../../utils/debug-flags'
+import { debugFlags, featureFlags } from '../../utils/debug-flags'
 import { setStyleProperty } from '../../utils/dom'
 import { nearestMultiple } from '../../utils/nearestMultiple'
 import { CulledShapes } from '../CulledShapes'
@@ -137,6 +137,7 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 					</div>
 					<InFrontOfTheCanvasWrapper />
 				</div>
+				<MovingCameraHitTestBlocker />
 			</div>
 		</>
 	)
@@ -589,4 +590,24 @@ function InFrontOfTheCanvasWrapper() {
 	const { InFrontOfTheCanvas } = useEditorComponents()
 	if (!InFrontOfTheCanvas) return null
 	return <InFrontOfTheCanvas />
+}
+
+function MovingCameraHitTestBlocker() {
+	const editor = useEditor()
+	const shouldDisplay = useValue(
+		'should display',
+		() => featureFlags.blockHitTestsWhileMovingCamera.get(),
+		[editor]
+	)
+	const cameraState = useValue('camera state', () => editor.getCameraState(), [editor])
+
+	if (!shouldDisplay) return null
+
+	return (
+		<div
+			className={classNames('tl-hit-test-blocker', {
+				'tl-hit-test-blocker__hidden': cameraState === 'idle',
+			})}
+		/>
+	)
 }

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -17,7 +17,7 @@ import { Box } from '../../primitives/Box'
 import { Mat } from '../../primitives/Mat'
 import { Vec } from '../../primitives/Vec'
 import { toDomPrecision } from '../../primitives/utils'
-import { debugFlags, featureFlags } from '../../utils/debug-flags'
+import { debugFlags } from '../../utils/debug-flags'
 import { setStyleProperty } from '../../utils/dom'
 import { nearestMultiple } from '../../utils/nearestMultiple'
 import { CulledShapes } from '../CulledShapes'
@@ -594,14 +594,7 @@ function InFrontOfTheCanvasWrapper() {
 
 function MovingCameraHitTestBlocker() {
 	const editor = useEditor()
-	const shouldDisplay = useValue(
-		'should display',
-		() => featureFlags.blockHitTestsWhileMovingCamera.get(),
-		[editor]
-	)
 	const cameraState = useValue('camera state', () => editor.getCameraState(), [editor])
-
-	if (!shouldDisplay) return null
 
 	return (
 		<div

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -9,7 +9,7 @@ import { deleteFromSessionStorage, getFromSessionStorage, setInSessionStorage } 
 // `true` by default in development and staging, and `false` in production.
 /** @internal */
 export const featureFlags: Record<string, DebugFlag<boolean>> = {
-	// canMoveArrowLabel: createFeatureFlag('canMoveArrowLabel'),
+	blockHitTestsWhileMovingCamera: createFeatureFlag('moving camera blocker'),
 }
 
 /** @internal */
@@ -104,16 +104,16 @@ function createDebugValue<T>(
 	})
 }
 
-// function createFeatureFlag(
-// 	name: string,
-// 	defaults: Defaults<boolean> = { all: true, production: false }
-// ) {
-// 	return createDebugValueBase({
-// 		name,
-// 		defaults,
-// 		shouldStoreForSession: true,
-// 	})
-// }
+function createFeatureFlag(
+	name: string,
+	defaults: Defaults<boolean> = { all: true, production: false }
+) {
+	return createDebugValueBase({
+		name,
+		defaults,
+		shouldStoreForSession: true,
+	})
+}
 
 function createDebugValueBase<T>(def: DebugFlagDef<T>): DebugFlag<T> {
 	const defaultValue = getDefaultValue(def)

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -8,7 +8,9 @@ import { deleteFromSessionStorage, getFromSessionStorage, setInSessionStorage } 
 // development. Use `createFeatureFlag` to create a boolean flag which will be
 // `true` by default in development and staging, and `false` in production.
 /** @internal */
-export const featureFlags: Record<string, DebugFlag<boolean>> = {}
+export const featureFlags: Record<string, DebugFlag<boolean>> = {
+	// canMoveArrowLabel: createFeatureFlag('canMoveArrowLabel'),
+}
 
 /** @internal */
 export const pointerCaptureTrackingObject = createDebugValue(
@@ -102,17 +104,16 @@ function createDebugValue<T>(
 	})
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function createFeatureFlag(
-	name: string,
-	defaults: Defaults<boolean> = { all: true, production: false }
-) {
-	return createDebugValueBase({
-		name,
-		defaults,
-		shouldStoreForSession: true,
-	})
-}
+// function createFeatureFlag(
+// 	name: string,
+// 	defaults: Defaults<boolean> = { all: true, production: false }
+// ) {
+// 	return createDebugValueBase({
+// 		name,
+// 		defaults,
+// 		shouldStoreForSession: true,
+// 	})
+// }
 
 function createDebugValueBase<T>(def: DebugFlagDef<T>): DebugFlag<T> {
 	const defaultValue = getDefaultValue(def)

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -8,9 +8,7 @@ import { deleteFromSessionStorage, getFromSessionStorage, setInSessionStorage } 
 // development. Use `createFeatureFlag` to create a boolean flag which will be
 // `true` by default in development and staging, and `false` in production.
 /** @internal */
-export const featureFlags: Record<string, DebugFlag<boolean>> = {
-	blockHitTestsWhileMovingCamera: createFeatureFlag('moving camera blocker'),
-}
+export const featureFlags: Record<string, DebugFlag<boolean>> = {}
 
 /** @internal */
 export const pointerCaptureTrackingObject = createDebugValue(
@@ -104,6 +102,7 @@ function createDebugValue<T>(
 	})
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function createFeatureFlag(
 	name: string,
 	defaults: Defaults<boolean> = { all: true, production: false }


### PR DESCRIPTION
This PR uses an element that prevents hit tests on shapes while the camera is moving.

https://github.com/tldraw/tldraw/assets/23072548/9905f3d4-ba64-4e4d-ae99-194f513eaac8

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features


### Test Plan

1. Move the camera.
2. Interact with the canvas.
3. Zoom in and out.

### Release Notes

- Improves performance of canvas while the camera is moving.