### PR TITLE
Export some missing components that are used in the `DefaultToolbar`

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1155,6 +1155,9 @@ export function LineToolbarItem(): JSX_2.Element;
 export function MiscMenuGroup(): JSX_2.Element;
 
 // @public (undocumented)
+export function MobileStylePanel(): JSX_2.Element | null;
+
+// @public (undocumented)
 export function MoveToPageMenu(): JSX_2.Element | null;
 
 // @public (undocumented)
@@ -1262,6 +1265,11 @@ export function OpacitySlider(): JSX_2.Element | null;
 
 // @public (undocumented)
 export function OvalToolbarItem(): JSX_2.Element;
+
+// @public (undocumented)
+export function OverflowingToolbar({ children }: {
+    children: React.ReactNode;
+}): JSX_2.Element;
 
 // @public (undocumented)
 export const PageItemInput: ({ name, id, isCurrentPage, }: PageItemInputProps) => JSX_2.Element;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -132,6 +132,7 @@ export {
 	ViewSubmenu,
 } from './lib/ui/components/MainMenu/DefaultMainMenuContent'
 export { DefaultMinimap } from './lib/ui/components/Minimap/DefaultMinimap'
+export { MobileStylePanel } from './lib/ui/components/MobileStylePanel'
 export { DefaultNavigationPanel } from './lib/ui/components/NavigationPanel/DefaultNavigationPanel'
 export { OfflineIndicator } from './lib/ui/components/OfflineIndicator/OfflineIndicator'
 export { DefaultPageMenu } from './lib/ui/components/PageMenu/DefaultPageMenu'
@@ -202,6 +203,7 @@ export {
 	useIsToolSelected,
 	type ToolbarItemProps,
 } from './lib/ui/components/Toolbar/DefaultToolbarContent'
+export { OverflowingToolbar } from './lib/ui/components/Toolbar/OverflowingToolbar'
 export {
 	CenteredTopPanelContainer,
 	type CenteredTopPanelContainerProps,

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -17,6 +17,7 @@ import {
 	TldrawUiPopoverTrigger,
 } from './primitives/TldrawUiPopover'
 
+/** @public @react */
 export function MobileStylePanel() {
 	const editor = useEditor()
 	const msg = useTranslation()

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -18,6 +18,7 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 
 export const IsInOverflowContext = createContext(false)
 
+/** @public @react */
 export function OverflowingToolbar({ children }: { children: React.ReactNode }) {
 	const editor = useEditor()
 	const id = useSafeId()


### PR DESCRIPTION
This exports some components that are used in the `DefaultToolbar` components. This will allow the users to reuse them and customize the existing toolbar, while allowing them to reused these components.

[Discussion](https://discord.com/channels/859816885297741824/1266843619072016496/1268015153199190126).

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Export `OverflowingToolbar` and `MobileStylePanel` panel components so they can be reused for building a custom `Toolbar`.