### PR TITLE
Fix bug when resizing rotated arrows

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -506,15 +506,14 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				normalizedAnchor: endNormalizedAnchor.toJson(),
 			})
 		}
-
 		const next = {
+			...shape,
 			props: {
 				start,
 				end,
 				bend,
 			},
 		}
-
 		return next
 	}
 

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -506,13 +506,20 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				normalizedAnchor: endNormalizedAnchor.toJson(),
 			})
 		}
-		const next = {
-			...shape,
+		let next = {
 			props: {
 				start,
 				end,
 				bend,
 			},
+		}
+		if (bindings.start || bindings.end) {
+			next = {
+				...shape,
+				props: {
+					...next.props,
+				},
+			}
 		}
 		return next
 	}


### PR DESCRIPTION
Fixes #3839 The arrow shape wasn't being returned at the end which meant the rotation wasn't preserved.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

-  Create 2 shapes with an arrow binding them
- Select one shape and the arrow and rotate
- Select all three shapes and resize
- Resizing should work as normal 

### Release Notes

- Fix a bug with resizing rotated arrows
