### PR TITLE
interpolated props: Experiment with discrete props

### DIFF
--- a/apps/examples/src/examples/basic/BasicExample.tsx
+++ b/apps/examples/src/examples/basic/BasicExample.tsx
@@ -1,75 +1,10 @@
-import { createShapeId, Tldraw } from 'tldraw'
+import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function BasicExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw
-				onMount={(editor) => {
-					const arrowId = createShapeId()
-					const rectId = createShapeId()
-					editor.createShape({
-						id: arrowId,
-						x: 300,
-						y: 300,
-						type: 'arrow',
-						props: {
-							color: 'light-green',
-							size: 's',
-							bend: 0,
-							start: {
-								x: 0,
-								y: 0,
-							},
-							end: {
-								x: 400,
-								y: 0,
-							},
-							text: '',
-							labelPosition: 0.5,
-						},
-					})
-					editor.zoomToFit()
-					// editor.createShape({
-					// 	id: rectId,
-					// 	type: 'geo',
-					// 	x: 600,
-					// 	y: 300,
-					// })
-
-					// editor.createBindings([
-					// 	{
-					// 		type: 'arrow',
-					// 		fromId: arrowId,
-					// 		toId: rectId,
-					// 		props: {
-					// 			terminal: 'end',
-					// 			normalizedAnchor: { x: 0.5, y: 0.5 },
-					// 			isExact: false,
-					// 			isPrecise: false,
-					// 		},
-					// 	},
-					// ])
-
-					setTimeout(() => {
-						editor.animateShapes(
-							[
-								{
-									id: arrowId,
-									type: 'arrow',
-									props: {
-										arrowheadStart: 'diamond',
-										color: 'blue',
-										text: 'Helloooooooo',
-										labelPosition: 0.5,
-									},
-								},
-							],
-							{ animation: { duration: 1000 } }
-						)
-					}, 1000)
-				}}
-			/>
+			<Tldraw persistenceKey="example" />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/basic/BasicExample.tsx
+++ b/apps/examples/src/examples/basic/BasicExample.tsx
@@ -1,10 +1,75 @@
-import { Tldraw } from 'tldraw'
+import { createShapeId, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function BasicExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" />
+			<Tldraw
+				onMount={(editor) => {
+					const arrowId = createShapeId()
+					const rectId = createShapeId()
+					editor.createShape({
+						id: arrowId,
+						x: 300,
+						y: 300,
+						type: 'arrow',
+						props: {
+							color: 'light-green',
+							size: 's',
+							bend: 0,
+							start: {
+								x: 0,
+								y: 0,
+							},
+							end: {
+								x: 400,
+								y: 0,
+							},
+							text: '',
+							labelPosition: 0.5,
+						},
+					})
+					editor.zoomToFit()
+					// editor.createShape({
+					// 	id: rectId,
+					// 	type: 'geo',
+					// 	x: 600,
+					// 	y: 300,
+					// })
+
+					// editor.createBindings([
+					// 	{
+					// 		type: 'arrow',
+					// 		fromId: arrowId,
+					// 		toId: rectId,
+					// 		props: {
+					// 			terminal: 'end',
+					// 			normalizedAnchor: { x: 0.5, y: 0.5 },
+					// 			isExact: false,
+					// 			isPrecise: false,
+					// 		},
+					// 	},
+					// ])
+
+					setTimeout(() => {
+						editor.animateShapes(
+							[
+								{
+									id: arrowId,
+									type: 'arrow',
+									props: {
+										arrowheadStart: 'diamond',
+										color: 'blue',
+										text: 'Helloooooooo',
+										labelPosition: 0.5,
+									},
+								},
+							],
+							{ animation: { duration: 1000 } }
+						)
+					}, 1000)
+				}}
+			/>
 		</div>
 	)
 }

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -53,6 +53,7 @@ import { TLArrowBinding } from '@tldraw/editor';
 import { TLArrowBindingProps } from '@tldraw/editor';
 import { TLArrowShape } from '@tldraw/editor';
 import { TLArrowShapeArrowheadStyle } from '@tldraw/editor';
+import { TLArrowShapeProps } from '@tldraw/editor';
 import { TLAssetId } from '@tldraw/editor';
 import { TLBookmarkShape } from '@tldraw/editor';
 import { TLClickEvent } from '@tldraw/editor';
