### PR TITLE
`ShapeUtil.getInterpolatedProps`

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -173,6 +173,8 @@ export abstract class BaseBoxShapeUtil<Shape extends TLBaseBoxShape> extends Sha
     // (undocumented)
     getHandleSnapGeometry(shape: Shape): HandleSnapGeometry;
     // (undocumented)
+    getInterpolatedProps(startShape: Shape, endShape: Shape, t: number): Shape['props'];
+    // (undocumented)
     onResize: TLOnResizeHandler<any>;
 }
 
@@ -2040,6 +2042,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     abstract getGeometry(shape: Shape): Geometry2d;
     getHandles?(shape: Shape): TLHandle[];
     getHandleSnapGeometry(shape: Shape): HandleSnapGeometry;
+    getInterpolatedProps?(startShape: Shape, endShape: Shape, progress: number): Shape['props'];
     hideResizeHandles: TLShapeUtilFlag<Shape>;
     hideRotateHandle: TLShapeUtilFlag<Shape>;
     hideSelectionBoundsBg: TLShapeUtilFlag<Shape>;

--- a/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
@@ -27,4 +27,12 @@ export abstract class BaseBoxShapeUtil<Shape extends TLBaseBoxShape> extends Sha
 			points: this.getGeometry(shape).bounds.cornersAndCenter,
 		}
 	}
+
+	override getInterpolatedProps(startShape: Shape, endShape: Shape, t: number): Shape['props'] {
+		return {
+			...endShape.props,
+			w: startShape.props.w + (endShape.props.w - startShape.props.w) * t,
+			h: startShape.props.h + (endShape.props.h - startShape.props.h) * t,
+		}
+	}
 }

--- a/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
@@ -1,4 +1,5 @@
 import { TLBaseShape } from '@tldraw/tlschema'
+import { lerp } from '@tldraw/utils'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import { Rectangle2d } from '../../primitives/geometry/Rectangle2d'
 import { HandleSnapGeometry } from '../managers/SnapManager/HandleSnaps'

--- a/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseBoxShapeUtil.tsx
@@ -31,8 +31,8 @@ export abstract class BaseBoxShapeUtil<Shape extends TLBaseBoxShape> extends Sha
 	override getInterpolatedProps(startShape: Shape, endShape: Shape, t: number): Shape['props'] {
 		return {
 			...endShape.props,
-			w: startShape.props.w + (endShape.props.w - startShape.props.w) * t,
-			h: startShape.props.h + (endShape.props.h - startShape.props.h) * t,
+			w: lerp(startShape.props.w, endShape.props.w, t),
+			h: lerp(startShape.props.h, endShape.props.h, t),
 		}
 	}
 }

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -217,6 +217,22 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @example
 	 *
 	 * ```ts
+	 * util.getInterpolatedProps?.(startShape, endShape, t)
+	 * ```
+	 *
+	 * @param startShape - The initial shape.
+	 * @param endShape - The initial shape.
+	 * @param progress - The normalized progress between zero (start) and 1 (end).
+	 * @public
+	 */
+	getInterpolatedProps?(startShape: Shape, endShape: Shape, progress: number): Shape['props']
+
+	/**
+	 * Get an array of handle models for the shape. This is an optional method.
+	 *
+	 * @example
+	 *
+	 * ```ts
 	 * util.getHandles?.(myShape)
 	 * ```
 	 *

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -212,7 +212,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	backgroundComponent?(shape: Shape): any
 
 	/**
-	 * Get an array of handle models for the shape. This is an optional method.
+	 * Get the interpolated props for an animating shape. This is an optional method.
 	 *
 	 * @example
 	 *


### PR DESCRIPTION
This PR adds a `getInterpolatedProps` method to the `ShapeUtil` class. It is used in `Editor.animateShapes` to allow shapes to lerp values that the editor doesn't specifically know about.

![Kapture 2024-07-13 at 09 12 48](https://github.com/user-attachments/assets/f9711aa0-278b-4a26-84d3-4b6bbe610b81)

### Change type

- [x] `feature`
- [x] `api`

### Test plan

1. Animate a shape's props.

```ts

const shape = editor.getOnlySelectedShape()

setInterval(() => {
	editor.animateShape(
		{
			...shape,
			x: Math.random() * 500,
			y: Math.random() * 200,
			props: { w: 200 + Math.random() * 200, h: 200 + Math.random() * 200 },
		},
		{ animation: { duration: 500 } }
	)
}, 1000)
```

- [ ] Unit tests (Could be done!)

### Release notes

- SDK: adds `ShapeUtil.getInterpolatedProps` so that shapes can better participate in animations.