### PR TITLE
Subtle crypto

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -57,9 +57,7 @@
 		"eventemitter3": "^4.0.7",
 		"idb": "^7.1.1",
 		"is-plain-object": "^5.0.0",
-		"nanoid": "4.0.2",
-		"tweetnacl": "^1.0.3",
-		"tweetnacl-util": "^0.15.1"
+		"nanoid": "4.0.2"
 	},
 	"peerDependencies": {
 		"react": "^18",

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -711,11 +711,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._tickManager.start()
 		})
 
-		this.licenseManager = new LicenseManager()
-		this.watermarkManager = new WatermarkManager(this)
 		this.checkLicenseKey = async () => {
-			const license = await this.licenseManager.getLicenseFromKey(licenseKey)
-			this.watermarkManager.checkWatermark(license)
+			const licenseManager = new LicenseManager()
+			const watermarkManager = new WatermarkManager(this)
+			const license = await licenseManager.getLicenseFromKey(licenseKey)
+			watermarkManager.checkWatermark(license)
 		}
 		this.checkLicenseKey()
 
@@ -820,20 +820,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	private focusManager: FocusManager
 
 	/**
-	 * A manager for licensing.
-	 *
-	 * @internal
-	 */
-	private licenseManager: LicenseManager
-	/**
-	 * A manager for the watermark.
-	 *
-	 * @internal
-	 */
-	private watermarkManager: WatermarkManager
-
-	/**
-	 * A function that checks the watermark.
+	 * A function that instantiates the license manager and watermark manager, and
+	 * checks the license key. Showing a watermark if the license key is invalid.
 	 *
 	 */
 	private checkLicenseKey: () => void

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -713,14 +713,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.licenseManager = new LicenseManager()
 		this.watermarkManager = new WatermarkManager(this)
-		this.licenseManager
-			.getLicenseFromKey(licenseKey)
-			.then((license) => {
-				this.watermarkManager.checkWatermark(license)
-			})
-			.catch((error) => {
-				throw new Error(`Error getting license: ${error}`)
-			})
+		this.checkLicenseKey = async () => {
+			const license = await this.licenseManager.getLicenseFromKey(licenseKey)
+			this.watermarkManager.checkWatermark(license)
+		}
+		this.checkLicenseKey()
 
 		this.performanceTracker = new PerformanceTracker()
 	}
@@ -834,6 +831,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @internal
 	 */
 	private watermarkManager: WatermarkManager
+
+	/**
+	 * A function that checks the watermark.
+	 *
+	 */
+	private checkLicenseKey: () => void
 
 	/**
 	 * The current HTML element containing the editor.

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -712,9 +712,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 
 		this.licenseManager = new LicenseManager()
-		const license = this.licenseManager.getLicenseFromKey(licenseKey)
 		this.watermarkManager = new WatermarkManager(this)
-		this.watermarkManager.checkWatermark(license)
+		this.licenseManager
+			.getLicenseFromKey(licenseKey)
+			.then((license) => {
+				this.watermarkManager.checkWatermark(license)
+			})
+			.catch((error) => {
+				throw new Error(`Error getting license: ${error}`)
+			})
 
 		this.performanceTracker = new PerformanceTracker()
 	}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -711,13 +711,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._tickManager.start()
 		})
 
-		this.checkLicenseKey = async () => {
-			const licenseManager = new LicenseManager()
-			const watermarkManager = new WatermarkManager(this)
-			const license = await licenseManager.getLicenseFromKey(licenseKey)
-			watermarkManager.checkWatermark(license)
-		}
-		this.checkLicenseKey()
+		this.checkLicenseKey(licenseKey)
 
 		this.performanceTracker = new PerformanceTracker()
 	}
@@ -824,7 +818,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * checks the license key. Showing a watermark if the license key is invalid.
 	 *
 	 */
