### PR TITLE
Set bemo url in examples app

### DIFF
--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -20,9 +20,12 @@ setDefaultEditorAssetUrls(assetUrls)
 // eslint-disable-next-line local/no-at-internal
 setDefaultUiAssetUrls(assetUrls)
 const gettingStartedExamples = examples.find((e) => e.id === 'Getting started')
-if (!gettingStartedExamples) throw new Error('Could not find getting started exmaples')
+if (!gettingStartedExamples) throw new Error('Could not find getting started examples')
 const basicExample = gettingStartedExamples.value.find((e) => e.title === 'Tldraw component')
 if (!basicExample) throw new Error('Could not find initial example')
+
+// eslint-disable-next-line no-console
+console.log('bemo', process.env.TLDRAW_BEMO_URL)
 
 const router = createBrowserRouter([
 	{

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -19,6 +19,9 @@ function getEnv() {
 
 const env = getEnv()
 
+// eslint-disable-next-line no-console
+console.log('build env:', env)
+
 const TLDRAW_BEMO_URL_STRING =
 	env === 'production'
 		? '"https://demo.tldraw.xyz"'

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -2,6 +2,32 @@ import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 import { PluginOption, defineConfig } from 'vite'
 
+const PR_NUMBER = process.env.NEXT_PUBLIC_VERCEL_GIT_PULL_REQUEST_ID
+
+function getEnv() {
+	if (!process.env.NEXT_PUBLIC_VERCEL_ENV) {
+		return 'local'
+	}
+	if (PR_NUMBER !== undefined && PR_NUMBER !== '') {
+		return 'preview'
+	}
+	if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
+		return 'production'
+	}
+	return 'canary'
+}
+
+const env = getEnv()
+
+const TLDRAW_BEMO_URL =
+	env === 'production'
+		? 'https://demo.tldraw.xyz'
+		: env === 'canary'
+			? 'https://canary-demo.tldraw.xyz'
+			: env === 'preview'
+				? `https://pr-${PR_NUMBER}-demo.tldraw.xyz`
+				: 'http://localhost:8989'
+
 export default defineConfig({
 	plugins: [react({ tsDecorators: true }), exampleReadmePlugin()],
 	root: path.join(__dirname, 'src'),
@@ -26,6 +52,7 @@ export default defineConfig({
 	},
 	define: {
 		'process.env.TLDRAW_ENV': JSON.stringify(process.env.VERCEL_ENV ?? 'development'),
+		'process.env.TLDRAW_BEMO_URL': JSON.stringify(TLDRAW_BEMO_URL),
 	},
 })
 

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -6,7 +6,7 @@ const PR_NUMBER = process.env.VERCEL_GIT_PULL_REQUEST_ID
 
 function getEnv() {
 	if (!process.env.VERCEL_ENV) {
-		return 'local'
+		return 'development'
 	}
 	if (PR_NUMBER !== undefined && PR_NUMBER !== '') {
 		return 'preview'
@@ -19,14 +19,15 @@ function getEnv() {
 
 const env = getEnv()
 
-const TLDRAW_BEMO_URL =
+const TLDRAW_BEMO_URL_STRING =
 	env === 'production'
-		? 'https://demo.tldraw.xyz'
+		? '"https://demo.tldraw.xyz"'
 		: env === 'canary'
-			? 'https://canary-demo.tldraw.xyz'
+			? '"https://canary-demo.tldraw.xyz"'
 			: env === 'preview'
-				? `https://pr-${PR_NUMBER}-demo.tldraw.xyz`
-				: 'http://localhost:8989'
+				? `"https://pr-${PR_NUMBER}-demo.tldraw.xyz"`
+				: // local dev fallback
+					'`http://${location.hostname}:8989`'
 
 export default defineConfig({
 	plugins: [react({ tsDecorators: true }), exampleReadmePlugin()],
@@ -52,7 +53,7 @@ export default defineConfig({
 	},
 	define: {
 		'process.env.TLDRAW_ENV': JSON.stringify(process.env.VERCEL_ENV ?? 'development'),
-		'process.env.TLDRAW_BEMO_URL': JSON.stringify(TLDRAW_BEMO_URL),
+		'process.env.TLDRAW_BEMO_URL': TLDRAW_BEMO_URL_STRING,
 	},
 })
 

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -22,17 +22,29 @@ const env = getEnv()
 // eslint-disable-next-line no-console
 console.log('build env:', env)
 
+function urlOrLocalFallback(mode: string, url: string | undefined, localFallbackPort: number) {
+	if (url) {
+		return JSON.stringify(url)
+	}
+
+	if (mode === 'development') {
+		// in dev, vite lets us inline javascript expressions - so we return a template string that
+		// will be evaluated on the client
+		return '`http://${location.hostname}:' + localFallbackPort + '`'
+	} else {
+		// in production, we have to fall back to a hardcoded value
+		return JSON.stringify(`http://localhost:${localFallbackPort}`)
+	}
+}
+
 const TLDRAW_BEMO_URL_STRING =
 	env === 'production'
 		? '"https://demo.tldraw.xyz"'
 		: env === 'canary'
 			? '"https://canary-demo.tldraw.xyz"'
-			: env === 'preview'
-				? `"https://pr-${PR_NUMBER}-demo.tldraw.xyz"`
-				: // local dev fallback
-					'`http://${location.hostname}:8989`'
+			: `"https://pr-${PR_NUMBER}-demo.tldraw.xyz"`
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
 	plugins: [react({ tsDecorators: true }), exampleReadmePlugin()],
 	root: path.join(__dirname, 'src'),
 	publicDir: path.join(__dirname, 'public'),
@@ -56,9 +68,9 @@ export default defineConfig({
 	},
 	define: {
 		'process.env.TLDRAW_ENV': JSON.stringify(process.env.VERCEL_ENV ?? 'development'),
-		'process.env.TLDRAW_BEMO_URL': TLDRAW_BEMO_URL_STRING,
+		'process.env.TLDRAW_BEMO_URL': urlOrLocalFallback(mode, TLDRAW_BEMO_URL_STRING, 8989),
 	},
-})
+}))
 
 function exampleReadmePlugin(): PluginOption {
 	return {

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -2,16 +2,16 @@ import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 import { PluginOption, defineConfig } from 'vite'
 
-const PR_NUMBER = process.env.NEXT_PUBLIC_VERCEL_GIT_PULL_REQUEST_ID
+const PR_NUMBER = process.env.VERCEL_GIT_PULL_REQUEST_ID
 
 function getEnv() {
-	if (!process.env.NEXT_PUBLIC_VERCEL_ENV) {
+	if (!process.env.VERCEL_ENV) {
 		return 'local'
 	}
 	if (PR_NUMBER !== undefined && PR_NUMBER !== '') {
 		return 'preview'
 	}
-	if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
+	if (process.env.VERCEL_ENV === 'production') {
 		return 'production'
 	}
 	return 'canary'


### PR DESCRIPTION
This PR just adds a thing to set the bemo URL during build. No bemo example page yet

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with...