### PR TITLE
fix broken links

### DIFF
--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -31,9 +31,9 @@ The tldraw SDK includes deep support for real-time collaboration. The easiest wa
 
 ## tldraw sync
 
-[tldraw sync](/sync) is our library for fast multi-user collaboration. It's purpose-built for the tldraw canvas and it's what we use to power collaboration on our flagship app tldraw.com.
+[tldraw sync](/docs/sync) is our library for fast multi-user collaboration. It's purpose-built for the tldraw canvas and it's what we use to power collaboration on our flagship app tldraw.com.
 
-You can read our full article on [tldraw sync](/sync).
+You can read our full article on [tldraw sync](/docs/sync).
 
 ### tldraw sync demo
 
@@ -75,7 +75,7 @@ The sync demo is great for prototyping but you should not use it in production. 
 
 ### Using tldraw sync in production
 
-To use tldraw sync in production, you will need to self-host the tldraw sync server. To learn more, see our article on [tldraw sync](/sync).
+To use tldraw sync in production, you will need to self-host the tldraw sync server. To learn more, see our article on [tldraw sync](/docs/sync).
 
 > We don't offer a hosted solution for tldraw sync in production, but if you're interested in that please let us know at hello@tldraw.com.
 


### PR DESCRIPTION
The collaboration docs have the wrong link for the sync docs

### Change type

- [x] `other`
