### PR TITLE
Add option for max pasted / dropped files

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -705,6 +705,7 @@ export const defaultTldrawOptions: {
     readonly handleRadius: 12;
     readonly hitTestMargin: 8;
     readonly longPressDurationMs: 500;
+    readonly maxFilesAtOnce: 100;
     readonly maxPages: 40;
     readonly maxPointsPerDrawShape: 500;
     readonly maxShapesPerPage: 4000;
@@ -2611,6 +2612,8 @@ export interface TldrawOptions {
     readonly hitTestMargin: number;
     // (undocumented)
     readonly longPressDurationMs: number;
+    // (undocumented)
+    readonly maxFilesAtOnce: number;
     // (undocumented)
     readonly maxPages: number;
     // (undocumented)

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -17,6 +17,7 @@
  */
 export interface TldrawOptions {
 	readonly maxShapesPerPage: number
+	readonly maxFilesAtOnce: number
 	readonly maxPages: number
 	readonly animationMediumMs: number
 	readonly followChaseViewportSnap: number
@@ -54,6 +55,7 @@ export interface TldrawOptions {
 /** @public */
 export const defaultTldrawOptions = {
 	maxShapesPerPage: 4000,
+	maxFilesAtOnce: 100,
 	maxPages: 40,
 	animationMediumMs: 320,
 	followChaseViewportSnap: 2,

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -253,6 +253,10 @@ export function registerDefaultExternalContentHandlers(
 
 		const assets: TLAsset[] = []
 
+		if (files.length > editor.options.maxFilesAtOnce) {
+			throw Error('Too many files')
+		}
+
 		await Promise.all(
 			files.map(async (file, i) => {
 				if (file.size > maxAssetSize) {

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -296,6 +296,9 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 
 	// Just paste the files, nothing else
 	if (files.length) {
+		if (files.length > editor.options.maxFilesAtOnce) {
+			throw Error('Too many files')
+		}
 		const fileBlobs = await Promise.all(files.map((t) => t.source!))
 		const urls = (fileBlobs.filter(Boolean) as (File | Blob)[]).map((blob) =>
 			URL.createObjectURL(blob)


### PR DESCRIPTION
This PR adds an editor option for the maximum number of pasted or inserted files. The default is 100, a simple sanity check.

### Change type

- [x] `improvement`

### Test plan

1. paste 101 files
2. it should error

### Release notes

- We now have an editor option for the maximum number of files that a user can paste at once.