### PR TITLE
docs: fix up prev/next for api reference

### DIFF
--- a/apps/docs/utils/ContentDatabase.ts
+++ b/apps/docs/utils/ContentDatabase.ts
@@ -83,9 +83,16 @@ export class ContentDatabase {
 
 		// the prev is the article with the same section but one less sectionIndex
 		let prev = await this.db.get<Article>(
-			`SELECT id, title, categoryId, sectionId, path FROM articles WHERE articles.sectionId = ? AND articles.sectionIndex = ?`,
+			`SELECT id, title, categoryId, sectionId, path FROM articles
+			   WHERE articles.sectionId = ?
+				   AND ((articles.groupId = ? AND ? IS NOT NULL) OR (articles.groupId IS NULL AND ? is NULL))
+					 AND articles.sectionIndex < ? 
+			   ORDER BY articles.sectionIndex DESC LIMIT 1`,
 			article.sectionId,
-			sectionIndex - 1
+			article.groupId,
+			article.groupId,
+			article.groupId,
+			sectionIndex
 		)
 
 		// If there's no next, then get the LAST article from the prev section
@@ -104,7 +111,9 @@ export class ContentDatabase {
 				// get the article with the section id and the highest section index
 				prev = await this.db.get<Article>(
 					// here we only need certian info for the link
-					`SELECT id, title, categoryId, sectionId, path FROM articles WHERE articles.sectionId = ? ORDER BY articles.sectionIndex DESC LIMIT 1`,
+					`SELECT id, title, categoryId, sectionId, path FROM articles
+					   WHERE articles.sectionId = ?
+					   ORDER BY articles.sectionIndex DESC LIMIT 1`,
 					prevSectionId
 				)
 			}
@@ -112,9 +121,16 @@ export class ContentDatabase {
 
 		// the next is the article with the same section but next sectionIndex
 		let next = await this.db.get<Article>(
-			`SELECT id, title, categoryId, sectionId, path FROM articles WHERE articles.sectionId = ? AND articles.sectionIndex = ?`,
+			`SELECT id, title, categoryId, sectionId, path FROM articles
+			   WHERE articles.sectionId = ?
+				   AND ((articles.groupId = ? AND ? IS NOT NULL) OR (articles.groupId IS NULL AND ? is NULL))
+					 AND articles.sectionIndex > ?
+			   ORDER BY articles.sectionIndex ASC LIMIT 1`,
 			article.sectionId,
-			sectionIndex + 1
+			article.groupId,
+			article.groupId,
+			article.groupId,
+			sectionIndex
 		)
 
 		// If there's no next, then get the FIRST article from the next section
@@ -132,7 +148,9 @@ export class ContentDatabase {
 			if (nextSection) {
 				const { id: nextSectionId } = nextSection
 				next = await this.db.get<Article>(
-					`SELECT id, title, categoryId, sectionId, path FROM articles WHERE articles.sectionId = ? ORDER BY articles.sectionIndex ASC LIMIT 1`,
+					`SELECT id, title, categoryId, sectionId, path FROM articles
+					 	 WHERE articles.sectionId = ?
+						 ORDER BY articles.sectionIndex ASC LIMIT 1`,
 					nextSectionId
 				)
 			}


### PR DESCRIPTION
small thing that was driving me nuts. prev/next didn't really work.

before
<img width="1237" alt="Screenshot 2024-07-15 at 12 29 45" src="https://github.com/user-attachments/assets/bfe28ad9-40bc-4ca3-b5c9-97f08ea36c8f">

after
<img width="1343" alt="Screenshot 2024-07-15 at 12 32 31" src="https://github.com/user-attachments/assets/ca1f3423-000d-47a8-843e-9e4a63784df3">

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Docs: fix up prev/next.