### PR TITLE
fix assets prop on tldraw component

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -276,6 +276,7 @@ function TldrawEditorWithOwnStore(
 		persistenceKey,
 		sessionId,
 		user,
+		assets,
 	} = props
 
 	const syncedStore = useLocalStore({
@@ -286,6 +287,7 @@ function TldrawEditorWithOwnStore(
 		sessionId,
 		defaultName,
 		snapshot,
+		assets,
 	})
 
 	return <TldrawEditorWithLoadingStore {...props} store={syncedStore} user={user} />

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -4,6 +4,7 @@ import {
 	BaseBoxShapeUtil,
 	Editor,
 	HTMLContainer,
+	TLAssetStore,
 	TLBaseShape,
 	TldrawEditor,
 	createShapeId,
@@ -339,6 +340,39 @@ describe('<TldrawEditor />', () => {
 				props: { w: 152.74967383200806, h: 134.57489438369782 },
 			},
 		])
+	})
+
+	it('passes through the `assets` prop when creating its own in-memory store', async () => {
+		const myUploadFn = jest.fn()
+		const assetStore: TLAssetStore = { upload: myUploadFn }
+
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => (
+				<TldrawEditor onMount={onMount} shapeUtils={defaultShapeUtils} assets={assetStore} />
+			),
+			{ waitForPatterns: true }
+		)
+
+		expect(editor.store.props.assets.upload).toBe(myUploadFn)
+	})
+
+	it('passes through the `assets` prop when using `persistenceKey`', async () => {
+		const myUploadFn = jest.fn()
+		const assetStore: TLAssetStore = { upload: myUploadFn }
+
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => (
+				<TldrawEditor
+					onMount={onMount}
+					shapeUtils={defaultShapeUtils}
+					assets={assetStore}
+					persistenceKey="hello-world"
+				/>
+			),
+			{ waitForPatterns: true }
+		)
+
+		expect(editor.store.props.assets.upload).toBe(myUploadFn)
 	})
 })
 

--- a/packages/tldraw/src/test/testutils/renderTldrawComponent.tsx
+++ b/packages/tldraw/src/test/testutils/renderTldrawComponent.tsx
@@ -18,6 +18,7 @@ export async function renderTldrawComponent(
 	{ waitForPatterns }: { waitForPatterns: boolean }
 ) {
 	const result = render(element)
+	await result.findAllByTestId('canvas')
 	if (waitForPatterns) await result.findByTestId('ready-pattern-fill-defs')
 	return result
 }


### PR DESCRIPTION
This wasn't getting passed into `useLocalStore` correctly.

### Change type

- [x] `bugfix`

### Release notes

- The `assets` prop on the `<Tldraw />` and `<TldrawEditor />` components is now respected.