### PR TITLE
bookmark: dont show broken favicon and cleanup HTML entities in title

### DIFF
--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -14,6 +14,8 @@ import {
 	stopEventPropagation,
 	toDomPrecision,
 } from '@tldraw/editor'
+import { useState } from 'react'
+import { convertCommonTitleHTMLEntities } from '../../utils/text/text'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { LINK_ICON } from '../shared/icons-editor'
 import { getRotatedBoxShadow } from '../shared/rotated-box-shadow'
@@ -55,6 +57,10 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 
 		const address = getHumanReadableAddress(shape)
 
+		/* eslint-disable-next-line react-hooks/rules-of-hooks */
+		const [isFaviconValid, setIsFaviconValid] = useState(true)
+		const onFaviconError = () => setIsFaviconValid(false)
+
 		return (
 			<HTMLContainer>
 				<div
@@ -84,7 +90,9 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 					)}
 					<div className="tl-bookmark__copy_container">
 						{asset?.props.title ? (
-							<h2 className="tl-bookmark__heading">{asset.props.title}</h2>
+							<h2 className="tl-bookmark__heading">
+								{convertCommonTitleHTMLEntities(asset.props.title)}
+							</h2>
 						) : null}
 						{asset?.props.description && asset?.props.image ? (
 							<p className="tl-bookmark__description">{asset.props.description}</p>
@@ -98,11 +106,12 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 							onPointerUp={stopEventPropagation}
 							onClick={stopEventPropagation}
 						>
-							{asset?.props.favicon ? (
+							{isFaviconValid && asset?.props.favicon ? (
 								<img
 									className="tl-bookmark__favicon"
 									src={asset?.props.favicon}
 									referrerPolicy="strict-origin-when-cross-origin"
+									onError={onFaviconError}
 									alt={`favicon of ${address}`}
 								/>
 							) : (

--- a/packages/tldraw/src/lib/utils/text/text.ts
+++ b/packages/tldraw/src/lib/utils/text/text.ts
@@ -39,6 +39,32 @@ function stripCommonMinimumIndentation(text: string): string {
 	return lines.map((line) => line.slice(minIndentation)).join('\n')
 }
 
+const COMMON_ENTITY_MAP = {
+	'&amp;': '&',
+	'&quot;': '"',
+	'&apos;': "'",
+	'&#34;': '"',
+	'&#38;': '&',
+	'&#39;': "'",
+	'&#8211;': '–',
+	'&#8212;': '—',
+	'&#8216;': '‘',
+	'&#8217;': '’',
+	'&#8220;': '“',
+	'&#8221;': '”',
+	'&#8230;': '…',
+}
+const entityRegex = new RegExp(Object.keys(COMMON_ENTITY_MAP).join('|'), 'g')
+
+/**
+ * Takes common HTML entities found in web page titles and converts them to regular characters.
+ * @param text - The text to convert HTML entities.
+ * @internal
+ */
+export function convertCommonTitleHTMLEntities(text: string) {
+	return text.replace(entityRegex, (m) => COMMON_ENTITY_MAP[m as keyof typeof COMMON_ENTITY_MAP])
+}
+
 /**
  * Strip trailing whitespace from each line and remove any trailing newlines.
  * @param text - The text to strip.


### PR DESCRIPTION
doing all the HTML entities would be overkill - i pulled these entities from my open source stuff that parses RSS feeds. these are the most common ones you'll find in HTML web page titles.

before
<img width="418" alt="Screenshot 2024-08-01 at 11 23 11" src="https://github.com/user-attachments/assets/3d87bf5a-651a-4355-b482-cd7f87d0a417">


after
<img width="483" alt="Screenshot 2024-08-01 at 11 23 58" src="https://github.com/user-attachments/assets/2874781d-769d-4c9d-a9ea-8ee898eed51c">


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- bookmark: dont show broken favicon and cleanup HTML entities in title