### PR TITLE
assets: fix up videos with indexedDB

### DIFF
--- a/apps/dotcom/src/utils/assetHandler.ts
+++ b/apps/dotcom/src/utils/assetHandler.ts
@@ -15,12 +15,6 @@ export const resolveAsset =
 	async (asset: TLAsset | null | undefined, context: AssetContextProps) => {
 		if (!asset || !asset.props.src) return null
 
-		// We don't deal with videos at the moment.
-		if (asset.type === 'video') return asset.props.src
-
-		// Assert it's an image to make TS happy.
-		if (asset.type !== 'image') return null
-
 		// Retrieve a local image from the DB.
 		if (persistenceKey && asset.props.src.startsWith('asset:')) {
 			return await objectURLCache.get(
@@ -28,6 +22,12 @@ export const resolveAsset =
 				async () => await getLocalAssetObjectURL(persistenceKey, asset.id)
 			)
 		}
+
+		// We don't deal with videos at the moment.
+		if (asset.type === 'video') return asset.props.src
+
+		// Assert it's an image to make TS happy.
+		if (asset.type !== 'image') return null
 
 		// Don't try to transform data: URLs, yikes.
 		if (!asset.props.src.startsWith('http:') && !asset.props.src.startsWith('https:'))

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -580,12 +580,6 @@ export const defaultResolveAsset =
 	(persistenceKey?: string) => async (asset: TLAsset | null | undefined) => {
 		if (!asset || !asset.props.src) return null
 
-		// We don't deal with videos at the moment.
-		if (asset.type === 'video') return asset.props.src
-
-		// Assert it's an image to make TS happy.
-		if (asset.type !== 'image') return null
-
 		// Retrieve a local image from the DB.
 		if (persistenceKey && asset.props.src.startsWith('asset:')) {
 			return await objectURLCache.get(
@@ -593,6 +587,12 @@ export const defaultResolveAsset =
 				async () => await getLocalAssetObjectURL(persistenceKey, asset.id)
 			)
 		}
+
+		// We don't deal with videos at the moment.
+		if (asset.type === 'video') return asset.props.src
+
+		// Assert it's an image to make TS happy.
+		if (asset.type !== 'image') return null
 
 		return asset.props.src
 	}


### PR DESCRIPTION
Whoops, the logic needs to check for `asset:` first before videos.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know
