### PR TITLE
Add dialog/toasts example

### DIFF
--- a/apps/examples/src/examples/toasts-and-dialogs/README.md
+++ b/apps/examples/src/examples/toasts-and-dialogs/README.md
@@ -3,7 +3,7 @@ title: Toasts and dialogs
 component: ./ToastsDialogsExample.tsx
 category: ui
 priority: 3
-keywords: [ui, components, dialogs, toasts, ]
+keywords: [ui, components, dialogs, toasts]
 ---
 
 To control toasts and dialogs your app, you can use the `useToasts` and `useDialogs` hooks.

--- a/apps/examples/src/examples/toasts-and-dialogs/README.md
+++ b/apps/examples/src/examples/toasts-and-dialogs/README.md
@@ -1,0 +1,17 @@
+---
+title: Toasts and dialogs
+component: ./ToastsDialogsExample.tsx
+category: ui
+priority: 3
+keywords: [ui, components, dialogs, toasts, ]
+---
+
+To control toasts and dialogs your app, you can use the `useToasts` and `useDialogs` hooks.
+These hooks give you access to functions which allow you to add, remove and clear toasts
+and dialogs.
+
+---
+
+Dialogs are especially customisable, allowing you to pass in a custom component to render
+as the dialog content. Alternatively, you can use the `ExampleDialog` component which is
+provided by the library.

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -1,0 +1,57 @@
+import { ExampleDialog, TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// There's a guide at the bottom of this file
+
+const CustomSharePanel = () => {
+	const { addToast } = useToasts()
+	const { addDialog } = useDialogs()
+
+	return (
+		<button
+			style={{ fontSize: 18, backgroundColor: 'thistle', pointerEvents: 'all' }}
+			onClick={() => {
+				addToast({ title: 'Hello world!', severity: 'success' })
+				addDialog({
+					component: ({ onClose }) => (
+						<ExampleDialog
+							title="Hello World!"
+							body="This is a dialog body."
+							cancel="myCancelButton"
+							confirm="myConfirmButton"
+							onCancel={() => onClose()}
+							onContinue={() => onClose()}
+						/>
+					),
+					onClose: () => {
+						void null
+					},
+				})
+			}}
+		>
+			Show toast/dialog
+		</button>
+	)
+}
+const components: TLComponents = {
+	SharePanel: CustomSharePanel,
+}
+export default function ToastsDialogsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw components={components} persistenceKey="example" />
+		</div>
+	)
+}
+
+/* 
+
+To control toasts and dialogs your app, you can use the `useToasts` and `useDialogs` hooks. 
+These hooks give you access to functions which allow you to add, remove and clear toasts 
+and dialogs.
+
+Dialogs are especially customisable, allowing you to pass in a custom component to render
+as the dialog content. Alternatively, you can use the `ExampleDialog` component which is
+provided by the library.
+
+*/

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -2,8 +2,11 @@ import { TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file
+interface MyDialogProps {
+	onClose: () => void
+}
 
-function MyDialog({ onClose }: { onClose: () => void }) {
+function MyDialog({ onClose }: MyDialogProps) {
 	return (
 		<div>
 			<h1>My Dialog Title</h1>

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -16,7 +16,7 @@ import 'tldraw/tldraw.css'
 // There's a guide at the bottom of this file
 
 // [1]
-function MyDialog({ onClose }: { onClose: () => void }) {
+function MyDialog({ onClose }: { onClose(): void }) {
 	return (
 		<>
 			<TldrawUiDialogHeader>
@@ -37,7 +37,7 @@ function MyDialog({ onClose }: { onClose: () => void }) {
 }
 
 // [2]
-function MySimpleDialog({ onClose }: { onClose: () => void }) {
+function MySimpleDialog({ onClose }: { onClose(): void }) {
 	return (
 		<div style={{ padding: 16 }}>
 			<h2>Title</h2>

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -2,11 +2,8 @@ import { TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file
-interface MyDialogProps {
-	onClose: () => void
-}
 
-function MyDialog({ onClose }: MyDialogProps) {
+function MyDialog({ onClose }: { onClose: () => void }) {
 	return (
 		<div>
 			<h1>My Dialog Title</h1>

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -1,14 +1,48 @@
-import { TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
+import {
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiDialogBody,
+	TldrawUiDialogCloseButton,
+	TldrawUiDialogFooter,
+	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
+	useDialogs,
+	useToasts,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file
 
+// [1]
 function MyDialog({ onClose }: { onClose: () => void }) {
 	return (
-		<div>
-			<h1>My Dialog Title</h1>
-			<p>My dialog body</p>
-			<button onClick={onClose}>close</button>
+		<>
+			<TldrawUiDialogHeader>
+				<TldrawUiDialogTitle>Title</TldrawUiDialogTitle>
+				<TldrawUiDialogCloseButton />
+			</TldrawUiDialogHeader>
+			<TldrawUiDialogBody style={{ maxWidth: 350 }}>Description...</TldrawUiDialogBody>
+			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+				<TldrawUiButton type="normal" onClick={onClose}>
+					<TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
+				</TldrawUiButton>
+				<TldrawUiButton type="primary" onClick={onClose}>
+					<TldrawUiButtonLabel>Continue</TldrawUiButtonLabel>
+				</TldrawUiButton>
+			</TldrawUiDialogFooter>
+		</>
+	)
+}
+
+// [2]
+function MySimpleDialog({ onClose }: { onClose: () => void }) {
+	return (
+		<div style={{ padding: 16 }}>
+			<h2>Title</h2>
+			<p>Description...</p>
+			<button onClick={onClose}>Okay</button>
 		</div>
 	)
 }
@@ -18,26 +52,48 @@ const CustomSharePanel = () => {
 	const { addDialog } = useDialogs()
 
 	return (
-		<button
-			style={{ fontSize: 18, backgroundColor: 'thistle', pointerEvents: 'all' }}
-			onClick={() => {
-				addToast({ title: 'Hello world!', severity: 'success' })
-				addDialog({
-					component: ({ onClose }) => <MyDialog onClose={() => onClose()} />,
-					onClose: () => {
-						// You can do something after the dialog is closed
-						void null
-					},
-				})
-			}}
-		>
-			Show toast/dialog
-		</button>
+		<div style={{ padding: 16, gap: 16, display: 'flex', pointerEvents: 'all' }}>
+			<button
+				onClick={() => {
+					addToast({ title: 'Hello world!', severity: 'success' })
+				}}
+			>
+				Show toast
+			</button>
+			<button
+				onClick={() => {
+					addDialog({
+						component: MyDialog,
+						onClose: () => {
+							// You can do something after the dialog is closed
+							void null
+						},
+					})
+				}}
+			>
+				Show dialog
+			</button>
+			<button
+				onClick={() => {
+					addDialog({
+						component: MySimpleDialog,
+						onClose: () => {
+							// You can do something after the dialog is closed
+							void null
+						},
+					})
+				}}
+			>
+				Show simple dialog
+			</button>
+		</div>
 	)
 }
+
 const components: TLComponents = {
 	SharePanel: CustomSharePanel,
 }
+
 export default function ToastsDialogsExample() {
 	return (
 		<div className="tldraw__editor">
@@ -56,4 +112,11 @@ Dialogs are especially customisable, allowing you to pass in a custom component 
 as the dialog content. Alternatively, you can use the `ExampleDialog` component which is
 provided by the library.
 
+[1]
+The tldraw library provides a set of components that you can use to build your dialogs. 
+The `onClose` function passed to the dialog component runs when the dialog closes or 
+is dismissed, but you can also call it from buttons to close the dialog.
+
+[2]
+...or you can build your own dialog component!
 */

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -1,7 +1,17 @@
-import { ExampleDialog, TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
+import { TLComponents, Tldraw, useDialogs, useToasts } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file
+
+function MyDialog({ onClose }: { onClose: () => void }) {
+	return (
+		<div>
+			<h1>My Dialog Title</h1>
+			<p>My dialog body</p>
+			<button onClick={onClose}>close</button>
+		</div>
+	)
+}
 
 const CustomSharePanel = () => {
 	const { addToast } = useToasts()
@@ -13,17 +23,9 @@ const CustomSharePanel = () => {
 			onClick={() => {
 				addToast({ title: 'Hello world!', severity: 'success' })
 				addDialog({
-					component: ({ onClose }) => (
-						<ExampleDialog
-							title="Hello World!"
-							body="This is a dialog body."
-							cancel="myCancelButton"
-							confirm="myConfirmButton"
-							onCancel={() => onClose()}
-							onContinue={() => onClose()}
-						/>
-					),
+					component: ({ onClose }) => <MyDialog onClose={() => onClose()} />,
 					onClose: () => {
+						// You can do something after the dialog is closed
 						void null
 					},
 				})

--- a/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -64,7 +64,7 @@ const CustomSharePanel = () => {
 				onClick={() => {
 					addDialog({
 						component: MyDialog,
-						onClose: () => {
+						onClose() {
 							// You can do something after the dialog is closed
 							void null
 						},
@@ -77,7 +77,7 @@ const CustomSharePanel = () => {
 				onClick={() => {
 					addDialog({
 						component: MySimpleDialog,
-						onClose: () => {
+						onClose() {
 							// You can do something after the dialog is closed
 							void null
 						},


### PR DESCRIPTION
Adds an example for how to use toasts and dialogs

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- [Examples] added a toasts/dialogs example