### PR TITLE
embed: prevent nested tldraw

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -539,7 +539,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
     canResize: (shape: TLEmbedShape) => boolean;
     // (undocumented)
-    component(shape: TLEmbedShape): JSX_2.Element;
+    component(shape: TLEmbedShape): JSX_2.Element | null;
     // (undocumented)
     getDefaultProps(): TLEmbedShape['props'];
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -99,6 +99,11 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 		const isInteractive = isEditing || isHoveringWhileEditingSameShape
 
+		// Prevent nested embedding of tldraw
+		const isIframe =
+			typeof window !== 'undefined' && (window !== window.top || window.self !== window.parent)
+		if (isIframe && embedInfo?.definition.type === 'tldraw') return null
+
 		if (embedInfo?.definition.type === 'github_gist') {
 			const idFromGistUrl = embedInfo.url.split('/').pop()
 			if (!idFromGistUrl) throw Error('No gist id!')


### PR DESCRIPTION
don't allow infinite nesting :)

<img width="1072" alt="Screenshot 2024-04-30 at 12 02 41" src="https://github.com/tldraw/tldraw/assets/469604/fcb29ac8-5bde-4ff4-8c40-f093ab519c56">


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Embeds: Fix infinite nesting of tldraw rooms.
