### PR TITLE
Fix duplication of shapes.

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5731,12 +5731,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const parentId = originalShape.parentId
 				const siblings = this.getSortedChildIdsForParent(parentId)
 				const currentIndex = siblings.indexOf(originalShape.id)
-				const siblingAboveId = siblings[currentIndex + 1]
-				const siblingAbove = siblingAboveId ? this.getShape(siblingAboveId) : null
 
-				const index = siblingAbove
-					? getIndexBetween(originalShape.index, siblingAbove.index)
-					: getIndexAbove(originalShape.index)
+				const index = getIndexBetween(
+					originalShape.index,
+					this.getShape(siblings[currentIndex + 1])?.index
+				)
 				shape.index = index
 			})
 			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape }) => shape)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5695,8 +5695,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 					const shapesToCreate: TLShape[] = []
 					for (const originalId of orderedShapeIds) {
-						const originalShape = this.getShape(originalId)
 						const duplicatedId = assertExists(shapeIds.get(originalId))
+						const originalShape = this.getShape(originalId)
 						if (!originalShape) continue
 
 						let ox = 0

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5675,10 +5675,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				shapeIds.set(shapeId, createShapeId())
 			}
 
-			const { shapesToCreatWithOriginals, bindingsToCreate } = withIsolatedShapes(
-				this,
-				shapeIdSet,
-				(bindingIdsToMaintain) => {
+			const { shapesToCreatWithOriginals: shapesToCreateWithOriginals, bindingsToCreate } =
+				withIsolatedShapes(this, shapeIdSet, (bindingIdsToMaintain) => {
 					const bindingsToCreate: TLBinding[] = []
 					for (const originalId of bindingIdsToMaintain) {
 						const originalBinding = this.getBinding(originalId)
@@ -5725,12 +5723,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 					}
 
 					return { shapesToCreatWithOriginals, bindingsToCreate }
-				}
-			)
+				})
 
 			// We will update the indexes after the `withIsolatedShapes`, since we cannot rely on the indexes
 			// to be correct inside of it.
-			shapesToCreatWithOriginals.forEach(({ shape, originalShape }) => {
+			shapesToCreateWithOriginals.forEach(({ shape, originalShape }) => {
 				const parentId = originalShape.parentId
 				const siblings = this.getSortedChildIdsForParent(parentId)
 				const currentIndex = siblings.indexOf(originalShape.id)
@@ -5742,7 +5739,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 					: getIndexAbove(originalShape.index)
 				shape.index = index
 			})
-			const shapesToCreate = shapesToCreatWithOriginals.map(({ shape }) => shape)
+			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape }) => shape)
 
 			const maxShapesReached =
 				shapesToCreate.length + this.getCurrentPageShapeIds().size > this.options.maxShapesPerPage

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5675,8 +5675,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				shapeIds.set(shapeId, createShapeId())
 			}
 
-			const { shapesToCreatWithOriginals: shapesToCreateWithOriginals, bindingsToCreate } =
-				withIsolatedShapes(this, shapeIdSet, (bindingIdsToMaintain) => {
+			const { shapesToCreateWithOriginals, bindingsToCreate } = withIsolatedShapes(
+				this,
+				shapeIdSet,
+				(bindingIdsToMaintain) => {
 					const bindingsToCreate: TLBinding[] = []
 					for (const originalId of bindingIdsToMaintain) {
 						const originalBinding = this.getBinding(originalId)
@@ -5691,7 +5693,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						})
 					}
 
-					const shapesToCreatWithOriginals: { shape: TLShape; originalShape: TLShape }[] = []
+					const shapesToCreateWithOriginals: { shape: TLShape; originalShape: TLShape }[] = []
 					for (const originalId of orderedShapeIds) {
 						const duplicatedId = assertExists(shapeIds.get(originalId))
 						const originalShape = this.getShape(originalId)
@@ -5707,7 +5709,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							oy = vec.y
 						}
 
-						shapesToCreatWithOriginals.push({
+						shapesToCreateWithOriginals.push({
 							shape: {
 								...originalShape,
 								id: duplicatedId,
@@ -5722,8 +5724,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 						})
 					}
 
-					return { shapesToCreatWithOriginals, bindingsToCreate }
-				})
+					return { shapesToCreateWithOriginals, bindingsToCreate }
+				}
+			)
 
 			// We will update the indexes after the `withIsolatedShapes`, since we cannot rely on the indexes
 			// to be correct inside of it.

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5734,11 +5734,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const parentId = originalShape.parentId
 				const siblings = this.getSortedChildIdsForParent(parentId)
 				const currentIndex = siblings.indexOf(originalShape.id)
+				const siblingAboveId = siblings[currentIndex + 1]
+				const siblingAbove = siblingAboveId ? this.getShape(siblingAboveId) : undefined
 
