### PR TITLE
license: add special license option with watermark

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -308,6 +308,19 @@ describe('LicenseManager', () => {
 		)) as ValidLicenseKeyResult
 		expect(result.isInternalLicense).toBe(true)
 	})
+
+	it('Checks for license with watermark', async () => {
+		const withWatermarkLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+		withWatermarkLicenseInfo[PROPERTIES.FLAGS] |= FLAGS.WITH_WATERMARK
+		const withWatermarkLicenseKey = await generateLicenseKey(
+			JSON.stringify(withWatermarkLicenseInfo),
+			keyPair
+		)
+		const result = (await licenseManager.getLicenseFromKey(
+			withWatermarkLicenseKey
+		)) as ValidLicenseKeyResult
+		expect(result.isLicensedWithWatermark).toBe(true)
+	})
 })
 
 async function generateLicenseKey(
@@ -388,8 +401,6 @@ export function ab2str(buf: ArrayBuffer) {
 	return String.fromCharCode.apply(null, new Uint8Array(buf) as unknown as number[])
 }
 
-// is license?
-
 function getDefaultLicenseResult(overrides: Partial<ValidLicenseKeyResult>): ValidLicenseKeyResult {
 	return {
 		isAnnualLicense: true,
@@ -400,6 +411,7 @@ function getDefaultLicenseResult(overrides: Partial<ValidLicenseKeyResult>): Val
 		isPerpetualLicense: false,
 		isPerpetualLicenseExpired: false,
 		isLicenseParseable: true as const,
+		isLicensedWithWatermark: false,
 		// WatermarkManager does not check these fields, it relies on the calculated values like isAnnualLicenseExpired
 		license: {
 			id: 'id',
@@ -515,5 +527,12 @@ describe(isEditorUnlicensed, () => {
 			expiryDate,
 		})
 		expect(() => isEditorUnlicensed(licenseResult)).toThrow(/License: Internal license expired/)
+	})
+
+	it('shows watermark when license has that flag specified', () => {
+		const licenseResult = getDefaultLicenseResult({
+			isLicensedWithWatermark: true,
+		})
+		expect(isEditorUnlicensed(licenseResult)).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -83,12 +83,10 @@ export class LicenseManager {
 				const isUnlicensed = isEditorUnlicensed(result)
 				if (isUnlicensed) {
 					this.state.set('unlicensed')
+				} else if ((result as ValidLicenseKeyResult).isLicensedWithWatermark) {
+					this.state.set('licensed-with-watermark')
 				} else {
-					this.state.set(
-						(result as ValidLicenseKeyResult).isLicensedWithWatermark
-							? 'licensed-with-watermark'
-							: 'licensed'
-					)
+					this.state.set('licensed')
 				}
 			})
 		}

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -9,6 +9,7 @@ export const FLAGS = {
 	ANNUAL_LICENSE: 0x1,
 	PERPETUAL_LICENSE: 0x2,
 	INTERNAL_LICENSE: 0x4,
+	WITH_WATERMARK: 0x8,
 }
 const HIGHEST_FLAG = Math.max(...Object.values(FLAGS))
 
@@ -48,6 +49,7 @@ export interface ValidLicenseKeyResult {
 	isPerpetualLicense: boolean
 	isPerpetualLicenseExpired: boolean
 	isInternalLicense: boolean
+	isLicensedWithWatermark: boolean
 }
 
 type TestEnvironment = 'development' | 'production'
@@ -59,7 +61,10 @@ export class LicenseManager {
 	public isDevelopment: boolean
 	public isTest: boolean
 	public isCryptoAvailable: boolean
-	state = atom<'pending' | 'licensed' | 'unlicensed'>('license state', 'pending')
+	state = atom<'pending' | 'licensed' | 'licensed-with-watermark' | 'unlicensed'>(
+		'license state',
+		'pending'
+	)
 
 	constructor(
 		licenseKey: string | undefined,
@@ -76,9 +81,14 @@ export class LicenseManager {
 		} else {
 			this.getLicenseFromKey(licenseKey).then((result) => {
 				const isUnlicensed = isEditorUnlicensed(result)
-				this.state.set(isUnlicensed ? 'unlicensed' : 'licensed')
 				if (isUnlicensed) {
-					// todo: fetch to analytics endpoint?
+					this.state.set('unlicensed')
+				} else {
+					this.state.set(
+						(result as ValidLicenseKeyResult).isLicensedWithWatermark
+							? 'licensed-with-watermark'
+							: 'licensed'
+					)
 				}
 			})
 		}
@@ -187,6 +197,7 @@ export class LicenseManager {
 				isPerpetualLicense,
 				isPerpetualLicenseExpired: isPerpetualLicense && this.isPerpetualLicenseExpired(expiryDate),
 				isInternalLicense: this.isFlagEnabled(licenseInfo.flags, FLAGS.INTERNAL_LICENSE),
+				isLicensedWithWatermark: this.isFlagEnabled(licenseInfo.flags, FLAGS.WITH_WATERMARK),
 			}
 			this.outputLicenseInfoIfNeeded(result)
 
@@ -336,5 +347,6 @@ export function isEditorUnlicensed(result: LicenseFromKeyResult) {
 		}
 		return true
 	}
+
 	return false
 }

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -42,7 +42,21 @@ describe('Watermark', () => {
 		featureFlags.enableLicensing.set(true)
 		const result = await renderComponent()
 
-		// Don't wanna but a data-testid here - makes it too easy to querySelect on.
+		// Don't wanna put a data-testid here - makes it too easy to querySelect on.
+		await waitFor(() =>
+			expect((result.container.firstChild! as Element).nextElementSibling!.className).toBe(
+				LicenseManager.className
+			)
+		)
+	})
+
+	it('Displays the watermark when the editor is licensed with watermark', async () => {
+		featureFlags.enableLicensing.set(true)
+
+		mockLicenseState = 'licensed-with-watermark'
+		const result = await renderComponent()
+
+		// Don't wanna put a data-testid here - makes it too easy to querySelect on.
 		await waitFor(() =>
 			expect((result.container.firstChild! as Element).nextElementSibling!.className).toBe(
 				LicenseManager.className

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -63,7 +63,7 @@ export const Watermark = React.memo(function Watermark({
 		() =>
 			featureFlags.enableLicensing.get() &&
 			editor.getViewportScreenBounds().width > 760 &&
-			licenseManager.state.get() === 'unlicensed',
+			['licensed-with-watermark', 'unlicensed'].includes(licenseManager.state.get()),
 		[editor, licenseManager]
 	)
 
@@ -99,8 +99,9 @@ export const Watermark = React.memo(function Watermark({
 				{`
 /* ------------------- SEE LICENSE -------------------
 The tldraw watermark is part of tldraw's license. It is shown for unlicensed
-users. By using this library, you agree to keep the watermark's behavior, 
-keeping it visible, unobscured, and available to user-interaction.
+or "licensed-with-watermark" users. By using this library, you agree to
+keep the watermark's behavior, keeping it visible, unobscured, and
+available to user-interaction.
 
 To remove the watermark, please purchase a license at tldraw.dev.
 */


### PR DESCRIPTION
Adds option for a license that is licensed but still also shows watermark.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- license: add special license option with watermark