### PR TITLE
Hacky fix safari transparency

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -276,6 +276,11 @@ export class MinimapManager {
 		this.gl.prepareTriangles(this.gl.viewport, len)
 		this.gl.setFillColor(this.colors.viewportFill)
 		this.gl.drawTrianglesTransparently(len)
+		if (this.editor.environment.isSafari) {
+			this.gl.drawTrianglesTransparently(len)
+			this.gl.drawTrianglesTransparently(len)
+			this.gl.drawTrianglesTransparently(len)
+		}
 	}
 
 	drawCollaborators() {


### PR DESCRIPTION
This PR fixes the missing viewport on Safari. Blending on webgl in Safari is cursed.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `feature` — New feature