### PR TITLE
stickies: dont remove selection ranges when edit->edit

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -100,10 +100,6 @@ export class EditingShape extends StateNode {
 
 							this.editor.mark('editing on pointer up')
 							this.editor.select(selectingShape.id)
-
-							// When clicking on a different shape's label, we need to clear the other selection
-							// proactively until the pointer up happens.
-							requestAnimationFrame(() => window.getSelection()?.removeAllRanges())
 							return
 						}
 					}


### PR DESCRIPTION
This was necessary before but with latest refactors it doesn't help anything. Also, it causes a minor issue with document title: https://linear.app/tldraw/issue/TLD-2398/double-clicking-board-title-when-editing-text-doesnt-auto-select-the

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

