### PR TITLE
assets: fix copy/paste with missing src

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -28,7 +28,7 @@ export function useAsset(assetId: TLAssetId | null, width: number) {
 			clearTimeout(timer)
 			isCancelled = true
 		}
-	}, [assetId, screenScale, editor])
+	}, [assetId, asset?.props.src, screenScale, editor])
 
 	return { asset, url }
 }


### PR DESCRIPTION
There was a race condition when pasting tldraw content. The paste would sometimes resolve in time and sometimes not. We need to listen to when the asset is actually updated/synced in the db.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Assets: fix copy/paste for new asset resolver mechanic.
