### PR TITLE
[fix] allow loading files

### DIFF
--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -62,7 +62,7 @@ const schemaV2 = T.object<SerializedSchemaV2>({
 
 const tldrawFileValidator: T.Validator<TldrawFile> = T.object({
 	tldrawFileFormatVersion: T.nonZeroInteger,
-	schema: T.union('schemaVersion', {
+	schema: T.numberUnion('schemaVersion', {
 		1: schemaV1,
 		2: schemaV2,
 	}),

--- a/packages/validate/api-report.md
+++ b/packages/validate/api-report.md
@@ -83,6 +83,9 @@ function nullable<T>(validator: Validatable<T>): Validator<null | T>;
 // @public
 const number: Validator<number>;
 
+// @internal (undocumented)
+function numberUnion<Key extends string, Config extends UnionValidatorConfig<Key, Config>>(key: Key, config: Config): UnionValidator<Key, Config>;
+
 // @public
 function object<Shape extends object>(config: {
     readonly [K in keyof Shape]: Validatable<Shape[K]>;
@@ -134,6 +137,7 @@ declare namespace T {
         jsonDict,
         dict,
         union,
+        numberUnion,
         model,
         setEnum,
         optional,
@@ -178,7 +182,7 @@ function union<Key extends string, Config extends UnionValidatorConfig<Key, Conf
 
 // @public (undocumented)
 export class UnionValidator<Key extends string, Config extends UnionValidatorConfig<Key, Config>, UnknownValue = never> extends Validator<TypeOf<Config[keyof Config]> | UnknownValue> {
-    constructor(key: Key, config: Config, unknownValueValidation: (value: object, variant: string) => UnknownValue);
+    constructor(key: Key, config: Config, unknownValueValidation: (value: object, variant: string) => UnknownValue, useNumberKeys: boolean);
     // (undocumented)
     validateUnknownVariants<Unknown>(unknownValueValidation: (value: object, variant: string) => Unknown): UnionValidator<Key, Config, Unknown>;
 }

--- a/packages/validate/api/api.json
+++ b/packages/validate/api/api.json
@@ -3029,6 +3029,14 @@
                     },
                     {
                       "kind": "Content",
+                      "text": ", useNumberKeys: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "boolean"
+                    },
+                    {
+                      "kind": "Content",
                       "text": ");"
                     }
                   ],
@@ -3057,6 +3065,14 @@
                       "parameterTypeTokenRange": {
                         "startIndex": 5,
                         "endIndex": 6
+                      },
+                      "isOptional": false
+                    },
+                    {
+                      "parameterName": "useNumberKeys",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 7,
+                        "endIndex": 8
                       },
                       "isOptional": false
                     }
@@ -4262,6 +4278,14 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", useNumberKeys: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
                   "text": ");"
                 }
               ],
@@ -4290,6 +4314,14 @@
                   "parameterTypeTokenRange": {
                     "startIndex": 5,
                     "endIndex": 6
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "useNumberKeys",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
                   },
                   "isOptional": false
                 }


### PR DESCRIPTION
I messed up the schema validator for loading files.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


