### PR TITLE
Stickies: fix sticky note clipping

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3973,13 +3973,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	@computed private _getShapeMaskCache(): ComputedCache<Vec[], TLShape> {
 		return this.store.createComputedCache('pageMaskCache', (shape) => {
-			// todo: Consider adding a flag for this hardcoded behaviour
-			if (
-				isPageId(shape.parentId) ||
-				shape.type === 'note' ||
-				this.findShapeAncestor(shape, (v) => v.type === 'note')
-			)
-				return undefined
+			if (isPageId(shape.parentId)) return undefined
 
 			const frameAncestors = this.getShapeAncestors(shape.id).filter((shape) =>
 				this.isShapeOfType<TLFrameShape>(shape, 'frame')


### PR DESCRIPTION
This PR restores masking for sticky notes that are the child of frames.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix