### PR TITLE
Update the templates to include a dropdown to distinguish between dotcom and package bugs / feature requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
     id: reproduction
     attributes:
       label: How can we reproduce the bug?
-      description: If you can make the bug happen again, please share the steps involved. You can [fork this CodeSandbox](https://codesandbox.io/p/sandbox/tldraw-example-n539u) to make a reproduction.
+      description: If you can make the bug happen again, please share the steps involved. When applicable please also include a screenshot or a screen recording to help us better understand and resolve the issue. You can [fork this CodeSandbox](https://codesandbox.io/p/sandbox/tldraw-example-n539u) to make a reproduction.
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,6 +32,15 @@ body:
         - Chrome
         - Safari
         - Microsoft Edge
+  - type: dropdown
+    id: product
+    attributes:
+      label: Where did this happen?
+      options:
+        - The tldraw.com website
+        - The developer package
+      validations:
+        required: true
   - type: input
     id: contact
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
     id: reproduction
     attributes:
       label: How can we reproduce the bug?
-      description: If you can make the bug happen again, please share the steps involved. When applicable please also include a screenshot or a screen recording to help us better understand and resolve the issue. You can [fork this CodeSandbox](https://codesandbox.io/p/sandbox/tldraw-example-n539u) to make a reproduction.
+      description: If you can make the bug happen again, please share the steps involved. If possible please also include a screenshot or a screen recording to help us better understand and resolve the issue. You can [fork this CodeSandbox](https://codesandbox.io/p/sandbox/tldraw-example-n539u) to make a reproduction.
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,7 +18,7 @@ body:
   - type: dropdown
     id: product
     attributes:
-      label: Where did this happen?
+      label: Where would you like this feature?
       options:
         - The tldraw.com website
         - The developer package

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,6 +15,15 @@ body:
       description: Describe the feature, who it would help, and link to any examples from other apps.
     validations:
       required: true
+  - type: dropdown
+    id: product
+    attributes:
+      label: Where did this happen?
+      options:
+        - The tldraw.com website
+        - The developer package
+      validations:
+        required: true
   - type: input
     id: contact
     attributes:


### PR DESCRIPTION
Add a dropdown to the templates. 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Update bug and feature request templates to include a dropdown to help us distinguish between tldraw.com and the dev package.