### PR TITLE
Prevent duplicate from creating any shapes if we reach max allowed shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5105,15 +5105,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			if (maxShapesReached) {
 				alertMaxShapes(this)
+				return
 			}
 
-			const newShapes = maxShapesReached
-				? shapesToCreate.slice(0, MAX_SHAPES_PER_PAGE - this.getCurrentPageShapeIds().size)
-				: shapesToCreate
+			const ids = shapesToCreate.map((s) => s.id)
 
-			const ids = newShapes.map((s) => s.id)
-
-			this.createShapes(newShapes)
+			this.createShapes(shapesToCreate)
 			this.setSelectedShapes(ids)
 
 			if (offset !== undefined) {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4963,6 +4963,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (ids.length <= 0) return this
 
+		const maxShapesReached =
+			shapes.length + this.getCurrentPageShapeIds().size > MAX_SHAPES_PER_PAGE
+
+		if (maxShapesReached) {
+			alertMaxShapes(this)
+			return this
+		}
+
 		const initialIds = new Set(ids)
 		const idsToCreate: TLShapeId[] = []
 		const idsToCheck = [...ids]
@@ -5100,14 +5108,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 
 		this.history.batch(() => {
-			const maxShapesReached =
-				shapesToCreate.length + this.getCurrentPageShapeIds().size > MAX_SHAPES_PER_PAGE
-
-			if (maxShapesReached) {
-				alertMaxShapes(this)
-				return
-			}
-
 			const ids = shapesToCreate.map((s) => s.id)
 
 			this.createShapes(shapesToCreate)


### PR DESCRIPTION
This prevents duplicating shapes if we get to the max allowed shapes. Before this change we would create as many shapes as we could and skip the rest. After this change we don't create any shapes in this case.

We already do this for [copy pasting](https://github.com/tldraw/tldraw/blob/mitja%2Fduplicate-shapes/packages/editor/src/lib/editor/Editor.ts#L7595-L7600)  (via `putContentOntoCurrentPage`), so no change was needed there.

Resolves https://github.com/tldraw/tldraw/issues/3669

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Create close to 2000 shapes.
2. Select so many shapes that duplicating them would go over the 2000 shapes per page limit.
3. Duplicate.
4. You should not create any shapes even if there is space for some of them.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Prevent duplicating shapes if we would go over the maximum shape limit. It's now an all or nothing operation, where as before some shapes would get created.
