### PR TITLE
Allow DefaultErrorFallback to be used independently

### DIFF
--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -23,7 +23,13 @@ export const DefaultErrorFallback: TLErrorFallbackComponent = ({ error, editor }
 	const [didCopy, setDidCopy] = useState(false)
 	const [shouldShowResetConfirmation, setShouldShowResetConfirmation] = useState(false)
 
-	const { Canvas } = useEditorComponents()
+	let Canvas: React.ComponentType | null = null
+	try {
+		const components = useEditorComponents()
+		Canvas = components.Canvas ?? null
+	} catch (e) {
+		// allow this to fail silently
+	}
 
 	const errorMessage = error instanceof Error ? error.message : String(error)
 	const errorStack = error instanceof Error ? error.stack : null


### PR DESCRIPTION
Follow up to #3750 – this broke our error pages because they try to use the Canvas component if they are in a tldraw subtree but it was designed to work outside of a tldraw subtree too.
 
### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
