### PR TITLE
Load watermark, and fall back to local if it fails or takes too long

### DIFF
--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { featureFlags } from '../utils/debug-flags'
 import { LicenseManager } from './LicenseManager'
 import { Watermark } from './Watermark'
@@ -17,8 +17,11 @@ jest.mock('./LicenseProvider', () => ({
 	useLicenseContext: jest.fn().mockReturnValue({ state: { get: () => mockLicenseState } }),
 }))
 
+jest.useFakeTimers()
+
 export async function renderComponent() {
 	const result = render(<Watermark />)
+	jest.advanceTimersByTime(3000)
 	return result
 }
 
@@ -38,9 +41,12 @@ describe('Watermark', () => {
 	it('Displays the watermark when the editor is unlicensed', async () => {
 		featureFlags.enableLicensing.set(true)
 		const result = await renderComponent()
+
 		// Don't wanna but a data-testid here - makes it too easy to querySelect on.
-		expect((result.container.firstChild! as Element).nextElementSibling!.className).toBe(
-			LicenseManager.className
+		await waitFor(() =>
+			expect((result.container.firstChild! as Element).nextElementSibling!.className).toBe(
+				LicenseManager.className
+			)
 		)
 	})
 

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -1,6 +1,6 @@
 import { useValue } from '@tldraw/state-react'
 import { fetch } from '@tldraw/utils'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
 import { getDefaultCdnBaseUrl } from '../utils/assets'
@@ -88,8 +88,6 @@ export const Watermark = React.memo(function Watermark({
 		}
 	}, [shouldUseLocal, showWatermark])
 
-	const ref = useRef<HTMLAnchorElement>(null)
-
 	if (!showWatermark || !src) return null
 
 	const className = LicenseManager.className
@@ -164,7 +162,6 @@ To remove the watermark, please purchase a license at tldraw.dev.
 			</style>
 			<div className={className} data-debug={isDebugMode} draggable={false} {...events}>
 				<a
-					ref={ref}
 					href="https://tldraw.dev"
 					target="_blank"
 					rel="noreferrer"

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -73,6 +73,8 @@ export const Watermark = React.memo(function Watermark({
 	const [src, setSrc] = useState<string | null>(null)
 	const shouldUseLocal = forceLocal || licenseManager.isDevelopment
 	useEffect(() => {
+		if (!showWatermark) return
+
 		let isCancelled = false
 
 		;(async () => {
@@ -84,7 +86,7 @@ export const Watermark = React.memo(function Watermark({
 		return () => {
 			isCancelled = true
 		}
-	}, [shouldUseLocal])
+	}, [shouldUseLocal, showWatermark])
 
 	const ref = useRef<HTMLAnchorElement>(null)
 


### PR DESCRIPTION
Instead of relying on isOffline, we actually attempt to load the watermark properly and if it fails, then we fall back to the local version. 

I also noticed that the watermark URL was incorrect whilst testing this.

### Change type

- [x] `improvement`
