### PR TITLE
Improve arrow label snapping

### DIFF
--- a/apps/examples/src/examples/basic/BasicExample.tsx
+++ b/apps/examples/src/examples/basic/BasicExample.tsx
@@ -4,12 +4,7 @@ import 'tldraw/tldraw.css'
 export default function BasicExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw
-				onMount={(editor) => {
-					;(window as any).editor = editor
-				}}
-				persistenceKey="example"
-			/>
+			<Tldraw persistenceKey="example" />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/basic/BasicExample.tsx
+++ b/apps/examples/src/examples/basic/BasicExample.tsx
@@ -4,7 +4,12 @@ import 'tldraw/tldraw.css'
 export default function BasicExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" />
+			<Tldraw
+				onMount={(editor) => {
+					;(window as any).editor = editor
+				}}
+				persistenceKey="example"
+			/>
 		</div>
 	)
 }

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -813,7 +813,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	}
 }
 
-function getLength(editor: Editor, shape: TLArrowShape): number {
+export function getArrowLength(editor: Editor, shape: TLArrowShape): number {
 	const info = getArrowInfo(editor, shape)!
 
 	return info.isStraight
@@ -853,7 +853,7 @@ const ArrowSvg = track(function ArrowSvg({
 	if (shouldDisplayHandles) {
 		const sw = 2 / editor.getZoomLevel()
 		const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
-			getLength(editor, shape),
+			getArrowLength(editor, shape),
 			sw,
 			{
 				end: 'skip',

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -23,6 +23,7 @@ import {
 	STROKE_SIZES,
 	TEXT_PROPS,
 } from '../shared/default-shape-constants'
+import { getArrowLength } from './ArrowShapeUtil'
 import { TLArrowInfo } from './arrow-types'
 import { getArrowInfo } from './shared'
 
@@ -265,36 +266,31 @@ function getCurvedArrowLabelRange(
 	const end = angleDistance(startAngle, constrainedEndAngle, direction) / fullDistance
 	return { start, end, dbg }
 }
-
+interface ArrowheadInfo {
+	hasStartBinding: boolean
+	hasEndBinding: boolean
+	hasStartArrowhead: boolean
+	hasEndArrowhead: boolean
+}
 export function getArrowLabelPosition(editor: Editor, shape: TLArrowShape) {
 	let labelCenter
 	const debugGeom: Geometry2d[] = []
 	const info = getArrowInfo(editor, shape)!
 
-	const hasStartBinding = !!info.bindings.start
-	const hasEndBinding = !!info.bindings.end
-	const hasStartArrowhead = info.start.arrowhead !== 'none'
-	const hasEndArrowhead = info.end.arrowhead !== 'none'
+	const arrowheadInfo: ArrowheadInfo = {
+		hasStartBinding: !!info.bindings.start,
+		hasEndBinding: !!info.bindings.end,
+		hasStartArrowhead: info.start.arrowhead !== 'none',
+		hasEndArrowhead: info.end.arrowhead !== 'none',
+	}
 	if (info.isStraight) {
 		const range = getStraightArrowLabelRange(editor, shape, info)
-		let clampedPosition = clamp(
-			shape.props.labelPosition,
-			hasStartArrowhead || hasStartBinding ? range.start : 0,
-			hasEndArrowhead || hasEndBinding ? range.end : 1
-		)
-		// This makes the position snap in the middle.
-		clampedPosition = clampedPosition >= 0.48 && clampedPosition <= 0.52 ? 0.5 : clampedPosition
+		const clampedPosition = getClampedPosition(editor, shape, range, arrowheadInfo)
 		labelCenter = Vec.Lrp(info.start.point, info.end.point, clampedPosition)
 	} else {
 		const range = getCurvedArrowLabelRange(editor, shape, info)
 		if (range.dbg) debugGeom.push(...range.dbg)
-		let clampedPosition = clamp(
-			shape.props.labelPosition,
-			hasStartArrowhead || hasStartBinding ? range.start : 0,
-			hasEndArrowhead || hasEndBinding ? range.end : 1
-		)
-		// This makes the position snap in the middle.
-		clampedPosition = clampedPosition >= 0.48 && clampedPosition <= 0.52 ? 0.5 : clampedPosition
+		const clampedPosition = getClampedPosition(editor, shape, range, arrowheadInfo)
 		const labelAngle = interpolateArcAngles(
 			Vec.Angle(info.bodyArc.center, info.start.point),
 			Vec.Angle(info.bodyArc.center, info.end.point),
@@ -307,6 +303,33 @@ export function getArrowLabelPosition(editor: Editor, shape: TLArrowShape) {
 	const labelSize = getArrowLabelSize(editor, shape)
 
 	return { box: Box.FromCenter(labelCenter, labelSize), debugGeom }
+}
+
+function getClampedPosition(
+	editor: Editor,
+	shape: TLArrowShape,
+	range: { start: number; end: number },
+	arrowheadInfo: ArrowheadInfo
+) {
+	const { hasEndArrowhead, hasEndBinding, hasStartBinding, hasStartArrowhead } = arrowheadInfo
+	const arrowLength = getArrowLength(editor, shape)
+	let clampedPosition = clamp(
+		shape.props.labelPosition,
+		hasStartArrowhead || hasStartBinding ? range.start : 0,
+		hasEndArrowhead || hasEndBinding ? range.end : 1
+	)
+	let snapDistance = 0.02
+	const zoomLevel = editor.getZoomLevel()
+	// When the arrow is very long and the user is zoomed in very far,
+	//or if the arrow is extremely long, reduce the snap distance
+	if ((arrowLength > 2000 && zoomLevel > 3) || arrowLength > 2500) snapDistance = 0.01
+	// when the arrow is super short and the user is zoomed out, increase the snap distance
+	if (arrowLength < 100) snapDistance = 0.03
+	clampedPosition =
+		clampedPosition >= 0.5 - snapDistance && clampedPosition <= 0.5 + snapDistance
+			? 0.5
+			: clampedPosition
+	return clampedPosition
 }
 
 function intersectArcPolygon(

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -14,7 +14,6 @@ import {
 	getPointOnCircle,
 	intersectCirclePolygon,
 	intersectLineSegmentPolygon,
-	lerp,
 } from '@tldraw/editor'
 import {
 	ARROW_LABEL_FONT_SIZES,
@@ -319,30 +318,12 @@ function getClampedPosition(
 		hasStartArrowhead || hasStartBinding ? range.start : 0,
 		hasEndArrowhead || hasEndBinding ? range.end : 1
 	)
-	const minLength = 100
-	const maxLength = 1500
-	const minSnapDistance = 0.03
-	const maxSnapDistance = 0.005
+	const snapDistance = Math.min(0.02, (500 / arrowLength) * 0.02)
 
-	let snapDistance = minSnapDistance
-	if (arrowLength > minLength) {
-		if (arrowLength < maxLength) {
-			snapDistance = lerp(
-				minSnapDistance,
-				maxSnapDistance,
-				(arrowLength - minLength) / (maxLength - minLength)
-			)
-		} else {
-			snapDistance = maxSnapDistance
-		}
-	}
-
-	const wasClamped = clampedPosition >= 0.5 - snapDistance && clampedPosition <= 0.5 + snapDistance
-
-	if (wasClamped) {
-		clampedPosition = 0.5
-		editor.updateShape({ ...shape, props: { ...shape.props, labelPosition: clampedPosition } })
-	}
+	clampedPosition =
+		clampedPosition >= 0.5 - snapDistance && clampedPosition <= 0.5 + snapDistance
+			? 0.5
+			: clampedPosition
 
 	return clampedPosition
 }


### PR DESCRIPTION
closes TLD-2242 , #2901

I tried scaling snapping behaviour with zoom, but then changing zoom levels changed the snap distance and caused some arrow labels to shift positions, which looked bad. Now the snap distance changes depending on the length of the arrow. Labels on longer arrows do still snap over longer distances, but the difference is less pronounced.

Labels do now snap to new positions sometimes when being resized.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a very long arrow
3. Label should now snap across a shorter distance

### Release notes

- Improved snapping distances on very long arrows