### PR TITLE
Demo server bookmark unfurl endpoint

### DIFF
--- a/apps/bemo-worker/src/worker.ts
+++ b/apps/bemo-worker/src/worker.ts
@@ -21,7 +21,7 @@ const cors = createCors({ origins: ['*'] })
 export default class Worker extends WorkerEntrypoint<Environment> {
 	private readonly router = Router()
 		.all('*', cors.preflight)
-		.get('/v1/uploads/:objectName', (request) => {
+		.get('/uploads/:objectName', (request) => {
 			return handleUserAssetGet({
 				request,
 				bucket: this.env.BEMO_BUCKET,
@@ -29,7 +29,7 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 				context: this.ctx,
 			})
 		})
-		.post('/v1/uploads/:objectName', async (request) => {
+		.post('/uploads/:objectName', async (request) => {
 			return handleUserAssetUpload({
 				request,
 				bucket: this.env.BEMO_BUCKET,
@@ -37,7 +37,7 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 				context: this.ctx,
 			})
 		})
-		.get('/v1/bookmarks/unfurl', async (request) => {
+		.get('/bookmarks/unfurl', async (request) => {
 			const query = parseRequestQuery(request, urlMetadataQueryValidator)
 			return Response.json(await getUrlMetadata(query))
 		})

--- a/apps/dotcom-worker/src/worker.ts
+++ b/apps/dotcom-worker/src/worker.ts
@@ -7,7 +7,7 @@ import {
 	ROOM_PREFIX,
 } from '@tldraw/dotcom-shared'
 import { T } from '@tldraw/validate'
-import { createSentry, notFound } from '@tldraw/worker-shared'
+import { createSentry, getUrlMetadata, notFound } from '@tldraw/worker-shared'
 import { Router, createCors, json } from 'itty-router'
 import { createRoom } from './routes/createRoom'
 import { createRoomSnapshot } from './routes/createRoomSnapshot'
@@ -18,7 +18,6 @@ import { getRoomHistorySnapshot } from './routes/getRoomHistorySnapshot'
 import { getRoomSnapshot } from './routes/getRoomSnapshot'
 import { joinExistingRoom } from './routes/joinExistingRoom'
 import { Environment } from './types'
-import { unfurl } from './utils/unfurl'
 export { TLDrawDurableObject } from './TLDrawDurableObject'
 
 const { preflight, corsify } = createCors({
@@ -47,7 +46,7 @@ const router = Router()
 		if (typeof req.query.url !== 'string' || !T.httpUrl.isValid(req.query.url)) {
 			return new Response('url query param is required', { status: 400 })
 		}
-		return json(await unfurl(req.query.url))
+		return json(await getUrlMetadata(req.query.url))
 	})
 	.post(`/${ROOM_PREFIX}/:roomId/restore`, forwardRoomRequest)
 	.all('*', notFound)

--- a/apps/dotcom/src/utils/createAssetFromUrl.ts
+++ b/apps/dotcom/src/utils/createAssetFromUrl.ts
@@ -9,6 +9,7 @@ interface ResponseBody {
 }
 
 export async function createAssetFromUrl({ url }: { type: 'url'; url: string }): Promise<TLAsset> {
+	const urlHash = getHashForString(url)
 	try {
 		// First, try to get the meta data from our endpoint
 		const fetchUrl =
@@ -18,65 +19,34 @@ export async function createAssetFromUrl({ url }: { type: 'url'; url: string }):
 				url,
 			}).toString()
 
-		const meta = (await (await fetch(fetchUrl)).json()) as ResponseBody
+		const meta = (await (await fetch(fetchUrl)).json()) as ResponseBody | null
 
 		return {
-			id: AssetRecordType.createId(getHashForString(url)),
+			id: AssetRecordType.createId(urlHash),
 			typeName: 'asset',
 			type: 'bookmark',
 			props: {
 				src: url,
-				description: meta.description ?? '',
-				image: meta.image ?? '',
-				favicon: meta.favicon ?? '',
-				title: meta.title ?? '',
+				description: meta?.description ?? '',
+				image: meta?.image ?? '',
+				favicon: meta?.favicon ?? '',
+				title: meta?.title ?? '',
 			},
 			meta: {},
 		}
 	} catch (error) {
-		// Otherwise, fallback to fetching data from the url
-
-		let meta: { image: string; favicon: string; title: string; description: string }
-
-		try {
-			const resp = await fetch(url, {
-				method: 'GET',
-				mode: 'no-cors',
-			})
-			const html = await resp.text()
-			const doc = new DOMParser().parseFromString(html, 'text/html')
-			meta = {
-				image: doc.head.querySelector('meta[property="og:image"]')?.getAttribute('content') ?? '',
-				favicon:
-					doc.head.querySelector('link[rel="apple-touch-icon"]')?.getAttribute('href') ??
-					doc.head.querySelector('link[rel="icon"]')?.getAttribute('href') ??
-					'',
-				title: doc.head.querySelector('meta[property="og:title"]')?.getAttribute('content') ?? '',
-				description:
-					doc.head.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
-			}
-			if (!meta.image.startsWith('http')) {
-				meta.image = new URL(meta.image, url).href
-			}
-			if (!meta.favicon.startsWith('http')) {
-				meta.favicon = new URL(meta.favicon, url).href
-			}
-		} catch (error) {
-			console.error(error)
-			meta = { image: '', favicon: '', title: '', description: '' }
-		}
-
-		// Create the bookmark asset from the meta
+		// Otherwise, fallback to a blank bookmark
+		console.error(error)
 		return {
-			id: AssetRecordType.createId(getHashForString(url)),
+			id: AssetRecordType.createId(urlHash),
 			typeName: 'asset',
 			type: 'bookmark',
 			props: {
 				src: url,
-				image: meta.image,
-				favicon: meta.favicon,
-				title: meta.title,
-				description: meta.description,
+				description: '',
+				image: '',
+				favicon: '',
+				title: '',
 			},
 			meta: {},
 		}

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -104,31 +104,31 @@ export const CameraRecordType: RecordType<TLCamera, never>;
 export const canvasUiColorTypeValidator: T.Validator<"accent" | "black" | "laser" | "muted-1" | "selection-fill" | "selection-stroke" | "white">;
 
 // @public
-export function createAssetValidator<Type extends string, Props extends JsonObject>(type: Type, props: T.Validator<Props>): T.ObjectValidator<{ [P in T.ExtractRequiredKeys<{
-        id: TLAssetId;
-        meta: JsonObject;
-        props: Props;
-        type: Type;
-        typeName: 'asset';
-    }>]: {
-        id: TLAssetId;
-        meta: JsonObject;
-        props: Props;
-        type: Type;
-        typeName: 'asset';
-    }[P]; } & { [P_1 in T.ExtractOptionalKeys<{
-        id: TLAssetId;
-        meta: JsonObject;
-        props: Props;
-        type: Type;
-        typeName: 'asset';
-    }>]?: {
-        id: TLAssetId;
-        meta: JsonObject;
-        props: Props;
-        type: Type;
-        typeName: 'asset';
-    }[P_1] | undefined; }>;
+export function createAssetValidator<Type extends string, Props extends JsonObject>(type: Type, props: T.Validator<Props>): T.ObjectValidator<Expand<    { [P in T.ExtractRequiredKeys<{
+id: TLAssetId;
+meta: JsonObject;
+props: Props;
+type: Type;
+typeName: 'asset';
+}>]: {
+id: TLAssetId;
+meta: JsonObject;
+props: Props;
+type: Type;
+typeName: 'asset';
+}[P]; } & { [P_1 in T.ExtractOptionalKeys<{
+id: TLAssetId;
+meta: JsonObject;
+props: Props;
+type: Type;
+typeName: 'asset';
+}>]?: {
+id: TLAssetId;
+meta: JsonObject;
+props: Props;
+type: Type;
+typeName: 'asset';
+}[P_1] | undefined; }>>;
 
 // @public (undocumented)
 export function createBindingId(id?: string): TLBindingId;
@@ -146,7 +146,7 @@ export function createBindingValidator<Type extends string, Props extends JsonOb
     [K in keyof Props]: T.Validatable<Props[K]>;
 }, meta?: {
     [K in keyof Meta]: T.Validatable<Meta[K]>;
-}): T.ObjectValidator<{ [P in T.ExtractRequiredKeys<TLBaseBinding<Type, Props>>]: TLBaseBinding<Type, Props>[P]; } & { [P_1 in T.ExtractOptionalKeys<TLBaseBinding<Type, Props>>]?: TLBaseBinding<Type, Props>[P_1] | undefined; }>;
+}): T.ObjectValidator<Expand<    { [P in T.ExtractRequiredKeys<TLBaseBinding<Type, Props>>]: TLBaseBinding<Type, Props>[P]; } & { [P_1 in T.ExtractOptionalKeys<TLBaseBinding<Type, Props>>]?: TLBaseBinding<Type, Props>[P_1] | undefined; }>>;
 
 // @public
 export const createPresenceStateDerivation: ($user: Signal<{
@@ -171,7 +171,7 @@ export function createShapeValidator<Type extends string, Props extends JsonObje
     [K in keyof Props]: T.Validatable<Props[K]>;
 }, meta?: {
     [K in keyof Meta]: T.Validatable<Meta[K]>;
-}): T.ObjectValidator<{ [P in T.ExtractRequiredKeys<TLBaseShape<Type, Props>>]: TLBaseShape<Type, Props>[P]; } & { [P_1 in T.ExtractOptionalKeys<TLBaseShape<Type, Props>>]?: TLBaseShape<Type, Props>[P_1] | undefined; }>;
+}): T.ObjectValidator<Expand<    { [P in T.ExtractRequiredKeys<TLBaseShape<Type, Props>>]: TLBaseShape<Type, Props>[P]; } & { [P_1 in T.ExtractOptionalKeys<TLBaseShape<Type, Props>>]?: TLBaseShape<Type, Props>[P_1] | undefined; }>>;
 
 // @public
 export function createTLSchema({ shapes, bindings, migrations, }?: {
@@ -588,7 +588,7 @@ export function idValidator<Id extends RecordId<UnknownRecord>>(prefix: Id['__ty
 export const ImageShapeCrop: T.ObjectValidator<{
     bottomRight: VecModel;
     topLeft: VecModel;
-} & {}>;
+}>;
 
 // @public (undocumented)
 export const imageShapeMigrations: TLPropsMigrations;
@@ -596,10 +596,10 @@ export const imageShapeMigrations: TLPropsMigrations;
 // @public (undocumented)
 export const imageShapeProps: {
     assetId: T.Validator<TLAssetId | null>;
-    crop: T.Validator<({
+    crop: T.Validator<{
         bottomRight: VecModel;
         topLeft: VecModel;
-    } & {}) | null>;
+    } | null>;
     h: T.Validator<number>;
     playing: T.Validator<boolean>;
     url: T.Validator<string>;
@@ -753,7 +753,7 @@ export const lineShapeProps: {
         index: IndexKey;
         x: number;
         y: number;
-    } & {}>;
+    }>;
     scale: T.Validator<number>;
     size: EnumStyleProp<"l" | "m" | "s" | "xl">;
     spline: EnumStyleProp<"cubic" | "line">;

--- a/packages/validate/api-report.md
+++ b/packages/validate/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Expand } from '@tldraw/utils';
 import { IndexKey } from '@tldraw/utils';
 import { JsonValue } from '@tldraw/utils';
 
@@ -102,11 +103,11 @@ function numberUnion<Key extends string, Config extends UnionValidatorConfig<Key
 // @public
 function object<Shape extends object>(config: {
     readonly [K in keyof Shape]: Validatable<Shape[K]>;
-}): ObjectValidator<{
+}): ObjectValidator<Expand<{
     [P in ExtractRequiredKeys<Shape>]: Shape[P];
 } & {
     [P in ExtractOptionalKeys<Shape>]?: Shape[P];
-}>;
+}>>;
 
 // @public (undocumented)
 export class ObjectValidator<Shape extends object> extends Validator<Shape> {

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -1,4 +1,5 @@
 import {
+	Expand,
 	IndexKey,
 	JsonValue,
 	STRUCTURED_CLONE_OBJECT_PROTOTYPE,
@@ -696,7 +697,11 @@ export type ExtractOptionalKeys<T extends object> = {
 export function object<Shape extends object>(config: {
 	readonly [K in keyof Shape]: Validatable<Shape[K]>
 }): ObjectValidator<
-	{ [P in ExtractRequiredKeys<Shape>]: Shape[P] } & { [P in ExtractOptionalKeys<Shape>]?: Shape[P] }
+	Expand<
+		{ [P in ExtractRequiredKeys<Shape>]: Shape[P] } & {
+			[P in ExtractOptionalKeys<Shape>]?: Shape[P]
+		}
+	>
 > {
 	return new ObjectValidator(config) as any
 }

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -10,6 +10,8 @@
 	"dependencies": {
 		"@cloudflare/workers-types": "^4.20240620.0",
 		"@tldraw/utils": "workspace:*",
+		"@tldraw/validate": "workspace:*",
+		"itty-router": "^4.0.13",
 		"lazyrepo": "0.0.0-alpha.27",
 		"toucan-js": "^3.4.0",
 		"typescript": "^5.3.3"

--- a/packages/worker-shared/src/getUrlMetadata.ts
+++ b/packages/worker-shared/src/getUrlMetadata.ts
@@ -1,3 +1,9 @@
+import { T } from '@tldraw/validate'
+
+export const urlMetadataQueryValidator = T.object({
+	url: T.httpUrl,
+})
+
 class TextExtractor {
 	string = ''
 	text({ text }: any) {
@@ -38,16 +44,24 @@ class IconExtractor {
 	}
 }
 
-export async function getUrlMetadata(url: string) {
+export async function getUrlMetadata({ url }: { url: string }) {
 	const meta$ = new MetaExtractor()
 	const title$ = new TextExtractor()
 	const icon$ = new IconExtractor()
+
+	let response
+	try {
+		response = await fetch(url)
+	} catch {
+		return null
+	}
+
 	// we use cloudflare's special html parser https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/
 	await new HTMLRewriter()
 		.on('meta', meta$)
 		.on('title', title$)
 		.on('link', icon$)
-		.transform((await fetch(url)) as any)
+		.transform(response as any)
 		.blob()
 
 	const { og, twitter } = meta$

--- a/packages/worker-shared/src/getUrlMetadata.ts
+++ b/packages/worker-shared/src/getUrlMetadata.ts
@@ -38,7 +38,7 @@ class IconExtractor {
 	}
 }
 
-export async function unfurl(url: string) {
+export async function getUrlMetadata(url: string) {
 	const meta$ = new MetaExtractor()
 	const title$ = new TextExtractor()
 	const icon$ = new IconExtractor()
@@ -48,7 +48,7 @@ export async function unfurl(url: string) {
 		.on('title', title$)
 		.on('link', icon$)
 		.transform((await fetch(url)) as any)
-		.blob?.()
+		.blob()
 
 	const { og, twitter } = meta$
 	const title = og['og:title'] ?? twitter['twitter:title'] ?? title$.string ?? undefined

--- a/packages/worker-shared/src/getUrlMetadata.ts
+++ b/packages/worker-shared/src/getUrlMetadata.ts
@@ -49,21 +49,18 @@ export async function getUrlMetadata({ url }: { url: string }) {
 	const title$ = new TextExtractor()
 	const icon$ = new IconExtractor()
 
-	let response
 	try {
-		response = await fetch(url)
+		await new HTMLRewriter()
+			.on('meta', meta$)
+			.on('title', title$)
+			.on('link', icon$)
+			.transform((await fetch(url)) as any)
+			.blob()
 	} catch {
 		return null
 	}
 
 	// we use cloudflare's special html parser https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/
-	await new HTMLRewriter()
-		.on('meta', meta$)
-		.on('title', title$)
-		.on('link', icon$)
-		.transform(response as any)
-		.blob()
-
 	const { og, twitter } = meta$
 	const title = og['og:title'] ?? twitter['twitter:title'] ?? title$.string ?? undefined
 	const description =

--- a/packages/worker-shared/src/handleRequest.ts
+++ b/packages/worker-shared/src/handleRequest.ts
@@ -1,0 +1,73 @@
+import { T } from '@tldraw/validate'
+import { IRequest, RouteHandler, Router, RouterType, StatusError } from 'itty-router'
+import { SentryEnvironment, createSentry } from './sentry'
+
+export type ApiRoute<Env extends SentryEnvironment, Ctx extends ExecutionContext> = (
+	path: string,
+	...handlers: RouteHandler<IRequest, [env: Env, ctx: Ctx]>[]
+) => RouterType<ApiRoute<Env, Ctx>, [env: Env, ctx: Ctx]>
+
+export type ApiRouter<Env extends SentryEnvironment, Ctx extends ExecutionContext> = RouterType<
+	ApiRoute<Env, Ctx>,
+	[env: Env, ctx: Ctx]
+>
+
+export function createRouter<
+	Env extends SentryEnvironment,
+	Ctx extends ExecutionContext = ExecutionContext,
+>() {
+	const router: ApiRouter<Env, Ctx> = Router()
+	return router
+}
+
+export async function handleApiRequest<
+	Env extends SentryEnvironment,
+	Ctx extends ExecutionContext,
+>({
+	router,
+	request,
+	env,
+	ctx,
+	after,
+}: {
+	router: ApiRouter<Env, Ctx>
+	request: Request
+	env: Env
+	ctx: Ctx
+	after: (response: Response) => Response | Promise<Response>
+}) {
+	let response
+	try {
+		response = await router.handle(request, env, ctx)
+	} catch (error: any) {
+		if (error instanceof StatusError) {
+			console.error(`${error.status}: ${error.stack}`)
+			response = Response.json({ error: error.message }, { status: error.status })
+		} else {
+			response = Response.json({ error: 'Internal server error' }, { status: 500 })
+			console.error(error.stack ?? error)
+			// eslint-disable-next-line deprecation/deprecation
+			createSentry(ctx, env, request)?.captureException(error)
+		}
+	}
+
+	try {
+		return await after(response)
+	} catch (error: any) {
+		console.error(error.stack ?? error)
+		// eslint-disable-next-line deprecation/deprecation
+		createSentry(ctx, env, request)?.captureException(error)
+		return Response.json({ error: 'Internal server error' }, { status: 500 })
+	}
+}
+
+export function parseRequestQuery<Params>(request: IRequest, validator: T.Validator<Params>) {
+	try {
+		return validator.validate(request.query)
+	} catch (err) {
+		if (err instanceof T.ValidationError) {
+			throw new StatusError(400, `Query parameters: ${err.message}`)
+		}
+		throw err
+	}
+}

--- a/packages/worker-shared/src/index.ts
+++ b/packages/worker-shared/src/index.ts
@@ -2,5 +2,6 @@
 /// <reference types="@cloudflare/workers-types" />
 
 export { notFound } from './errors'
+export { getUrlMetadata } from './getUrlMetadata'
 export { createSentry } from './sentry'
 export { handleUserAssetGet, handleUserAssetUpload } from './userAssetUploads'

--- a/packages/worker-shared/src/index.ts
+++ b/packages/worker-shared/src/index.ts
@@ -2,6 +2,13 @@
 /// <reference types="@cloudflare/workers-types" />
 
 export { notFound } from './errors'
-export { getUrlMetadata } from './getUrlMetadata'
+export { getUrlMetadata, urlMetadataQueryValidator } from './getUrlMetadata'
+export {
+	createRouter,
+	handleApiRequest,
+	parseRequestQuery,
+	type ApiRoute,
+	type ApiRouter,
+} from './handleRequest'
 export { createSentry } from './sentry'
 export { handleUserAssetGet, handleUserAssetUpload } from './userAssetUploads'

--- a/packages/worker-shared/src/sentry.ts
+++ b/packages/worker-shared/src/sentry.ts
@@ -7,7 +7,7 @@ interface Context {
 	request?: Request
 }
 
-interface SentryEnvironment {
+export interface SentryEnvironment {
 	readonly SENTRY_DSN: string | undefined
 	readonly TLDRAW_ENV?: string | undefined
 	readonly WORKER_NAME: string | undefined

--- a/packages/worker-shared/tsconfig.json
+++ b/packages/worker-shared/tsconfig.json
@@ -9,6 +9,9 @@
 	"references": [
 		{
 			"path": "../utils"
+		},
+		{
+			"path": "../validate"
 		}
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,6 +6357,8 @@ __metadata:
   dependencies:
     "@cloudflare/workers-types": "npm:^4.20240620.0"
     "@tldraw/utils": "workspace:*"
+    "@tldraw/validate": "workspace:*"
+    itty-router: "npm:^4.0.13"
     lazyrepo: "npm:0.0.0-alpha.27"
     toucan-js: "npm:^3.4.0"
     typescript: "npm:^5.3.3"


### PR DESCRIPTION
This adds the HTMLRewriter-based bookmark unfurler to the demo server. It moves the unfurler into worker-shared, and adds some better shared error handling across our workers.

I removed the fallback bookmark fetcher where we try and fetch websites locally. This will almost never work, as it requires sites to set public CORS.

### Change type
- [x] `other`
