### PR TITLE
Layout constraints example

### DIFF
--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -15,9 +15,8 @@ import {
 } from 'tldraw'
 import snapShot from './snapshot.json'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 type ElementShape = TLBaseShape<'element', { color: string }>
-// eslint-disable-next-line @typescript-eslint/ban-types
+
 type ContainerShape = TLBaseShape<'element', { height: number; width: number }>
 
 class ElementShapeUtil extends ShapeUtil<ElementShape> {

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -70,14 +70,14 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 		if (!binding) return
 		this.editor.deleteBinding(binding)
 		const layoutBindingUtil = this.editor.getBindingUtil('layout') as LayoutBindingUtil
-		layoutBindingUtil.reShuffleAnchors(binding)
+		layoutBindingUtil.reShufflePositions(binding)
 		layoutBindingUtil.updateContainerWidth(binding)
 	}
 
 	override onTranslateEnd = (initial: ElementShape, element: ElementShape) => {
 		const bindings = this.editor.getBindingsToShape(element, 'layout') as LayoutBinding[]
-		const bindingExists = bindings.length > 0
-		if (bindingExists) return
+		if (bindings.length > 0) return // Early return if binding exists
+
 		const pageAnchor = this.editor.getShapePageTransform(element).applyToPoint({ x: 50, y: 50 })
 		const target = this.editor.getShapeAtPoint(pageAnchor, {
 			hitInside: true,
@@ -86,49 +86,32 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 		})
 
 		if (!target) return
+
 		const elementCount = this.editor.getBindingsFromShape(target, 'layout').length + 1
 		const bindingId = createBindingId()
-
 		const atEnd = pageAnchor.x > target.x + (elementCount - 1) * 100
+		const position = atEnd ? elementCount : Math.ceil((pageAnchor.x - target.x) / 100)
+		const adjustedPosition = Math.min(Math.max(position, 1), 4) // Assuming positions are 1-indexed and max 4
 
-		// first element, or at the end
-		if (elementCount === 0 || atEnd) {
-			this.editor.createBinding({
-				id: bindingId,
-				type: 'layout',
-				fromId: target.id,
-				toId: element.id,
-				props: {
-					anchor: elementCount,
-				},
-			})
-		} else {
-			// find which two elements to insert between, and shuffle the anchors
-			const atStart = pageAnchor.x < target.x + 100
-			const afterFirstElement = pageAnchor.x > target.x + 100 && pageAnchor.x < target.x + 200
-			const afterSecondElement = pageAnchor.x > target.x + 200 && pageAnchor.x < target.x + 300
+		// Create binding with calculated position
+		this.editor.createBinding({
+			id: bindingId,
+			type: 'layout',
+			fromId: target.id,
+			toId: element.id,
+			props: {
+				position: adjustedPosition,
+			},
+		})
 
-			const anchor = atStart ? 1 : afterFirstElement ? 2 : afterSecondElement ? 3 : 4
-
-			this.editor.createBinding({
-				id: bindingId,
-				type: 'layout',
-				fromId: target.id,
-				toId: element.id,
-				props: {
-					anchor: anchor,
-				},
-			})
-		}
-
+		// Re-shuffle and move elements to their new positions
 		const layoutBindingUtil = this.editor.getBindingUtil('layout') as LayoutBindingUtil
 		const binding = this.editor.getBinding(bindingId) as LayoutBinding
-
-		layoutBindingUtil.reShuffleAnchors(binding)
+		layoutBindingUtil.reShufflePositions(binding)
 		const bindingsFrom = this.editor.getBindingsFromShape(target, 'layout') as LayoutBinding[]
-		for (const currentBinding of bindingsFrom) {
-			layoutBindingUtil.moveElementToAnchor(currentBinding, target)
-		}
+		bindingsFrom.forEach((currentBinding) => {
+			layoutBindingUtil.moveElementToPosition(currentBinding, target)
+		})
 	}
 }
 
@@ -191,7 +174,7 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 type LayoutBinding = TLBaseBinding<
 	'layout',
 	{
-		anchor: number
+		position: number
 	}
 >
 class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
