### PR TITLE
Remove alpha mention in installation for static assets

### DIFF
--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -141,7 +141,7 @@ If you use a CDN for hosting these files you can specify the base url of your as
 
 ```ts
 const assetUrls = getAssetUrls({
-	baseUrl: 'https://unpkg.com/@tldraw/assets@2.0.0-alpha.12/',
+	baseUrl: 'https://unpkg.com/@tldraw/assets',
 })
 ```
 


### PR DESCRIPTION
This PR changes a line in our static assets section of the docs.

### Change Type

- [x] `docs` — Changes to the documentation, examples, or templates.
- [x] `chore` — Updating dependencies, other boring stuff