### PR TITLE
startEditingShapeWithLabel: shouldn't zoom to editing shape's bounds

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -126,7 +126,6 @@ export function startEditingShapeWithLabel(editor: Editor, shape: TLShape, selec
 	if (selectAll) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
-	zoomToShapeIfOffscreen(editor)
 }
 
 const ZOOM_TO_SHAPE_PADDING = 16


### PR DESCRIPTION
In [`startEditingShapeWithLabel`]( https://github.com/xmliszt/tldraw/blob/ef3a9df8c7df9bb8139c6b946957bd0ed7f9dfaf/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts#L118), previously, we called `zoomToShapeIfOffscreen(editor)` function to zoom to the bounds of the shape that is being edited. However, this causes sometimes, when the shape (e.g. a frame) that is very long, to be zoomed to center, such that the label to be edited is out of the screen. IMO this is not a good experience to the user (as you can see from the screen recording below.

My reasons:
- When a user wants to edit the label, the label will definitely to be moved into visible view. Therefore, I think there is no need to zoom to the shape whose label is being edited?
- The scenario I mentioned will cause user to need to _blind type_ to change the label, as the label is no longer in the view. And if user tries to pan back (when using keyboard and mouse, not trackpad), it will cause editing to be stopped.

### Demo

| Before | After |
| ------- | ----- |
|  https://github.com/tldraw/tldraw/assets/44829092/258c655e-c2b4-4f64-9da2-7cc6644bf77b | https://github.com/tldraw/tldraw/assets/44829092/25d3c65c-ae4c-4a6f-9ce2-b64caed8432b |


### Change type

- [x] `bugfix`

### Test plan

1. Create a frame, make it very long such that when zooming in, part of the frame is out of the view
2. Then go to the label, double-click to edit it.
3. Observe that the zoom shouldn't happen so that the editing label is still visible

### Release notes

- Fixed a bug with `startEditingShapeWithLabel` function no longer zoom to the editing shape's bounds if the shape is partially off the screen, causing the label to be edited to be moved out of the screen.