### PR TITLE
Camera tests

### DIFF
--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -74,7 +74,7 @@ test.describe('camera', () => {
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0.9)
 	})
 
-	test.only('pinching on touchscreen', async ({ page, isMobile }) => {
+	test('pinching on touchscreen', async ({ page, isMobile }) => {
 		test.skip(!isMobile)
 
 		client = await page.context().newCDPSession(page)

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -63,15 +63,28 @@ test.describe('camera', () => {
 		).toStrictEqual([160, 160])
 	})
 
-	test('pinching on trackpad', async ({ page, isMobile }) => {
+	test.only('pinching on trackpad', async ({ page, isMobile }) => {
 		// pinching on trackpad is the same event as ctrl+scrollwheel
 		test.skip(isMobile)
+		await page.evaluate(() => editor.updateInstanceState({ isGridMode: true }))
 		const { mouse, keyboard } = page
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(1)
+		// zooming in
 		await keyboard.down('Control')
-		await mouse.wheel(0, 14)
+		// scrolling 15px on the mouse wheel is a bit less that 0.1 zoom level at default zoom speed
+		await mouse.wheel(0, 15) // 0.9
+		await mouse.wheel(0, 15) // 0.81
+		await mouse.wheel(0, 15) // 0.72
 		await keyboard.up('Control')
-		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0.9)
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBeCloseTo(0.72, 1)
+		// zooming out
+		// scrolling back doesn't progress in the same steps
+		await keyboard.down('Control')
+		await mouse.wheel(0, -15) // 0.8019000000000001
+		await mouse.wheel(0, -15) // 0.88209
+		await mouse.wheel(0, -15) // 0.970299
+		await keyboard.up('Control')
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBeCloseTo(0.97)
 	})
 
 	test('pinching on touchscreen', async ({ page, isMobile }) => {
@@ -80,7 +93,6 @@ test.describe('camera', () => {
 		client = await page.context().newCDPSession(page)
 
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(1)
-		await page.evaluate(() => editor.updateInstanceState({ isGridMode: true }))
 
 		// zoom out
 

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -127,7 +127,7 @@ test.describe('camera', () => {
 		}
 		await dispatchTouch(client, 'touchEnd', finalTouch)
 		await sleep(10)
-		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0)
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(8)
 	})
 
 	test.fixme('minimap', () => {

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -63,7 +63,7 @@ test.describe('camera', () => {
 		).toStrictEqual([160, 160])
 	})
 
-	test.only('pinching on trackpad', async ({ page, isMobile }) => {
+	test('pinching on trackpad', async ({ page, isMobile }) => {
 		// pinching on trackpad is the same event as ctrl+scrollwheel
 		test.skip(isMobile)
 		await page.evaluate(() => editor.updateInstanceState({ isGridMode: true }))

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -1,5 +1,19 @@
-import test from '@playwright/test'
+import { CDPSession, expect } from '@playwright/test'
+import { Editor } from 'tldraw'
 import { setup } from '../shared-e2e'
+import test from './fixtures/fixtures'
+
+declare const editor: Editor
+
+let client: CDPSession
+
+const dispatchTouch = async (
+	client: CDPSession,
+	type: 'touchStart' | 'touchMove' | 'touchEnd' | 'touchCancel',
+	touchPoints: { x: number; y: number }[]
+) => {
+	await client.send('Input.dispatchTouchEvent', { type, touchPoints })
+}
 
 export function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
@@ -8,12 +22,46 @@ export function sleep(ms: number) {
 test.describe('camera', () => {
 	test.beforeEach(setup)
 
-	test.fixme('panning', () => {
-		// todo
+	test.only('panning', async ({ isMobile, page, toolbar }) => {
+		test.skip(!isMobile)
+		client = await page.context().newCDPSession(page)
+
+		/*
+		// This just makes a rectangle so it's easier to see the panning 
+		await toolbar.moreToolsButton.click()
+		const rectangle = toolbar.popOverTools.popoverRectangle
+		await rectangle.click()
+		await page.mouse.click(50, 50) */
+
+		expect(await page.evaluate(() => editor.inputs.currentPagePoint)).toEqual({
+			x: 50,
+			y: 50,
+			z: 0,
+		})
+		await dispatchTouch(client, 'touchStart', [
+			{ x: 100, y: 100 },
+			{ x: 200, y: 200 },
+		])
+		for (let i = 100; i > 0; i--) {
+			await dispatchTouch(client, 'touchMove', [
+				{ x: 100 + i * 10, y: 100 + i * 10 },
+				{ x: 200 + i * 10, y: 200 + i * 10 },
+			])
+			await sleep(10)
+		}
+		expect(await page.evaluate(() => editor.inputs.currentPagePoint.x)).toBeCloseTo(144, 0)
 	})
 
-	test.fixme('pinching', () => {
-		// todo
+	test('pinching', async ({ page, isMobile }) => {
+		// This test doesn't yet use touch events, it only tests punching on the trackpad
+		// A pinch on the trackpad is the same as a ctrl+scrollwheel
+		test.skip(isMobile)
+		const { mouse, keyboard } = page
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(1)
+		await keyboard.down('Control')
+		await mouse.wheel(0, 14)
+		await keyboard.up('Control')
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0.9)
 	})
 
 	test.fixme('minimap', () => {


### PR DESCRIPTION
This PR adds tests for camera panning and pinching. 

It simulates touch events necessary for panning and zooming by dispatching events to the browser. I could encapsulate this logic into a fixture or functions to use in other tests if it felt useful. Something like gesture.pinch({start: {}, end: {}, steps: number}), gesture.pan({start: {}, end: {}, steps: number}).

It simulates trackpad pinching by dispatching a scroll wheel event, though I haven't been able to work out the relationship between pixels scrolled and zoom speed. It also seems important to await each scroll event in steps for some reason.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [x] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
