### PR TITLE
Revert "[signia] Smart dirty checking of active computeds (#3516)"

### DIFF
--- a/packages/state/src/lib/core/Computed.ts
+++ b/packages/state/src/lib/core/Computed.ts
@@ -4,7 +4,7 @@ import { HistoryBuffer } from './HistoryBuffer'
 import { maybeCaptureParent, startCapturingParents, stopCapturingParents } from './capture'
 import { GLOBAL_START_EPOCH } from './constants'
 import { EMPTY_ARRAY, equals, haveParentsChanged, singleton } from './helpers'
-import { getGlobalEpoch, getIsReacting } from './transactions'
+import { getGlobalEpoch } from './transactions'
 import { Child, ComputeDiff, RESET_VALUE, Signal } from './types'
 import { logComputedGetterWarning } from './warnings'
 
@@ -189,15 +189,8 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 	__unsafe__getWithoutCapture(ignoreErrors?: boolean): Value {
 		const isNew = this.lastChangedEpoch === GLOBAL_START_EPOCH
 
-		const globalEpoch = getGlobalEpoch()
-
-		if (
-			!isNew &&
-			(this.lastCheckedEpoch === globalEpoch ||
-				(this.isActivelyListening && getIsReacting() && this.lastTraversedEpoch < globalEpoch) ||
-				!haveParentsChanged(this))
-		) {
-			this.lastCheckedEpoch = globalEpoch
+		if (!isNew && (this.lastCheckedEpoch === getGlobalEpoch() || !haveParentsChanged(this))) {
+			this.lastCheckedEpoch = getGlobalEpoch()
 			if (this.error) {
 				if (!ignoreErrors) {
 					throw this.error.thrownValue

--- a/packages/state/src/lib/core/transactions.ts
+++ b/packages/state/src/lib/core/transactions.ts
@@ -70,10 +70,6 @@ export function getGlobalEpoch() {
 	return inst.globalEpoch
 }
 
-export function getIsReacting() {
-	return inst.globalIsReacting
-}
-
 /**
  * Collect all of the reactors that need to run for an atom and run them.
  *


### PR DESCRIPTION
This reverts commit 741ed00bda22f3b445f5996a40ce4bd54a629cc6.

This was causing a bug with computed's not getting invalidated correctly. To reproduce:
- Draw a rectangle
- Hold alt to drag out a duplicate
- Delete the duplicate

We'd then get errors and sometimes a crash where the indicator continued trying to render a now-deleted shape. 

### Change Type
- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

