### PR TITLE
Only run when shapes change.

### DIFF
--- a/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
+++ b/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
@@ -7,6 +7,7 @@ type Parents2Children = Record<TLParentId, TLShapeId[]>
 
 export const parentsToChildren = (store: TLStore) => {
 	const shapeIdsQuery = store.query.ids<'shape'>('shape')
+	const shapeHistory = store.query.filterHistory('shape')
 
 	function fromScratch() {
 		const result: Parents2Children = {}
@@ -35,7 +36,7 @@ export const parentsToChildren = (store: TLStore) => {
 				return fromScratch()
 			}
 
-			const diff = store.history.getDiffSince(lastComputedEpoch)
+			const diff = shapeHistory.getDiffSince(lastComputedEpoch)
 
 			if (diff === RESET_VALUE) {
 				return fromScratch()


### PR DESCRIPTION
Before we were running this on any change, even mouse position changes. Now we only run it when shapes change.

Results wouldn't change in any case, so there's not a huge improvement. Still, why run it if it is not necessary.

Before:

https://github.com/tldraw/tldraw/assets/2523721/b4111494-488a-42d0-9dfe-7fbc2ed88315

After:

https://github.com/tldraw/tldraw/assets/2523721/d96de329-235b-4dcb-93ea-fe297062985d



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
