### PR TITLE
add version attribute

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -12,6 +12,7 @@ import React, {
 } from 'react'
 
 import classNames from 'classnames'
+import { version } from '../version'
 import { OptionalErrorBoundary } from './components/ErrorBoundary'
 import { DefaultErrorFallback } from './components/default-components/DefaultErrorFallback'
 import { TLEditorSnapshot } from './config/TLEditorSnapshot'
@@ -223,6 +224,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 	return (
 		<div
 			ref={setContainer}
+			data-tldraw={version}
 			draggable={false}
 			className={classNames(`${TL_CONTAINER_CLASS} tl-theme__light`, className)}
 			onPointerDown={stopEventPropagation}


### PR DESCRIPTION
Occasionally I come across tldraw in the wild and want to see what version it is.

### Change type

- [x] `other`
