### PR TITLE
dx: PR labels re-revamp

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -26,6 +26,7 @@ apps/vscode/extension/editor/index.js
 apps/vscode/extension/editor/tldraw-assets.json
 **/sentry.server.config.js
 **/scripts/upload-sourcemaps.js
+**/scripts/lib/auto-plugin.js
 **/coverage/**/*
 
 apps/dotcom/public/sw.js

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,13 @@ Describe what your pull request does. If appropriate, add GIFs or images showing
 
 ### Change Type
 
+
 <!-- ❗ Please select a 'Type' label ❗️ -->
 
 - [ ] `feature` — New feature
 - [ ] `improvement` — Product improvement
 - [ ] `api` — API change
-- [ ] `bugfix` — Bug Fix
+- [ ] `bugfix` — Bug fix
 - [ ] `other` — Changes that don't affect SDK users, e.g. internal or .com changes
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,11 @@ Describe what your pull request does. If appropriate, add GIFs or images showing
 
 <!-- ❗ Please select a 'Type' label ❗️ -->
 
-- [ ] `improvement` — Improving existing features
-- [ ] `bugfix` — Bug fix
-- [ ] `api` — API Change
-- [ ] `other` — Internal or flagship .com change
+- [ ] `feature` — New feature
+- [ ] `improvement` — Product improvement
+- [ ] `api` — API change
+- [ ] `bugfix` — Bug Fix
+- [ ] `other` — Changes that don't affect SDK users, e.g. internal or .com changes
 
 
 ### Test Plan

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,24 +2,12 @@ Describe what your pull request does. If appropriate, add GIFs or images showing
 
 ### Change Type
 
-<!-- ❗ Please select a 'Scope' label ❗️ -->
-
-- [ ] `sdk` — Changes the tldraw SDK
-- [ ] `dotcom` — Changes the tldraw.com web app
-- [ ] `docs` — Changes to the documentation, examples, or templates.
-- [ ] `vs code` — Changes to the vscode plugin
-- [ ] `internal` — Does not affect user-facing stuff
-
 <!-- ❗ Please select a 'Type' label ❗️ -->
 
-- [ ] `bugfix` — Bug fix
-- [ ] `feature` — New feature
 - [ ] `improvement` — Improving existing features
-- [ ] `chore` — Updating dependencies, other boring stuff
-- [ ] `galaxy brain` — Architectural changes
-- [ ] `tests` — Changes to any test code
-- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
-- [ ] `dunno` — I don't know
+- [ ] `bugfix` — Bug fix
+- [ ] `api` — API Change
+- [ ] `other` — Internal or flagship .com change
 
 
 ### Test Plan

--- a/apps/huppy/src/flows/enforcePrLabels.tsx
+++ b/apps/huppy/src/flows/enforcePrLabels.tsx
@@ -56,6 +56,10 @@ export const enforcePrLabels: Flow = {
 			return fail('Please add a label to the PR.')
 		}
 
+		if (pull.body?.includes('Add a brief release note for your PR here.')) {
+			return fail('Add a release note to the PR body.')
+		}
+
 		// add any labels that are checked
 		console.log('adding labels')
 		if (selectedReleaseLabels.length > 0) {

--- a/scripts/lib/auto-plugin.js
+++ b/scripts/lib/auto-plugin.js
@@ -1,0 +1,42 @@
+module.exports = class AutoPlugin {
+	constructor() {
+		this.name = 'tldraw'
+	}
+
+	apply(auto) {
+		// Exclude bots.
+		auto.hooks.onCreateLogParse.tap(this.name, (changelog) =>
+			changelog.hooks.omitCommit.tap(this.name, (commit) =>
+				commit.authors.some((author) => author.type === 'Bot')
+			)
+		)
+
+		// Render the release note line, not the commit line.
+		auto.hooks.onCreateChangelog.tap(this.name, (changelog) =>
+			changelog.hooks.renderChangelogLine.tap(this.name, async (line, commit) => {
+				const releaseNote = /### Release Notes\n\n-(.*)/g.exec(
+					commit.pullRequest.body.replaceAll('\r\n', '\n')
+				)
+				// For some reason, there's duplicate authors.
+				const uniqueAuthors = commit.authors.filter(
+					(author, index, array) => array.findIndex((a) => a.username === author.username) === index
+				)
+				const authors = uniqueAuthors
+					.map((author) => `([@${author.username}](${author.html_url}))`)
+					.join(' ')
+				return releaseNote
+					? `- ${releaseNote[1].trim()} [#${commit.pullRequest.number}](https://github.com/tldraw/tldraw/pull/${commit.pullRequest.number}) ${authors}`
+					: line
+			})
+		)
+
+		// Only write out changelog, not release notes (they're not very good).
+		auto.hooks.onCreateChangelog.tap(this.name, (changelog) =>
+			changelog.hooks.omitReleaseNotes.tap(this.name, (commit) => true)
+		)
+	}
+}
+
+function uniq(value, index, array) {
+	return array.indexOf(value) === index
+}

