### PR TITLE
Share menu improvements

### DIFF
--- a/apps/dotcom/src/components/ShareMenu.tsx
+++ b/apps/dotcom/src/components/ShareMenu.tsx
@@ -134,7 +134,12 @@ export const ShareMenu = React.memo(function ShareMenu() {
 		let cancelled = false
 
 		const shareUrl = window.location.href
-		if (!shareState.qrCodeDataUrl && shareState.state === SHARE_CURRENT_STATE.SHARED_READ_WRITE) {
+		const url = new URL(shareUrl)
+		if (
+			!shareState.qrCodeDataUrl &&
+			shareState.state === SHARE_CURRENT_STATE.SHARED_READ_WRITE &&
+			(url.searchParams.has('v') || url.searchParams.has('p'))
+		) {
 			// Fetch the QR code data URL
 			createQRCodeImageDataString(shareUrl).then((dataUrl) => {
 				if (!cancelled) {

--- a/apps/dotcom/src/utils/sharing.ts
+++ b/apps/dotcom/src/utils/sharing.ts
@@ -165,7 +165,7 @@ export function useSharing(persistenceKey?: string): TLUiOverrides {
 							if (runningInIFrame) {
 								window.open(`${origin}${pathname}`)
 							} else {
-								navigate(pathname)
+								navigate(pathname, { state: { shouldOpenShareMenu: true } })
 							}
 						} catch (error) {
 							console.error(error)


### PR DESCRIPTION
Improves share menu:
* Seems like we lost the logic of opening the share menu after sharing a project.
* Using `/new` did open the share menu after creating a new room, but the qr code flickered. This was because the create project action created a new room but there were no search params set (for viewport and page). So we first created the qr code for that url, but then we update the url with those params and regenerate the qr code which caused the flicker. That said the current logic does show a gray box a bit longer, so not sure how much of an improvement this is.

### Before

https://github.com/tldraw/tldraw/assets/2523721/cdb4e3b8-46cb-48d9-bd23-66b2f4f55cff

### After

https://github.com/tldraw/tldraw/assets/2523721/f035bd48-6e59-4d3d-8e04-640c866c9395

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Share a local room. The share menu should be open after the redirect.

1. Use the `/new` route. The qr code in the share menu should not flicker.

### Release notes

- Make sure the share menu is open after sharing a room. Prevent the qr code from flickering when navigating to `/new`