-	private checkLicenseKey: () => void
+	private async checkLicenseKey(licenseKey: string | undefined) {
+		const licenseManager = new LicenseManager()
+		const watermarkManager = new WatermarkManager(this)
+		const license = await licenseManager.getLicenseFromKey(licenseKey)
+		watermarkManager.checkWatermark(license)
+	}
 
 	/**
 	 * The current HTML element containing the editor.

--- a/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
@@ -1,4 +1,5 @@
-import { ab2str, exportCryptoKey, str2ab } from '../../utils/licensing'
+import crypto from 'crypto'
+import { ab2str, str2ab } from '../../utils/licensing'
 import { LicenseManager } from './LicenseManager'
 
 describe('LicenseManager', () => {
@@ -116,4 +117,11 @@ async function generateKeyPair() {
 	const privateKey = await exportCryptoKey(keyPair.privateKey)
 
 	return { publicKey, privateKey }
+}
+
+async function exportCryptoKey(key: CryptoKey, isPublic = false) {
+	const keyType = isPublic ? 'PUBLIC' : 'PRIVATE'
+	const exported = await crypto.subtle.exportKey(isPublic ? 'spki' : 'pkcs8', key)
+	const exportedAsBase64 = btoa(ab2str(exported))
+	return `-----BEGIN ${keyType} KEY-----\n${exportedAsBase64}\n-----END ${keyType} KEY-----`
 }

--- a/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
@@ -1,35 +1,48 @@
+import { generateKeyPair, generateLicenseKey } from '../../utils/licensing'
 import { LicenseManager } from './LicenseManager'
 
 describe('LicenseManager', () => {
-	const licenseManager = new LicenseManager()
-
-	it('Checks if a license key was provided', () => {
-		const result = licenseManager.getLicenseFromKey('')
+	it('Checks if a license key was provided', async () => {
+		const licenseManager = new LicenseManager()
+		const result = await licenseManager.getLicenseFromKey('')
 		expect(result).toMatchObject({ isLicenseValid: false, reason: 'no-key-provided' })
 	})
-	/* it('Validates the license key', () => {
-		const invalidLicenseKey = generateKey(
+	it('Validates the license key', async () => {
+		const keyPair = await generateKeyPair()
+		const licenseManager = new LicenseManager(keyPair.publicKey)
+		const invalidLicenseKey = await generateLicenseKey(
 			JSON.stringify({
 				expiryDate: 123456789,
 				companyName: 'Test Company',
 				validHosts: ['localhost'],
-			})
+			}),
+			keyPair
 		)
-		const result = licenseManager.getLicenseFromKey(invalidLicenseKey)
-		expect(result).toMatchObject({ isLicenseValid: false, message: 'Invalid license key' })
-	}) */
-	it.todo('Checks if the license key has expired')
+		const result = await licenseManager.getLicenseFromKey(invalidLicenseKey)
+		expect(result).toMatchObject({ isLicenseValid: false, reason: 'invalid-license-key' })
+	})
+	it('Checks if the license key has expired', async () => {
+		const keyPair = await generateKeyPair()
+		const licenseManager = new LicenseManager(keyPair.publicKey)
+		const licenseInfo = {
+			expiry: Date.now() - 1000,
+			company: 'Test Company',
+			hosts: ['localhost'],
+		}
+		const expiredLicenseKey = await generateLicenseKey(JSON.stringify(licenseInfo), keyPair)
+		const result = await licenseManager.getLicenseFromKey(expiredLicenseKey)
+		expect(result).toMatchObject({
+			isLicenseValid: true,
+			license: { ...licenseInfo },
+			isDomainValid: true,
+			isLicenseExpired: true,
+		})
+	})
+	it.todo('It allows a grace period for expired licenses')
 	it.todo('Checks versions and permissions')
+	it.todo(
+		'Perpetual license: it allows updating important security patches past the release version'
+	)
 	it.todo('Checks the environment')
 	it.todo('Checks the host')
 })
-
-/* function generateKey(msgStr: string) {
-	if (!process.env.SECRET_KEY) throw new Error('No secret key provided')
-	const secretKey = process.env.SECRET_KEY
-	const s = util.decodeBase64(secretKey)
-	const msg = util.decodeUTF8(msgStr)
-	const signature = nacl.sign(msg, s)
-	const signatureB64 = util.encodeBase64(signature)
-	return signatureB64
-} */

