### PR TITLE
tests: fix edit→edit flakiness

### DIFF
--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -197,29 +197,31 @@ test.describe('Focus', () => {
 		expect(await page.evaluate(() => document.activeElement?.nodeName === 'TEXTAREA')).toBe(true)
 	})
 
-	// test('edit->edit, focus stays in the text areas when going from shape-to-shape', async ({
-	// 	page,
-	// }) => {
-	// 	await page.goto('http://localhost:5420/end-to-end')
-	// 	await page.waitForSelector('.tl-canvas')
+	test('edit->edit, focus stays in the text areas when going from shape-to-shape', async ({
+		page,
+	}) => {
+		await page.goto('http://localhost:5420/end-to-end')
+		await page.waitForSelector('.tl-canvas')
 
-	// 	const EditorA = (await page.$(`.tl-container`))!
-	// 	expect(EditorA).toBeTruthy()
+		const EditorA = (await page.$(`.tl-container`))!
+		expect(EditorA).toBeTruthy()
 
-	// 	// Create a new note, text should be focused
-	// 	await page.keyboard.press('n')
-	// 	await (await page.$('body'))?.click()
-	// 	await page.waitForSelector('.tl-shape')
-	// 	await page.keyboard.type('test')
+		// Create a new note, text should be focused
+		await page.keyboard.press('n')
+		await (await page.$('body'))?.click()
+		await page.waitForSelector('.tl-shape')
+		await page.keyboard.type('test')
 
-	// 	// create new note next to it
-	// 	await page.keyboard.press('Tab')
+		// create new note next to it
+		await page.keyboard.press('Tab')
 
-	// 	await (await page.$('body'))?.click()
+		await (await page.$('body'))?.click()
 
-	// 	// First note's textarea should be focused.
-	// 	expect(await EditorA.evaluate(() => !!document.querySelector('.tl-shape textarea:focus'))).toBe(
-	// 		true
-	// 	)
-	// })
+		await page.waitForTimeout(1000)
+
+		// First note's textarea should be focused.
+		expect(await EditorA.evaluate(() => !!document.querySelector('.tl-shape textarea:focus'))).toBe(
+			true
+		)
+	})
 })


### PR DESCRIPTION
Similar to https://github.com/tldraw/tldraw/pull/3829

Trying to see if adding a small timeout helps fix this flaky test.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [x] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
