### PR TITLE
Ghost image tweaks

### DIFF
--- a/apps/dotcom/src/utils/assetHandler.ts
+++ b/apps/dotcom/src/utils/assetHandler.ts
@@ -69,8 +69,10 @@ async function getLocalAssetObjectURL(persistenceKey: string, assetId: TLAssetId
 		assetId: assetId,
 		persistenceKey,
 	})
+
 	if (blob) {
 		return URL.createObjectURL(blob)
 	}
+
 	return null
 }

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -24,6 +24,7 @@ import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
 import { PerformanceTracker } from '@tldraw/utils';
 import { PointerEventHandler } from 'react';
+import { RC } from '@tldraw/utils';
 import { react } from '@tldraw/state';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
@@ -846,7 +847,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     capturedPointerId: null | number;
     centerOnPoint(point: VecLike, opts?: TLCameraMoveOptions): this;
     clearOpenMenus(): this;
-    clearTemporaryAssetPreview(objectUrl: string): void;
     // @internal
     protected _clickManager: ClickManager;
     complete(): this;
@@ -871,6 +871,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     createPage(page: Partial<TLPage>): this;
     createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this;
     createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this;
+    createTemporaryAssetPreview(assetId: TLAssetId, file: File): RC<string>;
     deleteAssets(assets: TLAsset[] | TLAssetId[]): this;
     deleteBinding(binding: TLBinding | TLBindingId, opts?: Parameters<this['deleteBindings']>[1]): this;
     deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
@@ -1055,7 +1056,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         svg: string;
         width: number;
     } | undefined>;
-    getTemporaryAssetPreview(assetId: TLAssetId): string;
+    getTemporaryAssetPreview(assetId: TLAssetId): RC<string> | undefined;
     // @internal (undocumented)
     getUnorderedRenderingShapes(useEditorState: boolean): {
         backgroundIndex: number;
@@ -1178,7 +1179,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     setSelectedShapes(shapes: TLShape[] | TLShapeId[]): this;
     setStyleForNextShapes<T>(style: StyleProp<T>, value: T, historyOptions?: TLHistoryBatchOptions): this;
     setStyleForSelectedShapes<S extends StyleProp<any>>(style: S, value: StylePropValue<S>): this;
-    setTemporaryAssetPreview(assetId: TLAssetId, file: File): void;
     shapeUtils: {
         readonly [K in string]?: ShapeUtil<TLUnknownShape>;
     };

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -24,7 +24,6 @@ import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
 import { PerformanceTracker } from '@tldraw/utils';
 import { PointerEventHandler } from 'react';
-import { RC } from '@tldraw/utils';
 import { react } from '@tldraw/state';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
@@ -32,6 +31,7 @@ import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RecordProps } from '@tldraw/tlschema';
 import { RecordsDiff } from '@tldraw/store';
+import { ReferenceCounterWithFixedTimeout } from '@tldraw/utils';
 import { SerializedSchema } from '@tldraw/store';
 import { SerializedStore } from '@tldraw/store';
 import { Signal } from '@tldraw/state';
@@ -871,7 +871,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     createPage(page: Partial<TLPage>): this;
     createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this;
     createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this;
-    createTemporaryAssetPreview(assetId: TLAssetId, file: File): RC<string>;
+    createTemporaryAssetPreview(assetId: TLAssetId, file: File): ReferenceCounterWithFixedTimeout<string>;
     deleteAssets(assets: TLAsset[] | TLAssetId[]): this;
     deleteBinding(binding: TLBinding | TLBindingId, opts?: Parameters<this['deleteBindings']>[1]): this;
     deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
@@ -1056,7 +1056,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         svg: string;
         width: number;
     } | undefined>;
-    getTemporaryAssetPreview(assetId: TLAssetId): RC<string> | undefined;
+    getTemporaryAssetPreview(assetId: TLAssetId): ReferenceCounterWithFixedTimeout<string> | undefined;
     // @internal (undocumented)
     getUnorderedRenderingShapes(useEditorState: boolean): {
         backgroundIndex: number;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -631,15 +631,58 @@ input,
 	align-items: center;
 }
 
