### PR TITLE
Fix drag distance

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8730,7 +8730,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (
 							inputs.isPointing &&
 							!inputs.isDragging &&
-							Vec.Dist2(originPagePoint, currentPagePoint) >
+							Vec.Dist2(originPagePoint, currentPagePoint) * this.getZoomLevel() >
 								(instanceState.isCoarsePointer
 									? this.options.coarseDragDistanceSquared
 									: this.options.dragDistanceSquared) /

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -691,7 +691,7 @@ describe('dragging', () => {
 	})
 
 	it('drags correctly at 150% zoom', () => {
-		editor.setCamera({ x: 0, y: 0, z: 2 }).forceTick()
+		editor.setCamera({ x: 0, y: 0, z: 8 }).forceTick()
 
 		expect(editor.inputs.isDragging).toBe(false)
 		editor.pointerMove(0, 0).pointerDown()
@@ -703,7 +703,7 @@ describe('dragging', () => {
 	})
 
 	it('drags correctly at 50% zoom', () => {
-		editor.setCamera({ x: 0, y: 0, z: 0.5 }).forceTick()
+		editor.setCamera({ x: 0, y: 0, z: 0.1 }).forceTick()
 
 		expect(editor.inputs.isDragging).toBe(false)
 		editor.pointerMove(0, 0).pointerDown()

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -678,3 +678,39 @@ describe('middle-click panning', () => {
 		expect(editor.inputs.isPanning).toBe(false)
 	})
 })
+
+describe('dragging', () => {
+	it('drags correctly at 100% zoom', () => {
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 0).pointerDown()
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 1)
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 5)
+		expect(editor.inputs.isDragging).toBe(true)
+	})
+
+	it('drags correctly at 150% zoom', () => {
+		editor.setCamera({ x: 0, y: 0, z: 2 }).forceTick()
+
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 0).pointerDown()
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 2)
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 5)
+		expect(editor.inputs.isDragging).toBe(true)
+	})
+
+	it('drags correctly at 50% zoom', () => {
+		editor.setCamera({ x: 0, y: 0, z: 0.5 }).forceTick()
+
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 0).pointerDown()
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 2)
+		expect(editor.inputs.isDragging).toBe(false)
+		editor.pointerMove(0, 5)
+		expect(editor.inputs.isDragging).toBe(true)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where the drag distance for an interaction was being measured in page space rather than screen space. It should be measured in screen space. The actual check for `isDragging` is a little ugly but this is correct.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

1. Zoom in
2. Drag the center handle of an arrow shape

- [x] Unit Tests

### Release Notes

- Fixed a bug where the minimum distance for a drag was wrong when zoomed in or out.