### PR TITLE
textfields: fix Safari cursor rendering bug, take 2

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableText.ts
@@ -58,8 +58,10 @@ export function useEditableText(id: TLShapeId, type: string, text: string) {
 		} else {
 			// This fixes iOS not showing the cursor sometimes. This "shakes" the cursor
 			// awake.
-			elm.blur()
-			elm.focus()
+			if (editor.environment.isSafari) {
+				elm.blur()
+				elm.focus()
+			}
 		}
 
 		// When the selection changes, save the selection ranges


### PR DESCRIPTION
Take 2 on what this PR was trying to do: https://github.com/tldraw/tldraw/pull/3373
Fixes https://github.com/tldraw/tldraw/issues/3398 hopefully this time without the infinite recursion 🙃 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

