### PR TITLE
Fix broken files

### DIFF
--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -18,7 +18,6 @@ import {
 	createTLStore,
 	exhaustiveSwitchError,
 	partition,
-	transact,
 } from '@tldraw/editor'
 import { TLUiToastsContextType } from '../../ui/context/toasts'
 import { TLUiTranslationKey } from '../../ui/hooks/useTranslation/TLUiTranslationKey'
@@ -292,7 +291,7 @@ export async function parseAndLoadDocument(
 	// just restore everything, so if the user has opened
 	// this file before they'll get their camera etc.
 	// restored. we could change this in the future.
-	transact(() => {
+	editor.store.atomic(() => {
 		const initialBounds = editor.getViewportScreenBounds().clone()
 		const isFocused = editor.getInstanceState().isFocused
 		editor.store.clear()


### PR DESCRIPTION
This PR fixes a bug that prevented files (which included an arrow) from opening correctly.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

1. Open a file that includes at least one arrow
