### PR TITLE
Fixup staging worker deploys

### DIFF
--- a/apps/dotcom-asset-upload/wrangler.toml
+++ b/apps/dotcom-asset-upload/wrangler.toml
@@ -1,52 +1,65 @@
-name = "tldraw-assets"
 main = "src/index.ts"
 compatibility_date = "2022-09-22"
 
 [dev]
 port = 8788
 
-[[r2_buckets]]
-binding = 'UPLOADS'
-bucket_name = 'uploads'
-preview_bucket_name = 'uploads-preview'
-
-[[analytics_engine_datasets]] 
+[[analytics_engine_datasets]]
 binding = "MEASURE"
 
-# staging settings
+#################### Environment names ####################
+# dev should never actually get deployed anywhere
+[env.dev]
+name = 'tldraw-assets-dev'
+
+# we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.
+
+# staging is the same as a preview on main:
 [env.staging]
 name = "main-tldraw-assets"
 
-[[env.staging.r2_buckets]]
-binding = 'UPLOADS'
-bucket_name = 'uploads'
-preview_bucket_name = 'uploads-preview'
-
-[[env.staging.analytics_engine_datasets]] 
-binding = "MEASURE"
-
-
-# production settings
+# production gets the proper name
 [env.production]
 name = "tldraw-assets"
 
+#################### Assets R2 bucket ####################
+# in dev, we write to the preview bucket and need a `preview_bucket_name`
+[[env.dev.r2_buckets]]
+binding = 'UPLOADS'
+bucket_name = 'uploads-preview'
+preview_bucket_name = 'uploads-preview'
+
+# in preview and staging we write to the preview bucket
+[[env.preview.r2_buckets]]
+binding = 'UPLOADS'
+bucket_name = 'uploads-preview'
+
+[[env.stating.r2_buckets]]
+binding = 'UPLOADS'
+bucket_name = 'uploads-preview'
+
+# in production, we write to the main bucket
+[[env.production.r2_buckets]]
+binding = "ROOMS"
+bucket_name = "uploads"
+
+#################### Analytics engine ####################
+# analytics engine has the same configuration in all environments:
+[[env.dev.analytics_engine_datasets]]
+binding = "MEASURE"
+
+[[env.preview.analytics_engine_datasets]]
+binding = "MEASURE"
+
+[[env.staging.analytics_engine_datasets]]
+binding = "MEASURE"
+
+[[env.production.analytics_engine_datasets]]
+binding = "MEASURE"
+
+#################### Routes ####################
+# in production, we use a custom domain. others get a default *.tldraw.workers.dev domain
 [[env.production.routes]]
 pattern = 'assets.tldraw.xyz'
 custom_domain = true
 zone_name = 'tldraw.xyz'
-
-[[env.production.r2_buckets]]
-binding = 'UPLOADS'
-bucket_name = 'uploads'
-preview_bucket_name = 'uploads-preview'
-
-[[env.production.analytics_engine_datasets]] 
-binding = "MEASURE"
-
-[[env.preview.r2_buckets]]
-binding = 'UPLOADS'
-bucket_name = 'uploads'
-preview_bucket_name = 'uploads-preview'
-
-[[env.preview.analytics_engine_datasets]] 
-binding = "MEASURE"

--- a/apps/health-worker/wrangler.toml
+++ b/apps/health-worker/wrangler.toml
@@ -1,3 +1,2 @@
-name = "health-worker"
 main = "src/index.ts"
 compatibility_date = "2023-12-18"

--- a/scripts/deploy-bemo.ts
+++ b/scripts/deploy-bemo.ts
@@ -87,6 +87,7 @@ async function deployBemoWorker({ dryRun }: { dryRun: boolean }) {
 	if (previewId && !didUpdateBemoWorker) {
 		await setWranglerPreviewConfig(workerDir, {
 			name: workerId,
+			customDomain: `${previewId}-demo.tldraw.xyz`,
 		})
 		didUpdateBemoWorker = true
 	}

--- a/scripts/deploy-bemo.ts
+++ b/scripts/deploy-bemo.ts
@@ -87,7 +87,6 @@ async function deployBemoWorker({ dryRun }: { dryRun: boolean }) {
 	if (previewId && !didUpdateBemoWorker) {
 		await setWranglerPreviewConfig(workerDir, {
 			name: workerId,
-			customDomain: `${previewId}-demo.tldraw.xyz`,
 		})
 		didUpdateBemoWorker = true
 	}

--- a/scripts/lib/deploy.ts
+++ b/scripts/lib/deploy.ts
@@ -139,13 +139,13 @@ export async function wranglerDeploy({
 		}
 
 		// create a sentry release:
-		exec('yarn', ['run', '-T', 'sentry-cli', 'releases', 'new', release], {
+		await exec('yarn', ['run', '-T', 'sentry-cli', 'releases', 'new', release], {
 			pwd: location,
 			env: sentryEnv,
 		})
 
 		// upload sourcemaps to the release:
-		exec(
+		await exec(
 			'yarn',
 			[
 				'run',

--- a/scripts/lib/deploy.ts
+++ b/scripts/lib/deploy.ts
@@ -123,7 +123,7 @@ export async function wranglerDeploy({
 		throw new Error('Could not find the deploy ID in wrangler output')
 	}
 
-	const workerNameMatch = out.match(/Uploaded: ([^ ]+)/)
+	const workerNameMatch = out.match(/Uploaded ([^ ]+)/)
 
 	if (!workerNameMatch) {
 		throw new Error('Could not find the worker name in wrangler output')

--- a/scripts/lib/deploy.ts
+++ b/scripts/lib/deploy.ts
@@ -1,9 +1,7 @@
 import * as github from '@actions/github'
-import { readFileSync } from 'fs'
 import { appendFile } from 'fs/promises'
 import { join } from 'path'
 import { env } from 'process'
-import toml from 'toml'
 import { exec } from './exec'
 
 export function getDeployInfo() {
@@ -125,16 +123,14 @@ export async function wranglerDeploy({
 		throw new Error('Could not find the deploy ID in wrangler output')
 	}
 
-	const workerName = toml.parse(readFileSync(join(location, 'wrangler.toml')).toString())?.env?.[
-		env
-	]?.name
+	const workerNameMatch = out.match(/Uploaded: ([^ ]+)/)
 
-	if (!workerName) {
+	if (!workerNameMatch) {
 		throw new Error('Could not find the worker name in wrangler output')
 	}
 
 	if (sentry) {
-		const release = sentry.release ?? `${workerName}.${versionMatch[1]}`
+		const release = sentry.release ?? `${workerNameMatch[1]}.${versionMatch[1]}`
 
 		const sentryEnv = {
 			SENTRY_AUTH_TOKEN: sentry.authToken,


### PR DESCRIPTION
- Structure wrangler.toml for asset uploads the same way we structure it for other workers
- Extract worker name from wrangler output, not wrangler.toml - not all workers have explicit names for all environments
- Remove DNS settings for preview workers - `tldraw.workers.dev` is fine

### Change type

- [x] `bugfix`
