### PR TITLE
Editor.run tweaks

### DIFF
--- a/apps/dotcom/src/hooks/useUrlState.ts
+++ b/apps/dotcom/src/hooks/useUrlState.ts
@@ -56,12 +56,9 @@ export function useUrlState(onChangeUrl: (params: UrlStateParams) => void) {
 				url.searchParams.get(PARAMS.page) ?? 'page:' + url.searchParams.get(PARAMS.p)
 			if (newPageId) {
 				if (editor.store.has(newPageId as TLPageId)) {
-					editor.run(
-						() => {
-							editor.setCurrentPage(newPageId as TLPageId)
-						},
-						{ history: 'ignore' }
-					)
+					editor.run({ history: 'ignore' }, () => {
+						editor.setCurrentPage(newPageId as TLPageId)
+					})
 				}
 			}
 		}

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -820,9 +820,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     bail(): this;
     bailToMark(id: string): this;
     // @deprecated (undocumented)
-    batch(fn: () => void, opts?: Partial<TLHistoryBatchOptions & {
-        ignoreShapeLock: boolean;
-    }>): this;
+    batch(fn: () => void, opts?: TLEditorRunOptions): this;
     bindingUtils: {
         readonly [K in string]?: BindingUtil<TLUnknownBinding>;
     };
@@ -1158,9 +1156,9 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): Promise<null | string>;
     readonly root: StateNode;
     rotateShapesBy(shapes: TLShape[] | TLShapeId[], delta: number): this;
-    run(fn: () => void, opts?: Partial<TLHistoryBatchOptions & {
-        ignoreShapeLock: boolean;
-    }>): this;
+    run(opts: TLEditorRunOptions | undefined, fn: () => void): this;
+    // (undocumented)
+    run(fn: () => void): this;
     screenToPage(point: VecLike): Vec;
     readonly scribbles: ScribbleManager;
     select(...shapes: TLShape[] | TLShapeId[]): this;