@@ -199,7 +182,7 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 
 	override getDefaultProps() {
 		return {
-			anchor: 1,
+			position: 1,
 		}
 	}
 
@@ -211,16 +194,16 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 		binding,
 		shapeAfter,
 	}: BindingOnShapeChangeOptions<LayoutBinding>): void {
-		this.moveElementToAnchor(binding, shapeAfter)
+		this.moveElementToPosition(binding, shapeAfter)
 	}
 
-	reShuffleAnchors(binding: LayoutBinding) {
+	reShufflePositions(binding: LayoutBinding) {
 		const bindings = this.editor.getBindingsFromShape(binding.fromId, 'layout') as LayoutBinding[]
 		if (bindings.length === 0) return
 
 		const sorted = bindings.sort((a, b) => {
-			if (a.props.anchor === b.props.anchor) return -1
-			return a.props.anchor - b.props.anchor
+			if (a.props.position === b.props.position) return -1
+			return a.props.position - b.props.position
 		})
 
 		for (let i = 0; i < sorted.length; i++) {
@@ -228,17 +211,17 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 				...sorted[i],
 				props: {
 					...sorted[i].props,
-					anchor: i + 1,
+					position: i + 1,
 				},
 			})
 		}
 	}
 
-	moveElementToAnchor(binding: LayoutBinding, shapeAfter: TLShape) {
+	moveElementToPosition(binding: LayoutBinding, shapeAfter: TLShape) {
 		const element = this.editor.getShape<ElementShape>(binding.toId)!
 		const containerBounds = this.editor.getShapeGeometry(binding.fromId).bounds
 		const pageAnchor = this.editor.getShapePageTransform(shapeAfter).applyToPoint({
-			x: containerBounds.x + PADDING * binding.props.anchor + 100 * (binding.props.anchor - 1),
+			x: containerBounds.x + PADDING * binding.props.position + 100 * (binding.props.position - 1),
 			y: containerBounds.y + PADDING,
 		})
 

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -2,6 +2,7 @@ import {
 	BindingOnChangeOptions,
 	BindingOnCreateOptions,
 	BindingOnDeleteOptions,
+	BindingOnShapeChangeOptions,
 	BindingUtil,
 	HTMLContainer,
 	IndexKey,
@@ -291,6 +292,10 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 		this.updateElementsForContainer(bindingAfter)
 	}
 
+	override onAfterChangeFromShape({ binding }: BindingOnShapeChangeOptions<LayoutBinding>): void {
+		this.updateElementsForContainer(binding)
+	}
+
 	override onAfterDelete({ binding }: BindingOnDeleteOptions<LayoutBinding>): void {
 		this.updateElementsForContainer(binding)
 	}
@@ -318,12 +323,16 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 
 			const point = this.editor.getShapePageTransform(container).applyToPoint(offset)
 
-			this.editor.updateShape({
-				id: binding.toId,
-				type: 'element',
-				x: point.x,
-				y: point.y,
-			})
+			const shape = this.editor.getShape<ElementShape>(binding.toId)
+
+			if (shape && (shape.x !== point.x || shape.y !== point.y)) {
+				this.editor.updateShape({
+					id: binding.toId,
+					type: 'element',
+					x: point.x,
+					y: point.y,
+				})
+			}
 		}
 
 		const width =

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -321,11 +321,15 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 
 			const offset = new Vec(CONTAINER_PADDING + i * (100 + CONTAINER_PADDING), CONTAINER_PADDING)
 
-			const point = this.editor.getShapePageTransform(container).applyToPoint(offset)
-
 			const shape = this.editor.getShape<ElementShape>(binding.toId)
+			if (!shape) continue
 
-			if (shape && (shape.x !== point.x || shape.y !== point.y)) {
+			const point = this.editor.getPointInParentSpace(
+				shape,
+				this.editor.getShapePageTransform(container)!.applyToPoint(offset)
+			)
+
+			if (shape.x !== point.x || shape.y !== point.y) {
 				this.editor.updateShape({
 					id: binding.toId,
 					type: 'element',

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -1,7 +1,6 @@
 import {
 	BindingOnCreateOptions,
 	BindingOnShapeChangeOptions,
-	BindingOnShapeDeleteOptions,
 	BindingUtil,
 	HTMLContainer,
 	RecordProps,
@@ -13,8 +12,8 @@ import {
 	TLShape,
 	Tldraw,
 	createBindingId,
-	createShapeId,
 } from 'tldraw'
+import snapShot from './snapshot.json'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ElementShape = TLBaseShape<'element', { color: string }>
@@ -172,8 +171,15 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 	override component(shape: ContainerShape) {
 		return (
 			<HTMLContainer
-				style={{ backgroundColor: '#efefef', width: shape.props.width }}
-			></HTMLContainer>
+				style={{
+					backgroundColor: '#efefef',
+					width: shape.props.width,
+					textAlign: 'center',
+					padding: 8,
+				}}
+			>
+				Container
+			</HTMLContainer>
 		)
 	}
 
@@ -206,10 +212,6 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 		shapeAfter,
 	}: BindingOnShapeChangeOptions<LayoutBinding>): void {
 		this.moveElementToAnchor(binding, shapeAfter)
-	}
-
-	override onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<LayoutBinding>): void {
-		this.editor.deleteShape(binding.fromId)
 	}
 
 	reShuffleAnchors(binding: LayoutBinding) {
@@ -268,18 +270,10 @@ export default function LayoutExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
+				// @ts-ignore
+				snapshot={snapShot}
 				onMount={(editor) => {
 					;(window as any).editor = editor
-					const elementIds = [1, 2, 3, 4].map(() => createShapeId())
-					const containerId = createShapeId()
-
-					editor.createShapes([
-						{ id: containerId, type: 'container', x: 500, y: 500 },
-						{ id: elementIds[0], type: 'element', x: 100, y: 100, props: { color: '#AEC6CF' } },
-						{ id: elementIds[1], type: 'element', x: 100, y: 100, props: { color: '#FF6961' } },
-						{ id: elementIds[2], type: 'element', x: 100, y: 100, props: { color: '#C1E1C1' } },
-						{ id: elementIds[3], type: 'element', x: 100, y: 100, props: { color: '#FFFAA0' } },
-					])
 				}}
 				shapeUtils={[ContainerShapeUtil, ElementShapeUtil]}
 				bindingUtils={[LayoutBindingUtil]}

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -1,0 +1,215 @@
+import {
+	BindingOnShapeChangeOptions,
+	BindingOnShapeDeleteOptions,
+	BindingUtil,
+	Box,
+	HTMLContainer,
+	RecordProps,
+	Rectangle2d,
+	ShapeUtil,
+	T,
+	TLBaseBinding,
+	TLBaseShape,
+	Tldraw,
+	VecModel,
+	createShapeId,
+	invLerp,
+} from 'tldraw'
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type ElementShape = TLBaseShape<'element', { color: string }>
+// eslint-disable-next-line @typescript-eslint/ban-types
+type ContainerShape = TLBaseShape<'element', { height: number; width: number }>
+
+class ElementShapeUtil extends ShapeUtil<ElementShape> {
+	static override type = 'element' as const
+	static override props: RecordProps<ElementShape> = {
+		color: T.string,
+	}
+
+	override getDefaultProps() {
+		return {
+			color: '#AEC6CF',
+		}
+	}
+
+	override canBind({
+		fromShapeType,
+		toShapeType,
+		bindingType,
+	}: {
+		fromShapeType: string
+		toShapeType: string
+		bindingType: string
+	}) {
+		return fromShapeType === 'element' && toShapeType === 'container' && bindingType === 'layout'
+	}
+	override canEdit = () => false
+	override canResize = () => false
+	override hideRotateHandle = () => true
+	override isAspectRatioLocked = () => true
+
+	override getGeometry() {
+		return new Rectangle2d({
+			width: 100,
+			height: 100,
+			isFilled: true,
+		})
+	}
+
+	override component(shape: ElementShape) {
+		return <HTMLContainer style={{ backgroundColor: shape.props.color }}></HTMLContainer>
+	}
+
+	override indicator() {
+		return <rect width={100} height={100} />
+	}
+
+	override onTranslateStart = (shape: ElementShape) => {
+		const bindings = this.editor.getBindingsFromShape(shape, 'layout')
+		this.editor.deleteBindings(bindings)
+	}
+
+	override onTranslateEnd = (initial: ElementShape, element: ElementShape) => {
+		const pageAnchor = this.editor.getShapePageTransform(element).applyToPoint({ x: 50, y: 50 })
+		const target = this.editor.getShapeAtPoint(pageAnchor, {
+			hitInside: true,
+			filter: (shape) =>
+				this.editor.canBindShapes({ fromShape: element, toShape: shape, binding: 'layout' }),
+		})
+
+		if (!target) return
+		console.log('target', target)
+		const targetBounds = Box.ZeroFix(this.editor.getShapeGeometry(target)!.bounds)
+		const pointInTargetSpace = this.editor.getPointInShapeSpace(target, pageAnchor)
+
+		const anchor = {
+			x: invLerp(targetBounds.minX, targetBounds.maxX, pointInTargetSpace.x),
+			y: invLerp(targetBounds.minY, targetBounds.maxY, pointInTargetSpace.y),
+		}
+
+		this.editor.createBinding({
+			type: 'layout',
+			fromId: element.id,
+			toId: target.id,
+			props: {
+				anchor,
+			},
+		})
+	}
+}
+
+const PADDING = 24
+class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
+	static override type = 'container' as const
+	static override props: RecordProps<ContainerShape> = { height: T.number, width: T.number }
+
+	override getDefaultProps() {
+		return {
+			width: PADDING * 2,
+			height: 100 + PADDING * 2,
+		}
+	}
+
+	override canBind({
+		fromShapeType,
+		toShapeType,
+		bindingType,
+	}: {
+		fromShapeType: string
+		toShapeType: string
+		bindingType: string
+	}) {
+		return fromShapeType === 'element' && toShapeType === 'container' && bindingType === 'layout'
+	}
+	override canEdit = () => false
+	override canResize = () => false
+	override hideRotateHandle = () => true
+	override isAspectRatioLocked = () => true
+
+	override getGeometry(shape: ContainerShape) {
+		return new Rectangle2d({
+			width: shape.props.width,
+			height: shape.props.height,
+			isFilled: true,
+		})
+	}
+
+	override onBeforeUpdate = (shape: ContainerShape, changes: Partial<ContainerShape>) => {
+		const bindings = this.editor.getBindingsToShape(shape, 'layout')
+		const numberOfElements = bindings.length
+
+		const next = {
+			...shape,
+			x: changes.x ?? shape.x,
+			y: changes.y ?? shape.y,
+			props: {
+				...shape.props,
+				width: numberOfElements * 100 + PADDING * (2 + numberOfElements),
+			},
+		}
+		return next
+	}
+	override component(shape: ContainerShape) {
+		return (
+			<HTMLContainer
+				style={{ backgroundColor: '#efefef', width: shape.props.width }}
+			></HTMLContainer>
+		)
+	}
+
+	override indicator(shape: ContainerShape) {
+		return <rect width={shape.props.width} height={shape.props.height} />
+	}
+}
+
+type LayoutBinding = TLBaseBinding<
+	'layout',
+	{
+		anchor: VecModel
+	}
+>
+class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
+	static override type = 'layout' as const
+
+	override getDefaultProps() {
+		return {
+			anchor: { x: 0.5, y: 0.5 },
+		}
+	}
+
+	// when the shape we're stuck to changes, update the sticker's position
+	override onAfterChangeToShape({
+		binding,
+		shapeAfter,
+	}: BindingOnShapeChangeOptions<LayoutBinding>): void {}
+
+	// when the thing we're stuck to is deleted, delete the sticker too
+	override onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<LayoutBinding>): void {
+		this.editor.deleteShape(binding.fromId)
+	}
+}
+
+export default function LayoutExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				onMount={(editor) => {
+					;(window as any).editor = editor
+					const elementIds = [1, 2, 3, 4].map(() => createShapeId())
+					const containerId = createShapeId()
+
+					editor.createShapes([
+						{ id: containerId, type: 'container', x: 500, y: 500 },
+						{ id: elementIds[0], type: 'element', x: 100, y: 100, props: { color: '#AEC6CF' } },
+						{ id: elementIds[1], type: 'element', x: 100, y: 100, props: { color: '#FF6961' } },
+						{ id: elementIds[2], type: 'element', x: 100, y: 100, props: { color: '#C1E1C1' } },
+						{ id: elementIds[3], type: 'element', x: 100, y: 100, props: { color: '#FFFAA0' } },
+					])
+				}}
+				shapeUtils={[ContainerShapeUtil, ElementShapeUtil]}
+				bindingUtils={[LayoutBindingUtil]}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/layout-bindings/README.md
+++ b/apps/examples/src/examples/layout-bindings/README.md
@@ -1,0 +1,9 @@
+---
+title: Layout (bindings)
+component: ./LayoutExample.tsx
+category: shapes/tools
+---
+
+How to constrain shapes to a layout using bindings.
+
+---

--- a/apps/examples/src/examples/layout-bindings/README.md
+++ b/apps/examples/src/examples/layout-bindings/README.md
@@ -10,4 +10,3 @@ How to constrain shapes to a layout using bindings.
 ---
 
 You can use bindings to make shapes respond to changes to other shapes. This is useful for enforcing layout constraints
-

--- a/apps/examples/src/examples/layout-bindings/README.md
+++ b/apps/examples/src/examples/layout-bindings/README.md
@@ -1,9 +1,13 @@
 ---
-title: Layout (bindings)
+title: Layout constraints (bindings)
 component: ./LayoutExample.tsx
 category: shapes/tools
+keywords: [constraints, group, shape, custom, bindings, drag, drop, position]
 ---
 
 How to constrain shapes to a layout using bindings.
 
 ---
+
+You can use bindings to make shapes respond to changes to other shapes. This is useful for enforcing layout constraints
+

--- a/apps/examples/src/examples/layout-bindings/snapshot.json
+++ b/apps/examples/src/examples/layout-bindings/snapshot.json
@@ -14,106 +14,155 @@
 			"index": "a1",
 			"typeName": "page"
 		},
