### PR TITLE
Fix cursor chat in context menu.

### DIFF
--- a/apps/dotcom/src/utils/context-menu/CursorChatMenuItem.tsx
+++ b/apps/dotcom/src/utils/context-menu/CursorChatMenuItem.tsx
@@ -7,7 +7,7 @@ export function CursorChatMenuItem() {
 	const shouldShow = useValue(
 		'show cursor chat',
 		() => {
-			return editor.getInstanceState().isCoarsePointer && !editor.getSelectedShapes().length
+			return !editor.getInstanceState().isCoarsePointer
 		},
 		[editor]
 	)


### PR DESCRIPTION
This PR fixes flipped boolean logic for displaying the cursor chat option on coarse pointer devices.

### Change Type

- [x] `dotcom` — Changes the tldraw.com web app
- [x] `bugfix` — Bug fix