### PR TITLE
More sync papercuts

### DIFF
--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -202,6 +202,74 @@ Refer to the simple server example for example [client](https://github.com/tldra
 	client rolls out.
 </Callout>
 
+### Custom shapes & bindings
+
+`@tldraw/sync` validates the contents of your document and run migrations to make sure clients of
+different versions can collaborate without issue. To support this, you need to make sure that both
+the sync client and server know about any custom shapes or bindings you've added.
+
+#### On the client
+
+You can pass `shapeUtils` and `bindingUtils` props to `useSync`. Unlike `<Tldraw />`,
+these don't automatically include tldraw's default shapes like arrows and rectangles. You should
+pass those in explicitly if you're using them:
+
+```tsx
+import { Tldraw, defaultShapeUtils, defaultBindingUtils } from 'tldraw'
+import { useSync } from '@tldraw/sync'
+
+function MyApp() {
+	const store = useSync({
+		uri: '...',
+		assets: myAssetStore,
+		shapeUtils: useMemo(() => [...customShapeUtils, ...defaultShapeUtils], []),
+		bindingUtils: useMemo(() => [...customBindingUtils, ...defaultBindingUtils], []),
+	})
+
+	return <Tldraw store={store} shapeUtils={customShapeUtils} bindingUtils={customBindingUtils} />
+}
+```
+
+#### On the server
+
+Use [`createTLSchema`](?) to create a store schema, and pass that into [`TLSocketRoom`](?). You can
+use shape/binding utils here, but schema will only look at two properties:
+[`props`](/reference/editor/ShapeUtil#props) and
+[`migrations`](/docs/persistence#Shape-props-migrations). You need to provide the default shape
+schemas if you're using them.
+
+```tsx
+import { createTLSchema, defaultShapeSchemas, defaultBindingSchemas } from '@tldraw/tlschema'
+import { TLSocketRoom } from '@tldraw/sync-core'
+
+const schema = createTLSchema({
+	shapes: {
+		...defaultShapeSchemas,
+
+		myCustomShape: {
+			// validations for this shapes `props`
+			props: myCustomShapeProps,
+			// migrations between versions of this shape
+			migrations: myCustomShapeMigrations,
+		},
+
+		// the schema knows about this shape, but it has no migrations or validation
+		mySimpleShape: {},
+	},
+	bindings: defaultBindingSchemas,
+})
+
+// later, in your app server:
+const room = new TLSocketRoom({
+	schema: schema,
+	// ...
+})
+```
+
+Both `props` and `migration` are optional. You can omit them, but doing so will mean that you don't
+have server-side validation for your shape in the case of `props`, and that clients on different
+versions might encounter errors in the case of `migrations`.
+
 ## Or roll your own sync engine
 
 While tldraw sync is the easiest way to add sync capabilities to your tldraw canvas, we expose low-level persistence and multiplayer APIs so that you can

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -191,17 +191,6 @@ This should be registered with the [`Editor`](?) when it loads.
 
 Refer to the simple server example for example [client](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/client/App.tsx) and [server](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/server/unfurl.ts) code.
 
-### Deployment concerns
-
-<Callout icon="⚠️">
-	You must make sure that the tldraw version in your client matches the version on the server. We
-	don't guarantee server backwards compatibility forever, and very occasionally we might release a
-	version where the backend cannot meaningfully support older clients, in which case tldraw will
-	display a "please refresh the page" message. So you should make sure that the backend is updated
-	at the same time as the client, and that the new backend is up and running just before the new
-	client rolls out.
-</Callout>
-
 ### Custom shapes & bindings
 
 `@tldraw/sync` validates the contents of your document and run migrations to make sure clients of
@@ -266,9 +255,20 @@ const room = new TLSocketRoom({
 })
 ```
 
-Both `props` and `migration` are optional. You can omit them, but doing so will mean that you don't
-have server-side validation for your shape in the case of `props`, and that clients on different
-versions might encounter errors in the case of `migrations`.
+Both `props` and `migration` are optional. If you omit `props`, you won't have any server-side
+validation for your shape, which could result in bad data being stored. If you omit `migrations`,
+clients on different versions won't be able to collaborate without errors.
+
+### Deployment concerns
+
+<Callout icon="⚠️">
+	You must make sure that the tldraw version in your client matches the version on the server. We
+	don't guarantee server backwards compatibility forever, and very occasionally we might release a
+	version where the backend cannot meaningfully support older clients, in which case tldraw will
+	display a "please refresh the page" message. So you should make sure that the backend is updated
+	at the same time as the client, and that the new backend is up and running just before the new
+	client rolls out.
+</Callout>
 
 ## Or roll your own sync engine
 

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -193,7 +193,7 @@ Refer to the simple server example for example [client](https://github.com/tldra
 
 ### Custom shapes & bindings
 
-`@tldraw/sync` validates the contents of your document and run migrations to make sure clients of
+`@tldraw/sync` validates the contents of your document and runs migrations to make sure clients of
 different versions can collaborate without issue. To support this, you need to make sure that both
 the sync client and server know about any custom shapes or bindings you've added.
 

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -17,6 +17,117 @@ order: 3
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
+### [v2.4.0](/releases/v2.4.0)
+
+Welcome to the 2.4.0 release of the tldraw SDK. This month we’ve been working to bring our sync engine (the backend we developed for tldraw.com) into the SDK as a technology for general use. This release also includes new animation options for shapes, support for image flipping, and a long list of bug fixes and developer experience enhancements. Read on for the highlights and see the bottom of these notes for the list of significant fixes and changes.
+
+Thank you also to our first-time contributors Albert Brand ([@AlbertBrand](https://github.com/AlbertBrand)) and Guillaume Grossetie ([@ggrossetie](https://github.com/ggrossetie))!
+
+#### What's new
+
+##### Sync
+
+For the first time, we’re releasing our real-time collaboration engine—the one we developed for tldraw.com—as a general library that developers can use for their own projects. The SDK will of course still support any backend for collaboration, however we hope this will be the best and easiest for developers to use alongside the rest of the tldraw SDK. While we’re shipping the code in this release, we still have some work to do on our messaging and our documentation, so keep an eye out for an announcement in the coming weeks. For now, see the new `sync` package in the repository and the new multiplayer-demo example in the tldraw repository.
+
+##### Interpolation
+
+Did you know that tldraw has basic support for animation? You can use the `Editor.animateShapes` method to animate shapes on the canvas, but up to now only the position and rotation properties would be animated. In this release, we’ve given the `ShapeUtil` class a new `getInterpolatedProps` method. You can use this to describe how your custom shape’s other properties should be animated. We’ve only started to implement this feature for our own shapes, but check our `BaseBoxShapeUtil` as an example.
+
+```ts
+override getInterpolatedProps(startShape: Shape, endShape: Shape, t: number): Shape['props'] {
+	return {
+		...endShape.props,
+		w: lerp(startShape.props.w, endShape.props.w, t),
+		h: lerp(startShape.props.h, endShape.props.h, t),
+	}
+}
+```
+
+##### `Editor.run`
+
+You can use the new `Editor.run` method to run a function within some additional context. By default, the function will be run inside of a transaction, meaning that all changes made during the transaction will be settled at once. This improves performance and avoids unnecessary renders in the user interface. You can also use `Editor.run`’s contextual options to ignore history or ignore locked shapes.
+
+```ts
+editor.run(
+	() => {
+		editor.createShapes(myShapes)
+		editor.sendToBack(myShapes)
+		editor.selectNone()
+	},
+	{ history: 'ignore' }
+)
+```
+
+##### Assets
+
+As part of our work on sync, we have a new system for handling large assets like images and videos. You can provide a [`TLAssetStore`](https://tldraw.dev/reference/tlschema/TLAssetStore) to control how assets are uploaded and retrieved.
+
+In your own shapes & tools, these options are available through the new [`Editor.uploadAsset`](https://tldraw.dev/reference/editor/Editor#uploadAsset) and [`Editor.resolveAssetURL`](https://staging.tldraw.dev/reference/editor/Editor#resolveAssetUrl) methods.
+
+---
+
+#### Breaking changes
+
+- `editor.history.ignore(cb)` has been replaced with `editor.run(cb, {history: ‘ignore’})`
+- `editor.batch` is deprecated, replaced with `editor.run`
+- If you’re importing from `@tldraw/state` directly, the `track` function and all hooks (e.g. `useValue`) have moved to `@tldraw/state-react`.
+
+#### Improvements
+
+- Images now support horizontal and vertical flipping. ([#4113](https://github.com/tldraw/tldraw/pull/4113))
+- Custom tools can now decide whether or not they are affected by shape lock. [#4208](https://github.com/tldraw/tldraw/pull/4208)
+- We now serve our icons as a single SVG rather than many individual requests. ([#4150](https://github.com/tldraw/tldraw/pull/4150))
+- Paste at point behavior is now based on a user preference. ([#4104](https://github.com/tldraw/tldraw/pull/4104))
+- We now show a toast when uploading an unsupported file type or a file that is too large. ([#4114](https://github.com/tldraw/tldraw/pull/4114))
+- We now show a toast when pasting failed due to missing clipboard permissions. ([#4117](https://github.com/tldraw/tldraw/pull/4117))
+- You can use the new `ShapeIndicators` component to add custom logic about when to display indicators. ([#4083](https://github.com/tldraw/tldraw/pull/4083))
+- A shape’s opacity will now also animate. ([#4242](<[https://github.com/tldraw/tldraw/pull/](https://github.com/tldraw/tldraw/pull/4042)4242>))
+
+#### API changes
+
+- The `@tldraw/state` library is now split into `@tldraw/state` and `@tldraw/state-react`. ([#4170](https://github.com/tldraw/tldraw/pull/4170))
+- We now export the `DefaultMenuPanel`. ([#4193](https://github.com/tldraw/tldraw/pull/4193))
+- The `fileSize` property of `TLImageAsset` and `TLVideoAsset` is now optional. ([#4206](https://github.com/tldraw/tldraw/pull/4206))
+- You can now pass a partial `TLEditorSnapshot` to `TldrawImage` and `useTLStore`. ([#4190](https://github.com/tldraw/tldraw/pull/4190))
+- We explicitly type our defaults for better documentation. ([#4191](https://github.com/tldraw/tldraw/pull/4191))
+- `EffectScheduler` and `useStateTracking` are now public. ([#4155](https://github.com/tldraw/tldraw/pull/4155))]
+- Add `setDefaultValue` to `StyleProp`. ([#4044](https://github.com/tldraw/tldraw/pull/4044))
+- Add `ShapeUtil.getInterpolatedProps`. ([#4162](https://github.com/tldraw/tldraw/pull/4162))
+- Add `Editor.run`, replacing `Editor.batch` ([#4042](https://github.com/tldraw/tldraw/pull/4042))
+
+#### Bug fixes
+
+- The font style is now correctly exported as SVG. ([#4195](https://github.com/tldraw/tldraw/pull/4195))
+- The `force` flag is now taken into account for additional camera methods. ([#4214](https://github.com/tldraw/tldraw/pull/4214))
+- The user's color scheme is shown in the menu by default. ([#4184](https://github.com/tldraw/tldraw/pull/4184))
+- The padding for text shapes is now correct for dynamically scaled text shapes. ([#4140](https://github.com/tldraw/tldraw/pull/4140))
+- Changing `cameraOptions` via react no longer causes the editor to re-mount. ([#4089](https://github.com/tldraw/tldraw/pull/4089))
+- High-res images may now be uploaded. ([#4198](https://github.com/tldraw/tldraw/pull/4198))
+- Locked shapes can no longer be updated, grouped, and ungrouped programmatically. ([#4042](https://github.com/tldraw/tldraw/pull/4042))
+- The snapshots prop is now used by `createTLStore`. ([#4233](https://github.com/tldraw/tldraw/pull/4233)
+- Grid backgrounds work properly with multiple tldraw instances. ([#4132](https://github.com/tldraw/tldraw/pull/4132))
+- The offline icon is back! ([#4127](https://github.com/tldraw/tldraw/pull/4127))
+- Inputs stay in the right place while viewport-following. ([#4108](https://github.com/tldraw/tldraw/pull/4108))
+- Bookmarks render correctly across devices. ([#4118](https://github.com/tldraw/tldraw/pull/4118))
+- The `InFrontOfTheCanvas` component is displayed at the right stack-order. ([#4024](https://github.com/tldraw/tldraw/pull/4024))
+- Frame headers stop editing correctly when they lose focus. ([#4092](https://github.com/tldraw/tldraw/pull/4092))
+- The distance offset for duplicated shapes now matches other duplication distance offsets. ([#4056](https://github.com/tldraw/tldraw/pull/4056))
+- Filled draw shapes work close with correct distance when dynamic sized. ([#3974](https://github.com/tldraw/tldraw/pull/3974))
+- Remove an artificial delay in showing an image. ([#4058](https://github.com/tldraw/tldraw/pull/4058))
+- The context menu no longer displays an empty edit menu. ([#4037](https://github.com/tldraw/tldraw/pull/4037))
+- Right-clicking the selected shape no longer selects its children. ([#4034](https://github.com/tldraw/tldraw/pull/4034))
+
+#### Authors
+
+- Albert Brand ([@AlbertBrand](https://github.com/AlbertBrand))
+- alex ([@SomeHats](https://github.com/SomeHats))
+- David Sheldrick ([@ds300](https://github.com/ds300))
+- Guillaume Grossetie ([@ggrossetie](https://github.com/ggrossetie))
+- Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
+- Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
+- Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
+- Taha ([@Taha-Hassan-Git](https://github.com/Taha-Hassan-Git))
+
 ### [v2.3.0](/releases/v2.3.0)
 
 # The headlines
@@ -416,25 +527,6 @@ This performance optimisation introduced a regression where sometimes computed c
 - alex ([@SomeHats](https://github.com/SomeHats))
 
 ### [v2.1.1](/releases/v2.1.1)
-
-#### fix migration exports ([#3594](https://github.com/tldraw/tldraw/pull/3594))
-
-We were missing an export `createShapePropsMigrationIds`, part of the new migrations API introduced in [v2.1.0](https://tldraw.dev/releases/v2.1.0). This release fixes that, and also adds exports for a few extra APIs that we were using in our examples, but weren't exporting properly: `defaultEditorAssetUrls`, `PORTRAIT_BREAKPOINT`, `useDefaultColorTheme`, & `getPerfectDashProps`
-
----
-
-#### 🐛 Bug Fix
-
-- `tldraw`, `@tldraw/tlschema`
-  - fix migration exports [#3594](https://github.com/tldraw/tldraw/pull/3594) ([@SomeHats](https://github.com/SomeHats))
-
-#### ⚠️ Pushed to `v2.1.x`
-
-- v2.1.x: fix ([@SomeHats](https://github.com/SomeHats))
-
-#### Authors: 1
-
-- alex ([@SomeHats](https://github.com/SomeHats))
 
 ### [v2.1.0](/releases/v2.1.0)
 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2062,7 +2062,6 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     hideSelectionBoundsFg: TLShapeUtilFlag<Shape>;
     abstract indicator(shape: Shape): any;
     isAspectRatioLocked: TLShapeUtilFlag<Shape>;
-    // (undocumented)
     static migrations?: LegacyMigrations | MigrationSequence | TLPropsMigrations;
     onBeforeCreate?: TLOnBeforeCreateHandler<Shape>;
     onBeforeUpdate?: TLOnBeforeUpdateHandler<Shape>;
@@ -2087,7 +2086,6 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onTranslate?: TLOnTranslateHandler<Shape>;
     onTranslateEnd?: TLOnTranslateEndHandler<Shape>;
     onTranslateStart?: TLOnTranslateStartHandler<Shape>;
-    // (undocumented)
     static props?: RecordProps<TLUnknownShape>;
     // @internal
     providesBackgroundForChildren(shape: Shape): boolean;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -56,7 +56,41 @@ export interface TLShapeUtilCanvasSvgDef {
 /** @public */
 export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	constructor(public editor: Editor) {}
+
+	/**
+	 * Props allow you to define the shape's properties in a way that the editor can understand.
+	 * This has two main uses:
+	 *
+	 * 1. Validation. Shapes will be validated using these props to stop bad data from being saved.
+	 * 2. Styles. Each {@link @tldraw/tlschema#StyleProp} in the props can be set on many shapes at
+	 *    once, and will be remembered from one shape to the next.
+	 *
+	 * @example
+	 * ```tsx
+	 * import {T, TLBaseShape, TLDefaultColorStyle, DefaultColorStyle, ShapeUtil} from 'tldraw'
+	 *
+	 * type MyShape = TLBaseShape<'mine', {
+	 *      color: TLDefaultColorStyle,
+	 *      text: string,
+	 * }>
+	 *
+	 * class MyShapeUtil extends ShapeUtil<MyShape> {
+	 *     static props = {
+	 *         // we use tldraw's built-in color style:
+	 *         color: DefaultColorStyle,
+	 *         // validate that the text prop is a string:
+	 *         text: T.string,
+	 *     }
+	 * }
+	 * ```
+	 */
 	static props?: RecordProps<TLUnknownShape>
+
+	/**
+	 * Migrations allow you to make changes to a shape's props over time. Read the
+	 * {@link https://staging.tldraw.dev/docs/persistence#Shape-props-migrations | shape prop migrations}
+	 * guide for more information.
+	 */
 	static migrations?: LegacyMigrations | TLPropsMigrations | MigrationSequence
 
 	/**

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -66,6 +66,26 @@ The frontend client is under [`client`](./client):
 - **[`client/getBookmarkPreview.tsx`](./client/getBookmarkPreview.tsx):** how does the client fetch
   bookmark previews from the worker?
 
+## Adding cloudflare to your own repo
+
+If you already have an app using tldraw and want to use the system in this repo, you can copy and
+paste the relevant parts to your own app.
+
+To point your existing client at the server defined in this repo, copy
+[`client/multiplayerAssetStore.tsx`](./client/multiplayerAssetStore.tsx) and
+[`client/getBookmarkPreview.tsx`](./client/getBookmarkPreview.tsx) into your app. Then, adapt the
+code from [`client/App.tsx`](./client/App.tsx) to your own app. When you call `useSync`, you'll need
+to pass it a URL. In development, that's `http://localhost:5172/connect/some-room-id`. We use an
+environment variable set in [`./vite.config.ts`](./vite.config.ts) to set the server URL.
+
+To add the server to your own app, copy the contents of the [`worker`](./worker/) folder and
+[`./wrangler.toml`](./wrangler.toml) into your app. Add the dependencies from
+[`package.json`](./package.json). If you're using TypeScript, you'll also need to adapt
+`tsconfig.worker.json` for your own project. You can run the worker using `wrangler dev` in the same
+folder as `./wrangler.toml`.
+
+## Custom shapes
+
 ## Deployment
 
 To deploy this example, you'll need to create a cloudflare account and create an R2 bucket to store
@@ -82,22 +102,6 @@ Finally, deploy your client HTML & JavaScript. Create a production build with
 
 When you visit your published client, it should connect to your cloudflare workers domain and sync
 your document across devices.
-
-## Adding cloudflare to your own repo
-
-If you already have an app using tldraw and want to use the system in this repo, you can copy and
-paste the relevant parts to your own app.
-
-To point your existing client at the server defined in this repo, copy
-[`client/multiplayerAssetStore.tsx`](./client/multiplayerAssetStore.tsx) and
-[`client/getBookmarkPreview.tsx`](./client/getBookmarkPreview.tsx) into your app. Then, adapt the
-code from [`client/App.tsx`](./client/App.tsx) to your own app. When you call `useSync`, you'll need
-to pass it a URL. In development, that's `http://localhost:5172/connect/some-room-id`. We use an
-environment variable set in [`./vite.config.ts`](./vite.config.ts) to set the server URL.
-
-To add the server to your own app, copy the contents of the [`worker`](./worker/) folder and
-[`./wrangler.toml`](./wrangler.toml) into your app. You can run the worker using `wrangler dev` in
-the same folder as `./wrangler.toml`.
 
 ## License
 

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -42,7 +42,8 @@ them faster.
 To install dependencies, run `yarn`. To start a local development server, run `yarn dev`. This will
 start a [`vite`](https://vitejs.dev/) dev server for the frontend of your application, and a
 [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) dev server for your workers
-backend.
+backend. The app should now be running at http://localhost:5137 (and the server at
+http://localhost:5172).
 
 The backend worker is under [`worker`](./worker/), and is split across several files:
 

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -66,6 +66,11 @@ The frontend client is under [`client`](./client):
 - **[`client/getBookmarkPreview.tsx`](./client/getBookmarkPreview.tsx):** how does the client fetch
   bookmark previews from the worker?
 
+## Custom shapes
+
+To add support for custom shapes, see the [tldraw sync custom shapes
+docs](https://tldraw.dev/docs/sync#Custom-shapes--bindings).
+
 ## Adding cloudflare to your own repo
 
 If you already have an app using tldraw and want to use the system in this repo, you can copy and
@@ -83,8 +88,6 @@ To add the server to your own app, copy the contents of the [`worker`](./worker/
 [`package.json`](./package.json). If you're using TypeScript, you'll also need to adapt
 `tsconfig.worker.json` for your own project. You can run the worker using `wrangler dev` in the same
 folder as `./wrangler.toml`.
-
-## Custom shapes
 
 ## Deployment
 

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -62,9 +62,9 @@ export class TldrawDurableObject extends DurableObject<Environment> {
 
 	// what happens when someone tries to connect to this room?
 	async handleConnect(request: IRequest): Promise<Response> {
-		// extract query params from request, should include instanceId
-		const sessionKey = request.query.sessionKey as string
-		if (!sessionKey) return error(400, 'Missing sessionKey')
+		// extract query params from request
+		const sessionId = request.query.sessionId as string
+		if (!sessionId) return error(400, 'Missing sessionId')
 
 		// Create the websocket pair for the client
 		const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair()
@@ -74,7 +74,7 @@ export class TldrawDurableObject extends DurableObject<Environment> {
 		const room = await this.getRoom()
 
 		// connect the client to the room
-		room.handleSocketConnect(sessionKey, serverWebSocket)
+		room.handleSocketConnect({ sessionId, socket: serverWebSocket })
 
 		// return the websocket connection to the client
 		return new Response(null, { status: 101, webSocket: clientWebSocket })

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -5,7 +5,6 @@ import {
 	// defaultBindingSchemas,
 	defaultShapeSchemas,
 } from '@tldraw/tlschema'
-import { DurableObject } from 'cloudflare:workers'
 import { AutoRouter, IRequest, error } from 'itty-router'
 import throttle from 'lodash.throttle'
 import { Environment } from './types'
@@ -21,7 +20,7 @@ const schema = createTLSchema({
 
 // there's only ever one durable object instance per room. it keeps all the room state in memory and
 // handles websocket connections. periodically, it persists the room state to the R2 bucket.
-export class TldrawDurableObject extends DurableObject<Environment> {
+export class TldrawDurableObject {
 	private r2: R2Bucket
 	// the room ID will be missing whilst the room is being initialized
 	private roomId: string | null = null
@@ -30,7 +29,6 @@ export class TldrawDurableObject extends DurableObject<Environment> {
 	private roomPromise: Promise<TLSocketRoom<TLRecord, void>> | null = null
 
 	constructor(state: DurableObjectState, env: Environment) {
-		super(state, env)
 		this.r2 = env.TLDRAW_BUCKET
 
 		state.blockConcurrencyWhile(async () => {


### PR DESCRIPTION
- Fix a bug in the cloudflare template
- Remove awkward `cloudflare:*` dep from template
- Slightly rework cloudflare readme for clarity
- Add custom shapes section to sync docs
- Make sure we have at least some reference docs on the relevant concepts needed for custom shapes.