### PR TITLE
Make it easy to load preexisting snapshots into TLSocketRoom

### DIFF
--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -212,3 +212,36 @@ While tldraw sync is the easiest way to add sync capabilities to your tldraw can
 Refer to the [Persistence docs](/docs/persistence) to learn about these lower-level APIs.
 
 One example of this in practice is the [Yjs integration](https://github.com/tldraw/tldraw-yjs-example) (not production ready, use only as a guide).
+
+## Migrating data from a custom sync engine
+
+[`TLSocketRoom`](?) supports loading [`TLStoreSnapshot`] snapshots, so in your persistence layer you can add a backwards-compatibility layer that lazily imports data from your old sync engine and converts it to a `TLStoreSnapshot`.
+
+Something like
+
+```tsx
+import { TLSocketRoom } from '@tldraw/sync-core'
+
+async function loadOrMakeRoom(roomId: string) {
+	const data = await loadRoomDataFromCurrentStore(roomId)
+	if (data) {
+		return new TLSocketRoom({ initialSnapshot: data })
+	}
+	const legacyData = await loadRoomDataFromLegacyStore(roomId)
+	if (legacyData) {
+		// convert your old data to a TLStoreSnapshot
+		const snapshot = convertOldDataToSnapshot(legacyData)
+		// load it into the room
+		const room = new TLSocketRoom({ initialSnapshot: snapshot })
+		// save an updated copy of the snapshot in the new place
+		// so that next time we can load it directly
+		await saveRoomData(roomId, room.getCurrentSnapshot())
+		// optionally delete the old data
+		await deleteLegacyRoomData(roomId)
+		// and finally return the room
+		return room
+	}
+	// if there's no data at all, just make a new blank room
+	return new TLSocketRoom()
+}
+```

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -14,6 +14,7 @@ import { Signal } from '@tldraw/state';
 import { Store } from '@tldraw/store';
 import { StoreSchema } from '@tldraw/store';
 import { TLRecord } from '@tldraw/tlschema';
+import { TLStoreSnapshot } from '@tldraw/tlschema';
 import { UnknownRecord } from '@tldraw/store';
 
 // @internal (undocumented)
@@ -290,7 +291,7 @@ export type TLSocketClientSentEvent<R extends UnknownRecord> = TLConnectRequest 
 export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta = void> {
     constructor(opts: {
         clientTimeout?: number;
-        initialSnapshot?: RoomSnapshot;
+        initialSnapshot?: RoomSnapshot | TLStoreSnapshot;
         log?: TLSyncLog;
         onAfterReceiveMessage?: (args: {
             message: TLSocketServerSentEvent<R>;
@@ -326,13 +327,13 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     handleSocketMessage(sessionId: string, message: AllowSharedBufferSource | string): void;
     // (undocumented)
     isClosed(): boolean;
-    loadSnapshot(snapshot: RoomSnapshot): void;
+    loadSnapshot(snapshot: RoomSnapshot | TLStoreSnapshot): void;
     // (undocumented)
     readonly log?: TLSyncLog;
     // (undocumented)
     readonly opts: {
         clientTimeout?: number;
-        initialSnapshot?: RoomSnapshot;
+        initialSnapshot?: RoomSnapshot | TLStoreSnapshot;
         log?: TLSyncLog;
         onAfterReceiveMessage?: (args: {
             message: TLSocketServerSentEvent<R>;

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -1,5 +1,6 @@
 import type { StoreSchema, UnknownRecord } from '@tldraw/store'
-import { createTLSchema } from '@tldraw/tlschema'
+import { TLStoreSnapshot, createTLSchema } from '@tldraw/tlschema'
+import { objectMapValues } from 'tldraw'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
 import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
 import { JsonChunkAssembler } from './chunk'
@@ -23,7 +24,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 
 	constructor(
 		public readonly opts: {
-			initialSnapshot?: RoomSnapshot
+			initialSnapshot?: RoomSnapshot | TLStoreSnapshot
 			schema?: StoreSchema<R, any>
 			// how long to wait for a client to communicate before disconnecting them
 			clientTimeout?: number
@@ -51,10 +52,15 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 			onDataChange?: () => void
 		}
 	) {
-		const initialClock = opts.initialSnapshot?.clock ?? 0
+		const initialSnapshot =
+			opts.initialSnapshot && 'store' in opts.initialSnapshot
+				? convertStoreSnapshotToRoomSnapshot(opts.initialSnapshot!)
+				: opts.initialSnapshot
+
+		const initialClock = initialSnapshot?.clock ?? 0
 		this.room = new TLSyncRoom<R, SessionMeta>({
 			schema: opts.schema ?? (createTLSchema() as any),
-			snapshot: opts.initialSnapshot,
+			snapshot: initialSnapshot,
 			log: opts.log,
 		})
 		if (this.room.clock !== initialClock) {
@@ -240,7 +246,10 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 * Load a snapshot of the document state, overwriting the current state.
 	 * @param snapshot - The snapshot to load
 	 */
-	loadSnapshot(snapshot: RoomSnapshot) {
+	loadSnapshot(snapshot: RoomSnapshot | TLStoreSnapshot) {
+		if ('store' in snapshot) {
+			snapshot = convertStoreSnapshotToRoomSnapshot(snapshot)
+		}
 		const oldRoom = this.room
 		const oldIds = oldRoom.getSnapshot().documents.map((d) => d.state.id)
 		const newIds = new Set(snapshot.documents.map((d) => d.state.id))
@@ -291,4 +300,16 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 /** @public */
 export type OmitVoid<T, KS extends keyof T = keyof T> = {
 	[K in KS extends any ? (void extends T[KS] ? never : KS) : never]: T[K]
+}
+
+function convertStoreSnapshotToRoomSnapshot(snapshot: TLStoreSnapshot): RoomSnapshot {
+	return {
+		clock: 0,
+		documents: objectMapValues(snapshot.store).map((state) => ({
+			state,
+			lastChangedClock: 0,
+		})),
+		schema: snapshot.schema,
+		tombstones: {},
+	}
 }

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -1,6 +1,6 @@
 import type { StoreSchema, UnknownRecord } from '@tldraw/store'
 import { TLStoreSnapshot, createTLSchema } from '@tldraw/tlschema'
-import { objectMapValues } from 'tldraw'
+import { objectMapValues } from '@tldraw/utils'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
 import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
 import { JsonChunkAssembler } from './chunk'

--- a/packages/sync-core/src/test/TLSocketRoom.test.ts
+++ b/packages/sync-core/src/test/TLSocketRoom.test.ts
@@ -1,0 +1,100 @@
+import { createTLSchema, createTLStore } from 'tldraw'
+import { TLSocketRoom } from '../lib/TLSocketRoom'
+
+function getStore() {
+	const schema = createTLSchema()
+	const store = createTLStore({ schema })
+	return store
+}
+
+describe(TLSocketRoom, () => {
+	it('allows being initialized with an empty TLStoreSnapshot', () => {
+		const store = getStore()
+		const snapshot = store.getStoreSnapshot()
+		const room = new TLSocketRoom({
+			initialSnapshot: snapshot,
+		})
+
+		expect(room.getCurrentSnapshot()).toMatchObject({ clock: 0, documents: [] })
+		expect(room.getCurrentSnapshot().documents.length).toBe(0)
+	})
+
+	it('allows being initialized with a non-empty TLStoreSnapshot', () => {
+		const store = getStore()
+		// populate with an empty document (document:document and page:page records)
+		store.ensureStoreIsUsable()
+		const snapshot = store.getStoreSnapshot()
+		const room = new TLSocketRoom({
+			initialSnapshot: snapshot,
+		})
+		expect(room.getCurrentSnapshot()).not.toMatchObject({ clock: 0, documents: [] })
+		expect(room.getCurrentSnapshot().clock).toBe(0)
+		expect(room.getCurrentSnapshot().documents.sort((a, b) => a.state.id.localeCompare(b.state.id)))
+			.toMatchInlineSnapshot(`
+		[
+		  {
+		    "lastChangedClock": 0,
+		    "state": {
+		      "gridSize": 10,
+		      "id": "document:document",
+		      "meta": {},
+		      "name": "",
+		      "typeName": "document",
+		    },
+		  },
+		  {
+		    "lastChangedClock": 0,
+		    "state": {
+		      "id": "page:page",
+		      "index": "a1",
+		      "meta": {},
+		      "name": "Page 1",
+		      "typeName": "page",
+		    },
+		  },
+		]
+	`)
+	})
+
+	it('allows loading a TLStoreSnapshot at some later time', () => {
+		const store = getStore()
+		const room = new TLSocketRoom({
+			initialSnapshot: store.getStoreSnapshot(),
+		})
+
+		expect(room.getCurrentSnapshot()).toMatchObject({ clock: 0, documents: [] })
+
+		// populate with an empty document (document:document and page:page records)
+		store.ensureStoreIsUsable()
+
+		const snapshot = store.getStoreSnapshot()
+		room.loadSnapshot(snapshot)
+
+		expect(room.getCurrentSnapshot().clock).toBe(1)
+		expect(room.getCurrentSnapshot().documents.sort((a, b) => a.state.id.localeCompare(b.state.id)))
+			.toMatchInlineSnapshot(`
+		[
+		  {
+		    "lastChangedClock": 1,
+		    "state": {
+		      "gridSize": 10,
+		      "id": "document:document",
+		      "meta": {},
+		      "name": "",
+		      "typeName": "document",
+		    },
+		  },
+		  {
+		    "lastChangedClock": 1,
+		    "state": {
+		      "id": "page:page",
+		      "index": "a1",
+		      "meta": {},
+		      "name": "Page 1",
+		      "typeName": "page",
+		    },
+		  },
+		]
+	`)
+	})
+})


### PR DESCRIPTION
This PR adds the ability for TLSocketRoom to load snapshots in the TLStoreSnapshot format, which should make it much easier for people who have built sync engines around yjs or whatever to just pull in existing data to tldraw sync.

Also adds some basic docs to guide folks.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`


### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Allow `TLSocketRoom` to load regular `TLStoreSnapshot` snapshots. 