### PR TITLE
Add `setDefaultValue` to `StyleProp`

### DIFF
--- a/apps/examples/src/examples/changing-default-style/ChangingDefaultStyleExample.tsx
+++ b/apps/examples/src/examples/changing-default-style/ChangingDefaultStyleExample.tsx
@@ -1,0 +1,12 @@
+import { DefaultSizeStyle, Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+DefaultSizeStyle.setDefaultValue('s')
+
+export default function ChangingDefaultStyleExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="example" />
+		</div>
+	)
+}

--- a/apps/examples/src/examples/changing-default-style/README.md
+++ b/apps/examples/src/examples/changing-default-style/README.md
@@ -1,0 +1,13 @@
+---
+title: Changing default style
+component: ./ChangingDefaultStyleExample.tsx
+category: ui
+priority: 1
+keywords: [size, styles, default]
+---
+
+Change the default value for a style prop.
+
+---
+
+Want to set the default value for a property to something other than it's built-in default? In this example we make the size style have small as its default calue.

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -851,7 +851,7 @@ export class StyleProp<Type> implements T.Validatable<Type> {
     // (undocumented)
     readonly id: string;
     // (undocumented)
-    setDefault(value: Type): void;
+    setDefaultValue(value: Type): void;
     // (undocumented)
     readonly type: T.Validatable<Type>;
     // (undocumented)

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -839,7 +839,7 @@ export class StyleProp<Type> implements T.Validatable<Type> {
     // @internal
     protected constructor(id: string, defaultValue: Type, type: T.Validatable<Type>);
     // (undocumented)
-    readonly defaultValue: Type;
+    defaultValue: Type;
     static define<Type>(uniqueId: string, options: {
         defaultValue: Type;
         type?: T.Validatable<Type>;
@@ -850,6 +850,8 @@ export class StyleProp<Type> implements T.Validatable<Type> {
     }): EnumStyleProp<Values[number]>;
     // (undocumented)
     readonly id: string;
+    // (undocumented)
+    setDefault(value: Type): void;
     // (undocumented)
     readonly type: T.Validatable<Type>;
     // (undocumented)

--- a/packages/tlschema/src/styles/StyleProp.ts
+++ b/packages/tlschema/src/styles/StyleProp.ts
@@ -87,7 +87,7 @@ export class StyleProp<Type> implements T.Validatable<Type> {
 		readonly type: T.Validatable<Type>
 	) {}
 
-	setDefault(value: Type) {
+	setDefaultValue(value: Type) {
 		this.defaultValue = value
 	}
 

--- a/packages/tlschema/src/styles/StyleProp.ts
+++ b/packages/tlschema/src/styles/StyleProp.ts
@@ -83,9 +83,13 @@ export class StyleProp<Type> implements T.Validatable<Type> {
 	/** @internal */
 	protected constructor(
 		readonly id: string,
-		readonly defaultValue: Type,
+		public defaultValue: Type,
 		readonly type: T.Validatable<Type>
 	) {}
+
+	setDefault(value: Type) {
+		this.defaultValue = value
+	}
 
 	validate(value: unknown) {
 		return this.type.validate(value)


### PR DESCRIPTION
This PR adds a way to set the default value of a style property.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Adds a method for changing the default style of a `StyleProp` instance.