### PR TITLE
Deprecate editor.mark, fix cropping tests

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -94,21 +94,17 @@ For information about how to synchronize the store with other processes, i.e. ho
 
 ### Undo and redo
 
-The history stack in tldraw contains two types of data: "marks" and "commands". Commands have their own `undo` and `redo` methods that describe how the state should change when the command is undone or redone.
+The history stack in tldraw contains two types of data: 
 
-You can call [Editor#mark](?) to add a mark to the history stack with the given `id`.
+- "diffs" the changes you make to the store
+- "marks" undo/redo stopping points, created by calling [Editor#markHistoryStoppingPoint](?)
 
-```ts
-editor.mark('my-id')
-// do some stuff
-editor.bailToMark('my-id')
-```
-
-When you call [Editor#undo](?), the editor will undo each command until it finds either a mark or the start of the stack. When you call [Editor#redo](?), the editor will redo each command until it finds either a mark or the end of the stack.
+When you call [Editor#undo](?), the editor will undo each diff until it finds either a mark or the start of the stack. When you call [Editor#redo](?), the editor will redo each diff until it finds either a mark or the end of the stack.
 
 ```ts
+editor.createShapes(...)
 // A
-editor.mark('duplicate everything')
+editor.markHistoryStoppingPoint()
 editor.selectAll()
 editor.duplicateShapes(editor.getSelectedShapeIds())
 // B
@@ -117,11 +113,12 @@ editor.undo() // will return to A
 editor.redo() // will return to B
 ```
 
-You can call [Editor#bail](?) to undo and delete all commands in the stack until the first mark.
+You can call [Editor#bail](?) to undo and delete all the diffs to the nearest mark, so they cannot be redone.
 
 ```ts
+editor.createShapes(...)
 // A
-editor.mark('duplicate everything')
+editor.markHistoryStoppingPoint()
 editor.selectAll()
 editor.duplicateShapes(editor.getSelectedShapeIds())
 // B
@@ -130,18 +127,18 @@ editor.bail() // will return to A
 editor.redo() // will do nothing
 ```
 
-You can use [Editor#bailToMark](?) to undo and delete all commands and marks until you reach a mark with the given `id`.
+[Editor#markHistoryStoppingPoint](?) returns an id that you can use with [Editor#bailToMark](?) to bail to a specific mark.
 
 ```ts
 // A
-editor.mark('first')
+const firstMark = editor.markHistoryStoppingPoint()
 editor.selectAll()
 // B
-editor.mark('second')
+const secondMark = editor.markHistoryStoppingPoint()
 editor.duplicateShapes(editor.getSelectedShapeIds())
 // C
 
-editor.bailToMark('first') // will return to A
+editor.bailToMark(firstMark) // will return to A
 ```
 
 ## Running code in context

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -94,7 +94,7 @@ For information about how to synchronize the store with other processes, i.e. ho
 
 ### Undo and redo
 
-The history stack in tldraw contains two types of data: 
+The history stack in tldraw contains two types of data:
 
 - "diffs" the changes you make to the store
 - "marks" undo/redo stopping points, created by calling [Editor#markHistoryStoppingPoint](?)

--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -275,7 +275,7 @@ class PinTool extends StateNode {
 	override onPointerDown: TLEventHandlers['onPointerDown'] = (info) => {
 		const { currentPagePoint } = this.editor.inputs
 		const pinId = createShapeId()
-		this.editor.mark(`creating:${pinId}`)
+		this.editor.markHistoryStoppingPoint()
 		this.editor.createShape({
 			id: pinId,
 			type: 'pin',

--- a/apps/examples/src/examples/selection-ui/SelectionUiExample.tsx
+++ b/apps/examples/src/examples/selection-ui/SelectionUiExample.tsx
@@ -102,7 +102,7 @@ function DuplicateInDirectionButton({
 				const selectionPageBounds = editor.getSelectionPageBounds()!
 				if (!(rotatedPageBounds && selectionPageBounds)) return
 
-				editor.mark('duplicating in direction')
+				editor.markHistoryStoppingPoint()
 
 				const PADDING = 32
 

--- a/apps/examples/src/examples/shape-with-custom-styles/ShapeWithCustomStylesExample.tsx
+++ b/apps/examples/src/examples/shape-with-custom-styles/ShapeWithCustomStylesExample.tsx
@@ -87,7 +87,7 @@ function CustomStylePanel() {
 						style={{ width: '100%', padding: 4 }}
 						value={rating.type === 'mixed' ? '' : rating.value}
 						onChange={(e) => {
-							editor.mark('changing rating')
+							editor.markHistoryStoppingPoint()
 							const value = myRatingStyle.validate(+e.currentTarget.value)
 							editor.setStyleForSelectedShapes(myRatingStyle, value)
 						}}

--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -173,7 +173,7 @@ class StickerTool extends StateNode {
 	override onPointerDown: TLEventHandlers['onPointerDown'] = (info) => {
 		const { currentPagePoint } = this.editor.inputs
 		const stickerId = createShapeId()
-		this.editor.mark(`creating:${stickerId}`)
+		this.editor.markHistoryStoppingPoint()
 		this.editor.createShape({
 			id: stickerId,
 			type: 'sticker',

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1123,7 +1123,9 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     isShapeOrAncestorLocked(id?: TLShapeId): boolean;
     loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot): this;
+    // @deprecated
     mark(markId?: string): this;
+    markHistoryStoppingPoint(name?: string): string;
     moveShapesToPage(shapes: TLShape[] | TLShapeId[], pageId: TLPageId): this;
     nudgeShapes(shapes: TLShape[] | TLShapeId[], offset: VecLike): this;
     // (undocumented)
@@ -1574,8 +1576,12 @@ export class HistoryManager<R extends UnknownRecord> {
     getNumUndos(): number;
     // @internal (undocumented)
     _isInBatch: boolean;
-    // (undocumented)
-    mark: (id?: string) => string;
+    // @deprecated (undocumented)
+    mark: (arg?: {
+        name?: string;
+    } | string) => string;
+    // @internal (undocumented)
+    _mark(id: string): void;
     // (undocumented)
     redo: () => this;
     // (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -980,6 +980,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     getIsFocused(): boolean;
     getIsMenuOpen(): boolean;
+    // @internal
+    getMarkIdMatching(idSubstring: string): null | string;
     getOnlySelectedShape(): null | TLShape;
     getOnlySelectedShapeId(): null | TLShapeId;
     getOpenMenus(): string[];
@@ -1570,6 +1572,8 @@ export class HistoryManager<R extends UnknownRecord> {
     };
     // (undocumented)
     readonly dispose: () => void;
+    // @internal (undocumented)
+    getMarkIdMatching(idSubstring: string): null | string;
     // (undocumented)
     getNumRedos(): number;
     // (undocumented)

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1580,10 +1580,6 @@ export class HistoryManager<R extends UnknownRecord> {
     getNumUndos(): number;
     // @internal (undocumented)
     _isInBatch: boolean;
-    // @deprecated (undocumented)
-    mark: (arg?: {
-        name?: string;
-    } | string) => string;
     // @internal (undocumented)
     _mark(id: string): void;
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -982,9 +982,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @deprecated use {@link Editor.markHistoryStoppingPoint} instead
 	 */
 	mark(markId?: string): this {
-		console.warn('Editor.mark is deprecated. Use Editor.markHistoryStoppingPoint instead.')
+		if (typeof markId === 'string') {
+			console.warn(
+				'[tldraw] `editor.history.mark("myMarkId")` is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint()` instead.'
+			)
+		} else {
+			console.warn(
+				'[tldraw] `editor.mark()` is deprecated. Use `editor.markHistoryStoppingPoint()` instead.'
+			)
+		}
 		// eslint-disable-next-line deprecation/deprecation
-		this.history.mark(markId)
+		this.history._mark(markId ?? uniqueId())
 		return this
 	}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1005,13 +1005,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @public
-	 * @param name - The name of the mark
+	 * @param name - The name of the mark, useful for debugging the undo/redo stacks
 	 * @returns a unique id for the mark that can be used with `squashToMark` or `bailToMark`.
 	 */
 	markHistoryStoppingPoint(name?: string): string {
 		const id = `[${name ?? 'stop'}]_${uniqueId()}`
 		this.history._mark(id)
 		return id
+	}
+
+	/**
+	 * @internal this is only used to implement some backwards-compatibility logic. Should be fine to delete after 6 months or whatever.
+	 */
+	getMarkIdMatching(idSubstring: string) {
+		return this.history.getMarkIdMatching(idSubstring)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -994,14 +994,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @example
 	 * ```ts
-	 * editor.markHistoryStoppingPoint('flip shapes')
+	 * editor.markHistoryStoppingPoint()
 	 * editor.flipShapes(editor.getSelectedShapes())
 	 * ```
 	 * @example
 	 * ```ts
-	 * const markId = editor.markHistoryStoppingPoint('rotate shapes')
+	 * const beginRotateMark = editor.markHistoryStoppingPoint()
 	 * // if the use cancels the rotation, you can bail back to this mark
-	 * editor.bailToMark(markId)
+	 * editor.bailToMark(beginRotateMark)
 	 * ```
 	 *
 	 * @public
@@ -1021,9 +1021,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @example
 	 * ```ts
-	 * editor.mark('bump shapes')
+	 * const bumpShapesMark = editor.markHistoryStoppingPoint()
 	 * // ... some changes
-	 * editor.squashToMark('bump shapes')
+	 * editor.squashToMark(bumpShapesMark)
 	 * ```
 	 *
 	 * @param markId - The mark id to squash to.
@@ -1034,7 +1034,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * Undo to the closest mark, but do not allow redoing the undone changes.
+	 * Undo to the closest mark, discarding the changes so they cannot be redone.
 	 *
 	 * @example
 	 * ```ts
@@ -1049,11 +1049,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * Undo to the given mark, but do not allow redoing the undone changes.
+	 * Undo to the given mark, discarding the changes so they cannot be redone.
 	 *
 	 * @example
 	 * ```ts
-	 * editor.bailToMark('dragging')
+	 * const beginDrag = editor.markHistoryStoppingPoint()
+	 * // ... some changes
+	 * editor.bailToMark(beginDrag)
 	 * ```
 	 *
 	 * @public

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -979,14 +979,45 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @param markId - The mark's id, usually the reason for adding the mark.
 	 *
 	 * @public
+	 * @deprecated use {@link Editor.markHistoryStoppingPoint} instead
 	 */
 	mark(markId?: string): this {
+		console.warn('Editor.mark is deprecated. Use Editor.markHistoryStoppingPoint instead.')
+		// eslint-disable-next-line deprecation/deprecation
 		this.history.mark(markId)
 		return this
 	}
 
 	/**
-	 * Squash the history to the given mark id.
+	 * Create a new "mark", or stopping point, in the undo redo history. Creating a mark will clear
+	 * any redos. You typically want to do this just before a user interaction begins or is handled.
+	 *
+	 * @example
+	 * ```ts
+	 * editor.markHistoryStoppingPoint('flip shapes')
+	 * editor.flipShapes(editor.getSelectedShapes())
+	 * ```
+	 * @example
+	 * ```ts
+	 * const markId = editor.markHistoryStoppingPoint('rotate shapes')
+	 * // if the use cancels the rotation, you can bail back to this mark
+	 * editor.bailToMark(markId)
+	 * ```
+	 *
+	 * @public
+	 * @param name - The name of the mark
+	 * @returns a unique id for the mark that can be used with `squashToMark` or `bailToMark`.
+	 */
+	markHistoryStoppingPoint(name?: string): string {
+		const id = `[${name ?? 'stop'}]_${uniqueId()}`
+		this.history._mark(id)
+		return id
+	}
+
+	/**
+	 * Coalesces all changes since the given mark into a single change, removing any intermediate marks.
+	 *
+	 * This is useful if you need to 'compress' the recent history to simplify the undo/redo experience of a complex interaction.
 	 *
 	 * @example
 	 * ```ts
@@ -1003,7 +1034,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * Clear all marks in the undo stack back to the next mark.
+	 * Undo to the closest mark, but do not allow redoing the undone changes.
 	 *
 	 * @example
 	 * ```ts
@@ -1018,7 +1049,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * Clear all marks in the undo stack back to the mark with the provided mark id.
+	 * Undo to the given mark, but do not allow redoing the undone changes.
 	 *
 	 * @example
 	 * ```ts

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -991,7 +991,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				'[tldraw] `editor.mark()` is deprecated. Use `editor.markHistoryStoppingPoint()` instead.'
 			)
 		}
-		// eslint-disable-next-line deprecation/deprecation
 		this.history._mark(markId ?? uniqueId())
 		return this
 	}

--- a/packages/editor/src/lib/editor/managers/HistoryManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.test.ts
@@ -92,7 +92,7 @@ describe(HistoryManager, () => {
 		expect(editor.getCount()).toBe(0)
 		editor.increment()
 		editor.increment()
-		editor.history.mark('stop at 2')
+		editor.history._mark('stop at 2')
 		editor.increment()
 		editor.increment()
 		editor.decrement()
@@ -110,12 +110,12 @@ describe(HistoryManager, () => {
 	it('allows undoing and redoing', () => {
 		expect(editor.getCount()).toBe(0)
 		editor.increment()
-		editor.history.mark('stop at 1')
+		editor.history._mark('stop at 1')
 		editor.increment()
-		editor.history.mark('stop at 2')
+		editor.history._mark('stop at 2')
 		editor.increment()
 		editor.increment()
-		editor.history.mark('stop at 4')
+		editor.history._mark('stop at 4')
 		editor.increment()
 		editor.increment()
 		editor.increment()
@@ -147,12 +147,12 @@ describe(HistoryManager, () => {
 	it('clears the redo stack if you execute commands, but not if you mark stopping points', () => {
 		expect(editor.getCount()).toBe(0)
 		editor.increment()
-		editor.history.mark('stop at 1')
+		editor.history._mark('stop at 1')
 		editor.increment()
-		editor.history.mark('stop at 2')
+		editor.history._mark('stop at 2')
 		editor.increment()
 		editor.increment()
-		editor.history.mark('stop at 4')
+		editor.history._mark('stop at 4')
 		editor.increment()
 		editor.increment()
 		editor.increment()
@@ -160,7 +160,7 @@ describe(HistoryManager, () => {
 		editor.history.undo()
 		editor.history.undo()
 		expect(editor.getCount()).toBe(2)
-		editor.history.mark('wayward stopping point')
+		editor.history._mark('wayward stopping point')
 		editor.history.redo()
 		editor.history.redo()
 		expect(editor.getCount()).toBe(7)
@@ -179,7 +179,7 @@ describe(HistoryManager, () => {
 	it('allows squashing of commands', () => {
 		editor.increment()
 
-		editor.history.mark('stop at 1')
+		editor.history._mark('stop at 1')
 		expect(editor.getCount()).toBe(1)
 
 		editor.increment(1)
@@ -193,7 +193,7 @@ describe(HistoryManager, () => {
 	})
 	it('allows ignore commands that do not affect the stack', () => {
 		editor.increment()
-		editor.history.mark('stop at 1')
+		editor.history._mark('stop at 1')
 		editor.increment()
 		editor.setName('wilbur')
 		editor.increment()
@@ -206,14 +206,14 @@ describe(HistoryManager, () => {
 
 	it('allows inconsequential commands that do not clear the redo stack', () => {
 		editor.increment()
-		editor.history.mark('stop at 1')
+		editor.history._mark('stop at 1')
 		editor.increment()
 		expect(editor.getCount()).toBe(2)
 		editor.history.undo()
 		expect(editor.getCount()).toBe(1)
-		editor.history.mark('stop at age 35')
+		editor.history._mark('stop at age 35')
 		editor.setAge(23)
-		editor.history.mark('stop at age 23')
+		editor.history._mark('stop at age 23')
 		expect(editor.getCount()).toBe(1)
 		editor.history.redo()
 		expect(editor.getCount()).toBe(2)
@@ -239,9 +239,9 @@ describe(HistoryManager, () => {
 	})
 
 	it('does not allow new history entries to be pushed if a command invokes them while bailing', () => {
-		editor.history.mark('0')
+		editor.history._mark('0')
 		editor.incrementTwice()
-		editor.history.mark('2')
+		editor.history._mark('2')
 		editor.incrementTwice()
 		editor.incrementTwice()
 		expect(editor.history.getNumUndos()).toBe(4)
@@ -256,11 +256,11 @@ describe(HistoryManager, () => {
 
 	it('supports bailing to a particular mark', () => {
 		editor.increment()
-		editor.history.mark('1')
+		editor.history._mark('1')
 		editor.increment()
-		editor.history.mark('2')
+		editor.history._mark('2')
 		editor.increment()
-		editor.history.mark('3')
+		editor.history._mark('3')
 		editor.increment()
 
 		expect(editor.getCount()).toBe(4)
@@ -299,11 +299,11 @@ describe('history options', () => {
 	})
 
 	it('undos, redoes, separate marks', () => {
-		manager.mark()
+		manager._mark('')
 		setA(1)
-		manager.mark()
+		manager._mark('')
 		setB(1)
-		manager.mark()
+		manager._mark('')
 		setB(2)
 
 		expect(getState()).toMatchObject({ a: 1, b: 2 })
@@ -318,11 +318,11 @@ describe('history options', () => {
 	})
 
 	it('undos, redos, squashing', () => {
-		manager.mark()
+		manager._mark('')
 		setA(1)
-		manager.mark()
+		manager._mark('')
 		setB(1)
-		manager.mark()
+		manager._mark('')
 		setB(2)
 		setB(3)
 		setB(4)
@@ -339,11 +339,11 @@ describe('history options', () => {
 	})
 
 	it('undos, redos, ignore', () => {
-		manager.mark()
+		manager._mark('')
 		setA(1)
-		manager.mark()
+		manager._mark('')
 		setB(1) // B 0->1
-		manager.mark()
+		manager._mark('')
 		setB(2, { history: 'ignore' }) // B 0->2, but ignore
 
 		expect(getState()).toMatchObject({ a: 1, b: 2 })
@@ -358,9 +358,9 @@ describe('history options', () => {
 	})
 
 	it('squashing, undos, redos', () => {
-		manager.mark()
+		manager._mark('')
 		setA(1)
-		manager.mark()
+		manager._mark('')
 		setB(1)
 		setB(2) // squashes with the previous command
 		setB(3) // squashes with the previous command
@@ -377,9 +377,9 @@ describe('history options', () => {
 	})
 
 	it('squashing, undos, redos, ignore', () => {
-		manager.mark()
+		manager._mark('')
 		setA(1)
-		manager.mark()
+		manager._mark('')
 		setB(1)
 		setB(2) // squashes with the previous command
 		setB(3, { history: 'ignore' }) // squashes with the previous command
@@ -396,7 +396,7 @@ describe('history options', () => {
 	})
 
 	it('nested ignore', () => {
-		manager.mark()
+		manager._mark('')
 		manager.batch(
 			() => {
 				setA(1)
@@ -412,7 +412,7 @@ describe('history options', () => {
 		manager.undo()
 		expect(getState()).toMatchObject({ a: 2, b: 1 })
 
-		manager.mark()
+		manager._mark('')
 		manager.batch(
 			() => {
 				setA(3)
@@ -432,22 +432,22 @@ describe('history options', () => {
 	})
 
 	it('squashToMark works', () => {
-		const a = manager.mark()
+		manager._mark('a')
 		setA(1)
-		const b = manager.mark()
+		manager._mark('b')
 		setB(1)
 		setB(2)
 		setB(3)
-		manager.mark()
+		manager._mark('')
 		setA(2)
 		setB(4)
-		manager.mark()
+		manager._mark('')
 		setB(5)
 		setB(6)
 
 		expect(getState()).toMatchObject({ a: 2, b: 6 })
 
-		manager.squashToMark(b)
+		manager.squashToMark('b')
 
 		// does not affect state
 		expect(getState()).toMatchObject({ a: 2, b: 6 })
@@ -465,7 +465,7 @@ describe('history options', () => {
 		expect(getState()).toMatchObject({ a: 0, b: 0 })
 
 		manager.redo().redo()
-		manager.squashToMark(a)
+		manager.squashToMark('a')
 
 		expect(getState()).toMatchObject({ a: 2, b: 6 })
 		manager.undo()

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -9,7 +9,6 @@ import {
 	squashRecordDiffsMutable,
 } from '@tldraw/store'
 import { exhaustiveSwitchError, noop } from '@tldraw/utils'
-import { uniqueId } from '../../utils/uniqueId'
 import { TLHistoryBatchOptions, TLHistoryEntry } from '../types/history-types'
 import { stack } from './Stack'
 
@@ -295,20 +294,6 @@ export class HistoryManager<R extends UnknownRecord> {
 			this.flushPendingDiff()
 			this.stacks.update(({ undos, redos }) => ({ undos: undos.push({ type: 'stop', id }), redos }))
 		})
-	}
-
-	/**
-	 * @deprecated Use {@link Editor#markHistoryStoppingPoint} instead.
-	 */
-	mark = (arg?: string | { name?: string }) => {
-		if (typeof arg === 'string') {
-			console.warn(
-				'editor.history.markHistoryStoppingPoint("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint()` instead.'
-			)
-		}
-		const id = typeof arg === 'string' ? arg : arg?.name ? `${arg.name}/${uniqueId()}` : uniqueId()
-		this._mark(id)
-		return id
 	}
 
 	clear() {

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -303,7 +303,7 @@ export class HistoryManager<R extends UnknownRecord> {
 	mark = (arg?: string | { name?: string }) => {
 		if (typeof arg === 'string') {
 			console.warn(
-				'editor.history.mark("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint()` instead.'
+				'editor.history.markHistoryStoppingPoint("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint()` instead.'
 			)
 		}
 		const id = typeof arg === 'string' ? arg : arg?.name ? `${arg.name}/${uniqueId()}` : uniqueId()
@@ -314,6 +314,18 @@ export class HistoryManager<R extends UnknownRecord> {
 	clear() {
 		this.stacks.set({ undos: stack(), redos: stack() })
 		this.pendingDiff.clear()
+	}
+
+	/** @internal */
+	getMarkIdMatching(idSubstring: string) {
+		let top = this.stacks.get().undos
+		while (top.head) {
+			if (top.head.type === 'stop' && top.head.id.includes(idSubstring)) {
+				return top.head.id
+			}
+			top = top.tail
+		}
+		return null
 	}
 
 	/** @internal */

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -167,12 +167,21 @@ export class HistoryManager<R extends UnknownRecord> {
 							break
 						case 'stop':
 							if (!toMark) break loop
-							if (undo.id === toMark) break loop
+							if (undo.id === toMark) {
+								didFindMark = true
+								break loop
+							}
 							break
 						default:
 							exhaustiveSwitchError(undo)
 					}
 				}
+			}
+
+			if (!didFindMark && toMark) {
+				// whoops, we didn't find the mark we were looking for
+				// don't do anything
+				return this
 			}
 
 			this.store.applyDiff(diffToUndo, { ignoreEphemeralKeys: true })

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -289,12 +289,25 @@ export class HistoryManager<R extends UnknownRecord> {
 		return this
 	}
 
-	mark = (id = uniqueId()) => {
+	/** @internal */
+	_mark(id: string) {
 		transact(() => {
 			this.flushPendingDiff()
 			this.stacks.update(({ undos, redos }) => ({ undos: undos.push({ type: 'stop', id }), redos }))
 		})
+	}
 
+	/**
+	 * @deprecated Use {@link Editor#markHistoryStoppingPoint} instead.
+	 */
+	mark = (arg?: string | { name?: string }) => {
+		if (typeof arg === 'string') {
+			console.warn(
+				'editor.history.mark("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint("myMarkName")` instead.'
+			)
+		}
+		const id = typeof arg === 'string' ? arg : arg?.name ? `${arg.name}/${uniqueId()}` : uniqueId()
+		this._mark(id)
 		return id
 	}
 

--- a/packages/editor/src/lib/editor/managers/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager.ts
@@ -303,7 +303,7 @@ export class HistoryManager<R extends UnknownRecord> {
 	mark = (arg?: string | { name?: string }) => {
 		if (typeof arg === 'string') {
 			console.warn(
-				'editor.history.mark("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint("myMarkName")` instead.'
+				'editor.history.mark("myMarkId") is deprecated. Please use `const myMarkId = editor.markHistoryStoppingPoint()` instead.'
 			)
 		}
 		const id = typeof arg === 'string' ? arg : arg?.name ? `${arg.name}/${uniqueId()}` : uniqueId()

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -9,8 +9,6 @@ import { BaseBoxShapeTool } from '../BaseBoxShapeTool'
 export class Pointing extends StateNode {
 	static override id = 'pointing'
 
-	markId = ''
-
 	wasFocusedOnEnter = false
 
 	override onEnter = () => {
@@ -25,7 +23,7 @@ export class Pointing extends StateNode {
 
 			const id = createShapeId()
 
-			this.markId = this.editor.markHistoryStoppingPoint(`creating:${id}`)
+			const creatingMarkId = this.editor.markHistoryStoppingPoint(`creating_box:${id}`)
 
 			this.editor
 				.createShapes<TLBaseBoxShape>([
@@ -41,15 +39,19 @@ export class Pointing extends StateNode {
 					},
 				])
 				.select(id)
-			this.editor.setCurrentTool('select.resizing', {
-				...info,
-				target: 'selection',
-				handle: 'bottom_right',
-				isCreating: true,
-				creationCursorOffset: { x: 1, y: 1 },
-				onInteractionEnd: this.parent.id,
-				onCreate: (this.parent as BaseBoxShapeTool).onCreate,
-			})
+			this.editor.setCurrentTool(
+				'select.resizing',
+				{
+					...info,
+					target: 'selection',
+					handle: 'bottom_right',
+					isCreating: true,
+					creatingMarkId,
+					creationCursorOffset: { x: 1, y: 1 },
+					onInteractionEnd: this.parent.id,
+					onCreate: (this.parent as BaseBoxShapeTool).onCreate,
+				} /** satisfies ResizingInfo, defined in main tldraw package 😧 */
+			)
 		}
 	}
 
@@ -80,7 +82,7 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		this.markId = this.editor.markHistoryStoppingPoint(`creating.complete:${id}`)
+		this.editor.markHistoryStoppingPoint(`creating.complete:${id}`)
 
 		// todo: add scale here when dynamic size is enabled (is this still needed?)
 		this.editor.createShapes<TLBaseBoxShape>([

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -25,9 +25,7 @@ export class Pointing extends StateNode {
 
 			const id = createShapeId()
 
-			this.markId = `creating:${id}`
-
-			this.editor.mark(this.markId)
+			this.markId = this.editor.markHistoryStoppingPoint(`creating:${id}`)
 
 			this.editor
 				.createShapes<TLBaseBoxShape>([
@@ -78,16 +76,13 @@ export class Pointing extends StateNode {
 			return
 		}
 
-		this.editor.mark(this.markId)
-
 		const shapeType = (this.parent as BaseBoxShapeTool)!.shapeType as TLBaseBoxShape['type']
 
 		const id = createShapeId()
 
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint(`creating.complete:${id}`)
 
-		// todo: add scale here when dynamic size is enabled
-
+		// todo: add scale here when dynamic size is enabled (is this still needed?)
 		this.editor.createShapes<TLBaseBoxShape>([
 			{
 				id,

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -82,7 +82,7 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		this.editor.markHistoryStoppingPoint(`creating.complete:${id}`)
+		this.editor.markHistoryStoppingPoint(`creating_box:${id}`)
 
 		// todo: add scale here when dynamic size is enabled (is this still needed?)
 		this.editor.createShapes<TLBaseBoxShape>([

--- a/packages/sync-core/src/test/FuzzEditor.ts
+++ b/packages/sync-core/src/test/FuzzEditor.ts
@@ -350,7 +350,7 @@ export class FuzzEditor extends RandomSource {
 			}
 
 			case 'mark-stopping-point': {
-				this.editor.mark()
+				this.editor.markHistoryStoppingPoint()
 				break
 			}
 

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -8,6 +8,7 @@ export class Pointing extends StateNode {
 	markId = ''
 
 	override onEnter = () => {
+		this.markId = ''
 		this.didTimeout = false
 
 		const target = this.editor.getShapeAtPoint(this.editor.inputs.currentPagePoint, {
@@ -52,6 +53,7 @@ export class Pointing extends StateNode {
 				shape: this.shape,
 				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0 },
 				isCreating: true,
+				creatingMarkId: this.markId || undefined,
 				onInteractionEnd: 'arrow',
 			})
 		}

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -87,8 +87,7 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		this.markId = `creating:${id}`
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint(`creating_arrow:${id}`)
 
 		this.editor.createShape<TLArrowShape>({
 			id,

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -169,8 +169,7 @@ export class Drawing extends StateNode {
 			inputs: { originPagePoint, isPen },
 		} = this.editor
 
-		this.markId = 'draw start ' + uniqueId()
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('draw start')
 
 		// If the pressure is weird, then it's probably a stylus reporting as a mouse
 		// We treat pen/stylus inputs differently in the drawing tool, so we need to

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -22,9 +22,7 @@ export class Pointing extends StateNode {
 
 			const id = createShapeId()
 
-			this.markId = `creating:${id}`
-
-			this.editor.mark(this.markId)
+			this.markId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
 
 			this.editor
 				.createShapes<TLGeoShape>([
@@ -70,9 +68,7 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		this.markId = `creating:${id}`
-
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
 
 		const scale = this.editor.user.getIsDynamicResizeMode() ? 1 / this.editor.getZoomLevel() : 1
 

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -10,8 +10,6 @@ import {
 export class Pointing extends StateNode {
 	static override id = 'pointing'
 
-	markId = ''
-
 	override onPointerUp: TLEventHandlers['onPointerUp'] = () => {
 		this.complete()
 	}
@@ -22,7 +20,7 @@ export class Pointing extends StateNode {
 
 			const id = createShapeId()
 
-			this.markId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
+			const creatingMarkId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
 
 			this.editor
 				.createShapes<TLGeoShape>([
@@ -45,6 +43,7 @@ export class Pointing extends StateNode {
 					target: 'selection',
 					handle: 'bottom_right',
 					isCreating: true,
+					creatingMarkId,
 					creationCursorOffset: { x: 1, y: 1 },
 					onInteractionEnd: 'geo',
 				})
@@ -68,7 +67,7 @@ export class Pointing extends StateNode {
 
 		const id = createShapeId()
 
-		this.markId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
+		this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
 
 		const scale = this.editor.user.getIsDynamicResizeMode() ? 1 / this.editor.getZoomLevel() : 1
 

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -117,6 +117,7 @@ export class Pointing extends StateNode {
 			this.editor.setCurrentTool('select.dragging_handle', {
 				shape: this.shape,
 				isCreating: true,
+				creatingMarkId: this.markId,
 				// remove the offset that we added to the handle when we created it
 				handle: { ...lastHandle, x: lastHandle.x - 0.1, y: lastHandle.y - 0.1 },
 				onInteractionEnd: 'line',

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -33,8 +33,7 @@ export class Pointing extends StateNode {
 
 		if (shape && inputs.shiftKey) {
 			// Extending a previous shape
-			this.markId = `creating:${shape.id}`
-			this.editor.mark(this.markId)
+			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${shape.id}`)
 			this.shape = shape
 
 			const handles = this.editor.getShapeHandles(this.shape)
@@ -86,8 +85,7 @@ export class Pointing extends StateNode {
 		} else {
 			const id = createShapeId()
 
-			this.markId = `creating:${id}`
-			this.editor.mark(this.markId)
+			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${id}`)
 
 			this.editor.createShapes<TLLineShape>([
 				{

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -432,7 +432,7 @@ function useNoteKeydownHandler(id: TLShapeId) {
 				const newNote = getNoteShapeForAdjacentPosition(editor, shape, adjacentCenter, pageRotation)
 
 				if (newNote) {
-					editor.mark('editing adjacent shape')
+					editor.markHistoryStoppingPoint('editing adjacent shape')
 					startEditingShapeWithLabel(editor, newNote, true /* selectAll */)
 				}
 			}

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -191,7 +191,7 @@ export function getNoteShapeForAdjacentPosition(
 
 	// If we didn't find any in that position, then create a new one
 	if (!nextNote || forceNew) {
-		editor.mark('creating note shape')
+		editor.markHistoryStoppingPoint('creating note shape')
 		const id = createShapeId()
 
 		// We create it at the center first, so that it becomes

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -72,6 +72,7 @@ export class Pointing extends StateNode {
 				shape: this.shape,
 				onInteractionEnd: 'note',
 				isCreating: true,
+				creatingMarkId: this.markId,
 				onCreate: () => {
 					this.editor.setEditingShape(this.shape.id)
 					this.editor.setCurrentTool('select.editing_shape')

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -34,8 +34,7 @@ export class Pointing extends StateNode {
 
 		if (this.wasFocusedOnEnter) {
 			const id = createShapeId()
-			this.markId = `creating:${id}`
-			editor.mark(this.markId)
+			this.markId = editor.markHistoryStoppingPoint(`creating_note:${id}`)
 
 			// Check for note pits; if the pointer is close to one, place the note centered on the pit
 			const center = this.editor.inputs.originPagePoint.clone()

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -27,8 +27,7 @@ export class Pointing extends StateNode {
 
 			const id = createShapeId()
 
-			this.markId = `creating:${id}`
-			this.editor.mark(this.markId)
+			this.markId = this.editor.markHistoryStoppingPoint(`creating_text:${id}`)
 
 			const shape = this.createTextShape(id, originPagePoint, false)
 			if (!shape) {
@@ -73,7 +72,7 @@ export class Pointing extends StateNode {
 	}
 
 	private complete() {
-		this.editor.mark('creating text shape')
+		this.editor.markHistoryStoppingPoint('creating text shape')
 		const id = createShapeId()
 		const { currentPagePoint } = this.editor.inputs
 		const shape = this.createTextShape(id, currentPagePoint, true)

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -45,6 +45,7 @@ export class Pointing extends StateNode {
 				target: 'selection',
 				handle: 'right',
 				isCreating: true,
+				creatingMarkId: this.markId,
 				creationCursorOffset: { x: 18, y: 1 },
 				onInteractionEnd: 'text',
 				onCreate: () => {

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -17,8 +17,7 @@ export class Erasing extends StateNode {
 	private excludedShapeIds = new Set<TLShapeId>()
 
 	override onEnter = (info: TLPointerEventInfo) => {
-		this.markId = 'erase scribble begin'
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('erase scribble begin')
 		this.info = info
 
 		const { originPagePoint } = this.editor.inputs

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -86,7 +86,7 @@ export class Pointing extends StateNode {
 		const erasingShapeIds = this.editor.getErasingShapeIds()
 
 		if (erasingShapeIds.length) {
-			this.editor.mark('erase end')
+			this.editor.markHistoryStoppingPoint('erase end')
 			this.editor.deleteShapes(erasingShapeIds)
 		}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -1,4 +1,4 @@
-import { StateNode, uniqueId } from '@tldraw/editor'
+import { StateNode } from '@tldraw/editor'
 import { Cropping } from './children/Cropping'
 import { Idle } from './children/Idle'
 import { PointingCrop } from './children/PointingCrop'
@@ -19,8 +19,7 @@ export class Crop extends StateNode {
 	markId = ''
 	override onEnter = () => {
 		this.didExit = false
-		this.markId = 'crop: ' + uniqueId()
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('crop')
 	}
 	didExit = false
 	override onExit = () => {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -1,4 +1,4 @@
-import { StateNode } from '@tldraw/editor'
+import { StateNode, uniqueId } from '@tldraw/editor'
 import { Cropping } from './children/Cropping'
 import { Idle } from './children/Idle'
 import { PointingCrop } from './children/PointingCrop'
@@ -18,19 +18,24 @@ export class Crop extends StateNode {
 
 	markId = ''
 	override onEnter = () => {
-		this.didCancel = false
-		this.markId = 'crop'
+		this.didExit = false
+		this.markId = 'crop: ' + uniqueId()
 		this.editor.mark(this.markId)
 	}
-	didCancel = false
+	didExit = false
 	override onExit = () => {
-		if (this.didCancel) {
-			this.editor.bailToMark(this.markId)
-		} else {
-			this.editor.squashToMark(this.markId)
-		}
+		this.onComplete()
 	}
 	override onCancel = () => {
-		this.didCancel = true
+		if (!this.didExit) {
+			this.didExit = true
+			this.editor.bailToMark(this.markId)
+		}
+	}
+	override onComplete = () => {
+		if (!this.didExit) {
+			this.didExit = true
+			this.editor.squashToMark(this.markId)
+		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -23,18 +23,15 @@ export class Crop extends StateNode {
 	}
 	didExit = false
 	override onExit = () => {
-		this.onComplete()
+		if (!this.didExit) {
+			this.didExit = true
+			this.editor.squashToMark(this.markId)
+		}
 	}
 	override onCancel = () => {
 		if (!this.didExit) {
 			this.didExit = true
 			this.editor.bailToMark(this.markId)
-		}
-	}
-	override onComplete = () => {
-		if (!this.didExit) {
-			this.didExit = true
-			this.editor.squashToMark(this.markId)
 		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -38,8 +38,7 @@ export class Cropping extends StateNode {
 		}
 	) => {
 		this.info = info
-		this.markId = 'cropping'
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('cropping')
 		this.snapshot = this.createSnapshot()
 		this.updateShapes()
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -182,7 +182,7 @@ export class Idle extends StateNode {
 			if (!ephemeral) {
 				// We don't want to create new marks if the user
 				// is just holding down the arrow keys
-				this.editor.mark('translate crop')
+				this.editor.markHistoryStoppingPoint('translate crop')
 			}
 
 			this.editor.updateShapes<ShapeWithCrop>([partial])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLEventHandlers, TLPointerEventInfo } from '@tldraw/editor'
+import { StateNode, TLEventHandlers, TLPointerEventInfo, uniqueId } from '@tldraw/editor'
 import { ShapeWithCrop, getTranslateCroppedImageChange } from './crop_helpers'
 
 type Snapshot = ReturnType<TranslatingCrop['createSnapshot']>
@@ -12,20 +12,17 @@ export class TranslatingCrop extends StateNode {
 		onInteractionEnd?: string
 	}
 
-	markId = 'translating crop'
+	markId = ''
 
 	private snapshot = {} as any as Snapshot
 
 	override onEnter = (
-		info: TLPointerEventInfo & {
-			target: 'shape'
-			isCreating?: boolean
-			onInteractionEnd?: string
-		}
+		info: TLPointerEventInfo & { target: 'shape'; isCreating?: boolean; onInteractionEnd?: string }
 	) => {
 		this.info = info
 		this.snapshot = this.createSnapshot()
 
+		this.markId = 'translating_crop: ' + uniqueId()
 		this.editor.mark(this.markId)
 		this.editor.setCursor({ type: 'move', rotation: 0 })
 		this.updateShapes()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLEventHandlers, TLPointerEventInfo, uniqueId } from '@tldraw/editor'
+import { StateNode, TLEventHandlers, TLPointerEventInfo } from '@tldraw/editor'
 import { ShapeWithCrop, getTranslateCroppedImageChange } from './crop_helpers'
 
 type Snapshot = ReturnType<TranslatingCrop['createSnapshot']>
@@ -22,8 +22,7 @@ export class TranslatingCrop extends StateNode {
 		this.info = info
 		this.snapshot = this.createSnapshot()
 
-		this.markId = 'translating_crop: ' + uniqueId()
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('translating_crop')
 		this.editor.setCursor({ type: 'move', rotation: 0 })
 		this.updateShapes()
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -18,6 +18,14 @@ import {
 import { getArrowBindings } from '../../../shapes/arrow/shared'
 import { kickoutOccludedShapes } from '../selectHelpers'
 
+export type DraggingHandleInfo = TLPointerEventInfo & {
+	shape: TLArrowShape | TLLineShape
+	target: 'handle'
+	onInteractionEnd?: string
+	isCreating?: boolean
+	creatingMarkId?: string
+}
+
 export class DraggingHandle extends StateNode {
 	static override id = 'dragging_handle'
 
@@ -30,32 +38,32 @@ export class DraggingHandle extends StateNode {
 	initialPageTransform: any
 	initialPageRotation: any
 
-	info = {} as TLPointerEventInfo & {
-		shape: TLArrowShape | TLLineShape
-		target: 'handle'
-		onInteractionEnd?: string
-		isCreating: boolean
-	}
+	info = {} as DraggingHandleInfo
 
 	isPrecise = false
 	isPreciseId = null as TLShapeId | null
 	pointingId = null as TLShapeId | null
 
-	override onEnter: TLEnterEventHandler = (
-		info: TLPointerEventInfo & {
-			shape: TLArrowShape | TLLineShape
-			target: 'handle'
-			onInteractionEnd?: string
-			isCreating: boolean
-		}
-	) => {
-		const { shape, isCreating, handle } = info
+	override onEnter: TLEnterEventHandler = (info: DraggingHandleInfo) => {
+		const { shape, isCreating, creatingMarkId, handle } = info
 		this.info = info
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		this.shapeId = shape.id
 		this.markId = ''
 
-		if (!isCreating) {
+		if (isCreating) {
+			if (creatingMarkId) {
+				this.markId = creatingMarkId
+			} else {
+				// handle legacy implicit `creating:{shapeId}` marks
+				const markId = this.editor.getMarkIdMatching(
+					`creating:${this.editor.getOnlySelectedShapeId()}`
+				)
+				if (markId) {
+					this.markId = markId
+				}
+			}
+		} else {
 			this.markId = this.editor.markHistoryStoppingPoint('dragging handle')
 		}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -53,8 +53,11 @@ export class DraggingHandle extends StateNode {
 		this.info = info
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		this.shapeId = shape.id
-		this.markId = isCreating ? `creating:${shape.id}` : 'dragging handle'
-		if (!isCreating) this.editor.mark(this.markId)
+		this.markId = ''
+
+		if (!isCreating) {
+			this.markId = this.editor.markHistoryStoppingPoint('dragging handle')
+		}
 
 		this.initialHandle = structuredClone(handle)
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -88,7 +88,7 @@ export class EditingShape extends StateNode {
 						} else {
 							this.hitShapeForPointerUp = selectingShape
 
-							this.editor.mark('editing on pointer up')
+							this.editor.markHistoryStoppingPoint('editing on pointer up')
 							this.editor.select(selectingShape.id)
 							return
 						}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -261,7 +261,7 @@ export class Idle extends StateNode {
 					) {
 						const change = util.onDoubleClickEdge?.(onlySelectedShape)
 						if (change) {
-							this.editor.mark('double click edge')
+							this.editor.markHistoryStoppingPoint('double click edge')
 							this.editor.updateShapes([change])
 							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
 							return
@@ -303,7 +303,7 @@ export class Idle extends StateNode {
 						return
 					} else if (util.canCrop(shape) && !this.editor.isShapeOrAncestorLocked(shape)) {
 						// crop on double click
-						this.editor.mark('select and crop')
+						this.editor.markHistoryStoppingPoint('select and crop')
 						this.editor.select(info.shape?.id)
 						this.parent.transition('crop', info)
 						return
@@ -404,7 +404,7 @@ export class Idle extends StateNode {
 						selectedShapeIds.includes(shape.id)
 					)
 				) {
-					this.editor.mark('selecting shape')
+					this.editor.markHistoryStoppingPoint('selecting shape')
 					this.editor.setSelectedShapes([targetShape.id])
 				}
 				break
@@ -419,7 +419,7 @@ export class Idle extends StateNode {
 		) {
 			this.editor.popFocusedGroupId()
 		} else {
-			this.editor.mark('clearing selection')
+			this.editor.markHistoryStoppingPoint('clearing selection')
 			this.editor.selectNone()
 		}
 	}
@@ -530,7 +530,7 @@ export class Idle extends StateNode {
 		shouldSelectAll?: boolean
 	) {
 		if (this.editor.isShapeOrAncestorLocked(shape) && shape.type !== 'embed') return
-		this.editor.mark('editing shape')
+		this.editor.markHistoryStoppingPoint('editing shape')
 		startEditingShapeWithLabel(this.editor, shape, shouldSelectAll)
 		this.parent.transition('editing_shape', info)
 	}
@@ -563,7 +563,7 @@ export class Idle extends StateNode {
 		// Create text shape and transition to editing_shape
 		if (this.editor.getInstanceState().isReadonly) return
 
-		this.editor.mark('creating text shape')
+		this.editor.markHistoryStoppingPoint('creating text shape')
 
 		const id = createShapeId()
 
@@ -618,7 +618,7 @@ export class Idle extends StateNode {
 
 		if (delta.equals(new Vec(0, 0))) return
 
-		if (!ephemeral) this.editor.mark('nudge shapes')
+		if (!ephemeral) this.editor.markHistoryStoppingPoint('nudge shapes')
 
 		const { gridSize } = this.editor.getDocumentSettings()
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -55,8 +55,7 @@ export class PointingArrowLabel extends StateNode {
 
 		this._labelDragOffset = Vec.Sub(labelGeometry.center, pointInShapeSpace)
 
-		this.markId = 'label-drag start'
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('label-drag start')
 		this.editor.setSelectedShapes([this.shapeId])
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -9,7 +9,7 @@ export class PointingCanvas extends StateNode {
 
 		if (!inputs.shiftKey) {
 			if (this.editor.getSelectedShapeIds().length > 0) {
-				this.editor.mark('selecting none')
+				this.editor.markHistoryStoppingPoint('selecting none')
 				this.editor.selectNone()
 			}
 		}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -48,11 +48,11 @@ export class PointingShape extends StateNode {
 		if (shiftKey && !altKey) {
 			this.editor.cancelDoubleClick()
 			if (!selectedShapeIds.includes(outermostSelectingShape.id)) {
-				this.editor.mark('shift selecting shape')
+				this.editor.markHistoryStoppingPoint('shift selecting shape')
 				this.editor.setSelectedShapes([...selectedShapeIds, outermostSelectingShape.id])
 			}
 		} else {
-			this.editor.mark('selecting shape')
+			this.editor.markHistoryStoppingPoint('selecting shape')
 			this.editor.setSelectedShapes([outermostSelectingShape.id])
 		}
 	}
@@ -82,7 +82,7 @@ export class PointingShape extends StateNode {
 			if (util.onClick) {
 				const change = util.onClick?.(selectingShape)
 				if (change) {
-					this.editor.mark('shape on click')
+					this.editor.markHistoryStoppingPoint('shape on click')
 					this.editor.updateShapes([change])
 					this.parent.transition('idle', info)
 					return
@@ -91,7 +91,7 @@ export class PointingShape extends StateNode {
 
 			if (selectingShape.id === focusedGroupId) {
 				if (selectedShapeIds.length > 0) {
-					this.editor.mark('clearing shape ids')
+					this.editor.markHistoryStoppingPoint('clearing shape ids')
 					this.editor.setSelectedShapes([])
 				} else {
 					this.editor.popFocusedGroupId()
@@ -116,7 +116,7 @@ export class PointingShape extends StateNode {
 			if (selectedShapeIds.includes(outermostSelectableShape.id)) {
 				// same shape, so deselect it if shift is pressed, otherwise deselect all others
 				if (shiftKey) {
-					this.editor.mark('deselecting on pointer up')
+					this.editor.markHistoryStoppingPoint('deselecting on pointer up')
 					this.editor.deselect(selectingShape)
 				} else {
 					if (selectedShapeIds.includes(selectingShape.id)) {
@@ -143,7 +143,7 @@ export class PointingShape extends StateNode {
 									textLabel.hitTestPoint(pointInShapeSpace)
 								) {
 									this.editor.run(() => {
-										this.editor.mark('editing on pointer up')
+										this.editor.markHistoryStoppingPoint('editing on pointer up')
 										this.editor.select(selectingShape.id)
 
 										const util = this.editor.getShapeUtil(selectingShape)
@@ -166,10 +166,10 @@ export class PointingShape extends StateNode {
 						}
 
 						// We just want to select the single shape from the selection
-						this.editor.mark('selecting on pointer up')
+						this.editor.markHistoryStoppingPoint('selecting on pointer up')
 						this.editor.select(selectingShape.id)
 					} else {
-						this.editor.mark('selecting on pointer up')
+						this.editor.markHistoryStoppingPoint('selecting on pointer up')
 						this.editor.select(selectingShape)
 					}
 				}
@@ -178,13 +178,13 @@ export class PointingShape extends StateNode {
 				// Deselect any ancestors and add the target shape to the selection
 				const ancestors = this.editor.getShapeAncestors(outermostSelectableShape)
 
-				this.editor.mark('shift deselecting on pointer up')
+				this.editor.markHistoryStoppingPoint('shift deselecting on pointer up')
 				this.editor.setSelectedShapes([
 					...this.editor.getSelectedShapeIds().filter((id) => !ancestors.find((a) => a.id === id)),
 					outermostSelectableShape.id,
 				])
 			} else {
-				this.editor.mark('selecting on pointer up')
+				this.editor.markHistoryStoppingPoint('selecting on pointer up')
 				// different shape and we are drilling down, but no shift held so just select it straight up
 				this.editor.setSelectedShapes([outermostSelectableShape.id])
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -31,8 +31,7 @@ export class Rotating extends StateNode {
 		this.info = info
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 
-		this.markId = 'rotate start'
-		this.editor.mark(this.markId)
+		this.markId = this.editor.markHistoryStoppingPoint('rotate start')
 
 		const snapshot = getRotationSnapshot({ editor: this.editor })
 		if (!snapshot) return this.parent.transition('idle', this.info)

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -29,11 +29,11 @@ export function selectOnCanvasPointerUp(editor: Editor) {
 
 			if (selectedShapeIds.includes(outermostSelectableShape.id)) {
 				// Remove it from selected shapes
-				editor.mark('deselecting shape')
+				editor.markHistoryStoppingPoint('deselecting shape')
 				editor.deselect(outermostSelectableShape)
 			} else {
 				// Add it to selected shapes
-				editor.mark('shift selecting shape')
+				editor.markHistoryStoppingPoint('shift selecting shape')
 				editor.setSelectedShapes([...selectedShapeIds, outermostSelectableShape.id])
 			}
 		} else {
@@ -59,7 +59,7 @@ export function selectOnCanvasPointerUp(editor: Editor) {
 			}
 
 			if (shapeToSelect && !selectedShapeIds.includes(shapeToSelect.id)) {
-				editor.mark('selecting shape')
+				editor.markHistoryStoppingPoint('selecting shape')
 				editor.select(shapeToSelect.id)
 			}
 		}
@@ -74,7 +74,7 @@ export function selectOnCanvasPointerUp(editor: Editor) {
 			// nothing instead of their current selection.
 
 			if (selectedShapeIds.length > 0) {
-				editor.mark('selecting none')
+				editor.markHistoryStoppingPoint('selecting none')
 				editor.selectNone()
 			}
 

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -253,7 +253,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 		if (isReadonlyMode) return
 
 		editor.run(() => {
-			editor.mark('creating page')
+			editor.markHistoryStoppingPoint('creating page')
 			const newPageId = PageRecordType.createId()
 			editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
 			editor.setCurrentPage(newPageId)

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
@@ -22,7 +22,7 @@ export const PageItemInput = function PageItemInput({
 	const rInput = useRef<HTMLInputElement | null>(null)
 
 	const handleFocus = useCallback(() => {
-		editor.mark('rename page')
+		editor.markHistoryStoppingPoint('rename page')
 	}, [editor])
 
 	const handleChange = useCallback(

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -33,7 +33,7 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	const trackEvent = useUiEvents()
 
 	const onDuplicate = useCallback(() => {
-		editor.mark('creating page')
+		editor.markHistoryStoppingPoint('creating page')
 		const newId = PageRecordType.createId()
 		editor.duplicatePage(item.id as TLPageId, newId)
 		trackEvent('duplicate-page', { source: 'page-menu' })
@@ -48,7 +48,7 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	}, [editor, item, index, trackEvent])
 
 	const onDelete = useCallback(() => {
-		editor.mark('deleting page')
+		editor.markHistoryStoppingPoint('deleting page')
 		editor.deletePage(item.id as TLPageId)
 		trackEvent('delete-page', { source: 'page-menu' })
 	}, [editor, item, trackEvent])

--- a/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
@@ -31,7 +31,7 @@ export const onMovePage = (
 	}
 
 	if (index !== pages[from].index) {
-		editor.mark('moving page')
+		editor.markHistoryStoppingPoint('moving page')
 		editor.updatePage({
 			id: id as TLPageId,
 			index,

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -67,7 +67,7 @@ function _DropdownPicker<T extends string>({
 									data-testid={`style.${uiType}.${item.value}`}
 									title={msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)}
 									onClick={() => {
-										editor.mark('select style dropdown item')
+										editor.markHistoryStoppingPoint('select style dropdown item')
 										onValueChange(style, item.value)
 									}}
 								>

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -452,7 +452,7 @@ export function MoveToPageMenu() {
 						disabled={currentPageId === page.id}
 						label={page.name}
 						onSelect={() => {
-							editor.mark('move_shapes_to_page')
+							editor.markHistoryStoppingPoint('move_shapes_to_page')
 							editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId)
 
 							const toPage = editor.getPage(page.id)
@@ -466,7 +466,7 @@ export function MoveToPageMenu() {
 											label: 'Go Back',
 											type: 'primary',
 											onClick: () => {
-												editor.mark('change-page')
+												editor.markHistoryStoppingPoint('change-page')
 												editor.setCurrentPage(currentPageId)
 											},
 										},

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -69,14 +69,14 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 			const { id } = e.currentTarget.dataset
 			if (value.type === 'shared' && value.value === id) return
 
-			editor.mark('point picker item')
+			editor.markHistoryStoppingPoint('point picker item')
 			onValueChange(style, id as T)
 		}
 
 		const handleButtonPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
 			const { id } = e.currentTarget.dataset
 
-			editor.mark('point picker item')
+			editor.markHistoryStoppingPoint('point picker item')
 			onValueChange(style, id as T)
 
 			rPointing.current = true

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -28,7 +28,7 @@ export const TldrawUiSlider = memo(function Slider(props: TLUiSliderProps) {
 	)
 
 	const handlePointerDown = useCallback(() => {
-		editor.mark('click slider')
+		editor.markHistoryStoppingPoint('click slider')
 	}, [editor])
 
 	const handlePointerUp = useCallback(() => {

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -127,7 +127,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('edit-link', { source })
-					editor.mark('edit-link')
+					editor.markHistoryStoppingPoint('edit-link')
 					addDialog({ component: EditLinkDialog })
 				},
 			},
@@ -324,7 +324,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('toggle-auto-size', { source })
-					editor.mark('toggling auto size')
+					editor.markHistoryStoppingPoint('toggling auto size')
 					const shapes = editor
 						.getSelectedShapes()
 						.filter(
@@ -424,7 +424,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							deleteList.push(shape.id)
 						}
 
-						editor.mark('convert shapes to bookmark')
+						editor.markHistoryStoppingPoint('convert shapes to bookmark')
 						editor.deleteShapes(deleteList)
 						editor.createShapes(createList)
 					})
@@ -479,7 +479,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							deleteList.push(shape.id)
 						}
 
-						editor.mark('convert shapes to embed')
+						editor.markHistoryStoppingPoint('convert shapes to embed')
 						editor.deleteShapes(deleteList)
 						editor.createShapes(createList)
 					})
@@ -517,7 +517,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 								}
 					}
 
-					editor.mark('duplicate shapes')
+					editor.markHistoryStoppingPoint('duplicate shapes')
 					editor.duplicateShapes(ids, offset)
 
 					if (instanceState.duplicateProps) {
@@ -542,7 +542,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('ungroup-shapes', { source })
-					editor.mark('ungroup')
+					editor.markHistoryStoppingPoint('ungroup')
 					editor.ungroupShapes(editor.getSelectedShapeIds())
 				},
 			},
@@ -558,10 +558,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					trackEvent('group-shapes', { source })
 					const onlySelectedShape = editor.getOnlySelectedShape()
 					if (onlySelectedShape && editor.isShapeOfType<TLGroupShape>(onlySelectedShape, 'group')) {
-						editor.mark('ungroup')
+						editor.markHistoryStoppingPoint('ungroup')
 						editor.ungroupShapes(editor.getSelectedShapeIds())
 					} else {
-						editor.mark('group')
+						editor.markHistoryStoppingPoint('group')
 						editor.groupShapes(editor.getSelectedShapeIds())
 					}
 				},
@@ -579,7 +579,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						selectedShapes.length > 0 &&
 						selectedShapes.every((shape) => editor.isShapeOfType<TLFrameShape>(shape, 'frame'))
 					) {
-						editor.mark('remove-frame')
+						editor.markHistoryStoppingPoint('remove-frame')
 						removeFrame(
 							editor,
 							selectedShapes.map((shape) => shape.id)
@@ -596,7 +596,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					trackEvent('fit-frame-to-content', { source })
 					const onlySelectedShape = editor.getOnlySelectedShape()
 					if (onlySelectedShape && editor.isShapeOfType<TLFrameShape>(onlySelectedShape, 'frame')) {
-						editor.mark('fit-frame-to-content')
+						editor.markHistoryStoppingPoint('fit-frame-to-content')
 						fitFrameToContent(editor, onlySelectedShape.id)
 					}
 				},
@@ -611,7 +611,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'left', source })
-					editor.mark('align left')
+					editor.markHistoryStoppingPoint('align left')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'left')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -630,7 +630,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-horizontal', source })
-					editor.mark('align center horizontal')
+					editor.markHistoryStoppingPoint('align center horizontal')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'center-horizontal')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -646,7 +646,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'right', source })
-					editor.mark('align right')
+					editor.markHistoryStoppingPoint('align right')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'right')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -665,7 +665,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-vertical', source })
-					editor.mark('align center vertical')
+					editor.markHistoryStoppingPoint('align center vertical')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'center-vertical')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -681,7 +681,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'top', source })
-					editor.mark('align top')
+					editor.markHistoryStoppingPoint('align top')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'top')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -697,7 +697,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'bottom', source })
-					editor.mark('align bottom')
+					editor.markHistoryStoppingPoint('align bottom')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.alignShapes(selectedShapeIds, 'bottom')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -716,7 +716,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'horizontal', source })
-					editor.mark('distribute horizontal')
+					editor.markHistoryStoppingPoint('distribute horizontal')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.distributeShapes(selectedShapeIds, 'horizontal')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -735,7 +735,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'vertical', source })
-					editor.mark('distribute vertical')
+					editor.markHistoryStoppingPoint('distribute vertical')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.distributeShapes(selectedShapeIds, 'vertical')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -753,7 +753,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'horizontal', source })
-					editor.mark('stretch horizontal')
+					editor.markHistoryStoppingPoint('stretch horizontal')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.stretchShapes(selectedShapeIds, 'horizontal')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -771,7 +771,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'vertical', source })
-					editor.mark('stretch vertical')
+					editor.markHistoryStoppingPoint('stretch vertical')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.stretchShapes(selectedShapeIds, 'vertical')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -789,7 +789,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'horizontal', source })
-					editor.mark('flip horizontal')
+					editor.markHistoryStoppingPoint('flip horizontal')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.flipShapes(selectedShapeIds, 'horizontal')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -804,7 +804,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'vertical', source })
-					editor.mark('flip vertical')
+					editor.markHistoryStoppingPoint('flip vertical')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.flipShapes(selectedShapeIds, 'vertical')
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -819,7 +819,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('pack-shapes', { source })
-					editor.mark('pack')
+					editor.markHistoryStoppingPoint('pack')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.packShapes(selectedShapeIds, editor.options.adjacentShapeMargin)
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -837,7 +837,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'vertical', source })
-					editor.mark('stack-vertical')
+					editor.markHistoryStoppingPoint('stack-vertical')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.stackShapes(selectedShapeIds, 'vertical', 16)
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -855,7 +855,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'horizontal', source })
-					editor.mark('stack-horizontal')
+					editor.markHistoryStoppingPoint('stack-horizontal')
 					const selectedShapeIds = editor.getSelectedShapeIds()
 					editor.stackShapes(selectedShapeIds, 'horizontal', 16)
 					kickoutOccludedShapes(editor, selectedShapeIds)
@@ -871,7 +871,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toFront', source })
-					editor.mark('bring to front')
+					editor.markHistoryStoppingPoint('bring to front')
 					editor.bringToFront(editor.getSelectedShapeIds())
 				},
 			},
@@ -885,7 +885,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'forward', source })
-					editor.mark('bring forward')
+					editor.markHistoryStoppingPoint('bring forward')
 					editor.bringForward(editor.getSelectedShapeIds())
 				},
 			},
@@ -899,7 +899,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'backward', source })
-					editor.mark('send backward')
+					editor.markHistoryStoppingPoint('send backward')
 					editor.sendBackward(editor.getSelectedShapeIds())
 				},
 			},
@@ -913,7 +913,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toBack', source })
-					editor.mark('send to back')
+					editor.markHistoryStoppingPoint('send to back')
 					editor.sendToBack(editor.getSelectedShapeIds())
 				},
 			},
@@ -925,7 +925,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (!canApplySelectionAction()) return
 					if (mustGoBackToSelectToolFirst()) return
 
-					editor.mark('cut')
+					editor.markHistoryStoppingPoint('cut')
 					cut(source)
 				},
 			},
@@ -975,7 +975,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 						trackEvent('select-all-shapes', { source })
 
-						editor.mark('select all kbd')
+						editor.markHistoryStoppingPoint('select all kbd')
 						editor.selectAll()
 					})
 				},
@@ -989,7 +989,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('select-none-shapes', { source })
-					editor.mark('select none')
+					editor.markHistoryStoppingPoint('select none')
 					editor.selectNone()
 				},
 			},
@@ -1003,7 +1003,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('delete-shapes', { source })
-					editor.mark('delete')
+					editor.markHistoryStoppingPoint('delete')
 					editor.deleteShapes(editor.getSelectedShapeIds())
 				},
 			},
@@ -1016,7 +1016,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('rotate-cw', { source })
-					editor.mark('rotate-cw')
+					editor.markHistoryStoppingPoint('rotate-cw')
 					const offset = editor.getSelectionRotation() % (HALF_PI / 2)
 					const dontUseOffset = approximately(offset, 0) || approximately(offset, HALF_PI / 2)
 					const selectedShapeIds = editor.getSelectedShapeIds()
@@ -1033,7 +1033,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('rotate-ccw', { source })
-					editor.mark('rotate-ccw')
+					editor.markHistoryStoppingPoint('rotate-ccw')
 					const offset = editor.getSelectionRotation() % (HALF_PI / 2)
 					const offsetCloseToZero = approximately(offset, 0)
 					const selectedShapeIds = editor.getSelectedShapeIds()
@@ -1351,7 +1351,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.toggle-lock',
 				kbd: '!l',
 				onSelect(source) {
-					editor.mark('locking')
+					editor.markHistoryStoppingPoint('locking')
 					trackEvent('toggle-lock', { source })
 					editor.toggleLock(editor.getSelectedShapeIds())
 				},
@@ -1363,7 +1363,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const newPageId = PageRecordType.createId()
 					const ids = editor.getSelectedShapeIds()
 					editor.run(() => {
-						editor.mark('move_shapes_to_page')
+						editor.markHistoryStoppingPoint('move_shapes_to_page')
 						editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
 						editor.moveShapesToPage(ids, newPageId)
 					})
@@ -1377,7 +1377,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect(source) {
 					const style = DefaultColorStyle
 					editor.run(() => {
-						editor.mark('change-color')
+						editor.markHistoryStoppingPoint('change-color')
 						if (editor.isIn('select')) {
 							editor.setStyleForSelectedShapes(style, 'white')
 						}
@@ -1393,7 +1393,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect(source) {
 					const style = DefaultFillStyle
 					editor.run(() => {
-						editor.mark('change-fill')
+						editor.markHistoryStoppingPoint('change-fill')
 						if (editor.isIn('select')) {
 							editor.setStyleForSelectedShapes(style, 'fill')
 						}
@@ -1410,7 +1410,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const ids = editor.getSelectedShapeIds()
 					if (ids.length === 0) return
 
-					editor.mark('flattening to image')
+					editor.markHistoryStoppingPoint('flattening to image')
 					trackEvent('flatten-to-image', { source })
 
 					const newShapeIds = await flattenShapesToImages(

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/__snapshots__/pasteExcalidrawContent.test.tsx.snap
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/__snapshots__/pasteExcalidrawContent.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -222,7 +222,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -268,7 +268,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -332,7 +332,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -378,7 +378,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -418,7 +418,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -452,7 +452,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -486,7 +486,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "align": "middle",
       "color": "black",
@@ -516,7 +516,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -568,7 +568,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -614,7 +614,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -666,7 +666,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -706,7 +706,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -746,7 +746,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -780,7 +780,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -820,7 +820,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -866,7 +866,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -918,7 +918,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -970,7 +970,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1022,7 +1022,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1068,7 +1068,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1102,7 +1102,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1142,7 +1142,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1188,7 +1188,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1240,7 +1240,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "align": "middle",
       "color": "black",
@@ -1270,7 +1270,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1322,7 +1322,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1362,7 +1362,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1402,7 +1402,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1460,7 +1460,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1506,7 +1506,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "align": "middle",
       "color": "black",
@@ -1536,7 +1536,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",
@@ -1570,8 +1570,8 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "x": 221.5413287284482,
     "y": 106.76849833351537,
   },
-  "shape:76": {
-    "id": "shape:76",
+  "shape:77": {
+    "id": "shape:77",
     "index": "aY",
     "isLocked": false,
     "meta": {},
@@ -1590,7 +1590,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "align": "middle",
       "color": "black",
@@ -1620,7 +1620,7 @@ exports[`pasteExcalidrawContent test fixtures line-drawing.json 1`] = `
     "isLocked": false,
     "meta": {},
     "opacity": 1,
-    "parentId": "shape:76",
+    "parentId": "shape:77",
     "props": {
       "color": "black",
       "dash": "solid",

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteExcalidrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteExcalidrawContent.ts
@@ -316,7 +316,7 @@ export async function pasteExcalidrawContent(editor: Editor, clipboard: any, poi
 
 	const p = point ?? (editor.inputs.shiftKey ? editor.inputs.currentPagePoint : undefined)
 
-	editor.mark('paste')
+	editor.markHistoryStoppingPoint('paste')
 
 	editor.putContentOntoCurrentPage(tldrawContent, {
 		point: p,

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
@@ -17,7 +17,7 @@ export async function pasteFiles(
 	const blobs = await Promise.all(urls.map(async (url) => await (await fetch(url)).blob()))
 	const files = blobs.map((blob) => new File([blob], 'tldrawFile', { type: blob.type }))
 
-	editor.mark('paste')
+	editor.markHistoryStoppingPoint('paste')
 
 	await editor.putExternalContent({
 		type: 'files',

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteTldrawContent.ts
@@ -10,7 +10,7 @@ import { Editor, TLContent, VecLike } from '@tldraw/editor'
  */
 export function pasteTldrawContent(editor: Editor, clipboard: TLContent, point?: VecLike) {
 	const selectionBoundsBefore = editor.getSelectionPageBounds()
-	editor.mark('paste')
+	editor.markHistoryStoppingPoint('paste')
 	editor.putContentOntoCurrentPage(clipboard, {
 		point: point,
 		select: true,

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
@@ -15,7 +15,7 @@ export async function pasteUrl(
 	point?: VecLike,
 	sources?: TLExternalContentSource[]
 ) {
-	editor.mark('paste')
+	editor.markHistoryStoppingPoint('paste')
 
 	return await editor.putExternalContent({
 		type: 'url',

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -115,7 +115,7 @@ const handleText = (
 	} else if (isValidHttpURL(data)) {
 		pasteUrl(editor, data, point)
 	} else if (isSvgText(data)) {
-		editor.mark('paste')
+		editor.markHistoryStoppingPoint('paste')
 		editor.putExternalContent({
 			type: 'svg-text',
 			text: data,
@@ -123,7 +123,7 @@ const handleText = (
 			sources,
 		})
 	} else {
-		editor.mark('paste')
+		editor.markHistoryStoppingPoint('paste')
 		editor.putExternalContent({
 			type: 'text',
 			text: data,

--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -14,7 +14,7 @@ export function useInsertMedia() {
 		async function onchange(e: Event) {
 			const fileList = (e.target as HTMLInputElement).files
 			if (!fileList || fileList.length === 0) return
-			editor.mark('insert media')
+			editor.markHistoryStoppingPoint('insert media')
 			await editor.putExternalContent({
 				type: 'files',
 				files: Array.from(fileList),

--- a/packages/tldraw/src/lib/utils/tldr/__snapshots__/buildFromV1Document.test.ts.snap
+++ b/packages/tldraw/src/lib/utils/tldr/__snapshots__/buildFromV1Document.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
 {
-  "binding:15": {
-    "fromId": "shape:13",
-    "id": "binding:15",
+  "binding:19": {
+    "fromId": "shape:17",
+    "id": "binding:19",
     "meta": {},
     "props": {
       "isExact": false,
@@ -15,13 +15,13 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
       },
       "terminal": "start",
     },
-    "toId": "shape:11",
+    "toId": "shape:15",
     "type": "arrow",
     "typeName": "binding",
   },
-  "binding:17": {
-    "fromId": "shape:13",
-    "id": "binding:17",
+  "binding:21": {
+    "fromId": "shape:17",
+    "id": "binding:21",
     "meta": {},
     "props": {
       "isExact": false,
@@ -32,7 +32,7 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
       },
       "terminal": "end",
     },
-    "toId": "shape:9",
+    "toId": "shape:13",
     "type": "arrow",
     "typeName": "binding",
   },
@@ -50,8 +50,38 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
     "name": "Page 1",
     "typeName": "page",
   },
-  "shape:11": {
-    "id": "shape:11",
+  "shape:13": {
+    "id": "shape:13",
+    "index": "a1",
+    "isLocked": false,
+    "meta": {},
+    "opacity": 1,
+    "parentId": "page:page",
+    "props": {
+      "align": "middle",
+      "color": "red",
+      "dash": "draw",
+      "fill": "solid",
+      "font": "draw",
+      "geo": "rectangle",
+      "growY": 0,
+      "h": 177.03,
+      "labelColor": "red",
+      "scale": 1,
+      "size": "m",
+      "text": "",
+      "url": "",
+      "verticalAlign": "middle",
+      "w": 136.64,
+    },
+    "rotation": 0,
+    "type": "geo",
+    "typeName": "shape",
+    "x": 1388.92,
+    "y": 820.52,
+  },
+  "shape:15": {
+    "id": "shape:15",
     "index": "a2",
     "isLocked": false,
     "meta": {},
@@ -80,8 +110,8 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
     "x": 1616.09,
     "y": 584.28,
   },
-  "shape:13": {
-    "id": "shape:13",
+  "shape:17": {
+    "id": "shape:17",
     "index": "a3",
     "isLocked": false,
     "meta": {},
@@ -115,8 +145,61 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
     "x": 1541.56,
     "y": 698.67,
   },
-  "shape:9": {
-    "id": "shape:9",
+}
+`;
+
+exports[`buildFromV1Document test fixtures exact-arrow-binding.tldr 1`] = `
+{
+  "binding:18": {
+    "fromId": "shape:16",
+    "id": "binding:18",
+    "meta": {},
+    "props": {
+      "isExact": true,
+      "isPrecise": true,
+      "normalizedAnchor": {
+        "x": 0.6250000000000002,
+        "y": 0.5700000000000003,
+      },
+      "terminal": "start",
+    },
+    "toId": "shape:14",
+    "type": "arrow",
+    "typeName": "binding",
+  },
+  "binding:20": {
+    "fromId": "shape:16",
+    "id": "binding:20",
+    "meta": {},
+    "props": {
+      "isExact": true,
+      "isPrecise": true,
+      "normalizedAnchor": {
+        "x": 0.5,
+        "y": 0.5,
+      },
+      "terminal": "end",
+    },
+    "toId": "shape:12",
+    "type": "arrow",
+    "typeName": "binding",
+  },
+  "document:document": {
+    "gridSize": 10,
+    "id": "document:document",
+    "meta": {},
+    "name": "",
+    "typeName": "document",
+  },
+  "page:page": {
+    "id": "page:page",
+    "index": "a1",
+    "meta": {},
+    "name": "Page 1",
+    "typeName": "page",
+  },
+  "shape:12": {
+    "id": "shape:12",
     "index": "a1",
     "isLocked": false,
     "meta": {},
@@ -142,64 +225,11 @@ exports[`buildFromV1Document test fixtures arrow-binding.tldr 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 1388.92,
-    "y": 820.52,
+    "x": 1418.93,
+    "y": 779.31,
   },
-}
-`;
-
-exports[`buildFromV1Document test fixtures exact-arrow-binding.tldr 1`] = `
-{
-  "binding:14": {
-    "fromId": "shape:12",
-    "id": "binding:14",
-    "meta": {},
-    "props": {
-      "isExact": true,
-      "isPrecise": true,
-      "normalizedAnchor": {
-        "x": 0.6250000000000002,
-        "y": 0.5700000000000003,
-      },
-      "terminal": "start",
-    },
-    "toId": "shape:10",
-    "type": "arrow",
-    "typeName": "binding",
-  },
-  "binding:16": {
-    "fromId": "shape:12",
-    "id": "binding:16",
-    "meta": {},
-    "props": {
-      "isExact": true,
-      "isPrecise": true,
-      "normalizedAnchor": {
-        "x": 0.5,
-        "y": 0.5,
-      },
-      "terminal": "end",
-    },
-    "toId": "shape:8",
-    "type": "arrow",
-    "typeName": "binding",
-  },
-  "document:document": {
-    "gridSize": 10,
-    "id": "document:document",
-    "meta": {},
-    "name": "",
-    "typeName": "document",
-  },
-  "page:page": {
-    "id": "page:page",
-    "index": "a1",
-    "meta": {},
-    "name": "Page 1",
-    "typeName": "page",
-  },
-  "shape:10": {
-    "id": "shape:10",
+  "shape:14": {
+    "id": "shape:14",
     "index": "a2",
     "isLocked": false,
     "meta": {},
@@ -228,8 +258,8 @@ exports[`buildFromV1Document test fixtures exact-arrow-binding.tldr 1`] = `
     "x": 1616.09,
     "y": 584.28,
   },
-  "shape:12": {
-    "id": "shape:12",
+  "shape:16": {
+    "id": "shape:16",
     "index": "a3",
     "isLocked": false,
     "meta": {},
@@ -263,8 +293,44 @@ exports[`buildFromV1Document test fixtures exact-arrow-binding.tldr 1`] = `
     "x": 1510.86,
     "y": 661.97,
   },
-  "shape:8": {
-    "id": "shape:8",
+}
+`;
+
+exports[`buildFromV1Document test fixtures incorrect-arrow-binding.tldr 1`] = `
+{
+  "binding:18": {
+    "fromId": "shape:16",
+    "id": "binding:18",
+    "meta": {},
+    "props": {
+      "isExact": false,
+      "isPrecise": true,
+      "normalizedAnchor": {
+        "x": 0.385,
+        "y": 0.425,
+      },
+      "terminal": "end",
+    },
+    "toId": "shape:12",
+    "type": "arrow",
+    "typeName": "binding",
+  },
+  "document:document": {
+    "gridSize": 10,
+    "id": "document:document",
+    "meta": {},
+    "name": "",
+    "typeName": "document",
+  },
+  "page:page": {
+    "id": "page:page",
+    "index": "a1",
+    "meta": {},
+    "name": "Page 1",
+    "typeName": "page",
+  },
+  "shape:12": {
+    "id": "shape:12",
     "index": "a1",
     "isLocked": false,
     "meta": {},
@@ -290,47 +356,11 @@ exports[`buildFromV1Document test fixtures exact-arrow-binding.tldr 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 1418.93,
-    "y": 779.31,
+    "x": 1391.66,
+    "y": 769.92,
   },
-}
-`;
-
-exports[`buildFromV1Document test fixtures incorrect-arrow-binding.tldr 1`] = `
-{
-  "binding:14": {
-    "fromId": "shape:12",
-    "id": "binding:14",
-    "meta": {},
-    "props": {
-      "isExact": false,
-      "isPrecise": true,
-      "normalizedAnchor": {
-        "x": 0.385,
-        "y": 0.425,
-      },
-      "terminal": "end",
-    },
-    "toId": "shape:8",
-    "type": "arrow",
-    "typeName": "binding",
-  },
-  "document:document": {
-    "gridSize": 10,
-    "id": "document:document",
-    "meta": {},
-    "name": "",
-    "typeName": "document",
-  },
-  "page:page": {
-    "id": "page:page",
-    "index": "a1",
-    "meta": {},
-    "name": "Page 1",
-    "typeName": "page",
-  },
-  "shape:10": {
-    "id": "shape:10",
+  "shape:14": {
+    "id": "shape:14",
     "index": "a2",
     "isLocked": false,
     "meta": {},
@@ -359,8 +389,8 @@ exports[`buildFromV1Document test fixtures incorrect-arrow-binding.tldr 1`] = `
     "x": 1362.24,
     "y": 784.23,
   },
-  "shape:12": {
-    "id": "shape:12",
+  "shape:16": {
+    "id": "shape:16",
     "index": "a1V",
     "isLocked": false,
     "meta": {},
@@ -393,36 +423,6 @@ exports[`buildFromV1Document test fixtures incorrect-arrow-binding.tldr 1`] = `
     "typeName": "shape",
     "x": 1544.3,
     "y": 817.34,
-  },
-  "shape:8": {
-    "id": "shape:8",
-    "index": "a1",
-    "isLocked": false,
-    "meta": {},
-    "opacity": 1,
-    "parentId": "page:page",
-    "props": {
-      "align": "middle",
-      "color": "red",
-      "dash": "draw",
-      "fill": "solid",
-      "font": "draw",
-      "geo": "rectangle",
-      "growY": 0,
-      "h": 177.03,
-      "labelColor": "red",
-      "scale": 1,
-      "size": "m",
-      "text": "",
-      "url": "",
-      "verticalAlign": "middle",
-      "w": 136.64,
-    },
-    "rotation": 0,
-    "type": "geo",
-    "typeName": "shape",
-    "x": 1391.66,
-    "y": 769.92,
   },
 }
 `;

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -207,7 +207,7 @@ export class TestEditor extends Editor {
 		if (this.clipboard !== null) {
 			const p = this.inputs.shiftKey ? this.inputs.currentPagePoint : point
 
-			this.mark('pasting')
+			this.markHistoryStoppingPoint('pasting')
 			this.putContentOntoCurrentPage(this.clipboard, {
 				point: p,
 				select: true,

--- a/packages/tldraw/src/test/cleanup.test.ts
+++ b/packages/tldraw/src/test/cleanup.test.ts
@@ -47,7 +47,7 @@ describe('restoring bound arrows', () => {
 	})
 
 	it('removes bound arrows on delete, restores them on undo but only when change was done by user', () => {
-		editor.mark('deleting')
+		editor.markHistoryStoppingPoint('deleting')
 		editor.deleteShapes([ids.box2])
 		expect(bindings().end).toBeUndefined()
 		editor.undo()
@@ -57,7 +57,7 @@ describe('restoring bound arrows', () => {
 	})
 
 	it('removes / restores multiple bindings', () => {
-		editor.mark('deleting')
+		editor.markHistoryStoppingPoint('deleting')
 		expect(bindings().start).toBeDefined()
 		expect(bindings().end).toBeDefined()
 
@@ -77,7 +77,7 @@ describe('restoring bound arrows', () => {
 
 describe('restoring bound arrows multiplayer', () => {
 	it('restores bound arrows after the shape was deleted by a different client', () => {
-		editor.mark('before creating box shape')
+		editor.markHistoryStoppingPoint('before creating box shape')
 		editor.createShapes([{ id: ids.box2, type: 'geo', x: 100, y: 0 }])
 
 		editor.setCurrentTool('arrow').pointerMove(0, 50).pointerDown().pointerMove(150, 50).pointerUp()

--- a/packages/tldraw/src/test/commands/alignShapes.test.tsx
+++ b/packages/tldraw/src/test/commands/alignShapes.test.tsx
@@ -32,7 +32,7 @@ describe('when less than two shapes are selected', () => {
 
 describe('when multiple shapes are selected', () => {
 	it('does, undoes and redoes command', () => {
-		editor.mark('align')
+		editor.markHistoryStoppingPoint('align')
 		editor.alignShapes(editor.getSelectedShapeIds(), 'top')
 		jest.advanceTimersByTime(1000)
 

--- a/packages/tldraw/src/test/commands/centerOnPoint.test.ts
+++ b/packages/tldraw/src/test/commands/centerOnPoint.test.ts
@@ -21,7 +21,7 @@ it('centers on the point with animation', () => {
 })
 
 it('is not undoable', () => {
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.centerOnPoint({ x: 400, y: 400 })
 	editor.undo()
 	expect(editor.getViewportPageCenter()).toMatchObject({ x: 400, y: 400 })

--- a/packages/tldraw/src/test/commands/createPage.test.ts
+++ b/packages/tldraw/src/test/commands/createPage.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 it('Creates a page', () => {
 	const oldPageId = editor.getCurrentPageId()
 	const n = editor.getPages().length
-	editor.mark('creating new page')
+	editor.markHistoryStoppingPoint('creating new page')
 	editor.createPage({ name: 'Page 1' })
 	expect(editor.getPages().length).toBe(n + 1)
 	const newPageId = editor.getPages()[n].id

--- a/packages/tldraw/src/test/commands/deletePage.test.ts
+++ b/packages/tldraw/src/test/commands/deletePage.test.ts
@@ -20,13 +20,13 @@ describe('deletePage', () => {
 	})
 	it('is undoable and redoable', () => {
 		const page2Id = PageRecordType.createId('page2')
-		editor.mark('before creating page')
+		editor.markHistoryStoppingPoint('before creating page')
 		editor.createPage({ name: 'New Page 2', id: page2Id })
 
 		const pages = editor.getPages()
 		expect(pages.length).toBe(2)
 
-		editor.mark('before deleting page')
+		editor.markHistoryStoppingPoint('before deleting page')
 		editor.deletePage(pages[0].id)
 		expect(editor.getPages().length).toBe(1)
 
@@ -39,7 +39,7 @@ describe('deletePage', () => {
 	})
 	it('does not allow deleting all pages', () => {
 		const page2Id = PageRecordType.createId('page2')
-		editor.mark('before creating page')
+		editor.markHistoryStoppingPoint('before creating page')
 		editor.createPage({ name: 'New Page 2', id: page2Id })
 
 		const pages = editor.getPages()
@@ -53,7 +53,7 @@ describe('deletePage', () => {
 	})
 	it('switches the page if you are deleting the current page', () => {
 		const page2Id = PageRecordType.createId('page2')
-		editor.mark('before creating page')
+		editor.markHistoryStoppingPoint('before creating page')
 		editor.createPage({ name: 'New Page 2', id: page2Id })
 
 		const currentPageId = editor.getCurrentPageId()
@@ -65,7 +65,7 @@ describe('deletePage', () => {
 	it('switches the page if another user or tab deletes the current page', () => {
 		const currentPageId = editor.getCurrentPageId()
 		const page2Id = PageRecordType.createId('page2')
-		editor.mark('before creating')
+		editor.markHistoryStoppingPoint('before creating')
 		editor.createPage({ name: 'New Page 2', id: page2Id })
 
 		editor.store.mergeRemoteChanges(() => {

--- a/packages/tldraw/src/test/commands/deleteShapes.test.ts
+++ b/packages/tldraw/src/test/commands/deleteShapes.test.ts
@@ -66,7 +66,7 @@ beforeEach(() => {
 describe('Editor.deleteShapes', () => {
 	it('Deletes a shape', () => {
 		editor.select(ids.box3, ids.box4)
-		editor.mark('before deleting')
+		editor.markHistoryStoppingPoint('before deleting')
 		editor.deleteShapes(editor.getSelectedShapeIds()) // delete the selected shapes
 		expect(editor.getShape(ids.box3)).toBeUndefined()
 		expect(editor.getShape(ids.box4)).toBeUndefined()
@@ -91,7 +91,7 @@ describe('Editor.deleteShapes', () => {
 	it('Deletes descendants', () => {
 		editor.reparentShapes([ids.box4], ids.box3)
 		editor.select(ids.box3)
-		editor.mark('before deleting')
+		editor.markHistoryStoppingPoint('before deleting')
 		editor.deleteShapes(editor.getSelectedShapeIds()) // should be a noop, nothing to delete
 		expect(editor.getShape(ids.box3)).toBeUndefined()
 		expect(editor.getShape(ids.box4)).toBeUndefined()
@@ -110,7 +110,7 @@ describe('When deleting arrows', () => {
 	}
 	it('Restores any bindings on undo', () => {
 		editor.select(ids.arrow1)
-		editor.mark('before deleting')
+		editor.markHistoryStoppingPoint('before deleting')
 
 		expect(bindings().start).toBeDefined()
 		expect(bindings().end).toBeDefined()

--- a/packages/tldraw/src/test/commands/moveShapesToPage.test.ts
+++ b/packages/tldraw/src/test/commands/moveShapesToPage.test.ts
@@ -91,7 +91,7 @@ describe('Editor.moveShapesToPage', () => {
 			ids.ellipse1,
 		])
 
-		editor.mark('move shapes to page')
+		editor.markHistoryStoppingPoint('move shapes to page')
 		editor.moveShapesToPage([ids.box2], ids.page2)
 
 		expect(editor.getCurrentPageId()).toBe(ids.page2)

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -38,22 +38,22 @@ function nudgeAndGet(ids: TLShapeId[], key: string, shiftKey: boolean) {
 	const step = editor.getInstanceState().isGridMode ? (shiftKey ? 50 : 10) : shiftKey ? 10 : 1
 	switch (key) {
 		case 'ArrowLeft': {
-			editor.mark('nudge')
+			editor.markHistoryStoppingPoint('nudge')
 			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(-step, 0))
 			break
 		}
 		case 'ArrowRight': {
-			editor.mark('nudge')
+			editor.markHistoryStoppingPoint('nudge')
 			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(step, 0))
 			break
 		}
 		case 'ArrowUp': {
-			editor.mark('nudge')
+			editor.markHistoryStoppingPoint('nudge')
 			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(0, -step))
 			break
 		}
 		case 'ArrowDown': {
-			editor.mark('nudge')
+			editor.markHistoryStoppingPoint('nudge')
 			editor.nudgeShapes(editor.getSelectedShapeIds(), new Vec(0, step))
 			break
 		}

--- a/packages/tldraw/src/test/commands/pan.test.ts
+++ b/packages/tldraw/src/test/commands/pan.test.ts
@@ -27,7 +27,7 @@ describe('When panning', () => {
 	})
 
 	it('Is not undoable', () => {
-		editor.mark()
+		editor.markHistoryStoppingPoint()
 		editor.pan({ x: 200, y: 200 })
 		editor.undo()
 		editor.expectCameraToBe(200, 200, 1)

--- a/packages/tldraw/src/test/commands/reorderShapes.test.ts
+++ b/packages/tldraw/src/test/commands/reorderShapes.test.ts
@@ -869,7 +869,7 @@ describe('When undoing and redoing...', () => {
 			ids['G']
 		)
 
-		editor.mark('before sending to back')
+		editor.markHistoryStoppingPoint('before sending to back')
 		editor.sendBackward([ids['F'], ids['G']])
 
 		expectShapesInOrder(

--- a/packages/tldraw/src/test/commands/resetZoom.test.ts
+++ b/packages/tldraw/src/test/commands/resetZoom.test.ts
@@ -30,12 +30,12 @@ describe('When resetting zoom', () => {
 
 	it('is not undoable', () => {
 		editor.zoomOut()
-		editor.mark()
+		editor.markHistoryStoppingPoint()
 		editor.resetZoom()
 		editor.undo()
 		expect(editor.getZoomLevel()).toBe(1)
 
-		editor.mark()
+		editor.markHistoryStoppingPoint()
 		editor.zoomIn()
 		editor.resetZoom()
 		editor.undo()

--- a/packages/tldraw/src/test/commands/resizeShape.test.ts
+++ b/packages/tldraw/src/test/commands/resizeShape.test.ts
@@ -23,7 +23,7 @@ describe('resizing a shape', () => {
 	it('always squashes history entries', () => {
 		editor.createShapes([{ id: ids.boxA, type: 'geo', props: { w: 100, h: 100 } }])
 
-		editor.mark('start')
+		editor.markHistoryStoppingPoint('start')
 		const startHistoryLength = editor.getHistory().getNumUndos()
 		editor.resizeShape(ids.boxA, { x: 2, y: 2 })
 		expect(editor.getHistory().getNumUndos()).toBe(startHistoryLength + 1)

--- a/packages/tldraw/src/test/commands/setSelectedIds.test.ts
+++ b/packages/tldraw/src/test/commands/setSelectedIds.test.ts
@@ -36,7 +36,7 @@ it('Deleting the parent also deletes descendants', () => {
 	expect(editor.getShape(ids.box2)).not.toBeUndefined()
 	expect(editor.getShape(ids.ellipse1)).not.toBeUndefined()
 
-	editor.mark('')
+	editor.markHistoryStoppingPoint('')
 	editor.deleteShapes([ids.box2])
 
 	expect(editor.getSelectedShapeIds()).toMatchObject([])
@@ -57,12 +57,12 @@ it('Deleting the parent also deletes descendants', () => {
 })
 
 it('preserves the redo stack', () => {
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.select(ids.box1)
 	editor.translateSelection(10, 10)
 	expect(editor.getShape(ids.box1)).toMatchObject({ x: 110, y: 110 })
 
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.translateSelection(10, 10)
 	expect(editor.getShape(ids.box1)).toMatchObject({ x: 120, y: 120 })
 

--- a/packages/tldraw/src/test/commands/stretch.test.tsx
+++ b/packages/tldraw/src/test/commands/stretch.test.tsx
@@ -89,7 +89,7 @@ describe('when multiple shapes are selected', () => {
 	})
 
 	it('does, undoes and redoes command', () => {
-		editor.mark('stretch')
+		editor.markHistoryStoppingPoint('stretch')
 		editor.stretchShapes(editor.getSelectedShapeIds(), 'horizontal')
 		jest.advanceTimersByTime(1000)
 

--- a/packages/tldraw/src/test/commands/updateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/updateShapes.test.ts
@@ -81,7 +81,7 @@ it('Uses typescript generics', () => {
 })
 
 it('updates shapes', () => {
-	editor.mark('update shapes')
+	editor.markHistoryStoppingPoint('update shapes')
 	editor.updateShapes([
 		{
 			id: ids.box1,

--- a/packages/tldraw/src/test/commands/zoomIn.test.ts
+++ b/packages/tldraw/src/test/commands/zoomIn.test.ts
@@ -26,7 +26,7 @@ it('zooms by increments', () => {
 it('is ignored by undo/redo', () => {
 	const cameraOptions = editor.getCameraOptions()
 
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.zoomIn()
 	editor.undo()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4])

--- a/packages/tldraw/src/test/commands/zoomOut.test.ts
+++ b/packages/tldraw/src/test/commands/zoomOut.test.ts
@@ -25,7 +25,7 @@ it('zooms out and in by increments', () => {
 it('is ignored by undo/redo', () => {
 	const cameraOptions = editor.getCameraOptions()
 
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.zoomOut()
 	editor.undo()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2])

--- a/packages/tldraw/src/test/commands/zoomToBounds.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToBounds.test.ts
@@ -50,7 +50,7 @@ it('does not zoom to bounds when camera is frozen', () => {
 })
 
 it('is ignored by undo/redo', () => {
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.zoomToBounds(new Box(200, 300, 300, 300))
 	editor.undo()
 	expect(editor.getViewportPageCenter().toJson()).toCloselyMatchObject({ x: 350, y: 450 })

--- a/packages/tldraw/src/test/commands/zoomToFit.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToFit.test.ts
@@ -20,7 +20,7 @@ it('does not zoom to bounds when camera is frozen', () => {
 })
 
 it('is ignored by undo/redo', () => {
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.zoomToFit()
 	const camera = editor.getCamera()
 	editor.undo()

--- a/packages/tldraw/src/test/commands/zoomToSelection.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToSelection.test.ts
@@ -42,7 +42,7 @@ it('does not zoom to selection when camera is frozen', () => {
 })
 
 it('is ignored by undo/redo', () => {
-	editor.mark()
+	editor.markHistoryStoppingPoint()
 	editor.setSelectedShapes([ids.box1, ids.box2])
 	editor.zoomToSelection()
 	const camera = editor.getCamera()

--- a/packages/tldraw/src/test/flipShapes.test.ts
+++ b/packages/tldraw/src/test/flipShapes.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
 describe('When flipping horizontally', () => {
 	it('Flips the selected shapes', () => {
 		editor.select(ids.boxA, ids.boxB, ids.boxC)
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 
 		editor.expectShapeToMatch(
@@ -88,7 +88,7 @@ describe('When flipping horizontally', () => {
 	})
 
 	it('Flips the provided shapes', () => {
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes([ids.boxA, ids.boxB], 'horizontal')
 
 		editor.expectShapeToMatch(
@@ -109,7 +109,7 @@ describe('When flipping horizontally', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
 		const a = editor.getSelectionPageBounds()
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 
 		const b = editor.getSelectionPageBounds()
@@ -134,7 +134,7 @@ describe('When flipping horizontally', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
 		const a = editor.getSelectionPageBounds()
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 
 		const b = editor.getSelectionPageBounds()
@@ -145,7 +145,7 @@ describe('When flipping horizontally', () => {
 describe('When flipping vertically', () => {
 	it('Flips the selected shapes', () => {
 		editor.select(ids.boxA, ids.boxB, ids.boxC)
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'vertical')
 
 		editor.expectShapeToMatch(
@@ -168,7 +168,7 @@ describe('When flipping vertically', () => {
 	})
 
 	it('Flips the provided shapes', () => {
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes([ids.boxA, ids.boxB], 'vertical')
 
 		editor.expectShapeToMatch(
@@ -189,7 +189,7 @@ describe('When flipping vertically', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
 		const a = editor.getSelectionPageBounds()
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'vertical')
 
 		const b = editor.getSelectionPageBounds()
@@ -213,7 +213,7 @@ describe('When flipping vertically', () => {
 		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
 		const a = editor.getSelectionPageBounds()
-		editor.mark('flipped')
+		editor.markHistoryStoppingPoint('flipped')
 		editor.flipShapes(editor.getSelectedShapeIds(), 'vertical')
 
 		const b = editor.getSelectionPageBounds()
@@ -224,12 +224,12 @@ describe('When flipping vertically', () => {
 it('Preserves the selection bounds.', () => {
 	editor.selectAll()
 	const a = editor.getSelectionPageBounds()
-	editor.mark('flipped')
+	editor.markHistoryStoppingPoint('flipped')
 	editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 
 	const b = editor.getSelectionPageBounds()
 	expect(a).toMatchObject(b!)
-	editor.mark('flipped')
+	editor.markHistoryStoppingPoint('flipped')
 	editor.flipShapes(editor.getSelectedShapeIds(), 'vertical')
 
 	const c = editor.getSelectionPageBounds()
@@ -237,7 +237,7 @@ it('Preserves the selection bounds.', () => {
 })
 
 it('Does, undoes and redoes', () => {
-	editor.mark('flip vertical')
+	editor.markHistoryStoppingPoint('flip vertical')
 	editor.flipShapes([ids.boxA, ids.boxB], 'vertical')
 
 	editor.expectShapeToMatch(

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2173,3 +2173,39 @@ describe('Note shape grid helper positions / pits', () => {
 		editor.expectShapeToMatch({ id: shapeC.id, x: 221, y: 1 }) // not snapped
 	})
 })
+
+describe('cancelling a translate operation', () => {
+	it('undoes any changes since the start of the translate operation', () => {
+		editor.createShape<TLGeoShape>({
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: {
+				w: 100,
+				h: 100,
+			},
+		})
+
+		const shape = editor.getLastCreatedShape()
+
+		editor.select(shape)
+
+		const bounds = editor.getShapePageBounds(shape.id)!
+		editor.pointerDown(bounds.midX, bounds.midY)
+		editor.pointerMove(bounds.midX + 100, bounds.midY)
+		expect(editor.getShapePageBounds(shape.id)).toMatchObject({ x: 100, y: 0, w: 100, h: 100 })
+		editor.cancel()
+		expect(editor.getShapePageBounds(shape.id)).toMatchObject({ x: 0, y: 0, w: 100, h: 100 })
+	})
+
+	it('undoes the shape creation if creating a shape', () => {
+		editor.setCurrentTool('note')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('select.translating')
+		const shape = editor.getLastCreatedShape()
+		expect(editor.getShapePageBounds(shape)?.center).toMatchObject({ x: 100, y: 100 })
+		editor.cancel()
+		expect(editor.getShape(shape.id)).toBeUndefined()
+	})
+})

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -11,6 +11,7 @@ import {
 	createShapeId,
 } from '@tldraw/editor'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
+import { TranslatingInfo } from '../lib/tools/SelectTool/childStates/Translating'
 import { TestEditor } from './TestEditor'
 import { getSnapLines } from './getSnapLines'
 
@@ -2207,5 +2208,97 @@ describe('cancelling a translate operation', () => {
 		expect(editor.getShapePageBounds(shape)?.center).toMatchObject({ x: 100, y: 100 })
 		editor.cancel()
 		expect(editor.getShape(shape.id)).toBeUndefined()
+	})
+
+	it('handles legacy creating:{shapeId} marks created with editor.mark', () => {
+		const shapeId = createShapeId()
+
+		editor
+			.createShape<TLGeoShape>({
+				id: shapeId,
+				type: 'geo',
+				x: 0,
+				y: 0,
+				props: {
+					w: 100,
+					h: 100,
+				},
+			})
+			.select(shapeId)
+		const shape = editor.getOnlySelectedShape()!
+		editor.mark(`before`)
+		editor.updateShape({ ...shape, meta: { a: 'before' } })
+		editor.mark(`creating:${shapeId}`)
+		editor.updateShape({ ...shape, meta: { a: 'creating' } })
+		editor.mark(`after`)
+		editor.updateShape({ ...shape, meta: { a: 'after' } })
+		editor.pointerMove(0, 0)
+		editor.setCurrentTool('select.translating', {
+			type: 'pointer',
+			button: 0, // left mouse button
+			altKey: false,
+			ctrlKey: false,
+			isPen: false,
+			name: 'pointer_move',
+			point: { x: 0, y: 0 },
+			pointerId: 0,
+			shape: editor.getShape(shapeId)!,
+			shiftKey: false,
+			target: 'shape',
+			isCreating: true,
+		} satisfies TranslatingInfo)
+		expect(editor.getShapePageBounds(shapeId)?.center).toMatchObject({ x: 50, y: 50 })
+		editor.expectToBeIn('select.translating')
+		editor.pointerMove(100, 100)
+		expect(editor.getShapePageBounds(shapeId)?.center).toMatchObject({ x: 150, y: 150 })
+		expect(editor.getShape(shapeId)?.meta).toMatchObject({ a: 'after' })
+		editor.cancel()
+		expect(editor.getShape(shapeId)?.meta).toMatchObject({ a: 'before' })
+	})
+
+	it('handles legacy creating:{shapeId} marks created with editor.markHistoryStoppingPoint', () => {
+		const shapeId = createShapeId()
+
+		editor
+			.createShape<TLGeoShape>({
+				id: shapeId,
+				type: 'geo',
+				x: 0,
+				y: 0,
+				props: {
+					w: 100,
+					h: 100,
+				},
+			})
+			.select(shapeId)
+		const shape = editor.getOnlySelectedShape()!
+		editor.markHistoryStoppingPoint(`before`)
+		editor.updateShape({ ...shape, meta: { a: 'before' } })
+		editor.markHistoryStoppingPoint(`creating:${shapeId}`)
+		editor.updateShape({ ...shape, meta: { a: 'creating' } })
+		editor.markHistoryStoppingPoint(`after`)
+		editor.updateShape({ ...shape, meta: { a: 'after' } })
+		editor.pointerMove(0, 0)
+		editor.setCurrentTool('select.translating', {
+			type: 'pointer',
+			button: 0, // left mouse button
+			altKey: false,
+			ctrlKey: false,
+			isPen: false,
+			name: 'pointer_move',
+			point: { x: 0, y: 0 },
+			pointerId: 0,
+			shape: editor.getShape(shapeId)!,
+			shiftKey: false,
+			target: 'shape',
+			isCreating: true,
+		} satisfies TranslatingInfo)
+		expect(editor.getShapePageBounds(shapeId)?.center).toMatchObject({ x: 50, y: 50 })
+		editor.expectToBeIn('select.translating')
+		editor.pointerMove(100, 100)
+		expect(editor.getShapePageBounds(shapeId)?.center).toMatchObject({ x: 150, y: 150 })
+		expect(editor.getShape(shapeId)?.meta).toMatchObject({ a: 'after' })
+		editor.cancel()
+		expect(editor.getShape(shapeId)?.meta).toMatchObject({ a: 'before' })
 	})
 })

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2226,10 +2226,13 @@ describe('cancelling a translate operation', () => {
 			})
 			.select(shapeId)
 		const shape = editor.getOnlySelectedShape()!
+		// eslint-disable-next-line deprecation/deprecation
 		editor.mark(`before`)
 		editor.updateShape({ ...shape, meta: { a: 'before' } })
+		// eslint-disable-next-line deprecation/deprecation
 		editor.mark(`creating:${shapeId}`)
 		editor.updateShape({ ...shape, meta: { a: 'creating' } })
+		// eslint-disable-next-line deprecation/deprecation
 		editor.mark(`after`)
 		editor.updateShape({ ...shape, meta: { a: 'after' } })
 		editor.pointerMove(0, 0)


### PR DESCRIPTION
So it turns out `editor.mark(id)` is a bit problematic unless you always pass in unique id, because it's quite easy to create situations where you will call `bailToMark(id)` but the mark that you were _intending_ to bail to has already been popped off the stack due to another previous call to `bailToMark`.

I always suspected this might be the case (the original late 2022 history api was designed to avoid this, but it got changed at some point) and indeed I ran into this bug while investigating a cropping undo/redo test error.

To prevent issues for ourselves and our users, let's force people to use a randomly generated mark ID.

Also `editor.mark` is a bad name. `mark` could mean a million things, even in the context of `editor.history.mark` it's a pretty bad name. Let's help people out and make it more descriptive.

This PR deprecates the `editor.mark(id)` in favor of `id = editor.markHistoryStoppingPoint(name)`.

I converted a couple of usages of editor.mark over but there's a lot left to do so I only want to do it if you don't object @steveruizok 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

This deprecates `Editor.mark()` in favour of `Editor.markHistoryStoppingPoint()`.

This was done because calling `editor.mark(id)` is a potential footgun unless you always provide a random ID. So `editor.markHistoryStoppingPoint()` always returns a random id.