### PR TITLE
Allow null origins on dotcom worker requests

### DIFF
--- a/apps/dotcom-worker/src/worker.ts
+++ b/apps/dotcom-worker/src/worker.ts
@@ -105,7 +105,11 @@ async function blockUnknownOrigins(request: Request, env: Environment) {
 	}
 
 	const origin = request.headers.get('origin')
-	if (env.IS_LOCAL !== 'true' && (!origin || !isAllowedOrigin(origin))) {
+
+	// if there's no origin, this cannot be a cross-origin request, so we allow it.
+	if (!origin) return undefined
+
+	if (env.IS_LOCAL !== 'true' && !isAllowedOrigin(origin)) {
 		console.error('Attempting to connect from an invalid origin:', origin, env, request)
 		return new Response('Not allowed', { status: 403 })
 	}


### PR DESCRIPTION
GET requests to the same origin don't send the `origin` headers. in other situations we care about (CORS requests) we want to block unknown origins, but if the origin header is missing it's probably because this is a same-origin request, so we should allow it. Fixes an issue loading bookmarks on mobile devices

### Change type

- [x] `bugfix`


