### PR TITLE
bookmark: css tweaks

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -946,7 +946,7 @@ input,
 }
 
 .tl-bookmark__image_container {
-	flex: 1;
+	flex: 1 1 100%;
 	overflow: hidden;
 	border-top-left-radius: var(--radius-1);
 	border-top-right-radius: var(--radius-1);
@@ -980,6 +980,10 @@ input,
 	background-color: var(--color-muted);
 	padding: var(--space-4);
 	pointer-events: all;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	flex: 1;
 }
 
 .tl-bookmark__heading,

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -22,7 +22,7 @@ import { getRotatedBoxShadow } from '../shared/rotated-box-shadow'
 const BOOKMARK_WIDTH = 300
 const BOOKMARK_HEIGHT = 320
 const BOOKMARK_JUST_URL_HEIGHT = 46
-const SHORT_BOOKMARK_HEIGHT = 110
+const SHORT_BOOKMARK_HEIGHT = 101
 
 /** @public */
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {


### PR DESCRIPTION
just some padding tweaks:

before:
<img width="1108" alt="Screenshot 2024-06-17 at 12 29 03" src="https://github.com/tldraw/tldraw/assets/469604/ec497963-fc3b-442b-a3ee-70d89fb5dbe7">

after:
<img width="1147" alt="Screenshot 2024-06-17 at 12 28 32" src="https://github.com/tldraw/tldraw/assets/469604/3f5b048d-127f-4bb6-b631-d16b59277874">



### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Bookmarks: padding tweaks
