### PR TITLE
Fix an issue with minimap

### DIFF
--- a/apps/dotcom/src/utils/multiplayerAssetStore.test.ts
+++ b/apps/dotcom/src/utils/multiplayerAssetStore.test.ts
@@ -8,7 +8,7 @@ describe('multiplayerAssetStore.resolve', () => {
 	it('should return null if the asset has no src', async () => {
 		const asset = { type: 'image', props: { w: 100, fileSize: FILE_SIZE } }
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -24,7 +24,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.tldraw.dev/video.mp4', fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -40,7 +40,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.not-tldraw.dev/video.mp4', fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -56,7 +56,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.tldraw.dev/image.jpg', fileSize: 1000 },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -69,7 +69,7 @@ describe('multiplayerAssetStore.resolve', () => {
 	it('should return the original src for if original is asked for', async () => {
 		const asset = { type: 'image', props: { src: 'http://assets.tldraw.dev/image.jpg', w: 100 } }
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -82,7 +82,7 @@ describe('multiplayerAssetStore.resolve', () => {
 	it('should return the original src if it does not start with http or https', async () => {
 		const asset = { type: 'image', props: { src: 'data:somedata', w: 100, fileSize: FILE_SIZE } }
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -103,7 +103,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			},
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -124,7 +124,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			},
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -140,7 +140,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.tldraw.dev/doc.pdf', w: 100, fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 1,
 				dpr: 1,
@@ -156,7 +156,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.tldraw.dev/image.jpg', w: 100, fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 0.5,
 				dpr: 2,
@@ -172,7 +172,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'http://assets.tldraw.dev/image.jpg', w: 100, fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 0.5,
 				dpr: 2,
@@ -188,7 +188,7 @@ describe('multiplayerAssetStore.resolve', () => {
 			props: { src: 'https://assets.tldraw.dev/image.jpg', w: 100, fileSize: FILE_SIZE },
 		}
 		expect(
-			await resolver(asset as TLAsset, {
+			resolver(asset as TLAsset, {
 				screenScale: -1,
 				steppedScreenScale: 5,
 				dpr: 1,

--- a/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
@@ -58,6 +58,12 @@ export class HandleSnaps {
 		const { editor } = this
 		return editor.store.createComputedCache('handle snap geometry', (shape: TLShape) => {
 			const snapGeometry = editor.getShapeUtil(shape).getHandleSnapGeometry(shape)
+			const getSelfSnapOutline = snapGeometry.getSelfSnapOutline
+				? snapGeometry.getSelfSnapOutline.bind(snapGeometry)
+				: defaultGetSelfSnapOutline
+			const getSelfSnapPoints = snapGeometry.getSelfSnapPoints
+				? snapGeometry.getSelfSnapPoints.bind(snapGeometry)
+				: defaultGetSelfSnapPoints
 
 			return {
 				outline:
@@ -66,8 +72,8 @@ export class HandleSnaps {
 						: snapGeometry.outline,
 
 				points: snapGeometry.points ?? [],
-				getSelfSnapOutline: snapGeometry.getSelfSnapOutline ?? defaultGetSelfSnapOutline,
-				getSelfSnapPoints: snapGeometry.getSelfSnapPoints ?? defaultGetSelfSnapPoints,
+				getSelfSnapOutline,
+				getSelfSnapPoints,
 			}
 		})
 	}

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -1,4 +1,4 @@
-import { createShapeId } from '@tldraw/tlschema'
+import { TLShape, createShapeId } from '@tldraw/tlschema'
 import { structuredClone } from '@tldraw/utils'
 import { Vec } from '../../../../primitives/Vec'
 import { TLBaseBoxShape } from '../../../shapes/BaseBoxShapeUtil'
@@ -49,7 +49,7 @@ export class Pointing extends StateNode {
 					creatingMarkId,
 					creationCursorOffset: { x: 1, y: 1 },
 					onInteractionEnd: this.parent.id,
-					onCreate: (this.parent as BaseBoxShapeTool).onCreate,
+					onCreate: (shape: TLShape | null) => (this.parent as BaseBoxShapeTool).onCreate?.(shape),
 				} /** satisfies ResizingInfo, defined in main tldraw package 😧 */
 			)
 		}

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
@@ -1,4 +1,4 @@
-import { BaseBoxShapeTool, TLShape, TLShapeId, bind } from '@tldraw/editor'
+import { BaseBoxShapeTool, TLShape, TLShapeId } from '@tldraw/editor'
 
 /** @public */
 export class FrameShapeTool extends BaseBoxShapeTool {
@@ -6,7 +6,6 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 	static override initial = 'idle'
 	override shapeType = 'frame'
 
-	@bind
 	override onCreate(shape: TLShape | null): void {
 		if (!shape) return
 

--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -5,6 +5,7 @@ import {
 	TLShape,
 	Vec,
 	atom,
+	bind,
 	clamp,
 	computed,
 	react,
@@ -16,6 +17,8 @@ import { pie, rectangle, roundedRectangle } from './minimap-webgl-shapes'
 
 export class MinimapManager {
 	disposables = [] as (() => void)[]
+
+	@bind
 	close() {
 		return this.disposables.forEach((d) => d())
 	}
@@ -205,6 +208,7 @@ export class MinimapManager {
 		return new Vec(px, py)
 	}
 
+	@bind
 	render() {
 		// make sure we update when dark mode switches
 		const context = this.gl.context


### PR DESCRIPTION
Fixes an issue with minimap caused by #4288. Also makes the library use safer by handling some unbound calls in the library instead of relying of end users to bind things.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes
- Fixes a bug with the MiniMap not rendering. Makes the unbound uses safer.