### PR TITLE
csp: disable for now

### DIFF
--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -14,7 +14,7 @@ const commonSecurityHeaders = {
 	'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
 	'X-Content-Type-Options': 'nosniff',
 	'Referrer-Policy': 'no-referrer-when-downgrade',
-	'Content-Security-Policy': 'default-src *',
+	'Content-Security-Policy': `default-src 'unsafe-inline' 'unsafe-eval' data: blob: ws: *`,
 }
 
 // We load the list of routes that should be forwarded to our SPA's index.html here.

--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -14,7 +14,7 @@ const commonSecurityHeaders = {
 	'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
 	'X-Content-Type-Options': 'nosniff',
 	'Referrer-Policy': 'no-referrer-when-downgrade',
-	'Content-Security-Policy': `default-src 'unsafe-inline' 'unsafe-eval' data: blob: ws: *`,
+	// 'Content-Security-Policy': `default-src 'unsafe-inline' data: blob: ws: *`,
 }
 
 // We load the list of routes that should be forwarded to our SPA's index.html here.


### PR DESCRIPTION
the fix in https://github.com/tldraw/tldraw/pull/3906 actually made things worse. the CSP setting was broken from the beginning. i'll rework it in another PR.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
