### PR TITLE
Fix sticker example.

### DIFF
--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -90,6 +90,7 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		const target = this.editor.getShapeAtPoint(pageAnchor, {
 			hitInside: true,
 			filter: (shape) =>
+				shape.id !== sticker.id &&
 				this.editor.canBindShapes({ fromShape: sticker, toShape: shape, binding: 'sticker' }),
 		})
 


### PR DESCRIPTION
Stickers didn't stick since they were binding to themselves.

Fixes #3982

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Use the sticker example
2. The sticker should stick 😄 

### Release notes

- Fix the sticker example.