-				const index = getIndexBetween(
-					originalShape.index,
-					this.getShape(siblings[currentIndex + 1])?.index
-				)
+				const index = getIndexBetween(originalShape.index, siblingAbove?.index)
+
 				shape.index = index
 			})
 			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape }) => shape)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5674,7 +5674,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			for (const shapeId of shapeIdSet) {
 				shapeIds.set(shapeId, createShapeId())
 			}
-			const orderedShapes = compact(orderedShapeIds.map((id) => this.getShape(id)))
 
 			const { shapesToCreate, bindingsToCreate } = withIsolatedShapes(
 				this,
@@ -5695,9 +5694,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 					}
 
 					const shapesToCreate: TLShape[] = []
-					for (const originalShape of orderedShapes) {
-						const originalId = originalShape.id
+					for (const originalId of orderedShapeIds) {
+						const originalShape = this.getShape(originalId)
 						const duplicatedId = assertExists(shapeIds.get(originalId))
+						if (!originalShape) continue
 
 						let ox = 0
 						let oy = 0
@@ -5724,7 +5724,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				}
 			)
 
-			orderedShapes.forEach((originalShape, i) => {
+			orderedShapeIds.forEach((originalId, i) => {
+				const originalShape = this.getShape(originalId)
+				if (!originalShape) return
 				const parentId = originalShape.parentId
 				const siblings = this.getSortedChildIdsForParent(parentId)
 				const currentIndex = siblings.indexOf(originalShape.id)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5675,7 +5675,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				shapeIds.set(shapeId, createShapeId())
 			}
 
-			const { shapesToCreate, bindingsToCreate } = withIsolatedShapes(
+			const { shapesToCreatWithOriginals, bindingsToCreate } = withIsolatedShapes(
 				this,
 				shapeIdSet,
 				(bindingIdsToMaintain) => {
@@ -5693,7 +5693,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						})
 					}
 
-					const shapesToCreate: TLShape[] = []
+					const shapesToCreatWithOriginals: { shape: TLShape; originalShape: TLShape }[] = []
 					for (const originalId of orderedShapeIds) {
 						const duplicatedId = assertExists(shapeIds.get(originalId))
 						const originalShape = this.getShape(originalId)
@@ -5709,24 +5709,28 @@ export class Editor extends EventEmitter<TLEventMap> {
 							oy = vec.y
 						}
 
-						shapesToCreate.push({
-							...originalShape,
-							id: duplicatedId,
-							x: originalShape.x + ox,
-							y: originalShape.y + oy,
-							// Use a dummy index for now, it will get updated outside of the `withIsolatedShapes`
-							index: 'a1' as IndexKey,
-							parentId: shapeIds.get(originalShape.parentId as TLShapeId) ?? originalShape.parentId,
+						shapesToCreatWithOriginals.push({
+							shape: {
+								...originalShape,
+								id: duplicatedId,
+								x: originalShape.x + ox,
+								y: originalShape.y + oy,
+								// Use a dummy index for now, it will get updated outside of the `withIsolatedShapes`
+								index: 'a1' as IndexKey,
+								parentId:
+									shapeIds.get(originalShape.parentId as TLShapeId) ?? originalShape.parentId,
+							},
+							originalShape,
 						})
 					}
 
-					return { shapesToCreate, bindingsToCreate }
+					return { shapesToCreatWithOriginals, bindingsToCreate }
 				}
 			)
 
-			orderedShapeIds.forEach((originalId, i) => {
-				const originalShape = this.getShape(originalId)
-				if (!originalShape) return
+			// We will update the indexes after the `withIsolatedShapes`, since we cannot rely on the indexes
+			// to be correct inside of it.
+			shapesToCreatWithOriginals.forEach(({ shape, originalShape }) => {
 				const parentId = originalShape.parentId
 				const siblings = this.getSortedChildIdsForParent(parentId)
 				const currentIndex = siblings.indexOf(originalShape.id)
@@ -5736,8 +5740,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const index = siblingAbove
 					? getIndexBetween(originalShape.index, siblingAbove.index)
 					: getIndexAbove(originalShape.index)
-				shapesToCreate[i].index = index
+				shape.index = index
 			})
+			const shapesToCreate = shapesToCreatWithOriginals.map(({ shape }) => shape)
 
 			const maxShapesReached =
 				shapesToCreate.length + this.getCurrentPageShapeIds().size > this.options.maxShapesPerPage


### PR DESCRIPTION
This fixes some issues with indexes being incorrectly set when duplicating groups.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create three rectangles.
2. Create an arrow that goes from the third rectangle to the second one.
3. Group the first and third rectangle.
4. Now duplicate this group.
5. Now ungroup

Before this PR this would cause an error.

https://github.com/user-attachments/assets/1d61a74b-6763-4af1-9b1a-0ccbe67ab6fe

### Release notes

- Fix an issue with duplicating groups.