### PR TITLE
arrows: still use Dist instead of Dist2

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -92,8 +92,8 @@ export class PointingArrowLabel extends StateNode {
 		let nextLabelPosition
 		if (info.isStraight) {
 			// straight arrows
-			const lineLength = Vec.Dist2(info.start.point, info.end.point)
-			const segmentLength = Vec.Dist2(info.end.point, nearestPoint)
+			const lineLength = Vec.Dist(info.start.point, info.end.point)
+			const segmentLength = Vec.Dist(info.end.point, nearestPoint)
 			nextLabelPosition = 1 - segmentLength / lineLength
 		} else {
 			const { _center, measure, angleEnd, angleStart } = groupGeometry.children[0] as Arc2d


### PR DESCRIPTION
A little regression from https://github.com/tldraw/tldraw/pull/3454. We still need the exact distance here.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Fix arrow label positioning
