### PR TITLE
Interpolate arrow props

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -53,6 +53,7 @@ import { TLArrowBinding } from '@tldraw/editor';
 import { TLArrowBindingProps } from '@tldraw/editor';
 import { TLArrowShape } from '@tldraw/editor';
 import { TLArrowShapeArrowheadStyle } from '@tldraw/editor';
+import { TLArrowShapeProps } from '@tldraw/editor';
 import { TLAssetId } from '@tldraw/editor';
 import { TLBookmarkShape } from '@tldraw/editor';
 import { TLClickEvent } from '@tldraw/editor';
@@ -194,6 +195,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     getGeometry(shape: TLArrowShape): Group2d;
     // (undocumented)
     getHandles(shape: TLArrowShape): TLHandle[];
+    // (undocumented)
+    getInterpolatedProps(startShape: TLArrowShape, endShape: TLArrowShape, progress: number): TLArrowShapeProps;
     // (undocumented)
     hideResizeHandles: TLShapeUtilFlag<TLArrowShape>;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -11,6 +11,7 @@ import {
 	SvgExportContext,
 	TLArrowBinding,
 	TLArrowShape,
+	TLArrowShapeProps,
 	TLHandle,
 	TLOnEditEndHandler,
 	TLOnHandleDragHandler,
@@ -26,6 +27,7 @@ import {
 	arrowShapeMigrations,
 	arrowShapeProps,
 	getDefaultColorTheme,
+	lerp,
 	mapObjectMapValues,
 	structuredClone,
 	toDomPrecision,
@@ -789,6 +791,25 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				component: ArrowheadCrossDef,
 			},
 		]
+	}
+	override getInterpolatedProps(
+		startShape: TLArrowShape,
+		endShape: TLArrowShape,
+		progress: number
+	): TLArrowShapeProps {
+		return {
+			...endShape.props,
+			start: {
+				x: lerp(startShape.props.start.x, endShape.props.start.x, progress),
+				y: lerp(startShape.props.start.y, endShape.props.start.y, progress),
+			},
+			end: {
+				x: lerp(startShape.props.end.x, endShape.props.end.x, progress),
+				y: lerp(startShape.props.end.y, endShape.props.end.y, progress),
+			},
+			bend: lerp(startShape.props.bend, endShape.props.bend, progress),
+			labelPosition: lerp(startShape.props.labelPosition, endShape.props.labelPosition, progress),
+		}
 	}
 }
 


### PR DESCRIPTION
Interpolates handles, bend and label position. I tested this in a few different ways and it works well!

I thought dealing with bindings would be tricky but bindings code is very clever! Thanks for the good work Alex and David.

![2024-07-18 at 12 21 32 - Tan Swift](https://github.com/user-attachments/assets/83919565-87b5-4a44-b21f-1946bf4c6e86)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Create an arrow shape, optionally create other shapes and bindings
2. Animate the arrow shape's, bend, start and label position props
3. It should animate smoothly from one position to the next

### Release notes

- Added interpolated props for arrow shapes