### PR TITLE
license: allow wildcard to make apex domains also work

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -278,6 +278,24 @@ describe('LicenseManager', () => {
 		expect(result.isDomainValid).toBe(true)
 	})
 
+	it('Succeeds if has a subdomain wildcard but on an apex domain', async () => {
+		// @ts-ignore
+		delete window.location
+		// @ts-ignore
+		window.location = new URL('https://example.com')
+
+		const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
+		permissiveHostsInfo[PROPERTIES.HOSTS] = ['*.example.com']
+		const permissiveLicenseKey = await generateLicenseKey(
+			JSON.stringify(permissiveHostsInfo),
+			keyPair
+		)
+		const result = (await licenseManager.getLicenseFromKey(
+			permissiveLicenseKey
+		)) as ValidLicenseKeyResult
+		expect(result.isDomainValid).toBe(true)
+	})
+
 	it('Fails if has a subdomain wildcard isnt for the same base domain', async () => {
 		// @ts-ignore
 		delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -231,7 +231,7 @@ export class LicenseManager {
 			// Glob testing, we only support '*.somedomain.com' right now.
 			if (host.includes('*')) {
 				const globToRegex = new RegExp(host.replace(/\*/g, '.*?'))
-				return globToRegex.test(currentHostname)
+				return globToRegex.test(currentHostname) || globToRegex.test(`www.${currentHostname}`)
 			}
 
 			return false


### PR DESCRIPTION
saw on the latest key that the domains listed were example.com,*.example.com,example2.com,*.example2.com which was very repetitive to have to specify the apex domain separately. this removes that tediousness.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improve license domain check for apex domains when using wildcards.