### PR TITLE
fix snapshot prop

### DIFF
--- a/apps/dotcom/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/src/components/SnapshotsEditor.tsx
@@ -62,7 +62,7 @@ export function SnapshotsEditor({ schema, records }: SnapshotEditorProps) {
 	const sharingUiOverrides = useSharing()
 	const fileSystemUiOverrides = useFileSystem({ isMultiplayer: true })
 
-	const snaphot = useMemo(
+	const snapshot = useMemo(
 		() => ({
 			schema,
 			store: Object.fromEntries(records.map((record) => [record.id, record])),
@@ -75,7 +75,7 @@ export function SnapshotsEditor({ schema, records }: SnapshotEditorProps) {
 			<Tldraw
 				licenseKey={getLicenseKey()}
 				assetUrls={assetUrls}
-				snapshot={snaphot}
+				snapshot={snapshot}
 				overrides={[sharingUiOverrides, fileSystemUiOverrides]}
 				onUiEvent={handleUiEvent}
 				onMount={(editor) => {

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -3280,6 +3280,7 @@ export interface TLStoreBaseOptions {
     initialData?: SerializedStore<TLRecord>;
     multiplayerStatus?: null | Signal<'offline' | 'online'>;
     onEditorMount?: (editor: Editor) => (() => void) | void;
+    snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot;
 }
 
 // @public (undocumented)
@@ -3548,9 +3549,7 @@ export function useSvgExportContext(): {
 export function useTLSchemaFromUtils(opts: TLStoreSchemaOptions): StoreSchema<TLRecord, TLStoreProps>;
 
 // @public (undocumented)
-export function useTLStore(opts: TLStoreOptions & {
-    snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot;
-}): TLStore;
+export function useTLStore(opts: TLStoreOptions): TLStore;
 
 // @public (undocumented)
 export function useTransform(ref: React.RefObject<HTMLElement | SVGElement>, x?: number, y?: number, scale?: number, rotate?: number, additionalOffset?: VecLike): void;

--- a/packages/editor/src/lib/hooks/useTLStore.ts
+++ b/packages/editor/src/lib/hooks/useTLStore.ts
@@ -1,7 +1,5 @@
-import { TLStoreSnapshot } from '@tldraw/tlschema'
 import { areObjectsShallowEqual } from '@tldraw/utils'
 import { useState } from 'react'
-import { TLEditorSnapshot, loadSnapshot } from '../config/TLEditorSnapshot'
 import {
 	TLStoreOptions,
 	TLStoreSchemaOptions,
@@ -10,26 +8,11 @@ import {
 } from '../config/createTLStore'
 
 /** @public */
-type UseTLStoreOptions = TLStoreOptions & {
-	snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot
-}
-
-function createStore(opts: UseTLStoreOptions) {
-	const store = createTLStore(opts)
-	if (opts.snapshot) {
-		loadSnapshot(store, opts.snapshot)
-	}
-	return { store, opts }
-}
-
-/** @public */
-export function useTLStore(
-	opts: TLStoreOptions & { snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot }
-) {
-	const [current, setCurrent] = useState(() => createStore(opts))
+export function useTLStore(opts: TLStoreOptions) {
+	const [current, setCurrent] = useState(() => ({ store: createTLStore(opts), opts }))
 
 	if (!areObjectsShallowEqual(current.opts, opts)) {
-		const next = createStore(opts)
+		const next = { store: createTLStore(opts), opts }
 		setCurrent(next)
 		return next.store
 	}

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -11,9 +11,13 @@ import {
 	noop,
 } from '@tldraw/editor'
 import { StrictMode } from 'react'
+import { defaultShapeUtils } from '../lib/defaultShapeUtils'
 import { defaultTools } from '../lib/defaultTools'
 import { GeoShapeUtil } from '../lib/shapes/geo/GeoShapeUtil'
-import { renderTldrawComponent } from './testutils/renderTldrawComponent'
+import {
+	renderTldrawComponent,
+	renderTldrawComponentWithEditor,
+} from './testutils/renderTldrawComponent'
 
 function checkAllShapes(editor: Editor, shapes: string[]) {
 	expect(Object.keys(editor!.shapeUtils)).toStrictEqual(shapes)
@@ -243,6 +247,98 @@ describe('<TldrawEditor />', () => {
 		renderer.rerender(<TldrawEditor onMount={onMount} cameraOptions={{ isLocked: true }} />)
 		expect(editors.length).toBe(1)
 		expect(editors[0].getCameraOptions().isLocked).toBe(true)
+	})
+
+	it('will populate the store from the snapshot prop', async () => {
+		const snapshot = {
+			schema: {
+				schemaVersion: 2,
+				sequences: {
+					'com.tldraw.store': 4,
+					'com.tldraw.asset': 1,
+					'com.tldraw.camera': 1,
+					'com.tldraw.document': 2,
+					'com.tldraw.instance': 25,
+					'com.tldraw.instance_page_state': 5,
+					'com.tldraw.page': 1,
+					'com.tldraw.instance_presence': 5,
+					'com.tldraw.pointer': 1,
+					'com.tldraw.shape': 4,
+					'com.tldraw.asset.bookmark': 2,
+					'com.tldraw.asset.image': 5,
+					'com.tldraw.asset.video': 5,
+					'com.tldraw.shape.arrow': 5,
+					'com.tldraw.shape.bookmark': 2,
+					'com.tldraw.shape.draw': 2,
+					'com.tldraw.shape.embed': 4,
+					'com.tldraw.shape.frame': 0,
+					'com.tldraw.shape.geo': 9,
+					'com.tldraw.shape.group': 0,
+					'com.tldraw.shape.highlight': 1,
+					'com.tldraw.shape.image': 4,
+					'com.tldraw.shape.line': 5,
+					'com.tldraw.shape.note': 7,
+					'com.tldraw.shape.text': 2,
+					'com.tldraw.shape.video': 2,
+					'com.tldraw.binding.arrow': 0,
+				},
+			},
+			store: {
+				'document:document': {
+					gridSize: 10,
+					name: '',
+					meta: {},
+					id: 'document:document',
+					typeName: 'document',
+				},
+				'page:page': { meta: {}, id: 'page:page', name: 'Page 1', index: 'a1', typeName: 'page' },
+				'shape:SxHfVyCVdM4Ryl27eJNRD': {
+					x: 608.718221918489,
+					y: 298.97020222415506,
+					rotation: 0,
+					isLocked: false,
+					opacity: 1,
+					meta: {},
+					id: 'shape:SxHfVyCVdM4Ryl27eJNRD',
+					type: 'geo',
+					props: {
+						w: 152.74967383200806,
+						h: 134.57489438369782,
+						geo: 'rectangle',
+						color: 'black',
+						labelColor: 'black',
+						fill: 'none',
+						dash: 'draw',
+						size: 'm',
+						font: 'draw',
+						text: '',
+						align: 'middle',
+						verticalAlign: 'middle',
+						growY: 0,
+						url: '',
+						scale: 1,
+					},
+					parentId: 'page:page',
+					index: 'a1',
+					typeName: 'shape',
+				},
+			},
+		} as any
+
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => (
+				<TldrawEditor onMount={onMount} shapeUtils={defaultShapeUtils} snapshot={snapshot} />
+			),
+			{ waitForPatterns: true }
+		)
+
+		expect(editor.selectAll().getSelectedShapes()).toMatchObject([
+			{
+				id: 'shape:SxHfVyCVdM4Ryl27eJNRD',
+				type: 'geo',
+				props: { w: 152.74967383200806, h: 134.57489438369782 },
+			},
+		])
 	})
 })
 


### PR DESCRIPTION
Hotfix from #4233 

* In #1856, we added a snapshot prop. this was hooked in all the way down to `useTLStore`, but not into `createTLStore`
* In #4068, we refactored `useLocalStore` to use `createTLStore` directly, rather than using `useTLStore`
* This meant that the snapshot prop stopped working.

This diff updates `createTLStore` to also respect the `snapshot` prop, and adds a test to make sure this prop is respected.

### Change type

- [x] `bugfix`
