### PR TITLE
check worker bundle sizes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check scripts
         run: yarn check-scripts
 
+      - name: Check bundle sizes
+        run: yarn lazy check-bundle-size
+
       - name: Check PR template
         run: yarn update-pr-template --check
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ apps/docs/api
 /vercel.json
 license-report-prod.html
 license-report.html
+
+.bundle-meta.json

--- a/apps/dotcom-worker/package.json
+++ b/apps/dotcom-worker/package.json
@@ -18,6 +18,7 @@
 		"test-ci": "lazy inherit",
 		"test": "yarn run -T jest",
 		"test-coverage": "lazy inherit",
+		"check-bundle-size": "yarn run -T tsx ../../scripts/check-worker-bundle.ts --entry src/lib/worker.ts --size-limit-bytes 350000",
 		"lint": "yarn run -T tsx ../../scripts/lint.ts"
 	},
 	"dependencies": {

--- a/apps/health-worker/package.json
+++ b/apps/health-worker/package.json
@@ -6,6 +6,7 @@
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
+		"check-bundle-size": "yarn run -T tsx ../../scripts/check-worker-bundle.ts --entry src/index.ts --size-limit-bytes 35000",
 		"lint": "yarn run -T tsx ../../scripts/lint.ts"
 	},
 	"dependencies": {
@@ -15,6 +16,7 @@
 		"@cloudflare/workers-types": "^4.20240620.0",
 		"@types/node": "~20.11",
 		"discord-api-types": "^0.37.67",
+		"esbuild": "^0.18.4",
 		"typescript": "^5.3.3",
 		"wrangler": "3.61.0"
 	}

--- a/scripts/check-worker-bundle.ts
+++ b/scripts/check-worker-bundle.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync, rmSync } from 'fs'
+import kleur from 'kleur'
+import minimist from 'minimist'
+import { resolve } from 'path'
+import { exec } from './lib/exec'
+
+const args = minimist(process.argv.slice(2))
+const sizeLimit = Number(args['size-limit-bytes'])
+if (!isFinite(sizeLimit) || sizeLimit < 1) {
+	console.error(
+		'Invalid usage. Usage: yarn tsx check-worker-bundle.ts --size-limit-bytes <size> --entry <entry>'
+	)
+	process.exit(1)
+}
+
+const entry = args['entry']
+if (!existsSync(entry)) {
+	console.error('Entry file does not exist:', entry)
+	process.exit(1)
+}
+
+const bundleMetaFileName = '.bundle-meta.json'
+
+interface Meta {
+	outputs: {
+		[fileName: string]: {
+			bytes: number
+		}
+	}
+}
+
+async function checkBundleSize() {
+	rmSync(bundleMetaFileName, { force: true })
+
+	await exec('yarn', [
+		'esbuild',
+		entry,
+		'--bundle',
+		'--outfile=/dev/null',
+		'--minify',
+		'--external:cloudflare:workers',
+		'--metafile=' + bundleMetaFileName,
+	])
+
+	console.log(kleur.cyan().bold('Checking bundle size'), 'of', resolve(entry) + '\n')
+
+	const meta = JSON.parse(readFileSync(bundleMetaFileName).toString()) as Meta
+	const totalSize = Object.values(meta.outputs).reduce((acc, output) => acc + output.bytes, 0)
+	if (totalSize === 0) {
+		throw new Error('Invalid bundle meta in ' + process.cwd() + '/' + bundleMetaFileName)
+	}
+
+	if (totalSize > sizeLimit) {
+		console.error(
+			`${kleur.red().bold('ERROR')} Bundle size exceeds limit: ${totalSize} > ${sizeLimit}`
+		)
+		process.exit(1)
+	}
+
+	console.log(`Bundle size is within limit: ${totalSize} < ${sizeLimit}`)
+}
+
+checkBundleSize()

--- a/yarn.lock
+++ b/yarn.lock
@@ -13344,6 +13344,7 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     "@types/node": "npm:~20.11"
     discord-api-types: "npm:^0.37.67"
+    esbuild: "npm:^0.18.4"
     typescript: "npm:^5.3.3"
     wrangler: "npm:3.61.0"
   languageName: unknown


### PR DESCRIPTION
This PR aims to make sure #4030 doesn't need to happen again. We check that the worker file sizes stay within a given limit, and require people to explicitly up this limit if they decide to add new deps that grow the bundle size significantly.

### Change Type

<!-- ❗ Please select a 'Type' label ❗️ -->

- [ ] `feature` — New feature
- [ ] `improvement` — Product improvement
- [ ] `api` — API change
- [ ] `bugfix` — Bug fix
- [x] `other` — Changes that don't affect SDK users, e.g. internal or .com changes


### Test Plan

1. Add a step-by-step description of how to test your PR here.
2.

- [ ] Unit Tests
- [ ] End to end tests

### Release Notes

- Add a brief release note for your PR here.
