### PR TITLE
Performance measuring: The Torture Chamber

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -331,29 +331,6 @@ function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function createNShapesForUncullingTest(editor: Editor, n: number, offset = 0) {
-	const shapesToCreate: TLShapePartial[] = Array(n)
-	const cols = Math.floor(Math.sqrt(n))
-
-	for (let i = 0; i < n; i++) {
-		t++
-		shapesToCreate[i] = {
-			id: createShapeId('box' + t),
-			type: 'geo',
-			x: (i % cols) * 50 + offset,
-			y: Math.floor(i / cols) * 132,
-			props: {
-				w: 200,
-				h: 200,
-			},
-		}
-	}
-
-	editor.batch(() => {
-		editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
-	})
-}
-
 async function uncullingTest(editor: Editor) {
 	fpsTracker.reset()
 	const newPageId = setupPage(editor)

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -325,11 +325,17 @@ async function panningTest(editor: Editor) {
 	editor.selectNone()
 	editor.setCamera({ x: 18000, y: 200, z: 0.1 })
 
+	const timeStart = performance.now()
 	for (let i = 0; i < 100; i++) {
 		const pingPong = i % 2 === 0
 		editor.setCamera({ x: pingPong ? 6000 : 18000, y: 200 })
 		await sleep(100)
 	}
+	const timeEnd = performance.now()
+
+	removePage(editor, newPageId)
+
+	alert(`timeTaken ${timeEnd - timeStart}`)
 
 	// removePage(editor, newPageId)
 

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -298,8 +298,12 @@ function createNShapes(editor: Editor, n: number, offset = 0) {
 		shapesToCreate[i] = {
 			id: createShapeId('box' + t),
 			type: 'geo',
-			x: (i % cols) * 132 + offset,
+			x: (i % cols) * 50 + offset,
 			y: Math.floor(i / cols) * 132,
+			props: {
+				w: 200,
+				h: 200,
+			},
 		}
 	}
 
@@ -308,28 +312,41 @@ function createNShapes(editor: Editor, n: number, offset = 0) {
 	})
 }
 
