### PR TITLE
Fix empty edit context menu 

### DIFF
--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -330,6 +330,8 @@ export function DeleteMenuItem() {
 
 /** @public @react */
 export function EditMenuSubmenu() {
+	if (!useAnySelectedShapesCount(1)) return null
+
 	return (
 		<TldrawUiMenuSubmenu id="edit" label="context-menu.edit" size="small">
 			<GroupMenuItem />


### PR DESCRIPTION
This PR fixes a case where right clicking on an empty canvas would display the edit menu, even when there was nothing to do in the menu.

### Change Type

- [ ] `feature` — New feature
- [ ] `improvement` — Product improvement
- [ ] `api` — API change
- [x] `bugfix` — Bug fix
- [ ] `other` — Changes that don't affect SDK users, e.g. internal or .com changes


### Test Plan

1. Right click on the canvas

### Release Notes

- Fixes a bug where the context menu would display an empty edit menu.