### PR TITLE
Fix two issues with frame headers

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -36,6 +36,7 @@ export const FrameHeading = function FrameHeading({
 	const handlePointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			const event = getPointerInfo(e)
+			e.preventDefault()
 
 			// If we're editing the frame label, we shouldn't hijack the pointer event
 			if (editor.getEditingShapeId() === id) return
@@ -47,7 +48,6 @@ export const FrameHeading = function FrameHeading({
 				shape: editor.getShape(id)!,
 				...event,
 			})
-			e.preventDefault()
 		},
 		[editor, id]
 	)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -111,6 +111,7 @@ export class EditingShape extends StateNode {
 						// If we clicked on a frame, while editing its heading, cancel editing
 						if (this.editor.isShapeOfType<TLFrameShape>(selectingShape, 'frame')) {
 							this.editor.setEditingShape(null)
+							this.parent.transition('idle', info)
 						}
 						// If we clicked on the editing shape (which isn't a shape with a label), do nothing
 					} else {


### PR DESCRIPTION
As reported [here](https://discord.com/channels/859816885297741824/1258356318259904512/1258356318259904512) there are two issues with frame headers: 
* We would sometimes throw an `Expected an editing shape!` error. This was because we were setting the editing shape to `null`, but we remained in the `editing_shape` state.
* Frame heading input would sometimes blur, so it looked like you are no longer editing the heading. But we did not correctly exit the editing state. I prevented the blur from happening in this case. This happened when clicking just below the frame heading, looks like we have some padding there that still captures the pointer down so that you can't click between the header and the frame.

You can see this happening in the **exploded example**, but **not on tldraw.com**.

### Before
Throwing

https://github.com/tldraw/tldraw/assets/2523721/5cdc1fc5-debc-45cc-9132-ae729597889a

Blur issue

https://github.com/tldraw/tldraw/assets/2523721/8c7b9d04-de18-47c0-a61c-b455de70a2c5

### After

https://github.com/tldraw/tldraw/assets/2523721/4b2908cd-30cc-4f46-96a0-ca83f5ddbf91

https://github.com/tldraw/tldraw/assets/2523721/b18a7358-7f53-461b-90e0-59b135c774f4

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Double click the frame header to start editing it.
2. Click on the middle of the frame.
3. Click on the middle of the frame again. You shouldn't see an error.

1. Double click the frame header to start editing it.
2. Click just below the header input. The input should not loose focus.


### Release notes

- Fixes two issues with editing frame names.