### PR TITLE
arrows: fix bound arrow labels going over text shape

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -268,14 +268,16 @@ export function getArrowLabelPosition(editor: Editor, shape: TLArrowShape) {
 	const debugGeom: Geometry2d[] = []
 	const info = editor.getArrowInfo(shape)!
 
+	const hasStartBinding = shape.props.start.type === 'binding'
+	const hasEndBinding = shape.props.end.type === 'binding'
 	const hasStartArrowhead = info.start.arrowhead !== 'none'
 	const hasEndArrowhead = info.end.arrowhead !== 'none'
 	if (info.isStraight) {
 		const range = getStraightArrowLabelRange(editor, shape, info)
 		let clampedPosition = clamp(
 			shape.props.labelPosition,
-			hasStartArrowhead ? range.start : 0,
-			hasEndArrowhead ? range.end : 1
+			hasStartArrowhead || hasStartBinding ? range.start : 0,
+			hasEndArrowhead || hasEndBinding ? range.end : 1
 		)
 		// This makes the position snap in the middle.
 		clampedPosition = clampedPosition >= 0.48 && clampedPosition <= 0.52 ? 0.5 : clampedPosition
@@ -285,8 +287,8 @@ export function getArrowLabelPosition(editor: Editor, shape: TLArrowShape) {
 		if (range.dbg) debugGeom.push(...range.dbg)
 		let clampedPosition = clamp(
 			shape.props.labelPosition,
-			hasStartArrowhead ? range.start : 0,
-			hasEndArrowhead ? range.end : 1
+			hasStartArrowhead || hasStartBinding ? range.start : 0,
+			hasEndArrowhead || hasEndBinding ? range.end : 1
 		)
 		// This makes the position snap in the middle.
 		clampedPosition = clampedPosition >= 0.48 && clampedPosition <= 0.52 ? 0.5 : clampedPosition


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/3433

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Arrows: fix label positioning when bound.
