### PR TITLE
editing: don't allow editing locked shapes when edit→edit mode. 

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -37,6 +37,7 @@ export class EditingShape extends StateNode {
 		// and if they are, we need to transition to translating instead.
 		if (this.hitShapeForPointerUp && this.editor.inputs.isDragging) {
 			if (this.editor.getInstanceState().isReadonly) return
+			if (this.hitShapeForPointerUp.isLocked) return
 			this.editor.select(this.hitShapeForPointerUp)
 			this.parent.transition('translating', info)
 			this.hitShapeForPointerUp = null
@@ -137,6 +138,8 @@ export class EditingShape extends StateNode {
 
 		// Stay in edit mode to maintain flow of editing.
 		const util = this.editor.getShapeUtil(hitShape)
+		if (hitShape.isLocked) return
+
 		if (this.editor.getInstanceState().isReadonly) {
 			if (!util.canEditInReadOnly(hitShape)) {
 				this.parent.transition('pointing_shape', info)


### PR DESCRIPTION
@OrionReed found this little bug. I started digging into it and it turns out we have a bunch of problems around locking and it's all a bit janky :P I was thinking I'd fix this at a deeper level (prevent select and editing in the first place if locked) but @SomeHats advised that this is all a bit of a hot mess 🙃 

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [x] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [ ] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [x] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [ ] `dunno` — I don't know


### Release Notes

- Editing: don't allow editing locked shapes when edit→edit mode.
