### PR TITLE
Add a new environment for publishing

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -13,8 +13,9 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  publish:
     name: Publish VS Code Extension
+    environment: vsce publish
     timeout-minutes: 15
     runs-on: ubuntu-latest-16-cores-open
 


### PR DESCRIPTION
Hotfix for vs code publishing. See #3981 for more.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [x] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [x] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know

### Release Notes

- Hotfix for vs code publishing.
