### PR TITLE
Add missing bits to exploded example

### DIFF
--- a/apps/examples/src/examples/exploded/ExplodedExample.tsx
+++ b/apps/examples/src/examples/exploded/ExplodedExample.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react'
 import {
 	ContextMenu,
+	DEFAULT_SUPPORTED_IMAGE_TYPES,
+	DEFAULT_SUPPORT_VIDEO_TYPES,
 	DefaultContextMenuContent,
 	DefaultSpinner,
 	ErrorScreen,
@@ -16,7 +19,12 @@ import {
 	defaultShapeTools,
 	defaultShapeUtils,
 	defaultTools,
+	registerDefaultExternalContentHandlers,
+	registerDefaultSideEffects,
+	useEditor,
 	usePreloadAssets,
+	useToasts,
+	useTranslation,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 
@@ -59,34 +67,69 @@ export default function ExplodedExample() {
 				persistenceKey="exploded-example"
 			>
 				<TldrawUi>
-					<ContextMenu>
-						<DefaultContextMenuContent />
-					</ContextMenu>
+					<InsideEditorAndUiContext />
 				</TldrawUi>
 			</TldrawEditor>
 		</div>
 	)
 }
 
+function InsideEditorAndUiContext() {
+	const editor = useEditor()
+	const toasts = useToasts()
+	const msg = useTranslation()
+
+	// [3]
+	useEffect(() => {
+		registerDefaultExternalContentHandlers(
+			editor,
+			{
+				maxImageDimension: 5000,
+				maxAssetSize: 10 * 1024 * 1024, // 10mb
+				acceptedImageMimeTypes: DEFAULT_SUPPORTED_IMAGE_TYPES,
+				acceptedVideoMimeTypes: DEFAULT_SUPPORT_VIDEO_TYPES,
+			},
+			{
+				toasts,
+				msg,
+			}
+		)
+
+		const cleanupSideEffects = registerDefaultSideEffects(editor)
+
+		return () => {
+			cleanupSideEffects()
+		}
+	}, [editor, msg, toasts])
+
+	return (
+		<ContextMenu>
+			<DefaultContextMenuContent />
+		</ContextMenu>
+	)
+}
+
 /* 
-The tldraw library is built from many sublibraries. This example shows how to 
-build the tldraw component from its subcomponents for max customisation. You 
-can edit, omit or add to these subcomponents to create your app.
+The tldraw library is built from many sublibraries. This example shows how to build the tldraw
+component from its subcomponents for max customisation. You can edit, omit or add to these
+subcomponents to create your app.
 
-[1]
-Here we've imported some components from the tldraw library which we will later
-pass to the TldrawEditor component. These components are not part of the more 
-minimal defaults, so we need to import them separately. For help creating your
-own components to pass into the components prop check out the custom components 
-example.
+[1] Here we've imported some components from the tldraw library which we will later pass to the
+TldrawEditor component. These components are not part of the more minimal defaults, so we need to
+import them separately. For help creating your own components to pass into the components prop check
+out the custom components example.
 
-[2]
-Here we've passed the default components object to the TldrawEditor component. Along
-with default tools and shapeutils, You could input your own custom shapes/tools here. 
-For help creating your own shapes/tools check out the custom config example.
+[2] Here we've passed the default components object to the TldrawEditor component. Along with
+default tools and shapeutils, You could input your own custom shapes/tools here. For help creating
+your own shapes/tools check out the custom config example.
 
-We also set the initial state to 'select' and render the UI, context menu and canvas
-components. You could add your own custom components here, omit these ones, and/or 
-change the initial state of the application to whatever you want. 
+We also set the initial state to 'select' and render the UI, context menu and canvas components. You
+could add your own custom components here, omit these ones, and/or change the initial state of the
+application to whatever you want. 
+
+[3] Inside of the editor and UI context, we need to set up extra pieces to get the editor working
+with our default shapes and tools. We register the default external content handlers, which sets up
+handling for things like images and pasted content. We also register the default side effects, which
+react to changes to the editor's store.
 
 */

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1347,6 +1347,15 @@ export function PrintItem(): JSX_2.Element;
 // @public (undocumented)
 export function RectangleToolbarItem(): JSX_2.Element;
 
+// @public (undocumented)
+export function registerDefaultExternalContentHandlers(editor: Editor, { maxImageDimension, maxAssetSize, acceptedImageMimeTypes, acceptedVideoMimeTypes, }: Required<TLExternalContentProps>, { toasts, msg }: {
+    msg: ReturnType<typeof useTranslation>;
+    toasts: TLUiToastsContextType;
+}): void;
+
+// @public (undocumented)
+export function registerDefaultSideEffects(editor: Editor): () => void;
+
 // @public
 export function removeFrame(editor: Editor, ids: TLShapeId[]): void;
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -14,10 +14,12 @@ export { defaultBindingUtils } from './lib/defaultBindingUtils'
 export {
 	centerSelectionAroundPoint,
 	createShapesForAssets,
+	registerDefaultExternalContentHandlers,
 	type TLExternalContentProps,
 } from './lib/defaultExternalContentHandlers'
 export { defaultShapeTools } from './lib/defaultShapeTools'
 export { defaultShapeUtils } from './lib/defaultShapeUtils'
+export { registerDefaultSideEffects } from './lib/defaultSideEffects'
 export { defaultTools } from './lib/defaultTools'
 export { ArrowShapeTool } from './lib/shapes/arrow/ArrowShapeTool'
 export { ArrowShapeUtil } from './lib/shapes/arrow/ArrowShapeUtil'

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -169,7 +169,7 @@ function InsideOfEditorAndUiContext({
 	useOnMount(() => {
 		const unsubs: (void | (() => void) | undefined)[] = []
 
-		unsubs.push(...registerDefaultSideEffects(editor))
+		unsubs.push(registerDefaultSideEffects(editor))
 
 		// for content handling, first we register the default handlers...
 		registerDefaultExternalContentHandlers(

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -50,6 +50,7 @@ export interface TLExternalContentProps {
 	acceptedVideoMimeTypes?: readonly string[]
 }
 
+/** @public */
 export function registerDefaultExternalContentHandlers(
 	editor: Editor,
 	{

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -1,32 +1,35 @@
 import { Editor } from '@tldraw/editor'
 
+/** @public */
 export function registerDefaultSideEffects(editor: Editor) {
-	return [
-		editor.sideEffects.registerAfterChangeHandler('instance_page_state', (prev, next) => {
-			if (prev.croppingShapeId !== next.croppingShapeId) {
-				const isInCroppingState = editor.isIn('select.crop')
-				if (!prev.croppingShapeId && next.croppingShapeId) {
-					if (!isInCroppingState) {
-						editor.setCurrentTool('select.crop.idle')
-					}
-				} else if (prev.croppingShapeId && !next.croppingShapeId) {
-					if (isInCroppingState) {
-						editor.setCurrentTool('select.idle')
+	return editor.sideEffects.register({
+		instance_page_state: {
+			afterChange: (prev, next) => {
+				if (prev.croppingShapeId !== next.croppingShapeId) {
+					const isInCroppingState = editor.isIn('select.crop')
+					if (!prev.croppingShapeId && next.croppingShapeId) {
+						if (!isInCroppingState) {
+							editor.setCurrentTool('select.crop.idle')
+						}
+					} else if (prev.croppingShapeId && !next.croppingShapeId) {
+						if (isInCroppingState) {
+							editor.setCurrentTool('select.idle')
+						}
 					}
 				}
-			}
 
-			if (prev.editingShapeId !== next.editingShapeId) {
-				if (!prev.editingShapeId && next.editingShapeId) {
-					if (!editor.isIn('select.editing_shape')) {
-						editor.setCurrentTool('select.editing_shape')
-					}
-				} else if (prev.editingShapeId && !next.editingShapeId) {
-					if (editor.isIn('select.editing_shape')) {
-						editor.setCurrentTool('select.idle')
+				if (prev.editingShapeId !== next.editingShapeId) {
+					if (!prev.editingShapeId && next.editingShapeId) {
+						if (!editor.isIn('select.editing_shape')) {
+							editor.setCurrentTool('select.editing_shape')
+						}
+					} else if (prev.editingShapeId && !next.editingShapeId) {
+						if (editor.isIn('select.editing_shape')) {
+							editor.setCurrentTool('select.idle')
+						}
 					}
 				}
-			}
-		}),
-	]
+			},
+		},
+	})
 }


### PR DESCRIPTION
We didn't have the default external content handlers or default side effects

### Change type

- [x] `bugfix`

### Release notes

- Expose `registerDefaultSideEffects` and `registerDefaultExternalContentHandler`