--- a/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { ab2str, str2ab } from '../../utils/licensing'
+import { str2ab } from '../../utils/licensing'
 import { LicenseManager } from './LicenseManager'
 
 describe('LicenseManager', () => {
@@ -124,4 +124,12 @@ async function exportCryptoKey(key: CryptoKey, isPublic = false) {
 	const exported = await crypto.subtle.exportKey(isPublic ? 'spki' : 'pkcs8', key)
 	const exportedAsBase64 = btoa(ab2str(exported))
 	return `-----BEGIN ${keyType} KEY-----\n${exportedAsBase64}\n-----END ${keyType} KEY-----`
+}
+
+/*
+  Convert an ArrayBuffer into a string
+  from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
+*/
+export function ab2str(buf: ArrayBuffer) {
+	return String.fromCharCode.apply(null, buf as unknown as number[])
 }

--- a/packages/editor/src/lib/editor/managers/LicenseManager.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.ts
@@ -56,8 +56,12 @@ export class LicenseManager {
 			console.error(e)
 			throw new Error('Invalid signature')
 		}
-
-		const decodedData = JSON.parse(atob(encodedData))
+		let decodedData: any
+		try {
+			decodedData = JSON.parse(atob(encodedData))
+		} catch (e) {
+			throw new Error('Could not parse object')
+		}
 		return licenseInfoValidator.validate(decodedData)
 	}
 

--- a/packages/editor/src/lib/editor/managers/LicenseManager.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.ts
@@ -49,8 +49,8 @@ export class LicenseManager {
 					hash: { name: 'SHA-384' },
 				},
 				publicCryptoKey,
-				new Uint8Array(str2ab(signature)),
-				new Uint8Array(str2ab(encodedData))
+				str2ab(signature) as Uint8Array,
+				str2ab(encodedData) as Uint8Array
 			)
 		} catch (e) {
 			console.error(e)

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -1,11 +1,4 @@
 /*
-  Convert an ArrayBuffer into a string
-  from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
-*/
-export function ab2str(buf: ArrayBuffer) {
-	return String.fromCharCode.apply(null, buf as unknown as number[])
-}
-/*
   Convert a string into an ArrayBuffer
   from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
 */

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 /*
   Convert an ArrayBuffer into a string
   from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
@@ -26,51 +25,6 @@ export async function exportCryptoKey(key: CryptoKey, isPublic = false) {
 	return `-----BEGIN ${keyType} KEY-----\n${exportedAsBase64}\n-----END ${keyType} KEY-----`
 }
 
-/*
-  Generate a sign/verify key pair.
-*/
-export async function generateKeyPair() {
-	const keyPair = await crypto.subtle.generateKey(
-		{
-			name: 'ECDSA',
-			namedCurve: 'P-384',
-		},
-		true,
-		['sign', 'verify']
-	)
-	const publicKey = await exportCryptoKey(keyPair.publicKey, true /* isPublic */)
-	const privateKey = await exportCryptoKey(keyPair.privateKey)
-
-	return { publicKey, privateKey }
-}
-
-/*
-  Import a PEM encoded RSA private key, to use for RSA-PSS signing.
-  Takes a string containing the PEM encoded key, and returns a Promise
-  that will resolve to a CryptoKey representing the private key.
-*/
-export function importPrivateKey(pem: string) {
-	// fetch the part of the PEM string between header and footer
-	const pemHeader = '-----BEGIN PRIVATE KEY-----'
-	const pemFooter = '-----END PRIVATE KEY-----'
-	const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length - 1)
-	// base64 decode the string to get the binary data
-	const binaryDerString = atob(pemContents)
-	// convert from a binary string to an ArrayBuffer
-	const binaryDer = str2ab(binaryDerString) as Uint8Array
-
-	return crypto.subtle.importKey(
-		'pkcs8',
-		binaryDer,
-		{
-			name: 'ECDSA',
-			namedCurve: 'P-384',
-		},
-		true,
-		['sign']
-	)
-}
-
 export function importPublicKey(pem: string) {
 	const pemHeader = '-----BEGIN PUBLIC KEY-----'
 	const pemFooter = '-----END PUBLIC KEY-----'
@@ -90,28 +44,4 @@ export function importPublicKey(pem: string) {
 		true,
 		['verify']
 	)
-}
-
-export async function generateLicenseKey(
-	message: string,
-	keyPair: { publicKey: string; privateKey: string }
-) {
-	const enc = new TextEncoder()
-	const encodedMsg = enc.encode(message)
-	const privateKey = await importPrivateKey(keyPair.privateKey)
-
-	const signedLicenseKeyBuffer = await crypto.subtle.sign(
-		{
-			name: 'ECDSA',
-			hash: { name: 'SHA-384' },
-		},
-		privateKey,
-		encodedMsg
-	)
-
-	const signature = btoa(ab2str(signedLicenseKeyBuffer))
-	const prefix = 'tldraw'
-	const licenseKey = `${prefix}/${btoa(message)}.${signature}`
-
-	return licenseKey
 }

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -18,13 +18,6 @@ export function str2ab(str: string) {
 	return buf
 }
 
