### PR TITLE
[Experiment] Crows-feet arrows, clever bars

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1548,9 +1548,14 @@ export interface TLArrowPoint {
     // (undocumented)
     arrowhead: TLArrowShapeArrowheadStyle;
     // (undocumented)
-    handle: VecLike;
+    handle: Vec;
     // (undocumented)
-    point: VecLike;
+    intersection?: {
+        point: Vec;
+        segment: Vec[];
+    };
+    // (undocumented)
+    point: Vec;
 }
 
 // @public

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -821,6 +821,7 @@ export function getArrowLength(editor: Editor, shape: TLArrowShape): number {
 		: Math.abs(info.handleArc.length)
 }
 
+// todo: remove track
 const ArrowSvg = track(function ArrowSvg({
 	shape,
 	shouldDisplayHandles,

--- a/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
@@ -1,11 +1,12 @@
-import { TLArrowShapeArrowheadStyle, VecLike } from '@tldraw/editor'
+import { TLArrowShapeArrowheadStyle, Vec, VecLike } from '@tldraw/editor'
 import { TLArrowBindings } from './shared'
 
 /** @public */
 export interface TLArrowPoint {
-	handle: VecLike
-	point: VecLike
+	handle: Vec
+	point: Vec
 	arrowhead: TLArrowShapeArrowheadStyle
+	intersection?: { point: Vec; segment: Vec[] }
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -10,6 +10,7 @@ import {
 	Vec,
 } from '@tldraw/editor'
 import { createComputedCache } from '@tldraw/store'
+import { TLArrowPoint } from './arrow-types'
 import { getCurvedArrowInfo } from './curved-arrow'
 import { getStraightArrowInfo } from './straight-arrow'
 
@@ -21,11 +22,11 @@ export function getIsArrowStraight(shape: TLArrowShape) {
 
 export interface BoundShapeInfo<T extends TLShape = TLShape> {
 	shape: T
-	didIntersect: boolean
 	isExact: boolean
 	isClosed: boolean
 	transform: Mat
 	outline: Vec[]
+	intersection?: TLArrowPoint['intersection']
 }
 
 export function getBoundShapeInfoForTerminal(
@@ -54,7 +55,6 @@ export function getBoundShapeInfoForTerminal(
 		transform,
 		isClosed: geometry.isClosed,
 		isExact: binding.props.isExact,
-		didIntersect: false,
 		outline,
 	}
 }

--- a/packages/tldraw/src/lib/styles.tsx
+++ b/packages/tldraw/src/lib/styles.tsx
@@ -91,6 +91,7 @@ export const STYLES = {
 		{ value: 'diamond', icon: 'arrowhead-diamond' },
 		{ value: 'inverted', icon: 'arrowhead-triangle-inverted' },
 		{ value: 'bar', icon: 'arrowhead-bar' },
+		{ value: 'crow', icon: 'arrowhead-none' },
 	],
 	arrowheadEnd: [
 		{ value: 'none', icon: 'arrowhead-none' },
@@ -101,6 +102,7 @@ export const STYLES = {
 		{ value: 'diamond', icon: 'arrowhead-diamond' },
 		{ value: 'inverted', icon: 'arrowhead-triangle-inverted' },
 		{ value: 'bar', icon: 'arrowhead-bar' },
+		{ value: 'crow', icon: 'arrowhead-none' },
 	],
 	spline: [
 		{ value: 'line', icon: 'spline-line' },

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -30,10 +30,10 @@ export const arrowBindingMigrations: TLPropsMigrations;
 export const arrowBindingProps: RecordProps<TLArrowBinding>;
 
 // @public (undocumented)
-export const ArrowShapeArrowheadEndStyle: EnumStyleProp<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+export const ArrowShapeArrowheadEndStyle: EnumStyleProp<"arrow" | "bar" | "crow" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
 
 // @public (undocumented)
-export const ArrowShapeArrowheadStartStyle: EnumStyleProp<"arrow" | "bar" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
+export const ArrowShapeArrowheadStartStyle: EnumStyleProp<"arrow" | "bar" | "crow" | "diamond" | "dot" | "inverted" | "none" | "pipe" | "square" | "triangle">;
 
 // @public (undocumented)
 export const arrowShapeMigrations: MigrationSequence;

--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -26,6 +26,7 @@ const arrowheadTypes = [
 	'diamond',
 	'inverted',
 	'bar',
+	'crow',
 	'none',
 ] as const
 


### PR DESCRIPTION
This PR adds information about the intersection segment to the arrow head info, which lets us do things like crows-feet arrows and smart bar arrowheads. We're not actually slicing the expanded outline of the shape (that's hard) but it mostly looks right!

![Kapture 2024-07-27 at 12 34 09](https://github.com/user-attachments/assets/4c481669-91b4-42b6-84e6-29d8886d10b7)
![Kapture 2024-07-27 at 12 32 03](https://github.com/user-attachments/assets/a23fadf5-1fd5-4a4b-ad4c-804d8ec42015)

Still need:
- [ ] Extra arrowheads
- [ ] Extra arrowhead icons
- [ ] Can we fix the spacing between the shape and the arrowhead?

### Change type

- [x] `feature`

### Test plan

1. Create a shape with a bar arrowhead
2. Bind it to a shape

### Release notes

- Introduces the crows-feet arrowhead, adds bar arrowheads that follow the curve of the shape they're bound to.