### PR TITLE
Fix scale issue with new draw lines

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -650,6 +650,9 @@ export class Drawing extends StateNode {
 							y: toFixed(inputs.currentPagePoint.y),
 							props: {
 								isPen: this.isPenOrStylus,
+								scale: this.editor.user.getIsDynamicResizeMode()
+									? 1 / this.editor.getZoomLevel()
+									: 1,
 								segments: [
 									{
 										type: 'free',


### PR DESCRIPTION
This PR fixes a bug where new draw shapes (created after 500 points) would have scale 1.

### Change Type

- [x] `sdk` — Changes the tldraw SDK
- [x] `bugfix` — Bug fix

### Test Plan

1. Zoom in a lot
2. Draw for a long time
3. When the new draw shape happens, the new draw shape should have the correct scale
