### PR TITLE
Fix `/new` alert bug, make new user data stable

### DIFF
--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -144,6 +144,7 @@ export const defaultUserPreferences = Object.freeze({
 export function getFreshUserPreferences(): TLUserPreferences {
 	return {
 		id: uniqueId(),
+		color: getRandomColor(),
 	}
 }
 
@@ -233,7 +234,7 @@ export function getUserPreferences(): TLUserPreferences {
 	let prefs = globalUserPreferences.get()
 	if (!prefs) {
 		prefs = loadUserPreferences()
-		globalUserPreferences.set(prefs)
+		setUserPreferences(prefs)
 	}
 	return prefs
 }

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -333,6 +333,7 @@ export class TLLocalSyncClient {
 	 */
 	private async doPersist() {
 		assert(!this.isPersisting, 'persist already in progress')
+		if (this.didDispose) return
 		this.isPersisting = true
 
 		this.debug('doPersist start')


### PR DESCRIPTION
two changes in one here because I'm feeling lazy

- fix bug in staging, introduced in whichever bemo PR refactored the sync client+indexeddb stuff
    1. go to `/`
    2. file -> new shared project
    3. oh_no.jpg 
       <img width="618" alt="image" src="https://github.com/tldraw/tldraw/assets/1242537/8bff3498-2cc5-4c71-b407-830d459d3d36">

- fix bug in production
    1. make a new room
    2. clear localstorage
    3. refresh
    4. duplicate current tab in same browser context
    6. oh_no.jpg (there should only be one person)

       <img width="99" alt="image" src="https://github.com/tldraw/tldraw/assets/1242537/f4e434ba-8455-4913-a698-71661e5074fd">

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
8.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…