@@ -194,6 +195,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     getGeometry(shape: TLArrowShape): Group2d;
     // (undocumented)
     getHandles(shape: TLArrowShape): TLHandle[];
+    // (undocumented)
+    getInterpolatedProps(startShape: TLArrowShape, endShape: TLArrowShape, progress: number): TLArrowShapeProps;
     // (undocumented)
     hideResizeHandles: TLShapeUtilFlag<TLArrowShape>;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -11,6 +11,7 @@ import {
 	SvgExportContext,
 	TLArrowBinding,
 	TLArrowShape,
+	TLArrowShapeProps,
 	TLHandle,
 	TLOnEditEndHandler,
 	TLOnHandleDragHandler,
@@ -26,6 +27,7 @@ import {
 	arrowShapeMigrations,
 	arrowShapeProps,
 	getDefaultColorTheme,
+	lerp,
 	mapObjectMapValues,
 	structuredClone,
 	toDomPrecision,
@@ -789,6 +791,25 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				component: ArrowheadCrossDef,
 			},
 		]
+	}
+	override getInterpolatedProps(
+		startShape: TLArrowShape,
+		endShape: TLArrowShape,
+		progress: number
+	): TLArrowShapeProps {
+		return {
+			...endShape.props,
+			start: {
+				x: lerp(startShape.props.start.x, endShape.props.start.x, progress),
+				y: lerp(startShape.props.start.y, endShape.props.start.y, progress),
+			},
+			end: {
+				x: lerp(startShape.props.end.x, endShape.props.end.x, progress),
+				y: lerp(startShape.props.end.y, endShape.props.end.y, progress),
+			},
+			bend: lerp(startShape.props.bend, endShape.props.bend, progress),
+			labelPosition: lerp(startShape.props.labelPosition, endShape.props.labelPosition, progress),
+		}
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -792,13 +792,44 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			},
 		]
 	}
+
 	override getInterpolatedProps(
 		startShape: TLArrowShape,
 		endShape: TLArrowShape,
 		progress: number
 	): TLArrowShapeProps {
+		const discretePropKeys = [
+			'labelColor',
+			'color',
+			'fill',
+			'dash',
+			'size',
+			'arrowheadStart',
+			'arrowheadEnd',
+			'font',
+			'text',
+		]
+
+		const isOverHalfway = progress > 0.5
+		const sourceShape = isOverHalfway ? endShape : startShape
+
+		const discreteProps: Partial<TLArrowShapeProps> = {}
+
+		discretePropKeys.forEach((propKey) => {
+			;(discreteProps as any)[propKey] = (sourceShape.props as any)[propKey]
+		})
+
+		if (!startShape.props.text && endShape.props.text) {
+			// if there isn't text in the start shape, and there is in the end shape
+			// then we can stream it in
+			const textLength = endShape.props.text.length
+			const textToShow = Math.floor(textLength * progress)
+			discreteProps.text = endShape.props.text.substring(0, textToShow)
+		}
+
 		return {
 			...endShape.props,
+			...discreteProps,
 			start: {
 				x: lerp(startShape.props.start.x, endShape.props.start.x, progress),
 				y: lerp(startShape.props.start.y, endShape.props.start.y, progress),


### PR DESCRIPTION
Some ideas on how to handle props that can't be interpolated, like dash, size etc. I think it looks better when they change halfway through the animation. Animations will likely happen along with movement which helps smooth over the jolt of switching from one thing to another.

This is currently what it looks like:

![2024-07-18 at 13 11 32 - Amaranth Primate](https://github.com/user-attachments/assets/50570507-0b0a-4f61-a710-a180b7ddb00f)


This is what it looks like when the props change halfway:

![2024-07-18 at 13 12 40 - Teal Gerbil](https://github.com/user-attachments/assets/48a28e62-901a-45db-8d30-4a5a18b5960f)


The text usually changes at the halfway mark, but if there's no text to begin with, then any text in the end shape is streamed in:

![2024-07-18 at 15 18 34 - Tan Catshark](https://github.com/user-attachments/assets/ed59122c-7f52-4f57-94d5-9382ff8d62b1)

What do you think?

A further option: when going between sizes we could animate to any intermediary sizes in between. e.g. going from 's' to 'xl' would be
up to 25%: s
25 - 50%: m
50-75%: lg
75-100%: xl

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
3.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…