### PR TITLE
Allow users to edit the document title by double clicking it even when editing a shape.

### DIFF
--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -304,7 +304,10 @@ const DocumentNameEditor = track(function DocumentNameEditor({
 			) : (
 				<div
 					className="tlui-document-name__text"
-					onDoubleClick={() => setState((prev) => ({ ...prev, isEditing: true }))}
+					onDoubleClick={() => {
+						editor.setEditingShape(null)
+						setState((prev) => ({ ...prev, isEditing: true }))
+					}}
 				>
 					{addRealSpaceForWhitespace(name)}
 				</div>


### PR DESCRIPTION
Fixes [#3437](https://github.com/tldraw/tldraw/issues/3437)

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Create a shared document
2. Add a text note and start editing it
3. Double click document name. You should be now editing the document name.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Allow users to editing document name by double clicking even when previously editing text.
