### PR TITLE
Show toast when paste fails

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -86,7 +86,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 	const editor = useEditor()
 
 	const { addDialog, clearDialogs } = useDialogs()
-	const { clearToasts } = useToasts()
+	const { clearToasts, addToast } = useToasts()
 	const msg = useTranslation()
 
 	const insertMedia = useInsertMedia()
@@ -944,13 +944,23 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.paste',
 				kbd: '$v',
 				onSelect(source) {
-					navigator.clipboard?.read().then((clipboardItems) => {
-						paste(
-							clipboardItems,
-							source,
-							source === 'context-menu' ? editor.inputs.currentPagePoint : undefined
-						)
-					})
+					navigator.clipboard
+						?.read()
+						.then((clipboardItems) => {
+							paste(
+								clipboardItems,
+								source,
+								source === 'context-menu' ? editor.inputs.currentPagePoint : undefined
+							)
+						})
+						.catch((error) => {
+							addToast({
+								title: msg('toast.error.paste-fail.title'),
+								// Could have failed because of blocked permissions, so we show the error message
+								description: error.message,
+								severity: 'error',
+							})
+						})
 				},
 			},
 			{

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
@@ -120,6 +120,8 @@ export const DEFAULT_TRANSLATION = {
 	'action.zoom-to-fit': 'Zoom to fit',
 	'action.zoom-to-selection': 'Zoom to selection',
 	'assets.files.upload-failed': 'Upload failed',
+	'assets.files.size-exceeded-title': 'File size exceeded',
+	'assets.files.size-exceeded-desc': 'The file size exceeds the maximum allowed size of 10MB.',
 	'assets.url.failed': "Couldn't load URL preview",
 	'theme.dark': 'Dark',
 	'theme.light': 'Light',
@@ -387,6 +389,7 @@ export const DEFAULT_TRANSLATION = {
 	'toast.error.export-fail.desc': 'Failed to export image',
 	'toast.error.copy-fail.title': 'Failed copy',
 	'toast.error.copy-fail.desc': 'Failed to copy image',
+	'toast.error.paste-fail.title': 'Failed paste',
 	'context.pages.new-page': 'New page',
 	'vscode.file-open.desc':
 		"We've updated this document to work with the current version of tldraw. If you'd like to keep the original version (which will work on old.tldraw.com), click below to create a backup.",

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
@@ -120,8 +120,6 @@ export const DEFAULT_TRANSLATION = {
 	'action.zoom-to-fit': 'Zoom to fit',
 	'action.zoom-to-selection': 'Zoom to selection',
 	'assets.files.upload-failed': 'Upload failed',
-	'assets.files.size-exceeded-title': 'File size exceeded',
-	'assets.files.size-exceeded-desc': 'The file size exceeds the maximum allowed size of 10MB.',
 	'assets.url.failed': "Couldn't load URL preview",
 	'theme.dark': 'Dark',
 	'theme.light': 'Light',


### PR DESCRIPTION
Shows a toast when paste action fails. The paste could fail for a number of reasons, so I thought that attaching the error message was better than a pre-decided deescription.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Shows a toast when paste fails.