### PR TITLE
Fix duplicate distance

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -503,15 +503,15 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					} else {
 						ids = editor.getSelectedShapeIds()
 						const commonBounds = Box.Common(compact(ids.map((id) => editor.getShapePageBounds(id))))
-						offset = !editor.getCameraOptions().isLocked
+						offset = editor.getCameraOptions().isLocked
 							? {
-									x: commonBounds.width + 20,
-									y: 0,
+									// same as the adjacent note margin
+									x: editor.options.adjacentShapeMargin,
+									y: editor.options.adjacentShapeMargin,
 								}
 							: {
-									// same as the adjacent note margin
-									x: 20,
-									y: 20,
+									x: commonBounds.width + editor.options.adjacentShapeMargin,
+									y: 0,
 								}
 					}
 

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -20,9 +20,27 @@ const ids = {
 
 beforeEach(() => {
 	editor = new TestEditor()
-
 	editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
 })
+
+it('duplicates a shape in the same place', () => {
+	editor.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	editor.select(ids.box1)
+	editor.duplicateShapes([ids.box1])
+	expect(editor.getCurrentPageShapes().length).toBe(2)
+	expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0 })
+	expect(editor.getLastCreatedShape()).toMatchObject({ x: 0, y: 0 })
+})
+
+it('duplicates a shape with an offset', () => {
+	editor.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	editor.select(ids.box1)
+	editor.duplicateShapes([ids.box1], { x: 10, y: 10 })
+	expect(editor.getCurrentPageShapes().length).toBe(2)
+	expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0 })
+	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
+})
+
 it('creates new bindings for arrows when pasting', async () => {
 	editor
 		.selectAll()


### PR DESCRIPTION
This PR fixes the distance between duplicated shapes to match the editor.options.adjacentPositions value.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug that caused the distance offset for duplicated shapes to not match other duplication distance offsets.