### PR TITLE
rework canBind callback

### DIFF
--- a/apps/examples/src/examples/custom-config/CardShape/CardShapeUtil.tsx
+++ b/apps/examples/src/examples/custom-config/CardShape/CardShapeUtil.tsx
@@ -23,7 +23,6 @@ export class CardShapeUtil extends ShapeUtil<ICardShape> {
 	// [3]
 	override isAspectRatioLocked = (_shape: ICardShape) => false
 	override canResize = (_shape: ICardShape) => true
-	override canBind = (_shape: ICardShape) => true
 
 	// [4]
 	getDefaultProps(): ICardShape['props'] {

--- a/apps/examples/src/examples/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/custom-shape/CustomShapeExample.tsx
@@ -44,7 +44,6 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canBind = () => true
 	override canEdit = () => false
 	override canResize = () => true
 	override isAspectRatioLocked = () => false

--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -1,3 +1,4 @@
+import { TLShapeUtilCanBindOpts } from '@tldraw/editor/src/lib/editor/shapes/ShapeUtil'
 import {
 	BindingOnShapeChangeOptions,
 	BindingOnUnbindOptions,
@@ -44,7 +45,10 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 		return {}
 	}
 
-	override canBind = () => false
+	override canBind({ direction }: TLShapeUtilCanBindOpts<PinShape>) {
+		// bindings can go _from_ pins to other shapes, but not the other way round
+		return direction === 'from'
+	}
 	override canEdit = () => false
 	override canResize = () => false
 	override hideRotateHandle = () => true
@@ -93,7 +97,9 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 			.getShapesAtPoint(pageAnchor, { hitInside: true })
 			.filter(
 				(shape) =>
-					shape.type !== 'pin' && shape.parentId === pin.parentId && shape.index < pin.index
+					this.editor.canBindShapes(pin.id, shape.id, 'pin') &&
+					shape.parentId === pin.parentId &&
+					shape.index < pin.index
 			)
 
 		for (const target of targets) {

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -65,8 +65,6 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override canResize = (_shape: SpeechBubbleShape) => true
 
-	override canBind = (_shape: SpeechBubbleShape) => true
-
 	override canEdit = () => true
 
 	// [3]

--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -1,3 +1,4 @@
+import { TLShapeUtilCanBindOpts } from '@tldraw/editor/src/lib/editor/shapes/ShapeUtil'
 import {
 	BindingOnShapeChangeOptions,
 	BindingOnUnbindOptions,
@@ -40,7 +41,10 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		return {}
 	}
 
-	override canBind = () => false
+	override canBind(opts: TLShapeUtilCanBindOpts<StickerShape>) {
+		// bindings can go _from_ stickers to other shapes, but not the other way round
+		return opts.direction === 'from'
+	}
 	override canEdit = () => false
 	override canResize = () => false
 	override hideRotateHandle = () => true
@@ -86,7 +90,7 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		const pageAnchor = this.editor.getShapePageTransform(sticker).applyToPoint({ x: 0, y: 0 })
 		const target = this.editor.getShapeAtPoint(pageAnchor, {
 			hitInside: true,
-			filter: (shape) => shape.id !== sticker.id,
+			filter: (shape) => this.editor.canBindShapes(sticker, shape, 'sticker'),
 		})
 
 		if (!target) return

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -168,6 +168,7 @@ export {
 	type TLOnTranslateStartHandler,
 	type TLResizeInfo,
 	type TLResizeMode,
+	type TLShapeUtilCanBindOpts,
 	type TLShapeUtilCanvasSvgDef,
 	type TLShapeUtilConstructor,
 	type TLShapeUtilFlag,

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -32,6 +32,22 @@ export interface TLShapeUtilConstructor<
 /** @public */
 export type TLShapeUtilFlag<T> = (shape: T) => boolean
 
+/**@public */
+export interface TLShapeUtilCanBindOpts<Shape extends TLUnknownShape = TLShape> {
+	/** The shape from this util */
+	shape: Shape
+	/** The other shape being bound to. It may not exist yet, in which case it will be missing. */
+	otherShape?: TLShape
+	/**
+	 * The direction:
+	 * - `"to"` means the other shape is being bound to this shape.
+	 * - `"from"` means this shape is being bound to the other shape.
+	 */
+	direction: 'to' | 'from'
+	/** The type of binding, e.g. `"arrow"`. */
+	type: string
+}
+
 /** @public */
 export interface TLShapeUtilCanvasSvgDef {
 	key: string
@@ -97,12 +113,13 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	canScroll: TLShapeUtilFlag<Shape> = () => false
 
 	/**
-	 * Whether the shape can be bound to by an arrow.
+	 * Whether the shape can be bound to. See {@link TLShapeUtilCanBindOpts} for details.
 	 *
-	 * @param _otherShape - The other shape attempting to bind to this shape.
 	 * @public
 	 */
-	canBind = <K>(_shape: Shape, _otherShape?: K) => true
+	canBind(opts: TLShapeUtilCanBindOpts<Shape>): boolean {
+		return true
+	}
 
 	/**
 	 * Whether the shape can be double clicked to edit.

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -3,7 +3,7 @@ import { Box } from '../../primitives/Box'
 import { VecLike } from '../../primitives/Vec'
 
 /** @public */
-export type RequiredKeys<T, K extends keyof T> = Partial<Omit<T, K>> & Pick<T, K>
+export type RequiredKeys<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>
 /** @public */
 export type OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -115,6 +115,7 @@ import { TLSelectionHandle } from '@tldraw/editor';
 import { TLShape } from '@tldraw/editor';
 import { TLShapeId } from '@tldraw/editor';
 import { TLShapePartial } from '@tldraw/editor';
+import { TLShapeUtilCanBindOpts } from '@tldraw/editor';
 import { TLShapeUtilCanvasSvgDef } from '@tldraw/editor';
 import { TLShapeUtilFlag } from '@tldraw/editor';
 import { TLStore } from '@tldraw/editor';
@@ -169,7 +170,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBeLaidOut: TLShapeUtilFlag<TLArrowShape>;
     // (undocumented)
-    canBind: () => boolean;
+    canBind({ direction }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean;
     // (undocumented)
     canEdit: () => boolean;
     // (undocumented)
@@ -616,8 +617,6 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 
 // @public (undocumented)
 export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
-    // (undocumented)
-    canBind: () => boolean;
     // (undocumented)
     canDropShapes: (shape: TLFrameShape, _shapes: TLShape[]) => boolean;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -18,6 +18,7 @@ import {
 	TLOnTranslateHandler,
 	TLOnTranslateStartHandler,
 	TLShapePartial,
+	TLShapeUtilCanBindOpts,
 	TLShapeUtilCanvasSvgDef,
 	TLShapeUtilFlag,
 	Vec,
@@ -75,7 +76,10 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	static override migrations = arrowShapeMigrations
 
 	override canEdit = () => true
-	override canBind = () => false
+	override canBind({ direction }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean {
+		// bindings can go from arrows to shapes, but not from shapes to arrows
+		return direction === 'from'
+	}
 	override canSnap = () => false
 	override hideResizeHandles: TLShapeUtilFlag<TLArrowShape> = () => true
 	override hideRotateHandle: TLShapeUtilFlag<TLArrowShape> = () => true
@@ -153,7 +157,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a0',
 				x: info.start.handle.x,
 				y: info.start.handle.y,
-				canBind: true,
 			},
 			{
 				id: ARROW_HANDLES.MIDDLE,
@@ -161,7 +164,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a2',
 				x: info.middle.x,
 				y: info.middle.y,
-				canBind: false,
 			},
 			{
 				id: ARROW_HANDLES.END,
@@ -169,7 +171,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				index: 'a3',
 				x: info.end.handle.x,
 				y: info.end.handle.y,
-				canBind: true,
 			},
 		].filter(Boolean) as TLHandle[]
 	}
@@ -223,7 +224,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			hitFrameInside: true,
 			margin: 0,
 			filter: (targetShape) => {
-				return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+				return !targetShape.isLocked && this.editor.canBindShapes(shape, targetShape, 'arrow')
 			},
 		})
 
@@ -384,7 +385,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				hitFrameInside: true,
 				margin: 0,
 				filter: (targetShape) => {
-					return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+					return !targetShape.isLocked && this.editor.canBindShapes(shape, targetShape, 'arrow')
 				},
 			})
 

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -12,7 +12,7 @@ export class Pointing extends StateNode {
 
 		const target = this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
 			filter: (targetShape) => {
-				return !targetShape.isLocked && this.editor.getShapeUtil(targetShape).canBind(targetShape)
+				return !targetShape.isLocked && this.editor.canBindShapes(null, targetShape, 'arrow')
 			},
 			margin: 0,
 			hitInside: true,
@@ -47,7 +47,7 @@ export class Pointing extends StateNode {
 
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
-				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0, canBind: true },
+				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0 },
 				isCreating: true,
 				onInteractionEnd: 'arrow',
 			})

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -35,8 +35,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	static override props = frameShapeProps
 	static override migrations = frameShapeMigrations
 
