### PR TITLE
Fix readonly fetching happening too often.

### DIFF
--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -64,6 +64,23 @@ function getFreshShareState(): ShareState {
 	}
 }
 
+function getUpdatedState(previusReadonlyUrl: string | null) {
+	const freshState = getFreshShareState()
+	// We are in a readonly room and already have the url
+	if (freshState.readonlyUrl) return freshState
+	// We don't have a readonly url from before
+	if (!previusReadonlyUrl) return freshState
+
+	// Pull out the room prefix and the readonly slug from the existing readonly url
+	const segments = window.location.pathname.split('/')
+	const roSegments = new URL(previusReadonlyUrl).pathname.split('/')
+	segments[1] = roSegments[1]
+	segments[2] = roSegments[2]
+	const newPathname = segments.join('/')
+	freshState.readonlyUrl = `${window.location.origin}${newPathname}${window.location.search}`
+	return freshState
+}
+
 async function getReadonlyUrl() {
 	const pathname = window.location.pathname
 	const isReadOnly = isSharedReadonlyUrl(pathname)
@@ -146,7 +163,7 @@ export const ShareMenu = React.memo(function ShareMenu() {
 		const interval = setInterval(() => {
 			const url = window.location.href
 			if (shareState.url === url) return
-			setShareState(getFreshShareState())
+			setShareState(getUpdatedState(shareState.readonlyUrl))
 		}, 300)
 
 		return () => {


### PR DESCRIPTION
The problem happened because we cleared the `readonlyUrl` from shared state. This was happening every time the url changed (so panning, zooming,...). Now, instead of clearing the `readonlyUrl` we pull out the room prefix and slug from the readonly url.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Create a shared room.
2. Move the camera around.
3. We should not be constantly fetching the readonly slug.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Fix an issue where readonly slug was being fetched every time the url changed (panning, zooming,...).
