### PR TITLE
Add watermark tests

### DIFF
--- a/packages/editor/src/lib/editor/managers/LicenseManager.ts
+++ b/packages/editor/src/lib/editor/managers/LicenseManager.ts
@@ -281,10 +281,6 @@ export class LicenseManager {
 		}
 	}
 
-	private outputMessage(message: string) {
-		this.outputMessages([message])
-	}
-
 	private outputMessages(messages: string[]) {
 		if (!this.isDevelopment) return
 

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -39,23 +39,23 @@ describe('WatermarkManager', () => {
 	})
 
 	it('throws when an internal annual license has expired', () => {
-		const expireDate = new Date(2023, 1, 1)
+		const expiryDate = new Date(2023, 1, 1)
 		const licenseResult = getDefaultLicenseResult({
 			isAnnualLicense: true,
 			isAnnualLicenseExpired: true,
 			isInternalLicense: true,
-			expiryDate: expireDate,
+			expiryDate,
 		})
 		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
 	})
 
 	it('throws when an internal perpetual license has expired', () => {
-		const expireDate = new Date(2023, 1, 1)
+		const expiryDate = new Date(2023, 1, 1)
 		const licenseResult = getDefaultLicenseResult({
 			isPerpetualLicense: true,
 			isPerpetualLicenseExpired: true,
 			isInternalLicense: true,
-			expiryDate: expireDate,
+			expiryDate,
 		})
 		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
 	})

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -1,0 +1,62 @@
+import { createTLStore } from '../../config/createTLStore'
+import { Editor } from '../Editor'
+import { FLAGS, ValidLicenseKeyResult } from './LicenseManager'
+import { WatermarkManager } from './WatermarkManager'
+
+function getDefaultLicenseResult(overides: Partial<ValidLicenseKeyResult>): ValidLicenseKeyResult {
+	return {
+		isAnnualLicense: true,
+		isAnnualLicenseExpired: false,
+		isInternalLicense: false,
+		isDomainValid: true,
+		isPerpetualLicense: false,
+		isPerpetualLicenseExpired: false,
+		isLicenseParseable: true as const,
+		license: {
+			id: 'id',
+			hosts: ['localhost'],
+			flags: FLAGS.PERPETUAL_LICENSE,
+			version: '1.0.0',
+			expiryDate: new Date().toISOString(),
+		},
+		expiryDate: new Date(),
+		...overides,
+	}
+}
+
+describe('WatermarkManager', () => {
+	let watermarkManager: WatermarkManager
+	let editor: Editor
+	beforeAll(() => {
+		editor = new Editor({
+			store: createTLStore({}),
+			bindingUtils: [],
+			shapeUtils: [],
+			getContainer: () => document.createElement('div'),
+			tools: [],
+		})
+		watermarkManager = new WatermarkManager(editor)
+	})
+
+	it('throws when an internal annual license has expired', () => {
+		const expireDate = new Date(2023, 1, 1)
+		const licenseResult = getDefaultLicenseResult({
+			isAnnualLicense: true,
+			isAnnualLicenseExpired: true,
+			isInternalLicense: true,
+			expiryDate: expireDate,
+		})
+		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
+	})
+
+	it('throws when an internal perpetual license has expired', () => {
+		const expireDate = new Date(2023, 1, 1)
+		const licenseResult = getDefaultLicenseResult({
+			isPerpetualLicense: true,
+			isPerpetualLicenseExpired: true,
+			isInternalLicense: true,
+			expiryDate: expireDate,
+		})
+		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
+	})
+})

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -46,7 +46,9 @@ describe('WatermarkManager', () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
+		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(
+			/License: Internal license expired/
+		)
 	})
 
 	it('throws when an internal perpetual license has expired', () => {
@@ -57,6 +59,8 @@ describe('WatermarkManager', () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(/Internal license expired/)
+		expect(() => watermarkManager.checkWatermark(licenseResult)).toThrow(
+			/License: Internal license expired/
+		)
 	})
 })

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -12,6 +12,7 @@ function getDefaultLicenseResult(overides: Partial<ValidLicenseKeyResult>): Vali
 		isPerpetualLicense: false,
 		isPerpetualLicenseExpired: false,
 		isLicenseParseable: true as const,
+		// WatermarkManager does not check these fields, it relies on the calculated values like isAnnualLicenseExpired
 		license: {
 			id: 'id',
 			hosts: ['localhost'],


### PR DESCRIPTION
Add watermark tests for testing that an expired internal license throws.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Add watermark manager test for expired internal licenses.