### PR TITLE
remove onEditorMount prop

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -497,7 +497,7 @@ export function createSessionStateSnapshotSignal(store: TLStore): Signal<null | 
 export function createTLSchemaFromUtils(opts: TLStoreSchemaOptions): StoreSchema<TLRecord, TLStoreProps>;
 
 // @public
-export function createTLStore({ initialData, defaultName, id, assets, onEditorMount, multiplayerStatus, ...rest }?: TLStoreOptions): TLStore;
+export function createTLStore({ initialData, defaultName, id, assets, onMount, multiplayerStatus, ...rest }?: TLStoreOptions): TLStore;
 
 // @public (undocumented)
 export function createTLUser(opts?: {
@@ -3276,7 +3276,7 @@ export interface TLStoreBaseOptions {
     defaultName?: string;
     initialData?: SerializedStore<TLRecord>;
     multiplayerStatus?: null | Signal<'offline' | 'online'>;
-    onEditorMount?(editor: Editor): (() => void) | void;
+    onMount?(editor: Editor): (() => void) | void;
     snapshot?: Partial<TLEditorSnapshot> | TLStoreSnapshot;
 }
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -471,7 +471,7 @@ function Layout({ children, onMount }: { children: ReactNode; onMount?: TLOnMoun
 	useDarkMode()
 	useForceUpdate()
 	useOnMount((editor) => {
-		const teardownStore = editor.store.props.onEditorMount(editor)
+		const teardownStore = editor.store.props.onMount(editor)
 		const teardownCallback = onMount?.(editor)
 
 		return () => {

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -30,7 +30,7 @@ export interface TLStoreBaseOptions {
 	assets?: TLAssetStore
 
 	/** Called when the store is connected to an {@link Editor}. */
-	onEditorMount?(editor: Editor): void | (() => void)
+	onMount?(editor: Editor): void | (() => void)
 
 	/** Is this store connected to a multiplayer sync server? */
 	multiplayerStatus?: Signal<'online' | 'offline'> | null
@@ -98,7 +98,7 @@ export function createTLStore({
 	defaultName = '',
 	id,
 	assets = inlineBase64AssetStore,
-	onEditorMount,
+	onMount,
 	multiplayerStatus,
 	...rest
 }: TLStoreOptions = {}): TLStore {
@@ -114,9 +114,9 @@ export function createTLStore({
 				upload: assets.upload,
 				resolve: assets.resolve ?? defaultAssetResolve,
 			},
-			onEditorMount: (editor) => {
+			onMount: (editor) => {
 				assert(editor instanceof Editor)
-				onEditorMount?.(editor)
+				onMount?.(editor)
 			},
 			multiplayerStatus: multiplayerStatus ?? null,
 		},

--- a/packages/sync/api-report.md
+++ b/packages/sync/api-report.md
@@ -42,7 +42,7 @@ export interface UseSyncDemoOptions {
 export interface UseSyncOptions {
     assets: TLAssetStore;
     // @internal (undocumented)
-    onEditorMount?(editor: Editor): void;
+    onMount?(editor: Editor): void;
     // @internal
     roomId?: string;
     // @internal (undocumented)

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -71,7 +71,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		uri,
 		roomId = 'default',
 		assets,
-		onEditorMount,
+		onMount,
 		trackAnalyticsEvent: track,
 		userInfo,
 		...schemaOpts
@@ -143,7 +143,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			id: storeId,
 			schema,
 			assets,
-			onEditorMount,
+			onMount,
 			multiplayerStatus: computed('multiplayer status', () =>
 				socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
 			),
@@ -184,7 +184,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			socket.close()
 			setState(null)
 		}
-	}, [assets, onEditorMount, userAtom, roomId, schema, setState, track, uri])
+	}, [assets, onMount, userAtom, roomId, schema, setState, track, uri])
 
 	return useValue<RemoteTLStoreWithStatus>(
 		'remote synced store',
@@ -250,7 +250,7 @@ export interface UseSyncOptions {
 	assets: TLAssetStore
 
 	/** @internal */
-	onEditorMount?(editor: Editor): void
+	onMount?(editor: Editor): void
 	/** @internal used for analytics only, we should refactor this away */
 	roomId?: string
 	/** @internal */

--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -102,7 +102,7 @@ export function useSyncDemo(
 		roomId,
 		userInfo,
 		assets,
-		onEditorMount: useCallback(
+		onMount: useCallback(
 			(editor: Editor) => {
 				editor.registerExternalAssetHandler('url', async ({ url }) => {
 					return await createAssetFromUrlUsingDemoServer(host, url)

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -187,7 +187,7 @@ function InsideOfEditorAndUiContext({
 		)
 
 		// ...then we call the store's on mount which may override them...
-		unsubs.push(editor.store.props.onEditorMount(editor))
+		unsubs.push(editor.store.props.onMount(editor))
 
 		// ...then we run the user's onMount prop, which may override things again.
 		unsubs.push(onMount?.(editor))

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1640,7 +1640,7 @@ export interface TLStoreProps {
     defaultName: string;
     // (undocumented)
     multiplayerStatus: null | Signal<'offline' | 'online'>;
-    onEditorMount(editor: unknown): (() => void) | void;
+    onMount(editor: unknown): (() => void) | void;
 }
 
 // @public (undocumented)

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -98,7 +98,7 @@ export interface TLStoreProps {
 	/**
 	 * Called an {@link @tldraw/editor#Editor} connected to this store is mounted.
 	 */
-	onEditorMount(editor: unknown): void | (() => void)
+	onMount(editor: unknown): void | (() => void)
 	multiplayerStatus: Signal<'online' | 'offline'> | null
 }
 


### PR DESCRIPTION
This was showing up where it shouldn't, so lets rename it to `onMount` so it merges with the standard option.

### Change type

- [x] `api`

### Release notes

- **Breaking:** the `onEditorMount` option to `createTLStore` is now called `onMount`