### PR TITLE
Make note handles show only one when zoomed out

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -106,6 +106,18 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 		if (zoom < 0.25 || isCoarsePointer) return []
 
+		if (zoom < 0.5) {
+			return [
+				{
+					id: 'bottom',
+					index: 'a3' as IndexKey,
+					type: 'clone',
+					x: NOTE_SIZE / 2,
+					y: noteHeight + offset,
+				},
+			]
+		}
+
 		return [
 			{
 				id: 'top',

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -130,9 +130,8 @@ function getNoteForPit(editor: Editor, shape: TLNoteShape, handle: TLHandle, for
 	const pagePoint = pageTransform.point()
 	const pageRotation = pageTransform.rotation()
 	const pits = getNoteAdjacentPositions(pagePoint, pageRotation, shape.props.growY, 0)
-	const index = editor.getShapeHandles(shape.id)!.findIndex((h) => h.id === handle.id)
-	if (pits[index]) {
-		const pit = pits[index]
+	const pit = pits[handle.index]
+	if (pit) {
 		return getNoteShapeForAdjacentPosition(editor, shape, pit, pageRotation, forceNew)
 	}
 }


### PR DESCRIPTION
This PR will only show the bottom handle on a sticky note when zoomed out.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Test Plan

1. Zoom out to 45%.
2. The bottom handle should be visible.
3. The bottom handle should work as expected.

### Release Notes

- Show only the bottom handle on notes when zoomed between .25 and .5