### PR TITLE
Avoid the error when creating shape after we have reached max shapes.

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -77,6 +77,9 @@ import { useValue } from '@tldraw/state';
 import { VecModel } from '@tldraw/tlschema';
 import { whyAmIRunning } from '@tldraw/state';
 
+// @public (undocumented)
+export function alertMaxShapes(editor: Editor, pageId?: TLPageId): void;
+
 // @public
 export function angleDistance(fromAngle: number, toAngle: number, direction: number): number;
 
@@ -830,6 +833,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     isShapeOrAncestorLocked(id?: TLShapeId): boolean;
     mark(markId?: string, onUndo?: boolean, onRedo?: boolean): this;
+    maxShapesReached(): boolean;
     moveShapesToPage(shapes: TLShape[] | TLShapeId[], pageId: TLPageId): this;
     nudgeShapes(shapes: TLShape[] | TLShapeId[], offset: VecLike, historyOptions?: TLCommandHistoryOptions): this;
     packShapes(shapes: TLShape[] | TLShapeId[], gap: number): this;

--- a/packages/editor/api/api.json
+++ b/packages/editor/api/api.json
@@ -174,6 +174,69 @@
       "members": [
         {
           "kind": "Function",
+          "canonicalReference": "@tldraw/editor!alertMaxShapes:function(1)",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function alertMaxShapes(editor: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Editor",
+              "canonicalReference": "@tldraw/editor!Editor:class"
+            },
+            {
+              "kind": "Content",
+              "text": ", pageId?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TLPageId",
+              "canonicalReference": "@tldraw/tlschema!TLPageId:type"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "void"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "packages/editor/src/lib/editor/Editor.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 6
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "editor",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "pageId",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": true
+            }
+          ],
+          "name": "alertMaxShapes"
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@tldraw/editor!angleDistance:function(1)",
           "docComment": "/**\n * Get the angle of a point on an arc.\n *\n * @param fromAngle - The angle from center to arc's start point (A) on the circle\n *\n * @param toAngle - The angle from center to arc's end point (B) on the circle\n *\n * @param direction - The direction of the arc (1 = counter-clockwise, -1 = clockwise)\n *\n * @returns The distance in radians between the two angles according to the direction\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -15373,6 +15436,37 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "mark"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@tldraw/editor!Editor#maxShapesReached:member(1)",
+              "docComment": "/**\n * Get whether we have reached the maximum number of shapes per page.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "maxShapesReached(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "maxShapesReached"
             },
             {
               "kind": "Method",

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -130,6 +130,7 @@ export {
 } from './lib/constants'
 export {
 	Editor,
+	alertMaxShapes,
 	type TLAnimationOptions,
 	type TLEditorOptions,
 	type TLResizeShapeOptions,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8213,6 +8213,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
+	 * Get whether we have reached the maximum number of shapes per page.
+	 *
+	 * @public
+	 */
+	maxShapesReached() {
+		return this.getCurrentPageShapeIds().size >= MAX_SHAPES_PER_PAGE
+	}
+
+	/**
 	 * Dispatch a cancel event.
 	 *
 	 * @example
@@ -8843,7 +8852,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 }
 
-function alertMaxShapes(editor: Editor, pageId = editor.getCurrentPageId()) {
+/** @public */
+export function alertMaxShapes(editor: Editor, pageId = editor.getCurrentPageId()) {
 	const name = editor.getPage(pageId)!.name
 	editor.emit('max-shapes', { name, pageId, count: MAX_SHAPES_PER_PAGE })
 }

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -34,19 +34,21 @@ export class Pointing extends StateNode {
 
 			this.editor.mark(this.markId)
 
-			this.editor.createShapes<TLBaseBoxShape>([
-				{
-					id,
-					type: shapeType,
-					x: originPagePoint.x,
-					y: originPagePoint.y,
-					props: {
-						w: 1,
-						h: 1,
+			this.editor
+				.createShapes<TLBaseBoxShape>([
+					{
+						id,
+						type: shapeType,
+						x: originPagePoint.x,
+						y: originPagePoint.y,
+						props: {
+							w: 1,
+							h: 1,
+						},
 					},
-				},
-			])
-			this.editor.select(id)
+				])
+				.select(id)
+
 			this.editor.setCurrentTool('select.resizing', {
 				...info,
 				target: 'selection',

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -1,4 +1,10 @@
-import { StateNode, TLArrowShape, TLEventHandlers, createShapeId } from '@tldraw/editor'
+import {
+	StateNode,
+	TLArrowShape,
+	TLEventHandlers,
+	alertMaxShapes,
+	createShapeId,
+} from '@tldraw/editor'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -79,6 +85,12 @@ export class Pointing extends StateNode {
 	}
 
 	createArrowShape() {
+		if (this.editor.maxShapesReached()) {
+			alertMaxShapes(this.editor)
+			this.cancel()
+			return
+		}
+
 		const { originPagePoint } = this.editor.inputs
 
 		const id = createShapeId()

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -4,6 +4,7 @@ import {
 	StateNode,
 	TLEventHandlers,
 	TLGeoShape,
+	alertMaxShapes,
 	createShapeId,
 } from '@tldraw/editor'
 
@@ -18,6 +19,11 @@ export class Pointing extends StateNode {
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
 		if (this.editor.inputs.isDragging) {
+			if (this.editor.maxShapesReached()) {
+				alertMaxShapes(this.editor)
+				this.cancel()
+				return
+			}
 			const { originPagePoint } = this.editor.inputs
 
 			const id = createShapeId()

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -6,6 +6,7 @@ import {
 	TLLineShape,
 	TLShapeId,
 	Vec,
+	alertMaxShapes,
 	createShapeId,
 	getIndexAbove,
 	last,
@@ -84,6 +85,12 @@ export class Pointing extends StateNode {
 				},
 			])
 		} else {
+			if (this.editor.maxShapesReached()) {
+				alertMaxShapes(this.editor)
+				this.cancel()
+				return
+			}
+
 			const id = createShapeId()
 
 			this.markId = `creating:${id}`

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -107,15 +107,16 @@ export class Pointing extends StateNode {
 		this.markId = `creating:${id}`
 		this.editor.mark(this.markId)
 
-		this.editor.createShapes([
-			{
-				id,
-				type: 'note',
-				x: originPagePoint.x,
-				y: originPagePoint.y,
-			},
-		])
-		this.editor.select(id)
+		this.editor
+			.createShapes([
+				{
+					id,
+					type: 'note',
+					x: originPagePoint.x,
+					y: originPagePoint.y,
+				},
+			])
+			.select(id)
 
 		const shape = this.editor.getShape<TLNoteShape>(id)!
 		const bounds = this.editor.getShapeGeometry(shape).bounds

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -1,4 +1,10 @@
-import { StateNode, TLEventHandlers, TLTextShape, createShapeId } from '@tldraw/editor'
+import {
+	StateNode,
+	TLEventHandlers,
+	TLTextShape,
+	alertMaxShapes,
+	createShapeId,
+} from '@tldraw/editor'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -13,6 +19,11 @@ export class Pointing extends StateNode {
 
 	override onPointerMove: TLEventHandlers['onPointerMove'] = (info) => {
 		if (this.editor.inputs.isDragging) {
+			if (this.editor.maxShapesReached()) {
+				alertMaxShapes(this.editor)
+				this.cancel()
+				return
+			}
 			const {
 				inputs: { originPagePoint },
 			} = this.editor
@@ -75,6 +86,12 @@ export class Pointing extends StateNode {
 	}
 
 	private complete() {
+		if (this.editor.maxShapesReached()) {
+			alertMaxShapes(this.editor)
+			this.cancel()
+			return
+		}
+
 		this.editor.mark('creating text shape')
 		const id = createShapeId()
 		const { x, y } = this.editor.inputs.currentPagePoint


### PR DESCRIPTION
Even though we had a check in `createShapes` we don't return anything useful from it, so the `StateNotes` didn't know something went wrong. Not sure if I like this though 🤷‍♂️ 

Fixes [#3273](https://github.com/tldraw/tldraw/issues/3273)

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add 2000 shapes.
2. Try to add another shape. It should not bomb out. This happened with many shapes: notes, text, geo, line, frame,...

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Prevent an error when trying to add new shapes after we have already reached max shapes per page.
