### PR TITLE
css more shapes that need transparent behavior

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,7 +8,6 @@
 - Minor version bumps are released on a regular cadence. At the time of writing that cadence is monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible by providing warnings several releases in advance, and by providing tooling to help you migrate your code. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
-
 ## How to publish a new major or minor release
 
 New cadence releases are published from `main`. You trigger a release manually by running the workflow defined in `publish-new.yml`.

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1089,7 +1089,12 @@ input,
  *  - draw/line shapes, because it feels restrictive to have them be 'in the way' of clicking on a textfield
  */
 .tl-canvas[data-iseditinganything='true']
-	.tl-shape:not([data-shape-type='arrow'], [data-shape-type='draw'], [data-shape-type='line'], [data-shape-type='highlight']) {
+	.tl-shape:not(
+		[data-shape-type='arrow'],
+		[data-shape-type='draw'],
+		[data-shape-type='line'],
+		[data-shape-type='highlight']
+	) {
 	pointer-events: all;
 }
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1086,15 +1086,11 @@ input,
  * don't click on shapes that are behind other shapes.
  * One extra nuance is we don't use this behavior for:
  *  - arrows which have weird geometry and just gets in the way.
- *  - draw shapes, because it feels restrictive to have them be 'in the way' of clicking on a textfield
+ *  - draw/line shapes, because it feels restrictive to have them be 'in the way' of clicking on a textfield
  */
 .tl-canvas[data-iseditinganything='true']
-	.tl-shape:not([data-shape-type='arrow']):not([data-shape-type='draw']) {
+	.tl-shape:not([data-shape-type='arrow'], [data-shape-type='draw'], [data-shape-type='line'], [data-shape-type='highlight']) {
 	pointer-events: all;
-}
-/* But, re-disable the pointer-events rule for the svg container. */
-.tl-canvas[data-iseditinganything='true'] .tl-shape .tl-svg-container {
-	pointer-events: none;
 }
 
 .tl-text-label[data-textwrap='true'] > .tl-text-label__inner {


### PR DESCRIPTION
Couple more shapes need the z-index rule enabled, basically the 'draw'-y shapes.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