-function panningTest(editor: Editor) {
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function panningTest(editor: Editor) {
 	// hey run this 10 times
 	const newPageId = setupPage(editor)
 
 	createNShapes(editor, 1000)
-	createNShapes(editor, 1000, 8200)
+	createNShapes(editor, 1000, 10)
 	editor.selectNone()
-	editor.setCamera({ x: 0, y: 0, z: 0.25 })
-	setTimeout(() => {
-		performance.mark('panning-start')
-		editor.setCamera({ x: -8200, y: 0 })
-		requestAnimationFrame(() => {
-			performance.mark('panning-end')
-			// the rendering frame was sometimes 1 frame later, sometimes 2 frames later, not sure why, don't know how to test this
-			measureFrameTime((deltaTime) => {
-				console.log(`Time elapsed since last frame: ${deltaTime} ms`)
-			})
-			const measure = performance.measure('panning', 'panning-start', 'panning-end')
-			console.log(measure)
-			removePage(editor, newPageId)
-		})
-	}, 1000)
+	editor.setCamera({ x: 18000, y: 200, z: 0.1 })
+
+	for (let i = 0; i < 100; i++) {
+		const pingPong = i % 2 === 0
+		editor.setCamera({ x: pingPong ? 6000 : 18000, y: 200 })
+		await sleep(100)
+	}
+
+	// removePage(editor, newPageId)
+
+	// setTimeout(() => {
+	// 	performance.mark('panning-start')
+	// 	editor.setCamera({ x: -8200, y: 0 })
+	// 	requestAnimationFrame(() => {
+	// 		performance.mark('panning-end')
+	// 		// the rendering frame was sometimes 1 frame later, sometimes 2 frames later, not sure why, don't know how to test this
+	// 		measureFrameTime((deltaTime) => {
+	// 			console.log(`Time elapsed since last frame: ${deltaTime} ms`)
+	// 		})
+	// 		const measure = performance.measure('panning', 'panning-start', 'panning-end')
+	// 		// console.log(measure)
+	// 		removePage(editor, newPageId)
+	// 	})
+	// }, 1000)
 }
 
 function measureFrameTime(callback: (deltaTime: number) => void) {

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -313,16 +313,38 @@ function panningTest(editor: Editor) {
 	const newPageId = setupPage(editor)
 
 	createNShapes(editor, 1000)
-	createNShapes(editor, 1000, 4100)
+	createNShapes(editor, 1000, 8200)
 	editor.selectNone()
-	performance.mark('panning-start')
-	editor.setCamera({ x: -4000, y: -1000 })
-	requestAnimationFrame(() => {
-		performance.mark('panning-end')
-		const measure = performance.measure('panning', 'panning-start', 'panning-end')
-		console.log(measure)
-		removePage(editor, newPageId)
-	})
+	editor.setCamera({ x: 0, y: 0, z: 0.25 })
+	setTimeout(() => {
+		performance.mark('panning-start')
+		editor.setCamera({ x: -8200, y: 0 })
+		requestAnimationFrame(() => {
+			performance.mark('panning-end')
+			// the rendering frame was sometimes 1 frame later, sometimes 2 frames later, not sure why, don't know how to test this
+			measureFrameTime((deltaTime) => {
+				console.log(`Time elapsed since last frame: ${deltaTime} ms`)
+			})
+			const measure = performance.measure('panning', 'panning-start', 'panning-end')
+			console.log(measure)
+			removePage(editor, newPageId)
+		})
+	}, 1000)
+}
+
+function measureFrameTime(callback: (deltaTime: number) => void) {
+	let lastTimestamp: number | null = null
+
+	function frame(timestamp: number) {
+		if (lastTimestamp !== null) {
+			const deltaTime = timestamp - lastTimestamp
+			callback(deltaTime)
+		}
+		lastTimestamp = timestamp
+		requestAnimationFrame(frame)
+	}
+
+	requestAnimationFrame(frame)
 }
 
 const setupPage = (editor: Editor) => {

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -313,30 +313,30 @@ function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function uncullingTest(editor: Editor) {
-	function createNShapesForUncullingTest(editor: Editor, n: number, offset = 0) {
-		const shapesToCreate: TLShapePartial[] = Array(n)
-		const cols = Math.floor(Math.sqrt(n))
+function createNShapesForUncullingTest(editor: Editor, n: number, offset = 0) {
+	const shapesToCreate: TLShapePartial[] = Array(n)
+	const cols = Math.floor(Math.sqrt(n))
 
-		for (let i = 0; i < n; i++) {
-			t++
-			shapesToCreate[i] = {
-				id: createShapeId('box' + t),
-				type: 'geo',
-				x: (i % cols) * 50 + offset,
-				y: Math.floor(i / cols) * 132,
-				props: {
-					w: 200,
-					h: 200,
-				},
-			}
+	for (let i = 0; i < n; i++) {
+		t++
+		shapesToCreate[i] = {
+			id: createShapeId('box' + t),
+			type: 'geo',
+			x: (i % cols) * 50 + offset,
+			y: Math.floor(i / cols) * 132,
+			props: {
+				w: 200,
+				h: 200,
+			},
 		}
-
-		editor.batch(() => {
-			editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
-		})
 	}
 
+	editor.batch(() => {
+		editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
+	})
+}
+
+async function uncullingTest(editor: Editor) {
 	const newPageId = setupPage(editor)
 	createNShapesForUncullingTest(editor, 1000)
 	createNShapesForUncullingTest(editor, 1000, 10)

--- a/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
@@ -2,6 +2,29 @@ import { debugFlags, track, useEditor, useValue, Vec } from '@tldraw/editor'
 import { memo, useEffect, useRef, useState } from 'react'
 import { useTldrawUiComponents } from '../context/components'
 
+export class FpsTracker {
+	private fpsValues: number[]
+
+	constructor() {
+		this.fpsValues = []
+	}
+
+	reset() {
+		this.fpsValues = []
+	}
+
+	addFpsValue(value: number) {
+		this.fpsValues.push(value)
+	}
+
+	getAverageFps() {
+		return this.fpsValues.length > 0
+			? this.fpsValues.reduce((a, b) => a + b, 0) / this.fpsValues.length
+			: 0
+	}
+}
+export const fpsTracker = new FpsTracker()
+
 /** @internal */
 export const DefaultDebugPanel = memo(function DefaultDebugPanel() {
 	const { DebugMenu } = useTldrawUiComponents()
@@ -96,7 +119,7 @@ function FPS() {
 				if (fps > maxKnownFps) {
 					maxKnownFps = fps
 				}
-
+				fpsTracker.addFpsValue(fps)
 				const slowFps = maxKnownFps * 0.75
 				if ((fps < slowFps && !isSlow) || (fps >= slowFps && isSlow)) {
 					isSlow = !isSlow


### PR DESCRIPTION
An idea for how we might automate performance testing in the future. Thanks to Lu and Mitja for their help on this. 

The debug menu holds a few tests that automate zoom panning and zooming behaviour, they then output either the average FPS over the course of the test, or how long the test took. Depending on which is relevant.

The flow for working on performance in the future could look something like:

1. Decide on the behaviour you want to test.
2. Does a performance test exist for it already? If not write a new one.
3. Run the test on several devices on main and get your benchmark
4. Use chrome dev tools to diagnose where the bottlenecks are and optimise
5. Run tests again to confirm
6. If successful put these numbers in you PR

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
7.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
