### PR TITLE
Force flag should override isLocked in more cases

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1187,6 +1187,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     readonly sideEffects: StoreSideEffects<TLRecord>;
     slideCamera(opts?: {
         direction: VecLike;
+        force?: boolean | undefined;
         friction?: number | undefined;
         speed: number;
         speedThreshold?: number | undefined;

--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -1,0 +1,91 @@
+import { createTLStore } from '../config/createTLStore'
+import { Box } from '../primitives/Box'
+import { Editor } from './Editor'
+
+let editor: Editor
+
+beforeEach(() => {
+	editor = new Editor({
+		shapeUtils: [],
+		bindingUtils: [],
+		tools: [],
+		store: createTLStore({ shapeUtils: [] }),
+		getContainer: () => document.body,
+	})
+	editor.setCameraOptions({ isLocked: true })
+	editor.setCamera = jest.fn()
+})
+
+describe('centerOnPoint', () => {
+	it('no-op when isLocked is set', () => {
+		editor.centerOnPoint({ x: 0, y: 0 })
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.centerOnPoint({ x: 0, y: 0 }, { force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('resetZoom', () => {
+	it('no-op when isLocked is set', () => {
+		editor.centerOnPoint({ x: 0, y: 0 })
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.centerOnPoint({ x: 0, y: 0 }, { force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('zoomIn', () => {
+	it('no-op when isLocked is set', () => {
+		editor.zoomIn()
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.zoomIn(undefined, { force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('zoomOut', () => {
+	it('no-op when isLocked is set', () => {
+		editor.zoomOut()
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.zoomOut(undefined, { force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('zoomToSelection', () => {
+	it('no-op when isLocked is set', () => {
+		editor.getSelectionPageBounds = jest.fn(() => Box.From({ x: 0, y: 0, w: 100, h: 100 }))
+		editor.zoomToSelection()
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.getSelectionPageBounds = jest.fn(() => Box.From({ x: 0, y: 0, w: 100, h: 100 }))
+		editor.zoomToSelection({ force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('zoomToBounds', () => {
+	it('no-op when isLocked is set', () => {
+		editor.zoomToBounds({ x: 0, y: 0, w: 100, h: 100 })
+		expect(editor.setCamera).not.toHaveBeenCalled()
+	})
+
+	it('sets camera when isLocked is set and force flag is set', () => {
+		editor.zoomToBounds({ x: 0, y: 0, w: 100, h: 100 }, { force: true })
+		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2659,7 +2659,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	centerOnPoint(point: VecLike, opts?: TLCameraMoveOptions): this {
-		if (this.getCameraOptions().isLocked) return this
+		const { isLocked } = this.getCameraOptions()
+		if (isLocked && !opts?.force) return this
+
 		const { width: pw, height: ph } = this.getViewportPageBounds()
 		this.setCamera(new Vec(-(point.x - pw / 2), -(point.y - ph / 2), this.getCamera().z), opts)
 		return this
@@ -2703,7 +2705,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	resetZoom(point = this.getViewportScreenCenter(), opts?: TLCameraMoveOptions): this {
 		const { isLocked, constraints: constraints } = this.getCameraOptions()
-		if (isLocked) return this
+		if (isLocked && !opts?.force) return this
 
 		const currentCamera = this.getCamera()
 		const { x: cx, y: cy, z: cz } = currentCamera
@@ -2743,7 +2745,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	zoomIn(point = this.getViewportScreenCenter(), opts?: TLCameraMoveOptions): this {
-		if (this.getCameraOptions().isLocked) return this
+		const { isLocked } = this.getCameraOptions()
+		if (isLocked && !opts?.force) return this
 
 		const { x: cx, y: cy, z: cz } = this.getCamera()
 
@@ -2787,7 +2790,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	zoomOut(point = this.getViewportScreenCenter(), opts?: TLCameraMoveOptions): this {
-		if (this.getCameraOptions().isLocked) return this
+		const { isLocked } = this.getCameraOptions()
+		if (isLocked && !opts?.force) return this
 
 		const { zoomSteps } = this.getCameraOptions()
 		if (zoomSteps !== null && zoomSteps.length > 1) {
@@ -2829,7 +2833,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	zoomToSelection(opts?: TLCameraMoveOptions): this {
-		if (this.getCameraOptions().isLocked) return this
+		const { isLocked } = this.getCameraOptions()
+		if (isLocked && !opts?.force) return this
+
 		const selectionPageBounds = this.getSelectionPageBounds()
 		if (selectionPageBounds) {
 			this.zoomToBounds(selectionPageBounds, {
@@ -2860,7 +2866,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		opts?: { targetZoom?: number; inset?: number } & TLCameraMoveOptions
 	): this {
 		const cameraOptions = this._cameraOptions.__unsafe__getWithoutCapture()
-		if (cameraOptions.isLocked) return this
+		if (cameraOptions.isLocked && !opts?.force) return this
 
 		const viewportScreenBounds = this.getViewportScreenBounds()
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3021,9 +3021,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			direction: VecLike
 			friction?: number
 			speedThreshold?: number
+			force?: boolean
 		}
 	): this {
-		if (this.getCameraOptions().isLocked) return this
+		const { isLocked } = this.getCameraOptions()
+		if (isLocked && !opts?.force) return this
 
 		const animationSpeed = this.user.getAnimationSpeed()
 		if (animationSpeed === 0) return this


### PR DESCRIPTION
After locking the camera movement programmatically, there are several editor functions that have an option to 'force' their behaviour even though the camera is locked. But some of these functions do not check correctly if the force flag is set. This PR changes their behaviour so you can force camera movement even when the camera is locked.

### Change type

- [x] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Set the camera options `isLocked` to `true`
2. Call `centerOnPoint`, `resetZoom`, `zoomIn`, `zoomOut`, `zoomToSelection` or `zoomToBounds` with the `force: true` option flag.
3. See that these calls are performed as if `isLocked` was `false`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed the `force` flag not being taken in account after locking the camera and calling `centerOnPoint`, `resetZoom`, `zoomIn`, `zoomOut`, `zoomToSelection` or `zoomToBounds`.