### PR TITLE
local assets: make sure hard reset also clears out new asset db

### DIFF
--- a/packages/editor/src/lib/utils/sync/indexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/indexedDb.ts
@@ -6,6 +6,9 @@ import { TLSessionStateSnapshot } from '../../config/TLSessionStateSnapshot'
 
 // DO NOT CHANGE THESE WITHOUT ADDING MIGRATION LOGIC. DOING SO WOULD WIPE ALL EXISTING DATA.
 const STORE_PREFIX = 'TLDRAW_DOCUMENT_v2'
+// N.B. This isn't very clean but this value is also echoed in AssetBlobStore.ts.
+// You need to keep them in sync.
+// This is to make sure that hard reset also clears this asset store.
 const dbNameIndexKey = 'TLDRAW_DB_NAME_INDEX_v2'
 
 const Table = {


### PR DESCRIPTION
Not the prettiest way to do this, but meh. This is what we talked about offline @SomeHats 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

