### PR TITLE
[experiment] Cache manager

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -82,6 +82,7 @@ import { useQuickReactor } from '@tldraw/state';
 import { useReactor } from '@tldraw/state';
 import { useValue } from '@tldraw/state';
 import { VecModel } from '@tldraw/tlschema';
+import { WeakCache } from '@tldraw/utils';
 import { whyAmIRunning } from '@tldraw/state';
 
 // @public
@@ -699,6 +700,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     };
     bringForward(shapes: TLShape[] | TLShapeId[]): this;
     bringToFront(shapes: TLShape[] | TLShapeId[]): this;
+    readonly caches: CacheManager;
     cancel(): this;
     cancelDoubleClick(): void;
     // @internal (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -123,6 +123,7 @@ import { notVisibleShapes } from './derivations/notVisibleShapes'
 import { parentsToChildren } from './derivations/parentsToChildren'
 import { deriveShapeIdsInCurrentPage } from './derivations/shapeIdsInCurrentPage'
 import { getSvgJsx } from './getSvgJsx'
+import { CacheManager } from './managers/CacheManager'
 import { ClickManager } from './managers/ClickManager'
 import { EnvironmentManager } from './managers/EnvironmentManager'
 import { HistoryManager } from './managers/HistoryManager'
@@ -297,6 +298,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.environment = new EnvironmentManager(this)
 		this.scribbles = new ScribbleManager(this)
+		this.caches = new CacheManager(this)
 
 		// Cleanup
 
@@ -710,6 +712,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	readonly sideEffects: SideEffectManager<this>
+
+	/**
+	 * A manager for weak map caches.
+	 *
+	 * @public
+	 */
+	readonly caches: CacheManager
 
 	/**
 	 * The current HTML element containing the editor.

--- a/packages/editor/src/lib/editor/managers/CacheManager.ts
+++ b/packages/editor/src/lib/editor/managers/CacheManager.ts
@@ -1,0 +1,28 @@
+import { WeakCache } from '@tldraw/utils'
+import { Editor } from '../Editor'
+
+export class CacheManager {
+	constructor(public editor: Editor) {}
+
+	private caches = new Map<string, WeakCache<any, unknown>>()
+
+	createCache<T extends object, Q>(name: string) {
+		const cache = new WeakCache<T, Q>()
+		this.caches.set(name, cache)
+		return cache
+	}
+
+	get<T extends object, Q>(name: string): WeakCache<T, Q> {
+		return this.caches.get(name) as WeakCache<T, Q>
+	}
+
+	clear(name: string) {
+		const cache = this.caches.get(name)
+		if (!cache) throw Error(`Cache ${name} not found`)
+		cache.clear()
+	}
+
+	clearAll() {
+		this.caches.clear()
+	}
+}

--- a/packages/editor/src/lib/editor/managers/CacheManager.ts
+++ b/packages/editor/src/lib/editor/managers/CacheManager.ts
@@ -9,34 +9,56 @@ type CacheItem<T extends object, Q> = {
 export class CacheManager {
 	constructor(public editor: Editor) {}
 
+	/**
+	 * The manager's cache items.
+	 */
 	private items = new Map<string, CacheItem<any, any>>()
 
+	/**
+	 * Get a cache by name.
+	 */
+	private get<T extends object, Q>(name: string): CacheItem<T, Q> {
+		return this.items.get(name)!
+	}
+
+	/**
+	 * Get whether a cache exists.
+	 */
+	has(name: string) {
+		return this.items.has(name)
+	}
+
+	/**
+	 * Create a new cache.
+	 *
+	 * @param name - The name of the cache.
+	 * @param fn - The function to use to create a new cached value for a given input.
+	 */
 	createCache<T extends object, Q>(name: string, fn: (input: T) => Q) {
 		this.items.set(name, { cache: new WeakCache<T, Q>(), fn })
 		return this.get<T, Q>(name)
 	}
 
-	has(name: string) {
-		return this.items.has(name)
-	}
-
-	get<T extends object, Q>(name: string): CacheItem<T, Q> {
-		return this.items.get(name)!
-	}
-
+	/**
+	 * Get the value from a cache. If the cache does not exist, it will be created using the function provided when the cache was created.
+	 *
+	 * @param name - The name of the cache.
+	 * @param input - The input to the cache function.
+	 */
 	getValue<T extends object, Q>(name: string, input: T): Q {
 		const item = this.get<T, Q>(name)
 		if (!item) throw Error(`Cache ${name} not found`)
 		return item.cache.get(input, item.fn)
 	}
 
+	/**
+	 * Clear all values from a cache.
+	 *
+	 * @param name - The name of the cache.
+	 */
 	clear(name: string) {
 		const item = this.items.get(name)
 		if (!item) throw Error(`Cache ${name} not found`)
 		item.cache.clear()
-	}
-
-	clearAll() {
-		this.items.clear()
 	}
 }

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -339,6 +339,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		// When we start translating shapes, record where their bindings were in page space so we
 		// can maintain them as we translate the arrow
