### PR TITLE
Fix border color for following user

### DIFF
--- a/packages/editor/src/lib/hooks/usePresence.ts
+++ b/packages/editor/src/lib/hooks/usePresence.ts
@@ -15,7 +15,7 @@ export function usePresence(userId: string): TLInstancePresence | null {
 		() => {
 			return editor.getCollaborators().find((c) => c.userId === userId)
 		},
-		[editor]
+		[editor, userId]
 	)
 
 	return latestPresence ?? null


### PR DESCRIPTION
bad hook deps was causing the wrong presence record to be returned when switching between following users.

This also seems to have fixed the issue where the user following state wasn't updating on android

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
