### PR TITLE
Fix spacebar/mmb panning bug.

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8545,7 +8545,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						// Start a long press timeout
 						this._longPressTimeout = setTimeout(() => {
-							this.dispatch({ ...info, name: 'long_press' })
+							this.dispatch({ ...info, point: this.inputs.currentScreenPoint, name: 'long_press' })
 						}, LONG_PRESS_DURATION)
 
 						// Save the selected ids at pointer down

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8543,10 +8543,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// Close any open menus
 						this.clearOpenMenus()
 
-						// Start a long press timeout
-						this._longPressTimeout = setTimeout(() => {
-							this.dispatch({ ...info, point: this.inputs.currentScreenPoint, name: 'long_press' })
-						}, LONG_PRESS_DURATION)
+						if (!this.inputs.isPanning) {
+							// Start a long press timeout
+							this._longPressTimeout = setTimeout(() => {
+								this.dispatch({
+									...info,
+									point: this.inputs.currentScreenPoint,
+									name: 'long_press',
+								})
+							}, LONG_PRESS_DURATION)
+						}
 
 						// Save the selected ids at pointer down
 						this._selectedShapeIdsAtPointerDown = this.getSelectedShapeIds()


### PR DESCRIPTION
We had a bug in our inputs logic that would allow a long press timeout to be triggered if a user started pointing before holding spacebar. This PR fixes that bug! Thanks to @ds300 for the spot.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Release Notes

- Fix bug with panning