### PR TITLE
head: rm mask-icon

### DIFF
--- a/apps/dotcom/index.html
+++ b/apps/dotcom/index.html
@@ -13,7 +13,6 @@
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<meta name="apple-mobile-web-app-title" content="tldraw" />
-		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#FFFFFF" />
 
 		<meta name="description" content="A free and instant collaborative whiteboarding tool." />
 		<meta name="format-detection" content="telephone=no" />


### PR DESCRIPTION
"Safari formerly had a requirement of SVG monochrome icon for [pinned tabs](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html). However, since Safari 12, we can use a regular favicon for pinned tabs. Even [apple.com](https://www.apple.com/) doesn’t use the mask-icon anymore."

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
