### PR TITLE
[bemo] allow special chars in roomId

### DIFF
--- a/packages/sync/src/useMutliplayerDemo.ts
+++ b/packages/sync/src/useMutliplayerDemo.ts
@@ -50,7 +50,7 @@ export function useMultiplayerDemo({
 	const assets = useMemo(() => createDemoAssetStore(host), [host])
 
 	return useMultiplayerSync({
-		uri: `${host}/connect/${roomId}`,
+		uri: `${host}/connect/${encodeURIComponent(roomId)}`,
 		roomId,
 		userPreferences,
 		assets,


### PR DESCRIPTION
if people did weird room ids with non-url-safe chars like `blah/whatever` it wouldn't work. this fixes that

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…