### PR TITLE
Force `interface` instead of `type` for better docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
 			'error',
 			{ name: 'structuredClone', message: 'Use structuredClone from @tldraw/util instead' },
 		],
+		'@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
 	},
 	parser: '@typescript-eslint/parser',
 	parserOptions: {

--- a/apps/docs/components/ArticleDetails.tsx
+++ b/apps/docs/components/ArticleDetails.tsx
@@ -1,7 +1,7 @@
 import { Article } from '@/types/content-types'
 import { Icon } from './Icon'
 
-type ArticleDetailsProps = {
+interface ArticleDetailsProps {
 	article: Article
 }
 

--- a/apps/docs/components/ArticleNavLinks.tsx
+++ b/apps/docs/components/ArticleNavLinks.tsx
@@ -2,7 +2,7 @@ import { ArticleLinks } from '@/types/content-types'
 import Link from 'next/link'
 import { Icon } from './Icon'
 
-type ArticleNavLinksProps = {
+interface ArticleNavLinksProps {
 	links: ArticleLinks
 }
 

--- a/apps/docs/components/Autocomplete.tsx
+++ b/apps/docs/components/Autocomplete.tsx
@@ -13,13 +13,13 @@ import './Autocomplete.css'
 import { Icon } from './Icon'
 import { Spinner } from './Spinner'
 
-export type DropdownOption = {
+export interface DropdownOption {
 	label: string
 	value: string
 	group?: string
 }
 
-type AutocompleteProps = {
+interface AutocompleteProps {
 	customUI?: React.ReactNode
 	groups?: string[]
 	groupsToIcon?: {

--- a/apps/docs/scripts/functions/getApiMarkdown.ts
+++ b/apps/docs/scripts/functions/getApiMarkdown.ts
@@ -24,7 +24,10 @@ import {
 } from '@microsoft/api-extractor-model'
 import { MarkdownWriter, formatWithPrettier, getPath, getSlug } from '../utils'
 
-type Result = { markdown: string; keywords: string[] }
+interface Result {
+	markdown: string
+	keywords: string[]
+}
 
 const REPO_URL = 'https://github.com/tldraw/tldraw/blob/main/'
 

--- a/apps/docs/types/content-types.ts
+++ b/apps/docs/types/content-types.ts
@@ -1,4 +1,4 @@
-export type InputCategory = {
+export interface InputCategory {
 	id: string
 	title: string
 	description: string
@@ -6,7 +6,7 @@ export type InputCategory = {
 	hero: string | null
 }
 
-export type InputSection = {
+export interface InputSection {
 	id: string
 	title: string
 	description: string
@@ -15,7 +15,7 @@ export type InputSection = {
 	sidebar_behavior: 'show-links' | 'show-title' | 'hidden' | 'reference'
 }
 
-export type InputGroup = {
+export interface InputGroup {
 	id: string
 }
 
@@ -150,7 +150,7 @@ export type ArticleLink = Pick<
 	'id' | 'title' | 'description' | 'categoryId' | 'sectionId' | 'path'
 >
 
-export type ArticleLinks = {
+export interface ArticleLinks {
 	prev: ArticleLink | null
 	next: ArticleLink | null
 }
@@ -184,7 +184,7 @@ export type SidebarContentLink =
 	| SidebarContentCategoryLink
 	| SidebarContentArticleLink
 
-export type SidebarContentList = {
+export interface SidebarContentList {
 	sectionId: string | null
 	categoryId: string | null
 	articleId: string | null
@@ -197,4 +197,7 @@ export type SidebarContentList = {
 /** A table keyed by slug of articles. */
 export type Articles = Record<string, Article>
 
-export type GeneratedContent = { sections: Section[]; articles: Articles }
+export interface GeneratedContent {
+	sections: Section[]
+	articles: Articles
+}

--- a/apps/docs/types/search-types.ts
+++ b/apps/docs/types/search-types.ts
@@ -1,4 +1,4 @@
-export type SearchResult = {
+export interface SearchResult {
 	type: 'article' | 'category' | 'section' | 'heading'
 	id: string
 	subtitle: string

--- a/apps/dotcom-worker/src/lib/AlarmScheduler.ts
+++ b/apps/dotcom-worker/src/lib/AlarmScheduler.ts
@@ -1,6 +1,6 @@
 import { exhaustiveSwitchError, hasOwnProperty } from '@tldraw/utils'
 
-type AlarmOpts = {
+interface AlarmOpts {
 	overwrite: 'always' | 'if-sooner'
 }
 

--- a/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
+++ b/apps/dotcom-worker/src/lib/TLDrawDurableObject.ts
@@ -35,7 +35,7 @@ const MAX_CONNECTIONS = 50
 
 // increment this any time you make a change to this type
 const CURRENT_DOCUMENT_INFO_VERSION = 0
-type DocumentInfo = {
+interface DocumentInfo {
 	version: number
 	slug: string
 }

--- a/apps/dotcom-worker/src/lib/routes/createRoomSnapshot.ts
+++ b/apps/dotcom-worker/src/lib/routes/createRoomSnapshot.ts
@@ -6,7 +6,7 @@ import { getR2KeyForSnapshot } from '../r2'
 import { Environment } from '../types'
 import { validateSnapshot } from '../utils/validateSnapshot'
 
-export type R2Snapshot = {
+export interface R2Snapshot {
 	parent_slug: CreateSnapshotRequestBody['parent_slug']
 	drawing: RoomSnapshot
 }

--- a/apps/dotcom-worker/src/lib/types.ts
+++ b/apps/dotcom-worker/src/lib/types.ts
@@ -1,7 +1,7 @@
 // https://developers.cloudflare.com/analytics/analytics-engine/
 
 // This type isn't available in @cloudflare/workers-types yet
-export type Analytics = {
+export interface Analytics {
 	writeDataPoint(data: {
 		blobs?: string[]
 		doubles?: number[]

--- a/apps/dotcom-worker/src/lib/utils/validateSnapshot.ts
+++ b/apps/dotcom-worker/src/lib/utils/validateSnapshot.ts
@@ -3,7 +3,7 @@ import { TLRecord } from '@tldraw/tlschema'
 import { schema } from '@tldraw/tlsync'
 import { Result, objectMapEntries } from '@tldraw/utils'
 
-type SnapshotRequestBody = {
+interface SnapshotRequestBody {
 	schema: SerializedSchema
 	snapshot: SerializedStore<TLRecord>
 }

--- a/apps/dotcom/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/src/components/DocumentName/DocumentName.tsx
@@ -32,7 +32,7 @@ import { FORK_PROJECT_ACTION } from '../../utils/sharing'
 import { SAVE_FILE_COPY_ACTION } from '../../utils/useFileSystem'
 import { getShareUrl } from '../ShareMenu'
 
-type NameState = {
+interface NameState {
 	readonly name: string | null
 	readonly isEditing: boolean
 }

--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -28,7 +28,7 @@ const SHARE_CURRENT_STATE = {
 } as const
 type ShareCurrentState = (typeof SHARE_CURRENT_STATE)[keyof typeof SHARE_CURRENT_STATE]
 
-type ShareState = {
+interface ShareState {
 	state: ShareCurrentState
 	qrCodeDataUrl: string
 	url: string

--- a/apps/dotcom/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/src/components/SnapshotsEditor.tsx
@@ -63,7 +63,7 @@ const components: TLComponents = {
 	},
 }
 
-type SnapshotEditorProps = {
+interface SnapshotEditorProps {
 	schema: SerializedSchema
 	records: TLRecord[]
 }

--- a/apps/dotcom/src/utils/remote-sync/remote-sync.ts
+++ b/apps/dotcom/src/utils/remote-sync/remote-sync.ts
@@ -10,7 +10,7 @@ export class RemoteSyncError extends Error {
 }
 
 /** @public */
-export type UseSyncClientConfig = {
+export interface UseSyncClientConfig {
 	uri: string
 	roomId?: string
 	userPreferences?: Signal<TLUserPreferences>

--- a/apps/examples/e2e/tests/fixtures/fixtures.ts
+++ b/apps/examples/e2e/tests/fixtures/fixtures.ts
@@ -8,7 +8,7 @@ import { PageMenu } from './menus/PageMenu'
 import { StylePanel } from './menus/StylePanel'
 import { Toolbar } from './menus/Toolbar'
 
-type Fixtures = {
+interface Fixtures {
 	toolbar: Toolbar
 	stylePanel: StylePanel
 	actionsMenu: ActionsMenu

--- a/apps/examples/src/examples.tsx
+++ b/apps/examples/src/examples.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react'
 
-export type Example = {
+export interface Example {
 	title: string
 	description: string
 	details: string

--- a/apps/examples/src/examples/pdf-editor/PdfPicker.tsx
+++ b/apps/examples/src/examples/pdf-editor/PdfPicker.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react'
 import { AssetRecordType, Box, TLAssetId, TLShapeId, createShapeId } from 'tldraw'
 import tldrawPdf from './assets/tldraw.pdf'
 
-export type PdfPage = {
+export interface PdfPage {
 	src: string
 	bounds: Box
 	assetId: TLAssetId
 	shapeId: TLShapeId
 }
 
-export type Pdf = {
+export interface Pdf {
 	name: string
 	pages: PdfPage[]
 	source: string | ArrayBuffer

--- a/apps/examples/src/examples/slideshow/SlidesManager.tsx
+++ b/apps/examples/src/examples/slideshow/SlidesManager.tsx
@@ -4,7 +4,7 @@ import { atom, computed, structuredClone, uniqueId } from 'tldraw'
 export const SLIDE_SIZE = { x: 0, y: 0, w: 1600, h: 900 }
 export const SLIDE_MARGIN = 100
 
-type Slide = {
+interface Slide {
 	id: string
 	index: number
 	name: string

--- a/apps/health-worker/src/discord.ts
+++ b/apps/health-worker/src/discord.ts
@@ -8,7 +8,7 @@ const RED = 14692657
 const ORANGE = 16213767
 
 // docs: https://birdie0.github.io/discord-webhooks-guide/index.html
-export type DiscordPayload = {
+export interface DiscordPayload {
 	username: string
 	content: string
 	embeds: APIEmbed[]

--- a/apps/huppy/pages/deliveries.tsx
+++ b/apps/huppy/pages/deliveries.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps } from 'next'
 import { useEffect, useState } from 'react'
 import { getAppOctokit } from '../src/octokit'
 
-type Props = {
+interface Props {
 	deliveries: {
 		id: number
 		guid: string
@@ -39,7 +39,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (context) => 
 	return { props: { deliveries: deliveries.data, cursor } }
 }
 
-type SelectedDelivery = {
+interface SelectedDelivery {
 	id: number
 	data?: unknown
 }

--- a/apps/huppy/src/ctx.tsx
+++ b/apps/huppy/src/ctx.tsx
@@ -1,6 +1,6 @@
 import { App, Octokit } from 'octokit'
 
-export type Ctx = {
+export interface Ctx {
 	app: App
 	octokit: Octokit
 	installationToken: string

--- a/apps/huppy/src/flows/collectClaSignatures.tsx
+++ b/apps/huppy/src/flows/collectClaSignatures.tsx
@@ -14,13 +14,13 @@ const CLA_SIGNATURES_BRANCH = 'cla-signees'
 
 const pullRequestActionsToCheck = ['opened', 'synchronize', 'reopened', 'edited']
 
-type Signing = {
+interface Signing {
 	githubId: number
 	signedAt: string
 	signedVersion: 1
 	signingComment: string
 }
-type SigneeInfo = {
+interface SigneeInfo {
 	unsigned: Set<string>
 	signees: Map<string, { signing: Signing; fileSha: string }>
 	total: number

--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -96,7 +96,7 @@ export const TldrawWrapper = () => {
 	)
 }
 
-export type TLDrawInnerProps = {
+export interface TLDrawInnerProps {
 	assetSrc: string
 	fileContents: string
 	uri: string

--- a/apps/vscode/editor/src/utils/rpc.ts
+++ b/apps/vscode/editor/src/utils/rpc.ts
@@ -2,7 +2,7 @@ import { uniqueId } from 'tldraw'
 import type { VscodeMessagePairs } from '../../../messages'
 import { vscode } from './vscode'
 
-type SimpleRpcOpts = {
+interface SimpleRpcOpts {
 	timeout: number
 }
 class SimpleRpcError extends Error {

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,16 +1,16 @@
 import { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 
-export type Snapshot = {
+export interface Snapshot {
 	schema: SerializedSchema
 	snapshot: SerializedStore<TLRecord>
 }
 
-export type CreateRoomRequestBody = {
+export interface CreateRoomRequestBody {
 	origin: string
 	snapshot: Snapshot
 }
 
-export type CreateSnapshotRequestBody = {
+export interface CreateSnapshotRequestBody {
 	schema: SerializedSchema
 	snapshot: SerializedStore<TLRecord>
 	parent_slug?: string | undefined
@@ -26,4 +26,7 @@ export type CreateSnapshotResponseBody =
 			message: string
 	  }
 
-export type GetReadonlySlugResponseBody = { slug: string; isLegacy: boolean }
+export interface GetReadonlySlugResponseBody {
+	slug: string
+	isLegacy: boolean
+}

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1131,15 +1131,19 @@ export function extractSessionStateFromLegacySnapshot(store: Record<string, Unkn
 export const featureFlags: Record<string, DebugFlag<boolean>>;
 
 // @public (undocumented)
-export type GapsSnapIndicator = {
+export interface GapsSnapIndicator {
+    // (undocumented)
     direction: 'horizontal' | 'vertical';
+    // (undocumented)
     gaps: Array<{
         endEdge: [VecLike, VecLike];
         startEdge: [VecLike, VecLike];
     }>;
+    // (undocumented)
     id: string;
+    // (undocumented)
     type: 'gaps';
-};
+}
 
 // @public (undocumented)
 export abstract class Geometry2d {
@@ -1593,11 +1597,14 @@ export class Point2d extends Geometry2d {
 export function pointInPolygon(A: VecLike, points: VecLike[]): boolean;
 
 // @public (undocumented)
-export type PointsSnapIndicator = {
+export interface PointsSnapIndicator {
+    // (undocumented)
     id: string;
+    // (undocumented)
     points: VecLike[];
+    // (undocumented)
     type: 'points';
-};
+}
 
 // @public (undocumented)
 export class Polygon2d extends Polyline2d {
@@ -2057,12 +2064,29 @@ export interface TLBindingUtilConstructor<T extends TLUnknownBinding, U extends 
 }
 
 // @public (undocumented)
-export type TLBrushProps = {
+export interface TLBrushProps {
+    // (undocumented)
     brush: BoxModel;
+    // (undocumented)
     className?: string;
+    // (undocumented)
     color?: string;
+    // (undocumented)
     opacity?: number;
-};
+}
+
+// @public (undocumented)
+export interface TLCameraConstraints {
+    baseZoom: 'default' | 'fit-max-100' | 'fit-max' | 'fit-min-100' | 'fit-min' | 'fit-x-100' | 'fit-x' | 'fit-y-100' | 'fit-y';
+    behavior: 'contain' | 'fixed' | 'free' | 'inside' | 'outside' | {
+        x: 'contain' | 'fixed' | 'free' | 'inside' | 'outside';
+        y: 'contain' | 'fixed' | 'free' | 'inside' | 'outside';
+    };
+    bounds: BoxModel;
+    initialZoom: 'default' | 'fit-max-100' | 'fit-max' | 'fit-min-100' | 'fit-min' | 'fit-x-100' | 'fit-x' | 'fit-y-100' | 'fit-y';
+    origin: VecLike;
+    padding: VecLike;
+}
 
 // @public (undocumented)
 export type TLCameraMoveOptions = Partial<{
@@ -2076,33 +2100,25 @@ export type TLCameraMoveOptions = Partial<{
 }>;
 
 // @public (undocumented)
-export type TLCameraOptions = {
-    wheelBehavior: 'none' | 'pan' | 'zoom';
-    constraints?: {
-        behavior: 'contain' | 'fixed' | 'free' | 'inside' | 'outside' | {
-            x: 'contain' | 'fixed' | 'free' | 'inside' | 'outside';
-            y: 'contain' | 'fixed' | 'free' | 'inside' | 'outside';
-        };
-        bounds: BoxModel;
-        baseZoom: 'default' | 'fit-max-100' | 'fit-max' | 'fit-min-100' | 'fit-min' | 'fit-x-100' | 'fit-x' | 'fit-y-100' | 'fit-y';
-        initialZoom: 'default' | 'fit-max-100' | 'fit-max' | 'fit-min-100' | 'fit-min' | 'fit-x-100' | 'fit-x' | 'fit-y-100' | 'fit-y';
-        origin: VecLike;
-        padding: VecLike;
-    };
+export interface TLCameraOptions {
+    constraints?: TLCameraConstraints;
+    isLocked: boolean;
     panSpeed: number;
+    wheelBehavior: 'none' | 'pan' | 'zoom';
     zoomSpeed: number;
     zoomSteps: number[];
-    isLocked: boolean;
-};
+}
 
 // @public (undocumented)
 export type TLCancelEvent = (info: TLCancelEventInfo) => void;
 
 // @public (undocumented)
-export type TLCancelEventInfo = {
+export interface TLCancelEventInfo {
+    // (undocumented)
     name: 'cancel';
+    // (undocumented)
     type: 'misc';
-};
+}
 
 // @public (undocumented)
 export type TLClickEvent = (info: TLClickEventInfo) => void;
@@ -2121,23 +2137,31 @@ export type TLClickEventInfo = TLBaseEventInfo & {
 export type TLCLickEventName = 'double_click' | 'quadruple_click' | 'triple_click';
 
 // @public (undocumented)
-export type TLCollaboratorHintProps = {
+export interface TLCollaboratorHintProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     color: string;
+    // (undocumented)
     opacity?: number;
+    // (undocumented)
     point: VecModel;
+    // (undocumented)
     viewport: Box;
+    // (undocumented)
     zoom: number;
-};
+}
 
 // @public (undocumented)
 export type TLCompleteEvent = (info: TLCompleteEventInfo) => void;
 
 // @public (undocumented)
-export type TLCompleteEventInfo = {
+export interface TLCompleteEventInfo {
+    // (undocumented)
     name: 'complete';
+    // (undocumented)
     type: 'misc';
-};
+}
 
 // @public (undocumented)
 export interface TLContent {
@@ -2154,14 +2178,20 @@ export interface TLContent {
 }
 
 // @public (undocumented)
-export type TLCursorProps = {
+export interface TLCursorProps {
+    // (undocumented)
     chatMessage: string;
+    // (undocumented)
     className?: string;
+    // (undocumented)
     color?: string;
+    // (undocumented)
     name: null | string;
+    // (undocumented)
     point: null | VecModel;
+    // (undocumented)
     zoom: number;
-};
+}
 
 // @public (undocumented)
 export const TldrawEditor: React_2.NamedExoticComponent<TldrawEditorProps>;
@@ -2361,35 +2391,47 @@ export type TLExternalContentSource = {
 };
 
 // @public (undocumented)
-export type TLGridProps = {
+export interface TLGridProps {
+    // (undocumented)
     size: number;
+    // (undocumented)
     x: number;
+    // (undocumented)
     y: number;
+    // (undocumented)
     z: number;
-};
+}
 
 // @public (undocumented)
-export type TLHandleProps = {
+export interface TLHandleProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     handle: TLHandle;
+    // (undocumented)
     isCoarse: boolean;
+    // (undocumented)
     shapeId: TLShapeId;
+    // (undocumented)
     zoom: number;
-};
+}
 
 // @public (undocumented)
-export type TLHandlesProps = {
+export interface TLHandlesProps {
+    // (undocumented)
     children: ReactNode;
-};
+}
 
 // @public (undocumented)
 export type TLInterruptEvent = (info: TLInterruptEventInfo) => void;
 
 // @public (undocumented)
-export type TLInterruptEventInfo = {
+export interface TLInterruptEventInfo {
+    // (undocumented)
     name: 'interrupt';
+    // (undocumented)
     type: 'misc';
-};
+}
 
 // @public (undocumented)
 export type TLKeyboardEvent = (info: TLKeyboardEventInfo) => void;
@@ -2520,15 +2562,22 @@ export type TLPointerEventTarget = {
 export type TLResizeHandle = SelectionCorner | SelectionEdge;
 
 // @public
-export type TLResizeInfo<T extends TLShape> = {
+export interface TLResizeInfo<T extends TLShape> {
+    // (undocumented)
     handle: TLResizeHandle;
+    // (undocumented)
     initialBounds: Box;
+    // (undocumented)
     initialShape: T;
+    // (undocumented)
     mode: TLResizeMode;
+    // (undocumented)
     newPoint: Vec;
+    // (undocumented)
     scaleX: number;
+    // (undocumented)
     scaleY: number;
-};
+}
 
 // @public
 export type TLResizeMode = 'resize_bounds' | 'scale_shape';
@@ -2547,36 +2596,49 @@ export type TLResizeShapeOptions = Partial<{
 }>;
 
 // @public
-export type TLRotationSnapshot = {
+export interface TLRotationSnapshot {
+    // (undocumented)
     initialCursorAngle: number;
+    // (undocumented)
     initialSelectionRotation: number;
+    // (undocumented)
     selectionPageCenter: Vec;
+    // (undocumented)
     shapeSnapshots: {
         initialPagePoint: Vec;
         shape: TLShape;
     }[];
-};
+}
 
 // @public (undocumented)
-export type TLScribbleProps = {
+export interface TLScribbleProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     color?: string;
+    // (undocumented)
     opacity?: number;
+    // (undocumented)
     scribble: TLScribble;
+    // (undocumented)
     zoom: number;
-};
+}
 
 // @public (undocumented)
-export type TLSelectionBackgroundProps = {
+export interface TLSelectionBackgroundProps {
+    // (undocumented)
     bounds: Box;
+    // (undocumented)
     rotation: number;
-};
+}
 
 // @public (undocumented)
-export type TLSelectionForegroundProps = {
+export interface TLSelectionForegroundProps {
+    // (undocumented)
     bounds: Box;
+    // (undocumented)
     rotation: number;
-};
+}
 
 // @public (undocumented)
 export type TLSelectionHandle = RotateCorner | SelectionCorner | SelectionEdge;
@@ -2611,13 +2673,18 @@ export interface TLSessionStateSnapshot {
 }
 
 // @public (undocumented)
-export type TLShapeIndicatorProps = {
+export interface TLShapeIndicatorProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     color?: string | undefined;
+    // (undocumented)
     hidden?: boolean;
+    // (undocumented)
     opacity?: number;
+    // (undocumented)
     shapeId: TLShapeId;
-};
+}
 
 // @public (undocumented)
 export interface TLShapeUtilCanvasSvgDef {
@@ -2643,11 +2710,14 @@ export interface TLShapeUtilConstructor<T extends TLUnknownShape, U extends Shap
 export type TLShapeUtilFlag<T> = (shape: T) => boolean;
 
 // @public (undocumented)
-export type TLSnapIndicatorProps = {
+export interface TLSnapIndicatorProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     line: SnapIndicator;
+    // (undocumented)
     zoom: number;
-};
+}
 
 // @public (undocumented)
 export interface TLStateNodeConstructor {
@@ -2702,14 +2772,20 @@ export type TLStoreWithStatus = {
 };
 
 // @public (undocumented)
-export type TLSvgOptions = {
+export interface TLSvgOptions {
+    // (undocumented)
     background: boolean;
+    // (undocumented)
     bounds: Box;
+    // (undocumented)
     darkMode?: boolean;
+    // (undocumented)
     padding: number;
+    // (undocumented)
     preserveAspectRatio: React.SVGAttributes<SVGSVGElement>['preserveAspectRatio'];
+    // (undocumented)
     scale: number;
-};
+}
 
 // @public (undocumented)
 export type TLTickEvent = (info: TLTickEventInfo) => void;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -223,6 +223,7 @@ export {
 } from './lib/editor/types/external-content'
 export {
 	type RequiredKeys,
+	type TLCameraConstraints,
 	type TLCameraMoveOptions,
 	type TLCameraOptions,
 	type TLSvgOptions,

--- a/packages/editor/src/lib/components/ErrorBoundary.tsx
+++ b/packages/editor/src/lib/components/ErrorBoundary.tsx
@@ -8,7 +8,9 @@ export interface TLErrorBoundaryProps {
 	fallback: TLErrorFallbackComponent
 }
 
-type TLErrorBoundaryState = { error: Error | null }
+interface TLErrorBoundaryState {
+	error: Error | null
+}
 
 const initialState: TLErrorBoundaryState = { error: null }
 

--- a/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
@@ -4,7 +4,7 @@ import { useTransform } from '../../hooks/useTransform'
 import { toDomPrecision } from '../../primitives/utils'
 
 /** @public */
-export type TLBrushProps = {
+export interface TLBrushProps {
 	brush: BoxModel
 	color?: string
 	opacity?: number

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -26,7 +26,9 @@ import { LiveCollaborators } from '../LiveCollaborators'
 import { Shape } from '../Shape'
 
 /** @public */
-export type TLCanvasComponentProps = { className?: string }
+export interface TLCanvasComponentProps {
+	className?: string
+}
 
 /** @public */
 export function DefaultCanvas({ className }: TLCanvasComponentProps) {

--- a/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
@@ -7,7 +7,7 @@ import { Vec } from '../../primitives/Vec'
 import { clamp } from '../../primitives/utils'
 
 /** @public */
-export type TLCollaboratorHintProps = {
+export interface TLCollaboratorHintProps {
 	className?: string
 	point: VecModel
 	viewport: Box

--- a/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
@@ -4,7 +4,7 @@ import { memo, useRef } from 'react'
 import { useTransform } from '../../hooks/useTransform'
 
 /** @public */
-export type TLCursorProps = {
+export interface TLCursorProps {
 	className?: string
 	point: VecModel | null
 	zoom: number

--- a/packages/editor/src/lib/components/default-components/DefaultGrid.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultGrid.tsx
@@ -2,7 +2,7 @@ import { modulate } from '@tldraw/utils'
 import { GRID_STEPS } from '../../constants'
 
 /** @public */
-export type TLGridProps = {
+export interface TLGridProps {
 	x: number
 	y: number
 	z: number

--- a/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandle.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { COARSE_HANDLE_RADIUS, HANDLE_RADIUS, SIDES } from '../../constants'
 
 /** @public */
-export type TLHandleProps = {
+export interface TLHandleProps {
 	shapeId: TLShapeId
 	handle: TLHandle
 	zoom: number

--- a/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 /** @public */
-export type TLHandlesProps = {
+export interface TLHandlesProps {
 	children: ReactNode
 }
 

--- a/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { getSvgPathFromPoints } from '../../utils/getSvgPathFromPoints'
 
 /** @public */
-export type TLScribbleProps = {
+export interface TLScribbleProps {
 	scribble: TLScribble
 	zoom: number
 	color?: string

--- a/packages/editor/src/lib/components/default-components/DefaultSelectionBackground.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSelectionBackground.tsx
@@ -4,7 +4,7 @@ import { Box } from '../../primitives/Box'
 import { toDomPrecision } from '../../primitives/utils'
 
 /** @public */
-export type TLSelectionBackgroundProps = {
+export interface TLSelectionBackgroundProps {
 	bounds: Box
 	rotation: number
 }

--- a/packages/editor/src/lib/components/default-components/DefaultSelectionForeground.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSelectionForeground.tsx
@@ -7,7 +7,7 @@ import { Box } from '../../primitives/Box'
 import { toDomPrecision } from '../../primitives/utils'
 
 /** @public */
-export type TLSelectionForegroundProps = {
+export interface TLSelectionForegroundProps {
 	bounds: Box
 	rotation: number
 }

--- a/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
@@ -33,7 +33,7 @@ const InnerIndicator = ({ editor, id }: { editor: Editor; id: TLShapeId }) => {
 }
 
 /** @public */
-export type TLShapeIndicatorProps = {
+export interface TLShapeIndicatorProps {
 	shapeId: TLShapeId
 	color?: string | undefined
 	opacity?: number

--- a/packages/editor/src/lib/components/default-components/DefaultSnapIndictor.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSnapIndictor.tsx
@@ -154,7 +154,7 @@ function GapsSnapIndicator({ gaps, direction, zoom }: { zoom: number } & GapsSna
 }
 
 /** @public */
-export type TLSnapIndicatorProps = {
+export interface TLSnapIndicatorProps {
 	className?: string
 	line: SnapIndicator
 	zoom: number

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6771,7 +6771,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let remaining = duration
 		let t: number
 
-		type ShapeAnimation = {
+		interface ShapeAnimation {
 			partial: TLShapePartial
 			values: { prop: string; from: number; to: number }[]
 		}

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -3,7 +3,7 @@ import { Vec } from '../../primitives/Vec'
 import { uniqueId } from '../../utils/uniqueId'
 import { Editor } from '../Editor'
 
-type ScribbleItem = {
+interface ScribbleItem {
 	id: string
 	scribble: TLScribble
 	timeoutMs: number

--- a/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
@@ -44,9 +44,12 @@ export interface BoundsSnapPoint {
 	handle?: SelectionCorner
 }
 
-type SnapPair = { thisPoint: BoundsSnapPoint; otherPoint: BoundsSnapPoint }
+interface SnapPair {
+	thisPoint: BoundsSnapPoint
+	otherPoint: BoundsSnapPoint
+}
 
-type NearestPointsSnap = {
+interface NearestPointsSnap {
 	// selection snaps to a nearby snap point
 	type: 'points'
 	points: SnapPair
@@ -70,12 +73,12 @@ type NearestSnap =
 			nudge: number
 	  }
 
-type GapNode = {
+interface GapNode {
 	id: TLShapeId
 	pageBounds: Box
 }
 
-type Gap = {
+interface Gap {
 	// e.g.
 	//      start
 	//      edge     │         breadth

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
@@ -6,14 +6,14 @@ import { BoundsSnaps } from './BoundsSnaps'
 import { HandleSnaps } from './HandleSnaps'
 
 /** @public */
-export type PointsSnapIndicator = {
+export interface PointsSnapIndicator {
 	id: string
 	type: 'points'
 	points: VecLike[]
 }
 
 /** @public */
-export type GapsSnapIndicator = {
+export interface GapsSnapIndicator {
 	id: string
 	type: 'gaps'
 	direction: 'horizontal' | 'vertical'

--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -21,7 +21,7 @@ const textAlignmentsForLtr = {
 }
 
 type TLOverflowMode = 'wrap' | 'truncate-ellipsis' | 'truncate-clip'
-type TLMeasureTextSpanOpts = {
+interface TLMeasureTextSpanOpts {
 	overflow: TLOverflowMode
 	width: number
 	height: number

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -562,7 +562,7 @@ export type TLResizeMode = 'scale_shape' | 'resize_bounds'
  * @param initialShape - The shape at the start of the resize.
  * @public
  */
-export type TLResizeInfo<T extends TLShape> = {
+export interface TLResizeInfo<T extends TLShape> {
 	newPoint: Vec
 	handle: TLResizeHandle
 	mode: TLResizeMode

--- a/packages/editor/src/lib/editor/types/event-types.ts
+++ b/packages/editor/src/lib/editor/types/event-types.ts
@@ -96,13 +96,26 @@ export type TLWheelEventInfo = TLBaseEventInfo & {
 }
 
 /** @public */
-export type TLCancelEventInfo = { type: 'misc'; name: 'cancel' }
+export interface TLCancelEventInfo {
+	type: 'misc'
+	name: 'cancel'
+}
 /** @public */
-export type TLCompleteEventInfo = { type: 'misc'; name: 'complete' }
+export interface TLCompleteEventInfo {
+	type: 'misc'
+	name: 'complete'
+}
 /** @public */
-export type TLInterruptEventInfo = { type: 'misc'; name: 'interrupt' }
+export interface TLInterruptEventInfo {
+	type: 'misc'
+	name: 'interrupt'
+}
 /** @public */
-export type TLTickEventInfo = { type: 'misc'; name: 'tick'; elapsed: number }
+export interface TLTickEventInfo {
+	type: 'misc'
+	name: 'tick'
+	elapsed: number
+}
 
 /** @public */
 export type TLEventInfo =

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -8,7 +8,7 @@ export type RequiredKeys<T, K extends keyof T> = Partial<Omit<T, K>> & Pick<T, K
 export type OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 /** @public */
-export type TLSvgOptions = {
+export interface TLSvgOptions {
 	bounds: Box
 	scale: number
 	background: boolean
@@ -35,7 +35,7 @@ export type TLCameraMoveOptions = Partial<{
 }>
 
 /** @public */
-export type TLCameraOptions = {
+export interface TLCameraOptions {
 	/** Whether the camera is locked. */
 	isLocked: boolean
 	/** The speed of a scroll wheel / trackpad pan. Default is 1. */
@@ -52,74 +52,77 @@ export type TLCameraOptions = {
 	 */
 	wheelBehavior: 'zoom' | 'pan' | 'none'
 	/** The camera constraints. */
-	constraints?: {
-		/** The bounds (in page space) of the constrained space */
-		bounds: BoxModel
-		/** The padding inside of the viewport (in screen space) */
-		padding: VecLike
-		/** The origin for placement. Used to position the bounds within the viewport when an axis is fixed or contained and zoom is below the axis fit. */
-		origin: VecLike
-		/** The camera's initial zoom, used also when the camera is reset.
-		 *
-		 * - `default`: Sets the initial zoom to 100%.
-		 * - `fit-x`: The x axis will completely fill the viewport bounds.
-		 * - `fit-y`: The y axis will completely fill the viewport bounds.
-		 * - `fit-min`: The smaller axis will completely fill the viewport bounds.
-		 * - `fit-max`: The larger axis will completely fill the viewport bounds.
-		 * - `fit-x-100`: The x axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-y-100`: The y axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-min-100`: The smaller axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-max-100`: The larger axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 */
-		initialZoom:
-			| 'fit-min'
-			| 'fit-max'
-			| 'fit-x'
-			| 'fit-y'
-			| 'fit-min-100'
-			| 'fit-max-100'
-			| 'fit-x-100'
-			| 'fit-y-100'
-			| 'default'
-		/** The camera's base for its zoom steps.
-		 *
-		 * - `default`: Sets the initial zoom to 100%.
-		 * - `fit-x`: The x axis will completely fill the viewport bounds.
-		 * - `fit-y`: The y axis will completely fill the viewport bounds.
-		 * - `fit-min`: The smaller axis will completely fill the viewport bounds.
-		 * - `fit-max`: The larger axis will completely fill the viewport bounds.
-		 * - `fit-x-100`: The x axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-y-100`: The y axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-min-100`: The smaller axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 * - `fit-max-100`: The larger axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
-		 */
-		baseZoom:
-			| 'fit-min'
-			| 'fit-max'
-			| 'fit-x'
-			| 'fit-y'
-			| 'fit-min-100'
-			| 'fit-max-100'
-			| 'fit-x-100'
-			| 'fit-y-100'
-			| 'default'
-		/** The behavior for the constraints for both axes or each axis individually.
-		 *
-		 * - `free`: The bounds are ignored when moving the camera.
-		 * - 'fixed': The bounds will be positioned within the viewport based on the origin
-		 * - `contain`: The 'fixed' behavior will be used when the zoom is below the zoom level at which the bounds would fill the viewport; and when above this zoom, the bounds will use the 'inside' behavior.
-		 * - `inside`: The bounds will stay completely within the viewport.
-		 * - `outside`: The bounds will stay touching the viewport.
-		 */
-		behavior:
-			| 'free'
-			| 'fixed'
-			| 'inside'
-			| 'outside'
-			| 'contain'
-			| {
-					x: 'free' | 'fixed' | 'inside' | 'outside' | 'contain'
-					y: 'free' | 'fixed' | 'inside' | 'outside' | 'contain'
-			  }
-	}
+	constraints?: TLCameraConstraints
+}
+
+/** @public */
+export interface TLCameraConstraints {
+	/** The bounds (in page space) of the constrained space */
+	bounds: BoxModel
+	/** The padding inside of the viewport (in screen space) */
+	padding: VecLike
+	/** The origin for placement. Used to position the bounds within the viewport when an axis is fixed or contained and zoom is below the axis fit. */
+	origin: VecLike
+	/** The camera's initial zoom, used also when the camera is reset.
+	 *
+	 * - `default`: Sets the initial zoom to 100%.
+	 * - `fit-x`: The x axis will completely fill the viewport bounds.
+	 * - `fit-y`: The y axis will completely fill the viewport bounds.
+	 * - `fit-min`: The smaller axis will completely fill the viewport bounds.
+	 * - `fit-max`: The larger axis will completely fill the viewport bounds.
+	 * - `fit-x-100`: The x axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-y-100`: The y axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-min-100`: The smaller axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-max-100`: The larger axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 */
+	initialZoom:
+		| 'fit-min'
+		| 'fit-max'
+		| 'fit-x'
+		| 'fit-y'
+		| 'fit-min-100'
+		| 'fit-max-100'
+		| 'fit-x-100'
+		| 'fit-y-100'
+		| 'default'
+	/** The camera's base for its zoom steps.
+	 *
+	 * - `default`: Sets the initial zoom to 100%.
+	 * - `fit-x`: The x axis will completely fill the viewport bounds.
+	 * - `fit-y`: The y axis will completely fill the viewport bounds.
+	 * - `fit-min`: The smaller axis will completely fill the viewport bounds.
+	 * - `fit-max`: The larger axis will completely fill the viewport bounds.
+	 * - `fit-x-100`: The x axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-y-100`: The y axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-min-100`: The smaller axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 * - `fit-max-100`: The larger axis will completely fill the viewport bounds, or 100% zoom, whichever is smaller.
+	 */
+	baseZoom:
+		| 'fit-min'
+		| 'fit-max'
+		| 'fit-x'
+		| 'fit-y'
+		| 'fit-min-100'
+		| 'fit-max-100'
+		| 'fit-x-100'
+		| 'fit-y-100'
+		| 'default'
+	/** The behavior for the constraints for both axes or each axis individually.
+	 *
+	 * - `free`: The bounds are ignored when moving the camera.
+	 * - 'fixed': The bounds will be positioned within the viewport based on the origin
+	 * - `contain`: The 'fixed' behavior will be used when the zoom is below the zoom level at which the bounds would fill the viewport; and when above this zoom, the bounds will use the 'inside' behavior.
+	 * - `inside`: The bounds will stay completely within the viewport.
+	 * - `outside`: The bounds will stay touching the viewport.
+	 */
+	behavior:
+		| 'free'
+		| 'fixed'
+		| 'inside'
+		| 'outside'
+		| 'contain'
+		| {
+				x: 'free' | 'fixed' | 'inside' | 'outside' | 'contain'
+				y: 'free' | 'fixed' | 'inside' | 'outside' | 'contain'
+		  }
 }

--- a/packages/editor/src/lib/hooks/useEditorComponents.tsx
+++ b/packages/editor/src/lib/hooks/useEditorComponents.tsx
@@ -73,7 +73,7 @@ export interface BaseEditorComponents {
 }
 
 // These will always have defaults
-type ErrorComponents = {
+interface ErrorComponents {
 	ErrorFallback: TLErrorFallbackComponent
 	ShapeErrorFallback: TLShapeErrorFallbackComponent
 	ShapeIndicatorErrorFallback: TLShapeIndicatorErrorFallbackComponent
@@ -88,7 +88,7 @@ export type TLEditorComponents = Partial<
 
 const EditorComponentsContext = createContext<null | (TLEditorComponents & ErrorComponents)>(null)
 
-type ComponentsContextProviderProps = {
+interface ComponentsContextProviderProps {
 	overrides?: TLEditorComponents
 	children: ReactNode
 }

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -48,7 +48,7 @@ export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationS
  *
  * @public
  **/
-export type TLRotationSnapshot = {
+export interface TLRotationSnapshot {
 	selectionPageCenter: Vec
 	initialCursorAngle: number
 	initialSelectionRotation: number

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -26,7 +26,7 @@ const UPDATE_INSTANCE_STATE = Symbol('UPDATE_INSTANCE_STATE')
  * once it has the db integrated
  */
 
-type SyncMessage = {
+interface SyncMessage {
 	type: 'diff'
 	storeId: string
 	changes: RecordsDiff<UnknownRecord>
@@ -36,7 +36,7 @@ type SyncMessage = {
 // Sent by new clients when they connect
 // If another client is on the channel with a newer schema version
 // It will
-type AnnounceMessage = {
+interface AnnounceMessage {
 	type: 'announce'
 	schema: SerializedSchema
 }

--- a/packages/editor/src/lib/utils/sync/indexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/indexedDb.ts
@@ -38,13 +38,13 @@ async function withDb<T>(storeId: string, cb: (db: IDBPDatabase<StoreName>) => P
 	}
 }
 
-type LoadResult = {
+interface LoadResult {
 	records: TLRecord[]
 	schema?: SerializedSchema
 	sessionStateSnapshot?: TLSessionStateSnapshot | null
 }
 
-type SessionStateSnapshotRow = {
+interface SessionStateSnapshotRow {
 	id: string
 	snapshot: TLSessionStateSnapshot
 	updatedAt: number

--- a/packages/state/src/lib/core/Computed.ts
+++ b/packages/state/src/lib/core/Computed.ts
@@ -53,7 +53,10 @@ export const WithDiff = singleton(
 			) {}
 		}
 )
-export type WithDiff<Value, Diff> = { value: Value; diff: Diff }
+export interface WithDiff<Value, Diff> {
+	value: Value
+	diff: Diff
+}
 
 /**
  * When writing incrementally-computed signals it is convenient (and usually more performant) to incrementally compute the diff too.

--- a/packages/state/src/lib/core/__tests__/fuzz.tlstate.test.ts
+++ b/packages/state/src/lib/core/__tests__/fuzz.tlstate.test.ts
@@ -72,7 +72,7 @@ const unpack = (value: unknown): Letter => {
 	return value as Letter
 }
 
-type FuzzSystemState = {
+interface FuzzSystemState {
 	atoms: Record<string, Atom<Letter>>
 	atomsInAtoms: Record<string, Atom<Atom<Letter>>>
 	derivations: Record<string, { derivation: Computed<Letter>; sneakyGet: () => Letter }>

--- a/packages/state/src/lib/core/types.ts
+++ b/packages/state/src/lib/core/types.ts
@@ -49,7 +49,7 @@ export interface Signal<Value, Diff = unknown> {
 }
 
 /** @internal */
-export type Child = {
+export interface Child {
 	lastTraversedEpoch: number
 	readonly parentSet: ArraySet<Signal<any, any>>
 	readonly parents: Signal<any, any>[]

--- a/packages/store/api-report.md
+++ b/packages/store/api-report.md
@@ -23,15 +23,18 @@ export interface BaseRecord<TypeName extends string, Id extends RecordId<Unknown
 }
 
 // @public
-export type CollectionDiff<T> = {
+export interface CollectionDiff<T> {
+    // (undocumented)
     added?: Set<T>;
+    // (undocumented)
     removed?: Set<T>;
-};
+}
 
 // @public
-export type ComputedCache<Data, R extends UnknownRecord> = {
+export interface ComputedCache<Data, R extends UnknownRecord> {
+    // (undocumented)
     get(id: IdOf<R>): Data | undefined;
-};
+}
 
 // @public
 export function createComputedCache<Context extends StoreContext<any>, Result, Record extends ContextRecordType<Context> = ContextRecordType<Context>>(name: string, derive: (context: Context, record: Record) => Result | undefined, isEqual?: (a: Record, b: Record) => boolean): {
@@ -86,10 +89,12 @@ export function defineMigrations(opts: {
 export function devFreeze<T>(object: T): T;
 
 // @public
-export type HistoryEntry<R extends UnknownRecord = UnknownRecord> = {
+export interface HistoryEntry<R extends UnknownRecord = UnknownRecord> {
+    // (undocumented)
     changes: RecordsDiff<R>;
+    // (undocumented)
     source: ChangeSource;
-};
+}
 
 // @public (undocumented)
 export type IdOf<R extends UnknownRecord> = R['id'];
@@ -113,10 +118,12 @@ export class IncrementalSetConstructor<T> {
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>): boolean;
 
 // @public (undocumented)
-export type LegacyMigration<Before = any, After = any> = {
+export interface LegacyMigration<Before = any, After = any> {
+    // (undocumented)
     down: (newState: After) => Before;
+    // (undocumented)
     up: (oldState: Before) => After;
-};
+}
 
 // @public (undocumented)
 export interface LegacyMigrations extends LegacyBaseMigrationsInfo {
@@ -190,11 +197,14 @@ export type RecordId<R extends UnknownRecord> = string & {
 };
 
 // @public
-export type RecordsDiff<R extends UnknownRecord> = {
+export interface RecordsDiff<R extends UnknownRecord> {
+    // (undocumented)
     added: Record<IdOf<R>, R>;
+    // (undocumented)
     removed: Record<IdOf<R>, R>;
+    // (undocumented)
     updated: Record<IdOf<R>, [from: R, to: R]>;
-};
+}
 
 // @public
 export class RecordType<R extends UnknownRecord, RequiredProperties extends keyof Omit<R, 'id' | 'typeName'>> {
@@ -271,9 +281,10 @@ export function squashRecordDiffs<T extends UnknownRecord>(diffs: RecordsDiff<T>
 export function squashRecordDiffsMutable<T extends UnknownRecord>(target: RecordsDiff<T>, diffs: RecordsDiff<T>[]): void;
 
 // @public (undocumented)
-export type StandaloneDependsOn = {
+export interface StandaloneDependsOn {
+    // (undocumented)
     readonly dependsOn: readonly MigrationId[];
-};
+}
 
 // @public
 export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
@@ -358,13 +369,18 @@ export type StoreBeforeCreateHandler<R extends UnknownRecord> = (record: R, sour
 export type StoreBeforeDeleteHandler<R extends UnknownRecord> = (record: R, source: 'remote' | 'user') => false | void;
 
 // @public (undocumented)
-export type StoreError = {
+export interface StoreError {
+    // (undocumented)
     error: Error;
+    // (undocumented)
     isExistingValidationIssue: boolean;
+    // (undocumented)
     phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord';
+    // (undocumented)
     recordAfter: unknown;
+    // (undocumented)
     recordBefore?: unknown;
-};
+}
 
 // @public
 export type StoreListener<R extends UnknownRecord> = (entry: HistoryEntry<R>) => void;
@@ -407,8 +423,12 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 }
 
 // @public (undocumented)
-export type StoreSchemaOptions<R extends UnknownRecord, P> = {
+export interface StoreSchemaOptions<R extends UnknownRecord, P> {
+    // @internal (undocumented)
     createIntegrityChecker?: (store: Store<R, P>) => void;
+    // (undocumented)
+    migrations?: MigrationSequence[];
+    // (undocumented)
     onValidationFailure?: (data: {
         error: unknown;
         phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord';
@@ -416,8 +436,7 @@ export type StoreSchemaOptions<R extends UnknownRecord, P> = {
         recordBefore: null | R;
         store: Store<R>;
     }) => R;
-    migrations?: MigrationSequence[];
-};
+}
 
 // @public
 export class StoreSideEffects<R extends UnknownRecord> {
@@ -473,16 +492,20 @@ export class StoreSideEffects<R extends UnknownRecord> {
 }
 
 // @public (undocumented)
-export type StoreSnapshot<R extends UnknownRecord> = {
+export interface StoreSnapshot<R extends UnknownRecord> {
+    // (undocumented)
     schema: SerializedSchema;
+    // (undocumented)
     store: SerializedStore<R>;
-};
+}
 
 // @public (undocumented)
-export type StoreValidator<R extends UnknownRecord> = {
+export interface StoreValidator<R extends UnknownRecord> {
+    // (undocumented)
     validate: (record: unknown) => R;
+    // (undocumented)
     validateUsingKnownGoodVersion?: (knownGoodVersion: R, record: unknown) => R;
-};
+}
 
 // @public (undocumented)
 export type StoreValidators<R extends UnknownRecord> = {

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -6,7 +6,7 @@ import { IdOf, UnknownRecord } from './BaseRecord'
  *
  * @public
  */
-export type RecordsDiff<R extends UnknownRecord> = {
+export interface RecordsDiff<R extends UnknownRecord> {
 	added: Record<IdOf<R>, R>
 	updated: Record<IdOf<R>, [from: R, to: R]>
 	removed: Record<IdOf<R>, R>

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -26,11 +26,14 @@ type RecFromId<K extends RecordId<UnknownRecord>> = K extends RecordId<infer R> 
  *
  * @public
  */
-export type CollectionDiff<T> = { added?: Set<T>; removed?: Set<T> }
+export interface CollectionDiff<T> {
+	added?: Set<T>
+	removed?: Set<T>
+}
 
 export type ChangeSource = 'user' | 'remote'
 
-export type StoreListenerFilters = {
+export interface StoreListenerFilters {
 	source: ChangeSource | 'all'
 	scope: RecordScope | 'all'
 }
@@ -40,7 +43,7 @@ export type StoreListenerFilters = {
  *
  * @public
  */
-export type HistoryEntry<R extends UnknownRecord = UnknownRecord> = {
+export interface HistoryEntry<R extends UnknownRecord = UnknownRecord> {
 	changes: RecordsDiff<R>
 	source: ChangeSource
 }
@@ -57,7 +60,7 @@ export type StoreListener<R extends UnknownRecord> = (entry: HistoryEntry<R>) =>
  *
  * @public
  */
-export type ComputedCache<Data, R extends UnknownRecord> = {
+export interface ComputedCache<Data, R extends UnknownRecord> {
 	get(id: IdOf<R>): Data | undefined
 }
 
@@ -69,13 +72,13 @@ export type ComputedCache<Data, R extends UnknownRecord> = {
 export type SerializedStore<R extends UnknownRecord> = Record<IdOf<R>, R>
 
 /** @public */
-export type StoreSnapshot<R extends UnknownRecord> = {
+export interface StoreSnapshot<R extends UnknownRecord> {
 	store: SerializedStore<R>
 	schema: SerializedSchema
 }
 
 /** @public */
-export type StoreValidator<R extends UnknownRecord> = {
+export interface StoreValidator<R extends UnknownRecord> {
 	validate: (record: unknown) => R
 	validateUsingKnownGoodVersion?: (knownGoodVersion: R, record: unknown) => R
 }
@@ -86,7 +89,7 @@ export type StoreValidators<R extends UnknownRecord> = {
 }
 
 /** @public */
-export type StoreError = {
+export interface StoreError {
 	error: Error
 	phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests'
 	recordBefore?: unknown

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -74,7 +74,7 @@ export function upgradeSchema(schema: SerializedSchema): Result<SerializedSchema
 }
 
 /** @public */
-export type StoreSchemaOptions<R extends UnknownRecord, P> = {
+export interface StoreSchemaOptions<R extends UnknownRecord, P> {
 	migrations?: MigrationSequence[]
 	/** @public */
 	onValidationFailure?: (data: {

--- a/packages/store/src/lib/migrate.ts
+++ b/packages/store/src/lib/migrate.ts
@@ -128,7 +128,7 @@ export function createRecordMigrationSequence(opts: {
 }
 
 /** @public */
-export type LegacyMigration<Before = any, After = any> = {
+export interface LegacyMigration<Before = any, After = any> {
 	up: (oldState: Before) => After
 	down: (newState: After) => Before
 }
@@ -137,7 +137,7 @@ export type LegacyMigration<Before = any, After = any> = {
 export type MigrationId = `${string}/${number}`
 
 /** @public */
-export type StandaloneDependsOn = {
+export interface StandaloneDependsOn {
 	readonly dependsOn: readonly MigrationId[]
 }
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -555,10 +555,12 @@ export class EraserTool extends StateNode {
 export function EraserToolbarItem(): JSX_2.Element;
 
 // @public (undocumented)
-export type EventsProviderProps = {
+export interface EventsProviderProps {
+    // (undocumented)
     children: React_3.ReactNode;
+    // (undocumented)
     onEvent?: TLUiEventHandler;
-};
+}
 
 // @public (undocumented)
 export function ExampleDialog({ title, body, cancel, confirm, displayDontShowAgain, onCancel, onContinue, }: {
@@ -1501,11 +1503,14 @@ export type TLArrowInfo = {
 };
 
 // @public (undocumented)
-export type TLArrowPoint = {
+export interface TLArrowPoint {
+    // (undocumented)
     arrowhead: TLArrowShapeArrowheadStyle;
+    // (undocumented)
     handle: VecLike;
+    // (undocumented)
     point: VecLike;
-};
+}
 
 // @public (undocumented)
 export type TLComponents = Expand<TLEditorComponents & TLUiComponents>;
@@ -1823,29 +1828,35 @@ export interface TLUiActionItem<TransationKey extends string = string, IconType 
 export type TLUiActionsContextType = Record<string, TLUiActionItem>;
 
 // @public (undocumented)
-export type TLUiActionsMenuProps = {
+export interface TLUiActionsMenuProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
 export type TLUiAssetUrlOverrides = RecursivePartial<TLUiAssetUrls>;
 
 // @public (undocumented)
-export type TLUiButtonCheckProps = {
+export interface TLUiButtonCheckProps {
+    // (undocumented)
     checked: boolean;
-};
+}
 
 // @public (undocumented)
-export type TLUiButtonIconProps = {
+export interface TLUiButtonIconProps {
+    // (undocumented)
     icon: string;
+    // (undocumented)
     invertIcon?: boolean;
+    // (undocumented)
     small?: boolean;
-};
+}
 
 // @public (undocumented)
-export type TLUiButtonLabelProps = {
+export interface TLUiButtonLabelProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
 export interface TLUiButtonPickerProps<T extends string> {
@@ -1879,10 +1890,12 @@ export type TLUiComponents = Partial<{
 }>;
 
 // @public (undocumented)
-export type TLUiComponentsProviderProps = {
+export interface TLUiComponentsProviderProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     overrides?: TLUiComponents;
-};
+}
 
 // @public (undocumented)
 export interface TLUiContextMenuProps {
@@ -1891,9 +1904,10 @@ export interface TLUiContextMenuProps {
 }
 
 // @public (undocumented)
-export type TLUiDebugMenuProps = {
+export interface TLUiDebugMenuProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
 export interface TLUiDialog {
@@ -1906,23 +1920,30 @@ export interface TLUiDialog {
 }
 
 // @public (undocumented)
-export type TLUiDialogBodyProps = {
+export interface TLUiDialogBodyProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     className?: string;
+    // (undocumented)
     style?: React.CSSProperties;
-};
+}
 
 // @public (undocumented)
-export type TLUiDialogFooterProps = {
+export interface TLUiDialogFooterProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     className?: string;
-};
+}
 
 // @public (undocumented)
-export type TLUiDialogHeaderProps = {
+export interface TLUiDialogHeaderProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     className?: string;
-};
+}
 
 // @public (undocumented)
 export interface TLUiDialogProps {
@@ -1931,21 +1952,28 @@ export interface TLUiDialogProps {
 }
 
 // @public (undocumented)
-export type TLUiDialogsContextType = {
+export interface TLUiDialogsContextType {
+    // (undocumented)
     addDialog: (dialog: Omit<TLUiDialog, 'id'> & {
         id?: string;
     }) => string;
+    // (undocumented)
     clearDialogs: () => void;
+    // (undocumented)
     dialogs: TLUiDialog[];
+    // (undocumented)
     removeDialog: (id: string) => string;
+    // (undocumented)
     updateDialog: (id: string, newDialogData: Partial<TLUiDialog>) => string;
-};
+}
 
 // @public (undocumented)
-export type TLUiDialogTitleProps = {
+export interface TLUiDialogTitleProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     className?: string;
-};
+}
 
 // @public (undocumented)
 export interface TLUiDropdownMenuCheckboxItemProps {
@@ -1962,19 +1990,26 @@ export interface TLUiDropdownMenuCheckboxItemProps {
 }
 
 // @public (undocumented)
-export type TLUiDropdownMenuContentProps = {
+export interface TLUiDropdownMenuContentProps {
+    // (undocumented)
     align?: 'center' | 'end' | 'start';
+    // (undocumented)
     alignOffset?: number;
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     id?: string;
+    // (undocumented)
     side?: 'bottom' | 'left' | 'right' | 'top';
+    // (undocumented)
     sideOffset?: number;
-};
+}
 
 // @public (undocumented)
-export type TLUiDropdownMenuGroupProps = {
+export interface TLUiDropdownMenuGroupProps {
+    // (undocumented)
     children: ReactNode;
-};
+}
 
 // @public (undocumented)
 export interface TLUiDropdownMenuItemProps {
@@ -1985,26 +2020,36 @@ export interface TLUiDropdownMenuItemProps {
 }
 
 // @public (undocumented)
-export type TLUiDropdownMenuRootProps = {
+export interface TLUiDropdownMenuRootProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     debugOpen?: boolean;
+    // (undocumented)
     id: string;
+    // (undocumented)
     modal?: boolean;
-};
+}
 
 // @public (undocumented)
-export type TLUiDropdownMenuSubProps = {
+export interface TLUiDropdownMenuSubProps {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     id: string;
-};
+}
 
 // @public (undocumented)
-export type TLUiDropdownMenuSubTriggerProps = {
+export interface TLUiDropdownMenuSubTriggerProps {
+    // (undocumented)
     disabled?: boolean;
+    // (undocumented)
     id?: string;
+    // (undocumented)
     label: string;
+    // (undocumented)
     title?: string;
-};
+}
 
 // @public (undocumented)
 export interface TLUiDropdownMenuTriggerProps {
@@ -2189,14 +2234,16 @@ export interface TLUiEventMap {
 export type TLUiEventSource = 'actions-menu' | 'context-menu' | 'debug-panel' | 'dialog' | 'document-name' | 'export-menu' | 'help-menu' | 'helper-buttons' | 'kbd' | 'main-menu' | 'menu' | 'navigation-zone' | 'page-menu' | 'people-menu' | 'quick-actions' | 'share-menu' | 'style-panel' | 'toolbar' | 'unknown' | 'zoom-menu';
 
 // @public (undocumented)
-export type TLUiHelperButtonsProps = {
+export interface TLUiHelperButtonsProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
-export type TLUiHelpMenuProps = {
+export interface TLUiHelpMenuProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
 export interface TLUiIconProps extends React.HTMLProps<HTMLDivElement> {
@@ -2268,68 +2315,90 @@ export type TLUiKeyboardShortcutsDialogProps = TLUiDialogProps & {
 };
 
 // @public (undocumented)
-export type TLUiMainMenuProps = {
+export interface TLUiMainMenuProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
-export type TLUiMenuCheckboxItemProps<TranslationKey extends string = string, IconType extends string = string> = {
+export interface TLUiMenuCheckboxItemProps<TranslationKey extends string = string, IconType extends string = string> {
+    // (undocumented)
     checked?: boolean;
+    // (undocumented)
+    disabled?: boolean;
+    // (undocumented)
+    icon?: IconType;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    kbd?: string;
+    // (undocumented)
+    label?: {
+        [key: string]: TranslationKey;
+    } | TranslationKey;
+    // (undocumented)
+    onSelect: (source: TLUiEventSource) => Promise<void> | void;
+    // (undocumented)
+    readonlyOk?: boolean;
+    // (undocumented)
+    title?: string;
+    // (undocumented)
+    toggle?: boolean;
+}
+
+// @public (undocumented)
+export interface TLUiMenuContextProviderProps {
+    // (undocumented)
+    children: React.ReactNode;
+    // (undocumented)
+    sourceId: TLUiEventSource;
+    // (undocumented)
+    type: TldrawUiMenuContextType;
+}
+
+// @public (undocumented)
+export interface TLUiMenuGroupProps<TranslationKey extends string = string> {
+    // (undocumented)
+    children?: ReactNode;
+    // (undocumented)
+    id: string;
+    label?: {
+        [key: string]: TranslationKey;
+    } | TranslationKey;
+}
+
+// @public (undocumented)
+export interface TLUiMenuItemProps<TranslationKey extends string = string, IconType extends string = string> {
     disabled?: boolean;
     icon?: IconType;
+    // (undocumented)
     id: string;
+    isSelected?: boolean;
     kbd?: string;
     label?: {
         [key: string]: TranslationKey;
     } | TranslationKey;
-    onSelect: (source: TLUiEventSource) => Promise<void> | void;
-    readonlyOk?: boolean;
-    title?: string;
-    toggle?: boolean;
-};
-
-// @public (undocumented)
-export type TLUiMenuContextProviderProps = {
-    children: React.ReactNode;
-    sourceId: TLUiEventSource;
-    type: TldrawUiMenuContextType;
-};
-
-// @public (undocumented)
-export type TLUiMenuGroupProps<TranslationKey extends string = string> = {
-    label?: {
-        [key: string]: TranslationKey;
-    } | TranslationKey;
-    children?: ReactNode;
-    id: string;
-};
-
-// @public (undocumented)
-export type TLUiMenuItemProps<TranslationKey extends string = string, IconType extends string = string> = {
-    readonlyOk?: boolean;
     noClose?: boolean;
     onSelect: (source: TLUiEventSource) => Promise<void> | void;
-    icon?: IconType;
-    kbd?: string;
-    label?: {
-        [key: string]: TranslationKey;
-    } | TranslationKey;
-    isSelected?: boolean;
-    disabled?: boolean;
+    readonlyOk?: boolean;
     spinner?: boolean;
-    id: string;
-};
+}
 
 // @public (undocumented)
-export type TLUiMenuSubmenuProps<Translation extends string = string> = {
+export interface TLUiMenuSubmenuProps<Translation extends string = string> {
+    // (undocumented)
     children: ReactNode;
+    // (undocumented)
     disabled?: boolean;
+    // (undocumented)
     id: string;
+    // (undocumented)
     label?: {
         [key: string]: Translation;
     } | Translation;
+    // (undocumented)
     size?: 'medium' | 'small' | 'tiny' | 'wide';
-};
+}
 
 // @public (undocumented)
 export type TLUiOverrides = Partial<{
@@ -2339,21 +2408,30 @@ export type TLUiOverrides = Partial<{
 }>;
 
 // @public (undocumented)
-export type TLUiPopoverContentProps = {
+export interface TLUiPopoverContentProps {
+    // (undocumented)
     align?: 'center' | 'end' | 'start';
+    // (undocumented)
     alignOffset?: number;
+    // (undocumented)
     children: React_2.ReactNode;
+    // (undocumented)
     side: 'bottom' | 'left' | 'right' | 'top';
+    // (undocumented)
     sideOffset?: number;
-};
+}
 
 // @public (undocumented)
-export type TLUiPopoverProps = {
+export interface TLUiPopoverProps {
+    // (undocumented)
     children: React_2.ReactNode;
+    // (undocumented)
     id: string;
+    // (undocumented)
     onOpenChange?: (isOpen: boolean) => void;
+    // (undocumented)
     open?: boolean;
-};
+}
 
 // @public (undocumented)
 export interface TLUiPopoverTriggerProps {
@@ -2362,9 +2440,10 @@ export interface TLUiPopoverTriggerProps {
 }
 
 // @public (undocumented)
-export type TLUiQuickActionsProps = {
+export interface TLUiQuickActionsProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @internal (undocumented)
 export interface TLUiSliderProps {
@@ -2383,9 +2462,10 @@ export interface TLUiSliderProps {
 }
 
 // @public (undocumented)
-export type TLUiStylePanelContentProps = {
+export interface TLUiStylePanelContentProps {
+    // (undocumented)
     styles: ReturnType<typeof useRelevantStyles>;
-};
+}
 
 // @public (undocumented)
 export interface TLUiStylePanelProps {
@@ -2426,14 +2506,18 @@ export interface TLUiToastAction {
 }
 
 // @public (undocumented)
-export type TLUiToastsContextType = {
+export interface TLUiToastsContextType {
+    // (undocumented)
     addToast: (toast: Omit<TLUiToast, 'id'> & {
         id?: string;
     }) => string;
+    // (undocumented)
     clearToasts: () => void;
+    // (undocumented)
     removeToast: (id: TLUiToast['id']) => string;
+    // (undocumented)
     toasts: TLUiToast[];
-};
+}
 
 // @public (undocumented)
 export interface TLUiToolItem<TranslationKey extends string = string, IconType extends string = string> {
@@ -2461,20 +2545,26 @@ export interface TLUiToolItem<TranslationKey extends string = string, IconType e
 export type TLUiToolsContextType = Record<string, TLUiToolItem>;
 
 // @public (undocumented)
-export type TLUiToolsProviderProps = {
+export interface TLUiToolsProviderProps {
+    // (undocumented)
     children: React_3.ReactNode;
+    // (undocumented)
     overrides?: (editor: Editor, tools: TLUiToolsContextType, helpers: {
         insertMedia: () => void;
     }) => TLUiToolsContextType;
-};
+}
 
 // @public (undocumented)
-export type TLUiTranslation = {
+export interface TLUiTranslation {
+    // (undocumented)
     readonly dir: 'ltr' | 'rtl';
+    // (undocumented)
     readonly label: string;
+    // (undocumented)
     readonly locale: string;
+    // (undocumented)
     readonly messages: Record<TLUiTranslationKey, string>;
-};
+}
 
 // @public (undocumented)
 export type TLUiTranslationContextType = TLUiTranslation;
@@ -2483,9 +2573,10 @@ export type TLUiTranslationContextType = TLUiTranslation;
 export type TLUiTranslationKey = 'action.align-bottom' | 'action.align-center-horizontal.short' | 'action.align-center-horizontal' | 'action.align-center-vertical.short' | 'action.align-center-vertical' | 'action.align-left' | 'action.align-right' | 'action.align-top' | 'action.back-to-content' | 'action.bring-forward' | 'action.bring-to-front' | 'action.convert-to-bookmark' | 'action.convert-to-embed' | 'action.copy-as-json.short' | 'action.copy-as-json' | 'action.copy-as-png.short' | 'action.copy-as-png' | 'action.copy-as-svg.short' | 'action.copy-as-svg' | 'action.copy' | 'action.cut' | 'action.delete' | 'action.distribute-horizontal.short' | 'action.distribute-horizontal' | 'action.distribute-vertical.short' | 'action.distribute-vertical' | 'action.duplicate' | 'action.edit-link' | 'action.exit-pen-mode' | 'action.export-all-as-json.short' | 'action.export-all-as-json' | 'action.export-all-as-png.short' | 'action.export-all-as-png' | 'action.export-all-as-svg.short' | 'action.export-all-as-svg' | 'action.export-as-json.short' | 'action.export-as-json' | 'action.export-as-png.short' | 'action.export-as-png' | 'action.export-as-svg.short' | 'action.export-as-svg' | 'action.fit-frame-to-content' | 'action.flip-horizontal.short' | 'action.flip-horizontal' | 'action.flip-vertical.short' | 'action.flip-vertical' | 'action.fork-project-on-tldraw' | 'action.fork-project' | 'action.group' | 'action.insert-embed' | 'action.insert-media' | 'action.leave-shared-project' | 'action.new-project' | 'action.new-shared-project' | 'action.open-cursor-chat' | 'action.open-embed-link' | 'action.open-file' | 'action.pack' | 'action.paste' | 'action.print' | 'action.redo' | 'action.remove-frame' | 'action.rename' | 'action.rotate-ccw' | 'action.rotate-cw' | 'action.save-copy' | 'action.select-all' | 'action.select-none' | 'action.send-backward' | 'action.send-to-back' | 'action.share-project' | 'action.stack-horizontal.short' | 'action.stack-horizontal' | 'action.stack-vertical.short' | 'action.stack-vertical' | 'action.stop-following' | 'action.stretch-horizontal.short' | 'action.stretch-horizontal' | 'action.stretch-vertical.short' | 'action.stretch-vertical' | 'action.toggle-auto-size' | 'action.toggle-dark-mode.menu' | 'action.toggle-dark-mode' | 'action.toggle-debug-mode.menu' | 'action.toggle-debug-mode' | 'action.toggle-edge-scrolling.menu' | 'action.toggle-edge-scrolling' | 'action.toggle-focus-mode.menu' | 'action.toggle-focus-mode' | 'action.toggle-grid.menu' | 'action.toggle-grid' | 'action.toggle-lock' | 'action.toggle-reduce-motion.menu' | 'action.toggle-reduce-motion' | 'action.toggle-snap-mode.menu' | 'action.toggle-snap-mode' | 'action.toggle-tool-lock.menu' | 'action.toggle-tool-lock' | 'action.toggle-transparent.context-menu' | 'action.toggle-transparent.menu' | 'action.toggle-transparent' | 'action.toggle-wrap-mode.menu' | 'action.toggle-wrap-mode' | 'action.undo' | 'action.ungroup' | 'action.unlock-all' | 'action.zoom-in' | 'action.zoom-out' | 'action.zoom-to-100' | 'action.zoom-to-fit' | 'action.zoom-to-selection' | 'actions-menu.title' | 'align-style.end' | 'align-style.justify' | 'align-style.middle' | 'align-style.start' | 'arrowheadEnd-style.arrow' | 'arrowheadEnd-style.bar' | 'arrowheadEnd-style.diamond' | 'arrowheadEnd-style.dot' | 'arrowheadEnd-style.inverted' | 'arrowheadEnd-style.none' | 'arrowheadEnd-style.pipe' | 'arrowheadEnd-style.square' | 'arrowheadEnd-style.triangle' | 'arrowheadStart-style.arrow' | 'arrowheadStart-style.bar' | 'arrowheadStart-style.diamond' | 'arrowheadStart-style.dot' | 'arrowheadStart-style.inverted' | 'arrowheadStart-style.none' | 'arrowheadStart-style.pipe' | 'arrowheadStart-style.square' | 'arrowheadStart-style.triangle' | 'assets.files.upload-failed' | 'assets.url.failed' | 'color-style.black' | 'color-style.blue' | 'color-style.green' | 'color-style.grey' | 'color-style.light-blue' | 'color-style.light-green' | 'color-style.light-red' | 'color-style.light-violet' | 'color-style.orange' | 'color-style.red' | 'color-style.violet' | 'color-style.white' | 'color-style.yellow' | 'context-menu.arrange' | 'context-menu.copy-as' | 'context-menu.export-all-as' | 'context-menu.export-as' | 'context-menu.move-to-page' | 'context-menu.reorder' | 'context.pages.new-page' | 'cursor-chat.type-to-chat' | 'dash-style.dashed' | 'dash-style.dotted' | 'dash-style.draw' | 'dash-style.solid' | 'debug-panel.more' | 'document.default-name' | 'edit-link-dialog.cancel' | 'edit-link-dialog.clear' | 'edit-link-dialog.detail' | 'edit-link-dialog.invalid-url' | 'edit-link-dialog.save' | 'edit-link-dialog.title' | 'edit-link-dialog.url' | 'edit-pages-dialog.move-down' | 'edit-pages-dialog.move-up' | 'embed-dialog.back' | 'embed-dialog.cancel' | 'embed-dialog.create' | 'embed-dialog.instruction' | 'embed-dialog.invalid-url' | 'embed-dialog.title' | 'embed-dialog.url' | 'file-system.confirm-clear.cancel' | 'file-system.confirm-clear.continue' | 'file-system.confirm-clear.description' | 'file-system.confirm-clear.dont-show-again' | 'file-system.confirm-clear.title' | 'file-system.confirm-open.cancel' | 'file-system.confirm-open.description' | 'file-system.confirm-open.dont-show-again' | 'file-system.confirm-open.open' | 'file-system.confirm-open.title' | 'file-system.file-open-error.file-format-version-too-new' | 'file-system.file-open-error.generic-corrupted-file' | 'file-system.file-open-error.not-a-tldraw-file' | 'file-system.file-open-error.title' | 'file-system.shared-document-file-open-error.description' | 'file-system.shared-document-file-open-error.title' | 'fill-style.none' | 'fill-style.pattern' | 'fill-style.semi' | 'fill-style.solid' | 'focus-mode.toggle-focus-mode' | 'font-style.draw' | 'font-style.mono' | 'font-style.sans' | 'font-style.serif' | 'geo-style.arrow-down' | 'geo-style.arrow-left' | 'geo-style.arrow-right' | 'geo-style.arrow-up' | 'geo-style.check-box' | 'geo-style.cloud' | 'geo-style.diamond' | 'geo-style.ellipse' | 'geo-style.hexagon' | 'geo-style.octagon' | 'geo-style.oval' | 'geo-style.pentagon' | 'geo-style.rectangle' | 'geo-style.rhombus-2' | 'geo-style.rhombus' | 'geo-style.star' | 'geo-style.trapezoid' | 'geo-style.triangle' | 'geo-style.x-box' | 'help-menu.about' | 'help-menu.discord' | 'help-menu.github' | 'help-menu.keyboard-shortcuts' | 'help-menu.title' | 'help-menu.twitter' | 'home-project-dialog.description' | 'home-project-dialog.ok' | 'home-project-dialog.title' | 'menu.copy-as' | 'menu.edit' | 'menu.export-as' | 'menu.file' | 'menu.language' | 'menu.preferences' | 'menu.title' | 'menu.view' | 'navigation-zone.toggle-minimap' | 'navigation-zone.zoom' | 'opacity-style.0.1' | 'opacity-style.0.25' | 'opacity-style.0.5' | 'opacity-style.0.75' | 'opacity-style.1' | 'page-menu.create-new-page' | 'page-menu.edit-done' | 'page-menu.edit-start' | 'page-menu.go-to-page' | 'page-menu.max-page-count-reached' | 'page-menu.new-page-initial-name' | 'page-menu.submenu.delete' | 'page-menu.submenu.duplicate-page' | 'page-menu.submenu.move-down' | 'page-menu.submenu.move-up' | 'page-menu.submenu.rename' | 'page-menu.submenu.title' | 'page-menu.title' | 'people-menu.change-color' | 'people-menu.change-name' | 'people-menu.follow' | 'people-menu.following' | 'people-menu.invite' | 'people-menu.leading' | 'people-menu.title' | 'people-menu.user' | 'rename-project-dialog.cancel' | 'rename-project-dialog.rename' | 'rename-project-dialog.title' | 'share-menu.copy-link-note' | 'share-menu.copy-link' | 'share-menu.copy-readonly-link-note' | 'share-menu.copy-readonly-link' | 'share-menu.create-snapshot-link' | 'share-menu.default-project-name' | 'share-menu.fork-note' | 'share-menu.offline-note' | 'share-menu.project-too-large' | 'share-menu.readonly-link' | 'share-menu.save-note' | 'share-menu.share-project' | 'share-menu.snapshot-link-note' | 'share-menu.title' | 'share-menu.upload-failed' | 'sharing.confirm-leave.cancel' | 'sharing.confirm-leave.description' | 'sharing.confirm-leave.dont-show-again' | 'sharing.confirm-leave.leave' | 'sharing.confirm-leave.title' | 'shortcuts-dialog.collaboration' | 'shortcuts-dialog.edit' | 'shortcuts-dialog.file' | 'shortcuts-dialog.preferences' | 'shortcuts-dialog.title' | 'shortcuts-dialog.tools' | 'shortcuts-dialog.transform' | 'shortcuts-dialog.view' | 'size-style.l' | 'size-style.m' | 'size-style.s' | 'size-style.xl' | 'spline-style.cubic' | 'spline-style.line' | 'status.offline' | 'status.online' | 'style-panel.align' | 'style-panel.arrowhead-end' | 'style-panel.arrowhead-start' | 'style-panel.arrowheads' | 'style-panel.color' | 'style-panel.dash' | 'style-panel.fill' | 'style-panel.font' | 'style-panel.geo' | 'style-panel.mixed' | 'style-panel.opacity' | 'style-panel.position' | 'style-panel.size' | 'style-panel.spline' | 'style-panel.title' | 'style-panel.vertical-align' | 'toast.close' | 'toast.error.copy-fail.desc' | 'toast.error.copy-fail.title' | 'toast.error.export-fail.desc' | 'toast.error.export-fail.title' | 'tool-panel.drawing' | 'tool-panel.more' | 'tool-panel.shapes' | 'tool.arrow-down' | 'tool.arrow-left' | 'tool.arrow-right' | 'tool.arrow-up' | 'tool.arrow' | 'tool.asset' | 'tool.check-box' | 'tool.cloud' | 'tool.diamond' | 'tool.draw' | 'tool.ellipse' | 'tool.embed' | 'tool.eraser' | 'tool.frame' | 'tool.hand' | 'tool.hexagon' | 'tool.highlight' | 'tool.laser' | 'tool.line' | 'tool.note' | 'tool.octagon' | 'tool.oval' | 'tool.pentagon' | 'tool.rectangle' | 'tool.rhombus' | 'tool.select' | 'tool.star' | 'tool.text' | 'tool.trapezoid' | 'tool.triangle' | 'tool.x-box' | 'verticalAlign-style.end' | 'verticalAlign-style.middle' | 'verticalAlign-style.start' | 'vscode.file-open.backup-failed' | 'vscode.file-open.backup-saved' | 'vscode.file-open.backup' | 'vscode.file-open.desc' | 'vscode.file-open.dont-show-again' | 'vscode.file-open.open';
 
 // @public (undocumented)
-export type TLUiZoomMenuProps = {
+export interface TLUiZoomMenuProps {
+    // (undocumented)
     children?: ReactNode;
-};
+}
 
 // @public (undocumented)
 export function ToggleAutoSizeMenuItem(): JSX_2.Element | null;

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -27,7 +27,7 @@ import { getEmbedInfo } from './utils/embeds/embeds'
 import { cleanupText, isRightToLeftLanguage, truncateStringWithEllipsis } from './utils/text/text'
 
 /** @public */
-export type TLExternalContentProps = {
+export interface TLExternalContentProps {
 	// The maximum dimension (width or height) of an image. Images larger than this will be rescaled to fit. Defaults to infinity.
 	maxImageDimension: number
 	// The maximum size (in bytes) of an asset. Assets larger than this will be rejected. Defaults to 10mb (10 * 1024 * 1024).

--- a/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
@@ -2,7 +2,7 @@ import { TLArrowShapeArrowheadStyle, VecLike } from '@tldraw/editor'
 import { TLArrowBindings } from './shared'
 
 /** @public */
-export type TLArrowPoint = {
+export interface TLArrowPoint {
 	handle: VecLike
 	point: VecLike
 	arrowhead: TLArrowShapeArrowheadStyle

--- a/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
@@ -1,7 +1,7 @@
 import { HALF_PI, PI, Vec, VecLike, intersectCircleCircle } from '@tldraw/editor'
 import { TLArrowInfo } from './arrow-types'
 
-type TLArrowPointsInfo = {
+interface TLArrowPointsInfo {
 	point: VecLike
 	int: VecLike
 }

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -17,7 +17,7 @@ export function getIsArrowStraight(shape: TLArrowShape) {
 	return Math.abs(shape.props.bend) < 8 // snap to +-8px
 }
 
-export type BoundShapeInfo<T extends TLShape = TLShape> = {
+export interface BoundShapeInfo<T extends TLShape = TLShape> {
 	shape: T
 	didIntersect: boolean
 	isExact: boolean

--- a/packages/tldraw/src/lib/shapes/geo/cloudOutline.ts
+++ b/packages/tldraw/src/lib/shapes/geo/cloudOutline.ts
@@ -215,7 +215,7 @@ export function getCloudArcs(
 	return arcs
 }
 
-type Arc = {
+interface Arc {
 	leftPoint: Vec
 	rightPoint: Vec
 	arcPoint: Vec

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -12,7 +12,7 @@ import { TextHelpers } from './TextHelpers'
 import { isLegacyAlign } from './legacyProps'
 import { useEditableText } from './useEditableText'
 
-type TextLabelProps = {
+interface TextLabelProps {
 	id: TLShapeId
 	type: string
 	font: TLDefaultFontStyle

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -147,7 +147,11 @@ const canvasBlob = (size: [number, number], fn: (ctx: CanvasRenderingContext2D) 
 	fn(ctx)
 	return canvas.toDataURL()
 }
-type PatternDef = { zoom: number; url: string; theme: 'light' | 'dark' }
+interface PatternDef {
+	zoom: number
+	url: string
+	theme: 'light' | 'dark'
+}
 
 let defaultPixels: { white: string; black: string } | null = null
 function getDefaultPixels() {

--- a/packages/tldraw/src/lib/shapes/shared/getBrowserCanvasMaxSize.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/getBrowserCanvasMaxSize.tsx
@@ -1,6 +1,6 @@
 import canvasSize from 'canvas-size'
 
-export type CanvasMaxSize = {
+export interface CanvasMaxSize {
 	maxWidth: number
 	maxHeight: number
 	maxArea: number

--- a/packages/tldraw/src/lib/shapes/text/TextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextArea.tsx
@@ -1,7 +1,7 @@
 import { preventDefault, stopEventPropagation } from '@tldraw/editor'
 import { forwardRef } from 'react'
 
-type TextAreaProps = {
+interface TextAreaProps {
 	isEditing: boolean
 	text: string
 	handleFocus: () => void

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -77,7 +77,7 @@ export const TldrawUi = React.memo(function TldrawUi({
 	)
 })
 
-type TldrawUiContentProps = {
+interface TldrawUiContentProps {
 	hideUi?: boolean
 	shareZone?: ReactNode
 	topZone?: ReactNode

--- a/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
@@ -15,7 +15,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultActionsMenuContent } from './DefaultActionsMenuContent'
 
 /** @public */
-export type TLUiActionsMenuProps = {
+export interface TLUiActionsMenuProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
@@ -10,7 +10,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultDebugMenuContent } from './DefaultDebugMenuContent'
 
 /** @public */
-export type TLUiDebugMenuProps = {
+export interface TLUiDebugMenuProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelpMenu/DefaultHelpMenu.tsx
@@ -13,7 +13,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultHelpMenuContent } from './DefaultHelpMenuContent'
 
 /** @public */
-export type TLUiHelpMenuProps = {
+export interface TLUiHelpMenuProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/HelperButtons/DefaultHelperButtons.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/DefaultHelperButtons.tsx
@@ -3,7 +3,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultHelperButtonsContent } from './DefaultHelperButtonsContent'
 
 /** @public */
-export type TLUiHelperButtonsProps = {
+export interface TLUiHelperButtonsProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
@@ -9,7 +9,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultMainMenuContent } from './DefaultMainMenuContent'
 
 /** @public */
-export type TLUiMainMenuProps = {
+export interface TLUiMainMenuProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActions.tsx
+++ b/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActions.tsx
@@ -3,7 +3,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultQuickActionsContent } from './DefaultQuickActionsContent'
 
 /** @public */
-export type TLUiQuickActionsProps = {
+export interface TLUiQuickActionsProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -35,7 +35,7 @@ import { DoubleDropdownPicker } from './DoubleDropdownPicker'
 import { DropdownPicker } from './DropdownPicker'
 
 /** @public */
-export type TLUiStylePanelContentProps = {
+export interface TLUiStylePanelContentProps {
 	styles: ReturnType<typeof useRelevantStyles>
 }
 

--- a/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
@@ -10,7 +10,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 import { DefaultZoomMenuContent } from './DefaultZoomMenuContent'
 
 /** @public */
-export type TLUiZoomMenuProps = {
+export interface TLUiZoomMenuProps {
 	children?: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonCheck.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonCheck.tsx
@@ -1,7 +1,9 @@
 import { TldrawUiIcon } from '../TldrawUiIcon'
 
 /** @public */
-export type TLUiButtonCheckProps = { checked: boolean }
+export interface TLUiButtonCheckProps {
+	checked: boolean
+}
 
 /** @public */
 export function TldrawUiButtonCheck({ checked }: TLUiButtonCheckProps) {

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonIcon.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonIcon.tsx
@@ -1,7 +1,7 @@
 import { TldrawUiIcon } from '../TldrawUiIcon'
 
 /** @public */
-export type TLUiButtonIconProps = {
+export interface TLUiButtonIconProps {
 	icon: string
 	small?: boolean
 	invertIcon?: boolean

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonLabel.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonLabel.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from 'react'
 
 /** @public */
-export type TLUiButtonLabelProps = { children?: ReactNode }
+export interface TLUiButtonLabelProps {
+	children?: ReactNode
+}
 
 /** @public */
 export function TldrawUiButtonLabel({ children }: TLUiButtonLabelProps) {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
@@ -5,7 +5,7 @@ import { TldrawUiButton } from './Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from './Button/TldrawUiButtonIcon'
 
 /** @public */
-export type TLUiDialogHeaderProps = {
+export interface TLUiDialogHeaderProps {
 	className?: string
 	children: ReactNode
 }
@@ -16,7 +16,7 @@ export function TldrawUiDialogHeader({ className, children }: TLUiDialogHeaderPr
 }
 
 /** @public */
-export type TLUiDialogTitleProps = {
+export interface TLUiDialogTitleProps {
 	className?: string
 	children: ReactNode
 }
@@ -48,7 +48,7 @@ export function TldrawUiDialogCloseButton() {
 }
 
 /** @public */
-export type TLUiDialogBodyProps = {
+export interface TLUiDialogBodyProps {
 	className?: string
 	children: ReactNode
 	style?: React.CSSProperties
@@ -64,7 +64,7 @@ export function TldrawUiDialogBody({ className, children, style }: TLUiDialogBod
 }
 
 /** @public */
-export type TLUiDialogFooterProps = {
+export interface TLUiDialogFooterProps {
 	className?: string
 	children: ReactNode
 }

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -8,7 +8,7 @@ import { TldrawUiButtonLabel } from './Button/TldrawUiButtonLabel'
 import { TldrawUiIcon } from './TldrawUiIcon'
 
 /** @public */
-export type TLUiDropdownMenuRootProps = {
+export interface TLUiDropdownMenuRootProps {
 	id: string
 	children: ReactNode
 	modal?: boolean
@@ -57,7 +57,7 @@ export function TldrawUiDropdownMenuTrigger({ children, ...rest }: TLUiDropdownM
 }
 
 /** @public */
-export type TLUiDropdownMenuContentProps = {
+export interface TLUiDropdownMenuContentProps {
 	id?: string
 	children: ReactNode
 	alignOffset?: number
@@ -93,7 +93,10 @@ export function TldrawUiDropdownMenuContent({
 }
 
 /** @public */
-export type TLUiDropdownMenuSubProps = { id: string; children: ReactNode }
+export interface TLUiDropdownMenuSubProps {
+	id: string
+	children: ReactNode
+}
 
 /** @public */
 export function TldrawUiDropdownMenuSub({ id, children }: TLUiDropdownMenuSubProps) {
@@ -107,7 +110,7 @@ export function TldrawUiDropdownMenuSub({ id, children }: TLUiDropdownMenuSubPro
 }
 
 /** @public */
-export type TLUiDropdownMenuSubTriggerProps = {
+export interface TLUiDropdownMenuSubTriggerProps {
 	label: string
 	id?: string
 	title?: string
@@ -138,7 +141,7 @@ export function TldrawUiDropdownMenuSubTrigger({
 }
 
 /** @public */
-export type TLUiDropdownMenuSubContentProps = {
+export interface TLUiDropdownMenuSubContentProps {
 	id?: string
 	alignOffset?: number
 	sideOffset?: number
@@ -172,7 +175,7 @@ export function TldrawUiDropdownMenuSubContent({
 }
 
 /** @public */
-export type TLUiDropdownMenuGroupProps = {
+export interface TLUiDropdownMenuGroupProps {
 	children: ReactNode
 }
 

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 
 /** @public */
-export type TLUiPopoverProps = {
+export interface TLUiPopoverProps {
 	id: string
 	open?: boolean
 	children: React.ReactNode
@@ -40,7 +40,7 @@ export function TldrawUiPopoverTrigger({ children }: TLUiPopoverTriggerProps) {
 }
 
 /** @public */
-export type TLUiPopoverContentProps = {
+export interface TLUiPopoverContentProps {
 	children: React.ReactNode
 	side: 'top' | 'bottom' | 'left' | 'right'
 	align?: 'start' | 'center' | 'end'

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
@@ -11,10 +11,10 @@ import { TldrawUiKbd } from '../TldrawUiKbd'
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
 
 /** @public */
-export type TLUiMenuCheckboxItemProps<
+export interface TLUiMenuCheckboxItemProps<
 	TranslationKey extends string = string,
 	IconType extends string = string,
-> = {
+> {
 	icon?: IconType
 	id: string
 	kbd?: string

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuContext.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuContext.tsx
@@ -28,7 +28,7 @@ export function useTldrawUiMenuContext() {
 }
 
 /** @public */
-export type TLUiMenuContextProviderProps = {
+export interface TLUiMenuContextProviderProps {
 	type: TldrawUiMenuContextType
 	sourceId: TLUiEventSource
 	children: React.ReactNode

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
@@ -7,7 +7,7 @@ import { TldrawUiDropdownMenuGroup } from '../TldrawUiDropdownMenu'
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
 
 /** @public */
-export type TLUiMenuGroupProps<TranslationKey extends string = string> = {
+export interface TLUiMenuGroupProps<TranslationKey extends string = string> {
 	id: string
 	/**
 	 * The label to display on the item. If it's a string, it will be translated. If it's an object, the keys will be used as the language keys and the values will be translated.

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -16,10 +16,10 @@ import { TldrawUiKbd } from '../TldrawUiKbd'
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
 
 /** @public */
-export type TLUiMenuItemProps<
+export interface TLUiMenuItemProps<
 	TranslationKey extends string = string,
 	IconType extends string = string,
-> = {
+> {
 	id: string
 	/**
 	 * The icon to display on the item.

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
@@ -20,7 +20,7 @@ import {
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
 
 /** @public */
-export type TLUiMenuSubmenuProps<Translation extends string = string> = {
+export interface TLUiMenuSubmenuProps<Translation extends string = string> {
 	id: string
 	label?: Translation | { [key: string]: Translation }
 	disabled?: boolean
@@ -103,7 +103,10 @@ export function TldrawUiMenuSubmenu<Translation extends string = string>({
 }
 
 /** @private */
-export type TLUiContextMenuSubProps = { id: string; children: ReactNode }
+export interface TLUiContextMenuSubProps {
+	id: string
+	children: ReactNode
+}
 
 /** @private */
 export function ContextMenuSubWithMenu({ id, children }: TLUiContextMenuSubProps) {

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -59,7 +59,7 @@ export type TLUiActionsContextType = Record<string, TLUiActionItem>
 export const ActionsContext = React.createContext<TLUiActionsContextType | null>(null)
 
 /** @public */
-export type ActionsProviderProps = {
+export interface ActionsProviderProps {
 	overrides?: (
 		editor: Editor,
 		actions: TLUiActionsContextType,

--- a/packages/tldraw/src/lib/ui/context/components.tsx
+++ b/packages/tldraw/src/lib/ui/context/components.tsx
@@ -61,7 +61,7 @@ export type TLUiComponents = Partial<{
 const TldrawUiComponentsContext = createContext<TLUiComponents | null>(null)
 
 /** @public */
-export type TLUiComponentsProviderProps = {
+export interface TLUiComponentsProviderProps {
 	overrides?: TLUiComponents
 	children: ReactNode
 }

--- a/packages/tldraw/src/lib/ui/context/dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/context/dialogs.tsx
@@ -15,7 +15,7 @@ export interface TLUiDialog {
 }
 
 /** @public */
-export type TLUiDialogsContextType = {
+export interface TLUiDialogsContextType {
 	addDialog: (dialog: Omit<TLUiDialog, 'id'> & { id?: string }) => string
 	removeDialog: (id: string) => string
 	updateDialog: (id: string, newDialogData: Partial<TLUiDialog>) => string
@@ -27,7 +27,7 @@ export type TLUiDialogsContextType = {
 export const DialogsContext = createContext<TLUiDialogsContextType | null>(null)
 
 /** @internal */
-export type DialogsProviderProps = {
+export interface DialogsProviderProps {
 	overrides?: (editor: Editor) => TLUiDialogsContextType
 	children: ReactNode
 }

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -118,7 +118,7 @@ export type TLUiEventContextType = TLUiEventHandler<keyof TLUiEventMap>
 export const EventsContext = React.createContext<TLUiEventContextType | null>(null)
 
 /** @public */
-export type EventsProviderProps = {
+export interface EventsProviderProps {
 	onEvent?: TLUiEventHandler
 	children: React.ReactNode
 }

--- a/packages/tldraw/src/lib/ui/context/toasts.tsx
+++ b/packages/tldraw/src/lib/ui/context/toasts.tsx
@@ -26,7 +26,7 @@ export interface TLUiToastAction {
 }
 
 /** @public */
-export type TLUiToastsContextType = {
+export interface TLUiToastsContextType {
 	addToast: (toast: Omit<TLUiToast, 'id'> & { id?: string }) => string
 	removeToast: (id: TLUiToast['id']) => string
 	clearToasts: () => void
@@ -37,7 +37,7 @@ export type TLUiToastsContextType = {
 export const ToastsContext = createContext<TLUiToastsContextType | null>(null)
 
 /** @internal */
-export type ToastsProviderProps = {
+export interface ToastsProviderProps {
 	overrides?: (editor: Editor) => TLUiToastsContextType
 	children: ReactNode
 }

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -31,7 +31,7 @@ export type TLUiToolsContextType = Record<string, TLUiToolItem>
 export const ToolsContext = React.createContext<null | TLUiToolsContextType>(null)
 
 /** @public */
-export type TLUiToolsProviderProps = {
+export interface TLUiToolsProviderProps {
 	overrides?: (
 		editor: Editor,
 		tools: TLUiToolsContextType,

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/translations.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/translations.ts
@@ -13,7 +13,7 @@ import { DEFAULT_TRANSLATION } from './defaultTranslation'
 export const RTL_LANGUAGES = new Set(['ar', 'fa', 'he', 'ur', 'ku'])
 
 /** @public */
-export type TLUiTranslation = {
+export interface TLUiTranslation {
 	readonly locale: string
 	readonly label: string
 	readonly messages: Record<TLUiTranslationKey, string>

--- a/packages/tldraw/src/lib/utils/assets/assets.ts
+++ b/packages/tldraw/src/lib/utils/assets/assets.ts
@@ -1,7 +1,7 @@
 import { MediaHelpers, assertExists } from '@tldraw/editor'
 import { clampToBrowserMaxCanvasSize } from '../../shapes/shared/getBrowserCanvasMaxSize'
 
-type BoxWidthHeight = {
+interface BoxWidthHeight {
 	w: number
 	h: number
 }

--- a/packages/tldraw/src/lib/utils/assets/preload-font.ts
+++ b/packages/tldraw/src/lib/utils/assets/preload-font.ts
@@ -1,5 +1,5 @@
 /** @public */
-export type TLTypeFace = {
+export interface TLTypeFace {
 	url: string
 	display?: any // FontDisplay
 	featureSettings?: string

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -1,6 +1,6 @@
 import { getEmbedInfo, matchEmbedUrl, matchUrl } from './embeds'
 
-type MatchUrlTestMatchDef = {
+interface MatchUrlTestMatchDef {
 	url: string
 	match: true
 	output: {
@@ -8,7 +8,7 @@ type MatchUrlTestMatchDef = {
 		embedUrl: string
 	}
 }
-type MatchUrlTestNoMatchDef = {
+interface MatchUrlTestNoMatchDef {
 	url: string
 	match: false
 }
@@ -310,7 +310,7 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 	},
 ]
 
-type MatchEmbedTestMatchDef = {
+interface MatchEmbedTestMatchDef {
 	embedUrl: string
 	match: true
 	output: {
@@ -318,7 +318,7 @@ type MatchEmbedTestMatchDef = {
 		url: string
 	}
 }
-type MatchEmbedTestNoMatchDef = {
+interface MatchEmbedTestNoMatchDef {
 	embedUrl: string
 	match: false
 }

--- a/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
+++ b/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { version } from '../../ui/version'
 
 /** @public */
-export type TLEditorAssetUrls = {
+export interface TLEditorAssetUrls {
 	fonts: {
 		monospace: string
 		serif: string

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -884,7 +884,7 @@ enum FontStyle {
 	Mono = 'mono',
 }
 
-type ShapeStyles = {
+interface ShapeStyles {
 	color: ColorStyle
 	size: SizeStyle
 	dash: DashStyle
@@ -1010,7 +1010,7 @@ type TDShape =
 	| ImageShape
 	| VideoShape
 
-type TDPage = {
+interface TDPage {
 	id: string
 	name?: string
 	childIndex?: number

--- a/packages/tldraw/src/test/test-jsx.tsx
+++ b/packages/tldraw/src/test/test-jsx.tsx
@@ -20,7 +20,7 @@ const createElement = (tag: string) => {
 	return component
 }
 
-type CommonProps = {
+interface CommonProps {
 	x: number
 	y: number
 	id?: TLShapeId

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -432,23 +432,38 @@ export const EMBED_DEFINITIONS: readonly [{
 }];
 
 // @public (undocumented)
-export type EmbedDefinition = {
+export interface EmbedDefinition {
+    // (undocumented)
     readonly backgroundColor?: string;
+    // (undocumented)
     readonly doesResize: boolean;
+    // (undocumented)
     readonly fromEmbedUrl: (url: string) => string | undefined;
+    // (undocumented)
     readonly height: number;
+    // (undocumented)
     readonly hostnames: readonly string[];
+    // (undocumented)
     readonly instructionLink?: string;
+    // (undocumented)
     readonly isAspectRatioLocked?: boolean;
+    // (undocumented)
     readonly minHeight?: number;
+    // (undocumented)
     readonly minWidth?: number;
+    // (undocumented)
     readonly overrideOutlineRadius?: number;
+    // (undocumented)
     readonly overridePermissions?: TLEmbedShapePermissions;
+    // (undocumented)
     readonly title: string;
+    // (undocumented)
     readonly toEmbedUrl: (url: string) => string | undefined;
+    // (undocumented)
     readonly type: string;
+    // (undocumented)
     readonly width: number;
-};
+}
 
 // @public (undocumented)
 export const embedShapeMigrations: TLPropsMigrations;
@@ -996,19 +1011,24 @@ export type TLDefaultColorTheme = Expand<{
 } & Record<(typeof colors)[number], TLDefaultColorThemeColor>>;
 
 // @public (undocumented)
-export type TLDefaultColorThemeColor = {
+export interface TLDefaultColorThemeColor {
+    // (undocumented)
     highlight: {
         p3: string;
         srgb: string;
     };
+    // (undocumented)
     note: {
         fill: string;
         text: string;
     };
+    // (undocumented)
     pattern: string;
+    // (undocumented)
     semi: string;
+    // (undocumented)
     solid: string;
-};
+}
 
 // @public (undocumented)
 export type TLDefaultDashStyle = T.TypeOf<typeof DefaultDashStyle>;
@@ -1301,17 +1321,26 @@ export type TLRecord = TLAsset | TLBinding | TLCamera | TLDocument | TLInstance 
 export type TLSchema = StoreSchema<TLRecord, TLStoreProps>;
 
 // @public
-export type TLScribble = {
+export interface TLScribble {
+    // (undocumented)
     color: TLCanvasUiColor;
+    // (undocumented)
     delay: number;
+    // (undocumented)
     id: string;
+    // (undocumented)
     opacity: number;
+    // (undocumented)
     points: VecModel[];
+    // (undocumented)
     shrink: number;
+    // (undocumented)
     size: number;
+    // (undocumented)
     state: SetValue<typeof TL_SCRIBBLE_STATES>;
+    // (undocumented)
     taper: boolean;
-};
+}
 
 // @public (undocumented)
 export type TLSerializedStore = SerializedStore<TLRecord>;
@@ -1334,9 +1363,10 @@ export type TLShapePartial<T extends TLShape = TLShape> = T extends T ? {
 export type TLStore = Store<TLRecord, TLStoreProps>;
 
 // @public (undocumented)
-export type TLStoreProps = {
+export interface TLStoreProps {
+    // (undocumented)
     defaultName: string;
-};
+}
 
 // @public (undocumented)
 export type TLStoreSchema = StoreSchema<TLRecord, TLStoreProps>;

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -45,7 +45,7 @@ export type TLSerializedStore = SerializedStore<TLRecord>
 export type TLStoreSnapshot = StoreSnapshot<TLRecord>
 
 /** @public */
-export type TLStoreProps = {
+export interface TLStoreProps {
 	defaultName: string
 }
 

--- a/packages/tlschema/src/createTLSchema.ts
+++ b/packages/tlschema/src/createTLSchema.ts
@@ -39,7 +39,7 @@ import { videoShapeMigrations, videoShapeProps } from './shapes/TLVideoShape'
 import { storeMigrations } from './store-migrations'
 import { StyleProp } from './styles/StyleProp'
 
-type AnyValidator = {
+interface AnyValidator {
 	validate: (prop: any) => any
 	validateUsingKnownGoodVersion?: (prevVersion: any, newVersion: any) => any
 }

--- a/packages/tlschema/src/misc/TLScribble.ts
+++ b/packages/tlschema/src/misc/TLScribble.ts
@@ -13,7 +13,7 @@ export const TL_SCRIBBLE_STATES = new Set(['starting', 'paused', 'active', 'stop
  * A type for the scribble used by tldraw.
  *
  * @public */
-export type TLScribble = {
+export interface TLScribble {
 	id: string
 	points: VecModel[]
 	size: number

--- a/packages/tlschema/src/shapes/TLEmbedShape.ts
+++ b/packages/tlschema/src/shapes/TLEmbedShape.ts
@@ -638,7 +638,7 @@ export type TLEmbedShapeProps = RecordPropsType<typeof embedShapeProps>
 export type TLEmbedShape = TLBaseShape<'embed', TLEmbedShapeProps>
 
 /** @public */
-export type EmbedDefinition = {
+export interface EmbedDefinition {
 	readonly type: string
 	readonly title: string
 	readonly hostnames: readonly string[]

--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -19,7 +19,7 @@ const colors = [
 ] as const
 
 /** @public */
-export type TLDefaultColorThemeColor = {
+export interface TLDefaultColorThemeColor {
 	solid: string
 	semi: string
 	pattern: string

--- a/packages/tlschema/src/translations/translations.test.ts
+++ b/packages/tlschema/src/translations/translations.test.ts
@@ -1,6 +1,6 @@
 import { _getDefaultTranslationLocale } from './translations'
 
-type DefaultLanguageTest = {
+interface DefaultLanguageTest {
 	name: string
 	input: string[]
 	output: string

--- a/packages/tlsync/src/lib/ServerSocketAdapter.ts
+++ b/packages/tlsync/src/lib/ServerSocketAdapter.ts
@@ -3,7 +3,7 @@ import ws from 'ws'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentEvent } from './protocol'
 
-type ServerSocketAdapterOptions = {
+interface ServerSocketAdapterOptions {
 	readonly ws: WebSocket | ws.WebSocket
 	readonly logSendMessage: (type: string, size: number) => void
 }

--- a/packages/tlsync/src/lib/TLSyncClient.ts
+++ b/packages/tlsync/src/lib/TLSyncClient.ts
@@ -44,7 +44,7 @@ export type TLPersistentClientSocketStatus = 'online' | 'offline' | 'error'
  *
  * @public
  */
-export type TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> = {
+export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> {
 	/** Whether there is currently an open connection to the server. */
 	connectionStatus: 'online' | 'offline' | 'error'
 	/** Send a message to the server */

--- a/packages/tlsync/src/lib/TLSyncRoom.ts
+++ b/packages/tlsync/src/lib/TLSyncRoom.ts
@@ -48,7 +48,7 @@ import {
 } from './protocol'
 
 /** @public */
-export type TLRoomSocket<R extends UnknownRecord> = {
+export interface TLRoomSocket<R extends UnknownRecord> {
 	isOpen: boolean
 	sendMessage: (msg: TLSocketServerSentEvent<R>) => void
 	close: () => void
@@ -120,7 +120,7 @@ class DocumentState<R extends UnknownRecord> {
 }
 
 /** @public */
-export type RoomSnapshot = {
+export interface RoomSnapshot {
 	clock: number
 	documents: Array<{ state: UnknownRecord; lastChangedClock: number }>
 	tombstones?: Record<string, number>
@@ -814,7 +814,9 @@ export class TLSyncRoom<R extends UnknownRecord> {
 		transaction((rollback) => {
 			// collect actual ops that resulted from the push
 			// these will be broadcast to other users
-			type ActualChanges = { diff: NetworkDiff<R> | null }
+			interface ActualChanges {
+				diff: NetworkDiff<R> | null
+			}
 			const docChanges: ActualChanges = { diff: null }
 			const presenceChanges: ActualChanges = { diff: null }
 

--- a/packages/tlsync/src/lib/diff.ts
+++ b/packages/tlsync/src/lib/diff.ts
@@ -27,7 +27,7 @@ export type RecordOp<R extends UnknownRecord> =
  *
  * @public
  */
-export type NetworkDiff<R extends UnknownRecord> = {
+export interface NetworkDiff<R extends UnknownRecord> {
 	[id: string]: RecordOp<R>
 }
 
@@ -84,7 +84,7 @@ export type DeleteOp = [type: typeof ValueOpType.Delete]
 export type ValueOp = PutOp | AppendOp | PatchOp | DeleteOp
 
 /** @public */
-export type ObjectDiff = {
+export interface ObjectDiff {
 	[k: string]: ValueOp
 }
 

--- a/packages/tlsync/src/lib/protocol.ts
+++ b/packages/tlsync/src/lib/protocol.ts
@@ -61,7 +61,7 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 	  }
 
 /** @public */
-export type TLPushRequest<R extends UnknownRecord> = {
+export interface TLPushRequest<R extends UnknownRecord> {
 	type: 'push'
 	clientClock: number
 	diff?: NetworkDiff<R>
@@ -69,7 +69,7 @@ export type TLPushRequest<R extends UnknownRecord> = {
 }
 
 /** @public */
-export type TLConnectRequest = {
+export interface TLConnectRequest {
 	type: 'connect'
 	connectRequestId: string
 	lastServerClock: number
@@ -78,7 +78,7 @@ export type TLConnectRequest = {
 }
 
 /** @public */
-export type TLPingRequest = {
+export interface TLPingRequest {
 	type: 'ping'
 }
 

--- a/packages/tlsync/src/lib/server-types.ts
+++ b/packages/tlsync/src/lib/server-types.ts
@@ -1,7 +1,7 @@
 import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
 
 /** @public */
-export type RoomState = {
+export interface RoomState {
 	// the slug of the room
 	persistenceKey: string
 	// the room
@@ -9,4 +9,8 @@ export type RoomState = {
 }
 
 /** @public */
-export type PersistedRoomSnapshotForSupabase = { id: string; slug: string; drawing: RoomSnapshot }
+export interface PersistedRoomSnapshotForSupabase {
+	id: string
+	slug: string
+	drawing: RoomSnapshot
+}

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -53,10 +53,12 @@ export function deleteFromLocalStorage(key: string): void;
 export function deleteFromSessionStorage(key: string): void;
 
 // @public (undocumented)
-export type ErrorResult<E> = {
+export interface ErrorResult<E> {
+    // (undocumented)
     readonly error: E;
+    // (undocumented)
     readonly ok: false;
-};
+}
 
 // @internal (undocumented)
 export function exhaustiveSwitchError(value: never, property?: string): never;
@@ -159,9 +161,10 @@ export function isNonNullish<T>(value: T): value is typeof value extends undefin
 export type JsonArray = JsonValue[];
 
 // @public (undocumented)
-export type JsonObject = {
+export interface JsonObject {
+    // (undocumented)
     [key: string]: JsonValue | undefined;
-};
+}
 
 // @public (undocumented)
 export type JsonPrimitive = boolean | null | number | string;
@@ -248,10 +251,12 @@ export function objectMapValues<Key extends string, Value>(object: {
 }): Array<Value>;
 
 // @public (undocumented)
-export type OkResult<T> = {
+export interface OkResult<T> {
+    // (undocumented)
     readonly ok: true;
+    // (undocumented)
     readonly value: T;
-};
+}
 
 // @internal
 export function omitFromStackTrace<Args extends Array<unknown>, Return>(fn: (...args: Args) => Return): (...args: Args) => Return;

--- a/packages/utils/src/lib/control.ts
+++ b/packages/utils/src/lib/control.ts
@@ -1,9 +1,15 @@
 import { omitFromStackTrace } from './function'
 
 /** @public */
-export type OkResult<T> = { readonly ok: true; readonly value: T }
+export interface OkResult<T> {
+	readonly ok: true
+	readonly value: T
+}
 /** @public */
-export type ErrorResult<E> = { readonly ok: false; readonly error: E }
+export interface ErrorResult<E> {
+	readonly ok: false
+	readonly error: E
+}
 /** @public */
 export type Result<T, E> = OkResult<T> | ErrorResult<E>
 

--- a/packages/utils/src/lib/error.ts
+++ b/packages/utils/src/lib/error.ts
@@ -1,4 +1,4 @@
-type ErrorAnnotations = {
+interface ErrorAnnotations {
 	tags: Record<string, number | string | boolean | bigint | symbol | null | undefined>
 	extras: Record<string, unknown>
 }

--- a/packages/utils/src/lib/json-value.ts
+++ b/packages/utils/src/lib/json-value.ts
@@ -5,4 +5,6 @@ export type JsonPrimitive = boolean | null | string | number
 /** @public */
 export type JsonArray = JsonValue[]
 /** @public */
-export type JsonObject = { [key: string]: JsonValue | undefined }
+export interface JsonObject {
+	[key: string]: JsonValue | undefined
+}

--- a/packages/validate/api-report.md
+++ b/packages/validate/api-report.md
@@ -194,10 +194,11 @@ const unknown: Validator<unknown>;
 const unknownObject: Validator<Record<string, unknown>>;
 
 // @public (undocumented)
-type Validatable<T> = {
-    validateUsingKnownGoodVersion?: (knownGoodValue: T, newValue: unknown) => T;
+interface Validatable<T> {
+    // (undocumented)
     validate: (value: unknown) => T;
-};
+    validateUsingKnownGoodVersion?: (knownGoodValue: T, newValue: unknown) => T;
+}
 
 // @public (undocumented)
 class ValidationError extends Error {

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -17,7 +17,7 @@ export type ValidatorUsingKnownGoodVersionFn<In, Out = In> = (
 ) => Out
 
 /** @public */
-export type Validatable<T> = {
+export interface Validatable<T> {
 	validate: (value: unknown) => T
 	/**
 	 * This is a performance optimizing version of validate that can use a previous

--- a/packages/validate/src/test/validation.fuzz.test.ts
+++ b/packages/validate/src/test/validation.fuzz.test.ts
@@ -116,7 +116,7 @@ class RandomSource {
 	}
 }
 
-type TestType = {
+interface TestType {
 	validator: T.Validator<any>
 	generateValid: (source: RandomSource) => any
 	generateInvalid: (source: RandomSource) => any

--- a/scripts/lib/exec.ts
+++ b/scripts/lib/exec.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process'
 import { nicelog } from './nicelog'
 
-type ExecOpts = {
+interface ExecOpts {
 	pwd?: string
 	processStdoutLine?: (line: string) => void
 	processStderrLine?: (line: string) => void

--- a/scripts/lib/labels.ts
+++ b/scripts/lib/labels.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { REPO_ROOT, writeJsonFile } from './file'
 
-type Label = {
+interface Label {
 	// this is what the label is 'called' on github
 	name: string
 	// this is how we describe the label in our pull request template

--- a/scripts/lib/publishing.ts
+++ b/scripts/lib/publishing.ts
@@ -8,7 +8,7 @@ import { REPO_ROOT } from './file'
 import { nicelog } from './nicelog'
 import { getAllWorkspacePackages } from './workspace'
 
-export type PackageDetails = {
+export interface PackageDetails {
 	name: string
 	dir: string
 	localDeps: string[]

--- a/scripts/lib/workspace.ts
+++ b/scripts/lib/workspace.ts
@@ -6,7 +6,7 @@ export type PackageJson = { name: string; private?: boolean; workspaces?: string
 	string,
 	any
 >
-export type Package = {
+export interface Package {
 	packageJson: PackageJson
 	relativePath: string
 	path: string

--- a/scripts/prune-preview-deploys.ts
+++ b/scripts/prune-preview-deploys.ts
@@ -6,7 +6,7 @@ import { nicelog } from './lib/nicelog'
 // `env` instead. This makes sure that all required env vars are present.
 const env = makeEnv(['CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_API_TOKEN', 'GH_TOKEN'])
 
-type ListWorkersResult = {
+interface ListWorkersResult {
 	success: boolean
 	result: { id: string }[]
 }

--- a/scripts/refresh-assets.ts
+++ b/scripts/refresh-assets.ts
@@ -215,7 +215,10 @@ async function copyTranslations() {
 	// languages.ts
 
 	const languagesSource = await readJsonIfExists(join(sourceFolderPath, 'languages.json'))!
-	type Language = { label: string; locale: string }
+	interface Language {
+		label: string
+		locale: string
+	}
 	const languagesFile = `
 		/** @public */
 		export const LANGUAGES = ${JSON.stringify(


### PR DESCRIPTION
Typescript's type aliases (`type X = thing`) can refer to basically anything, which makes it hard to write an automatic document formatter for them. Interfaces on the other hand are only object, so they play much nicer with docs. Currently, object-flavoured type aliases don't really get expanded at all on our docs site, which means we have a bunch of docs content that's not shown on the site.

This diff introduces a lint rule that forces `interface X {foo: bar}`s instead of `type X = {foo: bar}` where possible, as it results in a much better documentation experience:

Before:
<img width="437" alt="Screenshot 2024-05-22 at 15 24 13" src="https://github.com/tldraw/tldraw/assets/1489520/32606fd1-6832-4a1e-aa5f-f0534d160c92">

After:
<img width="431" alt="Screenshot 2024-05-22 at 15 33 01" src="https://github.com/tldraw/tldraw/assets/1489520/4e0d59ee-c38e-4056-b9fd-6a7f15d28f0f">


### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `docs` — Changes to the documentation, examples, or templates.
- [x] `improvement` — Improving existing features


