### PR TITLE
Only show cursor chat button in select mode

### DIFF
--- a/apps/dotcom/src/utils/context-menu/CursorChatMenuItem.tsx
+++ b/apps/dotcom/src/utils/context-menu/CursorChatMenuItem.tsx
@@ -6,9 +6,7 @@ export function CursorChatMenuItem() {
 	const actions = useActions()
 	const shouldShow = useValue(
 		'show cursor chat',
-		() => {
-			return !editor.getInstanceState().isCoarsePointer
-		},
+		() => editor.getCurrentToolId() === 'select' && !editor.getInstanceState().isCoarsePointer,
 		[editor]
 	)
 


### PR DESCRIPTION
This PR hides the cursor chat context menu button when not in select tool.

fixes https://github.com/orgs/tldraw/projects/41/views/1?pane=issue&itemId=59908615

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fix cursor chat button appearing when not in select tool.
