### PR TITLE
Bump max shapes to 4000

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1443,7 +1443,7 @@ export interface MatModel {
 export const MAX_PAGES = 40;
 
 // @internal (undocumented)
-export const MAX_SHAPES_PER_PAGE = 2000;
+export const MAX_SHAPES_PER_PAGE = 4000;
 
 // @public
 export function moveCameraWhenCloseToEdge(editor: Editor): void;

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -2,7 +2,7 @@ import { TLCameraOptions } from './editor/types/misc-types'
 import { EASINGS } from './primitives/easings'
 
 /** @internal */
-export const MAX_SHAPES_PER_PAGE = 2000
+export const MAX_SHAPES_PER_PAGE = 4000
 /** @internal */
 export const MAX_PAGES = 40
 


### PR DESCRIPTION
This PR increases the maximum number of shapes per page from 2000 to 4000.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Test Plan

1. Create max shapes
2. Does it work?

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Increase maximum number of shapes per page from 2000 to 4000.