### PR TITLE
No batches?

### DIFF
--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -7478,7 +7478,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", 'selectedShapeIds'>>, historyOptions?: "
+                  "text": ", 'selectedShapeIds'>>, options?: "
                 },
                 {
                   "kind": "Reference",
@@ -8009,71 +8009,6 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "bailToMark"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@tldraw/editor!Editor#batch:member(1)",
-              "docComment": "/**\n * Run a function in a batch, which will be undone/redone as a single action.\n *\n * @example\n * ```ts\n * editor.batch(() => {\n * \teditor.selectAll()\n * \teditor.deleteShapes(editor.getSelectedShapeIds())\n * \teditor.createShapes(myShapes)\n * \teditor.selectNone()\n * })\n *\n * editor.undo() // will undo all of the above\n * ```\n *\n * @public\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "batch(fn: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", opts?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLHistoryBatchOptions",
-                  "canonicalReference": "@tldraw/editor!~TLHistoryBatchOptions:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "this"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 6
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "fn",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                },
-                {
-                  "parameterName": "opts",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 3,
-                    "endIndex": 4
-                  },
-                  "isOptional": true
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "batch"
             },
             {
               "kind": "Method",
@@ -15410,7 +15345,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!Editor#nudgeShapes:member(1)",
-              "docComment": "/**\n * Move shapes by a delta.\n *\n * @param shapes - The shapes (or shape ids) to move.\n *\n * @param direction - The direction in which to move the shapes.\n *\n * @param historyOptions - The history options for the change.\n *\n * @example\n * ```ts\n * editor.nudgeShapes(['box1', 'box2'], { x: 8, y: 8 })\n * ```\n *\n */\n",
+              "docComment": "/**\n * Move shapes by a delta.\n *\n * @param shapes - The shapes (or shape ids) to move.\n *\n * @param direction - The direction in which to move the shapes.\n *\n * @example\n * ```ts\n * editor.nudgeShapes(['box1', 'box2'], { x: 8, y: 8 })\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18058,7 +17993,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<this>"
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLRecord",
+                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
                 },
                 {
                   "kind": "Content",
@@ -18071,7 +18015,7 @@
               "name": "sideEffects",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 3
+                "endIndex": 5
               },
               "isStatic": false,
               "isProtected": false,
@@ -18997,7 +18941,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", historyOptions?: "
+                  "text": ", options?: "
                 },
                 {
                   "kind": "Reference",
@@ -19035,7 +18979,7 @@
                   "isOptional": false
                 },
                 {
-                  "parameterName": "historyOptions",
+                  "parameterName": "options",
                   "parameterTypeTokenRange": {
                     "startIndex": 8,
                     "endIndex": 9
@@ -23841,45 +23785,6 @@
               "isAbstract": false
             },
             {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!HistoryManager#batch:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "batch: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(fn: () => void, opts?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLHistoryBatchOptions",
-                  "canonicalReference": "@tldraw/editor!~TLHistoryBatchOptions:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => this"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "batch",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
               "kind": "Method",
               "canonicalReference": "@tldraw/editor!HistoryManager#clear:member(1)",
               "docComment": "",
@@ -24081,13 +23986,13 @@
               "isAbstract": false
             },
             {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!HistoryManager#onBatchComplete:member",
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!HistoryManager#record:member(1)",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "onBatchComplete: "
+                  "text": "record(fn: "
                 },
                 {
                   "kind": "Content",
@@ -24095,20 +24000,86 @@
                 },
                 {
                   "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "this"
+                },
+                {
+                  "kind": "Content",
                   "text": ";"
                 }
               ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "onBatchComplete",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
               "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
               "isProtected": false,
-              "isAbstract": false
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "fn",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "record"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!HistoryManager#recordPreservingRedoStack:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "recordPreservingRedoStack(fn: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "this"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "fn",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "recordPreservingRedoStack"
             },
             {
               "kind": "Property",
@@ -24139,6 +24110,79 @@
               "isStatic": false,
               "isProtected": false,
               "isAbstract": false
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!HistoryManager#runInMode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "runInMode(mode: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "null | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLHistoryMode",
+                  "canonicalReference": "@tldraw/editor!~TLHistoryMode:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", fn: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "this"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 7,
+                "endIndex": 8
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "mode",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "fn",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "runInMode"
             },
             {
               "kind": "Property",
@@ -32838,20 +32882,12 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare class SideEffectManager<CTX extends "
-            },
-            {
-              "kind": "Content",
-              "text": "{\n    store: "
+              "text": "export declare class SideEffectManager<R extends "
             },
             {
               "kind": "Reference",
-              "text": "TLStore",
-              "canonicalReference": "@tldraw/tlschema!TLStore:type"
-            },
-            {
-              "kind": "Content",
-              "text": ";\n    history: {\n        onBatchComplete: () => void;\n    };\n}"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -32862,10 +32898,10 @@
           "releaseTag": "Public",
           "typeParameters": [
             {
-              "typeParameterName": "CTX",
+              "typeParameterName": "R",
               "constraintTokenRange": {
                 "startIndex": 1,
-                "endIndex": 4
+                "endIndex": 2
               },
               "defaultTypeTokenRange": {
                 "startIndex": 0,
@@ -32884,11 +32920,16 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "constructor(editor: "
+                  "text": "constructor(store: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Store",
+                  "canonicalReference": "@tldraw/store!Store:class"
                 },
                 {
                   "kind": "Content",
-                  "text": "CTX"
+                  "text": "<R>"
                 },
                 {
                   "kind": "Content",
@@ -32900,71 +32941,14 @@
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "editor",
+                  "parameterName": "store",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 2
+                    "endIndex": 3
                   },
                   "isOptional": false
                 }
               ]
-            },
-            {
-              "kind": "Property",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#editor:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "editor: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "CTX"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "editor",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#history:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "history: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "{\n        onBatchComplete: () => void;\n    }"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "history",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
             },
             {
               "kind": "Method",
@@ -32976,13 +32960,8 @@
                   "text": "registerAfterChangeHandler<T extends "
                 },
                 {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
                   "kind": "Content",
-                  "text": "['typeName']"
+                  "text": "R['typeName']"
                 },
                 {
                   "kind": "Content",
@@ -33003,16 +32982,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
+                  "text": "<R & {\n        typeName: T;\n    }>"
                 },
                 {
                   "kind": "Content",
@@ -33032,7 +33002,7 @@
                   "typeParameterName": "T",
                   "constraintTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 3
+                    "endIndex": 2
                   },
                   "defaultTypeTokenRange": {
                     "startIndex": 0,
@@ -33042,8 +33012,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 8,
+                "endIndex": 9
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -33052,16 +33022,16 @@
                 {
                   "parameterName": "typeName",
                   "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "handler",
                   "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
+                    "startIndex": 5,
+                    "endIndex": 7
                   },
                   "isOptional": false
                 }
