### PR TITLE
Don't show edit link for locked shapes.

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
+++ b/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
@@ -176,7 +176,8 @@ export function useHasLinkShapeSelected() {
 			return !!(
 				onlySelectedShape &&
 				onlySelectedShape.type !== 'embed' &&
-				'url' in onlySelectedShape.props
+				'url' in onlySelectedShape.props &&
+				!onlySelectedShape.isLocked
 			)
 		},
 		[editor]


### PR DESCRIPTION
Hides the edit link option in the context menu for locked shapes.

Fixes [#3308](https://github.com/tldraw/tldraw/issues/3308)

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1.  Add a link to a shape.
2. Lock it
3. Right click it to open the context menu.
4. You should not see the `Edit link` option

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Hide edit link context menu option for locked shapes.
