### PR TITLE
Fix order of closed menus

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9008,9 +9008,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// If we're in pen mode and the input is not a pen type, then stop here
 						if (isPenMode && !isPen) return
 
-						// Close any open menus
-						this.clearOpenMenus()
-
 						if (!this.inputs.isPanning) {
 							// Start a long press timeout
 							this._longPressTimeout = this.timers.setTimeout(() => {
@@ -9235,6 +9232,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// active states, starting at the root.
 		this.root.handleEvent(info)
 		this.emit('event', info)
+
+		// close open menus at the very end on pointer down! after everything else! συντελείας τοῦ κώδικα!!
+		if (info.type === 'pointer' && info.name === 'pointer_down') {
+			this.clearOpenMenus()
+		}
 
 		return this
 	}


### PR DESCRIPTION
This PR changes the place in the editor where open menus are closed. It restores a feature where certain interactions would not occur or begin when a menu was open, to prevent random dots / shapes while closing menus.

### Change type

- [x] `bugfix`

### Test plan

1. Select the pen tool
2. Open a menu
3. Click on the canvas and release
4. You should see no dot

1. Select the pen tool
2. Open a menu
3. Click on the canvas and begin drawing
4. You should get the regular line

- [ ] Unit tests

### Release notes

- Prevent accidental drawing / tool usage when closing menus.