### PR TITLE
Make coarse pointer check dynamic

### DIFF
--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -20,10 +20,8 @@ export function useCoarsePointer() {
 			const mql = window.matchMedia('(any-pointer: coarse)')
 
 			const handler = (coarse?: boolean) => {
-				editor.updateInstanceState({ isCoarsePointer: !!mql.matches })
-				if (coarse !== undefined) {
-					editor.updateInstanceState({ isCoarsePointer: coarse })
-				}
+				editor.updateInstanceState({ isCoarsePointer: coarse ?? !!mql.matches })```
+
 			}
 
 			const touchStartHandler = () => handler(true)

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -20,8 +20,7 @@ export function useCoarsePointer() {
 			const mql = window.matchMedia('(any-pointer: coarse)')
 
 			const handler = (coarse?: boolean) => {
-				editor.updateInstanceState({ isCoarsePointer: coarse ?? !!mql.matches })```
-
+				editor.updateInstanceState({ isCoarsePointer: coarse ?? !!mql.matches })
 			}
 
 			const touchStartHandler = () => handler(true)

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -1,9 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useEditor } from './useEditor'
 
 /** @internal */
 export function useCoarsePointer() {
-	const previousCursor = useRef<boolean | undefined>(undefined)
 	const editor = useEditor()
 
 	useEffect(() => {

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -1,8 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useEditor } from './useEditor'
 
 /** @internal */
 export function useCoarsePointer() {
+	const previousCursor = useRef<boolean | undefined>(undefined)
 	const editor = useEditor()
 	useEffect(() => {
 		// This is a workaround for a Firefox bug where we don't correctly
@@ -17,10 +18,16 @@ export function useCoarsePointer() {
 			return
 		}
 		if (window.matchMedia) {
+			// Some devices have a touch screen but also a fine pointer (e.g. a mouse).
+			// If any pointer is coarse, we consider the device to have a coarse pointer.
+			// This is dynamically updated as the user switches between input devices.
 			const mql = window.matchMedia('(any-pointer: coarse)')
 
 			const handler = (coarse?: boolean) => {
+				const isCoarsePointer = coarse ?? !!mql.matches
+				if (isCoarsePointer === previousCursor.current) return
 				editor.updateInstanceState({ isCoarsePointer: coarse ?? !!mql.matches })
+				previousCursor.current = isCoarsePointer
 			}
 
 			const touchStartHandler = () => handler(true)

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -5,44 +5,68 @@ import { useEditor } from './useEditor'
 export function useCoarsePointer() {
 	const previousCursor = useRef<boolean | undefined>(undefined)
 	const editor = useEditor()
+
 	useEffect(() => {
+		// We'll track our own state for the pointer type
+		let isCoarse = editor.getInstanceState().isCoarsePointer
+
+		// 1.
+		// We'll use touch events / mouse events to detect coarse pointer.
+
+		// When the user touches the screen, we assume they have a coarse pointer
+		const handleTouchStart = () => {
+			if (isCoarse) return
+			isCoarse = true
+			editor.updateInstanceState({ isCoarsePointer: true })
+		}
+
+		// When the user moves the mouse, we assume they have a fine pointer
+		const handleMouseMove = () => {
+			if (!isCoarse) return
+			isCoarse = false
+			editor.updateInstanceState({ isCoarsePointer: false })
+		}
+
+		// Set up the listeners for touch and mouse events
+		window.addEventListener('touchstart', handleTouchStart)
+		window.addEventListener('mousemove', handleMouseMove)
+
+		// 2.
+		// We can also use the media query to detect / set the initial pointer type
+		// and update the state if the pointer type changes.
+
+		// We want the touch / mouse events to run even if the browser does not
+		// support matchMedia. We'll have to handle the media query changes
+		// conditionally in the code below.
+		const mql = window.matchMedia && window.matchMedia('(any-pointer: coarse)')
+
 		// This is a workaround for a Firefox bug where we don't correctly
 		// detect coarse VS fine pointer. For now, let's assume that you have a fine
 		// pointer if you're on Firefox on desktop.
-		if (
-			editor.environment.isFirefox &&
-			!editor.environment.isAndroid &&
-			!editor.environment.isIos
-		) {
-			editor.updateInstanceState({ isCoarsePointer: false })
-			return
+		const isForcedFinePointer =
+			editor.environment.isFirefox && !editor.environment.isAndroid && !editor.environment.isIos
+
+		const handleMediaQueryChange = () => {
+			const next = isForcedFinePointer ? false : mql.matches // get the value from the media query
+			if (isCoarse !== next) return // bail if the value hasn't changed
+			isCoarse = next // update the local value
+			editor.updateInstanceState({ isCoarsePointer: next }) // update the value in state
 		}
-		if (window.matchMedia) {
-			// Some devices have a touch screen but also a fine pointer (e.g. a mouse).
-			// If any pointer is coarse, we consider the device to have a coarse pointer.
-			// This is dynamically updated as the user switches between input devices.
-			const mql = window.matchMedia('(any-pointer: coarse)')
 
-			const handler = (coarse?: boolean) => {
-				const isCoarsePointer = coarse ?? !!mql.matches
-				if (isCoarsePointer === previousCursor.current) return
-				editor.updateInstanceState({ isCoarsePointer: coarse ?? !!mql.matches })
-				previousCursor.current = isCoarsePointer
-			}
+		if (mql) {
+			// set up the listener
+			mql.addEventListener('change', handleMediaQueryChange)
 
-			const touchStartHandler = () => handler(true)
-			const mouseMoveHandler = () => handler(false)
+			// and run the handler once to set the initial value
+			handleMediaQueryChange()
+		}
 
-			handler()
+		return () => {
+			window.removeEventListener('touchstart', handleTouchStart)
+			window.removeEventListener('mousemove', handleMouseMove)
+
 			if (mql) {
-				mql.addEventListener('change', () => handler())
-				window.addEventListener('touchstart', touchStartHandler)
-				window.addEventListener('mousemove', mouseMoveHandler)
-				return () => {
-					mql.removeEventListener('change', () => handler())
-					window.removeEventListener('touchstart', touchStartHandler)
-					window.removeEventListener('mousemove', mouseMoveHandler)
-				}
+				mql.removeEventListener('change', handleMediaQueryChange)
 			}
 		}
 	}, [editor])

--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -17,14 +17,28 @@ export function useCoarsePointer() {
 			return
 		}
 		if (window.matchMedia) {
-			const mql = window.matchMedia('(pointer: coarse)')
-			const handler = () => {
+			const mql = window.matchMedia('(any-pointer: coarse)')
+
+			const handler = (coarse?: boolean) => {
 				editor.updateInstanceState({ isCoarsePointer: !!mql.matches })
+				if (coarse !== undefined) {
+					editor.updateInstanceState({ isCoarsePointer: coarse })
+				}
 			}
+
+			const touchStartHandler = () => handler(true)
+			const mouseMoveHandler = () => handler(false)
+
 			handler()
 			if (mql) {
-				mql.addEventListener('change', handler)
-				return () => mql.removeEventListener('change', handler)
+				mql.addEventListener('change', () => handler())
+				window.addEventListener('touchstart', touchStartHandler)
+				window.addEventListener('mousemove', mouseMoveHandler)
+				return () => {
+					mql.removeEventListener('change', () => handler())
+					window.removeEventListener('touchstart', touchStartHandler)
+					window.removeEventListener('mousemove', mouseMoveHandler)
+				}
 			}
 		}
 	}, [editor])


### PR DESCRIPTION
When a device has both a touch screen and a mouse, pointer: coarse evaluates to false and then doesn't change even if the user begins to use the touch screen.

In this PR pointer: coarse is replaced with any-pointer: coarse, which checks if a touchscreen input is available. Event listeners for touchstart and mousemove update isCoursePointer dynamically. So if the user begins to move the mouse it changes to pointer: fine, if they then touch the screen the pointer is returned to coarse.

https://github.com/tldraw/tldraw/assets/98838967/fb86bb44-ec11-4161-bb2f-0e8c3ee83eb6



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Load tldraw on a device with both coarse and fine pointer inputs avaiable (e.g. an ipad with a keyboard and trackpad)
2. Switch between using the mouse and touch screen.
3. Handles on shapes should update dynamically. 

### Release Notes

- Add a brief release note for your PR here.
