### PR TITLE
Cancel pointer velocity while pinching

### DIFF
--- a/packages/editor/src/lib/editor/managers/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager.ts
@@ -20,13 +20,13 @@ export class TickManager {
 
 	cancelRaf?: null | (() => void)
 	isPaused = true
-	last = 0
+	now = 0
 
 	start = () => {
 		this.isPaused = false
 		this.cancelRaf?.()
 		this.cancelRaf = throttleToNextFrame(this.tick)
-		this.last = Date.now()
+		this.now = Date.now()
 	}
 
 	tick = () => {
@@ -35,8 +35,8 @@ export class TickManager {
 		}
 
 		const now = Date.now()
-		const elapsed = now - this.last
-		this.last = now
+		const elapsed = now - this.now
+		this.now = now
 
 		this.updatePointerVelocity(elapsed)
 		this.editor.emit('frame', elapsed)


### PR DESCRIPTION
There was a bug that could occur if you pinched while using the hand tool, where on pinch end the hand tool would slide the camera based on the pinching velocity. The fix is to cancel out any velocity while pinching.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

On mobile...

1. Select the hand tool.
2. Begin a pinch
3. Stop the pinch
4. The camera should stay where it is

### Release Notes

- Fixed a bug that could occur while pinching with the hand tool selected.