### PR TITLE
remove `canBind` flags

### DIFF
--- a/apps/examples/src/examples/custom-config/CardShape/CardShapeUtil.tsx
+++ b/apps/examples/src/examples/custom-config/CardShape/CardShapeUtil.tsx
@@ -23,7 +23,6 @@ export class CardShapeUtil extends ShapeUtil<ICardShape> {
 	// [3]
 	override isAspectRatioLocked = (_shape: ICardShape) => false
 	override canResize = (_shape: ICardShape) => true
-	override canBind = (_shape: ICardShape) => true
 
 	// [4]
 	getDefaultProps(): ICardShape['props'] {

--- a/apps/examples/src/examples/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/custom-shape/CustomShapeExample.tsx
@@ -44,7 +44,6 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canBind = () => true
 	override canEdit = () => false
 	override canResize = () => true
 	override isAspectRatioLocked = () => false

--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -44,7 +44,6 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 		return {}
 	}
 
-	override canBind = () => false
 	override canEdit = () => false
 	override canResize = () => false
 	override hideRotateHandle = () => true

--- a/apps/examples/src/examples/slides/SlideShapeUtil.tsx
+++ b/apps/examples/src/examples/slides/SlideShapeUtil.tsx
@@ -29,7 +29,6 @@ export class SlideShapeUtil extends ShapeUtil<SlideShape> {
 		h: T.number,
 	}
 
-	override canBind = () => false
 	override hideRotateHandle = () => true
 
 	getDefaultProps(): SlideShape['props'] {

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -65,8 +65,6 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override canResize = (_shape: SpeechBubbleShape) => true
 
-	override canBind = (_shape: SpeechBubbleShape) => true
-
 	override canEdit = () => true
 
 	// [3]

--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -40,7 +40,6 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		return {}
 	}
 
-	override canBind = () => false
 	override canEdit = () => false
 	override canResize = () => false
 	override hideRotateHandle = () => true

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1268,8 +1268,6 @@ export class Group2d extends Geometry2d {
 // @public (undocumented)
 export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
-    canBind: () => boolean;
-    // (undocumented)
     component(shape: TLGroupShape): JSX_2.Element | null;
     // (undocumented)
     getDefaultProps(): TLGroupShape['props'];
@@ -1778,7 +1776,6 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     // @internal
     backgroundComponent?(shape: Shape): any;
     canBeLaidOut: TLShapeUtilFlag<Shape>;
-    canBind: <K>(_shape: Shape, _otherShape?: K) => boolean;
     canCrop: TLShapeUtilFlag<Shape>;
     canDropShapes(shape: Shape, shapes: TLShape[]): boolean;
     canEdit: TLShapeUtilFlag<Shape>;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -97,14 +97,6 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	canScroll: TLShapeUtilFlag<Shape> = () => false
 
 	/**
-	 * Whether the shape can be bound to by an arrow.
-	 *
-	 * @param _otherShape - The other shape attempting to bind to this shape.
-	 * @public
-	 */
-	canBind = <K>(_shape: Shape, _otherShape?: K) => true
-
-	/**
 	 * Whether the shape can be double clicked to edit.
 	 *
 	 * @public

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -16,8 +16,6 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 
 	override hideSelectionBoundsFg = () => true
 
-	override canBind = () => false
-
 	getDefaultProps(): TLGroupShape['props'] {
 		return {}
 	}

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -169,8 +169,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBeLaidOut: TLShapeUtilFlag<TLArrowShape>;
     // (undocumented)
-    canBind: () => boolean;
-    // (undocumented)
     canEdit: () => boolean;
     // (undocumented)
     canSnap: () => boolean;
@@ -616,8 +614,6 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 
 // @public (undocumented)
 export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
-    // (undocumented)
-    canBind: () => boolean;
     // (undocumented)
     canDropShapes: (shape: TLFrameShape, _shapes: TLShape[]) => boolean;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -33,6 +33,7 @@ import {
 	useIsEditing,
 } from '@tldraw/editor'
 import React from 'react'
+import { SHAPES_WHICH_ARROWS_CANNOT_BIND_TO } from '../../ui/constants'
 import { ShapeFill, useDefaultColorTheme } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { ARROW_LABEL_FONT_SIZES, STROKE_SIZES } from '../shared/default-shape-constants'
@@ -75,7 +76,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	static override migrations = arrowShapeMigrations
 
 	override canEdit = () => true
-	override canBind = () => false
 	override canSnap = () => false
 	override hideResizeHandles: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideRotateHandle: TLShapeUtilFlag<TLArrowShape> = () => true
@@ -153,7 +153,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a0',
 				x: info.start.handle.x,
 				y: info.start.handle.y,
-				canBind: true,
 			},
 			{
 				id: ARROW_HANDLES.MIDDLE,
@@ -161,7 +160,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a2',
 				x: info.middle.x,
 				y: info.middle.y,
-				canBind: false,
 			},
 			{
 				id: ARROW_HANDLES.END,
@@ -169,7 +167,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a3',
 				x: info.end.handle.x,
 				y: info.end.handle.y,
-				canBind: true,
 			},
 		].filter(Boolean) as TLHandle[]
 	}
@@ -223,7 +220,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			hitFrameInside: true,
 			margin: 0,
 			filter: (targetShape) => {
-				return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+				return (
+					!targetShape.isLocked && !SHAPES_WHICH_ARROWS_CANNOT_BIND_TO.includes(targetShape.type)
+				)
 			},
 		})
 
@@ -384,7 +383,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				hitFrameInside: true,
 				margin: 0,
 				filter: (targetShape) => {
-					return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+					return (
+						!targetShape.isLocked && !SHAPES_WHICH_ARROWS_CANNOT_BIND_TO.includes(targetShape.type)
+					)
 				},
 			})
 

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -1,4 +1,5 @@
 import { StateNode, TLArrowShape, TLEventHandlers, createShapeId } from '@tldraw/editor'
+import { SHAPES_WHICH_ARROWS_CANNOT_BIND_TO } from '../../../ui/constants'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -12,7 +13,9 @@ export class Pointing extends StateNode {
 
 		const target = this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
 			filter: (targetShape) => {
-				return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+				return (
+					!targetShape.isLocked && !SHAPES_WHICH_ARROWS_CANNOT_BIND_TO.includes(targetShape.type)
+				)
 			},
 			margin: 0,
 			hitInside: true,
@@ -47,7 +50,7 @@ export class Pointing extends StateNode {
 
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
-				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0, canBind: true },
+				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0 },
 				isCreating: true,
 				onInteractionEnd: 'arrow',
 			})

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -35,8 +35,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	static override props = frameShapeProps
 	static override migrations = frameShapeMigrations
 
-	override canBind = () => true
-
 	override canEdit = () => true
 
 	override getDefaultProps(): TLFrameShape['props'] {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -283,7 +283,10 @@ export class DraggingHandle extends StateNode {
 		const next: TLShapePartial<any> = { id: shape.id, type: shape.type, ...changes }
 
 		// Arrows
-		if (initialHandle.canBind && this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')) {
+		if (
+			initialHandle.type === 'vertex' &&
+			this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')
+		) {
 			const bindingAfter = getArrowBindings(editor, shape)[initialHandle.id as 'start' | 'end']
 
 			if (bindingAfter) {

--- a/packages/tldraw/src/lib/ui/constants.ts
+++ b/packages/tldraw/src/lib/ui/constants.ts
@@ -15,3 +15,5 @@ export enum PORTRAIT_BREAKPOINT {
 }
 
 export const ADJACENT_SHAPE_MARGIN = 20
+
+export const SHAPES_WHICH_ARROWS_CANNOT_BIND_TO = ['arrow', 'group']

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -223,7 +223,6 @@ describe('Custom shapes', () => {
 
 		override isAspectRatioLocked = (_shape: CardShape) => false
 		override canResize = (_shape: CardShape) => true
-		override canBind = (_shape: CardShape) => true
 
 		override getDefaultProps(): CardShape['props'] {
 			return {

--- a/packages/tldraw/src/test/arrows-megabus.test.tsx
+++ b/packages/tldraw/src/test/arrows-megabus.test.tsx
@@ -1,5 +1,6 @@
 import { TLArrowShape, TLShapeId, Vec, createShapeId } from '@tldraw/editor'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
+import { SHAPES_WHICH_ARROWS_CANNOT_BIND_TO } from '../lib/ui/constants'
 import { TestEditor } from './TestEditor'
 import { TL } from './test-jsx'
 
@@ -94,19 +95,16 @@ describe('Making an arrow on the page', () => {
 				x: 0,
 				y: 0,
 				type: 'vertex',
-				canBind: true,
 			},
 			{
 				x: 50,
 				y: 0,
 				type: 'virtual',
-				canBind: false,
 			},
 			{
 				x: 100,
 				y: 0,
 				type: 'vertex',
-				canBind: true,
 			},
 		])
 	})
@@ -488,7 +486,7 @@ describe('When starting an arrow inside of multiple shapes', () => {
 
 		expect(
 			editor.getShapeAtPoint(new Vec(25, 25), {
-				filter: (shape) => editor.getShapeUtil(shape).canBind(shape),
+				filter: (shape) => !SHAPES_WHICH_ARROWS_CANNOT_BIND_TO.includes(shape.type),
 				hitInside: true,
 				hitFrameInside: true,
 				margin: 0,

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1073,8 +1073,6 @@ export type TLGroupShape = TLBaseShape<'group', TLGroupShapeProps>;
 // @public
 export interface TLHandle {
     // (undocumented)
-    canBind?: boolean;
-    // (undocumented)
     canSnap?: boolean;
     id: string;
     // (undocumented)

--- a/packages/tlschema/src/misc/TLHandle.ts
+++ b/packages/tlschema/src/misc/TLHandle.ts
@@ -22,7 +22,6 @@ export interface TLHandle {
 	/** A unique identifier for the handle. */
 	id: string
 	type: TLHandleType
-	canBind?: boolean
 	canSnap?: boolean
 	index: IndexKey
 	x: number


### PR DESCRIPTION
Remove `canBind` from handles and shape utils. Instead, we hard-code the bits that arrows need.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Release Notes

#### Breaking changes
- The `canBind` handle has been removed from `ShapeUtil`
