### PR TITLE
proof of concept: assets as references to blobs in indexedDB, not directly as base64 in store

### DIFF
--- a/apps/dotcom/src/utils/cloneAssetForShare.ts
+++ b/apps/dotcom/src/utils/cloneAssetForShare.ts
@@ -1,18 +1,32 @@
-import { TLAsset } from 'tldraw'
+import { Editor, TLAsset } from 'tldraw'
 
 export async function cloneAssetForShare(
 	asset: TLAsset,
+	editor: Editor,
 	uploadFileToAsset: (file: File) => Promise<TLAsset>
 ): Promise<TLAsset> {
 	if (asset.type === 'bookmark') return asset
-	if (asset.props.src) {
-		const dataUrlMatch = asset.props.src.match(/data:(.*?)(;base64)?,/)
-		if (!dataUrlMatch) return asset
 
-		const response = await fetch(asset.props.src)
-		const file = new File([await response.blob()], asset.props.name, {
-			type: dataUrlMatch[1] ?? asset.props.mimeType,
-		})
+	if (asset.props.src) {
+		let file: File | undefined
+		if (asset.props.src.startsWith('asset:')) {
+			const blob = await editor.getAssetBlobFromObjectStore(asset)
+			if (blob) {
+				file = new File([blob], asset.props.name, {
+					type: asset.props.mimeType || '',
+				})
+			} else {
+				return asset
+			}
+		} else {
+			const dataUrlMatch = asset.props.src.match(/data:(.*?)(;base64)?,/)
+			if (!dataUrlMatch) return asset
+
+			const response = await fetch(asset.props.src)
+			file = new File([await response.blob()], asset.props.name, {
+				type: dataUrlMatch[1] ?? asset.props.mimeType,
+			})
+		}
 
 		const uploadedAsset = await uploadFileToAsset(file)
 

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -241,7 +241,7 @@ async function getRoomData(
 			// processed it
 			if (!asset) continue
 
-			data[asset.id] = await cloneAssetForShare(asset, uploadFileToAsset)
+			data[asset.id] = await cloneAssetForShare(asset, editor, uploadFileToAsset)
 			// remove the asset after processing so we don't clone it multiple times
 			assets.delete(asset.id)
 		}

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -36,6 +36,7 @@ import { useLocalStore } from './hooks/useLocalStore'
 import { useSafariFocusOutFix } from './hooks/useSafariFocusOutFix'
 import { useZoomCss } from './hooks/useZoomCss'
 import { stopEventPropagation } from './utils/dom'
+import { AssetBlobObjectStore } from './utils/sync/AssetBlobObjectStore'
 import { TLStoreWithStatus } from './utils/sync/StoreWithStatus'
 
 /**
@@ -48,9 +49,11 @@ export type TldrawEditorProps = Expand<
 		(
 			| {
 					store: TLStore | TLStoreWithStatus
+					assetBlobStore: AssetBlobObjectStore
 			  }
 			| {
 					store?: undefined
+					assetBlobStore: AssetBlobObjectStore
 					migrations?: readonly MigrationSequence[]
 					snapshot?: StoreSnapshot<TLRecord>
 					initialData?: SerializedStore<TLRecord>
@@ -175,6 +178,10 @@ export const TldrawEditor = memo(function TldrawEditor({
 		components,
 	}
 
+	const assetBlobStore = new AssetBlobObjectStore(
+		'persistenceKey' in rest ? rest.persistenceKey || '' : ''
+	)
+
 	return (
 		<div
 			ref={setContainer}
@@ -193,14 +200,29 @@ export const TldrawEditor = memo(function TldrawEditor({
 							{store ? (
 								store instanceof Store ? (
 									// Store is ready to go, whether externally synced or not
-									<TldrawEditorWithReadyStore {...withDefaults} store={store} user={user} />
+									<TldrawEditorWithReadyStore
+										{...withDefaults}
+										store={store}
+										assetBlobStore={assetBlobStore}
+										user={user}
+									/>
 								) : (
 									// Store is a synced store, so handle syncing stages internally
-									<TldrawEditorWithLoadingStore {...withDefaults} store={store} user={user} />
+									<TldrawEditorWithLoadingStore
+										{...withDefaults}
+										store={store}
+										assetBlobStore={assetBlobStore}
+										user={user}
+									/>
 								)
 							) : (
 								// We have no store (it's undefined) so create one and possibly sync it
-								<TldrawEditorWithOwnStore {...withDefaults} store={store} user={user} />
+								<TldrawEditorWithOwnStore
+									{...withDefaults}
+									store={store}
+									assetBlobStore={assetBlobStore}
+									user={user}
+								/>
 							)}
 						</EditorComponentsProvider>
 					</ContainerProvider>
@@ -287,6 +309,7 @@ function TldrawEditorWithReadyStore({
 	onMount,
 	children,
 	store,
+	assetBlobStore,
 	tools,
 	shapeUtils,
 	bindingUtils,
@@ -309,6 +332,7 @@ function TldrawEditorWithReadyStore({
 	useLayoutEffect(() => {
 		const editor = new Editor({
 			store,
+			assetBlobStore,
 			shapeUtils,
 			bindingUtils,
 			tools,
@@ -329,6 +353,7 @@ function TldrawEditorWithReadyStore({
 		bindingUtils,
 		tools,
 		store,
+		assetBlobStore,
 		user,
 		initialState,
 		inferDarkMode,

--- a/packages/editor/src/lib/utils/sync/AssetBlobObjectStore.ts
+++ b/packages/editor/src/lib/utils/sync/AssetBlobObjectStore.ts
@@ -1,0 +1,18 @@
+import { TLAsset } from '@tldraw/tlschema'
+import { getAssetFromIndexedDb, storeAssetInIndexedDb } from './indexedDb'
+
+export class AssetBlobObjectStore {
+	constructor(public persistenceKey: string) {}
+
+	async getAssetBlobFromObjectStore({ asset }: { asset: TLAsset }): Promise<Blob | undefined> {
+		return await getAssetFromIndexedDb({ persistenceKey: this.persistenceKey, assetId: asset.id })
+	}
+
+	async putAssetBlobInObjectStore({ asset, assetBlob }: { asset: TLAsset; assetBlob: Blob }) {
+		await storeAssetInIndexedDb({
+			persistenceKey: this.persistenceKey,
+			assetId: asset.id,
+			assetBlob,
+		})
+	}
+}

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -1,7 +1,6 @@
 import {
 	AssetRecordType,
 	Editor,
-	FileHelpers,
 	MediaHelpers,
 	TLAsset,
 	TLAssetId,
@@ -97,13 +96,15 @@ export function registerDefaultExternalContentHandlers(
 			typeName: 'asset',
 			props: {
 				name,
-				src: await FileHelpers.blobToDataUrl(file),
+				src: assetId,
 				w: size.w,
 				h: size.h,
 				mimeType: file.type,
 				isAnimated,
 			},
 		})
+
+		await editor.putAssetBlobInObjectStore(asset, file)
 
 		return asset
 	})

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -40,8 +40,23 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const { time, playing } = shape.props
 		const isEditing = useIsEditing(shape.id)
 		const prefersReducedMotion = usePrefersReducedMotion()
+		const [url, setUrl] = useState(asset?.props.src || '')
 
 		const rVideo = useRef<HTMLVideoElement>(null!)
+
+		useEffect(() => {
+			async function retrieveAsset() {
+				// Retrieve a local image from the DB.
+				if (asset && url?.startsWith('asset:')) {
+					const blob = await editor.getAssetBlobFromObjectStore(asset)
+					if (blob) {
+						const imgURL = URL.createObjectURL(blob)
+						setUrl(imgURL)
+					}
+				}
+			}
+			retrieveAsset()
+		}, [url, asset, editor])
 
 		const handlePlay = useCallback<ReactEventHandler<HTMLVideoElement>>(
 			(e) => {
@@ -145,6 +160,8 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 			}
 		}, [rVideo, prefersReducedMotion])
 
+		if (url.startsWith('asset:')) return null
+
 		return (
 			<>
 				<HTMLContainer
@@ -157,7 +174,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 				>
 					<div className="tl-counter-scaled">
 						<div className="tl-video-container">
-							{asset?.props.src ? (
+							{url ? (
 								<video
 									ref={rVideo}
 									style={isEditing ? { pointerEvents: 'all' } : undefined}
@@ -178,7 +195,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 									onLoadedData={handleLoadedData}
 									hidden={!isLoaded}
 								>
-									<source src={asset.props.src} />
+									<source src={url} />
 								</video>
 							) : (
 								<BrokenAssetIcon />

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -981,7 +981,8 @@ export const linkUrl = string.check((value) => {
 	}
 })
 
-const validSrcProtocols = new Set(['http:', 'https:', 'data:'])
+// N.B. asset: is a reference to the local indexedDB object store.
+const validSrcProtocols = new Set(['http:', 'https:', 'data:', 'asset:'])
 
 /**
  * Validates that a valid is a url safe to load as an asset.


### PR DESCRIPTION
As I look at LOD holistically and whether we have multiple sources when working locally, I learned that our system used base64 encoding of assets directly. Issue https://github.com/tldraw/tldraw/issues/3728

<img width="1350" alt="assetstore" src="https://github.com/tldraw/tldraw/assets/469604/e7b41e29-6656-4d9b-b462-72d43b98f3f7">


The motivations and benefits are:
- store size: not having a huge base64 blobs injected in room data
- perf on loading snapshot: this helps with loading the room data more quickly
- multiple sources: furthermore, if we do decide to have multiple sources locally (for each asset), then we won't get a multiplicative effect of even larger JSON blobs that have lots of base64 data in them
- encoding/decoding perf: this also saves the (slow) step of having to base64 encode/decode our assets, we can just strictly with work with blobs.

The benefit here is clear! I created an `AssetBlobObjectStore` which probably needs some thought (again, this is proof-of-concept), so if we decide to move forward, let's discuss how best to integrate that part.

Todo:
- [x] decodes video and images
- [x] make sure it syncs to other tabs
- [x] make sure it syncs to other multiplayer room
- [ ] fix tests
- [ ] have backup for existing editors instantiated without assetBlobStore


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Test the shit out of uploading/downloading video/image assets, locally+multiplayer.

- [ ] Need to fix current tests and write new ones

### Release Notes

- Assets: store as reference to blob in indexedDB instead of storing directly as base64 in the snapshot.