-.tl-image-temporary {
-  mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right / 400% 100%;
-  background-repeat: no-repeat;
-  animation: shimmer 1s ease-in-out infinite;
+.tl-image-container {
+	position: relative;
+	overflow: hidden;
+}
+.tl-image {
+	position: absolute;
+	inset: 0;
+}
+.tl-image-pending {
+	opacity: 0;
+	pointer-events: none;
+}
+.tl-image-container::after {
+	content: ' ';
+	display: block;
+	position: absolute;
+	left: -100%;
+	right: -100%;
+	top: 0;
+	bottom: 0;
+
+	background: linear-gradient(
+		-60deg,
+		color-mix(in srgb, transparent 100%, var(--color-background)) 30%,
+		color-mix(in srgb, transparent 27.8%, var(--color-background)) 41.3%,
+		color-mix(in srgb, transparent 4.2%, var(--color-background)) 47.22%,
+		color-mix(in srgb, transparent 0%, var(--color-background)) 50%,
+		color-mix(in srgb, transparent 4.2%, var(--color-background)) 52.78%,
+		color-mix(in srgb, transparent 27.8%, var(--color-background)) 58.7%,
+		color-mix(in srgb, transparent 100%, var(--color-background)) 70%
+	);
+
+	animation: shimmer 1s linear infinite;
+
+	opacity: 0;
+	display: none;
+	transition:
+		opacity 0.5s,
+		display 0.5s allow-discrete;
+}
+
+.tl-image-container.tl-image-container-loading::after {
+	opacity: 0.3;
+	display: block;
 }
 
 @keyframes shimmer {
+	0% {
+		transform: translateX(-100%);
+	}
 	100% {
-		mask-position: left;
+		transform: translateX(100%);
 	}
 }
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -58,7 +58,7 @@ import {
 	IndexKey,
 	JsonObject,
 	PerformanceTracker,
-	RC,
+	ReferenceCounterWithFixedTimeout,
 	Result,
 	Timers,
 	annotateError,
@@ -7676,7 +7676,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/** @internal */
-	private readonly temporaryAssetPreview = new Map<TLAssetId, RC<string>>()
+	private readonly temporaryAssetPreview = new Map<
+		TLAssetId,
+		ReferenceCounterWithFixedTimeout<string>
+	>()
 
 	/**
 	 * Register an external content handler. This handler will be called when the editor receives
@@ -7720,13 +7723,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		assert(!this.temporaryAssetPreview.has(assetId), 'Asset preview already exists')
 
 		const urlString = URL.createObjectURL(file)
-		const urlResource = new RC(
+		const urlResource = new ReferenceCounterWithFixedTimeout(
 			urlString,
 			() => {
 				this.temporaryAssetPreview.delete(assetId)
 				URL.revokeObjectURL(urlString)
 			},
-			60_000
+			60 * 1000
 		)
 		this.temporaryAssetPreview.set(assetId, urlResource)
 		return urlResource

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -161,9 +161,6 @@ export class TLLocalSyncClient {
 		} catch (error: any) {
 			onLoadError(error)
 			showCantReadFromIndexDbAlert()
-			if (typeof window !== 'undefined') {
-				window.location.reload()
-			}
 			return
 		}
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -443,7 +443,7 @@ export const DefaultQuickActions: NamedExoticComponent<TLUiQuickActionsProps>;
 export function DefaultQuickActionsContent(): JSX_2.Element | undefined;
 
 // @public (undocumented)
-export const defaultShapeTools: (typeof ArrowShapeTool)[];
+export const defaultShapeTools: (typeof TextShapeTool)[];
 
 // @public (undocumented)
 export const defaultShapeUtils: TLAnyShapeUtilConstructor[];
@@ -1011,7 +1011,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     canCrop: () => boolean;
     // (undocumented)
-    component(shape: TLImageShape): JSX_2.Element | null;
+    component(shape: TLImageShape): JSX_2.Element;
     // (undocumented)
     getDefaultProps(): TLImageShape['props'];
     // (undocumented)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -3,7 +3,7 @@ import {
 	Editor,
 	FileHelpers,
 	MediaHelpers,
-	RC,
+	ReferenceCounterWithFixedTimeout,
 	TLAsset,
 	TLAssetId,
 	TLBookmarkShape,
@@ -228,7 +228,11 @@ export function registerDefaultExternalContentHandlers(
 
 		const pagePoint = new Vec(position.x, position.y)
 		const assets: TLAsset[] = []
-		const assetsToUpdate: { asset: TLAsset; file: File; temporaryAssetPreview?: RC<string> }[] = []
+		const assetsToUpdate: {
+			asset: TLAsset
+			file: File
+			temporaryAssetPreview?: ReferenceCounterWithFixedTimeout<string>
+		}[] = []
 		for (const file of files) {
 			if (file.size > maxAssetSize) {
 				console.warn(

--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -1,10 +1,11 @@
-import { TLAssetId, TLShapeId, useEditor, useValue } from '@tldraw/editor'
-import { useEffect, useState } from 'react'
+import { RC, TLAssetId, TLShapeId, useEditor, useValue } from '@tldraw/editor'
+import { useEffect, useRef, useState } from 'react'
 
 /** @internal */
 export function useAsset(shapeId: TLShapeId, assetId: TLAssetId | null, width: number) {
 	const editor = useEditor()
-	const [url, setUrl] = useState<string | null>(null)
+	const [url, setUrl] = useState<string | RC<string> | null>(null)
+	const [isPlaceholder, setIsPlaceholder] = useState(false)
 	const asset = assetId ? editor.getAsset(assetId) : null
 	const culledShapes = editor.getCulledShapes()
 	const isCulled = culledShapes.has(shapeId)
@@ -17,22 +18,68 @@ export function useAsset(shapeId: TLShapeId, assetId: TLAssetId | null, width: n
 		shapeScale,
 	])
 
+	const didAlreadyResolve = useRef(false)
+
+	useEffect(() => {
+		if (url) didAlreadyResolve.current = true
+	}, [url])
+
 	useEffect(() => {
 		if (isCulled) return
 
+		if (assetId && !asset?.props.src) {
+			const preview = editor.getTemporaryAssetPreview(assetId)
+			if (preview) {
+				setUrl(preview.retain())
+				setIsPlaceholder(true)
+				return () => {
+					preview.release()
+				}
+			}
+		}
+
 		let isCancelled = false
-		const timer = editor.timers.setTimeout(async () => {
+
+		async function resolve() {
 			const resolvedUrl = await editor.resolveAssetUrl(assetId, {
 				screenScale,
 			})
-			if (!isCancelled) setUrl(resolvedUrl)
-		}, 500)
+			if (!isCancelled) {
+				setUrl(resolvedUrl)
+				setIsPlaceholder(false)
+			}
+		}
 
-		return () => {
-			clearTimeout(timer)
-			isCancelled = true
+		// if we already resolved the URL, debounce resolution:
+		if (didAlreadyResolve.current) {
+			const timer = editor.timers.setTimeout(resolve, 500)
+
+			return () => {
+				clearTimeout(timer)
+				isCancelled = true
+			}
+		} else {
+			// if not, resolve immediately:
+			resolve()
+			return () => {
+				isCancelled = true
+			}
 		}
 	}, [assetId, asset?.props.src, isCulled, screenScale, editor])
 
-	return { asset, url }
+	return { asset, url, isPlaceholder }
+}
+
+/** @internal */
+export function useRC<T>(value: RC<T> | T): T {
+	useEffect(() => {
+		if (value instanceof RC) {
+			value.retain()
+			return () => {
+				value.release()
+			}
+		}
+	})
+
+	return value instanceof RC ? value.unsafeGetWithoutRetain() : value
 }

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -12,7 +12,7 @@ import {
 import { ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useAsset, useRC } from '../shared/useAsset'
+import { useAsset, useReferenceCounter } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -44,7 +44,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const prefersReducedMotion = usePrefersReducedMotion()
 		const { Spinner } = useEditorComponents()
 
-		const url = useRC(urlResource)
+		const url = useReferenceCounter(urlResource)
 
 		const rVideo = useRef<HTMLVideoElement>(null!)
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -12,7 +12,7 @@ import {
 import { ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useAsset } from '../shared/useAsset'
+import { useAsset, useRC } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -38,11 +38,13 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	component(shape: TLVideoShape) {
 		const { editor } = this
 		const showControls = editor.getShapeGeometry(shape).bounds.w * editor.getZoomLevel() >= 110
-		const { asset, url } = useAsset(shape.id, shape.props.assetId, shape.props.w)
+		const { asset, url: urlResource } = useAsset(shape.id, shape.props.assetId, shape.props.w)
 		const { time, playing } = shape.props
 		const isEditing = useIsEditing(shape.id)
 		const prefersReducedMotion = usePrefersReducedMotion()
 		const { Spinner } = useEditorComponents()
+
+		const url = useRC(urlResource)
 
 		const rVideo = useRef<HTMLVideoElement>(null!)
 

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -337,6 +337,17 @@ export function promiseWithResolve<T>(): Promise<T> & {
     resolve: (value: T) => void;
 };
 
+// @internal (undocumented)
+export class RC<out T> {
+    constructor(value: T, dispose: () => void, timeout?: number);
+    // (undocumented)
+    release(): void;
+    // (undocumented)
+    retain(): T;
+    // (undocumented)
+    unsafeGetWithoutRetain(): T;
+}
+
 // @public (undocumented)
 export type RecursivePartial<T> = {
     [P in keyof T]?: RecursivePartial<T[P]>;

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -337,8 +337,13 @@ export function promiseWithResolve<T>(): Promise<T> & {
     resolve: (value: T) => void;
 };
 
+// @public (undocumented)
+export type RecursivePartial<T> = {
+    [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
 // @internal (undocumented)
-export class RC<out T> {
+export class ReferenceCounterWithFixedTimeout<out T> {
     constructor(value: T, dispose: () => void, timeout?: number);
     // (undocumented)
     release(): void;
@@ -347,11 +352,6 @@ export class RC<out T> {
     // (undocumented)
     unsafeGetWithoutRetain(): T;
 }
-
-// @public (undocumented)
-export type RecursivePartial<T> = {
-    [P in keyof T]?: RecursivePartial<T[P]>;
-};
 
 // @internal (undocumented)
 type Required_2<T, K extends keyof T> = Expand<Omit<T, K> & {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './lib/array'
 export { WeakCache } from './lib/cache'
 export {
+	RC,
 	Result,
 	assert,
 	assertExists,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,7 +12,7 @@ export {
 } from './lib/array'
 export { WeakCache } from './lib/cache'
 export {
-	RC,
+	ReferenceCounterWithFixedTimeout,
 	Result,
 	assert,
 	assertExists,

--- a/packages/utils/src/lib/control.ts
+++ b/packages/utils/src/lib/control.ts
@@ -66,7 +66,7 @@ export function promiseWithResolve<T>(): Promise<T> & {
 }
 
 /** @internal */
-export class RC<out T> {
+export class ReferenceCounterWithFixedTimeout<out T> {
 	private count = 0
 	private disposeTimeout: NodeJS.Timeout | undefined
 

--- a/packages/utils/src/lib/control.ts
+++ b/packages/utils/src/lib/control.ts
@@ -64,3 +64,47 @@ export function promiseWithResolve<T>(): Promise<T> & {
 		reject: reject!,
 	})
 }
+
+/** @internal */
+export class RC<out T> {
+	private count = 0
+	private disposeTimeout: NodeJS.Timeout | undefined
+
+	constructor(
+		private readonly value: T,
+		private readonly dispose: () => void,
+		private readonly timeout = 0
+	) {
+		// if an RC value isn't immediately retained, it will be disposed:
+		this.scheduleDispose()
+	}
+
+	unsafeGetWithoutRetain() {
+		return this.value
+	}
+
+	retain() {
+		this.count++
+		if (this.disposeTimeout) {
+			clearTimeout(this.disposeTimeout)
+			this.disposeTimeout = undefined
+		}
+		return this.value
+	}
+
+	release() {
+		this.count--
+		this.scheduleDispose()
+	}
+
+	private scheduleDispose() {
+		if (this.count <= 0) {
+			// eslint-disable-next-line no-restricted-globals
+			this.disposeTimeout = setTimeout(() => {
+				if (this.count === 0) {
+					this.dispose()
+				}
+			}, this.timeout)
+		}
+	}
+}


### PR DESCRIPTION
There's a few things in here:
1. Animation changes
    - The shimmer is less sharp, we use a nicely eased gradient instead of a linear gradient with sharp edges
    - When the animation ends, the shimmer fades out instead of disappearing with a snap 
2. Loading bug fix
    - When an image first mounts, we currently wait 500ms before showing it. This is most obvious when duplicating an existing image
    - This is the same bug as fixed in #4045, although i think there's extra stuff in there? Not sure
3. React image preloading `key` trick
    - Instead of preloading in an effect with a temporary `Image`, you can preload with the actual `<img>` you're planning on using with a `key`. 
    - When the loading is finished, the new `<img>` will show and the old will be unmounted
    - Sometimes (depending on how caching etc. is configured), the separate `Image` trick can cause a flash whilst the new image is mounted and fetched from the cache. This doesn't happen with the react/key trick
4. Object URL resource management experiment
    - @mimecuvalo and I spent a while talking about different strategies for managing preview object URLs after the upload has finished. This is based on some ideas I had after that conversation
    - We use reference counting and a timeout to keep the object URL retained as long as the upload is happening, or anything is still making use of it.
    - imo this isn't worth the complexity. the 60s timeout (we could set it to 3-5 minutes if we're really worried) is probably good enough, even though there are times when it theoretically may result in temporarily broken images on very poor connections.

This PR has a bunch of ideas and they're all a bit muddled together, sorry! @mimecuvalo we should chat through what's in here. Roughly:
- I would like to land 1 and maybe 2 (depending on #4045). 
- I like 3, but the `Image` approach is probably good enough too. Could go either way!
- I don't think we should do 4, I don't think the gain is worth the complexity

### Change type

- [x] `improvement`