### PR TITLE
[Experiment] Make black stickies yellow in dark mode

### DIFF
--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -232,7 +232,7 @@ export const DefaultColorThemePalette: {
 		black: {
 			solid: '#f2f2f2',
 			note: {
-				fill: '#2c2c2c',
+				fill: '#B57E00',
 				text: '#f2f2f2',
 			},
 			semi: '#2c3036',


### PR DESCRIPTION
Make default stickies yellow 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. In dark mode.
2. Make a sticky.
3. Make sure it's yellow.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Made default stickies yellow in dark mode.
