### PR TITLE
Bring back `/r`

### DIFF
--- a/apps/dotcom/src/routes.tsx
+++ b/apps/dotcom/src/routes.tsx
@@ -1,6 +1,6 @@
 import { captureException } from '@sentry/react'
 import { useEffect } from 'react'
-import { createRoutesFromElements, Navigate, Outlet, Route, useRouteError } from 'react-router-dom'
+import { createRoutesFromElements, Outlet, Route, useRouteError } from 'react-router-dom'
 import { DefaultErrorFallback } from './components/DefaultErrorFallback/DefaultErrorFallback'
 import { ErrorPage } from './components/ErrorPage/ErrorPage'
 
@@ -29,7 +29,7 @@ export const router = createRoutesFromElements(
 	>
 		<Route errorElement={<DefaultErrorFallback />}>
 			<Route path="/" lazy={() => import('./pages/root')} />
-			<Route path="/r" element={<Navigate to="/" />} />
+			<Route path="/r" lazy={() => import('./pages/new')} />
 			<Route path="/new" lazy={() => import('./pages/new')} />
 			<Route path="/r/:roomId" lazy={() => import('./pages/public-multiplayer')} />
 			<Route path="/r/:boardId/history" lazy={() => import('./pages/history')} />


### PR DESCRIPTION
Went for straight up loading of `new` page instead of a redirect, so we don't have a few redirects in a row (`/r` -> `/new` -> `r/something`.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Brings back `/r` route for creating new rooms.
