### PR TITLE
Combino fixed text

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -3,6 +3,7 @@ import { TestEditor } from '../../../test/TestEditor'
 import { TextShapeTool } from './TextShapeTool'
 
 let editor: TestEditor
+jest.useFakeTimers()
 
 beforeEach(() => {
 	editor = new TestEditor()
@@ -103,10 +104,32 @@ describe('When in the pointing state', () => {
 	it('transitions to select.resizing when dragging and edits on pointer up', () => {
 		editor.setCurrentTool('text')
 		editor.pointerDown(0, 0)
-		editor.pointerMove(24, 24)
+
+		// doesn't matter how far we move if we haven't been pointing long enough
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('text.pointing')
+
+		// Go back to start and wait a little to satisfy the time requirement
+		editor.pointerMove(0, 0)
+		jest.advanceTimersByTime(200)
+
+		// y axis doesn't matter
+		editor.pointerMove(0, 100)
+		editor.expectToBeIn('text.pointing')
+
+		// x axis matters
+		editor.pointerMove(0, 10)
+		editor.expectToBeIn('text.pointing')
+
+		// needs to be far enough
+		editor.pointerMove(100, 0)
 		editor.expectToBeIn('select.resizing')
-		editor.pointerUp()
+
+		// Create the shape immediately
 		expect(editor.getCurrentPageShapes().length).toBe(1)
+
+		// Go to editing on pointer up
+		editor.pointerUp()
 		editor.expectToBeIn('select.editing_shape')
 	})
 
@@ -160,6 +183,7 @@ describe('When resizing', () => {
 	it('bails on escape while resizing and returns to text.idle', () => {
 		editor.setCurrentTool('text')
 		editor.pointerDown(0, 0)
+		jest.advanceTimersByTime(200)
 		editor.pointerMove(100, 100)
 		editor.expectToBeIn('select.resizing')
 		editor.cancel()
@@ -170,6 +194,7 @@ describe('When resizing', () => {
 	it('does not bails on interrupt while resizing', () => {
 		editor.setCurrentTool('text')
 		editor.pointerDown(0, 0)
+		jest.advanceTimersByTime(200)
 		editor.pointerMove(100, 100)
 		editor.expectToBeIn('select.resizing')
 		editor.interrupt()
@@ -181,6 +206,7 @@ describe('When resizing', () => {
 		const x = 0
 		const y = 0
 		editor.pointerDown(x, y)
+		jest.advanceTimersByTime(200)
 		editor.pointerMove(x + 100, y + 100)
 		expect(editor.getCurrentPageShapes()[0]).toMatchObject({
 			x,

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -41,21 +41,23 @@ export class Pointing extends StateNode {
 
 		const { originPagePoint, currentPagePoint } = editor.inputs
 
-		const currentSquaredDragDist = Math.abs(originPagePoint.x - currentPagePoint.x) ** 2
+		const currentDragDist = Math.abs(originPagePoint.x - currentPagePoint.x)
 
-		const baseMinSquaredDragDistForFixedWidth = editor.getInstanceState().isCoarsePointer
-			? editor.options.coarseDragDistanceSquared
-			: editor.options.dragDistanceSquared
+		const baseMinDragDistForFixedWidth = Math.sqrt(
+			editor.getInstanceState().isCoarsePointer
+				? editor.options.coarseDragDistanceSquared
+				: editor.options.dragDistanceSquared
+		)
 
 		// Ten times the base drag distance for fixed width
-		const minSquaredDragDist = (baseMinSquaredDragDistForFixedWidth * 10) / editor.getZoomLevel()
+		const minSquaredDragDist = (baseMinDragDistForFixedWidth * 10) / editor.getZoomLevel()
 
-		if (currentSquaredDragDist > minSquaredDragDist) {
+		if (currentDragDist > minSquaredDragDist) {
 			const id = createShapeId()
 			this.markId = editor.markHistoryStoppingPoint(`creating_text:${id}`)
 
 			// create the initial shape with the width that we've dragged
-			const shape = this.createTextShape(id, originPagePoint, false, currentSquaredDragDist)
+			const shape = this.createTextShape(id, originPagePoint, false, currentDragDist)
 
 			if (!shape) {
 				this.cancel()
@@ -74,7 +76,7 @@ export class Pointing extends StateNode {
 				isCreating: true,
 				creatingMarkId: this.markId,
 				// Make sure the cursor offset takes into account how far we've already dragged
-				creationCursorOffset: { x: currentSquaredDragDist, y: 1 },
+				creationCursorOffset: { x: currentDragDist, y: 1 },
 				onInteractionEnd: 'text',
 				onCreate: () => {
 					editor.setEditingShape(shape.id)

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -50,7 +50,7 @@ export class Pointing extends StateNode {
 		)
 
 		// Ten times the base drag distance for fixed width
-		const minSquaredDragDist = (baseMinDragDistForFixedWidth * 10) / editor.getZoomLevel()
+		const minSquaredDragDist = (baseMinDragDistForFixedWidth * 6) / editor.getZoomLevel()
 
 		if (currentDragDist > minSquaredDragDist) {
 			const id = createShapeId()

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -105,8 +105,8 @@ export class Pointing extends StateNode {
 	private complete() {
 		this.editor.markHistoryStoppingPoint('creating text shape')
 		const id = createShapeId()
-		const { currentPagePoint } = this.editor.inputs
-		const shape = this.createTextShape(id, currentPagePoint, true, 20)
+		const { originPagePoint } = this.editor.inputs
+		const shape = this.createTextShape(id, originPagePoint, true, 20)
 		if (!shape) return
 
 		this.editor.select(id)


### PR DESCRIPTION
This PR incorporates a few other PRs related to avoiding accidental fixed-width text shapes.

- the user must have been pointing for more that 150ms
- the user must have dragged 10 times more than usual for dragging (along the x axis)
- the initial shape's width is set using the user's drag distance

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a fixed size text shape while zoomed in / zoomed out
2. Click while moving the mouse with the text shape selected (should not create a fixed-width shape)

### Release notes

- Improved accidental fixed-width text shape creation.