### PR TITLE
docs/shapes: update import from 'tldraw' to '@tldraw/tldraw'

### DIFF
--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -96,7 +96,7 @@ You can create your own custom shapes. In the examples below, we will create a c
 In tldraw's data model, each shape is represented by a JSON object. Let's first create a type that describes what this object will look like.
 
 ```ts
-import { TLBaseShape } from 'tldraw'
+import { TLBaseShape } from '@tldraw/tldraw'
 
 type CardShape = TLBaseShape<'card', { w: number; h: number }>
 ```
@@ -112,7 +112,7 @@ While tldraw's shapes themselves are simple JSON objects, we use [ShapeUtil](?) 
 Let's create a [ShapeUtil](?) class for the shape.
 
 ```tsx
-import { HTMLContainer, ShapeUtil } from 'tldraw'
+import { HTMLContainer, ShapeUtil } from '@tldraw/tldraw'
 
 class CardShapeUtil extends ShapeUtil<CardShape> {
 	static override type = 'card' as const


### PR DESCRIPTION
I had to tweak the imports when copy-pasting

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [x] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [x] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan
N/A

### Release Notes

- docs/shapes.mdx: update tldraw imports in code snippets
