### PR TITLE
Improve page event tracking.

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2098,6 +2098,8 @@ export interface TLUiEventMap {
         locale: string;
     };
     // (undocumented)
+    'change-page': null;
+    // (undocumented)
     'change-user-name': null;
     // (undocumented)
     'close-menu': {
@@ -2118,11 +2120,15 @@ export interface TLUiEventMap {
     // (undocumented)
     'create-new-project': null;
     // (undocumented)
+    'delete-page': null;
+    // (undocumented)
     'delete-shapes': null;
     // (undocumented)
     'distribute-shapes': {
         operation: 'horizontal' | 'vertical';
     };
+    // (undocumented)
+    'duplicate-page': null;
     // (undocumented)
     'duplicate-shapes': null;
     // (undocumented)
@@ -2152,6 +2158,10 @@ export interface TLUiEventMap {
     // (undocumented)
     'insert-media': null;
     // (undocumented)
+    'move-page': null;
+    // (undocumented)
+    'move-to-new-page': null;
+    // (undocumented)
     'move-to-page': null;
     // (undocumented)
     'new-page': null;
@@ -2169,6 +2179,8 @@ export interface TLUiEventMap {
     'pack-shapes': null;
     // (undocumented)
     'remove-frame': null;
+    // (undocumented)
+    'rename-page': null;
     // (undocumented)
     'reorder-shapes': {
         operation: 'backward' | 'forward' | 'toBack' | 'toFront';

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -264,9 +264,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 
 	const changePage = useCallback(
 		(id: TLPageId) => {
-			editor.run(() => {
-				editor.setCurrentPage(id)
-			})
+			editor.setCurrentPage(id)
 			trackEvent('change-page', { source: 'page-menu' })
 		},
 		[editor, trackEvent]

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
@@ -1,5 +1,6 @@
 import { TLPageId, useEditor } from '@tldraw/editor'
 import { useCallback, useRef } from 'react'
+import { useUiEvents } from '../../context/events'
 import { TldrawUiInput } from '../primitives/TldrawUiInput'
 
 /** @public */
@@ -16,6 +17,7 @@ export const PageItemInput = function PageItemInput({
 	isCurrentPage,
 }: PageItemInputProps) {
 	const editor = useEditor()
+	const trackEvent = useUiEvents()
 
 	const rInput = useRef<HTMLInputElement | null>(null)
 
@@ -26,8 +28,9 @@ export const PageItemInput = function PageItemInput({
 	const handleChange = useCallback(
 		(value: string) => {
 			editor.renamePage(id, value || 'New Page')
+			trackEvent('rename-page', { source: 'page-menu' })
 		},
-		[editor, id]
+		[editor, id, trackEvent]
 	)
 
 	return (

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -1,5 +1,6 @@
 import { PageRecordType, TLPageId, track, useEditor } from '@tldraw/editor'
 import { useCallback } from 'react'
+import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
@@ -29,25 +30,28 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	const editor = useEditor()
 	const msg = useTranslation()
 	const pages = editor.getPages()
+	const trackEvent = useUiEvents()
 
 	const onDuplicate = useCallback(() => {
 		editor.mark('creating page')
 		const newId = PageRecordType.createId()
 		editor.duplicatePage(item.id as TLPageId, newId)
-	}, [editor, item])
+		trackEvent('duplicate-page', { source: 'page-menu' })
+	}, [editor, item, trackEvent])
 
 	const onMoveUp = useCallback(() => {
-		onMovePage(editor, item.id as TLPageId, index, index - 1)
-	}, [editor, item, index])
+		onMovePage(editor, item.id as TLPageId, index, index - 1, trackEvent)
+	}, [editor, item, index, trackEvent])
 
 	const onMoveDown = useCallback(() => {
-		onMovePage(editor, item.id as TLPageId, index, index + 1)
-	}, [editor, item, index])
+		onMovePage(editor, item.id as TLPageId, index, index + 1, trackEvent)
+	}, [editor, item, index, trackEvent])
 
 	const onDelete = useCallback(() => {
 		editor.mark('deleting page')
 		editor.deletePage(item.id as TLPageId)
-	}, [editor, item])
+		trackEvent('delete-page', { source: 'page-menu' })
+	}, [editor, item, trackEvent])
 
 	return (
 		<TldrawUiDropdownMenuRoot id={`page item submenu ${index}`}>

--- a/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
@@ -6,8 +6,15 @@ import {
 	IndexKey,
 	TLPageId,
 } from '@tldraw/editor'
+import { TLUiEventContextType } from '../../context/events'
 
-export const onMovePage = (editor: Editor, id: TLPageId, from: number, to: number) => {
+export const onMovePage = (
+	editor: Editor,
+	id: TLPageId,
+	from: number,
+	to: number,
+	trackEvent: TLUiEventContextType
+) => {
 	let index: IndexKey
 
 	const pages = editor.getPages()
@@ -29,5 +36,6 @@ export const onMovePage = (editor: Editor, id: TLPageId, from: number, to: numbe
 			id: id as TLPageId,
 			index,
 		})
+		trackEvent('move-page', { source: 'page-menu' })
 	}
 }

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -479,7 +479,7 @@ export function MoveToPageMenu() {
 				))}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="new-page">
-				<TldrawUiMenuItem {...actions['new-page']} />
+				<TldrawUiMenuItem {...actions['move-to-new-page']} />
 			</TldrawUiMenuGroup>
 		</TldrawUiMenuSubmenu>
 	)

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1357,7 +1357,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				},
 			},
 			{
-				id: 'new-page',
+				id: 'move-to-new-page',
 				label: 'context.pages.new-page',
 				onSelect(source) {
 					const newPageId = PageRecordType.createId()
@@ -1367,7 +1367,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
 						editor.moveShapesToPage(ids, newPageId)
 					})
-					trackEvent('new-page', { source })
+					trackEvent('move-to-new-page', { source })
 				},
 			},
 			{

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -29,8 +29,14 @@ export interface TLUiEventMap {
 	undo: null
 	redo: null
 	'change-language': { locale: string }
+	'change-page': null
+	'delete-page': null
+	'duplicate-page': null
+	'move-page': null
 	'new-page': null
+	'rename-page': null
 	'move-to-page': null
+	'move-to-new-page': null
 	'group-shapes': null
 	'ungroup-shapes': null
 	'remove-frame': null


### PR DESCRIPTION
Wanted to check how often new pages are created / deleted,... when I noticed that we are not tracking many of the page related events. This adds the missing event tracking and also renames `new-page` event to `move-to-new-page` as it was confusing.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Add additional tracking of page related events like renaming, duplicating, moving.

### Breaking change
`new-page` action was renamed to `move-to-new-page`.