### PR TITLE
[bugfix] don't crash if a bound shape doesn't exist

### DIFF
--- a/packages/editor/src/lib/editor/shapes/shared/arrow/shared.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/arrow/shared.ts
@@ -25,8 +25,9 @@ export function getBoundShapeInfoForTerminal(
 		return
 	}
 
-	const shape = editor.getShape(terminal.boundShapeId)!
-	const transform = editor.getShapePageTransform(shape)!
+	const shape = editor.getShape(terminal.boundShapeId)
+	if (!shape) return
+	const transform = editor.getShapePageTransform(shape)
 	const geometry = editor.getShapeGeometry(shape)
 
 	// This is hacky: we're only looking at the first child in the group. Really the arrow should


### PR DESCRIPTION
We saw this in r/ok

- somehow an arrow was created where the boundShapeId was pointing to a shape that doesn't exist
- we do need to be tolerant of such situations until our server can enforce binding constraints
- so let's not use `!` here

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

I copied the data from `/r/ok` and loaded it and this fixed the error
 
### Release Notes

- fixes an edge case in multiplayer rooms where the room can crash if an arrow's bound shape is deleted by a peer
