### PR TITLE
test: disable camera pinch test for now, too flaky

### DIFF
--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -118,6 +118,9 @@ test.describe('camera', () => {
 	})
 
 	test('pinching on trackpad', async ({ page, isMobile }) => {
+		// Test is flaky, disabling.
+		test.skip(true)
+
 		// pinching on trackpad is the same event as ctrl+scrollwheel
 		test.skip(isMobile)
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(1)
@@ -137,8 +140,6 @@ test.describe('camera', () => {
 			zoomDirection: 'out',
 			steps: 3,
 		})
-
-		await page.waitForTimeout(1000)
 
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBeCloseTo(expectedZoomLevel, 1)
 	})


### PR DESCRIPTION
this didn't work https://github.com/tldraw/tldraw/pull/3829
disabling this test for now

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [x] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