@@ -2696,6 +2694,12 @@ export interface TLEditorOptions {
     store: TLStore;
     tools: readonly TLStateNodeConstructor[];
     user?: TLUser;
+}
+
+// @public
+export interface TLEditorRunOptions extends TLHistoryBatchOptions {
+    // (undocumented)
+    ignoreShapeLock?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -128,7 +128,12 @@ export { createTLUser, type TLUser } from './lib/config/createTLUser'
 export { type TLAnyBindingUtilConstructor } from './lib/config/defaultBindings'
 export { coreShapes, type TLAnyShapeUtilConstructor } from './lib/config/defaultShapes'
 export { DEFAULT_ANIMATION_OPTIONS, DEFAULT_CAMERA_OPTIONS, SIDES } from './lib/constants'
-export { Editor, type TLEditorOptions, type TLResizeShapeOptions } from './lib/editor/Editor'
+export {
+	Editor,
+	type TLEditorOptions,
+	type TLEditorRunOptions,
+	type TLResizeShapeOptions,
+} from './lib/editor/Editor'
 export {
 	BindingUtil,
 	type BindingOnChangeOptions,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -482,13 +482,10 @@ function useOnMount(onMount?: TLOnMountHandler) {
 		let teardown: (() => void) | void = undefined
 		// If the user wants to do something when the editor mounts, we make sure it doesn't effect the history.
 		// todo: is this reeeeally what we want to do, or should we leave it up to the caller?
-		editor.run(
-			() => {
-				teardown = onMount?.(editor)
-				editor.emit('mount')
-			},
-			{ history: 'ignore' }
-		)
+		editor.run({ history: 'ignore' }, () => {
+			teardown = onMount?.(editor)
+			editor.emit('mount')
+		})
 		window.tldrawReady = true
 		return teardown
 	})

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -175,94 +175,73 @@ describe('Unlocking', () => {
 
 describe('When forced', () => {
 	it('Can be deleted', () => {
-		editor.run(
-			() => {
-				const numberOfShapesBefore = editor.getCurrentPageShapes().length
-				editor.deleteShapes([ids.lockedShapeA])
-				expect(editor.getCurrentPageShapes().length).toBe(numberOfShapesBefore - 1)
-			},
-			{ ignoreShapeLock: true }
-		)
+		editor.run({ ignoreShapeLock: true }, () => {
+			const numberOfShapesBefore = editor.getCurrentPageShapes().length
+			editor.deleteShapes([ids.lockedShapeA])
+			expect(editor.getCurrentPageShapes().length).toBe(numberOfShapesBefore - 1)
+		})
 	})
 
 	it('Can be changed', () => {
-		editor.run(
-			() => {
-				editor.updateShapes([{ id: ids.lockedShapeA, type: 'geo', x: 100 }])
-				expect(editor.getShape(ids.lockedShapeA)!.x).toBe(100)
-			},
-			{ ignoreShapeLock: true }
-		)
+		editor.run({ ignoreShapeLock: true }, () => {
+			editor.updateShapes([{ id: ids.lockedShapeA, type: 'geo', x: 100 }])
+			expect(editor.getShape(ids.lockedShapeA)!.x).toBe(100)
+		})
 	})
 
 	it('Can be grouped / ungrouped', () => {
-		editor.run(
-			() => {
-				const shapeCount = editor.getCurrentPageShapes().length
-				editor.groupShapes([ids.lockedShapeA, ids.unlockedShapeA, ids.unlockedShapeB])
-				expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
-				expect(editor.getShape(ids.lockedShapeA)!.parentId).not.toBe(editor.getCurrentPageId())
-			},
-			{ ignoreShapeLock: true }
-		)
+		editor.run({ ignoreShapeLock: true }, () => {
+			const shapeCount = editor.getCurrentPageShapes().length
+			editor.groupShapes([ids.lockedShapeA, ids.unlockedShapeA, ids.unlockedShapeB])
+			expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
+			expect(editor.getShape(ids.lockedShapeA)!.parentId).not.toBe(editor.getCurrentPageId())
+		})
 	})
 
 	it('Cannot be moved', () => {
-		editor.run(
-			() => {
-				const shape = editor.getShape(ids.lockedShapeA)
-				editor.pointerDown(150, 150, { target: 'shape', shape })
-				editor.expectToBeIn('select.pointing_canvas')
+		editor.run({ ignoreShapeLock: true }, () => {
+			const shape = editor.getShape(ids.lockedShapeA)
+			editor.pointerDown(150, 150, { target: 'shape', shape })
+			editor.expectToBeIn('select.pointing_canvas')
 
-				editor.pointerMove(10, 10)
-				editor.expectToBeIn('select.brushing')
+			editor.pointerMove(10, 10)
+			editor.expectToBeIn('select.brushing')
 
-				editor.pointerUp()
-				editor.expectToBeIn('select.idle')
-			},
-			{ ignoreShapeLock: true }
-		)
+			editor.pointerUp()
+			editor.expectToBeIn('select.idle')
+		})
 	})
 
 	it('Can be selected with select all', () => {
-		editor.run(
-			() => {
-				editor.selectAll()
-				expect(editor.getSelectedShapeIds()).toEqual([ids.unlockedShapeA, ids.unlockedShapeB])
-			},
-			{ ignoreShapeLock: true }
-		)
+		editor.run({ ignoreShapeLock: true }, () => {
+			editor.selectAll()
+			expect(editor.getSelectedShapeIds()).toEqual([ids.unlockedShapeA, ids.unlockedShapeB])
+		})
 	})
 
 	it('Cannot be selected by clicking', () => {
-		editor.run(
-			() => {
-				const shape = editor.getShape(ids.lockedShapeA)!
+		editor.run({ ignoreShapeLock: true }, () => {
+			const shape = editor.getShape(ids.lockedShapeA)!
 
-				editor
-					.pointerDown(10, 10, { target: 'shape', shape })
-					.expectToBeIn('select.pointing_canvas')
-					.pointerUp()
-					.expectToBeIn('select.idle')
-				expect(editor.getSelectedShapeIds()).not.toContain(shape.id)
-			},
-			{ ignoreShapeLock: true }
-		)
+			editor
+				.pointerDown(10, 10, { target: 'shape', shape })
+				.expectToBeIn('select.pointing_canvas')
+				.pointerUp()
+				.expectToBeIn('select.idle')
+			expect(editor.getSelectedShapeIds()).not.toContain(shape.id)
+		})
 	})
 
 	it('Cannot be edited', () => {
-		editor.run(
-			() => {
-				const shape = editor.getShape(ids.lockedShapeA)!
-				const shapeCount = editor.getCurrentPageShapes().length
+		editor.run({ ignoreShapeLock: true }, () => {
+			const shape = editor.getShape(ids.lockedShapeA)!
+			const shapeCount = editor.getCurrentPageShapes().length
 
-				// We create a new shape and we edit that one
-				editor.doubleClick(10, 10, { target: 'shape', shape }).expectToBeIn('select.editing_shape')
-				expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
-				expect(editor.getSelectedShapeIds()).not.toContain(shape.id)
-			},
-			{ ignoreShapeLock: true }
-		)
+			// We create a new shape and we edit that one
+			editor.doubleClick(10, 10, { target: 'shape', shape }).expectToBeIn('select.editing_shape')
+			expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
+			expect(editor.getSelectedShapeIds()).not.toContain(shape.id)
+		})
 	})
 })
 
@@ -289,20 +268,14 @@ it('works when forced', () => {
 	expect(editor.getShape(myShapeId)).toMatchObject(myLockedShape)
 
 	// update works
-	editor.run(
-		() => {
-			editor.updateShape({ ...myLockedShape, x: 100 })
-		},
-		{ ignoreShapeLock: true }
-	)
+	editor.run({ ignoreShapeLock: true }, () => {
+		editor.updateShape({ ...myLockedShape, x: 100 })
+	})
 	expect(editor.getShape(myShapeId)).toMatchObject({ ...myLockedShape, x: 100 })
 
 	// delete works
-	editor.run(
-		() => {
-			editor.deleteShapes([myLockedShape])
-		},
-		{ ignoreShapeLock: true }
-	)
+	editor.run({ ignoreShapeLock: true }, () => {
+		editor.deleteShapes([myLockedShape])
+	})
 	expect(editor.getShape(myShapeId)).toBeUndefined()
 })


### PR DESCRIPTION
Couple of changes to editor.run, the main one being the order. Previously, we did `editor.run(fn, opts)`. This sort of makes sense, because options objects usually come last. This diff switched us to `editor.run(opts, fn)`, which I think makes more sense for a few reasons:
1. Callback-comes-last is IMO a stronger convention than options-come-last
2. When the callback is long, having the options all the way down at the end and possibly off the screen makes it really hard to actually read what is happening and understand it. We know this code is it a `run`, but we don't know if that run is affecting history/locking until the bottom. having the options first makes things much more readable imo
3. Better tooling support from e.g. formatters. This is related to 1, but the callback-comes-last convention is known by tools like prettier/biome and so they format it differently. For us, this means removing an unneeded layer of indentation, and keeping the `run` call and its options all on one line.

Other changes:
- fix a bug where forced-ness wouldn't be restored properly after a `run` function
- interface for run options for nicer docs
- clearer name for `._force`
