### PR TITLE
[bindings] beforeUnbind/afterUnbind to replace beforeDelete/afterDelete

### DIFF
--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -1,6 +1,7 @@
 import {
 	BindingOnShapeChangeOptions,
-	BindingOnShapeDeleteOptions,
+	BindingOnUnbindOptions,
+	BindingUnbindReason,
 	BindingUtil,
 	Box,
 	DefaultFillStyle,
@@ -250,9 +251,10 @@ class PinBindingUtil extends BindingUtil<PinBinding> {
 	}
 
 	// when the thing we're stuck to is deleted, delete the pin too
-	override onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<PinBinding>): void {
-		const pin = this.editor.getShape<PinShape>(binding.fromId)
-		if (pin) this.editor.deleteShape(pin.id)
+	override onBeforeUnbind({ binding, reason }: BindingOnUnbindOptions<PinBinding>): void {
+		if (reason === BindingUnbindReason.DeletingToShape) {
+			this.editor.deleteShape(binding.fromId)
+		}
 	}
 }
 

--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -1,6 +1,7 @@
 import {
 	BindingOnShapeChangeOptions,
-	BindingOnShapeDeleteOptions,
+	BindingOnUnbindOptions,
+	BindingUnbindReason,
 	BindingUtil,
 	Box,
 	DefaultToolbar,
@@ -152,9 +153,10 @@ class StickerBindingUtil extends BindingUtil<StickerBinding> {
 	}
 
 	// when the thing we're stuck to is deleted, delete the sticker too
-	override onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<StickerBinding>): void {
-		const sticker = this.editor.getShape<StickerShape>(binding.fromId)
-		if (sticker) this.editor.deleteShape(sticker.id)
+	override onBeforeUnbind({ binding, reason }: BindingOnUnbindOptions<StickerBinding>): void {
+		if (reason === BindingUnbindReason.DeletingToShape) {
+			this.editor.deleteShape(binding.fromId)
+		}
 	}
 }
 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -230,6 +230,10 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
     // (undocumented)
     onAfterDelete?(options: BindingOnDeleteOptions<Binding>): void;
     // (undocumented)
+    onAfterDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
+    // (undocumented)
+    onAfterDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
+    // (undocumented)
     onBeforeChange?(options: BindingOnChangeOptions<Binding>): Binding | void;
     // (undocumented)
     onBeforeCreate?(options: BindingOnCreateOptions<Binding>): Binding | void;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -188,12 +188,6 @@ export interface BindingOnCreateOptions<Binding extends TLUnknownBinding> {
 }
 
 // @public (undocumented)
-export interface BindingOnDeleteOptions<Binding extends TLUnknownBinding> {
-    // (undocumented)
-    binding: Binding;
-}
-
-// @public (undocumented)
 export interface BindingOnShapeChangeOptions<Binding extends TLUnknownBinding> {
     // (undocumented)
     binding: Binding;
@@ -201,14 +195,6 @@ export interface BindingOnShapeChangeOptions<Binding extends TLUnknownBinding> {
     shapeAfter: TLShape;
     // (undocumented)
     shapeBefore: TLShape;
-}
-
-// @public (undocumented)
-export interface BindingOnShapeDeleteOptions<Binding extends TLUnknownBinding> {
-    // (undocumented)
-    binding: Binding;
-    // (undocumented)
-    shape: TLShape;
 }
 
 // @public (undocumented)
@@ -246,21 +232,11 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
     // (undocumented)
     onAfterCreate?(options: BindingOnCreateOptions<Binding>): void;
     // (undocumented)
-    onAfterDelete?(options: BindingOnDeleteOptions<Binding>): void;
-    // (undocumented)
-    onAfterDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
-    // (undocumented)
-    onAfterDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
+    onAfterUnbind?(options: BindingOnUnbindOptions<Binding>): void;
     // (undocumented)
     onBeforeChange?(options: BindingOnChangeOptions<Binding>): Binding | void;
     // (undocumented)
     onBeforeCreate?(options: BindingOnCreateOptions<Binding>): Binding | void;
-    // (undocumented)
-    onBeforeDelete?(options: BindingOnDeleteOptions<Binding>): void;
-    // (undocumented)
-    onBeforeDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
-    // (undocumented)
-    onBeforeDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
     // (undocumented)
     onBeforeUnbind?(options: BindingOnUnbindOptions<Binding>): void;
     // (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -212,6 +212,24 @@ export interface BindingOnShapeDeleteOptions<Binding extends TLUnknownBinding> {
 }
 
 // @public (undocumented)
