### PR TITLE
Relax the params

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -3539,7 +3539,7 @@ export function useTLSchemaFromUtils(opts: TLStoreSchemaOptions): StoreSchema<TL
 
 // @public (undocumented)
 export function useTLStore(opts: TLStoreOptions & {
-    snapshot?: TLEditorSnapshot | TLStoreSnapshot;
+    snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot;
 }): TLStore;
 
 // @public (undocumented)

--- a/packages/editor/src/lib/hooks/useTLStore.ts
+++ b/packages/editor/src/lib/hooks/useTLStore.ts
@@ -11,7 +11,7 @@ import {
 
 /** @public */
 type UseTLStoreOptions = TLStoreOptions & {
-	snapshot?: TLEditorSnapshot | TLStoreSnapshot
+	snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot
 }
 
 function createStore(opts: UseTLStoreOptions) {
@@ -24,7 +24,7 @@ function createStore(opts: UseTLStoreOptions) {
 
 /** @public */
 export function useTLStore(
-	opts: TLStoreOptions & { snapshot?: TLEditorSnapshot | TLStoreSnapshot }
+	opts: TLStoreOptions & { snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot }
 ) {
 	const [current, setCurrent] = useState(() => createStore(opts))
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1696,7 +1696,7 @@ export interface TldrawImageProps extends TLSvgOptions {
     licenseKey?: string;
     pageId?: TLPageId;
     shapeUtils?: readonly TLAnyShapeUtilConstructor[];
-    snapshot: TLEditorSnapshot | TLStoreSnapshot;
+    snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -24,7 +24,7 @@ export interface TldrawImageProps extends TLSvgOptions {
 	/**
 	 * The snapshot to display.
 	 */
-	snapshot: TLEditorSnapshot | TLStoreSnapshot
+	snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot
 
 	/**
 	 * The image format to use. Defaults to 'svg'.


### PR DESCRIPTION
Feels like we can relax what we expect? It gets passed to `loadSnapshot` which allows for partials.

Resolves https://github.com/tldraw/tldraw/issues/3999

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Allow passing partial `TLEditorSnapshot` to `TldrawImage` and `useTLStore`.