### PR TITLE
text shape: dont make a fixed width unless more intentional drag, take 2

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -103,7 +103,7 @@ describe('When in the pointing state', () => {
 	it('transitions to select.resizing when dragging and edits on pointer up', () => {
 		editor.setCurrentTool('text')
 		editor.pointerDown(0, 0)
-		editor.pointerMove(24, 24)
+		editor.pointerMove(34, 34)
 		editor.expectToBeIn('select.resizing')
 		editor.pointerUp()
 		expect(editor.getCurrentPageShapes().length).toBe(1)

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -38,7 +38,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return {
 			color: 'black',
 			size: 'm',
-			w: 64,
+			w: 8,
 			text: '',
 			font: 'draw',
 			textAlign: 'start',

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -38,7 +38,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return {
 			color: 'black',
 			size: 'm',
-			w: 8,
+			w: 64,
 			text: '',
 			font: 'draw',
 			textAlign: 'start',

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -24,16 +24,9 @@ export class Pointing extends StateNode {
 		// otherwise you get a vertical column of single characters if you accidentally
 		// drag a bit unintentionally.
 		const { editor } = this
-		const { isPointing, originPagePoint, currentPagePoint } = editor.inputs
-		if (
-			isPointing &&
-			Math.abs(originPagePoint.x - currentPagePoint.x) ** 2 >
-				((editor.getInstanceState().isCoarsePointer
-					? editor.options.coarseDragDistanceSquared
-					: editor.options.dragDistanceSquared) *
-					4) / // double the necessary drag distance for text shapes
-					editor.getZoomLevel()
-		) {
+		const { isPointing, originPagePoint, originScreenPoint, currentScreenPoint } = editor.inputs
+
+		if (isPointing && Math.abs(originScreenPoint.x - currentScreenPoint.x) > 32) {
 			const id = createShapeId()
 			this.markId = this.editor.markHistoryStoppingPoint(`creating_text:${id}`)
 
@@ -107,7 +100,11 @@ export class Pointing extends StateNode {
 			props: {
 				text: '',
 				autoSize,
-				w: 20,
+				w: autoSize
+					? 20
+					: this.editor.user.getIsDynamicResizeMode()
+						? 24 * this.editor.getZoomLevel()
+						: 64,
 				scale: this.editor.user.getIsDynamicResizeMode() ? 1 / this.editor.getZoomLevel() : 1,
 			},
 		})


### PR DESCRIPTION
follow-up to https://github.com/tldraw/tldraw/pull/4293

@steveruizok I think maybe we landed that PR a bit too soon. It still felt pretty easy to make accidental fixed-width text shapes. I know your technique was using pagePoint but I'm going for screenPoint b/c really it's not dependent on zoom level, we're trying to detect a flick of the finger, a fat-finger-fudge-factor, if you will — and that can happen at any zoom level.

This PR actually takes the first refinement and further adds a better starting width for a non-autoSized text shape. Right now, our starting width was 20 which made it a fixed column of 1 letter wide which...isn't really useful. The intention is, if you're gonna have a fixed width to at least have a couple letters.

I also noticed a bug with dynamic size + 800% zoom - the text shape would size in the wrong direction 🙃 

Let's talk tweak it some more!

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Text shape: dont make a fixed width unless more intentional drag