### PR TITLE
Hotfix to publish vs code

### DIFF
--- a/scripts/publish-vscode-extension.ts
+++ b/scripts/publish-vscode-extension.ts
@@ -34,6 +34,7 @@ async function updateExtensionVersion() {
 }
 
 async function packageAndPublish() {
+	await exec('yarn', ['lazy', 'run', 'build', '--filter=packages/*'])
 	await exec('yarn', ['package'], { pwd: EXTENSION_DIR })
 	await exec('yarn', ['publish'], { pwd: EXTENSION_DIR })
 }


### PR DESCRIPTION
Hotfixed the VS Code publishing workflow. See #3976 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [x] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [x] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Fix VS Code publishing.
