### PR TITLE
stickies: make ADJACENT_NOTE_MARGIN match adjacentShapeMargin (again)

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
@@ -4,7 +4,7 @@ import { NoteShapeTool } from './NoteShapeTool'
 let editor: TestEditor
 
 beforeEach(() => {
-	editor = new TestEditor()
+	editor = new TestEditor({ options: { adjacentShapeMargin: 20 } })
 })
 afterEach(() => {
 	editor?.dispose()

--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -4,7 +4,7 @@ import { TestEditor } from '../../../test/TestEditor'
 let editor: TestEditor
 
 beforeEach(() => {
-	editor = new TestEditor()
+	editor = new TestEditor({ options: { adjacentShapeMargin: 20 } })
 	// We don't want the camera to move when the shape gets created off screen
 	editor.updateViewportScreenBounds(new Box(0, 0, 2000, 2000))
 })

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -2,8 +2,6 @@ import { Editor, IndexKey, TLNoteShape, TLShape, Vec, compact, createShapeId } f
 import { zoomToShapeIfOffscreen } from '../../tools/SelectTool/selectHelpers'
 
 /** @internal */
-export const ADJACENT_NOTE_MARGIN = 20
-/** @internal */
 export const CLONE_HANDLE_MARGIN = 0
 /** @internal */
 export const NOTE_SIZE = 200
@@ -12,17 +10,30 @@ export const NOTE_CENTER_OFFSET = new Vec(NOTE_SIZE / 2, NOTE_SIZE / 2)
 /** @internal */
 export const NOTE_ADJACENT_POSITION_SNAP_RADIUS = 10
 
-const BASE_NOTE_POSITIONS = [
-	[['a1' as IndexKey], new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * -0.5 - ADJACENT_NOTE_MARGIN)], // t
-	[['a2' as IndexKey], new Vec(NOTE_SIZE * 1.5 + ADJACENT_NOTE_MARGIN, NOTE_SIZE * 0.5)], // r
-	[['a3' as IndexKey], new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * 1.5 + ADJACENT_NOTE_MARGIN)], // b
-	[['a4' as IndexKey], new Vec(NOTE_SIZE * -0.5 - ADJACENT_NOTE_MARGIN, NOTE_SIZE * 0.5)], // l
-] as const
+const BASE_NOTE_POSITIONS = (editor: Editor) =>
+	[
+		[
+			['a1' as IndexKey],
+			new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * -0.5 - editor.options.adjacentShapeMargin),
+		], // t
+		[
+			['a2' as IndexKey],
+			new Vec(NOTE_SIZE * 1.5 + editor.options.adjacentShapeMargin, NOTE_SIZE * 0.5),
+		], // r
+		[
+			['a3' as IndexKey],
+			new Vec(NOTE_SIZE * 0.5, NOTE_SIZE * 1.5 + editor.options.adjacentShapeMargin),
+		], // b
+		[
+			['a4' as IndexKey],
+			new Vec(NOTE_SIZE * -0.5 - editor.options.adjacentShapeMargin, NOTE_SIZE * 0.5),
+		], // l
+	] as const
 
-function getBaseAdjacentNotePositions(scale: number) {
-	if (scale === 1) return BASE_NOTE_POSITIONS
+function getBaseAdjacentNotePositions(editor: Editor, scale: number) {
+	if (scale === 1) return BASE_NOTE_POSITIONS(editor)
 	const s = NOTE_SIZE * scale
-	const m = ADJACENT_NOTE_MARGIN * scale
+	const m = editor.options.adjacentShapeMargin * scale
 	return [
 		[['a1' as IndexKey], new Vec(s * 0.5, s * -0.5 - m)], // t
 		[['a2' as IndexKey], new Vec(s * 1.5 + m, s * 0.5)], // r
@@ -41,6 +52,7 @@ function getBaseAdjacentNotePositions(scale: number) {
  *
  * @internal */
 export function getNoteAdjacentPositions(
+	editor: Editor,
 	pagePoint: Vec,
 	pageRotation: number,
 	growY: number,
@@ -48,7 +60,7 @@ export function getNoteAdjacentPositions(
 	scale: number
 ): Record<IndexKey, Vec> {
 	return Object.fromEntries(
-		getBaseAdjacentNotePositions(scale).map(([id, v], i) => {
+		getBaseAdjacentNotePositions(editor, scale).map(([id, v], i) => {
 			const point = v.clone()
 			if (i === 0 && extraHeight) {
 				// apply top margin (the growY of the moving note shape)
@@ -77,7 +89,7 @@ export function getAvailableNoteAdjacentPositions(
 	extraHeight: number
 ) {
 	const selectedShapeIds = new Set(editor.getSelectedShapeIds())
-	const minSize = (NOTE_SIZE + ADJACENT_NOTE_MARGIN + extraHeight) ** 2
+	const minSize = (NOTE_SIZE + editor.options.adjacentShapeMargin + extraHeight) ** 2
 	const allCenters = new Map<TLNoteShape, Vec>()
 	const positions: (Vec | undefined)[] = []
 
@@ -102,7 +114,14 @@ export function getAvailableNoteAdjacentPositions(
 		// And push its position to the positions array
 		positions.push(
 			...Object.values(
-				getNoteAdjacentPositions(transform.point(), rotation, shape.props.growY, extraHeight, scale)
+				getNoteAdjacentPositions(
+					editor,
+					transform.point(),
+					rotation,
+					shape.props.growY,
+					extraHeight,
+					scale
+				)
 			)
 		)
 	}
@@ -151,7 +170,7 @@ export function getNoteShapeForAdjacentPosition(
 	// Start from the top of the stack, and work our way down
 	const allShapesOnPage = editor.getCurrentPageShapesSorted()
 
-	const minDistance = (NOTE_SIZE + ADJACENT_NOTE_MARGIN ** 2) ** shape.props.scale
+	const minDistance = (NOTE_SIZE + editor.options.adjacentShapeMargin ** 2) ** shape.props.scale
 
 	for (let i = allShapesOnPage.length - 1; i >= 0; i--) {
 		const otherNote = allShapesOnPage[i]

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -125,6 +125,7 @@ function getNoteForPit(editor: Editor, shape: TLNoteShape, handle: TLHandle, for
 	const pagePoint = pageTransform.point()
 	const pageRotation = pageTransform.rotation()
 	const pits = getNoteAdjacentPositions(
+		editor,
 		pagePoint,
 		pageRotation,
 		shape.props.growY,

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -42,6 +42,7 @@ beforeEach(() => {
 	console.error = jest.fn()
 	editor = new TestEditor({
 		options: {
+			adjacentShapeMargin: 20,
 			edgeScrollDelay: 0,
 			edgeScrollEaseDuration: 0,
 		},


### PR DESCRIPTION
Regression from https://github.com/tldraw/tldraw/pull/4056
@steveruizok lemme know if there's something we wanna do here when dynamic size mode is on!
(thx @MitjaBezensek for catching)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Stickies: fix adjacent margin to match shape margin