### PR TITLE
Allow non default z value for scribble points.

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1998,7 +1998,7 @@ export interface ScribbleItem {
 // @public (undocumented)
 export class ScribbleManager {
     constructor(editor: Editor);
-    addPoint: (id: ScribbleItem['id'], x: number, y: number) => ScribbleItem;
+    addPoint: (id: ScribbleItem['id'], x: number, y: number, z?: number) => ScribbleItem;
     // (undocumented)
     addScribble: (scribble: Partial<TLScribble>, id?: string) => ScribbleItem;
     // (undocumented)

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.test.ts
@@ -1,0 +1,28 @@
+import { TestEditor } from '../../test/TestEditor'
+import { ScribbleManager } from './ScribbleManager'
+
+describe('ScribbleManager', () => {
+	let editor: TestEditor
+	let scribbleManager: ScribbleManager
+
+	beforeEach(() => {
+		editor = new TestEditor()
+		scribbleManager = new ScribbleManager(editor)
+	})
+
+	it('add a point with a default z value', () => {
+		const { id } = scribbleManager.addScribble({})
+		scribbleManager.addPoint(id, 0, 0)
+		scribbleManager.tick(0)
+
+		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([{ x: 0, y: 0, z: 0.5 }])
+	})
+
+	it('add a point with a custom z value', () => {
+		const { id } = scribbleManager.addScribble({})
+		scribbleManager.addPoint(id, 0, 0, 0.7)
+		scribbleManager.tick(0)
+
+		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([{ x: 0, y: 0, z: 0.7 }])
+	})
+})

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.test.ts
@@ -12,17 +12,21 @@ describe('ScribbleManager', () => {
 
 	it('add a point with a default z value', () => {
 		const { id } = scribbleManager.addScribble({})
-		scribbleManager.addPoint(id, 0, 0)
+		scribbleManager.addPoint(id, 5, 10)
 		scribbleManager.tick(0)
 
-		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([{ x: 0, y: 0, z: 0.5 }])
+		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([
+			{ x: 5, y: 10, z: 0.5 },
+		])
 	})
 
 	it('add a point with a custom z value', () => {
 		const { id } = scribbleManager.addScribble({})
-		scribbleManager.addPoint(id, 0, 0, 0.7)
+		scribbleManager.addPoint(id, 5, 10, 0.7)
 		scribbleManager.tick(0)
 
-		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([{ x: 0, y: 0, z: 0.7 }])
+		expect(scribbleManager.scribbleItems.get(id)!.scribble.points).toEqual([
+			{ x: 5, y: 10, z: 0.7 },
+		])
 	})
 })

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -68,11 +68,11 @@ export class ScribbleManager {
 	 * @param point - The point to add.
 	 * @public
 	 */
-	addPoint = (id: ScribbleItem['id'], x: number, y: number) => {
+	addPoint = (id: ScribbleItem['id'], x: number, y: number, z = 0.5) => {
 		const item = this.scribbleItems.get(id)
 		if (!item) throw Error(`Scribble with id ${id} not found`)
 		const { prev } = item
-		const point = { x, y, z: 0.5 }
+		const point = { x, y, z }
 		if (!prev || Vec.Dist(prev, point) >= 1) {
 			item.next = point
 		}

--- a/packages/editor/src/lib/test/TestEditor.ts
+++ b/packages/editor/src/lib/test/TestEditor.ts
@@ -1,0 +1,30 @@
+import { createTLStore } from '../config/createTLStore'
+import { Editor, TLEditorOptions } from '../editor/Editor'
+import { StateNode } from '../editor/tools/StateNode'
+
+class CustomTool extends StateNode {
+	static override id = 'custom'
+}
+
+export class TestEditor extends Editor {
+	constructor(options: Partial<Omit<TLEditorOptions, 'store'>> = {}) {
+		const elm = document.createElement('div')
+		elm.tabIndex = 0
+
+		const shapeUtils = [...(options.shapeUtils ?? [])]
+		const bindingUtils = [...(options.bindingUtils ?? [])]
+
+		super({
+			...options,
+			shapeUtils,
+			bindingUtils,
+			tools: [...(options.tools ?? [CustomTool])],
+			store: createTLStore({
+				shapeUtils,
+				bindingUtils,
+			}),
+			getContainer: () => elm,
+			initialState: options.initialState ?? 'custom',
+		})
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/tldraw/tldraw/issues/2894

Added a simple `TestEditor`, since the one we already have is defined in the `tldraw` package and the `editor` package should not depend on it.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Allow scribble points to have non default z values.