### PR TITLE
fractional indexing: rm the 0 check for indicies, outdated with jitter code

### DIFF
--- a/packages/utils/src/lib/reordering.ts
+++ b/packages/utils/src/lib/reordering.ts
@@ -20,45 +20,9 @@ export type IndexKey = string & { __brand: 'indexKey' }
  */
 export const ZERO_INDEX_KEY = 'a0' as IndexKey
 
-/**
- * Get the integer part of an index.
- *
- * @param index - The index to use.
- */
-function getIntegerPart(index: string): string {
-	const integerPartLength = getIntegerLength(index.charAt(0))
-	if (integerPartLength > index.length) {
-		throw new Error('invalid index: ' + index)
-	}
-	return index.slice(0, integerPartLength)
-}
-
-/**
- * Get the length of an integer.
- *
- * @param head - The integer to use.
- */
-function getIntegerLength(head: string): number {
-	if (head >= 'a' && head <= 'z') {
-		return head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
-	} else if (head >= 'A' && head <= 'Z') {
-		return 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
-	} else {
-		throw new Error('Invalid index key head: ' + head)
-	}
-}
-
 /** @internal */
 export function validateIndexKey(index: string): asserts index is IndexKey {
 	if (index === SMALLEST_INTEGER) {
-		throw new Error('invalid index: ' + index)
-	}
-	// getIntegerPart will throw if the first character is bad,
-	// or the key is too short.  we'd call it to check these things
-	// even if we didn't need the result
-	const i = getIntegerPart(index)
-	const f = index.slice(i.length)
-	if (f.slice(-1) === '0') {
 		throw new Error('invalid index: ' + index)
 	}
 }

--- a/packages/utils/src/lib/reordering.ts
+++ b/packages/utils/src/lib/reordering.ts
@@ -20,11 +20,43 @@ export type IndexKey = string & { __brand: 'indexKey' }
  */
 export const ZERO_INDEX_KEY = 'a0' as IndexKey
 
+/**
+ * Get the integer part of an index.
+ *
+ * @param index - The index to use.
+ */
+function getIntegerPart(index: string): string {
+	const integerPartLength = getIntegerLength(index.charAt(0))
+	if (integerPartLength > index.length) {
+		throw new Error('invalid index: ' + index)
+	}
+	return index.slice(0, integerPartLength)
+}
+
+/**
+ * Get the length of an integer.
+ *
+ * @param head - The integer to use.
+ */
+function getIntegerLength(head: string): number {
+	if (head >= 'a' && head <= 'z') {
+		return head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
+	} else if (head >= 'A' && head <= 'Z') {
+		return 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
+	} else {
+		throw new Error('Invalid index key head: ' + head)
+	}
+}
+
 /** @internal */
 export function validateIndexKey(index: string): asserts index is IndexKey {
 	if (index === SMALLEST_INTEGER) {
 		throw new Error('invalid index: ' + index)
 	}
+	// getIntegerPart will throw if the first character is bad,
+	// or the key is too short.  we'd call it to check these things
+	// even if we didn't need the result
+	getIntegerPart(index)
 }
 
 /**


### PR DESCRIPTION
This validation code was out-of-date with the new jitter code (from https://github.com/tldraw/tldraw/pull/4312 )

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix a bug with fractional indexing validation with the new jitter library.