+export interface BindingOnUnbindOptions<Binding extends TLUnknownBinding> {
+    // (undocumented)
+    binding: Binding;
+    // (undocumented)
+    reason: BindingUnbindReason;
+}
+
+// @public (undocumented)
+export enum BindingUnbindReason {
+    // (undocumented)
+    DeletingBinding = "deleting_binding",
+    // (undocumented)
+    DeletingFromShape = "deleting_from_shape",
+    // (undocumented)
+    DeletingToShape = "deleting_to_shape"
+}
+
+// @public (undocumented)
 export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBinding> {
     constructor(editor: Editor);
     // (undocumented)
@@ -243,6 +261,8 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
     onBeforeDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
     // (undocumented)
     onBeforeDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void;
+    // (undocumented)
+    onBeforeUnbind?(options: BindingOnUnbindOptions<Binding>): void;
     // (undocumented)
     onOperationComplete?(): void;
     // (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -124,12 +124,14 @@ export {
 } from './lib/constants'
 export { Editor, type TLEditorOptions, type TLResizeShapeOptions } from './lib/editor/Editor'
 export {
+	BindingUnbindReason,
 	BindingUtil,
 	type BindingOnChangeOptions,
 	type BindingOnCreateOptions,
 	type BindingOnDeleteOptions,
 	type BindingOnShapeChangeOptions,
 	type BindingOnShapeDeleteOptions,
+	type BindingOnUnbindOptions,
 	type TLBindingUtilConstructor,
 } from './lib/editor/bindings/BindingUtil'
 export { HistoryManager } from './lib/editor/managers/HistoryManager'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -128,9 +128,7 @@ export {
 	BindingUtil,
 	type BindingOnChangeOptions,
 	type BindingOnCreateOptions,
-	type BindingOnDeleteOptions,
 	type BindingOnShapeChangeOptions,
-	type BindingOnShapeDeleteOptions,
 	type BindingOnUnbindOptions,
 	type TLBindingUtilConstructor,
 } from './lib/editor/bindings/BindingUtil'

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -526,7 +526,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 					},
 					beforeDelete: (binding) => {
 						const util = this.getBindingUtil(binding)
+						// No need to track this binding if it's util doesn't care about the unbind operation
 						if (!util.onBeforeUnbind && !util.onAfterUnbind) return
+						// We only want to call this once per binding and it might be possible that the onBeforeUnbind
+						// callback will trigger a nested delete operation on the same binding so let's bail out if
+						// that is happening
 						if (deletedBindings.has(binding.id)) return
 						const opts: BindingOnUnbindOptions<any> = {
 							binding,
@@ -2339,7 +2343,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const { currentScreenPoint, currentPagePoint } = this.inputs
 			const { screenBounds } = this.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
 
-			// compare the next page point (derived from the curent camera) to the current page point
+			// compare the next page point (derived from the current camera) to the current page point
 			if (
 				currentScreenPoint.x / z - x !== currentPagePoint.x ||
 				currentScreenPoint.y / z - y !== currentPagePoint.y
@@ -2835,7 +2839,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.zoomToUser(myUserId, { animation: { duration: 200 } })
 	 * ```
 	 *
-	 * @param userId - The id of the user to aniamte to.
+	 * @param userId - The id of the user to animate to.
 	 * @param opts - The camera move options.
 	 * @public
 	 */
@@ -4261,7 +4265,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const selectedShapeIds = this.getSelectedShapeIds()
 		return this.getCurrentPageShapesSorted()
 			.filter((shape) => shape.type !== 'group' && selectedShapeIds.includes(shape.id))
-			.reverse() // findlast
+			.reverse() // find last
 			.find((shape) => this.isPointInShape(shape, point, { hitInside: true, margin: 0 }))
 	}
 
@@ -4340,7 +4344,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			if (this.isShapeOfType(shape, 'frame')) {
 				// On the rare case that we've hit a frame, test again hitInside to be forced true;
-				// this prevents clicks from passing through the body of a frame to shapes behhind it.
+				// this prevents clicks from passing through the body of a frame to shapes behind it.
 
 				// If the hit is within the frame's outer margin, then select the frame
 				const distance = geometry.distanceToPoint(pointInShapeSpace, hitInside)
@@ -4422,7 +4426,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								inMarginClosestToEdgeHit = shape
 							}
 						} else if (!inMarginClosestToEdgeHit) {
-							// If we're not within margin distnce to any edge, and if the
+							// If we're not within margin distance to any edge, and if the
 							// shape is hollow, then we want to hit the shape with the
 							// smallest area. (There's a bug here with self-intersecting
 							// shapes, like a closed drawing of an "8", but that's a bigger
@@ -4498,7 +4502,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const { hitInside = false, margin = 0 } = opts
 		const id = typeof shape === 'string' ? shape : shape.id
 		// If the shape is masked, and if the point falls outside of that
-		// mask, then it's defintely a miss—we don't need to test further.
+		// mask, then it's definitely a miss—we don't need to test further.
 		const pageMask = this.getShapeMask(id)
 		if (pageMask && !pointInPolygon(point, pageMask)) return false
 
@@ -4818,7 +4822,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const shapesToReparent = compact(ids.map((id) => this.getShape(id)))
 
-		// The user is allowed to re-parent locked shapes. Unintutive? Yeah! But there are plenty of
+		// The user is allowed to re-parent locked shapes. Unintuitive? Yeah! But there are plenty of
 		// times when a locked shape's parent is deleted... and we need to put that shape somewhere!
 		const lockedShapes = shapesToReparent.filter((shape) => shape.isLocked)
 
@@ -4926,7 +4930,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @param ids - The ids of the shapes to get descendants of.
 	 *
-	 * @returns The decscendant ids.
+	 * @returns The descendant ids.
 	 *
 	 * @public
 	 */
@@ -8373,7 +8377,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						let behavior = wheelBehavior
 
-						// If the camera behavior is "zoom" and the ctrl key is presssed, then pan;
+						// If the camera behavior is "zoom" and the ctrl key is pressed, then pan;
 						// If the camera behavior is "pan" and the ctrl key is not pressed, then zoom
 						if (inputs.ctrlKey) behavior = wheelBehavior === 'pan' ? 'zoom' : 'pan'
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -362,7 +362,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.sideEffects.registerOperationCompleteHandler(() => {
 				// this needs to be cleared here because further effects may delete more shapes
 				// and we want the next invocation of this handler to handle those separately
-				// TODO(david): test this behavior
 				deletedShapeIds.clear()
 
 				for (const parentId of invalidParents) {

--- a/packages/editor/src/lib/editor/bindings/BindingUtil.ts
+++ b/packages/editor/src/lib/editor/bindings/BindingUtil.ts
@@ -37,21 +37,10 @@ export interface BindingOnChangeOptions<Binding extends TLUnknownBinding> {
 }
 
 /** @public */
-export interface BindingOnDeleteOptions<Binding extends TLUnknownBinding> {
-	binding: Binding
-}
-
-/** @public */
 export interface BindingOnShapeChangeOptions<Binding extends TLUnknownBinding> {
 	binding: Binding
 	shapeBefore: TLShape
 	shapeAfter: TLShape
-}
-
-/** @public */
-export interface BindingOnShapeDeleteOptions<Binding extends TLUnknownBinding> {
-	binding: Binding
-	shape: TLShape
 }
 
 /** @public */
@@ -77,21 +66,14 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
 	onOperationComplete?(): void
 
 	onBeforeUnbind?(options: BindingOnUnbindOptions<Binding>): void
+	onAfterUnbind?(options: BindingOnUnbindOptions<Binding>): void
 
 	// self lifecycle hooks
 	onBeforeCreate?(options: BindingOnCreateOptions<Binding>): Binding | void
 	onAfterCreate?(options: BindingOnCreateOptions<Binding>): void
 	onBeforeChange?(options: BindingOnChangeOptions<Binding>): Binding | void
 	onAfterChange?(options: BindingOnChangeOptions<Binding>): void
-	onBeforeDelete?(options: BindingOnDeleteOptions<Binding>): void
-	onAfterDelete?(options: BindingOnDeleteOptions<Binding>): void
 
 	onAfterChangeFromShape?(options: BindingOnShapeChangeOptions<Binding>): void
 	onAfterChangeToShape?(options: BindingOnShapeChangeOptions<Binding>): void
-
-	onBeforeDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void
-	onBeforeDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void
-
-	onAfterDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void
-	onAfterDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void
 }

--- a/packages/editor/src/lib/editor/bindings/BindingUtil.ts
+++ b/packages/editor/src/lib/editor/bindings/BindingUtil.ts
@@ -18,6 +18,19 @@ export interface BindingOnCreateOptions<Binding extends TLUnknownBinding> {
 }
 
 /** @public */
+export enum BindingUnbindReason {
+	DeletingFromShape = 'deleting_from_shape',
+	DeletingToShape = 'deleting_to_shape',
+	DeletingBinding = 'deleting_binding',
+}
+
+/** @public */
+export interface BindingOnUnbindOptions<Binding extends TLUnknownBinding> {
+	binding: Binding
+	reason: BindingUnbindReason
+}
+
+/** @public */
 export interface BindingOnChangeOptions<Binding extends TLUnknownBinding> {
 	bindingBefore: Binding
 	bindingAfter: Binding
@@ -62,6 +75,8 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
 	abstract getDefaultProps(): Partial<Binding['props']>
 
 	onOperationComplete?(): void
+
+	onBeforeUnbind?(options: BindingOnUnbindOptions<Binding>): void
 
 	// self lifecycle hooks
 	onBeforeCreate?(options: BindingOnCreateOptions<Binding>): Binding | void

--- a/packages/editor/src/lib/editor/bindings/BindingUtil.ts
+++ b/packages/editor/src/lib/editor/bindings/BindingUtil.ts
@@ -76,4 +76,7 @@ export abstract class BindingUtil<Binding extends TLUnknownBinding = TLUnknownBi
 
 	onBeforeDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void
 	onBeforeDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void
+
+	onAfterDeleteFromShape?(options: BindingOnShapeDeleteOptions<Binding>): void
+	onAfterDeleteToShape?(options: BindingOnShapeDeleteOptions<Binding>): void
 }

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -2,7 +2,8 @@ import {
 	BindingOnChangeOptions,
 	BindingOnCreateOptions,
 	BindingOnShapeChangeOptions,
-	BindingOnShapeDeleteOptions,
+	BindingOnUnbindOptions,
+	BindingUnbindReason,
 	BindingUtil,
 	Editor,
 	IndexKey,
@@ -60,7 +61,9 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 	}
 
 	// when the shape the arrow is pointing to is deleted
-	override onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<TLArrowBinding>): void {
+	override onBeforeUnbind({ binding, reason }: BindingOnUnbindOptions<TLArrowBinding>): void {
+		// don't need to do anything if the arrow is being deleted
+		if (reason === BindingUnbindReason.DeletingFromShape) return
 		const arrow = this.editor.getShape<TLArrowShape>(binding.fromId)
 		if (!arrow) return
 		unbindArrowTerminal(this.editor, arrow, binding.props.terminal)

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -55,7 +55,7 @@ beforeEach(() => {
 })
 
 function bindShapes(fromId: TLShapeId, toId: TLShapeId) {
-	const bindingId = createBindingId('test')
+	const bindingId = createBindingId()
 	editor.createBinding({
 		id: bindingId,
 		type: 'test',
@@ -141,10 +141,46 @@ test('copying the to shape on its own does trigger the unbind operation', () => 
 	)
 })
 
-// test('cascading deletes in ', () => {
-// 	mockOnAfterUnbind.mockImplementation((options) => {
-// 		if (options.reason === BindingUnbindReason.DeletingToShape) {
-// 			editor.deleteShape(options.binding.fromId)
-// 		}
-// 	})
-// })
+test('cascading deletes in afterUnbind are handled correctly', () => {
+	mockOnAfterUnbind.mockImplementation((options) => {
+		if (options.reason === BindingUnbindReason.DeletingFromShape) {
+			editor.deleteShape(options.binding.toId)
+		}
+	})
+
+	bindShapes(ids.box1, ids.box2)
+	bindShapes(ids.box2, ids.box3)
+	bindShapes(ids.box3, ids.box4)
+
+	editor.deleteShape(ids.box1)
+
+	expect(editor.getShape(ids.box1)).toBeUndefined()
+	expect(editor.getShape(ids.box2)).toBeUndefined()
+	expect(editor.getShape(ids.box3)).toBeUndefined()
+	expect(editor.getShape(ids.box4)).toBeUndefined()
+
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(3)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(3)
+})
+
+test('cascading deletes in beforeUnbind are handled correctly', () => {
+	mockOnBeforeUnbind.mockImplementation((options) => {
+		if (options.reason === BindingUnbindReason.DeletingFromShape) {
+			editor.deleteShape(options.binding.toId)
+		}
+	})
+
+	bindShapes(ids.box1, ids.box2)
+	bindShapes(ids.box2, ids.box3)
+	bindShapes(ids.box3, ids.box4)
+
+	editor.deleteShape(ids.box1)
+
+	expect(editor.getShape(ids.box1)).toBeUndefined()
+	expect(editor.getShape(ids.box2)).toBeUndefined()
+	expect(editor.getShape(ids.box3)).toBeUndefined()
+	expect(editor.getShape(ids.box4)).toBeUndefined()
+
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(3)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(3)
+})

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -68,9 +68,11 @@ function bindShapes(fromId: TLShapeId, toId: TLShapeId) {
 test('deleting the from shape causes the reason to be "deleting_from_shape"', () => {
 	bindShapes(ids.box1, ids.box2)
 	editor.deleteShape(ids.box1)
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnBeforeUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingFromShape })
 	)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnAfterUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingFromShape })
 	)
@@ -79,9 +81,11 @@ test('deleting the from shape causes the reason to be "deleting_from_shape"', ()
 test('deleting the to shape causes the reason to be "deleting_to_shape"', () => {
 	bindShapes(ids.box1, ids.box2)
 	editor.deleteShape(ids.box2)
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnBeforeUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingToShape })
 	)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnAfterUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingToShape })
 	)
@@ -90,9 +94,12 @@ test('deleting the to shape causes the reason to be "deleting_to_shape"', () => 
 test('deleting the binding itself causes the reason to be "deleting_binding"', () => {
 	const bindingId = bindShapes(ids.box1, ids.box2)
 	editor.deleteBinding(bindingId)
+
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnBeforeUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnAfterUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)
@@ -110,9 +117,11 @@ test('copying the from shape on its own does trigger the unbind operation', () =
 	bindShapes(ids.box1, ids.box2)
 	editor.select(ids.box1)
 	editor.copy()
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnBeforeUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnAfterUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)
@@ -122,9 +131,11 @@ test('copying the to shape on its own does trigger the unbind operation', () => 
 	bindShapes(ids.box1, ids.box2)
 	editor.select(ids.box2)
 	editor.copy()
+	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnBeforeUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)
+	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(1)
 	expect(mockOnAfterUnbind).toHaveBeenCalledWith(
 		expect.objectContaining({ reason: BindingUnbindReason.DeletingBinding })
 	)

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -184,3 +184,27 @@ test('cascading deletes in beforeUnbind are handled correctly', () => {
 	expect(mockOnBeforeUnbind).toHaveBeenCalledTimes(3)
 	expect(mockOnAfterUnbind).toHaveBeenCalledTimes(3)
 })
+
+test('beforeUnbind is called before the from shape is deleted or the binding is deleted', () => {
+	mockOnBeforeUnbind.mockImplementationOnce(() => {
+		expect(editor.getShape(ids.box1)).toBeDefined()
+		expect(editor.getShape(ids.box2)).toBeDefined()
+		expect(editor.getBindingsFromShape(ids.box1, 'test')).toHaveLength(1)
+	})
+	bindShapes(ids.box1, ids.box2)
+	editor.deleteShape(ids.box1)
+
+	expect.assertions(3)
+})
+
+test('beforeUnbind is called before the to shape is deleted or the binding is deleted', () => {
+	mockOnBeforeUnbind.mockImplementationOnce(() => {
+		expect(editor.getShape(ids.box1)).toBeDefined()
+		expect(editor.getShape(ids.box2)).toBeDefined()
+		expect(editor.getBindingsToShape(ids.box2, 'test')).toHaveLength(1)
+	})
+	bindShapes(ids.box1, ids.box2)
+	editor.deleteShape(ids.box2)
+
+	expect.assertions(3)
+})


### PR DESCRIPTION
Before this PR the interface for doing cleanup when shapes/bindings were deleted was quite footgunny and inexpressive.

We were abusing the shape beforeDelete callbacks to implement copy+paste, which doesn't work in situations where cascading deletes are required. This caused bugs in both our pin and sticker examples, where copy+paste was broken. I noticed the same bug in my experiment with text labels, and I think the fact that it took us a while to notice these bugs indicates other users are gonna fall prey to the same bugs unless we help them out.

One suggestion to fix this was to add `onAfterDelete(From|To)Shape` callbacks. The cascading deletes could happen in those, while keeping the 'commit changes' kinds of updates in the `before` callbacks and theoretically that would fix the issues with copy+paste. However, expecting people to figure this out on their own is asking a heckuva lot IMO, and it's a heavy bit of nuance to try to convey in the docs. It's hard enough to convey it here. Plus I could imagine for some users it might easily even leave the store in an inconsistent state to allow a bound shape to exist for any length of time after the shape it was bound to was already deleted.

It also just makes an already large and muddy API surface area even larger and muddier and if that can be avoided let's avoid it.

This PR clears things up by making it so that there's only one callback for when a binding is removed. The callback is given a `reason` for why it is being called

The `reason` is one of the following:

- The 'from' is being deleted
- The 'to' shape is being deleted
- The binding is being deleted on it's own.

Technically a binding might end up being deleted when both the `from` and `to` shapes are being deleted, but it's very hard to know for certain when that is happening, so I decided to just ignore it for now. I think it would only matter for perf reasons, to avoid doing useless work.

So this PR replaces the `onBeforeDelete`, `onAfterDelete`, `onBeforeFromShapeDelete` and `onBeforeToShapeDelete` (and the prospective `onAfterFromShapeDelete` and `onAfterToShapeDelete`) with just two callbacks:

- `onBeforeUnbind({binding, reason})` - called before any shapes or the binding have been deleted.
- `onAfterUnbind({binding, reason})` - called after the binding and any shapes have been deleted.

This still allows all the same behaviour as before, without having to spread the logic between multiple callbacks. It's also just clearer IMO since you only get one callback invocation per unbinding rather than potentially two. It also fixes our copy+paste footgun since we can now implement that by just deleting the bindings rather than invoking the `onBeforeDelete(From|To)Shape` callbacks.

I'm not worried about losing the explicit before/after delete callbacks for the binding record or shape records because sdk users still have the ability to detect all those situations with full nuance in obvious ways. The one thing that would even require extra bookkeeping is getting access to a shape record after the shape was deleted, but that's probably not a thing anybody would want to do 🤷🏼 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