-export async function exportCryptoKey(key: CryptoKey, isPublic = false) {
-	const keyType = isPublic ? 'PUBLIC' : 'PRIVATE'
-	const exported = await crypto.subtle.exportKey(isPublic ? 'spki' : 'pkcs8', key)
-	const exportedAsBase64 = btoa(ab2str(exported))
-	return `-----BEGIN ${keyType} KEY-----\n${exportedAsBase64}\n-----END ${keyType} KEY-----`
-}
-
 export function importPublicKey(pem: string) {
 	const pemHeader = '-----BEGIN PUBLIC KEY-----'
 	const pemFooter = '-----END PUBLIC KEY-----'

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -1,0 +1,117 @@
+import crypto from 'crypto'
+/*
+  Convert an ArrayBuffer into a string
+  from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
+*/
+export function ab2str(buf: ArrayBuffer) {
+	return String.fromCharCode.apply(null, new Uint8Array(buf) as unknown as number[])
+}
+/*
+  Convert a string into an ArrayBuffer
+  from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+*/
+export function str2ab(str: string) {
+	const buf = new ArrayBuffer(str.length)
+	const bufView = new Uint8Array(buf)
+	for (let i = 0, strLen = str.length; i < strLen; i++) {
+		bufView[i] = str.charCodeAt(i)
+	}
+	return buf
+}
+
+export async function exportCryptoKey(key: CryptoKey, isPublic = false) {
+	const keyType = isPublic ? 'PUBLIC' : 'PRIVATE'
+	const exported = await crypto.subtle.exportKey(isPublic ? 'spki' : 'pkcs8', key)
+	const exportedAsBase64 = btoa(ab2str(exported))
+	return `-----BEGIN ${keyType} KEY-----\n${exportedAsBase64}\n-----END ${keyType} KEY-----`
+}
+
+/*
+  Generate a sign/verify key pair.
+*/
+export async function generateKeyPair() {
+	const keyPair = await crypto.subtle.generateKey(
+		{
+			name: 'ECDSA',
+			namedCurve: 'P-384',
+		},
+		true,
+		['sign', 'verify']
+	)
+	const publicKey = await exportCryptoKey(keyPair.publicKey, true /* isPublic */)
+	const privateKey = await exportCryptoKey(keyPair.privateKey)
+
+	return { publicKey, privateKey }
+}
+
+/*
+  Import a PEM encoded RSA private key, to use for RSA-PSS signing.
+  Takes a string containing the PEM encoded key, and returns a Promise
+  that will resolve to a CryptoKey representing the private key.
+*/
+export function importPrivateKey(pem: string) {
+	// fetch the part of the PEM string between header and footer
+	const pemHeader = '-----BEGIN PRIVATE KEY-----'
+	const pemFooter = '-----END PRIVATE KEY-----'
+	const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length - 1)
+	// base64 decode the string to get the binary data
+	const binaryDerString = atob(pemContents)
+	// convert from a binary string to an ArrayBuffer
+	const binaryDer = str2ab(binaryDerString)
+
+	return crypto.subtle.importKey(
+		'pkcs8',
+		new Uint8Array(binaryDer),
+		{
+			name: 'ECDSA',
+			namedCurve: 'P-384',
+		},
+		true,
+		['sign']
+	)
+}
+
+export function importPublicKey(pem: string) {
+	const pemHeader = '-----BEGIN PUBLIC KEY-----'
+	const pemFooter = '-----END PUBLIC KEY-----'
+	const pemContents = pem.substring(pemHeader.length, pem.length - pemFooter.length - 1)
+	// base64 decode the string to get the binary data
+	const binaryDerString = atob(pemContents)
+	// convert from a binary string to an ArrayBuffer
+	const binaryDer = str2ab(binaryDerString)
+
+	return crypto.subtle.importKey(
+		'spki',
+		new Uint8Array(binaryDer),
+		{
+			name: 'ECDSA',
+			namedCurve: 'P-384',
+		},
+		true,
+		['verify']
+	)
+}
+
+export async function generateLicenseKey(
+	message: string,
+	keyPair: { publicKey: string; privateKey: string }
+) {
+	const enc = new TextEncoder()
+	const encodedMsg = enc.encode(message)
+	const privateKey = await importPrivateKey(keyPair.privateKey)
+
+	const signedLicenseKeyBuffer = await crypto.subtle.sign(
+		{
+			name: 'ECDSA',
+			hash: { name: 'SHA-384' },
+		},
+		privateKey,
+		encodedMsg
+	)
+
+	const signature = btoa(ab2str(signedLicenseKeyBuffer))
+	const prefix = 'tldraw'
+	const licenseKey = `${prefix}/${btoa(message)}.${signature}`
+
+	return licenseKey
+}

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -4,7 +4,7 @@
 */
 export function str2ab(str: string) {
 	const buf = new ArrayBuffer(str.length) as Uint8Array
-	const bufView = buf
+	const bufView = new Uint8Array(buf)
 	for (let i = 0, strLen = str.length; i < strLen; i++) {
 		bufView[i] = str.charCodeAt(i)
 	}
@@ -22,7 +22,7 @@ export function importPublicKey(pem: string) {
 
 	return crypto.subtle.importKey(
 		'spki',
-		binaryDer,
+		new Uint8Array(binaryDer),
 		{
 			name: 'ECDSA',
 			namedCurve: 'P-384',

--- a/packages/editor/src/lib/utils/licensing.ts
+++ b/packages/editor/src/lib/utils/licensing.ts
@@ -4,15 +4,15 @@ import crypto from 'crypto'
   from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
 */
 export function ab2str(buf: ArrayBuffer) {
-	return String.fromCharCode.apply(null, new Uint8Array(buf) as unknown as number[])
+	return String.fromCharCode.apply(null, buf as unknown as number[])
 }
 /*
   Convert a string into an ArrayBuffer
   from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
 */
 export function str2ab(str: string) {
-	const buf = new ArrayBuffer(str.length)
-	const bufView = new Uint8Array(buf)
+	const buf = new ArrayBuffer(str.length) as Uint8Array
+	const bufView = buf
 	for (let i = 0, strLen = str.length; i < strLen; i++) {
 		bufView[i] = str.charCodeAt(i)
 	}
@@ -57,11 +57,11 @@ export function importPrivateKey(pem: string) {
 	// base64 decode the string to get the binary data
 	const binaryDerString = atob(pemContents)
 	// convert from a binary string to an ArrayBuffer
-	const binaryDer = str2ab(binaryDerString)
+	const binaryDer = str2ab(binaryDerString) as Uint8Array
 
 	return crypto.subtle.importKey(
 		'pkcs8',
-		new Uint8Array(binaryDer),
+		binaryDer,
 		{
 			name: 'ECDSA',
 			namedCurve: 'P-384',
@@ -78,11 +78,11 @@ export function importPublicKey(pem: string) {
 	// base64 decode the string to get the binary data
 	const binaryDerString = atob(pemContents)
 	// convert from a binary string to an ArrayBuffer
-	const binaryDer = str2ab(binaryDerString)
+	const binaryDer = str2ab(binaryDerString) as Uint8Array
 
 	return crypto.subtle.importKey(
 		'spki',
-		new Uint8Array(binaryDer),
+		binaryDer,
 		{
 			name: 'ECDSA',
 			namedCurve: 'P-384',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,8 +6145,6 @@ __metadata:
     nanoid: "npm:4.0.2"
     react-test-renderer: "npm:^18.2.0"
     resize-observer-polyfill: "npm:^1.5.1"
-    tweetnacl: "npm:^1.0.3"
-    tweetnacl-util: "npm:^0.15.1"
   peerDependencies:
     react: ^18
     react-dom: ^18
@@ -21859,20 +21857,6 @@ __metadata:
   dependencies:
     domino: "npm:^2.1.6"
   checksum: 40404935e1322caf4d84eae617d4537b3b3516b86ac2cac0c1b65d7a00716351f9cc25132dbcb89863ab112f4ef43d85e79ce821edf3aa89f236ac30dc5b8bb8
-  languageName: node
-  linkType: hard
-
-"tweetnacl-util@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "tweetnacl-util@npm:0.15.1"
-  checksum: ae6aa8a52cdd21a95103a4cc10657d6a2040b36c7a6da7b9d3ab811c6750a2d5db77e8c36969e75fdee11f511aa2b91c552496c6e8e989b6e490e54aca2864fc
-  languageName: node
-  linkType: hard
-
-"tweetnacl@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tweetnacl@npm:1.0.3"
-  checksum: ca122c2f86631f3c0f6d28efb44af2a301d4a557a62a3e2460286b08e97567b258c2212e4ad1cfa22bd6a57edcdc54ba76ebe946847450ab0999e6d48ccae332
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds subtle crypto

I've added a file to the utils folder called licensing, this contains some utils that are used by both the test file and the license manager. I wondered about keeping it close to the manager and test file, but this seemed better.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan


### Release notes

- Adapts license manager to use subtle crypto