### PR TITLE
Fix interactive shape example

### DIFF
--- a/apps/examples/src/examples/interactive-shape/my-interactive-shape-util.tsx
+++ b/apps/examples/src/examples/interactive-shape/my-interactive-shape-util.tsx
@@ -77,6 +77,11 @@ export class myInteractiveShape extends BaseBoxShapeUtil<IMyInteractiveShape> {
 							e.stopPropagation()
 						}
 					}}
+					onTouchStart={(e) => {
+						if (!shape.props.checked) {
+							e.stopPropagation()
+						}
+					}}
 					onTouchEnd={(e) => {
 						if (!shape.props.checked) {
 							e.stopPropagation()

--- a/apps/examples/src/examples/interactive-shape/my-interactive-shape-util.tsx
+++ b/apps/examples/src/examples/interactive-shape/my-interactive-shape-util.tsx
@@ -56,6 +56,8 @@ export class myInteractiveShape extends BaseBoxShapeUtil<IMyInteractiveShape> {
 					}
 					// [b] This is where we stop event propagation
 					onPointerDown={(e) => e.stopPropagation()}
+					onTouchStart={(e) => e.stopPropagation()}
+					onTouchEnd={(e) => e.stopPropagation()}
 				/>
 				<input
 					type="text"
@@ -71,6 +73,11 @@ export class myInteractiveShape extends BaseBoxShapeUtil<IMyInteractiveShape> {
 					}
 					// [c]
 					onPointerDown={(e) => {
+						if (!shape.props.checked) {
+							e.stopPropagation()
+						}
+					}}
+					onTouchEnd={(e) => {
 						if (!shape.props.checked) {
 							e.stopPropagation()
 						}


### PR DESCRIPTION
Stops event propogation on touch end to allow interacting with inputs.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with the interactive shape example, where you couldn't interact with the shape with touch devices.