### PR TITLE
Fix Content-Security-Policy browser warnings

### DIFF
--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -14,7 +14,7 @@ const commonSecurityHeaders = {
 	'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
 	'X-Content-Type-Options': 'nosniff',
 	'Referrer-Policy': 'no-referrer-when-downgrade',
-	'Content-Security-Policy': 'default-src: *',
+	'Content-Security-Policy': 'default-src *',
 }
 
 // We load the list of routes that should be forwarded to our SPA's index.html here.


### PR DESCRIPTION
I recently noticed some browser error spam in my [tldraw-cli](https://github.com/kitschpatrol/tldraw-cli) tool...

```sh
The Content-Security-Policy directive name 'default-src:' contains one or more invalid characters. Only ASCII alphanumeric characters or dashes '-' are allowed in directive names.
```

Also seeing the same on tldraw.com in the browser console:

```sh
Unrecognized Content-Security-Policy directive 'default-src:'.
```

Looks like `'Content-Security-Policy': 'default-src: *'` is not [valid syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources) for this header, instead we need 'Content-Security-Policy': 'default-src *'.

This heroic PR deletes a single `:` character to correct the syntax and silence the error. 😅

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [x] End to end tests

It could certainly be automated... but I've just been looking at the browser console.

### Release Notes

- Fix Content-Security-Policy warnings
