### PR TITLE
Prevent default on native clipboard events

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -661,8 +661,6 @@ export function useNativeClipboardEvents() {
 				return
 			}
 
-			preventDefault(e)
-
 			// If we're editing a shape, or we are focusing an editable input, then
 			// we would want the user's paste interaction to go to that element or
 			// input instead; e.g. when pasting text into a text shape's content
@@ -680,6 +678,7 @@ export function useNativeClipboardEvents() {
 				})
 			}
 
+			preventDefault(e)
 			trackEvent('paste', { source: 'kbd' })
 		}
 


### PR DESCRIPTION
This PR calls prevent default on native clipboard events. This prevents the error sound on Safari.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

1. Use the cut, copy, and paste events on Safari.
2. Everything should still work, but no sounds should play.

### Release Notes

- Fix copy sound on clipboard events.