### PR TITLE
tests: fix camera scroll flakiness

### DIFF
--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -137,6 +137,9 @@ test.describe('camera', () => {
 			zoomDirection: 'out',
 			steps: 3,
 		})
+
+		await page.waitForTimeout(1000)
+
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBeCloseTo(expectedZoomLevel, 1)
 	})
 


### PR DESCRIPTION
There's been some flakiness on the camera e2e tests. I _think_ this would help resolve it, theory being that it's not finished scrolling when we take the reading. 

example failure: https://github.com/tldraw/tldraw/actions/runs/9222574205/job/25373998190?pr=3827

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [x] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
