### PR TITLE
Fix 'insert media' undo operation

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -14,6 +14,7 @@ export function useInsertMedia() {
 		async function onchange(e: Event) {
 			const fileList = (e.target as HTMLInputElement).files
 			if (!fileList || fileList.length === 0) return
+			editor.mark('insert media')
 			await editor.putExternalContent({
 				type: 'files',
 				files: Array.from(fileList),


### PR DESCRIPTION
Before:

1. draw a shape
2. insert media (click the button in the toolbar, upload an image)
3. hit undo
4. the media disappears but so does the shape

After:

4. the media disappears the the shape remains 💆🏼 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
