### PR TITLE
geo: update X icon to reflect the actual shape

### DIFF
--- a/assets/icons/icon/geo-x-box.svg
+++ b/assets/icons/icon/geo-x-box.svg
@@ -1,5 +1,5 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M25 3C26.1046 3 27 3.89543 27 5V25C27 26.1046 26.1046 27 25 27H5C3.89543 27 3 26.1046 3 25V5C3 3.89543 3.89543 3 5 3H25Z" stroke="black" stroke-width="2"/>
-<path d="M8 8L22 22" stroke="black" stroke-width="2" stroke-linecap="round"/>
-<path d="M22 8L8 22" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M 3, 3, 27, 27" stroke="black" stroke-width="2" />
+<path d="M 27, 3, 3, 27" stroke="black" stroke-width="2" />
 </svg>


### PR DESCRIPTION
after:
<img width="30" alt="Screenshot 2024-07-25 at 12 31 35" src="https://github.com/user-attachments/assets/aa87a6fb-728f-40a2-9bf8-e75892e98d65">

before:
<img width="35" alt="Screenshot 2024-07-25 at 12 31 52" src="https://github.com/user-attachments/assets/c6f3a8fb-54ce-43f2-a091-b3cfcf0ae175">


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Geo: update [X] icon to reflect the actual shape.