--- a/scripts/lib/auto-plugin.js
+++ b/scripts/lib/auto-plugin.js
@@ -17,15 +17,8 @@ module.exports = class AutoPlugin {
 				const releaseNote = /### Release Notes\n\n-(.*)/g.exec(
 					commit.pullRequest.body.replaceAll('\r\n', '\n')
 				)
-				// For some reason, there's duplicate authors.
-				const uniqueAuthors = commit.authors.filter(
-					(author, index, array) => array.findIndex((a) => a.username === author.username) === index
-				)
-				const authors = uniqueAuthors
-					.map((author) => `([@${author.username}](${author.html_url}))`)
-					.join(' ')
 				return releaseNote
-					? `- ${releaseNote[1].trim()} [#${commit.pullRequest.number}](https://github.com/tldraw/tldraw/pull/${commit.pullRequest.number}) ${authors}`
+					? `- ${releaseNote[1].trim()} [#${commit.pullRequest.number}](https://github.com/tldraw/tldraw/pull/${commit.pullRequest.number})`
 					: line
 			})
 		)

--- a/scripts/lib/labels.ts
+++ b/scripts/lib/labels.ts
@@ -12,17 +12,26 @@ interface Label {
 
 const TYPE_LABELS = [
 	{
+		name: `feature`,
+		description: `New feature`,
+		changelogTitle: '🎉 New Features',
+	},
+	{
 		name: `improvement`,
-		description: `Product Improvement`,
+		description: `Product improvement`,
 		changelogTitle: '💄 Product Improvements',
+	},
+	{
+		name: `api`,
+		description: `API change`,
+		changelogTitle: '🛠️ API Changes',
 	},
 	{ name: `bugfix`, description: `Bug fix`, changelogTitle: '🐛 Bug Fixes' },
 	{
-		name: `api`,
-		description: `API Change`,
-		changelogTitle: '🛠️ API Changes',
+		name: `other`,
+		description: `Changes that don't affect SDK users, e.g. internal or .com changes`,
+		changelogTitle: '🤷 Other',
 	},
-	{ name: `other`, description: `Internal or flagship .com change`, changelogTitle: '🤷 Other' },
 ] as const satisfies Label[]
 
 export function getLabelNames() {
@@ -45,7 +54,7 @@ export async function generateAutoRcFile() {
 	const autoRcPath = join(REPO_ROOT, '.autorc')
 	await writeJsonFile(autoRcPath, {
 		plugins: ['npm', '../scripts/lib/auto-plugin.js'],
-		labels: [...TYPE_LABELS].map(({ name, changelogTitle }) => ({
+		labels: [...TYPE_LABELS.filter((l) => l.name !== 'other')].map(({ name, changelogTitle }) => ({
 			name,
 			changelogTitle,
 			releaseType: 'none',

--- a/scripts/lib/labels.ts
+++ b/scripts/lib/labels.ts
@@ -10,63 +10,23 @@ interface Label {
 	changelogTitle: string
 }
 
-const SCOPE_LABELS = [
-	{
-		name: `sdk`,
-		description: `Changes the tldraw SDK`,
-		changelogTitle: '📚 SDK Changes',
-	},
-	{
-		name: `dotcom`,
-		description: `Changes the tldraw.com web app`,
-		changelogTitle: '🖥️ tldraw.com Changes',
-	},
-	{
-		name: `docs`,
-		description: `Changes to the documentation, examples, or templates.`,
-		changelogTitle: '📖 Documentation changes',
-	},
-	{
-		name: `vs code`,
-		description: `Changes to the vscode plugin`,
-		changelogTitle: '👩‍💻 VS Code Plugin Changes',
-	},
-	{
-		name: `internal`,
-		description: `Does not affect user-facing stuff`,
-		changelogTitle: '🕵️‍♀️ Internal Changes',
-	},
-] as const satisfies Label[]
-
 const TYPE_LABELS = [
-	{ name: `bugfix`, description: `Bug fix`, changelogTitle: '🐛 Bug Fixes' },
-	{ name: `feature`, description: `New feature`, changelogTitle: '🚀 Features' },
 	{
 		name: `improvement`,
-		description: `Improving existing features`,
-		changelogTitle: '💄 Improvements',
+		description: `Product Improvement`,
+		changelogTitle: '💄 Product Improvements',
 	},
+	{ name: `bugfix`, description: `Bug fix`, changelogTitle: '🐛 Bug Fixes' },
 	{
-		name: `chore`,
-		description: `Updating dependencies, other boring stuff`,
-		changelogTitle: '🧹 Chores',
+		name: `api`,
+		description: `API Change`,
+		changelogTitle: '🛠️ API Changes',
 	},
-	{
-		name: `galaxy brain`,
-		description: `Architectural changes`,
-		changelogTitle: '🤯 Architectural changes',
-	},
-	{ name: `tests`, description: `Changes to any test code`, changelogTitle: '🧪 Tests' },
-	{
-		name: `tools`,
-		description: `Changes to infrastructure, CI, internal scripts, debugging tools, etc.`,
-		changelogTitle: '🛠️ Tools',
-	},
-	{ name: `dunno`, description: `I don't know`, changelogTitle: '🤷 Dunno' },
+	{ name: `other`, description: `Internal or flagship .com change`, changelogTitle: '🤷 Other' },
 ] as const satisfies Label[]
 
 export function getLabelNames() {
-	return [...SCOPE_LABELS, ...TYPE_LABELS].map((label) => label.name)
+	return [...TYPE_LABELS].map((label) => label.name)
 }
 
 function formatTemplateOption(label: Label) {
@@ -74,11 +34,7 @@ function formatTemplateOption(label: Label) {
 }
 
 export function formatLabelOptionsForPRTemplate() {
-	let result = `<!-- ❗ Please select a 'Scope' label ❗️ -->\n\n`
-	for (const label of SCOPE_LABELS) {
-		result += formatTemplateOption(label) + '\n'
-	}
-	result += `\n<!-- ❗ Please select a 'Type' label ❗️ -->\n\n`
+	let result = `\n<!-- ❗ Please select a 'Type' label ❗️ -->\n\n`
 	for (const label of TYPE_LABELS) {
 		result += formatTemplateOption(label) + '\n'
 	}
@@ -88,8 +44,8 @@ export function formatLabelOptionsForPRTemplate() {
 export async function generateAutoRcFile() {
 	const autoRcPath = join(REPO_ROOT, '.autorc')
 	await writeJsonFile(autoRcPath, {
-		plugins: ['npm'],
-		labels: [...SCOPE_LABELS, ...TYPE_LABELS].map(({ name, changelogTitle }) => ({
+		plugins: ['npm', '../scripts/lib/auto-plugin.js'],
+		labels: [...TYPE_LABELS].map(({ name, changelogTitle }) => ({
 			name,
 			changelogTitle,
 			releaseType: 'none',


### PR DESCRIPTION
This is a followup to https://github.com/tldraw/tldraw/pull/3112 after a discussion with Alex about how our release notes writing is really manual now.

This changes the labels to be a more limited set.

It also adds a plugin to help massage the release notes into what we want it to be:
- ignores bot commits
- use the release notes, if found, not the commit msg
- skip writing the "release notes" in general, just create the changelog which is what we want anyway.

### Change Type

<!-- ❗ Please select a 'Scope' label ❗️ -->

- [ ] `sdk` — Changes the tldraw SDK
- [ ] `dotcom` — Changes the tldraw.com web app
- [ ] `docs` — Changes to the documentation, examples, or templates.
- [ ] `vs code` — Changes to the vscode plugin
- [x] `internal` — Does not affect user-facing stuff

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `bugfix` — Bug fix
- [ ] `feature` — New feature
- [ ] `improvement` — Improving existing features
- [ ] `chore` — Updating dependencies, other boring stuff
- [ ] `galaxy brain` — Architectural changes
- [ ] `tests` — Changes to any test code
- [ ] `tools` — Changes to infrastructure, CI, internal scripts, debugging tools, etc.
- [x] `dunno` — I don't know

