### PR TITLE
Bring back `/new` for creating new rooms when not inside iframes.

### DIFF
--- a/apps/dotcom/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/src/components/ErrorPage/ErrorPage.tsx
@@ -7,7 +7,6 @@ export function ErrorPage({
 }: {
 	icon?: boolean
 	messages: { header: string; para1: string; para2?: string }
-	redirectTo?: string
 }) {
 	const inIframe = isInIframe()
 	return (

--- a/apps/dotcom/src/pages/history-snapshot.tsx
+++ b/apps/dotcom/src/pages/history-snapshot.tsx
@@ -32,7 +32,6 @@ export function Component() {
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',
 				}}
-				redirectTo="/"
 			/>
 		)
 

--- a/apps/dotcom/src/pages/history.tsx
+++ b/apps/dotcom/src/pages/history.tsx
@@ -29,7 +29,6 @@ export function Component() {
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',
 				}}
-				redirectTo="/"
 			/>
 		)
 	return (

--- a/apps/dotcom/src/pages/new.tsx
+++ b/apps/dotcom/src/pages/new.tsx
@@ -1,0 +1,41 @@
+import { Snapshot } from '@tldraw/dotcom-shared'
+import { schema } from '@tldraw/tlsync'
+import { Navigate } from 'react-router-dom'
+import '../../styles/globals.css'
+import { ErrorPage } from '../components/ErrorPage/ErrorPage'
+import { defineLoader } from '../utils/defineLoader'
+import { isInIframe } from '../utils/iFrame'
+import { getNewRoomResponse } from '../utils/sharing'
+
+const { loader, useData } = defineLoader(async (_args) => {
+	if (isInIframe()) return null
+
+	const res = await getNewRoomResponse({
+		schema: schema.serialize(),
+		snapshot: {},
+	} satisfies Snapshot)
+
+	const response = (await res.json()) as { error: boolean; slug?: string }
+	if (!res.ok || response.error) {
+		return null
+	}
+	return { slug: response.slug }
+})
+
+export { loader }
+
+export function Component() {
+	const data = useData()
+	if (!data || !data.slug)
+		return (
+			<ErrorPage
+				icon
+				messages={{
+					header: 'Page not found',
+					para1: 'The page you are looking does not exist or has been moved.',
+				}}
+				redirectTo="/"
+			/>
+		)
+	return <Navigate to={`/r/${data.slug}`} />
+}

--- a/apps/dotcom/src/pages/new.tsx
+++ b/apps/dotcom/src/pages/new.tsx
@@ -34,7 +34,6 @@ export function Component() {
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',
 				}}
-				redirectTo="/"
 			/>
 		)
 	return <Navigate to={`/r/${data.slug}`} />

--- a/apps/dotcom/src/pages/new.tsx
+++ b/apps/dotcom/src/pages/new.tsx
@@ -16,7 +16,7 @@ const { loader, useData } = defineLoader(async (_args) => {
 	} satisfies Snapshot)
 
 	const response = (await res.json()) as { error: boolean; slug?: string }
-	if (!res.ok || response.error) {
+	if (!res.ok || response.error || !response.slug) {
 		return null
 	}
 	return { slug: response.slug }
@@ -26,7 +26,7 @@ export { loader }
 
 export function Component() {
 	const data = useData()
-	if (!data || !data.slug)
+	if (!data)
 		return (
 			<ErrorPage
 				icon

--- a/apps/dotcom/src/pages/not-found.tsx
+++ b/apps/dotcom/src/pages/not-found.tsx
@@ -8,7 +8,6 @@ export function Component() {
 				header: 'Page not found',
 				para1: 'The page you are looking does not exist or has been moved.',
 			}}
-			redirectTo="/"
 		/>
 	)
 }

--- a/apps/dotcom/src/routes.tsx
+++ b/apps/dotcom/src/routes.tsx
@@ -30,7 +30,7 @@ export const router = createRoutesFromElements(
 		<Route errorElement={<DefaultErrorFallback />}>
 			<Route path="/" lazy={() => import('./pages/root')} />
 			<Route path="/r" element={<Navigate to="/" />} />
-			<Route path="/new" element={<Navigate to="/" />} />
+			<Route path="/new" lazy={() => import('./pages/new')} />
 			<Route path="/r/:roomId" lazy={() => import('./pages/public-multiplayer')} />
 			<Route path="/r/:boardId/history" lazy={() => import('./pages/history')} />
 			<Route

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -2,6 +2,7 @@ import {
 	CreateRoomRequestBody,
 	CreateSnapshotRequestBody,
 	CreateSnapshotResponseBody,
+	Snapshot,
 } from '@tldraw/dotcom-shared'
 import { useMemo } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -73,7 +74,7 @@ async function getSnapshotLink(
 	})
 }
 
-export async function getNewRoomResponse(snapshot: CreateRoomRequestBody['snapshot']) {
+export async function getNewRoomResponse(snapshot: Snapshot) {
 	return await fetch(SNAPSHOT_UPLOAD_URL, {
 		method: 'POST',
 		headers: {

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -34,7 +34,7 @@ export const LEAVE_SHARED_PROJECT_ACTION = 'leave-shared-project' as const
 export const FORK_PROJECT_ACTION = 'fork-project' as const
 
 const CREATE_SNAPSHOT_ENDPOINT = `/api/snapshots`
-const SNAPSHOT_UPLOAD_URLOAD_URL = `/api/new-room`
+const SNAPSHOT_UPLOAD_URL = `/api/new-room`
 
 async function getSnapshotLink(
 	source: string,
@@ -74,7 +74,7 @@ async function getSnapshotLink(
 }
 
 export async function getNewRoomResponse(snapshot: CreateRoomRequestBody['snapshot']) {
-	return await fetch(SNAPSHOT_UPLOAD_URLOAD_URL, {
+	return await fetch(SNAPSHOT_UPLOAD_URL, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',


### PR DESCRIPTION
This brings back the `/new` route for creating new rooms. But just when we are not inside an iframe.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
