### PR TITLE
Make ArrowBindingUtil public

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -9,6 +9,11 @@
 import { ArrayOfValidator } from '@tldraw/editor';
 import { BaseBoxShapeTool } from '@tldraw/editor';
 import { BaseBoxShapeUtil } from '@tldraw/editor';
+import { BindingOnChangeOptions } from '@tldraw/editor';
+import { BindingOnCreateOptions } from '@tldraw/editor';
+import { BindingOnShapeChangeOptions } from '@tldraw/editor';
+import { BindingOnShapeIsolateOptions } from '@tldraw/editor';
+import { BindingUtil } from '@tldraw/editor';
 import { Box } from '@tldraw/editor';
 import { Circle2d } from '@tldraw/editor';
 import { ComponentType } from 'react';
@@ -37,6 +42,7 @@ import * as React_3 from 'react';
 import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { ReadonlySharedStyleMap } from '@tldraw/editor';
+import { RecordProps } from '@tldraw/editor';
 import { Rectangle2d } from '@tldraw/editor';
 import { RecursivePartial } from '@tldraw/editor';
 import { Result } from '@tldraw/editor';
@@ -50,6 +56,7 @@ import { T } from '@tldraw/editor';
 import { TLAnyBindingUtilConstructor } from '@tldraw/editor';
 import { TLAnyShapeUtilConstructor } from '@tldraw/editor';
 import { TLArrowBinding } from '@tldraw/editor';
+import { TLArrowBindingProps } from '@tldraw/editor';
 import { TLArrowShape } from '@tldraw/editor';
 import { TLArrowShapeArrowheadStyle } from '@tldraw/editor';
 import { TLAssetId } from '@tldraw/editor';
@@ -129,6 +136,28 @@ export function AlignMenuItems(): JSX_2.Element;
 
 // @public (undocumented)
 export function ArrangeMenuSubmenu(): JSX_2.Element | null;
+
+// @public (undocumented)
+export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
+    // (undocumented)
+    getDefaultProps(): Partial<TLArrowBindingProps>;
+    // (undocumented)
+    static migrations: TLPropsMigrations;
+    // (undocumented)
+    onAfterChange({ bindingAfter }: BindingOnChangeOptions<TLArrowBinding>): void;
+    // (undocumented)
+    onAfterChangeFromShape({ shapeAfter, }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
+    // (undocumented)
+    onAfterChangeToShape({ binding }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
+    // (undocumented)
+    onAfterCreate({ binding }: BindingOnCreateOptions<TLArrowBinding>): void;
+    // (undocumented)
+    onBeforeIsolateFromShape({ binding, }: BindingOnShapeIsolateOptions<TLArrowBinding>): void;
+    // (undocumented)
+    static props: RecordProps<TLArrowBinding>;
+    // (undocumented)
+    static type: string;
+}
 
 // @public (undocumented)
 export function ArrowDownToolbarItem(): JSX_2.Element;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -5,6 +5,7 @@ export * from '@tldraw/editor'
 
 export { Tldraw, type TLComponents, type TldrawProps } from './lib/Tldraw'
 export { TldrawImage, type TldrawImageProps } from './lib/TldrawImage'
+export { ArrowBindingUtil } from './lib/bindings/arrow/ArrowBindingUtil'
 export { TldrawHandles } from './lib/canvas/TldrawHandles'
 export { TldrawScribble } from './lib/canvas/TldrawScribble'
 export { TldrawSelectionBackground } from './lib/canvas/TldrawSelectionBackground'

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -24,6 +24,9 @@ import {
 } from '@tldraw/editor'
 import { getArrowBindings, getArrowInfo, removeArrowBinding } from '../../shapes/arrow/shared'
 
+/**
+ * @public
+ */
 export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 	static override type = 'arrow'
 


### PR DESCRIPTION
I wanted to extend the arrow binding util to adapt holograph for the bindings api, but it wasn't being exported like all the shape utils were. I could have plucked it from the `defaultBindingUtils` array but that felt dirty. What do you think @SomeHats ?

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
