### PR TITLE
Fix text bug on iOS

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8386,7 +8386,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	dispatch = (info: TLEventInfo): this => {
 		this._pendingEventsForNextTick.push(info)
-		if (!(info.type === 'pointer' || info.type === 'wheel' || info.type === 'pinch')) {
+		if (
+			!(
+				(info.type === 'pointer' && info.name === 'pointer_move') ||
+				info.type === 'wheel' ||
+				info.type === 'pinch'
+			)
+		) {
 			this._flushEventsForTick(0)
 		}
 		return this


### PR DESCRIPTION
In this PR, we no longer buffer pointer down/ups. We now batch only `pointer_move`, `wheel`, and `pinch` events.

Batched inputs were causing text not to work on iOS. On iOS, the keyboard is only shown if we call `focus` during the same event loop as a user input. 

### Change Type
- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

1. Use text on iOS.