+		// TODO: replace with memo object
 		shapeAtTranslationStart.set(shape, {
 			pagePosition: shapePageTransform.applyToPoint(shape),
 			terminalBindings: mapObjectMapValues(terminalsInArrowSpace, (terminalName, point) => {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -372,7 +372,7 @@ function getNoteLabelSize(editor: Editor, props: TLNoteShape['props']) {
 
 function getLabelSize(editor: Editor, shape: TLNoteShape) {
 	if (!editor.caches.has('@tldraw/noteLabelSize')) {
-		editor.caches.createCache('@tldraw/textShapeSize', (props: TLNoteShape['props']) =>
+		editor.caches.createCache('@tldraw/noteLabelSize', (props: TLNoteShape['props']) =>
 			getNoteLabelSize(editor, props)
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -11,7 +11,6 @@ import {
 	TLShape,
 	TLShapeId,
 	Vec,
-	WeakCache,
 	getDefaultColorTheme,
 	noteShapeMigrations,
 	noteShapeProps,
@@ -372,10 +371,16 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 	}
 }
 
-const labelSizesForNote = new WeakCache<TLShape, ReturnType<typeof getNoteLabelSize>>()
-
 function getLabelSize(editor: Editor, shape: TLNoteShape) {
-	return labelSizesForNote.get(shape, () => getNoteLabelSize(editor, shape))
+	let cache = editor.caches.get<TLShape, ReturnType<typeof getNoteLabelSize>>(
+		'@tldraw/noteLabelSize'
+	)
+	if (!cache) {
+		cache = editor.caches.createCache<TLShape, ReturnType<typeof getNoteLabelSize>>(
+			'@tldraw/noteLabelSize'
+		)
+	}
+	return cache.get(shape, () => getNoteLabelSize(editor, shape))
 }
 
 function useNoteKeydownHandler(id: TLShapeId) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -11,7 +11,6 @@ import {
 	TLShapeUtilFlag,
 	TLTextShape,
 	Vec,
-	WeakCache,
 	getDefaultColorTheme,
 	preventDefault,
 	textShapeMigrations,
@@ -27,8 +26,6 @@ import { TextLabel } from '../shared/TextLabel'
 import { FONT_FAMILIES, FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
 import { resizeScaled } from '../shared/resizeScaled'
-
-const sizeCache = new WeakCache<TLTextShape['props'], { height: number; width: number }>()
 
 /** @public */
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
@@ -50,7 +47,16 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	}
 
 	getMinDimensions(shape: TLTextShape) {
-		return sizeCache.get(shape.props, (props) => getTextSize(this.editor, props))
+		const { editor } = this
+		let cache = editor.caches.get<TLTextShape['props'], { height: number; width: number }>(
+			'@tldraw/textShapeSize'
+		)
+		if (!cache) {
+			cache = editor.caches.createCache<TLTextShape['props'], { height: number; width: number }>(
+				'@tldraw/textShapeSize'
+			)
+		}
+		return cache.get(shape.props, (props) => getTextSize(this.editor, props))
 	}
 
 	getGeometry(shape: TLTextShape) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -48,15 +48,15 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	getMinDimensions(shape: TLTextShape) {
 		const { editor } = this
-		let cache = editor.caches.get<TLTextShape['props'], { height: number; width: number }>(
-			'@tldraw/textShapeSize'
-		)
-		if (!cache) {
-			cache = editor.caches.createCache<TLTextShape['props'], { height: number; width: number }>(
-				'@tldraw/textShapeSize'
+		if (!editor.caches.has('@tldraw/textShapeSize')) {
+			editor.caches.createCache('@tldraw/textShapeSize', (props: TLTextShape['props']) =>
+				getTextSize(this.editor, props)
 			)
 		}
-		return cache.get(shape.props, (props) => getTextSize(this.editor, props))
+		return editor.caches.getValue<TLTextShape['props'], { height: number; width: number }>(
+			'@tldraw/textShapeSize',
+			shape.props
+		)
 	}
 
 	getGeometry(shape: TLTextShape) {

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -349,6 +349,7 @@ export function warnDeprecatedGetter(name: string): void;
 
 // @public
 export class WeakCache<K extends object, V> {
+    clear(): void;
     get<P extends K>(item: P, cb: (item: P) => V): NonNullable<V>;
     items: WeakMap<K, V>;
 }

--- a/packages/utils/src/lib/cache.ts
+++ b/packages/utils/src/lib/cache.ts
@@ -20,4 +20,11 @@ export class WeakCache<K extends object, V> {
 
 		return this.items.get(item)!
 	}
+
+	/**
+	 * Clear the cache. (Technically we create a new WeakMap, but the old one will get cleaned up by the GC eventually.)
+	 */
+	clear() {
+		this.items = new WeakMap()
+	}
 }


### PR DESCRIPTION
This PR adds a central manager for the weak caches that we use in different places around our shapes.

We have a lot of caches in tldraw—computed caches in the editor, little WeakMaps in our shapes, that recycle values when their inputs haven't changed. This PR creates a centralized place for creating and storing those caches so that a developer has more of a blessed path to create, update, and use those caches.

- Is this necessary?
- Is it helpful?
- Could we create a hook for when shapes are mounted that creates any necessary caches?
- Could we create a nicer API for creating computed caches?

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `feature` — New feature

### Test Plan

- [x] Unit Tests

### Release Notes

-  SDK: adds `Editor.caches`, a manager for various caches used by the editor or shapes.
