### PR TITLE
assets: add crossorigin tag for preloaded fonts

### DIFF
--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -76,7 +76,7 @@ async function build() {
 		href="/assets/${assetsList.find((a) => a.startsWith(font))}"
 		as="font"
 		type="font/woff2"
-		crossorigin
+		crossorigin="anonymous"
 	/>`
 				)
 				.join('\n')

--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -76,6 +76,7 @@ async function build() {
 		href="/assets/${assetsList.find((a) => a.startsWith(font))}"
 		as="font"
 		type="font/woff2"
+		crossorigin
 	/>`
 				)
 				.join('\n')


### PR DESCRIPTION
Looks like we need the `crossorigin` tag ¯\\_(ツ)_/¯ 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
