### PR TITLE
Make arrow sequence not retroactive

### DIFF
--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -79,6 +79,7 @@ function propsMigration(migration: TLPropsMigration) {
 /** @public */
 export const arrowShapeMigrations = createMigrationSequence({
 	sequenceId: 'com.tldraw.shape.arrow',
+	retroactive: false,
 	sequence: [
 		propsMigration({
 			id: arrowShapeVersions.AddLabelColor,


### PR DESCRIPTION
this was a very minor oversight when doing the bindings work. It won't have caused any bugs for anyone but conceptually this should be `retroactive: false`

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with...