### PR TITLE
Remove 5s watermark from dev mode

### DIFF
--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -62,6 +62,15 @@ describe('WatermarkManager', () => {
 		expect(watermarkManager.checkWatermark(licenseResult)).toBe(true)
 	})
 
+	it('shows watermark when annual license has expired, even if dev mode', () => {
+		const licenseResult = getDefaultLicenseResult({
+			isAnnualLicense: true,
+			isAnnualLicenseExpired: true,
+			isDevelopment: true,
+		})
+		expect(watermarkManager.checkWatermark(licenseResult)).toBe(true)
+	})
+
 	it('shows watermark when perpetual license has expired', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isPerpetualLicense: true,

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.test.ts
@@ -103,6 +103,15 @@ describe('WatermarkManager', () => {
 		expect(watermarkManager.checkWatermark(licenseResult)).toBe(false)
 	})
 
+	it('does not show watermark when license is parseable and domain is not valid and dev mode', () => {
+		const licenseResult = getDefaultLicenseResult({
+			isLicenseParseable: true,
+			isDomainValid: false,
+			isDevelopment: true,
+		})
+		expect(watermarkManager.checkWatermark(licenseResult)).toBe(false)
+	})
+
 	it('throws when an internal annual license has expired', () => {
 		const expiryDate = new Date(2023, 1, 1)
 		const licenseResult = getDefaultLicenseResult({

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.ts
@@ -54,6 +54,7 @@ export class WatermarkManager {
 
 	private shouldShowWatermark(license: LicenseFromKeyResult) {
 		if (!license.isLicenseParseable) return true
+		if (license.isDevelopment) return false
 		if (!license.isDomainValid) return true
 
 		if (license.isPerpetualLicenseExpired || license.isAnnualLicenseExpired) {

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.ts
@@ -54,8 +54,7 @@ export class WatermarkManager {
 
 	private shouldShowWatermark(license: LicenseFromKeyResult) {
 		if (!license.isLicenseParseable) return true
-		if (license.isDevelopment) return false
-		if (!license.isDomainValid) return true
+		if (!license.isDomainValid && !license.isDevelopment) return true
 
 		if (license.isPerpetualLicenseExpired || license.isAnnualLicenseExpired) {
 			if (license.isInternalLicense) {

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.ts
@@ -18,7 +18,12 @@ export class WatermarkManager {
 		const isMobile = window.innerWidth < 840 /* PORTRAIT_BREAKPOINTS[TABLET] */
 
 		const width = isMobile ? '32px' : '120px'
-		const src = getWatermarkSrc({ forceLocal: this.forceLocal, isMobile })
+		let src = ''
+		if (navigator.onLine && !this.forceLocal) {
+			src = `${getDefaultCdnBaseUrl()}/${WATERMARKS_FOLDER}/${isMobile ? WATERMARK_MOBILE_FILENAME : WATERMARK_DESKTOP_FILENAME}`
+		} else {
+			src = isMobile ? watermarkMobile : watermarkDesktop
+		}
 
 		if (src !== watermark.src) {
 			watermark.style.width = width
@@ -93,15 +98,6 @@ export class WatermarkManager {
 			const watermark = this.createWatermark()
 
 			this.applyStyles(watermark)
-
-			if (
-				(!license.isLicenseParseable && license.reason === 'has-key-development-mode') ||
-				(license.isLicenseParseable && license.isDevelopment)
-			) {
-				// After 5 seconds, in development mode (dev, staging, CI), remove.
-				watermark.parentNode?.removeChild(watermark)
-				window.removeEventListener('resize', resizeListener)
-			}
 		}, 5000)
 
 		return true
@@ -126,19 +122,5 @@ export class WatermarkManager {
 			window.open('https://tldraw.dev', '_blank', 'noopener noreferrer')
 		}
 		this.setWatermarkSrc(watermark)
-	}
-}
-
-export function getWatermarkSrc({
-	forceLocal,
-	isMobile,
-}: {
-	forceLocal: boolean
-	isMobile: boolean
-}) {
-	if (navigator.onLine && !forceLocal) {
-		return `${getDefaultCdnBaseUrl()}/${WATERMARKS_FOLDER}/${isMobile ? WATERMARK_MOBILE_FILENAME : WATERMARK_DESKTOP_FILENAME}`
-	} else {
-		return isMobile ? watermarkMobile : watermarkDesktop
 	}
 }


### PR DESCRIPTION
drive-by: refactor getWatermarkSrc as it isn't being used elsewhere

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes

- Removed logic to show watermark for 5 seconds in dev mode