### PR TITLE
Update docs for dark mode. Add system color scheme docs.

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -638,7 +638,15 @@ editor.setCameraOptions({ isLocked: true })
 You can turn on or off dark mode via the [setUserPreferences](?) method. Note that this effects all editor instances that share the same user—even instances in other tabs.
 
 ```ts
-setUserPreferences({ isDarkMode: true })
+setUserPreferences({ colorScheme: 'dark' })
+```
+
+### Using the system color scheme
+
+You can also use the system color scheme via the [setUserPreferences](?) method.
+
+```ts
+setUserPreferences({ colorScheme: 'system' })
 ```
 
 ### Make changes without effecting the history


### PR DESCRIPTION
When reworking the dark mode I forgot to update the docs. Also added a section on using the system color scheme.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Update the dark mode docs. Add a section on how to use the system color scheme.