-		"shape:OGZdjaZmfGpP-7NhKAiPb": {
-			"x": 76,
-			"y": 76,
+		"shape:f4LKGB_8M2qsyWGpHR5Dq": {
+			"x": 30.9375,
+			"y": 69.48828125,
 			"rotation": 0,
 			"isLocked": false,
 			"opacity": 1,
 			"meta": {},
-			"id": "shape:OGZdjaZmfGpP-7NhKAiPb",
+			"id": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"type": "container",
 			"parentId": "page:page",
 			"index": "a1",
 			"props": {
-				"width": 272,
-				"height": 148
+				"width": 644,
+				"height": 132
 			},
 			"typeName": "shape"
 		},
-		"shape:VH_dbuD3N7aKtgNMVZy8T": {
-			"x": 100,
-			"y": 100,
+		"shape:2oThF4kJ4v31xqKN5lvq2": {
+			"x": 550.9375,
+			"y": 93.48828125,
 			"rotation": 0,
 			"isLocked": false,
 			"opacity": 1,
 			"meta": {},
-			"id": "shape:VH_dbuD3N7aKtgNMVZy8T",
+			"id": "shape:2oThF4kJ4v31xqKN5lvq2",
 			"type": "element",
 			"props": {
-				"color": "#AEC6CF"
+				"color": "#5BCEFA"
 			},
 			"parentId": "page:page",
 			"index": "a2",
 			"typeName": "shape"
 		},
-		"shape:-aQdotOYDqcLTVfByZJHE": {
-			"x": 224,
-			"y": 100,
+		"shape:K2vk_VTaNh-ANaRNOAvgY": {
+			"x": 426.9375,
+			"y": 93.48828125,
 			"rotation": 0,
 			"isLocked": false,
 			"opacity": 1,
 			"meta": {},
-			"id": "shape:-aQdotOYDqcLTVfByZJHE",
+			"id": "shape:K2vk_VTaNh-ANaRNOAvgY",
 			"type": "element",
 			"props": {
-				"color": "#FF6961"
+				"color": "#F5A9B8"
 			},
 			"parentId": "page:page",
 			"index": "a3",
 			"typeName": "shape"
 		},
-		"shape:1DfsTGcNZ9jFlWVl3dPTn": {
-			"x": 100,
-			"y": 254.3671875,
+		"shape:6uouhIK7PvyIRNQHACf-d": {
+			"x": 302.9375,
+			"y": 93.48828125,
 			"rotation": 0,
 			"isLocked": false,
 			"opacity": 1,
 			"meta": {},
-			"id": "shape:1DfsTGcNZ9jFlWVl3dPTn",
+			"id": "shape:6uouhIK7PvyIRNQHACf-d",
 			"type": "element",
 			"props": {
-				"color": "#C1E1C1"
+				"color": "#FFFFFF"
 			},
 			"parentId": "page:page",
 			"index": "a4",
 			"typeName": "shape"
 		},
-		"shape:Tv4go3B98c4qNSAkDdziW": {
-			"x": 224,
-			"y": 254.3671875,
+		"shape:GTQq2qxkWPHEK7KMIRtsh": {
+			"x": 54.9375,
+			"y": 93.48828125,
 			"rotation": 0,
 			"isLocked": false,
 			"opacity": 1,
 			"meta": {},
-			"id": "shape:Tv4go3B98c4qNSAkDdziW",
+			"id": "shape:GTQq2qxkWPHEK7KMIRtsh",
 			"type": "element",
 			"props": {
-				"color": "#FFFAA0"
+				"color": "#5BCEFA"
 			},
 			"parentId": "page:page",
 			"index": "a5",
 			"typeName": "shape"
 		},
-		"binding:yuM6WtQLtnKP33F7fSLsO": {
+		"shape:05jMujN6A0sIp6zzHMpbV": {
+			"x": 178.9375,
+			"y": 93.48828125,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
 			"meta": {},
-			"id": "binding:yuM6WtQLtnKP33F7fSLsO",
-			"type": "layout",
-			"fromId": "shape:OGZdjaZmfGpP-7NhKAiPb",
-			"toId": "shape:VH_dbuD3N7aKtgNMVZy8T",
+			"id": "shape:05jMujN6A0sIp6zzHMpbV",
+			"type": "element",
 			"props": {
-				"anchor": 1
+				"color": "#F5A9B8"
+			},
+			"parentId": "page:page",
+			"index": "a6",
+			"typeName": "shape"
+		},
+		"binding:iOBENBUHvzD8N7mBdIM5l": {
+			"meta": {},
+			"id": "binding:iOBENBUHvzD8N7mBdIM5l",
+			"type": "layout",
+			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
+			"toId": "shape:05jMujN6A0sIp6zzHMpbV",
+			"props": {
+				"position": 2
 			},
 			"typeName": "binding"
 		},
-		"binding:KiVYKXfxN7S-Wo7rdaIsw": {
+		"binding:YTIeOALEmHJk6dczRpQmE": {
 			"meta": {},
-			"id": "binding:KiVYKXfxN7S-Wo7rdaIsw",
+			"id": "binding:YTIeOALEmHJk6dczRpQmE",
 			"type": "layout",
-			"fromId": "shape:OGZdjaZmfGpP-7NhKAiPb",
-			"toId": "shape:-aQdotOYDqcLTVfByZJHE",
+			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
+			"toId": "shape:GTQq2qxkWPHEK7KMIRtsh",
 			"props": {
-				"anchor": 2
+				"position": 1
+			},
+			"typeName": "binding"
+		},
+		"binding:n4LY_pVuLfjV1qpOTZX-U": {
+			"meta": {},
+			"id": "binding:n4LY_pVuLfjV1qpOTZX-U",
+			"type": "layout",
+			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
+			"toId": "shape:6uouhIK7PvyIRNQHACf-d",
+			"props": {
+				"position": 3
+			},
+			"typeName": "binding"
+		},
+		"binding:8XayRsWB_nxAH2833SYg1": {
+			"meta": {},
+			"id": "binding:8XayRsWB_nxAH2833SYg1",
+			"type": "layout",
+			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
+			"toId": "shape:2oThF4kJ4v31xqKN5lvq2",
+			"props": {
+				"position": 5
+			},
+			"typeName": "binding"
+		},
+		"binding:MTYuIRiEVTn2DyVChthry": {
+			"meta": {},
+			"id": "binding:MTYuIRiEVTn2DyVChthry",
+			"type": "layout",
+			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
+			"toId": "shape:K2vk_VTaNh-ANaRNOAvgY",
+			"props": {
+				"position": 4
 			},
 			"typeName": "binding"
 		}

--- a/apps/examples/src/examples/layout-bindings/snapshot.json
+++ b/apps/examples/src/examples/layout-bindings/snapshot.json
@@ -27,7 +27,7 @@
 			"index": "a1",
 			"props": {
 				"width": 644,
-				"height": 132
+				"height": 148
 			},
 			"typeName": "shape"
 		},
@@ -118,7 +118,8 @@
 			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"toId": "shape:05jMujN6A0sIp6zzHMpbV",
 			"props": {
-				"position": 2
+				"index": "a2",
+				"placeholder": false
 			},
 			"typeName": "binding"
 		},
@@ -129,7 +130,8 @@
 			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"toId": "shape:GTQq2qxkWPHEK7KMIRtsh",
 			"props": {
-				"position": 1
+				"index": "a1",
+				"placeholder": false
 			},
 			"typeName": "binding"
 		},
@@ -140,7 +142,8 @@
 			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"toId": "shape:6uouhIK7PvyIRNQHACf-d",
 			"props": {
-				"position": 3
+				"index": "a3",
+				"placeholder": false
 			},
 			"typeName": "binding"
 		},
@@ -151,7 +154,8 @@
 			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"toId": "shape:2oThF4kJ4v31xqKN5lvq2",
 			"props": {
-				"position": 5
+				"index": "a5",
+				"placeholder": false
 			},
 			"typeName": "binding"
 		},
@@ -162,7 +166,8 @@
 			"fromId": "shape:f4LKGB_8M2qsyWGpHR5Dq",
 			"toId": "shape:K2vk_VTaNh-ANaRNOAvgY",
 			"props": {
-				"position": 4
+				"index": "a4",
+				"placeholder": false
 			},
 			"typeName": "binding"
 		}

--- a/apps/examples/src/examples/layout-bindings/snapshot.json
+++ b/apps/examples/src/examples/layout-bindings/snapshot.json
@@ -1,0 +1,156 @@
+{
+	"store": {
+		"document:document": {
+			"gridSize": 10,
+			"name": "",
+			"meta": {},
+			"id": "document:document",
+			"typeName": "document"
+		},
+		"page:page": {
+			"meta": {},
+			"id": "page:page",
+			"name": "Page 1",
+			"index": "a1",
+			"typeName": "page"
+		},
+		"shape:OGZdjaZmfGpP-7NhKAiPb": {
+			"x": 76,
+			"y": 76,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:OGZdjaZmfGpP-7NhKAiPb",
+			"type": "container",
+			"parentId": "page:page",
+			"index": "a1",
+			"props": {
+				"width": 272,
+				"height": 148
+			},
+			"typeName": "shape"
+		},
+		"shape:VH_dbuD3N7aKtgNMVZy8T": {
+			"x": 100,
+			"y": 100,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:VH_dbuD3N7aKtgNMVZy8T",
+			"type": "element",
+			"props": {
+				"color": "#AEC6CF"
+			},
+			"parentId": "page:page",
+			"index": "a2",
+			"typeName": "shape"
+		},
+		"shape:-aQdotOYDqcLTVfByZJHE": {
+			"x": 224,
+			"y": 100,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:-aQdotOYDqcLTVfByZJHE",
+			"type": "element",
+			"props": {
+				"color": "#FF6961"
+			},
+			"parentId": "page:page",
+			"index": "a3",
+			"typeName": "shape"
+		},
+		"shape:1DfsTGcNZ9jFlWVl3dPTn": {
+			"x": 100,
+			"y": 254.3671875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:1DfsTGcNZ9jFlWVl3dPTn",
+			"type": "element",
+			"props": {
+				"color": "#C1E1C1"
+			},
+			"parentId": "page:page",
+			"index": "a4",
+			"typeName": "shape"
+		},
+		"shape:Tv4go3B98c4qNSAkDdziW": {
+			"x": 224,
+			"y": 254.3671875,
+			"rotation": 0,
+			"isLocked": false,
+			"opacity": 1,
+			"meta": {},
+			"id": "shape:Tv4go3B98c4qNSAkDdziW",
+			"type": "element",
+			"props": {
+				"color": "#FFFAA0"
+			},
+			"parentId": "page:page",
+			"index": "a5",
+			"typeName": "shape"
+		},
+		"binding:yuM6WtQLtnKP33F7fSLsO": {
+			"meta": {},
+			"id": "binding:yuM6WtQLtnKP33F7fSLsO",
+			"type": "layout",
+			"fromId": "shape:OGZdjaZmfGpP-7NhKAiPb",
+			"toId": "shape:VH_dbuD3N7aKtgNMVZy8T",
+			"props": {
+				"anchor": 1
+			},
+			"typeName": "binding"
+		},
+		"binding:KiVYKXfxN7S-Wo7rdaIsw": {
+			"meta": {},
+			"id": "binding:KiVYKXfxN7S-Wo7rdaIsw",
+			"type": "layout",
+			"fromId": "shape:OGZdjaZmfGpP-7NhKAiPb",
+			"toId": "shape:-aQdotOYDqcLTVfByZJHE",
+			"props": {
+				"anchor": 2
+			},
+			"typeName": "binding"
+		}
+	},
+	"schema": {
+		"schemaVersion": 2,
+		"sequences": {
+			"com.tldraw.store": 4,
+			"com.tldraw.asset": 1,
+			"com.tldraw.camera": 1,
+			"com.tldraw.document": 2,
+			"com.tldraw.instance": 25,
+			"com.tldraw.instance_page_state": 5,
+			"com.tldraw.page": 1,
+			"com.tldraw.instance_presence": 5,
+			"com.tldraw.pointer": 1,
+			"com.tldraw.shape": 4,
+			"com.tldraw.asset.bookmark": 2,
+			"com.tldraw.asset.image": 4,
+			"com.tldraw.asset.video": 4,
+			"com.tldraw.shape.group": 0,
+			"com.tldraw.shape.text": 2,
+			"com.tldraw.shape.bookmark": 2,
+			"com.tldraw.shape.draw": 2,
+			"com.tldraw.shape.geo": 9,
+			"com.tldraw.shape.note": 7,
+			"com.tldraw.shape.line": 5,
+			"com.tldraw.shape.frame": 0,
+			"com.tldraw.shape.arrow": 5,
+			"com.tldraw.shape.highlight": 1,
+			"com.tldraw.shape.embed": 4,
+			"com.tldraw.shape.image": 3,
+			"com.tldraw.shape.video": 2,
+			"com.tldraw.shape.container": 0,
+			"com.tldraw.shape.element": 0,
+			"com.tldraw.binding.arrow": 0,
+			"com.tldraw.binding.layout": 0
+		}
+	}
+}


### PR DESCRIPTION
Adds an example of implementing layout contraints using bindings.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [x] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [x] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Adds an example of how to use bindings to create layout constraints
