### PR TITLE
[fix] setCamera animates to constrained viewport

### DIFF
--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -757,3 +757,29 @@ describe('Outside behavior', () => {
 describe('Allows mixed values for x and y', () => {
 	it.todo('Allows different values to be set for x and y axes')
 })
+
+test('it animated towards the constrained viewport rather than the given viewport', () => {
+	// @ts-expect-error
+	const mockAnimateToViewport = (editor._animateToViewport = jest.fn())
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: {
+			...DEFAULT_CONSTRAINTS,
+			behavior: 'contain',
+			origin: { x: 0.5, y: 0.5 },
+			padding: { x: 100, y: 100 },
+			initialZoom: 'fit-max',
+		},
+	})
+
+	editor.setCamera(new Vec(-1000000, -1000000), { animation: { duration: 4000 } })
+	expect(mockAnimateToViewport).toHaveBeenCalledTimes(1)
+	expect(mockAnimateToViewport.mock.calls[0][0]).toMatchInlineSnapshot(`
+		Box {
+		  "h": 900,
+		  "w": 1600,
+		  "x": -200,
+		  "y": -0,
+		}
+	`)
+})


### PR DESCRIPTION
Before this PR, calling `setCamera` with an `animation` option would calculate the target viewport based on the camera passed in without first applying constraints. That meant that if the camera did indeed need to be constrained you'd end up with some funky animations.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
