### PR TITLE
Allow clients to gracefully handle rejection

### DIFF
--- a/apps/dotcom/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/src/components/ErrorPage/ErrorPage.tsx
@@ -1,28 +1,39 @@
+import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { isInIframe } from '../../utils/iFrame'
 
-export function ErrorPage({
-	icon,
-	messages,
-}: {
-	icon?: boolean
-	messages: { header: string; para1: string; para2?: string }
-}) {
+const GoBackLink = () => {
 	const inIframe = isInIframe()
+	return (
+		<Link to={'/'} target={inIframe ? '_blank' : '_self'}>
+			{inIframe ? 'Open tldraw.' : 'Back to tldraw.'}
+		</Link>
+	)
+}
+
+const sadFaceIcon = (
+	<img width={36} height={36} src="/404-Sad-tldraw.svg" loading="lazy" role="presentation" />
+)
+
+export function ErrorPage({
+	messages,
+	icon = sadFaceIcon,
+	cta = <GoBackLink />,
+}: {
+	icon?: ReactNode
+	messages: { header: string; para1: string; para2?: string }
+	cta?: ReactNode
+}) {
 	return (
 		<div className="error-page">
 			<div className="error-page__container">
-				{icon && (
-					<img width={36} height={36} alt={'Not found'} src="/404-Sad-tldraw.svg" loading="lazy" />
-				)}
+				{icon}
 				<div className="error-page__content">
 					<h1>{messages.header}</h1>
 					<p>{messages.para1}</p>
 					{messages.para2 && <p>{messages.para2}</p>}
 				</div>
-				<Link to={'/'} target={inIframe ? '_blank' : '_self'}>
-					{inIframe ? 'Open tldraw.' : 'Back to tldraw.'}
-				</Link>
+				{cta}
 			</div>
 		</div>
 	)

--- a/apps/dotcom/src/components/StoreErrorScreen.tsx
+++ b/apps/dotcom/src/components/StoreErrorScreen.tsx
@@ -1,17 +1,33 @@
 import { TLIncompatibilityReason } from '@tldraw/tlsync'
 import { exhaustiveSwitchError } from 'tldraw'
+import 'tldraw/tldraw.css'
 import { RemoteSyncError } from '../utils/remote-sync/remote-sync'
 import { ErrorPage } from './ErrorPage/ErrorPage'
 
 export function StoreErrorScreen({ error }: { error: Error }) {
 	let header = 'Could not connect to server.'
 	let message = ''
-
 	if (error instanceof RemoteSyncError) {
 		switch (error.reason) {
 			case TLIncompatibilityReason.ClientTooOld: {
-				message = 'This client is out of date. Please refresh the page.'
-				break
+				return (
+					<ErrorPage
+						icon={
+							<img
+								width={36}
+								height={36}
+								src="/tldraw-white-on-black.svg"
+								loading="lazy"
+								role="presentation"
+							/>
+						}
+						messages={{
+							header: 'Refresh the page',
+							para1: 'You need to update to the latest version of tldraw to continue.',
+						}}
+						cta={<button onClick={() => window.location.reload()}>Refresh</button>}
+					/>
+				)
 			}
 			case TLIncompatibilityReason.ServerTooOld: {
 				message =
@@ -38,5 +54,5 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 		}
 	}
 
-	return <ErrorPage icon messages={{ header, para1: message }} />
+	return <ErrorPage messages={{ header, para1: message }} />
 }

--- a/apps/dotcom/src/hooks/useRemoteSyncClient.ts
+++ b/apps/dotcom/src/hooks/useRemoteSyncClient.ts
@@ -40,7 +40,11 @@ export function useRemoteSyncClient(opts: UseSyncClientConfig): RemoteTLStoreWit
 
 	const store = useTLStore({ schema })
 
+	const error: NonNullable<typeof state>['error'] = state?.error ?? undefined
+
 	useEffect(() => {
+		if (error) return
+
 		const userPreferences = computed<{ id: string; color: string; name: string }>(
 			'userPreferences',
 			() => {
@@ -107,7 +111,7 @@ export function useRemoteSyncClient(opts: UseSyncClientConfig): RemoteTLStoreWit
 			client.close()
 			socket.close()
 		}
-	}, [prefs, roomId, store, uri])
+	}, [prefs, roomId, store, uri, error])
 
 	return useValue<RemoteTLStoreWithStatus>(
 		'remote synced store',

--- a/apps/dotcom/src/pages/history-snapshot.tsx
+++ b/apps/dotcom/src/pages/history-snapshot.tsx
@@ -28,7 +28,6 @@ export function Component() {
 	if (!result || !result.timestamp)
 		return (
 			<ErrorPage
-				icon
 				messages={{
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',

--- a/apps/dotcom/src/pages/history.tsx
+++ b/apps/dotcom/src/pages/history.tsx
@@ -25,7 +25,6 @@ export function Component() {
 	if (!data)
 		return (
 			<ErrorPage
-				icon
 				messages={{
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',

--- a/apps/dotcom/src/pages/new.tsx
+++ b/apps/dotcom/src/pages/new.tsx
@@ -29,7 +29,6 @@ export function Component() {
 	if (!data)
 		return (
 			<ErrorPage
-				icon
 				messages={{
 					header: 'Page not found',
 					para1: 'The page you are looking does not exist or has been moved.',

--- a/apps/dotcom/src/pages/not-found.tsx
+++ b/apps/dotcom/src/pages/not-found.tsx
@@ -3,7 +3,6 @@ import { ErrorPage } from '../components/ErrorPage/ErrorPage'
 export function Component() {
 	return (
 		<ErrorPage
-			icon
 			messages={{
 				header: 'Page not found',
 				para1: 'The page you are looking does not exist or has been moved.',

--- a/packages/tlsync/src/lib/RoomSession.ts
+++ b/packages/tlsync/src/lib/RoomSession.ts
@@ -33,7 +33,6 @@ export type RoomSession<R extends UnknownRecord> =
 			state: typeof RoomSessionState.Connected
 			sessionKey: string
 			presenceId: string
-			isV4Client: boolean
 			socket: TLRoomSocket<R>
 			serializedSchema: SerializedSchema
 			lastInteractionTime: number

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -2,7 +2,7 @@ import { SerializedSchema, UnknownRecord } from '@tldraw/store'
 import { NetworkDiff, ObjectDiff, RecordOpType } from './diff'
 
 /** @public */
-export const TLSYNC_PROTOCOL_VERSION = 5
+export const TLSYNC_PROTOCOL_VERSION = 6
 
 /** @public */
 export const TLIncompatibilityReason = {


### PR DESCRIPTION
This PR fixes the issue where sync clients would get into a reconnect loop after being rejected by the sync server.

- Close the socket when in the error state (see useRemoteSyncClient)
- Show a 'plx refresh the page' screen that doesn't have a sad face on it
- If older clients who can't handle rejection well need to be rejected (e.g. due to a store migration being added) then we send them to a special purgatory where the canvas goes blank and it shows the offline indicator but the websocket connection stays open and it won't try to reconnect.

### Change Type

- [x] `dotcom` — Changes the tldraw.com web app
- [x] `bugfix` — Bug fix


### Test Plan

1. Gonna manually test this one by doing sneaky deploys to a test PR


