### PR TITLE
don't render the minimap if it fails to initialize the gl context

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -25,9 +25,19 @@ export function DefaultMinimap() {
 	const minimapRef = React.useRef<MinimapManager>()
 
 	React.useEffect(() => {
-		const minimap = new MinimapManager(editor, rCanvas.current, container)
-		minimapRef.current = minimap
-		return minimapRef.current.close
+		try {
+			const minimap = new MinimapManager(editor, rCanvas.current, container)
+			minimapRef.current = minimap
+			return minimapRef.current.close
+		} catch (e) {
+			editor.annotateError(e, {
+				origin: 'minimap',
+				willCrashApp: false,
+			})
+			setTimeout(() => {
+				throw e
+			})
+		}
 	}, [editor, container])
 
 	const onDoubleClick = React.useCallback(


### PR DESCRIPTION
So far 33 people have had tldraw crash due to getContext('webgl2') returning null for some reason. Maybe it's to do with what kind of graphics hardware they have available.

This PR adds a stopgap measure wherein the minimap manager just fails to render anything on the canvas element instead of crashing the app. Ideally we'd have better UX around this but that can wait.

I'm gonna hotfix this to dotcom.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

