### PR TITLE
Fix flipping of cropped images

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -67,6 +67,23 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 				flipY: info.scaleY < 0 !== flipY,
 			},
 		}
+		if (shape.props.crop && info.mode === 'scale_shape') {
+			const { topLeft, bottomRight } = shape.props.crop
+			// Vertical flip
+			if (info.scaleY === -1) {
+				resized.props.crop = {
+					topLeft: { x: topLeft.x, y: 1 - bottomRight.y },
+					bottomRight: { x: bottomRight.x, y: 1 - topLeft.y },
+				}
+			}
+			// Horizontal flip
+			if (info.scaleX === -1) {
+				resized.props.crop = {
+					topLeft: { x: 1 - bottomRight.x, y: topLeft.y },
+					bottomRight: { x: 1 - topLeft.x, y: bottomRight.y },
+				}
+			}
+		}
 		return resized
 	}
 


### PR DESCRIPTION
Fixes an issue with using the Flip horizontal / vertical feature.

We need to change the crop positions based on the flip: if the crop is on the left and we then flip horizontally it now needs to be on the right.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Before

https://github.com/user-attachments/assets/489ad837-7d16-48a3-a250-a64f578c890e

### After

https://github.com/user-attachments/assets/e5c27cff-f872-444c-9573-c1c6e862d88e

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix flipping of cropped shapes. The crop was applied to the wrong part of the picture.