### PR TITLE
[experiment] measure when shapes update, not when shapes render

### DIFF
--- a/apps/dotcom/src/components/CursorChatBubble.tsx
+++ b/apps/dotcom/src/components/CursorChatBubble.tsx
@@ -110,7 +110,7 @@ const CursorChatInput = track(function CursorChatInput({
 		const elm = ref.current
 		if (!elm) return
 
-		const textMeasurement = editor.textMeasure.measureText(value || placeholder, {
+		const textMeasurement = editor.textMeasure!.measureText(value || placeholder, {
 			fontFamily: 'var(--font-body)',
 			fontSize: 12,
 			fontWeight: '500',

--- a/apps/examples/e2e/tests/test-text.spec.ts
+++ b/apps/examples/e2e/tests/test-text.spec.ts
@@ -63,7 +63,7 @@ test.describe('text measurement', () => {
 
 	test('measures text', async () => {
 		const { w, h } = await page.evaluate<{ w: number; h: number }, typeof measureTextOptions>(
-			async (options) => editor.textMeasure.measureText('testing', options),
+			async (options) => editor.textMeasure!.measureText('testing', options),
 			measureTextOptions
 		)
 
@@ -88,7 +88,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('testing', options),
+			async (options) => editor.textMeasure!.measureTextSpans('testing', options),
 			measureTextSpansOptions
 		)
 
@@ -100,7 +100,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('testing', { ...options, width: 50 }),
+			async (options) => editor.textMeasure!.measureTextSpans('testing', { ...options, width: 50 }),
 			measureTextSpansOptions
 		)
 
@@ -112,7 +112,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('testing   testing', options),
+			async (options) => editor.textMeasure!.measureTextSpans('testing   testing', options),
 			measureTextSpansOptions
 		)
 
@@ -124,7 +124,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('testing testing   ', options),
+			async (options) => editor.textMeasure!.measureTextSpans('testing testing   ', options),
 			measureTextSpansOptions
 		)
 
@@ -140,7 +140,7 @@ test.describe('text measurement', () => {
 			typeof measureTextSpansOptions
 		>(
 			async (options) =>
-				editor.textMeasure.measureTextSpans('testing testing   ', { ...options, width: 200 }),
+				editor.textMeasure!.measureTextSpans('testing testing   ', { ...options, width: 200 }),
 			measureTextSpansOptions
 		)
 
@@ -153,7 +153,7 @@ test.describe('text measurement', () => {
 			typeof measureTextSpansOptions
 		>(
 			async (options) =>
-				editor.textMeasure.measureTextSpans('  testing testing', { ...options, width: 200 }),
+				editor.textMeasure!.measureTextSpans('  testing testing', { ...options, width: 200 }),
 			measureTextSpansOptions
 		)
 
@@ -165,7 +165,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('  testing testing', options),
+			async (options) => editor.textMeasure!.measureTextSpans('  testing testing', options),
 			measureTextSpansOptions
 		)
 
@@ -178,7 +178,7 @@ test.describe('text measurement', () => {
 			typeof measureTextSpansOptions
 		>(
 			async (options) =>
-				editor.textMeasure.measureTextSpans('   test\ning testing   \n  t', options),
+				editor.textMeasure!.measureTextSpans('   test\ning testing   \n  t', options),
 			measureTextSpansOptions
 		)
 
@@ -196,7 +196,7 @@ test.describe('text measurement', () => {
 			typeof measureTextSpansOptions
 		>(
 			async (options) =>
-				editor.textMeasure.measureTextSpans('testingtestingtestingtestingtestingtesting', options),
+				editor.textMeasure!.measureTextSpans('testingtestingtestingtestingtestingtesting', options),
 			measureTextSpansOptions
 		)
 
@@ -214,7 +214,7 @@ test.describe('text measurement', () => {
 		const spans = await page.evaluate<
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
-		>(async (options) => editor.textMeasure.measureTextSpans('', options), measureTextSpansOptions)
+		>(async (options) => editor.textMeasure!.measureTextSpans('', options), measureTextSpansOptions)
 
 		expect(formatLines(spans)).toEqual([])
 	})
@@ -224,7 +224,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('hi\n\n\n', options),
+			async (options) => editor.textMeasure!.measureTextSpans('hi\n\n\n', options),
 			measureTextSpansOptions
 		)
 
@@ -236,7 +236,7 @@ test.describe('text measurement', () => {
 			{ text: string; box: BoxModel }[],
 			typeof measureTextSpansOptions
 		>(
-			async (options) => editor.textMeasure.measureTextSpans('\n\n\n', options),
+			async (options) => editor.textMeasure!.measureTextSpans('\n\n\n', options),
 			measureTextSpansOptions
 		)
 

--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -226,7 +226,7 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	getGrowY(shape: SpeechBubbleShape, prevGrowY = 0) {
 		const PADDING = 17
 
-		const nextTextSize = this.editor.textMeasure.measureText(shape.props.text, {
+		const nextTextSize = this.editor.textMeasure!.measureText(shape.props.text, {
 			...TEXT_PROPS,
 			fontFamily: FONT_FAMILIES[shape.props.font],
 			fontSize: LABEL_FONT_SIZES[shape.props.size],

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -939,7 +939,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getCanUndo(): boolean;
     getCollaborators(): TLInstancePresence[];
     getCollaboratorsOnCurrentPage(): TLInstancePresence[];
-    getContainer: () => HTMLElement;
+    getContainer: () => HTMLElement | null;
     getContentFromCurrentPage(shapes: TLShape[] | TLShapeId[]): TLContent | undefined;
     // @internal
     getCrashingError(): unknown;
@@ -1199,7 +1199,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     styleProps: {
         [key: string]: Map<StyleProp<any>, string>;
     };
-    readonly textMeasure: TextManager;
+    readonly textMeasure: null | TextManager;
     readonly timers: Timers;
     toggleLock(shapes: TLShape[] | TLShapeId[]): this;
     undo(): this;
@@ -1220,6 +1220,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, historyOptions?: TLHistoryBatchOptions): this;
     updatePage(partial: RequiredKeys<Partial<TLPage>, 'id'>): this;
     updateShape<T extends TLUnknownShape>(partial: null | TLShapePartial<T> | undefined): this;
+    // (undocumented)
+    updateShapeMeasurements(shape: TLShape | TLShapeId): this;
     updateShapes<T extends TLUnknownShape>(partials: (null | TLShapePartial<T> | undefined)[]): this;
     updateViewportScreenBounds(screenBounds: Box, center?: boolean): this;
     readonly user: UserPreferencesManager;
@@ -2077,6 +2079,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onDropShapesOver?: TLOnDragHandler<Shape>;
     onEditEnd?: TLOnEditEndHandler<Shape>;
     onHandleDrag?: TLOnHandleDragHandler<Shape>;
+    onMeasure?(shape: Shape): TLShapePartial<Shape> | void;
     onResize?: TLOnResizeHandler<Shape>;
     onResizeEnd?: TLOnResizeEndHandler<Shape>;
     onResizeStart?: TLOnResizeStartHandler<Shape>;
@@ -2304,11 +2307,8 @@ export const TAB_ID: string;
 
 // @public (undocumented)
 export class TextManager {
-    constructor(editor: Editor);
     // (undocumented)
-    baseElm: HTMLDivElement;
-    // (undocumented)
-    editor: Editor;
+    static create(editor: Editor): null | TextManager;
     measureElementTextNodeSpans(element: HTMLElement, { shouldTruncateToFirstLine }?: {
         shouldTruncateToFirstLine?: boolean;
     }): {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -263,7 +263,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.getContainer = getContainer ?? (() => document.body)
 
-		this.textMeasure = new TextManager(this)
+		this.textMeasure = TextManager.create(this)
 		this._tickManager = new TickManager(this)
 
 		class NewRoot extends RootState {
@@ -694,8 +694,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.root.enter(undefined, 'initial')
 
 		this.edgeScrollManager = new EdgeScrollManager(this)
-		this.focusManager = new FocusManager(this, autoFocus)
-		this.disposables.add(this.focusManager.dispose.bind(this.focusManager))
+		this.focusManager = FocusManager.create(this, autoFocus)
+		if (this.focusManager) {
+			this.disposables.add(this.focusManager.dispose.bind(this.focusManager))
+		}
 
 		if (this.getInstanceState().followingUserId) {
 			this.stopFollowingUser()
@@ -770,7 +772,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	readonly textMeasure: TextManager
+	readonly textMeasure: TextManager | null
 
 	/**
 	 * A manager for the editor's environment.
@@ -805,7 +807,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @internal
 	 */
-	private focusManager: FocusManager
+	private focusManager: FocusManager | null
 
 	/**
 	 * The current HTML element containing the editor.
@@ -817,7 +819,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	getContainer: () => HTMLElement
+	getContainer: () => HTMLElement | null
 
 	/**
 	 * Dispose the editor.
@@ -8449,7 +8451,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	focus({ focusContainer = true } = {}): this {
 		if (focusContainer) {
-			this.focusManager.focus()
+			this.focusManager?.focus()
 		}
 		this.updateInstanceState({ isFocused: true })
 		return this
@@ -8476,7 +8478,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	blur({ blurContainer = true } = {}): this {
 		if (!this.getIsFocused()) return this
 		if (blurContainer) {
-			this.focusManager.blur()
+			this.focusManager?.blur()
 		} else {
 			this.complete() // stop any interaction
 		}

--- a/packages/editor/src/lib/editor/managers/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager.ts
@@ -12,8 +12,16 @@ import type { Editor } from '../Editor'
 export class FocusManager {
 	private disposeSideEffectListener?: () => void
 
+	static create(editor: Editor, autoFocus?: boolean) {
+		const container = editor.getContainer()
+		if (!container) return null
+
+		return new FocusManager(editor, container, autoFocus)
+	}
+
 	constructor(
 		public editor: Editor,
+		private container: HTMLElement,
 		autoFocus?: boolean
 	) {
 		this.disposeSideEffectListener = editor.sideEffects.registerAfterChangeHandler(
@@ -43,23 +51,22 @@ export class FocusManager {
 	 * special class on the container: tl-container__focused
 	 */
 	private updateContainerClass() {
-		const container = this.editor.getContainer()
 		const instanceState = this.editor.getInstanceState()
 
 		if (instanceState.isFocused) {
-			container.classList.add('tl-container__focused')
+			this.container.classList.add('tl-container__focused')
 		} else {
-			container.classList.remove('tl-container__focused')
+			this.container.classList.remove('tl-container__focused')
 		}
 	}
 
 	focus() {
-		this.editor.getContainer().focus()
+		this.container.focus()
 	}
 
 	blur() {
 		this.editor.complete() // stop any interaction
-		this.editor.getContainer().blur() // blur the container
+		this.container.blur() // blur the container
 	}
 
 	dispose() {

--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -38,24 +38,24 @@ const spaceCharacterRegex = /\s/
 
 /** @public */
 export class TextManager {
-	baseElm: HTMLDivElement
-
-	constructor(public editor: Editor) {
-		const container = this.editor.getContainer()
+	static create(editor: Editor) {
+		const container = editor.getContainer()
+		if (!container) return null
 
 		// Remove any existing text measure element that
 		// is a descendant of this editor's container
 		container.querySelector('#tldraw_text_measure')?.remove()
 
 		const elm = document.createElement('div')
-		elm.id = `tldraw_text_measure`
-		elm.classList.add('tl-text')
-		elm.classList.add('tl-text-measure')
+		elm.id = 'tldraw_text_measure'
+		elm.classList.add('tl-text', 'tl-text-measure')
 		elm.tabIndex = -1
 		container.appendChild(elm)
 
-		this.baseElm = elm
+		return new TextManager(elm)
 	}
+
+	private constructor(private baseElm: HTMLDivElement) {}
 
 	measureText = (
 		textToMeasure: string,

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -303,6 +303,14 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	//  Events
+	/**
+	 * A callback called whenever the current user changes or creates a shape. This is an
+	 * opportunity to make any measurements (e.g. text size) that are needed for the shape as a
+	 * result of this change.
+	 *
+	 * @returns The updated shape if needed.
+	 */
+	onMeasure?(shape: Shape): Shape | void
 
 	/**
 	 * A callback called just before a shape is created. This method provides a last chance to modify

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -310,7 +310,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 *
 	 * @returns The updated shape if needed.
 	 */
-	onMeasure?(shape: Shape): Shape | void
+	onMeasure?(shape: Shape): TLShapePartial<Shape> | void
 
 	/**
 	 * A callback called just before a shape is created. This method provides a last chance to modify

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -222,6 +222,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     onHandleDrag: TLOnHandleDragHandler<TLArrowShape>;
     // (undocumented)
+    onMeasure(shape: TLArrowShape): TLArrowShape | void;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLArrowShape>;
     // (undocumented)
     onTranslate?: TLOnTranslateHandler<TLArrowShape>;
@@ -239,6 +241,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
         labelColor: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow">;
         labelPosition: Validator<number>;
+        labelSize: Validator<VecModel | null>;
         scale: Validator<number>;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         start: Validator<VecModel>;
@@ -439,7 +442,7 @@ export const DefaultQuickActions: NamedExoticComponent<TLUiQuickActionsProps>;
 export function DefaultQuickActionsContent(): JSX_2.Element | undefined;
 
 // @public (undocumented)
-export const defaultShapeTools: (typeof ArrowShapeTool)[];
+export const defaultShapeTools: (typeof TextShapeTool)[];
 
 // @public (undocumented)
 export const defaultShapeUtils: TLAnyShapeUtilConstructor[];
@@ -765,6 +768,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
             growY: number;
             h: number;
             labelColor: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow";
+            labelSize: null | VecModel;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             text: string;
@@ -796,6 +800,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
             growY: number;
             h: number;
             labelColor: "black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow";
+            labelSize: null | VecModel;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             text: string;
@@ -844,6 +849,14 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLGeoShape>;
     // (undocumented)
+    onMeasure(shape: TLGeoShape): {
+        id: TLShapeId;
+        props: {
+            labelSize: VecModel;
+        };
+        type: "geo";
+    } | undefined;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLGeoShape>;
     // (undocumented)
     static props: {
@@ -856,6 +869,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
         growY: Validator<number>;
         h: Validator<number>;
         labelColor: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow">;
+        labelSize: Validator<null | VecModel>;
         scale: Validator<number>;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         text: Validator<string>;
@@ -1182,6 +1196,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             font: "draw" | "mono" | "sans" | "serif";
             fontSizeAdjustment: number;
             growY: number;
+            labelSize: {
+                fontSizeAdjustment: number;
+                h: number;
+                w: number;
+            } | null;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             text: string;
@@ -1208,6 +1227,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             font: "draw" | "mono" | "sans" | "serif";
             fontSizeAdjustment: number;
             growY: number;
+            labelSize: {
+                fontSizeAdjustment: number;
+                h: number;
+                w: number;
+            } | null;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             text: string;
@@ -1229,6 +1253,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
         fontSizeAdjustment: Validator<number>;
         growY: Validator<number>;
+        labelSize: Validator<    {
+        fontSizeAdjustment: number;
+        h: number;
+        w: number;
+        } | null>;
         scale: Validator<number>;
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         text: Validator<string>;
@@ -1490,11 +1519,6 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     getGeometry(shape: TLTextShape): Rectangle2d;
     // (undocumented)
-    getMinDimensions(shape: TLTextShape): {
-        height: number;
-        width: number;
-    };
-    // (undocumented)
     indicator(shape: TLTextShape): JSX_2.Element | null;
     // (undocumented)
     isAspectRatioLocked: TLShapeUtilFlag<TLTextShape>;
@@ -1516,6 +1540,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
             size: "l" | "m" | "s" | "xl";
             text: string;
             textAlign: "end" | "middle" | "start";
+            textSize: null | VecModel;
             w: number;
         };
         rotation: number;
@@ -1527,6 +1552,14 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     onEditEnd: TLOnEditEndHandler<TLTextShape>;
     // (undocumented)
+    onMeasure(shape: TLTextShape): {
+        id: TLShapeId;
+        props: {
+            textSize: VecModel;
+        };
+        type: "text";
+    } | undefined;
+    // (undocumented)
     onResize: TLOnResizeHandler<TLTextShape>;
     // (undocumented)
     static props: {
@@ -1537,6 +1570,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
         size: EnumStyleProp<"l" | "m" | "s" | "xl">;
         text: Validator<string>;
         textAlign: EnumStyleProp<"end" | "middle" | "start">;
+        textSize: Validator<null | VecModel>;
         w: Validator<number>;
     };
     // (undocumented)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -15,6 +15,7 @@ import {
 	VecLike,
 	WeakCache,
 	assert,
+	assertExists,
 	compact,
 	createShapeId,
 	fetch,
@@ -330,7 +331,9 @@ export function registerDefaultExternalContentHandlers(
 			align = isMultiLine ? (isRtl ? 'end' : 'start') : 'middle'
 		}
 
-		const rawSize = editor.textMeasure.measureText(textToPaste, {
+		const textMeasure = assertExists(editor.textMeasure, 'textMeasure not available')
+
+		const rawSize = textMeasure.measureText(textToPaste, {
 			...TEXT_PROPS,
 			fontFamily: FONT_FAMILIES[defaultProps.font],
 			fontSize: FONT_SIZES[defaultProps.size],
@@ -343,7 +346,7 @@ export function registerDefaultExternalContentHandlers(
 		)
 
 		if (rawSize.w > minWidth) {
-			const shrunkSize = editor.textMeasure.measureText(textToPaste, {
+			const shrunkSize = textMeasure.measureText(textToPaste, {
 				...TEXT_PROPS,
 				fontFamily: FONT_FAMILIES[defaultProps.font],
 				fontSize: FONT_SIZES[defaultProps.size],

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -46,7 +46,7 @@ import {
 } from '../shared/defaultStyleDefs'
 import { getPerfectDashProps } from '../shared/getPerfectDashProps'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
-import { getArrowLabelFontSize, getArrowLabelPosition } from './arrowLabel'
+import { getArrowLabelFontSize, getArrowLabelPosition, measureArrowLabelSize } from './arrowLabel'
 import { getArrowheadPathForType } from './arrowheads'
 import {
 	getCurvedArrowHandlePath,
@@ -109,6 +109,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			labelPosition: 0.5,
 			font: 'draw',
 			scale: 1,
+			labelSize: { x: 0, y: 0 },
 		}
 	}
 
@@ -147,6 +148,19 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		return new Group2d({
 			children: [...(labelGeom ? [bodyGeom, labelGeom] : [bodyGeom]), ...debugGeom],
 		})
+	}
+
+	override onMeasure(shape: TLArrowShape): void | TLArrowShape {
+		if (!shape.props.text) return
+		const measured = measureArrowLabelSize(this.editor, shape)
+		if (shape.props.labelSize && Vec.Equals(measured, shape.props.labelSize)) return
+		return {
+			...shape,
+			props: {
+				...shape.props,
+				labelSize: measured,
+			},
+		}
 	}
 
 	override getHandles(shape: TLArrowShape): TLHandle[] {

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -10,6 +10,7 @@ import {
 	Vec,
 	VecLike,
 	angleDistance,
+	assertExists,
 	clamp,
 	getPointOnCircle,
 	intersectCirclePolygon,
@@ -54,7 +55,7 @@ function getArrowLabelSize(editor: Editor, shape: TLArrowShape) {
 
 		const fontSize = getArrowLabelFontSize(shape)
 
-		const { w, h } = editor.textMeasure.measureText(shape.props.text, {
+		const { w, h } = assertExists(editor.textMeasure).measureText(shape.props.text, {
 			...TEXT_PROPS,
 			fontFamily: FONT_FAMILIES[shape.props.font],
 			fontSize,

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -106,11 +106,16 @@ export function getArrowBindings(editor: Editor, shape: TLArrowShape): TLArrowBi
 	}
 }
 
-const arrowInfoCache = createComputedCache('arrow info', (editor: Editor, shape: TLArrowShape) => {
+/** @internal */
+export function getArrowInfoUncached(editor: Editor, shape: TLArrowShape) {
 	const bindings = getArrowBindings(editor, shape)
 	return getIsArrowStraight(shape)
 		? getStraightArrowInfo(editor, shape, bindings)
 		: getCurvedArrowInfo(editor, shape, bindings)
+}
+
+const arrowInfoCache = createComputedCache('arrow info', (editor: Editor, shape: TLArrowShape) => {
+	return getArrowInfoUncached(editor, shape)
 })
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -139,7 +139,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 			verticalTextAlign: 'middle' as const,
 		}
 
-		const spans = this.editor.textMeasure.measureTextSpans(
+		const spans = this.editor.textMeasure!.measureTextSpans(
 			defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203),
 			opts
 		)

--- a/packages/tldraw/src/lib/shapes/shared/SvgTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/SvgTextLabel.tsx
@@ -57,7 +57,8 @@ export function SvgTextLabel({
 		strokeWidth: undefined as number | undefined,
 	}
 
-	const spans = assertExists(editor.textMeasure).measureTextSpans(text, opts)
+	const textMeasure = assertExists(editor.textMeasure, 'SvgTextLabel requires text measurement')
+	const spans = textMeasure.measureTextSpans(text, opts)
 	const offsetX = getLegacyOffsetX(align, padding, spans, bounds.width)
 	if (offsetX) {
 		opts.offsetX = offsetX

--- a/packages/tldraw/src/lib/shapes/shared/SvgTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/SvgTextLabel.tsx
@@ -4,6 +4,7 @@ import {
 	TLDefaultFontStyle,
 	TLDefaultHorizontalAlignStyle,
 	TLDefaultVerticalAlignStyle,
+	assertExists,
 	useEditor,
 } from '@tldraw/editor'
 import { createTextJsxFromSpans } from './createTextJsxFromSpans'
@@ -56,7 +57,7 @@ export function SvgTextLabel({
 		strokeWidth: undefined as number | undefined,
 	}
 
-	const spans = editor.textMeasure.measureTextSpans(text, opts)
+	const spans = assertExists(editor.textMeasure).measureTextSpans(text, opts)
 	const offsetX = getLegacyOffsetX(align, padding, spans, bounds.width)
 	if (offsetX) {
 		opts.offsetX = offsetX

--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -4,6 +4,7 @@ import {
 	Editor,
 	TLShape,
 	Vec,
+	assertExists,
 	atom,
 	clamp,
 	computed,
@@ -37,7 +38,8 @@ export class MinimapManager {
 	}
 
 	private _getColors() {
-		const style = getComputedStyle(this.editor.getContainer())
+		const container = assertExists(this.editor.getContainer(), 'editor must have container')
+		const style = getComputedStyle(container)
 
 		return {
 			shapeFill: getRgba(style.getPropertyValue('--color-text-3').trim()),

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -361,7 +361,7 @@ describe('currentToolId', () => {
 describe('isFocused', () => {
 	beforeEach(() => {
 		// lame but duplicated here since this was moved into a hook
-		const container = editor.getContainer()
+		const container = editor.getContainer()!
 
 		const updateFocus = debounce(() => {
 			const { activeElement } = document

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -85,7 +85,7 @@ export class TestEditor extends Editor {
 		this.elm.getBoundingClientRect = () => this.bounds as DOMRect
 		document.body.appendChild(this.elm)
 
-		this.textMeasure.measureText = (
+		this.textMeasure!.measureText = (
 			textToMeasure: string,
 			opts: {
 				fontStyle: string
@@ -114,8 +114,8 @@ export class TestEditor extends Editor {
 			}
 		}
 
-		this.textMeasure.measureTextSpans = (textToMeasure, opts) => {
-			const box = this.textMeasure.measureText(textToMeasure, {
+		this.textMeasure!.measureTextSpans = (textToMeasure, opts) => {
+			const box = this.textMeasure!.measureText(textToMeasure, {
 				...opts,
 				maxWidth: opts.width,
 				padding: `${opts.padding}px`,

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -50,6 +50,7 @@ export const arrowShapeProps: {
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
     labelColor: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow">;
     labelPosition: T.Validator<number>;
+    labelSize: T.Validator<null | VecModel>;
     scale: T.Validator<number>;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     start: T.Validator<VecModel>;
@@ -543,6 +544,7 @@ export const geoShapeProps: {
     growY: T.Validator<number>;
     h: T.Validator<number>;
     labelColor: EnumStyleProp<"black" | "blue" | "green" | "grey" | "light-blue" | "light-green" | "light-red" | "light-violet" | "orange" | "red" | "violet" | "white" | "yellow">;
+    labelSize: T.Validator<VecModel | null>;
     scale: T.Validator<number>;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     text: T.Validator<string>;
@@ -772,6 +774,11 @@ export const noteShapeProps: {
     font: EnumStyleProp<"draw" | "mono" | "sans" | "serif">;
     fontSizeAdjustment: T.Validator<number>;
     growY: T.Validator<number>;
+    labelSize: T.Validator<({
+        fontSizeAdjustment: number;
+        h: number;
+        w: number;
+    } & {}) | null>;
     scale: T.Validator<number>;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     text: T.Validator<string>;
@@ -873,6 +880,7 @@ export const textShapeProps: {
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     text: T.Validator<string>;
     textAlign: EnumStyleProp<"end" | "middle" | "start">;
+    textSize: T.Validator<VecModel | null>;
     w: T.Validator<number>;
 };
 

--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -56,6 +56,7 @@ export const arrowShapeProps = {
 	text: T.string,
 	labelPosition: T.number,
 	scale: T.nonZeroNumber,
+	labelSize: vecModelValidator.nullable(),
 }
 
 /** @public */
@@ -70,6 +71,7 @@ export const arrowShapeVersions = createShapePropsMigrationIds('arrow', {
 	AddLabelPosition: 3,
 	ExtractBindings: 4,
 	AddScale: 5,
+	AddLabelSize: 6,
 })
 
 function propsMigration(migration: TLPropsMigration) {
@@ -206,6 +208,15 @@ export const arrowShapeMigrations = createMigrationSequence({
 			},
 			down: (props) => {
 				delete props.scale
+			},
+		}),
+		propsMigration({
+			id: arrowShapeVersions.AddLabelSize,
+			up: (props) => {
+				props.labelSize = null
+			},
+			down: (props) => {
+				delete props.labelSize
 			},
 		}),
 	],

--- a/packages/tlschema/src/shapes/TLGeoShape.ts
+++ b/packages/tlschema/src/shapes/TLGeoShape.ts
@@ -1,4 +1,5 @@
 import { T } from '@tldraw/validate'
+import { vecModelValidator } from '../misc/geometry-types'
 import { createShapePropsMigrationIds, createShapePropsMigrationSequence } from '../records/TLShape'
 import { RecordPropsType } from '../recordsWithProps'
 import { StyleProp } from '../styles/StyleProp'
@@ -61,6 +62,7 @@ export const geoShapeProps = {
 	growY: T.positiveNumber,
 	text: T.string,
 	scale: T.nonZeroNumber,
+	labelSize: vecModelValidator.nullable(),
 }
 
 /** @public */
@@ -79,6 +81,7 @@ const geoShapeVersions = createShapePropsMigrationIds('geo', {
 	AddCloud: 7,
 	MakeUrlsValid: 8,
 	AddScale: 9,
+	AddLabelSize: 10,
 })
 
 export { geoShapeVersions as geoShapeVersions }
@@ -167,6 +170,15 @@ export const geoShapeMigrations = createShapePropsMigrationSequence({
 			},
 			down: (props) => {
 				delete props.scale
+			},
+		},
+		{
+			id: geoShapeVersions.AddLabelSize,
+			up: (props) => {
+				props.labelSize = null
+			},
+			down: (props) => {
+				delete props.labelSize
 			},
 		},
 	],

--- a/packages/tlschema/src/shapes/TLNoteShape.ts
+++ b/packages/tlschema/src/shapes/TLNoteShape.ts
@@ -20,6 +20,11 @@ export const noteShapeProps = {
 	url: T.linkUrl,
 	text: T.string,
 	scale: T.nonZeroNumber,
+	labelSize: T.object({
+		w: T.positiveNumber,
+		h: T.positiveInteger,
+		fontSizeAdjustment: T.number,
+	}).nullable(),
 }
 
 /** @public */
@@ -36,6 +41,7 @@ const Versions = createShapePropsMigrationIds('note', {
 	MakeUrlsValid: 5,
 	AddFontSizeAdjustment: 6,
 	AddScale: 7,
+	AddLabelSize: 8,
 })
 
 export { Versions as noteShapeVersions }
@@ -110,6 +116,15 @@ export const noteShapeMigrations = createShapePropsMigrationSequence({
 			},
 			down: (props) => {
 				delete props.scale
+			},
+		},
+		{
+			id: Versions.AddLabelSize,
+			up: (props) => {
+				props.labelSize = null
+			},
+			down: (props) => {
+				delete props.labelSize
 			},
 		},
 	],

--- a/packages/tlschema/src/shapes/TLTextShape.ts
+++ b/packages/tlschema/src/shapes/TLTextShape.ts
@@ -1,4 +1,5 @@
 import { T } from '@tldraw/validate'
+import { vecModelValidator } from '../misc/geometry-types'
 import { createShapePropsMigrationIds, createShapePropsMigrationSequence } from '../records/TLShape'
 import { RecordPropsType } from '../recordsWithProps'
 import { DefaultColorStyle } from '../styles/TLColorStyle'
@@ -17,6 +18,7 @@ export const textShapeProps = {
 	text: T.string,
 	scale: T.nonZeroNumber,
 	autoSize: T.boolean,
+	textSize: vecModelValidator.nullable(),
 }
 
 /** @public */
@@ -28,6 +30,7 @@ export type TLTextShape = TLBaseShape<'text', TLTextShapeProps>
 const Versions = createShapePropsMigrationIds('text', {
 	RemoveJustify: 1,
 	AddTextAlign: 2,
+	AddTextSize: 3,
 })
 
 export { Versions as textShapeVersions }
@@ -53,6 +56,15 @@ export const textShapeMigrations = createShapePropsMigrationSequence({
 			down: (props) => {
 				props.align = props.textAlign
 				delete props.textAlign
+			},
+		},
+		{
+			id: Versions.AddTextSize,
+			up: (props) => {
+				props.textSize = null
+			},
+			down: (props) => {
+				delete props.textSize
 			},
 		},
 	],

--- a/packages/tlsync/src/test/TLSyncRoom.test.ts
+++ b/packages/tlsync/src/test/TLSyncRoom.test.ts
@@ -58,6 +58,7 @@ const oldArrow: TLBaseShape<'arrow', Omit<TLArrowShapeProps, 'labelColor'>> = {
 		font: 'draw',
 		labelPosition: 0.5,
 		scale: 1,
+		labelSize: null,
 	},
 	meta: {},
 }


### PR DESCRIPTION
With this change, we store sizes on shapes. The last client to update that shape determines the size stored.

do not merge

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
