### PR TITLE
[experiment] laser + collaboration: indicate which shapes are being pointed at

### DIFF
--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -94,6 +94,34 @@ const Collaborator = track(function Collaborator({
 		cursor.y > viewportPageBounds.maxY - 16 / zoomLevel
 	)
 
+	let laserIndicatedShapeIndicator
+	// Highlight shapes that are being pointed at by the laser.
+	if (
+		CollaboratorScribble &&
+		CollaboratorShapeIndicator &&
+		scribbles.length === 1 &&
+		scribbles[0].color === 'laser'
+	) {
+		for (const shape of editor.getCurrentPageShapes()) {
+			const shapeId = shape.id
+
+			if (
+				editor.getShapeGeometry(shape).isPointInBounds(editor.getPointInShapeSpace(shape, cursor))
+			) {
+				laserIndicatedShapeIndicator = (
+					<CollaboratorShapeIndicator
+						className="tl-collaborator__shape-indicator"
+						key={userId + '_' + shapeId}
+						shapeId={shapeId}
+						color={color}
+						opacity={1}
+					/>
+				)
+				break
+			}
+		}
+	}
+
 	return (
 		<>
 			{brush && CollaboratorBrush ? (
@@ -137,6 +165,7 @@ const Collaborator = track(function Collaborator({
 							opacity={scribble.color === 'laser' ? 0.5 : 0.1}
 						/>
 					))}
+					{laserIndicatedShapeIndicator}
 				</>
 			) : null}
 			{CollaboratorShapeIndicator &&


### PR DESCRIPTION
This little tweak has been noodling in my head. Felt like lasering should make the shapes being pointed at have an indicator around them to help facilitate collaboration better.


https://github.com/tldraw/tldraw/assets/469604/c4ef46ab-d4b0-485e-88c8-2cfa794a1edd



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Laser: in multiplayer mode, indicate which shapes are being pointed at.