-	override canBind = () => true
-
 	override canEdit = () => true
 
 	override getDefaultProps(): TLFrameShape['props'] {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -283,7 +283,10 @@ export class DraggingHandle extends StateNode {
 		const next: TLShapePartial<any> = { id: shape.id, type: shape.type, ...changes }
 
 		// Arrows
-		if (initialHandle.canBind && this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')) {
+		if (
+			initialHandle.type === 'vertex' &&
+			this.editor.isShapeOfType<TLArrowShape>(shape, 'arrow')
+		) {
 			const bindingAfter = getArrowBindings(editor, shape)[initialHandle.id as 'start' | 'end']
 
 			if (bindingAfter) {

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -253,10 +253,10 @@ export class TestEditor extends Editor {
 	}
 
 	expectShapeToMatch = <T extends TLShape = TLShape>(
-		...model: RequiredKeys<TLShapePartial<T>, 'id'>[]
+		...model: RequiredKeys<Partial<TLShapePartial<T>>, 'id'>[]
 	) => {
 		model.forEach((model) => {
-			const shape = this.getShape(model.id)!
+			const shape = this.getShape(model.id!)!
 			const next = { ...shape, ...model }
 			expect(shape).toCloselyMatchObject(next)
 		})

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -223,7 +223,6 @@ describe('Custom shapes', () => {
 
 		override isAspectRatioLocked = (_shape: CardShape) => false
 		override canResize = (_shape: CardShape) => true
-		override canBind = (_shape: CardShape) => true
 
 		override getDefaultProps(): CardShape['props'] {
 			return {

--- a/packages/tldraw/src/test/arrows-megabus.test.tsx
+++ b/packages/tldraw/src/test/arrows-megabus.test.tsx
@@ -94,19 +94,16 @@ describe('Making an arrow on the page', () => {
 				x: 0,
 				y: 0,
 				type: 'vertex',
-				canBind: true,
 			},
 			{
 				x: 50,
 				y: 0,
 				type: 'virtual',
-				canBind: false,
 			},
 			{
 				x: 100,
 				y: 0,
 				type: 'vertex',
-				canBind: true,
 			},
 		])
 	})
@@ -488,7 +485,7 @@ describe('When starting an arrow inside of multiple shapes', () => {
 
 		expect(
 			editor.getShapeAtPoint(new Vec(25, 25), {
-				filter: (shape) => editor.getShapeUtil(shape).canBind(shape),
+				filter: (shape) => editor.canBindShapes(null, shape, 'arrow'),
 				hitInside: true,
 				hitFrameInside: true,
 				margin: 0,

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -2,7 +2,7 @@ import {
 	createBindingId,
 	createShapeId,
 	TLArrowShape,
-	TLBindingPartial,
+	TLBindingCreate,
 	TLShapePartial,
 } from '@tldraw/editor'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
@@ -92,7 +92,7 @@ it('creates new bindings for arrows when pasting', async () => {
 // blood moat incoming
 describe('When duplicating shapes that include arrows', () => {
 	let shapes: TLShapePartial[]
-	let bindings: TLBindingPartial[]
+	let bindings: TLBindingCreate[]
 
 	beforeEach(() => {
 		const box1 = createShapeId()

--- a/packages/tldraw/src/test/flipShapes.test.ts
+++ b/packages/tldraw/src/test/flipShapes.test.ts
@@ -3,7 +3,7 @@ import {
 	PI,
 	TLArrowShape,
 	TLArrowShapeProps,
-	TLBindingPartial,
+	TLBindingCreate,
 	TLShapeId,
 	TLShapePartial,
 	createBindingId,
@@ -467,7 +467,7 @@ describe('flipping rotated shapes', () => {
 
 describe('When flipping shapes that include arrows', () => {
 	let shapes: TLShapePartial[]
-	let bindings: TLBindingPartial[]
+	let bindings: TLBindingCreate[]
 
 	beforeEach(() => {
 		const box1 = createShapeId()

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -931,15 +931,29 @@ export interface TLBaseShape<Type extends string, Props extends object> extends 
 export type TLBinding = TLDefaultBinding | TLUnknownBinding;
 
 // @public (undocumented)
+export type TLBindingCreate<T extends TLBinding = TLBinding> = Expand<{
+    fromId: T['fromId'];
+    id?: TLBindingId;
+    meta?: Partial<T['meta']>;
+    props?: Partial<T['props']>;
+    toId: T['toId'];
+    type: T['type'];
+    typeName?: T['typeName'];
+}>;
+
+// @public (undocumented)
 export type TLBindingId = RecordId<TLUnknownBinding>;
 
 // @public (undocumented)
-export type TLBindingPartial<T extends TLBinding = TLBinding> = T extends T ? {
+export type TLBindingUpdate<T extends TLBinding = TLBinding> = Expand<{
+    fromId?: T['fromId'];
     id: TLBindingId;
     meta?: Partial<T['meta']>;
     props?: Partial<T['props']>;
+    toId?: T['toId'];
     type: T['type'];
-} & Partial<Omit<T, 'id' | 'meta' | 'props' | 'type'>> : never;
+    typeName?: T['typeName'];
+}>;
 
 // @public
 export type TLBookmarkAsset = TLBaseAsset<'bookmark', {
@@ -1072,8 +1086,6 @@ export type TLGroupShape = TLBaseShape<'group', TLGroupShapeProps>;
 
 // @public
 export interface TLHandle {
-    // (undocumented)
-    canBind?: boolean;
     // (undocumented)
     canSnap?: boolean;
     id: string;

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -60,8 +60,9 @@ export {
 	isBindingId,
 	rootBindingMigrations,
 	type TLBinding,
+	type TLBindingCreate,
 	type TLBindingId,
-	type TLBindingPartial,
+	type TLBindingUpdate,
 	type TLDefaultBinding,
 	type TLUnknownBinding,
 } from './records/TLBinding'

--- a/packages/tlschema/src/misc/TLHandle.ts
+++ b/packages/tlschema/src/misc/TLHandle.ts
@@ -22,7 +22,6 @@ export interface TLHandle {
 	/** A unique identifier for the handle. */
 	id: string
 	type: TLHandleType
-	canBind?: boolean
 	canSnap?: boolean
 	index: IndexKey
 	x: number

--- a/packages/tlschema/src/records/TLBinding.ts
+++ b/packages/tlschema/src/records/TLBinding.ts
@@ -5,7 +5,7 @@ import {
 	createRecordMigrationSequence,
 	createRecordType,
 } from '@tldraw/store'
-import { mapObjectMapValues } from '@tldraw/utils'
+import { Expand, mapObjectMapValues } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
 import { nanoid } from 'nanoid'
 import { TLArrowBinding } from '../bindings/TLArrowBinding'
@@ -34,14 +34,26 @@ export type TLUnknownBinding = TLBaseBinding<string, object>
 export type TLBinding = TLDefaultBinding | TLUnknownBinding
 
 /** @public */
-export type TLBindingPartial<T extends TLBinding = TLBinding> = T extends T
-	? {
-			id: TLBindingId
-			type: T['type']
-			props?: Partial<T['props']>
-			meta?: Partial<T['meta']>
-		} & Partial<Omit<T, 'type' | 'id' | 'props' | 'meta'>>
-	: never
+export type TLBindingUpdate<T extends TLBinding = TLBinding> = Expand<{
+	id: TLBindingId
+	type: T['type']
+	typeName?: T['typeName']
+	fromId?: T['fromId']
+	toId?: T['toId']
+	props?: Partial<T['props']>
+	meta?: Partial<T['meta']>
+}>
+
+/** @public */
+export type TLBindingCreate<T extends TLBinding = TLBinding> = Expand<{
+	id?: TLBindingId
+	type: T['type']
+	typeName?: T['typeName']
+	fromId: T['fromId']
+	toId: T['toId']
+	props?: Partial<T['props']>
+	meta?: Partial<T['meta']>
+}>
 
 /** @public */
 export type TLBindingId = RecordId<TLUnknownBinding>


### PR DESCRIPTION
This PR reworks the `canBind` callback to work with customizable bindings. It now accepts an object with a the shape, the other shape (optional - it may not exist yet), the direction, and the type of the binding. Devs can use this to create shapes that only participate in certain binding types, can have bindings from but not to them, etc.

If you're implementing a binding, you can see if binding two shapes is allowed using `editor.canBindShapes(fromShape, toShape, 'my binding type')`

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `improvement` — Improving existing features

### Release Notes

#### Breaking changes
The `canBind` flag now accepts an options object instead of just the shape in question. If you're relying on its arguments, you need to change from `canBind(shape) {}` to `canBind({shape}) {}`.
