### PR TITLE
Move from unpkg to our own cdn.

### DIFF
--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -137,11 +137,11 @@ const assetUrls = getAssetUrls()
 
 While these files must be available, you can overwrite the individual files: for example, by placing different icons under the same name or modifying / adding translations.
 
-If you use a CDN for hosting these files you can specify the base url of your assets. To recreate the above option of serving the assets from unpkg you would do the following:
+If you use a CDN for hosting these files you can specify the base url of your assets. To recreate the above option of serving the assets from our CDN you would do the following:
 
 ```ts
 const assetUrls = getAssetUrls({
-	baseUrl: 'https://unpkg.com/@tldraw/assets',
+	baseUrl: 'https://https://cdn.tldraw.xyz/',
 })
 ```
 

--- a/apps/examples/src/examples/static-assets/StaticAssetsExample.tsx
+++ b/apps/examples/src/examples/static-assets/StaticAssetsExample.tsx
@@ -22,5 +22,5 @@ export default function StaticAssetsExample() {
 
 /**
 These assets are stored in the /public folder of this Vite project, but this could be any URL.
-By default, the Tldraw component will pull in assets from the @tldraw/assets package on Unpkg.
+By default, the Tldraw component will pull in assets from tldraw's asset CDN.
 */

--- a/packages/tldraw/setupTests.js
+++ b/packages/tldraw/setupTests.js
@@ -38,7 +38,7 @@ Object.defineProperty(global.URL, 'createObjectURL', {
 const { version } = require('./package.json')
 
 window.fetch = async (input, init) => {
-	if (input === `https://unpkg.com/@tldraw/assets@${version}/translations/en.json`) {
+	if (input === `https://cdn.tldraw.xyz/${version}/translations/en.json`) {
 		const json = await import('@tldraw/assets/translations/main.json')
 		return {
 			ok: true,

--- a/packages/tldraw/src/lib/ui/assetUrls.ts
+++ b/packages/tldraw/src/lib/ui/assetUrls.ts
@@ -16,21 +16,18 @@ export type TLUiAssetUrlOverrides = RecursivePartial<TLUiAssetUrls>
 export let defaultUiAssetUrls: TLUiAssetUrls = {
 	...defaultEditorAssetUrls,
 	icons: Object.fromEntries(
-		iconTypes.map((name) => [
-			name,
-			`https://unpkg.com/@tldraw/assets@${version}/icons/icon/${name}.svg`,
-		])
+		iconTypes.map((name) => [name, `https://cdn.tldraw.xyz/${version}/icons/icon/${name}.svg`])
 	) as Record<TLUiIconType, string>,
 	translations: Object.fromEntries(
 		LANGUAGES.map((lang) => [
 			lang.locale,
-			`https://unpkg.com/@tldraw/assets@${version}/translations/${lang.locale}.json`,
+			`https://cdn.tldraw.xyz/${version}/translations/${lang.locale}.json`,
 		])
 	) as Record<(typeof LANGUAGES)[number]['locale'], string>,
 	embedIcons: Object.fromEntries(
 		EMBED_DEFINITIONS.map((def) => [
 			def.type,
-			`https://unpkg.com/@tldraw/assets@${version}/embed-icons/${def.type}.png`,
+			`https://cdn.tldraw.xyz/${version}/embed-icons/${def.type}.png`,
 		])
 	) as Record<(typeof EMBED_DEFINITIONS)[number]['type'], string>,
 }

--- a/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
+++ b/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
@@ -15,10 +15,10 @@ export interface TLEditorAssetUrls {
 /** @public */
 export let defaultEditorAssetUrls: TLEditorAssetUrls = {
 	fonts: {
-		draw: `https://unpkg.com/@tldraw/assets@${version}/fonts/Shantell_Sans-Tldrawish.woff2`,
-		serif: `https://unpkg.com/@tldraw/assets@${version}/fonts/IBMPlexSerif-Medium.woff2`,
-		sansSerif: `https://unpkg.com/@tldraw/assets@${version}/fonts/IBMPlexSans-Medium.woff2`,
-		monospace: `https://unpkg.com/@tldraw/assets@${version}/fonts/IBMPlexMono-Medium.woff2`,
+		draw: `https://cdn.tldraw.xyz/${version}/fonts/Shantell_Sans-Tldrawish.woff2`,
+		serif: `https://cdn.tldraw.xyz/${version}/fonts/IBMPlexSerif-Medium.woff2`,
+		sansSerif: `https://cdn.tldraw.xyz/${version}/fonts/IBMPlexSans-Medium.woff2`,
+		monospace: `https://cdn.tldraw.xyz/${version}/fonts/IBMPlexMono-Medium.woff2`,
 	},
 }
 


### PR DESCRIPTION
Switches from unpkg to our own cdn files.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [x] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Start using our own cdn instead of unpkg.
