### PR TITLE
Prevent unnecessary fetching of readonly slugs

### DIFF
--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -135,6 +135,12 @@ export const ShareMenu = React.memo(function ShareMenu() {
 					})
 				}
 			})
+		} else if (!shareState.readonlyQrCodeDataUrl) {
+			createQRCodeImageDataString(shareState.readonlyUrl).then((dataUrl) => {
+				if (!cancelled) {
+					setShareState((s) => ({ ...s, readonlyQrCodeDataUrl: dataUrl }))
+				}
+			})
 		}
 
 		const interval = setInterval(() => {

--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -124,20 +124,22 @@ export const ShareMenu = React.memo(function ShareMenu() {
 			})
 		}
 
-		getReadonlyUrl().then((readonlyUrl) => {
-			if (readonlyUrl && !shareState.readonlyQrCodeDataUrl) {
-				// fetch the readonly QR code data URL
-				createQRCodeImageDataString(readonlyUrl).then((dataUrl) => {
-					if (!cancelled) {
-						setShareState((s) => ({ ...s, readonlyUrl, readonlyQrCodeDataUrl: dataUrl }))
-					}
-				})
-			}
-		})
+		if (!shareState.readonlyUrl) {
+			getReadonlyUrl().then((readonlyUrl) => {
+				if (readonlyUrl) {
+					// fetch the readonly QR code data URL
+					createQRCodeImageDataString(readonlyUrl).then((dataUrl) => {
+						if (!cancelled) {
+							setShareState((s) => ({ ...s, readonlyUrl, readonlyQrCodeDataUrl: dataUrl }))
+						}
+					})
+				}
+			})
+		}
 
 		const interval = setInterval(() => {
 			const url = window.location.href
-			if (shareState.url === url) return
+			if (decodeURIComponent(url) === decodeURIComponent(shareState.url)) return
 			setShareState(getFreshShareState())
 		}, 300)
 

--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -19,6 +19,7 @@ import {
 import { useShareMenuIsOpen } from '../hooks/useShareMenuOpen'
 import { createQRCodeImageDataString } from '../utils/qrcode'
 import { SHARE_PROJECT_ACTION, SHARE_SNAPSHOT_ACTION } from '../utils/sharing'
+import { sameUrls } from '../utils/url'
 import { ShareButton } from './ShareButton'
 
 const SHARE_CURRENT_STATE = {
@@ -145,7 +146,7 @@ export const ShareMenu = React.memo(function ShareMenu() {
 
 		const interval = setInterval(() => {
 			const url = window.location.href
-			if (decodeURIComponent(url) === decodeURIComponent(shareState.url)) return
+			if (sameUrls(url, shareState.url)) return
 			setShareState(getFreshShareState())
 		}, 300)
 

--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -19,7 +19,6 @@ import {
 import { useShareMenuIsOpen } from '../hooks/useShareMenuOpen'
 import { createQRCodeImageDataString } from '../utils/qrcode'
 import { SHARE_PROJECT_ACTION, SHARE_SNAPSHOT_ACTION } from '../utils/sharing'
-import { sameUrls } from '../utils/url'
 import { ShareButton } from './ShareButton'
 
 const SHARE_CURRENT_STATE = {
@@ -146,7 +145,7 @@ export const ShareMenu = React.memo(function ShareMenu() {
 
 		const interval = setInterval(() => {
 			const url = window.location.href
-			if (sameUrls(url, shareState.url)) return
+			if (shareState.url === url) return
 			setShareState(getFreshShareState())
 		}, 300)
 

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -70,7 +70,9 @@ async function getSnapshotLink(
 		return ''
 	}
 	const paramsToUse = getViewportUrlQuery(editor)
-	const params = paramsToUse ? `?${new URLSearchParams(paramsToUse).toString()}` : ''
+	const params = paramsToUse
+		? decodeURIComponent(`?${new URLSearchParams(paramsToUse).toString()}`)
+		: ''
 	return new Blob([`${window.location.origin}/${SNAPSHOT_PREFIX}/${response.roomId}${params}`], {
 		type: 'text/plain',
 	})

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -134,7 +134,9 @@ export function useSharing(): TLUiOverrides {
 
 							const query = getViewportUrlQuery(editor)
 							const origin = window.location.origin
-							const pathname = `/${ROOM_PREFIX}/${response.slug}?${new URLSearchParams(query ?? {}).toString()}`
+							const pathname = decodeURIComponent(
+								`/${ROOM_PREFIX}/${response.slug}?${new URLSearchParams(query ?? {}).toString()}`
+							)
 							if (runningInIFrame) {
 								window.open(`${origin}${pathname}`)
 							} else {

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -70,6 +70,9 @@ async function getSnapshotLink(
 		return ''
 	}
 	const paramsToUse = getViewportUrlQuery(editor)
+	// React router has an issue with the search params being encoded, which can cause multiple navigations
+	// and can also make us believe that the URL has changed when it hasn't.
+	// https://github.com/tldraw/tldraw/pull/3663#discussion_r1584946080
 	const params = paramsToUse
 		? decodeURIComponent(`?${new URLSearchParams(paramsToUse).toString()}`)
 		: ''
@@ -136,6 +139,10 @@ export function useSharing(): TLUiOverrides {
 
 							const query = getViewportUrlQuery(editor)
 							const origin = window.location.origin
+
+							// React router has an issue with the search params being encoded, which can cause multiple navigations
+							// and can also make us believe that the URL has changed when it hasn't.
+							// https://github.com/tldraw/tldraw/pull/3663#discussion_r1584946080
 							const pathname = decodeURIComponent(
 								`/${ROOM_PREFIX}/${response.slug}?${new URLSearchParams(query ?? {}).toString()}`
 							)

--- a/apps/dotcom/src/utils/url.ts
+++ b/apps/dotcom/src/utils/url.ts
@@ -1,3 +1,26 @@
 export function openUrl(url: string) {
 	window.open(url, '_blank')
 }
+
+/**
+ * Compares two URLs to see if they are the same. This ignores encoding.
+ * @param first - The first URL to compare.
+ * @param second - The second URL to compare.
+ * @returns Whether the URLs are the same.
+ */
+export function sameUrls(first: string, second: string): boolean {
+	const firstUrl = new URL(first)
+	const secondUrl = new URL(second)
+	const firstPathname = decodeURIComponent(firstUrl.pathname)
+	const secondPathname = decodeURIComponent(secondUrl.pathname)
+	const firstSearch = decodeURIComponent(firstUrl.search)
+	const secondSearch = decodeURIComponent(secondUrl.search)
+	const firstHash = decodeURIComponent(firstUrl.hash)
+	const secondHash = decodeURIComponent(secondUrl.hash)
+	return (
+		firstUrl.origin === secondUrl.origin &&
+		firstPathname === secondPathname &&
+		firstSearch === secondSearch &&
+		firstHash === secondHash
+	)
+}

--- a/apps/dotcom/src/utils/url.ts
+++ b/apps/dotcom/src/utils/url.ts
@@ -1,26 +1,3 @@
 export function openUrl(url: string) {
 	window.open(url, '_blank')
 }
-
-/**
- * Compares two URLs to see if they are the same. This ignores encoding.
- * @param first - The first URL to compare.
- * @param second - The second URL to compare.
- * @returns Whether the URLs are the same.
- */
-export function sameUrls(first: string, second: string): boolean {
-	const firstUrl = new URL(first)
-	const secondUrl = new URL(second)
-	const firstPathname = decodeURIComponent(firstUrl.pathname)
-	const secondPathname = decodeURIComponent(secondUrl.pathname)
-	const firstSearch = decodeURIComponent(firstUrl.search)
-	const secondSearch = decodeURIComponent(secondUrl.search)
-	const firstHash = decodeURIComponent(firstUrl.hash)
-	const secondHash = decodeURIComponent(secondUrl.hash)
-	return (
-		firstUrl.origin === secondUrl.origin &&
-		firstPathname === secondPathname &&
-		firstSearch === secondSearch &&
-		firstHash === secondHash
-	)
-}


### PR DESCRIPTION
Prevents unnecessary fetching of readonly slugs. We only need to fetch it if we don't have it yet. 

There was also a weird issue with `window.location.href` sometimes returning encoded search params and sometimes decoded ones:

![image](https://github.com/tldraw/tldraw/assets/2523721/ca1e36c6-5e86-4e48-9350-c53de32a9f2e)

This then caused an additional fetch in the `setInterval` since the [urls did not match](https://github.com/tldraw/tldraw/blob/main/apps/dotcom/src/components/ShareMenu.tsx#L140).

![CleanShot 2024-04-30 at 14 37 12](https://github.com/tldraw/tldraw/assets/2523721/b1c540aa-902a-4574-a8e7-a0507f7dbda2)

Resolves https://github.com/tldraw/tldraw/issues/3661

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

Opening a multiplayer room

1. Open a multiplayer room. You should only see one fetch for the readonly slug.

Sharing a local room

1. Open a local room.
2. Share it. You should only see one fetch for the readonly slug.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Prevent unnecessary fetching of readonly slugs.
