### PR TITLE
license: show on dotcom dev mode

### DIFF
--- a/packages/dotcom-shared/src/license.ts
+++ b/packages/dotcom-shared/src/license.ts
@@ -1,4 +1,4 @@
 const getLicenseKey = () =>
-	process.env.TLDRAW_LICENSE ??
+	process.env.TLDRAW_LICENSE ||
 	'tldraw-tldraw-2025-07-10/WyJiTEZhTGFLRSIsWyIqLnRsZHJhdy5jb20iXSwxLCIyMDI1LTA3LTEwIl0.frNy824rh1/JzMGLzLuW9JFKrah66N23/+xY0Z+5XoyKQWO7UpIDdKgDN5+N//yHE5Fh1DThM7ykoGzul/RjrA'
 export default getLicenseKey


### PR DESCRIPTION
don't show the watermark in dev mode for dotcom

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