@@ -33080,13 +33050,8 @@
                   "text": "registerAfterCreateHandler<T extends "
                 },
                 {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
                   "kind": "Content",
-                  "text": "['typeName']"
+                  "text": "R['typeName']"
                 },
                 {
                   "kind": "Content",
@@ -33107,16 +33072,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
+                  "text": "<R & {\n        typeName: T;\n    }>"
                 },
                 {
                   "kind": "Content",
@@ -33136,7 +33092,7 @@
                   "typeParameterName": "T",
                   "constraintTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 3
+                    "endIndex": 2
                   },
                   "defaultTypeTokenRange": {
                     "startIndex": 0,
@@ -33146,8 +33102,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 8,
+                "endIndex": 9
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -33156,16 +33112,16 @@
                 {
                   "parameterName": "typeName",
                   "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "handler",
                   "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
+                    "startIndex": 5,
+                    "endIndex": 7
                   },
                   "isOptional": false
                 }
@@ -33184,13 +33140,8 @@
                   "text": "registerAfterDeleteHandler<T extends "
                 },
                 {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
                   "kind": "Content",
-                  "text": "['typeName']"
+                  "text": "R['typeName']"
                 },
                 {
                   "kind": "Content",
@@ -33211,16 +33162,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
+                  "text": "<R & {\n        typeName: T;\n    }>"
                 },
                 {
                   "kind": "Content",
@@ -33240,7 +33182,7 @@
                   "typeParameterName": "T",
                   "constraintTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 3
+                    "endIndex": 2
                   },
                   "defaultTypeTokenRange": {
                     "startIndex": 0,
@@ -33250,8 +33192,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 8,
+                "endIndex": 9
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -33260,16 +33202,16 @@
                 {
                   "parameterName": "typeName",
                   "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
+                    "startIndex": 3,
+                    "endIndex": 4
                   },
                   "isOptional": false
                 },
                 {
                   "parameterName": "handler",
                   "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
+                    "startIndex": 5,
+                    "endIndex": 7
                   },
                   "isOptional": false
                 }
