### PR TITLE
Pass assets prop to `useLocalStore`

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -276,6 +276,7 @@ function TldrawEditorWithOwnStore(
 		persistenceKey,
 		sessionId,
 		user,
+		assets,
 	} = props
 
 	const syncedStore = useLocalStore({
@@ -286,6 +287,7 @@ function TldrawEditorWithOwnStore(
 		sessionId,
 		defaultName,
 		snapshot,
+		assets,
 	})
 
 	return <TldrawEditorWithLoadingStore {...props} store={syncedStore} user={user} />


### PR DESCRIPTION
This PR fixes a bug where user asset code was not working.

### Change type

- [x] `bugfix`

### Release notes

- Asset stores created passed into tldraw were not being attached to the store instance.