### PR TITLE
stickies: a bit of fuzziness when calculating certain text

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -315,6 +315,12 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 	let labelHeight = NOTE_SIZE
 	let labelWidth = NOTE_SIZE
 
+	// N.B. For some note shapes with text like 'hjhjhjhjhjhjhjhj', you'll run into
+	// some text measurement fuzziness where the browser swears there's no overflow (scrollWidth === width)
+	// but really there is when you enable overflow-wrap again. This helps account for that little bit
+	// of give.
+	const FUZZ = 1
+
 	// We slightly make the font smaller if the text is too big for the note, width-wise.
 	do {
 		fontSizeAdjustment = Math.min(unadjustedFontSize, unadjustedFontSize - iterations)
@@ -322,7 +328,7 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 			...TEXT_PROPS,
 			fontFamily: FONT_FAMILIES[shape.props.font],
 			fontSize: fontSizeAdjustment,
-			maxWidth: NOTE_SIZE - LABEL_PADDING * 2,
+			maxWidth: NOTE_SIZE - LABEL_PADDING * 2 - FUZZ,
 			disableOverflowWrapBreaking: true,
 		})
 
@@ -336,7 +342,7 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 				...TEXT_PROPS,
 				fontFamily: FONT_FAMILIES[shape.props.font],
 				fontSize: fontSizeAdjustment,
-				maxWidth: NOTE_SIZE - LABEL_PADDING * 2,
+				maxWidth: NOTE_SIZE - LABEL_PADDING * 2 - FUZZ,
 			})
 			labelHeight = nextTextSizeWithOverflowBreak.h + LABEL_PADDING * 2
 			labelWidth = nextTextSizeWithOverflowBreak.w + LABEL_PADDING * 2


### PR DESCRIPTION
Fixes https://linear.app/tldraw/issue/TLD-2402/long-words-in-stickies-sometimes-wrap-before-the-font-size-shrinks

https://github.com/tldraw/tldraw/assets/15892272/0b6f6d3c-d21d-430b-97d0-7c9b5abefa0b

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

