### PR TITLE
Add a new environment for publishing

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -13,8 +13,9 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  publish:
     name: Publish VS Code Extension
+    environment: vsce publish
     timeout-minutes: 15
     runs-on: ubuntu-latest-16-cores-open
 


### PR DESCRIPTION
Added a new environment called `vsce publish` and added the VSCE_PAT secret to it.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [x] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [x] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Introduce a new CI environment and use it for publishing vs code extension.
