### PR TITLE
focus: fix dbl-click to edit text, when shape is selected, in label geometry hit area

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -1,6 +1,5 @@
 import { StateNode, TLEventHandlers, TLFrameShape, TLShape, TLTextShape } from '@tldraw/editor'
 import { getTextLabels } from '../../../utils/shapes/shapes'
-import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { updateHoveredShapeId } from '../../selection-logic/updateHoveredShapeId'
 
 export class EditingShape extends StateNode {
@@ -57,18 +56,6 @@ export class EditingShape extends StateNode {
 		this.hitShapeForPointerUp = null
 
 		switch (info.target) {
-			case 'canvas': {
-				const hitShape = getHitShapeOnCanvasPointerDown(this.editor, true /* hitLabels */)
-				if (hitShape) {
-					this.onPointerDown({
-						...info,
-						shape: hitShape,
-						target: 'shape',
-					})
-					return
-				}
-				break
-			}
 			case 'shape': {
 				const { shape: selectingShape } = info
 				const editingShape = this.editor.getEditingShape()


### PR DESCRIPTION
This took a while 😵‍💫 I tried many approaches. The bug is this and fairly specific:
- when shape is selected
- double-clicking _within_ the label geometry
- the text field is selected/focused on the first click, but then it loses the focus on the second click

This really showed up in the retro when dragging sticky notes around and then trying to edit them. (but it also applies to other geo shapes)

This only happens within the label geometry b/c of the extra logic we do around that. The problem is that the label geometry is actually not the geometry of the actual `<textarea>` and so our logic is sort of at odds with what we're actually rendering.
I tried first making the textarea larger with CSS to match the label geometry but this has a lot of downstream side-effects and was a bad idea. The other thing I was trying was some special dbl-click logic but that was also not working as intended.

Finally, I noticed that the canvas "loop" code that we have that feeds the click back into the state machine was one of the differentiators when following the code paths. Removing this fixes the issue and doesn't seem to have any other side effects.

I spelunked and checked on what the previous PRs for this code and it looks like it'll be fine. This logic has been reworked enough where we don't need it anymore:
- https://github.com/tldraw/tldraw/pull/1808
- https://github.com/tldraw/tldraw/pull/1806

This is a followup after this focus PR: https://github.com/tldraw/tldraw/pull/3718

Before:

https://github.com/user-attachments/assets/102ea9ca-9b11-4f36-973d-6cd6f9381d3d

After:

https://github.com/user-attachments/assets/40e575d8-3c1d-427e-b34f-2a30c7911c00

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Text editing: fix dbl-click to edit text, when shape is selected, in label geometry hit area