### PR TITLE
db: add fallback for FF versions < 126 (#4240)

### DIFF
--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -42,9 +42,11 @@ async function openLocalDb(persistenceKey: string) {
 }
 
 async function migrateLegacyAssetDbIfNeeded(persistenceKey: string) {
-	const databases = await window.indexedDB.databases()
+	const databases = window.indexedDB.databases
+		? (await window.indexedDB.databases()).map((db) => db.name)
+		: getAllIndexDbNames()
 	const oldStoreId = LEGACY_ASSET_STORE_PREFIX + persistenceKey
-	const existing = databases.find((db) => db.name === oldStoreId)
+	const existing = databases.find((dbName) => dbName === oldStoreId)
 	if (!existing) return
 
 	const oldAssetDb = await openDB<StoreName>(oldStoreId, 1, {


### PR DESCRIPTION
FF < 126 doesn't support `window.indexedDB.databases()` so this adds our original logic as a fallback for those older browsers.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix issue with indexedDB in older versions of Firefox < 126.
