### PR TITLE
Fix tests.

### DIFF
--- a/config/importMetaMock.js
+++ b/config/importMetaMock.js
@@ -1,0 +1,1 @@
+export const IMPORT_META_ENV_MODE = 'test'

--- a/config/jest/node/jest-preset.js
+++ b/config/jest/node/jest-preset.js
@@ -1,4 +1,5 @@
 const svgTransformPath = require.resolve('config/svgTransform.js')
+const importMetaMock = require.resolve('config/importMetaMock.js')
 
 module.exports = {
 	roots: ['<rootDir>/src'],
@@ -34,6 +35,9 @@ module.exports = {
 		'<rootDir>/.tsbuild-dev',
 		'<rootDir>/.tsbuild-pub',
 	],
+	moduleNameMapper: {
+		importMeta: importMetaMock,
+	},
 	transformIgnorePatterns: ['node_modules/(?!(nanoid)/)'],
 	collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
 }

--- a/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.test.ts
@@ -2,10 +2,6 @@ import crypto from 'crypto'
 import { str2ab } from '../../utils/licensing'
 import { FLAGS, LicenseManager, ValidLicenseKeyResult } from './LicenseManager'
 
-jest.mock('../../../importMeta.ts', () => ({
-	IMPORT_META_ENV_MODE: 'test',
-}))
-
 describe('LicenseManager', () => {
 	let keyPair: { publicKey: string; privateKey: string }
 	let licenseManager: LicenseManager

--- a/packages/editor/src/lib/editor/managers/LicenseManager.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.ts
@@ -78,7 +78,6 @@ export class LicenseManager {
 	}
 
 	private async extractLicenseKey(licenseKey: string): Promise<LicenseInfo> {
-		// eslint-disable-next-line
 		const [data, signature] = licenseKey.split('.')
 		const [prefix, encodedData] = data.split('/')
 


### PR DESCRIPTION
Fixes the issues with `import.meta` and jest 🤞 

This uses a global mock across all the tests. You can still override it locally in tests using
```ts
jest.mock('importMeta', () => ({
	IMPORT_META_ENV_MODE: 'mocking',
}))
```

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix jest tests issue with import meta.