### PR TITLE
move group select logic to action

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6632,7 +6632,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				},
 			])
 			this.reparentShapes(sortedShapeIds, groupId)
-			this.select(groupId)
 		})
 
 		return this

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -560,7 +560,9 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						editor.ungroupShapes(editor.getSelectedShapeIds())
 					} else {
 						editor.mark('group')
-						editor.groupShapes(editor.getSelectedShapeIds())
+						const groupId = createShapeId()
+						editor.groupShapes(editor.getSelectedShapeIds(), groupId)
+						editor.select(groupId)
 					}
 				},
 			},


### PR DESCRIPTION
This PR seeks to make it easier to disentangle shape selection logic from the grouping shapes logic. This is one of two approaches we could take to this problem.

Other PR is here: https://github.com/tldraw/tldraw/pull/3690 

This method removes selection logic from the group shapes method and puts it in the actions.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
