### PR TITLE
fix android long press changing cursor to non-coarse

### DIFF
--- a/packages/editor/src/lib/hooks/useCoarsePointer.ts
+++ b/packages/editor/src/lib/hooks/useCoarsePointer.ts
@@ -20,8 +20,12 @@ export function useCoarsePointer() {
 		}
 
 		// When the user moves the mouse, we assume they have a fine pointer
-		const handleMouseMove = () => {
+		const handleMouseMove = (
+			e: MouseEvent & { sourceCapabilities?: { firesTouchEvents: boolean } }
+		) => {
 			if (!isCoarse) return
+			// Fix Android Chrome bug where mousemove is fired even if the user long presses
+			if (e.sourceCapabilities?.firesTouchEvents) return
 			isCoarse = false
 			editor.updateInstanceState({ isCoarsePointer: false })
 		}


### PR DESCRIPTION


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Open a multip;ayer room on android chrome
2. Long press
3. Make sure coarse pointer isnt there

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
