### PR TITLE
timeouts: rework effectschedule timeout tracking

### DIFF
--- a/packages/state/src/lib/core/EffectScheduler.ts
+++ b/packages/state/src/lib/core/EffectScheduler.ts
@@ -35,7 +35,7 @@ interface EffectSchedulerOptions {
 	 * @param execute - A function that will execute the effect.
 	 * @returns
 	 */
-	scheduleEffect?: (execute: () => void) => number | void | (() => void)
+	scheduleEffect?: (execute: () => void) => void
 }
 
 class __EffectScheduler__<Result> {
@@ -64,14 +64,12 @@ class __EffectScheduler__<Result> {
 	}
 
 	/** @internal */
-	private maybeRaf: number | void | (() => void) = -1
-	/** @internal */
 	readonly parentSet = new ArraySet<Signal<any, any>>()
 	/** @internal */
 	readonly parentEpochs: number[] = []
 	/** @internal */
 	readonly parents: Signal<any, any>[] = []
-	private readonly _scheduleEffect?: (execute: () => void) => number | void | (() => void)
+	private readonly _scheduleEffect?: (execute: () => void) => void
 	constructor(
 		public readonly name: string,
 		private readonly runEffect: (lastReactedEpoch: number) => Result,
@@ -101,7 +99,7 @@ class __EffectScheduler__<Result> {
 		this._scheduleCount++
 		if (this._scheduleEffect) {
 			// if the effect should be deferred (e.g. until a react render), do so
-			this.maybeRaf = this._scheduleEffect(this.maybeExecute)
+			this._scheduleEffect(this.maybeExecute)
 		} else {
 			// otherwise execute right now!
 			this.execute()
@@ -137,7 +135,6 @@ class __EffectScheduler__<Result> {
 		for (let i = 0, n = this.parents.length; i < n; i++) {
 			detach(this.parents[i], this)
 		}
-		typeof this.maybeRaf === 'number' && cancelAnimationFrame(this.maybeRaf)
 	}
 
 	/**

--- a/packages/state/src/lib/react/useReactor.ts
+++ b/packages/state/src/lib/react/useReactor.ts
@@ -1,16 +1,16 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { EffectScheduler } from '../core'
 
 /** @public */
 export function useReactor(name: string, reactFn: () => void, deps: undefined | any[] = []) {
-	const [raf, setRaf] = useState(-1)
+	const raf = useRef(-1)
 	const scheduler = useMemo(
 		() =>
 			new EffectScheduler(name, reactFn, {
 				scheduleEffect: (cb) => {
-					const raf = requestAnimationFrame(cb)
-					setRaf(raf)
-					return raf
+					const rafId = requestAnimationFrame(cb)
+					raf.current = rafId
+					return rafId
 				},
 			}),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -22,7 +22,7 @@ export function useReactor(name: string, reactFn: () => void, deps: undefined | 
 		scheduler.execute()
 		return () => {
 			scheduler.detach()
-			cancelAnimationFrame(raf)
+			cancelAnimationFrame(raf.current)
 		}
 	}, [scheduler, raf])
 }

--- a/packages/state/src/lib/react/useReactor.ts
+++ b/packages/state/src/lib/react/useReactor.ts
@@ -24,5 +24,5 @@ export function useReactor(name: string, reactFn: () => void, deps: undefined | 
 			scheduler.detach()
 			cancelAnimationFrame(raf.current)
 		}
-	}, [scheduler, raf])
+	}, [scheduler])
 }

--- a/packages/state/src/lib/react/useReactor.ts
+++ b/packages/state/src/lib/react/useReactor.ts
@@ -1,10 +1,18 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { EffectScheduler } from '../core'
 
 /** @public */
 export function useReactor(name: string, reactFn: () => void, deps: undefined | any[] = []) {
+	const [raf, setRaf] = useState(-1)
 	const scheduler = useMemo(
-		() => new EffectScheduler(name, reactFn, { scheduleEffect: (cb) => requestAnimationFrame(cb) }),
+		() =>
+			new EffectScheduler(name, reactFn, {
+				scheduleEffect: (cb) => {
+					const raf = requestAnimationFrame(cb)
+					setRaf(raf)
+					return raf
+				},
+			}),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		deps
 	)
@@ -14,6 +22,7 @@ export function useReactor(name: string, reactFn: () => void, deps: undefined | 
 		scheduler.execute()
 		return () => {
 			scheduler.detach()
+			cancelAnimationFrame(raf)
 		}
-	}, [scheduler])
+	}, [scheduler, raf])
 }


### PR DESCRIPTION
talked to @ds300 and decided that we needed to rework this latest bit to cleanup outside of `EffectScheduler`

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
