### PR TITLE
[bugfix?] End interactions before switching page

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3537,6 +3537,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 
 		this.stopFollowingUser()
+		// cancel any in-progress interactions
+		this.cancel()
 
 		return this.batch(
 			() => this.store.put([{ ...this.getInstanceState(), currentPageId: pageId }]),

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3537,8 +3537,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 
 		this.stopFollowingUser()
-		// cancel any in-progress interactions
-		this.cancel()
+		// finish off any in-progress interactions
+		this.complete()
 
 		return this.batch(
 			() => this.store.put([{ ...this.getInstanceState(), currentPageId: pageId }]),

--- a/packages/tldraw/src/test/commands/setCurrentPage.test.ts
+++ b/packages/tldraw/src/test/commands/setCurrentPage.test.ts
@@ -85,4 +85,22 @@ describe('setCurrentPage', () => {
 		expect(console.error).toHaveBeenCalled()
 		expect(editor.getCurrentPageId()).toBe(initialPageId)
 	})
+
+	it('cancels any in-progress actions', () => {
+		const page1Id = editor.getPages()[0].id
+		const page2Id = PageRecordType.createId('page2')
+
+		editor.createPage({ name: 'New Page 2', id: page2Id })
+		expect(editor.getCurrentPageId()).toBe(page1Id)
+
+		const geoId = createShapeId()
+		editor.createShape({ type: 'geo', id: geoId, props: { w: 100, h: 100 } })
+		editor.select(geoId)
+		editor.keyUp('Enter')
+
+		expect(editor.isIn('select.editing_shape')).toBe(true)
+
+		editor.setCurrentPage(page2Id)
+		expect(editor.isIn('select.idle')).toBe(true)
+	})
 })


### PR DESCRIPTION
Looking at #3762 it seemed to have been caused by calling `setCurrentPage` during a `select.editing_shape` interaction. I wonder whether we should trigger a `cancel` event before switching pages in case this happens?

closes #3762 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
