### PR TITLE
npm: improve tldraw package readme

### DIFF
--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -6,8 +6,13 @@
 </div>
 
 # tldraw
+<div style="margin: -1.5rem 0 1.5rem 0; font-size: 12px;">a very good whiteboard</div>
 
-This package contains the source code for the tldraw library. Learn more at our docs site: [tldraw.dev](https://tldraw.dev).
+You can use the tldraw SDK to craft infinite canvas experiences for the web. It's perfect for collaborative whiteboards but you can use it for lots of other things, too.
+
+Learn more at our docs site: [tldraw.dev](https://tldraw.dev).
+
+This package is the main entry point when using tldraw. It's part of a larger suite of packages that you can find [here](https://www.npmjs.com/search?q=%40tldraw).
 
 ## Installation
 
@@ -15,12 +20,6 @@ Install the `tldraw` package.
 
 ```bash
 npm i tldraw
-```
-
-Then start the local development server.
-
-```bash
-npm run dev
 ```
 
 ## Usage
@@ -35,6 +34,15 @@ export default function () {
 ```
 
 Visit or [docs site](https://tldraw.dev) to learn more. See our [examples folder](https://github.com/tldraw/tldraw/tree/main/apps/examples) for more examples.
+
+
+## Package development
+
+To start the local development server:
+
+```bash
+npm run dev
+```
 
 ## Community
 

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -6,6 +6,7 @@
 </div>
 
 # tldraw
+
 <div style="margin: -1.5rem 0 1.5rem 0; font-size: 12px;">a very good whiteboard</div>
 
 You can use the tldraw SDK to craft infinite canvas experiences for the web. It's perfect for collaborative whiteboards but you can use it for lots of other things, too.
@@ -34,7 +35,6 @@ export default function () {
 ```
 
 Visit or [docs site](https://tldraw.dev) to learn more. See our [examples folder](https://github.com/tldraw/tldraw/tree/main/apps/examples) for more examples.
-
 
 ## Package development
 


### PR DESCRIPTION
If you get to tldraw via the npm search results, you get to a readme that is very ...odd, or at least uninviting. It tells you this is the source code (hah, ok? :P) and tells you to run the local development server to get started. Nope! We should be clearer here.

Screenshot:
<img width="926" alt="Screenshot 2024-05-30 at 14 11 33" src="https://github.com/tldraw/tldraw/assets/469604/64fcce89-981b-4ae7-8b85-2762820888df">


### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [x] `dunno` — I don't know

