### PR TITLE
Make asset.fileSize optional

### DIFF
--- a/apps/dotcom/src/utils/multiplayerAssetStore.ts
+++ b/apps/dotcom/src/utils/multiplayerAssetStore.ts
@@ -54,7 +54,8 @@ export const multiplayerAssetStore: TLAssetStore = {
 
 		// Assets that are under a certain file size aren't worth transforming (and incurring cost).
 		// We still send them through the image worker to get them optimized though.
-		const isWorthResizing = asset.props.fileSize !== -1 && asset.props.fileSize >= 1024 * 1024 * 1.5
+		const { fileSize = 0 } = asset.props
+		const isWorthResizing = fileSize >= 1024 * 1024 * 1.5
 
 		if (isWorthResizing) {
 			// N.B. navigator.connection is only available in certain browsers (mainly Blink-based browsers)

--- a/apps/examples/src/examples/image-annotator/ImageAnnotationEditor.tsx
+++ b/apps/examples/src/examples/image-annotator/ImageAnnotationEditor.tsx
@@ -48,7 +48,6 @@ export function ImageAnnotationEditor({
 				props: {
 					w: image.width,
 					h: image.height,
-					fileSize: -1,
 					mimeType: image.type,
 					src: image.src,
 					name: 'image',

--- a/apps/examples/src/examples/local-images/LocalImagesExample.tsx
+++ b/apps/examples/src/examples/local-images/LocalImagesExample.tsx
@@ -21,7 +21,6 @@ export default function LocalImagesExample() {
 					src: '/tldraw.png', // You could also use a base64 encoded string here
 					w: imageWidth,
 					h: imageHeight,
-					fileSize: -1,
 					mimeType: 'image/png',
 					isAnimated: false,
 				},

--- a/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
+++ b/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
@@ -43,7 +43,6 @@ export function PdfEditor({ pdf }: { pdf: Pdf }) {
 						props: {
 							w: page.bounds.w,
 							h: page.bounds.h,
-							fileSize: -1,
 							mimeType: 'image/png',
 							src: page.src,
 							name: 'page',

--- a/packages/sync/src/useMutliplayerDemo.ts
+++ b/packages/sync/src/useMutliplayerDemo.ts
@@ -132,8 +132,8 @@ function createDemoAssetStore(host: string): TLAssetStore {
 
 			// Assets that are under a certain file size aren't worth transforming (and incurring cost).
 			// We still send them through the image worker to get them optimized though.
-			const isWorthResizing =
-				asset.props.fileSize !== -1 && asset.props.fileSize >= 1024 * 1024 * 1.5
+			const { fileSize = 0 } = asset.props
+			const isWorthResizing = fileSize >= 1024 * 1024 * 1.5
 
 			if (isWorthResizing) {
 				// N.B. navigator.connection is only available in certain browsers (mainly Blink-based browsers)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -120,8 +120,7 @@ export function registerDefaultExternalContentHandlers(
 				mimeType: file.type,
 				isAnimated,
 			},
-			meta: {},
-		} satisfies TLAsset
+		} as TLAsset
 
 		assetInfo.props.src = await editor.uploadAsset(assetInfo, file)
 

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -120,7 +120,8 @@ export function registerDefaultExternalContentHandlers(
 				mimeType: file.type,
 				isAnimated,
 			},
-		} as TLAsset
+			meta: {},
+		} satisfies TLAsset
 
 		assetInfo.props.src = await editor.uploadAsset(assetInfo, file)
 

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -68,7 +68,6 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 						props: {
 							w: coerceDimension(v1Asset.size[0]),
 							h: coerceDimension(v1Asset.size[1]),
-							fileSize: -1,
 							name: v1Asset.fileName ?? 'Untitled',
 							isAnimated: false,
 							mimeType: null,
@@ -92,7 +91,6 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 								props: {
 									w: coerceDimension(v1Asset.size[0]),
 									h: coerceDimension(v1Asset.size[1]),
-									fileSize: -1,
 									name: v1Asset.fileName ?? 'Untitled',
 									isAnimated: true,
 									mimeType: null,

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -541,7 +541,6 @@ describe('snapshots', () => {
 				props: {
 					w: 1200,
 					h: 800,
-					fileSize: -1,
 					name: '',
 					isAnimated: false,
 					mimeType: 'png',

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1279,7 +1279,7 @@ export interface TLHighlightShapeProps {
 
 // @public
 export type TLImageAsset = TLBaseAsset<'image', {
-    fileSize: number;
+    fileSize?: number;
     h: number;
     isAnimated: boolean;
     mimeType: null | string;
@@ -1672,7 +1672,7 @@ export type TLUnknownShape = TLBaseShape<string, object>;
 
 // @public
 export type TLVideoAsset = TLBaseAsset<'video', {
-    fileSize: number;
+    fileSize?: number;
     h: number;
     isAnimated: boolean;
     mimeType: null | string;

--- a/packages/tlschema/src/assets/TLImageAsset.ts
+++ b/packages/tlschema/src/assets/TLImageAsset.ts
@@ -12,11 +12,11 @@ export type TLImageAsset = TLBaseAsset<
 	{
 		w: number
 		h: number
-		fileSize: number
 		name: string
 		isAnimated: boolean
 		mimeType: string | null
 		src: string | null
+		fileSize?: number
 	}
 >
 
@@ -26,11 +26,11 @@ export const imageAssetValidator: T.Validator<TLImageAsset> = createAssetValidat
 	T.object({
 		w: T.number,
 		h: T.number,
-		fileSize: T.number,
 		name: T.string,
 		isAnimated: T.boolean,
 		mimeType: T.string.nullable(),
 		src: T.srcUrl.nullable(),
+		fileSize: T.number.optional(),
 	})
 )
 
@@ -39,6 +39,7 @@ const Versions = createMigrationIds('com.tldraw.asset.image', {
 	RenameWidthHeight: 2,
 	MakeUrlsValid: 3,
 	AddFileSize: 4,
+	MakeFileSizeOptional: 5,
 } as const)
 
 export { Versions as imageAssetVersions }
@@ -91,6 +92,19 @@ export const imageAssetMigrations = createRecordMigrationSequence({
 			},
 			down: (asset: any) => {
 				delete asset.props.fileSize
+			},
+		},
+		{
+			id: Versions.MakeFileSizeOptional,
+			up: (asset: any) => {
+				if (asset.props.fileSize === -1) {
+					asset.props.fileSize = undefined
+				}
+			},
+			down: (asset: any) => {
+				if (asset.props.fileSize === undefined) {
+					asset.props.fileSize = -1
+				}
 			},
 		},
 	],

--- a/packages/tlschema/src/assets/TLVideoAsset.ts
+++ b/packages/tlschema/src/assets/TLVideoAsset.ts
@@ -12,11 +12,11 @@ export type TLVideoAsset = TLBaseAsset<
 	{
 		w: number
 		h: number
-		fileSize: number
 		name: string
 		isAnimated: boolean
 		mimeType: string | null
 		src: string | null
+		fileSize?: number
 	}
 >
 
@@ -26,11 +26,11 @@ export const videoAssetValidator: T.Validator<TLVideoAsset> = createAssetValidat
 	T.object({
 		w: T.number,
 		h: T.number,
-		fileSize: T.number,
 		name: T.string,
 		isAnimated: T.boolean,
 		mimeType: T.string.nullable(),
 		src: T.srcUrl.nullable(),
+		fileSize: T.number.optional(),
 	})
 )
 
@@ -39,6 +39,7 @@ const Versions = createMigrationIds('com.tldraw.asset.video', {
 	RenameWidthHeight: 2,
 	MakeUrlsValid: 3,
 	AddFileSize: 4,
+	MakeFileSizeOptional: 5,
 } as const)
 
 export { Versions as videoAssetVersions }
@@ -91,6 +92,19 @@ export const videoAssetMigrations = createRecordMigrationSequence({
 			},
 			down: (asset: any) => {
 				delete asset.props.fileSize
+			},
+		},
+		{
+			id: Versions.MakeFileSizeOptional,
+			up: (asset: any) => {
+				if (asset.props.fileSize === -1) {
+					asset.props.fileSize = undefined
+				}
+			},
+			down: (asset: any) => {
+				if (asset.props.fileSize === undefined) {
+					asset.props.fileSize = -1
+				}
 			},
 		},
 	],

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -121,7 +121,6 @@ describe('TLVideoAsset AddFileSize', () => {
 			width: 100,
 			height: 100,
 			mimeType: 'video/mp4',
-			fileSize: -1,
 		},
 	}
 
@@ -157,7 +156,6 @@ describe('TLImageAsset AddFileSize', () => {
 			width: 100,
 			height: 100,
 			mimeType: 'image/gif',
-			fileSize: -1,
 		},
 	}
 


### PR DESCRIPTION
This PR makes the `fileSize` property of `TLImageAsset` and `TLVideoAsset` optional. I first noticed this when I was updating the Draw Fast repo, but there are a bunch of cases where we don't know the file size when we're creating an asset. Instead of setting it to -1 (which is sort of magic), we can leave it off if we didn't know it already.

### Change type

- [x] `api`

### Test plan

- [x] Unit tests

### Release notes

- Made the `fileSize` property of `TLImageAsset` and `TLVideoAsset` optional