### PR TITLE
images: make isAnimated check on shared rooms work better

### DIFF
--- a/apps/dotcom/src/hooks/useMultiplayerAssets.ts
+++ b/apps/dotcom/src/hooks/useMultiplayerAssets.ts
@@ -35,11 +35,7 @@ export function useMultiplayerAssets(assetUploaderUrl: string) {
 
 			if (isImageType) {
 				size = await MediaHelpers.getImageSize(file)
-				if (MediaHelpers.isAnimatedImageType(file.type)) {
-					isAnimated = true // await getIsGifAnimated(file) todo export me from editor
-				} else {
-					isAnimated = false
-				}
+				isAnimated = await MediaHelpers.isAnimated(file)
 			} else {
 				isAnimated = true
 				size = await MediaHelpers.getVideoSize(file)

--- a/apps/dotcom/src/utils/createAssetFromFile.ts
+++ b/apps/dotcom/src/utils/createAssetFromFile.ts
@@ -33,11 +33,7 @@ export async function createAssetFromFile({ file }: { type: 'file'; file: File }
 
 	if (isImageType) {
 		size = await MediaHelpers.getImageSize(file)
-		if (MediaHelpers.isAnimatedImageType(file.type)) {
-			isAnimated = true // await getIsGifAnimated(file) todo export me from editor
-		} else {
-			isAnimated = false
-		}
+		isAnimated = await MediaHelpers.isAnimated(file)
 	} else {
 		isAnimated = true
 		size = await MediaHelpers.getVideoSize(file)


### PR DESCRIPTION
We just never ended up wiring this up.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Images: fix isAnimated checks when adding an image to a shared room.
