### PR TITLE
video: rm sync that doesn't really work; fix fullscreen rendering

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -583,6 +583,11 @@ input,
 	height: 100%;
 }
 
+.tl-video.tl-video-is-fullscreen {
+	object-fit: contain;
+	background-size: contain;
+}
+
 .tl-video-container,
 .tl-image-container,
 .tl-embed-container {

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -55,7 +55,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const [isFullscreen, setIsFullscreen] = useState(false)
 
 		useEffect(() => {
-			const fullscreenChange = () => setIsFullscreen(!!document.fullscreenElement)
+			const fullscreenChange = () => setIsFullscreen(document.fullscreenElement === rVideo.current)
 			document.addEventListener('fullscreenchange', fullscreenChange)
 
 			return () => document.removeEventListener('fullscreenchange', fullscreenChange)


### PR DESCRIPTION
Our syncing didn't really work, caused problems in multiplayer mode. We're ripping it out for now until we rethink this.

Drive-by fix: I noticed that in fullscreen, portrait videos were being cut off because we render in `cover` mode. This fixes that.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- video: rm sync that doesn't really work; fix fullscreen rendering