@@ -33280,17 +33222,287 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBatchCompleteHandler:member(1)",
-              "docComment": "/**\n * Register a handler to be called when a store completes a batch.\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * let count = 0\n *\n * editor.cleanup.registerBatchCompleteHandler(() => count++)\n *\n * editor.selectAll()\n * expect(count).toBe(1)\n *\n * editor.batch(() => {\n * \teditor.selectNone()\n * \teditor.selectAll()\n * })\n *\n * expect(count).toBe(2)\n * ```\n *\n * @public\n */\n",
+              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeChangeHandler:member(1)",
+              "docComment": "/**\n * Register a handler to be called before a record is changed. The handler is given the old and new record - you can return a modified record to apply a different update, or the old record to block the update entirely.\n *\n * Use this handler only for intercepting updates to the record itself. If you want to update other records in response to a change, use {@link SideEffectManager.registerAfterChangeHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeChangeHandler('shape', (prev, next, source) => {\n *     if (next.isLocked && !prev.isLocked) {\n *         // prevent shapes from ever being locked:\n *         return prev\n *     }\n *     // other types of change are allowed\n *     return next\n * })\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "registerBatchCompleteHandler(handler: "
+                  "text": "registerBeforeChangeHandler<T extends "
+                },
+                {
+                  "kind": "Content",
+                  "text": "R['typeName']"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">(typeName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", handler: "
                 },
                 {
                   "kind": "Reference",
-                  "text": "TLBatchCompleteHandler",
-                  "canonicalReference": "@tldraw/editor!TLBatchCompleteHandler:type"
+                  "text": "TLBeforeChangeHandler",
+                  "canonicalReference": "@tldraw/editor!TLBeforeChangeHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<R & {\n        typeName: T;\n    }>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "typeParameters": [
+                {
+                  "typeParameterName": "T",
+                  "constraintTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 8,
+                "endIndex": 9
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "typeName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "handler",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 7
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "registerBeforeChangeHandler"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeCreateHandler:member(1)",
+              "docComment": "/**\n * Register a handler to be called before a record of a certain type is created. Return a modified record from the handler to change the record that will be created.\n *\n * Use this handle only to modify the creation of the record itself. If you want to trigger a side-effect on a different record (for example, moving one shape when another is created), use {@link SideEffectManager.registerAfterCreateHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeCreateHandler('shape', (shape, source) => {\n *     // only modify shapes created by the user\n *     if (source !== 'user') return shape\n *\n *     //by default, arrow shapes have no label. Let's make sure they always have a label.\n *     if (shape.type === 'arrow') {\n *         return {...shape, props: {...shape.props, text: 'an arrow'}}\n *     }\n *\n *     // other shapes get returned unmodified\n *     return shape\n * })\n * ```\n *\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "registerBeforeCreateHandler<T extends "
+                },
+                {
+                  "kind": "Content",
+                  "text": "R['typeName']"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">(typeName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", handler: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLBeforeCreateHandler",
+                  "canonicalReference": "@tldraw/editor!TLBeforeCreateHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<R & {\n        typeName: T;\n    }>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "typeParameters": [
+                {
+                  "typeParameterName": "T",
+                  "constraintTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 8,
+                "endIndex": 9
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "typeName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "handler",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 7
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "registerBeforeCreateHandler"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeDeleteHandler:member(1)",
+              "docComment": "/**\n * Register a handler to be called before a record is deleted. The handler can return `false` to prevent the deletion.\n *\n * Use this handler only for intercepting deletions of the record itself. If you want to do something to other records in response to a deletion, use {@link SideEffectManager.registerAfterDeleteHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeDeleteHandler('shape', (shape, source) => {\n *     if (shape.props.color === 'red') {\n *         // prevent red shapes from being deleted\n * \t       return false\n *     }\n * })\n * ```\n *\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "registerBeforeDeleteHandler<T extends "
+                },
+                {
+                  "kind": "Content",
+                  "text": "R['typeName']"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">(typeName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", handler: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLBeforeDeleteHandler",
+                  "canonicalReference": "@tldraw/editor!TLBeforeDeleteHandler:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<R & {\n        typeName: T;\n    }>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "typeParameters": [
+                {
+                  "typeParameterName": "T",
+                  "constraintTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 8,
+                "endIndex": 9
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "typeName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "handler",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 7
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "registerBeforeDeleteHandler"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!SideEffectManager#registerCompleteHandler:member(1)",
+              "docComment": "/**\n * Register a handler to be called when the store completes an operation.\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * let count = 0\n *\n * editor.cleanup.registerBatchCompleteHandler(() => count++)\n *\n * editor.selectAll()\n * expect(count).toBe(1)\n *\n * editor.store.atomic(() => {\n * \teditor.selectNone()\n * \teditor.selectAll()\n * })\n *\n * expect(count).toBe(2)\n * ```\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "registerCompleteHandler(handler: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TLCompleteHandler",
+                  "canonicalReference": "@tldraw/editor!~TLCompleteHandler:type"
                 },
                 {
                   "kind": "Content",
@@ -33325,347 +33537,42 @@
               ],
               "isOptional": false,
               "isAbstract": false,
-              "name": "registerBatchCompleteHandler"
+              "name": "registerCompleteHandler"
             },
             {
-              "kind": "Method",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeChangeHandler:member(1)",
-              "docComment": "/**\n * Register a handler to be called before a record is changed. The handler is given the old and new record - you can return a modified record to apply a different update, or the old record to block the update entirely.\n *\n * Use this handler only for intercepting updates to the record itself. If you want to update other records in response to a change, use {@link SideEffectManager.registerAfterChangeHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeChangeHandler('shape', (prev, next, source) => {\n *     if (next.isLocked && !prev.isLocked) {\n *         // prevent shapes from ever being locked:\n *         return prev\n *     }\n *     // other types of change are allowed\n *     return next\n * })\n * ```\n *\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "registerBeforeChangeHandler<T extends "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "['typeName']"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">(typeName: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", handler: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLBeforeChangeHandler",
-                  "canonicalReference": "@tldraw/editor!TLBeforeChangeHandler:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "typeParameters": [
-                {
-                  "typeParameterName": "T",
-                  "constraintTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 3
-                  },
-                  "defaultTypeTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  }
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "typeName",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
-                  },
-                  "isOptional": false
-                },
-                {
-                  "parameterName": "handler",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "registerBeforeChangeHandler"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeCreateHandler:member(1)",
-              "docComment": "/**\n * Register a handler to be called before a record of a certain type is created. Return a modified record from the handler to change the record that will be created.\n *\n * Use this handle only to modify the creation of the record itself. If you want to trigger a side-effect on a different record (for example, moving one shape when another is created), use {@link SideEffectManager.registerAfterCreateHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeCreateHandler('shape', (shape, source) => {\n *     // only modify shapes created by the user\n *     if (source !== 'user') return shape\n *\n *     //by default, arrow shapes have no label. Let's make sure they always have a label.\n *     if (shape.type === 'arrow') {\n *         return {...shape, props: {...shape.props, text: 'an arrow'}}\n *     }\n *\n *     // other shapes get returned unmodified\n *     return shape\n * })\n * ```\n *\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "registerBeforeCreateHandler<T extends "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "['typeName']"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">(typeName: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", handler: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLBeforeCreateHandler",
-                  "canonicalReference": "@tldraw/editor!TLBeforeCreateHandler:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "typeParameters": [
-                {
-                  "typeParameterName": "T",
-                  "constraintTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 3
-                  },
-                  "defaultTypeTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  }
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "typeName",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
-                  },
-                  "isOptional": false
-                },
-                {
-                  "parameterName": "handler",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "registerBeforeCreateHandler"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@tldraw/editor!SideEffectManager#registerBeforeDeleteHandler:member(1)",
-              "docComment": "/**\n * Register a handler to be called before a record is deleted. The handler can return `false` to prevent the deletion.\n *\n * Use this handler only for intercepting deletions of the record itself. If you want to do something to other records in response to a deletion, use {@link SideEffectManager.registerAfterDeleteHandler} instead.\n *\n * @param typeName - The type of record to listen for\n *\n * @param handler - The handler to call\n *\n * @example\n * ```ts\n * editor.sideEffects.registerBeforeDeleteHandler('shape', (shape, source) => {\n *     if (shape.props.color === 'red') {\n *         // prevent red shapes from being deleted\n * \t       return false\n *     }\n * })\n * ```\n *\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "registerBeforeDeleteHandler<T extends "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "['typeName']"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">(typeName: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", handler: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLBeforeDeleteHandler",
-                  "canonicalReference": "@tldraw/editor!TLBeforeDeleteHandler:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "TLRecord",
-                  "canonicalReference": "@tldraw/tlschema!TLRecord:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": " & {\n        typeName: T;\n    }>"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "typeParameters": [
-                {
-                  "typeParameterName": "T",
-                  "constraintTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 3
-                  },
-                  "defaultTypeTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  }
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "typeName",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 4,
-                    "endIndex": 5
-                  },
-                  "isOptional": false
-                },
-                {
-                  "parameterName": "handler",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 6,
-                    "endIndex": 10
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "registerBeforeDeleteHandler"
-            },
-            {
-              "kind": "PropertySignature",
+              "kind": "Property",
               "canonicalReference": "@tldraw/editor!SideEffectManager#store:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "store: "
+                  "text": "readonly store: "
                 },
                 {
                   "kind": "Reference",
-                  "text": "TLStore",
-                  "canonicalReference": "@tldraw/tlschema!TLStore:type"
+                  "text": "Store",
+                  "canonicalReference": "@tldraw/store!Store:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<R>"
                 },
                 {
                   "kind": "Content",
                   "text": ";"
                 }
               ],
-              "isReadonly": false,
+              "isReadonly": true,
               "isOptional": false,
               "releaseTag": "Public",
               "name": "store",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 2
-              }
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -36168,8 +36075,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -36216,8 +36123,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -36264,8 +36171,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -36855,32 +36762,6 @@
         },
         {
           "kind": "TypeAlias",
-          "canonicalReference": "@tldraw/editor!TLBatchCompleteHandler:type",
-          "docComment": "/**\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export type TLBatchCompleteHandler = "
-            },
-            {
-              "kind": "Content",
-              "text": "() => void"
-            },
-            {
-              "kind": "Content",
-              "text": ";"
-            }
-          ],
-          "fileUrlPath": "packages/editor/src/lib/editor/managers/SideEffectManager.ts",
-          "releaseTag": "Public",
-          "name": "TLBatchCompleteHandler",
-          "typeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
-        },
-        {
-          "kind": "TypeAlias",
           "canonicalReference": "@tldraw/editor!TLBeforeChangeHandler:type",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
@@ -36890,8 +36771,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -36938,8 +36819,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -36986,8 +36867,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TLRecord",
-              "canonicalReference": "@tldraw/tlschema!TLRecord:type"
+              "text": "UnknownRecord",
+              "canonicalReference": "@tldraw/store!UnknownRecord:type"
             },
             {
               "kind": "Content",
@@ -39265,33 +39146,6 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "tick",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@tldraw/editor!TLEventMap#update:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "update: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "[]"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "update",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -139,7 +139,6 @@ export type {
 	TLAfterChangeHandler,
 	TLAfterCreateHandler,
 	TLAfterDeleteHandler,
-	TLBatchCompleteHandler,
 	TLBeforeChangeHandler,
 	TLBeforeCreateHandler,
 	TLBeforeDeleteHandler,

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -86,96 +86,94 @@ export class ScribbleManager {
 	 */
 	tick = (elapsed: number) => {
 		if (this.scribbleItems.size === 0) return
-		this.editor.batch(() => {
-			this.scribbleItems.forEach((item) => {
-				// let the item get at least eight points before
-				//  switching from starting to active
-				if (item.scribble.state === 'starting') {
-					const { next, prev } = item
+		this.scribbleItems.forEach((item) => {
+			// let the item get at least eight points before
+			//  switching from starting to active
+			if (item.scribble.state === 'starting') {
+				const { next, prev } = item
+				if (next && next !== prev) {
+					item.prev = next
+					item.scribble.points.push(next)
+				}
+
+				if (item.scribble.points.length > 8) {
+					item.scribble.state = 'active'
+				}
+				return
+			}
+
+			if (item.delayRemaining > 0) {
+				item.delayRemaining = Math.max(0, item.delayRemaining - elapsed)
+			}
+
+			item.timeoutMs += elapsed
+			if (item.timeoutMs >= 16) {
+				item.timeoutMs = 0
+			}
+
+			const { delayRemaining, timeoutMs, prev, next, scribble } = item
+
+			switch (scribble.state) {
+				case 'active': {
 					if (next && next !== prev) {
 						item.prev = next
-						item.scribble.points.push(next)
-					}
+						scribble.points.push(next)
 
-					if (item.scribble.points.length > 8) {
-						item.scribble.state = 'active'
-					}
-					return
-				}
-
-				if (item.delayRemaining > 0) {
-					item.delayRemaining = Math.max(0, item.delayRemaining - elapsed)
-				}
-
-				item.timeoutMs += elapsed
-				if (item.timeoutMs >= 16) {
-					item.timeoutMs = 0
-				}
-
-				const { delayRemaining, timeoutMs, prev, next, scribble } = item
-
-				switch (scribble.state) {
-					case 'active': {
-						if (next && next !== prev) {
-							item.prev = next
-							scribble.points.push(next)
-
-							// If we've run out of delay, then shrink the scribble from the start
-							if (delayRemaining === 0) {
-								if (scribble.points.length > 8) {
-									scribble.points.shift()
-								}
-							}
-						} else {
-							// While not moving, shrink the scribble from the start
-							if (timeoutMs === 0) {
-								if (scribble.points.length > 1) {
-									scribble.points.shift()
-								} else {
-									// Reset the item's delay
-									item.delayRemaining = scribble.delay
-								}
-							}
-						}
-						break
-					}
-					case 'stopping': {
-						if (item.delayRemaining === 0) {
-							if (timeoutMs === 0) {
-								// If the scribble is down to one point, we're done!
-								if (scribble.points.length === 1) {
-									this.scribbleItems.delete(item.id) // Remove the scribble
-									return
-								}
-
-								if (scribble.shrink) {
-									// Drop the scribble's size as it shrinks
-									scribble.size = Math.max(1, scribble.size * (1 - scribble.shrink))
-								}
-
-								// Drop the scribble's first point (its tail)
+						// If we've run out of delay, then shrink the scribble from the start
+						if (delayRemaining === 0) {
+							if (scribble.points.length > 8) {
 								scribble.points.shift()
 							}
 						}
-						break
+					} else {
+						// While not moving, shrink the scribble from the start
+						if (timeoutMs === 0) {
+							if (scribble.points.length > 1) {
+								scribble.points.shift()
+							} else {
+								// Reset the item's delay
+								item.delayRemaining = scribble.delay
+							}
+						}
 					}
-					case 'paused': {
-						// Nothing to do while paused.
-						break
-					}
+					break
 				}
-			})
+				case 'stopping': {
+					if (item.delayRemaining === 0) {
+						if (timeoutMs === 0) {
+							// If the scribble is down to one point, we're done!
+							if (scribble.points.length === 1) {
+								this.scribbleItems.delete(item.id) // Remove the scribble
+								return
+							}
 
-			// The object here will get frozen into the record, so we need to
-			// create a copies of the parts that what we'll be mutating later.
-			this.editor.updateInstanceState({
-				scribbles: Array.from(this.scribbleItems.values())
-					.map(({ scribble }) => ({
-						...scribble,
-						points: [...scribble.points],
-					}))
-					.slice(-5), // limit to three as a minor sanity check
-			})
+							if (scribble.shrink) {
+								// Drop the scribble's size as it shrinks
+								scribble.size = Math.max(1, scribble.size * (1 - scribble.shrink))
+							}
+
+							// Drop the scribble's first point (its tail)
+							scribble.points.shift()
+						}
+					}
+					break
+				}
+				case 'paused': {
+					// Nothing to do while paused.
+					break
+				}
+			}
+		})
+
+		// The object here will get frozen into the record, so we need to
+		// create a copies of the parts that what we'll be mutating later.
+		this.editor.updateInstanceState({
+			scribbles: Array.from(this.scribbleItems.values())
+				.map(({ scribble }) => ({
+					...scribble,
+					points: [...scribble.points],
+				}))
+				.slice(-5), // limit to three as a minor sanity check
 		})
 	}
 }

--- a/packages/editor/src/lib/editor/types/emit-types.ts
+++ b/packages/editor/src/lib/editor/types/emit-types.ts
@@ -8,7 +8,6 @@ export interface TLEventMap {
 	mount: []
 	'max-shapes': [{ name: string; pageId: TLPageId; count: number }]
 	change: [HistoryEntry<TLRecord>]
-	update: []
 	crash: [{ error: unknown }]
 	'stop-camera-animation': []
 	'stop-following': []

--- a/packages/editor/src/lib/editor/types/history-types.ts
+++ b/packages/editor/src/lib/editor/types/history-types.ts
@@ -17,11 +17,13 @@ export type TLHistoryEntry<R extends UnknownRecord> = TLHistoryMark | TLHistoryD
 
 /** @public */
 export interface TLHistoryBatchOptions {
-	/**
-	 * How should this change interact with the history stack?
-	 * - record: Add to the undo stack and clear the redo stack
-	 * - record-preserveRedoStack: Add to the undo stack but do not clear the redo stack
-	 * - ignore: Do not add to the undo stack or the redo stack
-	 */
-	history?: 'record' | 'record-preserveRedoStack' | 'ignore'
+	history?: TLHistoryMode
 }
+
+/**
+ * How should this change interact with the history stack?
+ * - record: Add to the undo stack and clear the redo stack
+ * - record-preserveRedoStack: Add to the undo stack but do not clear the redo stack
+ * - ignore: Do not add to the undo stack or the redo stack
+ */
+export type TLHistoryMode = 'record' | 'record-preserveRedoStack' | 'ignore'

--- a/packages/store/api-report.md
+++ b/packages/store/api-report.md
@@ -265,6 +265,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
     markAsPossiblyCorrupted(): void;
     mergeRemoteChanges: (fn: () => void) => void;
     migrateSnapshot(snapshot: StoreSnapshot<R>): StoreSnapshot<R>;
+    onAfterAtomic?: (source: 'remote' | 'user') => void;
     onAfterChange?: (prev: R, next: R, source: 'remote' | 'user') => void;
     onAfterCreate?: (record: R, source: 'remote' | 'user') => void;
     onAfterDelete?: (prev: R, source: 'remote' | 'user') => void;

--- a/packages/store/api/api.json
+++ b/packages/store/api/api.json
@@ -4110,6 +4110,36 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@tldraw/store!Store#onAfterAtomic:member",
+              "docComment": "/**\n * A callback fired after an atomic operation is completed.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onAfterAtomic?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(source: 'remote' | 'user') => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onAfterAtomic",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@tldraw/store!Store#onAfterChange:member",
               "docComment": "/**\n * A callback fired after each record's change.\n *\n * @param prev - The previous value, if any.\n *\n * @param next - The next value.\n */\n",
               "excerptTokens": [

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -377,21 +377,19 @@ export function registerDefaultExternalContentHandlers(
 			}
 		}
 
-		editor.batch(() => {
-			if (shouldAlsoCreateAsset) {
-				editor.createAssets([asset])
-			}
+		if (shouldAlsoCreateAsset) {
+			editor.createAssets([asset])
+		}
 
-			editor.updateShapes([
-				{
-					id: shape.id,
-					type: shape.type,
-					props: {
-						assetId: asset.id,
-					},
+		editor.updateShapes([
+			{
+				id: shape.id,
+				type: shape.type,
+				props: {
+					assetId: asset.id,
 				},
-			])
-		})
+			},
+		])
 	})
 }
 
@@ -459,19 +457,17 @@ export async function createShapesForAssets(
 		}
 	}
 
-	editor.batch(() => {
-		// Create any assets
-		const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
-		if (assetsToCreate.length) {
-			editor.createAssets(assetsToCreate)
-		}
+	// Create any assets
+	const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
+	if (assetsToCreate.length) {
+		editor.createAssets(assetsToCreate)
+	}
 
-		// Create the shapes
-		editor.createShapes(partials).select(...partials.map((p) => p.id))
+	// Create the shapes
+	editor.createShapes(partials).select(...partials.map((p) => p.id))
 
-		// Re-position shapes so that the center of the group is at the provided point
-		centerSelectionAroundPoint(editor, position)
-	})
+	// Re-position shapes so that the center of the group is at the provided point
+	centerSelectionAroundPoint(editor, position)
 
 	return partials.map((p) => p.id)
 }
@@ -522,10 +518,8 @@ export function createEmptyBookmarkShape(
 		},
 	}
 
-	editor.batch(() => {
-		editor.createShapes([partial]).select(partial.id)
-		centerSelectionAroundPoint(editor, position)
-	})
+	editor.createShapes([partial]).select(partial.id)
+	centerSelectionAroundPoint(editor, position)
 
 	return editor.getShape(partial.id) as TLBookmarkShape
 }

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -180,17 +180,15 @@ const createBookmarkAssetOnUrlChange = debounce(async (editor: Editor, shape: TL
 		return
 	}
 
-	editor.batch(() => {
-		// Create the new asset
-		editor.createAssets([asset])
+	// Create the new asset
+	editor.createAssets([asset])
 
-		// And update the shape
-		editor.updateShapes<TLBookmarkShape>([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { assetId: asset.id },
-			},
-		])
-	})
+	// And update the shape
+	editor.updateShapes<TLBookmarkShape>([
+		{
+			id: shape.id,
+			type: shape.type,
+			props: { assetId: asset.id },
+		},
+	])
 }, 500)

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -32,9 +32,7 @@ export class DragAndDropManager {
 
 	private setDragTimer(movingShapes: TLShape[], duration: number, cb: () => void) {
 		this.droppingNodeTimer = setTimeout(() => {
-			this.editor.batch(() => {
-				this.handleDrag(this.editor.inputs.currentPagePoint, movingShapes, cb)
-			})
+			this.handleDrag(this.editor.inputs.currentPagePoint, movingShapes, cb)
 			this.droppingNodeTimer = null
 		}, duration)
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -146,20 +146,18 @@ export class PointingShape extends StateNode {
 									labelGeometry.bounds.containsPoint(pointInShapeSpace, 0) &&
 									labelGeometry.hitTestPoint(pointInShapeSpace)
 								) {
-									this.editor.batch(() => {
-										this.editor.mark('editing on pointer up')
-										this.editor.select(selectingShape.id)
+									this.editor.mark('editing on pointer up')
+									this.editor.select(selectingShape.id)
 
-										const util = this.editor.getShapeUtil(selectingShape)
-										if (this.editor.getInstanceState().isReadonly) {
-											if (!util.canEditInReadOnly(selectingShape)) {
-												return
-											}
+									const util = this.editor.getShapeUtil(selectingShape)
+									if (this.editor.getInstanceState().isReadonly) {
+										if (!util.canEditInReadOnly(selectingShape)) {
+											return
 										}
+									}
 
-										this.editor.setEditingShape(selectingShape.id)
-										this.editor.setCurrentTool('select.editing_shape')
-									})
+									this.editor.setEditingShape(selectingShape.id)
+									this.editor.setCurrentTool('select.editing_shape')
 									return
 								}
 							}

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -294,7 +294,5 @@ function createNShapes(editor: Editor, n: number) {
 		}
 	}
 
-	editor.batch(() => {
-		editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
-	})
+	editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
 }

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -251,13 +251,11 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 	const handleCreatePageClick = useCallback(() => {
 		if (isReadonlyMode) return
 
-		editor.batch(() => {
-			editor.mark('creating page')
-			const newPageId = PageRecordType.createId()
-			editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
-			editor.setCurrentPage(newPageId)
-			setIsEditing(true)
-		})
+		editor.mark('creating page')
+		const newPageId = PageRecordType.createId()
+		editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
+		editor.setCurrentPage(newPageId)
+		setIsEditing(true)
 	}, [editor, msg, isReadonlyMode])
 
 	return (
@@ -400,10 +398,8 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 															editor.renamePage(page.id, name)
 														}
 													} else {
-														editor.batch(() => {
-															setIsEditing(true)
-															editor.setCurrentPage(page.id)
-														})
+														setIsEditing(true)
+														editor.setCurrentPage(page.id)
 													}
 												}}
 											/>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -78,13 +78,11 @@ function useStyleChangeCallback() {
 	return React.useMemo(
 		() =>
 			function handleStyleChange<T>(style: StyleProp<T>, value: T) {
-				editor.batch(() => {
-					if (editor.isIn('select')) {
-						editor.setStyleForSelectedShapes(style, value)
-					}
-					editor.setStyleForNextShapes(style, value)
-					editor.updateInstanceState({ isChangingStyle: true })
-				})
+				if (editor.isIn('select')) {
+					editor.setStyleForSelectedShapes(style, value)
+				}
+				editor.setStyleForNextShapes(style, value)
+				editor.updateInstanceState({ isChangingStyle: true })
 
 				trackEvent('set-style', { source: 'style-panel', id: style.id, value: value as string })
 			},
@@ -327,13 +325,11 @@ export function OpacitySlider() {
 	const handleOpacityValueChange = React.useCallback(
 		(value: number) => {
 			const item = tldrawSupportedOpacities[value]
-			editor.batch(() => {
-				if (editor.isIn('select')) {
-					editor.setOpacityForSelectedShapes(item)
-				}
-				editor.setOpacityForNextShapes(item)
-				editor.updateInstanceState({ isChangingStyle: true })
-			})
+			if (editor.isIn('select')) {
+				editor.setOpacityForSelectedShapes(item)
+			}
+			editor.setOpacityForNextShapes(item)
+			editor.updateInstanceState({ isChangingStyle: true })
 
 			trackEvent('set-style', { source: 'style-panel', id: 'opacity', value })
 		},

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -386,40 +386,38 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (!canApplySelectionAction()) return
 					if (mustGoBackToSelectToolFirst()) return
 
-					editor.batch(() => {
-						trackEvent('convert-to-bookmark', { source })
-						const shapes = editor.getSelectedShapes()
+					trackEvent('convert-to-bookmark', { source })
+					const shapes = editor.getSelectedShapes()
 
-						const createList: TLShapePartial[] = []
-						const deleteList: TLShapeId[] = []
-						for (const shape of shapes) {
-							if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed') || !shape.props.url)
-								continue
+					const createList: TLShapePartial[] = []
+					const deleteList: TLShapeId[] = []
+					for (const shape of shapes) {
+						if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed') || !shape.props.url)
+							continue
 
-							const newPos = new Vec(shape.x, shape.y)
-							newPos.rot(-shape.rotation)
-							newPos.add(new Vec(shape.props.w / 2 - 300 / 2, shape.props.h / 2 - 320 / 2)) // see bookmark shape util
-							newPos.rot(shape.rotation)
-							const partial: TLShapePartial<TLBookmarkShape> = {
-								id: createShapeId(),
-								type: 'bookmark',
-								rotation: shape.rotation,
-								x: newPos.x,
-								y: newPos.y,
-								opacity: 1,
-								props: {
-									url: shape.props.url,
-								},
-							}
-
-							createList.push(partial)
-							deleteList.push(shape.id)
+						const newPos = new Vec(shape.x, shape.y)
+						newPos.rot(-shape.rotation)
+						newPos.add(new Vec(shape.props.w / 2 - 300 / 2, shape.props.h / 2 - 320 / 2)) // see bookmark shape util
+						newPos.rot(shape.rotation)
+						const partial: TLShapePartial<TLBookmarkShape> = {
+							id: createShapeId(),
+							type: 'bookmark',
+							rotation: shape.rotation,
+							x: newPos.x,
+							y: newPos.y,
+							opacity: 1,
+							props: {
+								url: shape.props.url,
+							},
 						}
 
-						editor.mark('convert shapes to bookmark')
-						editor.deleteShapes(deleteList)
-						editor.createShapes(createList)
-					})
+						createList.push(partial)
+						deleteList.push(shape.id)
+					}
+
+					editor.mark('convert shapes to bookmark')
+					editor.deleteShapes(deleteList)
+					editor.createShapes(createList)
 				},
 			},
 			{
@@ -431,50 +429,48 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					trackEvent('convert-to-embed', { source })
 
-					editor.batch(() => {
-						const ids = editor.getSelectedShapeIds()
-						const shapes = compact(ids.map((id) => editor.getShape(id)))
+					const ids = editor.getSelectedShapeIds()
+					const shapes = compact(ids.map((id) => editor.getShape(id)))
 
-						const createList: TLShapePartial[] = []
-						const deleteList: TLShapeId[] = []
-						for (const shape of shapes) {
-							if (!editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark')) continue
+					const createList: TLShapePartial[] = []
+					const deleteList: TLShapeId[] = []
+					for (const shape of shapes) {
+						if (!editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark')) continue
 
-							const { url } = shape.props
+						const { url } = shape.props
 
-							const embedInfo = getEmbedInfo(shape.props.url)
+						const embedInfo = getEmbedInfo(shape.props.url)
 
-							if (!embedInfo) continue
-							if (!embedInfo.definition) continue
+						if (!embedInfo) continue
+						if (!embedInfo.definition) continue
 
-							const { width, height } = embedInfo.definition
+						const { width, height } = embedInfo.definition
 
-							const newPos = new Vec(shape.x, shape.y)
-							newPos.rot(-shape.rotation)
-							newPos.add(new Vec(shape.props.w / 2 - width / 2, shape.props.h / 2 - height / 2))
-							newPos.rot(shape.rotation)
+						const newPos = new Vec(shape.x, shape.y)
+						newPos.rot(-shape.rotation)
+						newPos.add(new Vec(shape.props.w / 2 - width / 2, shape.props.h / 2 - height / 2))
+						newPos.rot(shape.rotation)
 
-							const shapeToCreate: TLShapePartial<TLEmbedShape> = {
-								id: createShapeId(),
-								type: 'embed',
-								x: newPos.x,
-								y: newPos.y,
-								rotation: shape.rotation,
-								props: {
-									url: url,
-									w: width,
-									h: height,
-								},
-							}
-
-							createList.push(shapeToCreate)
-							deleteList.push(shape.id)
+						const shapeToCreate: TLShapePartial<TLEmbedShape> = {
+							id: createShapeId(),
+							type: 'embed',
+							x: newPos.x,
+							y: newPos.y,
+							rotation: shape.rotation,
+							props: {
+								url: url,
+								w: width,
+								h: height,
+							},
 						}
 
-						editor.mark('convert shapes to embed')
-						editor.deleteShapes(deleteList)
-						editor.createShapes(createList)
-					})
+						createList.push(shapeToCreate)
+						deleteList.push(shape.id)
+					}
+
+					editor.mark('convert shapes to embed')
+					editor.deleteShapes(deleteList)
+					editor.createShapes(createList)
 				},
 			},
 			{
@@ -921,14 +917,12 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$a',
 				readonlyOk: true,
 				onSelect(source) {
-					editor.batch(() => {
-						if (mustGoBackToSelectToolFirst()) return
+					if (mustGoBackToSelectToolFirst()) return
 
-						trackEvent('select-all-shapes', { source })
+					trackEvent('select-all-shapes', { source })
 
-						editor.mark('select all kbd')
-						editor.selectAll()
-					})
+					editor.mark('select all kbd')
+					editor.selectAll()
 				},
 			},
 			{
@@ -1177,12 +1171,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					// this needs to be deferred because it causes the menu
 					// UI to unmount which puts us in a dodgy state
 					requestAnimationFrame(() => {
-						editor.batch(() => {
-							trackEvent('toggle-focus-mode', { source })
-							clearDialogs()
-							clearToasts()
-							editor.updateInstanceState({ isFocusMode: !editor.getInstanceState().isFocusMode })
-						})
+						trackEvent('toggle-focus-mode', { source })
+						clearDialogs()
+						clearToasts()
+						editor.updateInstanceState({ isFocusMode: !editor.getInstanceState().isFocusMode })
 					})
 				},
 			},
@@ -1271,11 +1263,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect(source) {
 					const newPageId = PageRecordType.createId()
 					const ids = editor.getSelectedShapeIds()
-					editor.batch(() => {
-						editor.mark('move_shapes_to_page')
-						editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
-						editor.moveShapesToPage(ids, newPageId)
-					})
+					editor.mark('move_shapes_to_page')
+					editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
+					editor.moveShapesToPage(ids, newPageId)
 					trackEvent('new-page', { source })
 				},
 			},
@@ -1285,14 +1275,12 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '?t',
 				onSelect(source) {
 					const style = DefaultColorStyle
-					editor.batch(() => {
-						editor.mark('change-color')
-						if (editor.isIn('select')) {
-							editor.setStyleForSelectedShapes(style, 'white')
-						}
-						editor.setStyleForNextShapes(style, 'white')
-						editor.updateInstanceState({ isChangingStyle: true })
-					})
+					editor.mark('change-color')
+					if (editor.isIn('select')) {
+						editor.setStyleForSelectedShapes(style, 'white')
+					}
+					editor.setStyleForNextShapes(style, 'white')
+					editor.updateInstanceState({ isChangingStyle: true })
 					trackEvent('set-style', { source, id: style.id, value: 'white' })
 				},
 			},

--- a/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuIsOpen.ts
@@ -12,18 +12,16 @@ export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void) {
 		(isOpen: boolean) => {
 			rIsOpen.current = isOpen
 
-			editor.batch(() => {
-				if (isOpen) {
-					editor.complete()
-					editor.addOpenMenu(id)
-				} else {
-					editor.updateInstanceState({
-						openMenus: editor.getOpenMenus().filter((m) => !m.startsWith(id)),
-					})
-				}
+			if (isOpen) {
+				editor.complete()
+				editor.addOpenMenu(id)
+			} else {
+				editor.updateInstanceState({
+					openMenus: editor.getOpenMenus().filter((m) => !m.startsWith(id)),
+				})
+			}
 
-				cb?.(isOpen)
-			})
+			cb?.(isOpen)
 		},
 		[editor, id, cb]
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -101,11 +101,9 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				kbd: id === 'rectangle' ? 'r' : id === 'ellipse' ? 'o' : undefined,
 				icon: ('geo-' + id) as TLUiIconType,
 				onSelect(source: TLUiEventSource) {
-					editor.batch(() => {
-						editor.setStyleForNextShapes(GeoShapeGeoStyle, id)
-						editor.setCurrentTool('geo')
-						trackEvent('select-tool', { source, id: `geo-${id}` })
-					})
+					editor.setStyleForNextShapes(GeoShapeGeoStyle, id)
+					editor.setCurrentTool('geo')
+					trackEvent('select-tool', { source, id: `geo-${id}` })
 				},
 			})),
 			{

--- a/packages/tldraw/src/lib/utils/frames/frames.ts
+++ b/packages/tldraw/src/lib/utils/frames/frames.ts
@@ -17,17 +17,15 @@ export function removeFrame(editor: Editor, ids: TLShapeId[]) {
 	if (!frames.length) return
 
 	const allChildren: TLShapeId[] = []
-	editor.batch(() => {
-		frames.map((frame) => {
-			const children = editor.getSortedChildIdsForParent(frame.id)
-			if (children.length) {
-				editor.reparentShapes(children, frame.parentId, frame.index)
-				allChildren.push(...children)
-			}
-		})
-		editor.setSelectedShapes(allChildren)
-		editor.deleteShapes(ids)
+	frames.map((frame) => {
+		const children = editor.getSortedChildIdsForParent(frame.id)
+		if (children.length) {
+			editor.reparentShapes(children, frame.parentId, frame.index)
+			allChildren.push(...children)
+		}
 	})
+	editor.setSelectedShapes(allChildren)
+	editor.deleteShapes(ids)
 }
 
 /** @internal */
@@ -66,28 +64,26 @@ export function fitFrameToContent(editor: Editor, id: TLShapeId, opts = {} as { 
 	if (dx === 0 && dy === 0 && frame.props.w === w && frame.props.h === h) return
 
 	const diff = new Vec(dx, dy).rot(frame.rotation)
-	editor.batch(() => {
-		const changes: TLShapePartial[] = childIds.map((child) => {
-			const shape = editor.getShape(child)!
-			return {
-				id: shape.id,
-				type: shape.type,
-				x: shape.x + dx,
-				y: shape.y + dy,
-			}
-		})
-
-		changes.push({
-			id: frame.id,
-			type: frame.type,
-			x: frame.x - diff.x,
-			y: frame.y - diff.y,
-			props: {
-				w,
-				h,
-			},
-		})
-
-		editor.updateShapes(changes)
+	const changes: TLShapePartial[] = childIds.map((child) => {
+		const shape = editor.getShape(child)!
+		return {
+			id: shape.id,
+			type: shape.type,
+			x: shape.x + dx,
+			y: shape.y + dy,
+		}
 	})
+
+	changes.push({
+		id: frame.id,
+		type: frame.type,
+		x: frame.x - diff.x,
+		y: frame.y - diff.y,
+		props: {
+			w,
+			h,
+		},
+	})
+
+	editor.updateShapes(changes)
 }


### PR DESCRIPTION
megamind.jpg

`editor.batch` is an alias for `history.batch`. `history.batch` does almost nothing: it runs some code, and if it's the top-level batch, it calls an `onBatchComplete` callback. This was apparently not always the case - the documentation for `editor.batch` claims that it groups a bunch of operations together so that they all happen in one undo/redo operation. This hasn't been true for a very very long time though, even before #3364.

Given that `editor.batch` does almost nothing apart from scheduling a callback, what does it look like to remove? That callback is pretty useful for running some cleanup code whenever _something_ happens - for example, we use it to collect any invalidations of parents with per-record `after` callbacks, then deal with those invalidations once we've collected them all. We can't do that with just record-level callbacks, so we can add an overall store "after something happened" callback to replace it.

The result is some much simpler code (no need to call `editor.batch` ever) at the expense of a callback running slightly more often. The callback doesn't do much though, so I think it's fine! For optimisation reasons we can always wrap things in `editor.store.atomic` to defer callbacks until the end of a large set of operations.

## Breaking change
This is a breaking change - the `editor.batch` function is no more. It's a straight-forward migration path though: just delete it and run the code you were batching directly. The function was doing almost nothing anyway.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

