### PR TITLE
Add function property warning.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
 		'local/no-export-star': 'error',
 		'local/no-internal-imports': 'error',
 		'local/tagged-components': 'error',
+		'local/prefer-class-methods': 'warn',
 		'no-only-tests/no-only-tests': 'error',
 		'no-restricted-syntax': [
 			'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,6 @@ module.exports = {
 		'local/no-export-star': 'error',
 		'local/no-internal-imports': 'error',
 		'local/tagged-components': 'error',
-		'local/prefer-class-methods': 'warn',
 		'no-only-tests/no-only-tests': 'error',
 		'no-restricted-syntax': [
 			'error',

--- a/scripts/lib/eslint-plugin.ts
+++ b/scripts/lib/eslint-plugin.ts
@@ -428,4 +428,44 @@ exports.rules = {
 		},
 		defaultOptions: [],
 	}),
+	'prefer-class-methods': ESLintUtils.RuleCreator.withoutDocs({
+		create(context) {
+			return {
+				ClassBody(node: TSESTree.ClassBody) {
+					node.body.forEach((member) => {
+						if (
+							member.type === 'PropertyDefinition' &&
+							member.value &&
+							member.value.type === 'ArrowFunctionExpression'
+						) {
+							context.report({
+								node: member,
+								messageId: 'preferMethod',
+								fix(fixer) {
+									const sourceCode = context.getSourceCode()
+									const propertyName = sourceCode.getText(member.key)
+									if (!member.value || member.value.type !== 'ArrowFunctionExpression') return null
+
+									const functionBody = member.value.body
+										? sourceCode.getText(member.value.body)
+										: '{}'
+									const params = member.value.params.map((p) => sourceCode.getText(p)).join(', ')
+									return fixer.replaceText(member, `${propertyName}(${params}) ${functionBody}`)
+								},
+							})
+						}
+					})
+				},
+			}
+		},
+		meta: {
+			messages: {
+				preferMethod: 'Prefer using a method instead of an arrow function property.',
+			},
+			type: 'problem',
+			schema: [],
+			fixable: 'code',
+		},
+		defaultOptions: [],
+	}),
 }

--- a/scripts/lib/eslint-plugin.ts
+++ b/scripts/lib/eslint-plugin.ts
@@ -459,7 +459,7 @@ exports.rules = {
 									} else {
 										// For arrow functions with concise body: () => true
 										const bodyText = sourceCode.getText(arrowFunction.body)
-										methodBody = `{ return ${bodyText}; }`
+										methodBody = `{ return ${bodyText} }`
 									}
 
 									const fixedMethod = `${asyncModifier}${propertyName}(${params})${typeAnnotation} ${methodBody}`


### PR DESCRIPTION
Solves https://github.com/tldraw/tldraw/issues/2799

This isn't perfect. It's a bit hard to distinguish these two cases:

```ts
class StateNode {
   id: string
   onExit?: TLExitEventHandler
}
```
That said as soon as you write an `onExit` implementation you will see the warning. So I'm not sure if it's worth going further than this?

![image](https://github.com/user-attachments/assets/18ef06b2-b740-4d1a-96d1-3d6cd2e50d6a)

Number of warnings:
![image](https://github.com/user-attachments/assets/5b43256f-543c-420d-99bd-331bc52c35c3)
![image](https://github.com/user-attachments/assets/78c869ef-ebe6-4565-a060-8bfcbe4ae8c0)

Happy to go through them if we decide to go with this.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Adds a lint rule to warn when using function properties. We prefer using methods, since they are more easily extensible.