### PR TITLE
Prevent wobble during viewport following

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1033,7 +1033,9 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): this;
     readonly snaps: SnapManager;
     stackShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical', gap: number): this;
-    startFollowingUser(userId: string): this;
+    startFollowingUser(userId: string, { animateToUser }?: {
+        animateToUser?: boolean;
+    }): this;
     stopCameraAnimation(): this;
     stopFollowingUser(): this;
     readonly store: TLStore;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1033,9 +1033,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): this;
     readonly snaps: SnapManager;
     stackShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical', gap: number): this;
-    startFollowingUser(userId: string, { animateToUser }?: {
-        animateToUser?: boolean;
-    }): this;
+    startFollowingUser(userId: string): this;
     stopCameraAnimation(): this;
     stopFollowingUser(): this;
     readonly store: TLStore;

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -20,15 +20,8 @@ export const DEFAULT_CAMERA_OPTIONS: TLCameraOptions = {
 	zoomSteps: [0.1, 0.25, 0.5, 1, 2, 4, 8],
 }
 
-export const FOLLOW_CHASE_PROPORTION = 0.5
 /** @internal */
-export const FOLLOW_CHASE_PAN_SNAP = 0.1
-/** @internal */
-export const FOLLOW_CHASE_PAN_UNSNAP = 0.2
-/** @internal */
-export const FOLLOW_CHASE_ZOOM_SNAP = 0.005
-/** @internal */
-export const FOLLOW_CHASE_ZOOM_UNSNAP = 0.05
+export const FOLLOW_CHASE_VIEWPORT_SNAP = 2
 
 /** @internal */
 export const DOUBLE_CLICK_DURATION = 450

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3265,7 +3265,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	stopFollowingUser(): this {
-		console.error('why did i stop')
 		this.batch(() => {
 			// commit the current camera to the store
 			this._setCamera(this.getCamera())

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3141,10 +3141,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	startFollowingUser(
-		userId: string,
-		{ animateToUser = true }: { animateToUser?: boolean } = {}
-	): this {
+	startFollowingUser(userId: string): this {
 		const leaderPresences = this._getCollaboratorsQuery()
 			.get()
 			.filter((p) => p.userId === userId)
@@ -3202,7 +3199,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				const animationSpeed = this.user.getAnimationSpeed()
 
-				if (!animateToUser || animationSpeed === 0) {
+				if (animationSpeed === 0) {
 					this._isLockedOnFollowingUser.set(true)
 					return
 				}

--- a/packages/tlsync/src/lib/TLSyncClient.ts
+++ b/packages/tlsync/src/lib/TLSyncClient.ts
@@ -431,26 +431,37 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			// if we're offline, don't do anything
 			return
 		}
-		let req: TLPushRequest<R> | null = null
+
+		let presence: TLPushRequest<any>['presence'] = undefined
 		if (!this.lastPushedPresenceState && nextPresence) {
 			// we don't have a last presence state, so we need to push the full state
-			req = {
-				type: 'push',
-				presence: [RecordOpType.Put, nextPresence],
-				clientClock: this.clientClock++,
-			}
+			presence = [RecordOpType.Put, nextPresence]
 		} else if (this.lastPushedPresenceState && nextPresence) {
 			// we have a last presence state, so we need to push a diff if there is one
 			const diff = diffRecord(this.lastPushedPresenceState, nextPresence)
 			if (diff) {
-				req = {
-					type: 'push',
-					presence: [RecordOpType.Patch, diff],
-					clientClock: this.clientClock++,
-				}
+				presence = [RecordOpType.Patch, diff]
 			}
 		}
+
+		if (!presence) return
 		this.lastPushedPresenceState = nextPresence
+
+		// if there is a pending push that has not been sent and does not already include a presence update,
+		// then add this presence update to it
+		const lastPush = this.pendingPushRequests.at(-1)
+		if (lastPush && !lastPush.sent && !lastPush.request.presence) {
+			lastPush.request.presence = presence
+			return
+		}
+
+		// otherwise, create a new push request
+		const req: TLPushRequest<R> = {
+			type: 'push',
+			clientClock: this.clientClock++,
+			presence,
+		}
+
 		if (req) {
 			this.pendingPushRequests.push({ request: req, sent: false })
 			this.flushPendingPushRequests()
@@ -590,7 +601,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 						this.pendingPushRequests.shift()
 					} else if (diff.action === 'commit') {
 						const { request } = this.pendingPushRequests.shift()!
-						if ('diff' in request) {
+						if ('diff' in request && request.diff) {
 							this.applyNetworkDiff(request.diff, true)
 						}
 					} else {
@@ -602,7 +613,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				try {
 					this.speculativeChanges = this.store.extractingChanges(() => {
 						for (const { request } of this.pendingPushRequests) {
-							if (!('diff' in request)) continue
+							if (!('diff' in request) || !request.diff) continue
 							this.applyNetworkDiff(request.diff, true)
 						}
 					})

--- a/packages/tlsync/src/lib/TLSyncClient.ts
+++ b/packages/tlsync/src/lib/TLSyncClient.ts
@@ -423,6 +423,10 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	lastPushedPresenceState: R | null = null
 
 	private pushPresence(nextPresence: R | null) {
+		// make sure we push any document changes first
+		// TODO: need to send presence changes in the same push request as document changes
+		// in order to not get into weird states
+		this.store._flushHistory()
 		if (!this.isConnectedToRoom) {
 			// if we're offline, don't do anything
 			return

--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -814,11 +814,13 @@ export class TLSyncRoom<R extends UnknownRecord> {
 		transaction((rollback) => {
 			// collect actual ops that resulted from the push
 			// these will be broadcast to other users
-			let mergedChanges: NetworkDiff<R> | null = null
+			type ActualChanges = { diff: NetworkDiff<R> | null }
+			const docChanges: ActualChanges = { diff: null }
+			const presenceChanges: ActualChanges = { diff: null }
 
-			const propagateOp = (id: string, op: RecordOp<R>) => {
-				if (!mergedChanges) mergedChanges = {}
-				mergedChanges[id] = op
+			const propagateOp = (changes: ActualChanges, id: string, op: RecordOp<R>) => {
+				if (!changes.diff) changes.diff = {}
+				changes.diff[id] = op
 			}
 
 			const fail = (reason: TLIncompatibilityReason): Result<void, void> => {
@@ -830,7 +832,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 				return Result.err(undefined)
 			}
 
-			const addDocument = (id: string, _state: R): Result<void, void> => {
+			const addDocument = (changes: ActualChanges, id: string, _state: R): Result<void, void> => {
 				const res = this.schema.migratePersistedRecord(_state, session.serializedSchema, 'up')
 				if (res.type === 'error') {
 					return fail(
@@ -852,7 +854,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 						return fail(TLIncompatibilityReason.InvalidRecord)
 					}
 					if (diff.value) {
-						propagateOp(id, [RecordOpType.Patch, diff.value])
+						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
 					}
 				} else {
 					// Otherwise, if we don't already have a document with this id
@@ -861,13 +863,17 @@ export class TLSyncRoom<R extends UnknownRecord> {
 					if (!result.ok) {
 						return fail(TLIncompatibilityReason.InvalidRecord)
 					}
-					propagateOp(id, [RecordOpType.Put, state])
+					propagateOp(changes, id, [RecordOpType.Put, state])
 				}
 
 				return Result.ok(undefined)
 			}
 
-			const patchDocument = (id: string, patch: ObjectDiff): Result<void, void> => {
+			const patchDocument = (
+				changes: ActualChanges,
+				id: string,
+				patch: ObjectDiff
+			): Result<void, void> => {
 				// if it was already deleted, there's no need to apply the patch
 				const doc = this.getDocument(id)
 				if (!doc) return Result.ok(undefined)
@@ -889,7 +895,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 						return fail(TLIncompatibilityReason.InvalidRecord)
 					}
 					if (diff.value) {
-						propagateOp(id, [RecordOpType.Patch, diff.value])
+						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
 					}
 				} else {
 					// need to apply the patch to the downgraded version and then upgrade it
@@ -912,7 +918,7 @@ export class TLSyncRoom<R extends UnknownRecord> {
 						return fail(TLIncompatibilityReason.InvalidRecord)
 					}
 					if (diff.value) {
-						propagateOp(id, [RecordOpType.Patch, diff.value])
+						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
 					}
 				}
 
@@ -929,24 +935,25 @@ export class TLSyncRoom<R extends UnknownRecord> {
 				switch (type) {
 					case RecordOpType.Put: {
 						// Try to put the document. If it fails, stop here.
-						const res = addDocument(id, { ...val, id, typeName })
+						const res = addDocument(presenceChanges, id, { ...val, id, typeName })
+						// if res.ok is false here then we already called `fail` and we should stop immediately
 						if (!res.ok) return
 						break
 					}
 					case RecordOpType.Patch: {
 						// Try to patch the document. If it fails, stop here.
-						const res = patchDocument(id, {
+						const res = patchDocument(presenceChanges, id, {
 							...val,
 							id: [ValueOpType.Put, id],
 							typeName: [ValueOpType.Put, typeName],
 						})
+						// if res.ok is false here then we already called `fail` and we should stop immediately
 						if (!res.ok) return
 						break
 					}
 				}
 			}
-			const hasDiff = 'diff' in message && message.diff
-			if (hasDiff) {
+			if (message.diff) {
 				// The push request was for the document scope.
 				for (const [id, op] of Object.entries(message.diff!)) {
 					switch (op[0]) {
@@ -956,13 +963,15 @@ export class TLSyncRoom<R extends UnknownRecord> {
 							if (!this.documentTypes.has(op[1].typeName)) {
 								return fail(TLIncompatibilityReason.InvalidRecord)
 							}
-							const res = addDocument(id, op[1])
+							const res = addDocument(docChanges, id, op[1])
+							// if res.ok is false here then we already called `fail` and we should stop immediately
 							if (!res.ok) return
 							break
 						}
 						case RecordOpType.Patch: {
 							// Try to patch the document. If it fails, stop here.
-							const res = patchDocument(id, op[1])
+							const res = patchDocument(docChanges, id, op[1])
+							// if res.ok is false here then we already called `fail` and we should stop immediately
 							if (!res.ok) return
 							break
 						}
@@ -982,60 +991,68 @@ export class TLSyncRoom<R extends UnknownRecord> {
 							this.removeDocument(id, this.clock)
 							// Schedule a pruneTombstones call to happen on the next call stack
 							setTimeout(this.pruneTombstones, 0)
-							propagateOp(id, op)
+							propagateOp(docChanges, id, op)
 							break
 						}
 					}
 				}
+			}
 
-				// Let the client know what action to take based on the results of the push
-				if (!hasDiff || isEqual(mergedChanges, message.diff)) {
-					// COMMIT
-					// Applying the client's changes had the exact same effect on the server as
-					// they had on the client, so the client should keep the diff
-					this.sendMessage(session.sessionKey, {
-						type: 'push_result',
-						serverClock: this.clock,
-						clientClock,
-						action: 'commit',
-					})
-				} else if (!mergedChanges) {
-					// DISCARD
-					// Applying the client's changes had no effect, so the client should drop the diff
-					this.sendMessage(session.sessionKey, {
-						type: 'push_result',
-						serverClock: this.clock,
-						clientClock,
-						action: 'discard',
-					})
-				} else {
-					// REBASE
-					// Applying the client's changes had a different non-empty effect on the server,
-					// so the client should rebase with our gold-standard / authoritative diff.
-					// First we need to migrate the diff to the client's version
-					const migrateResult = this.migrateDiffForSession(session.serializedSchema, mergedChanges)
-					if (!migrateResult.ok) {
-						return fail(
-							migrateResult.error === MigrationFailureReason.TargetVersionTooNew
-								? TLIncompatibilityReason.ServerTooOld
-								: TLIncompatibilityReason.ClientTooOld
-						)
-					}
-					// If the migration worked, send the rebased diff to the client
-					this.sendMessage(session.sessionKey, {
-						type: 'push_result',
-						serverClock: this.clock,
-						clientClock,
-						action: { rebaseWithDiff: migrateResult.value },
-					})
+			// Let the client know what action to take based on the results of the push
+			if (
+				// if there was only a presence push, the client doesn't need to do anything aside from
+				// shift the push request.
+				!message.diff ||
+				isEqual(docChanges.diff, message.diff)
+			) {
+				// COMMIT
+				// Applying the client's changes had the exact same effect on the server as
+				// they had on the client, so the client should keep the diff
+				this.sendMessage(session.sessionKey, {
+					type: 'push_result',
+					serverClock: this.clock,
+					clientClock,
+					action: 'commit',
+				})
+			} else if (!docChanges.diff) {
+				// DISCARD
+				// Applying the client's changes had no effect, so the client should drop the diff
+				this.sendMessage(session.sessionKey, {
+					type: 'push_result',
+					serverClock: this.clock,
+					clientClock,
+					action: 'discard',
+				})
+			} else {
+				// REBASE
+				// Applying the client's changes had a different non-empty effect on the server,
+				// so the client should rebase with our gold-standard / authoritative diff.
+				// First we need to migrate the diff to the client's version
+				const migrateResult = this.migrateDiffForSession(session.serializedSchema, docChanges.diff)
+				if (!migrateResult.ok) {
+					return fail(
+						migrateResult.error === MigrationFailureReason.TargetVersionTooNew
+							? TLIncompatibilityReason.ServerTooOld
+							: TLIncompatibilityReason.ClientTooOld
+					)
 				}
+				// If the migration worked, send the rebased diff to the client
+				this.sendMessage(session.sessionKey, {
+					type: 'push_result',
+					serverClock: this.clock,
+					clientClock,
+					action: { rebaseWithDiff: migrateResult.value },
+				})
 			}
 
 			// If there are merged changes, broadcast them to all other clients
-			if (mergedChanges !== null) {
+			if (docChanges.diff || presenceChanges.diff) {
 				this.broadcastPatch({
 					sourceSessionKey: session.sessionKey,
-					diff: mergedChanges,
+					diff: {
+						...docChanges.diff,
+						...presenceChanges.diff,
+					},
 				})
 			}
 

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -61,17 +61,12 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 	  }
 
 /** @public */
-export type TLPushRequest<R extends UnknownRecord> =
-	| {
-			type: 'push'
-			clientClock: number
-			presence: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
-	  }
-	| {
-			type: 'push'
-			clientClock: number
-			diff: NetworkDiff<R>
-	  }
+export type TLPushRequest<R extends UnknownRecord> = {
+	type: 'push'
+	clientClock: number
+	diff?: NetworkDiff<R>
+	presence?: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
+}
 
 /** @public */
 export type TLConnectRequest = {


### PR DESCRIPTION
This revives the old 'derived camera' idea to prevent cursor wobbling during viewport following.

Before this PR we updated the camera on a tick during viewport following, but the shapes and cursors were not moving on the same tick (we tried that during the perf work and it was all kinds of problematic). Frankly I've forgotten how we ever managed to eliminate wobble here in the first place?

Anyway after this PR we derive the camera based on whether or not we are following a user. When you follow a user it makes it so that your viewport contains their viewport. If your viewport is not already very close to their viewport it will animate the initial position, after which it will 'lock' in place and the derived value will be used from then on. 

This exposed a minor issue in our sync engine: the fact that we send presence updates in separate websocket messages from document updates. We get into situations like this

1. user A follows user B
2. user B deletes the current page they are on
3. user B's page deletion diff gets sent
4. user B's presence update gets sent with a new currentPageId
5. user A receives the page deletion
6. user A still thinks that user B is on the old page and doesn't know how to update the follow state.

So to fix this I made it so that we can (and do) send presence updates in the same websocket messages as document updates so the server can handle them atomically.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix



### Test Plan

1. Add a step-by-step description of how to test your PR here.
8.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fixes a bug that caused the cursor & shapes to wiggle around when following someone else's viewport
