### PR TITLE
Fix markdown list rendering on docs site

### DIFF
--- a/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch
+++ b/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch
@@ -1,0 +1,91 @@
+diff --git a/lib-commonjs/emitters/TSDocEmitter.js b/lib-commonjs/emitters/TSDocEmitter.js
+index 36c607ac192810524ae28ce818d64652efedca98..41650ab83b6825d33b75fb86ec9b8eb0f0b5dfc7 100644
+--- a/lib-commonjs/emitters/TSDocEmitter.js
++++ b/lib-commonjs/emitters/TSDocEmitter.js
+@@ -278,6 +278,9 @@ var TSDocEmitter = /** @class */ (function () {
+                 var docPlainText = docNode;
+                 this._writeContent(docPlainText.text);
+                 break;
++            case DocNode_1.DocNodeKind.SoftBreak:
++                this._ensureAtStartOfLine();
++                break;
+         }
+     };
+     TSDocEmitter.prototype._renderInlineTag = function (docInlineTagBase, writeInlineTagContent) {
+diff --git a/lib-commonjs/transforms/TrimSpacesTransform.js b/lib-commonjs/transforms/TrimSpacesTransform.js
+index 8d8a92b9a2c97347c29094df7d0e2b23cdcdffaf..6c5946e3f9adb61e46ce1d7d39ab07ee81db923e 100644
+--- a/lib-commonjs/transforms/TrimSpacesTransform.js
++++ b/lib-commonjs/transforms/TrimSpacesTransform.js
+@@ -18,6 +18,25 @@ var TrimSpacesTransform = /** @class */ (function () {
+         // We always trim leading whitespace for a paragraph.  This flag gets set to true
+         // as soon as nonempty content is encountered.
+         var finishedSkippingLeadingSpaces = false;
++
++        function pushAccumulatedText() {
++            const lines = accumulatedTextChunks.join('').split('\n')
++            for (let i = 0; i < lines.length; i++) {
++                const line = lines[i]
++                transformedNodes.push(new nodes_1.DocPlainText({
++                    configuration: docParagraph.configuration,
++                    text: line
++                }));
++                if (i < lines.length - 1) {
++                    transformedNodes.push(new nodes_1.DocSoftBreak({
++                        configuration: docParagraph.configuration
++                    }));
++                }
++            }
++            accumulatedTextChunks.length = 0;
++            accumulatedNodes.length = 0;
++        }
++
+         for (var _i = 0, _a = docParagraph.nodes; _i < _a.length; _i++) {
+             var node = _a[_i];
+             switch (node.kind) {
+@@ -44,9 +63,15 @@ var TrimSpacesTransform = /** @class */ (function () {
+                     }
+                     break;
+                 case nodes_1.DocNodeKind.SoftBreak:
+-                    if (finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
++                    // by default, this transform strips out all soft-breaks and replaces them with
++                    // spaces where needed. because we're rendering to markdown and markdown is
++                    // whitespace-sensitive, we don't want to do this. instead, we accumulate the
++                    // soft-breaks and emit them as normal.
++                    
++                    // if (finishedSkippingLeadingSpaces) {
++                    // pendingSpace = true;
++                    // }
++                    accumulatedTextChunks.push('\n');
+                     accumulatedNodes.push(node);
+                     break;
+                 default:
+@@ -58,12 +83,7 @@ var TrimSpacesTransform = /** @class */ (function () {
+                     if (accumulatedTextChunks.length > 0) {
+                         // TODO: We should probably track the accumulatedNodes somehow, e.g. so we can map them back to the
+                         // original excerpts.  But we need a developer scenario before we can design this API.
+-                        transformedNodes.push(new nodes_1.DocPlainText({
+-                            configuration: docParagraph.configuration,
+-                            text: accumulatedTextChunks.join('')
+-                        }));
+-                        accumulatedTextChunks.length = 0;
+-                        accumulatedNodes.length = 0;
++                        pushAccumulatedText()
+                     }
+                     transformedNodes.push(node);
+                     finishedSkippingLeadingSpaces = true;
+@@ -71,12 +91,7 @@ var TrimSpacesTransform = /** @class */ (function () {
+         }
+         // Push the accumulated text
+         if (accumulatedTextChunks.length > 0) {
+-            transformedNodes.push(new nodes_1.DocPlainText({
+-                configuration: docParagraph.configuration,
+-                text: accumulatedTextChunks.join('')
+-            }));
+-            accumulatedTextChunks.length = 0;
+-            accumulatedNodes.length = 0;
++            pushAccumulatedText()
+         }
+         var transformedParagraph = new nodes_1.DocParagraph({
+             configuration: docParagraph.configuration

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,7 +46,7 @@
 		"@ariakit/react": "^0.4.1",
 		"@codesandbox/sandpack-react": "^2.11.3",
 		"@microsoft/api-extractor-model": "^7.26.4",
-		"@microsoft/tsdoc": "^0.14.2",
+		"@microsoft/tsdoc": "patch:@microsoft/tsdoc@npm%3A0.14.2#~/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch",
 		"@radix-ui/react-accordion": "^1.1.2",
 		"@radix-ui/react-navigation-menu": "^1.1.4",
 		"@tldraw/utils": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
 		"@microsoft/api-extractor@^7.35.4": "patch:@microsoft/api-extractor@npm%3A7.35.4#./.yarn/patches/@microsoft-api-extractor-npm-7.35.4-5f4f0357b4.patch",
 		"vectra@^0.4.4": "patch:vectra@npm%3A0.4.4#./.yarn/patches/vectra-npm-0.4.4-6aac3f6c29.patch",
 		"domino@^2.1.6": "patch:domino@npm%3A2.1.6#./.yarn/patches/domino-npm-2.1.6-b0dc3de857.patch",
-		"canvas": "npm:empty-npm-package@1.0.0"
+		"canvas": "npm:empty-npm-package@1.0.0",
+		"@microsoft/tsdoc@npm:0.14.2": "patch:@microsoft/tsdoc@npm%3A0.14.2#~/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch"
 	},
 	"dependencies": {
 		"@sentry/cli": "^2.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,10 +4253,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/tsdoc@npm:0.14.2, @microsoft/tsdoc@npm:^0.14.2":
+"@microsoft/tsdoc@npm:0.14.2":
   version: 0.14.2
   resolution: "@microsoft/tsdoc@npm:0.14.2"
   checksum: 00c3d4fc184e8e09e17aef57e4a990402bd9752607a5d50bd62a9e85bc4b8791c985a51e238affa6b9a2d23110f24d373becbfc84e1e6e9a84cf977822e3b00a
+  languageName: node
+  linkType: hard
+
+"@microsoft/tsdoc@patch:@microsoft/tsdoc@npm%3A0.14.2#~/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch":
+  version: 0.14.2
+  resolution: "@microsoft/tsdoc@patch:@microsoft/tsdoc@npm%3A0.14.2#~/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch::version=0.14.2&hash=86fc72"
+  checksum: a92a4f7a3382f8a188107e69b0d8e4c726aed8ddb9425565218c45b8bfca43cdeb7e3f22cbdef228fd62d4ab7a1a97f1b98b6cfb7601562faf633e8800925a85
   languageName: node
   linkType: hard
 
@@ -7430,7 +7437,7 @@ __metadata:
     "@ariakit/react": "npm:^0.4.1"
     "@codesandbox/sandpack-react": "npm:^2.11.3"
     "@microsoft/api-extractor-model": "npm:^7.26.4"
-    "@microsoft/tsdoc": "npm:^0.14.2"
+    "@microsoft/tsdoc": "patch:@microsoft/tsdoc@npm%3A0.14.2#~/.yarn/patches/@microsoft-tsdoc-npm-0.14.2-9988282153.patch"
     "@radix-ui/react-accordion": "npm:^1.1.2"
     "@radix-ui/react-navigation-menu": "npm:^1.1.4"
     "@tldraw/utils": "workspace:*"


### PR DESCRIPTION
We write our API docs in markdown embedded in tsdocs comments. vscode's hover preview of these docs renders them as expected, but api-extract treats whitespace as insignificant and strips out most newlines, which breaks markdown lists. See https://github.com/microsoft/tsdoc/issues/178 for details.

This PR patches tsdoc's emitter so that it preserves newlines. That way, we can write markdown lists and have them picked up as expected by the docs site markdown parser. I don't expect this to introduce other issues with previously ignored line breaks and markdown is only sensitive to linebreaks in certain scenarios (like lists) anyway.

(Extracted from bindings docs - #3812)

Before:
<img width="740" alt="Screenshot 2024-05-22 at 15 00 43" src="https://github.com/tldraw/tldraw/assets/1489520/846f88b1-9480-48a6-9795-6a9f27ca242a">

After:
<img width="708" alt="Screenshot 2024-05-22 at 14 51 28" src="https://github.com/tldraw/tldraw/assets/1489520/80c54b8e-4f74-45e7-9cba-0287175e9f97">


### Change Type

- [x] `docs` — Changes to the documentation, examples, or templates.
- [x] `bugfix` — Bug fix

