### PR TITLE
Unify menus. Disable erroring.

### DIFF
--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -1,14 +1,18 @@
 import { getAssetUrlsByImport } from '@tldraw/assets/imports'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
-	DefaultHelpMenu,
-	DefaultHelpMenuContent,
+	DefaultMainMenu,
 	DefaultSpinner,
+	EditSubmenu,
 	Editor,
 	ErrorBoundary,
+	ExportFileContentSubMenu,
+	ExtrasGroup,
+	HelpGroup,
+	PreferencesGroup,
 	TLComponents,
 	Tldraw,
-	TldrawUiMenuGroup,
+	ViewSubmenu,
 	setRuntimeOverrides,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
@@ -107,13 +111,16 @@ export interface TLDrawInnerProps {
 }
 
 const components: TLComponents = {
-	HelpMenu: () => (
-		<DefaultHelpMenu>
-			<TldrawUiMenuGroup id="help">
-				<DefaultHelpMenuContent />
-			</TldrawUiMenuGroup>
+	MainMenu: () => (
+		<DefaultMainMenu>
+			<EditSubmenu />
+			<ViewSubmenu />
+			<ExportFileContentSubMenu />
+			<ExtrasGroup />
+			<PreferencesGroup />
+			<HelpGroup />
 			<Links />
-		</DefaultHelpMenu>
+		</DefaultMainMenu>
 	),
 }
 function TldrawInner({ uri, assetSrc, isDarkMode, fileContents }: TLDrawInnerProps) {

--- a/packages/editor/src/lib/editor/managers/WatermarkManager.ts
+++ b/packages/editor/src/lib/editor/managers/WatermarkManager.ts
@@ -117,6 +117,7 @@ export class WatermarkManager {
 			// we still fallback to the local watermark.
 			this.forceLocal = true
 			this.setWatermarkSrc(watermark)
+			watermark.onerror = null
 		}
 		watermark.onclick = () => {
 			window.open('https://tldraw.dev', '_blank', 'noopener noreferrer')


### PR DESCRIPTION
Unify the VS Code extension menus with what we have on dot com. Prevent an error cycle.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Unify the VS Code extension menus (Help and Main menus) with what we have on tldraw.com
- Prevent an onerror cycle.