### PR TITLE
Fix some broken links in the docs

### DIFF
--- a/apps/docs/content/docs/assets.mdx
+++ b/apps/docs/content/docs/assets.mdx
@@ -39,4 +39,4 @@ While we're working on docs for this part of the project, please refer to the ex
 - [A simple asset store that uploads content to a remote
   server](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/client/App.tsx)
 - [A more complex asset store that optimizes images when retrieving
-  them](https://github.com/tldraw/tldraw/blob/main/packages/sync/src/useMutliplayerDemo.ts#L87)
+  them](https://github.com/tldraw/tldraw/blob/main/packages/sync/src/useSyncDemo.ts#L87)

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -17,7 +17,7 @@ keywords:
 
 You can add realtime multi-user collaboration to your tldraw app by using **tldraw sync**. It's our library for fast, fault-tolerant shared document syncing, and is used in production on our flagship app [tldraw.com](https://tldraw.com).
 
-We offer a [hosted demo](/collaboration#tldraw-sync-demo) of tldraw sync which is suitable for prototyping. To use tldraw sync in production, you will need to host it yourself.
+We offer a [hosted demo](/docs/collaboration#tldraw-sync-demo) of tldraw sync which is suitable for prototyping. To use tldraw sync in production, you will need to host it yourself.
 
 ## Deploying tldraw sync
 

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -67,7 +67,7 @@ The content of tldraw's menus can be controlled via the `overrides` prop. This p
 
 The user interface has a set of shared `actions` that are used in the menus and keyboard shortcuts. These actions can be overridden by passing a new set of actions to the `overrides.actions` method.
 
-To create, update, or delete actions, provide an `actions` method that receives both the editor and the [default actions](https://github.com/tldraw/tldraw/blob/main/packages/tldraw/src/lib/ui/hooks/useActions.tsx) and returns a mutated actions object.
+To create, update, or delete actions, provide an `actions` method that receives both the editor and the [default actions](https://github.com/tldraw/tldraw/blob/main/packages/tldraw/src/lib/ui/context/actions.tsx) and returns a mutated actions object.
 
 ```ts
 const myOverrides: TLUiOverrides = {

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -17,6 +17,17 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
+### [v2.4.3](/releases/v2.4.3)
+
+#### 🐛 Bug Fix
+
+- `tldraw`
+  - Alex/v2.4.3 [#4328](https://github.com/tldraw/tldraw/pull/4328) ([@SomeHats](https://github.com/SomeHats))
+
+#### Authors: 1
+
+- alex ([@SomeHats](https://github.com/SomeHats))
+
 ### [v2.4.2](/releases/v2.4.2)
 
 #### 🐛 Bug Fix
@@ -97,7 +108,7 @@ editor.run(
 
 As part of our work on sync, we have a new system for handling large assets like images and videos. You can provide a [`TLAssetStore`](https://tldraw.dev/reference/tlschema/TLAssetStore) to control how assets are uploaded and retrieved.
 
-In your own shapes & tools, these options are available through the new [`Editor.uploadAsset`](https://tldraw.dev/reference/editor/Editor#uploadAsset) and [`Editor.resolveAssetURL`](https://staging.tldraw.dev/reference/editor/Editor#resolveAssetUrl) methods.
+In your own shapes & tools, these options are available through the new [`Editor.uploadAsset`](https://tldraw.dev/reference/editor/Editor#uploadAsset) and [`Editor.resolveAssetURL`](https://tldraw.dev/reference/editor/Editor#resolveAssetUrl) methods.
 
 ---
 
@@ -116,7 +127,7 @@ In your own shapes & tools, these options are available through the new [`Editor
 - We now show a toast when uploading an unsupported file type or a file that is too large. ([#4114](https://github.com/tldraw/tldraw/pull/4114))
 - We now show a toast when pasting failed due to missing clipboard permissions. ([#4117](https://github.com/tldraw/tldraw/pull/4117))
 - You can use the new `ShapeIndicators` component to add custom logic about when to display indicators. ([#4083](https://github.com/tldraw/tldraw/pull/4083))
-- A shape’s opacity will now also animate. ([#4242](<[https://github.com/tldraw/tldraw/pull/](https://github.com/tldraw/tldraw/pull/4042)4242>))
+- A shape’s opacity will now also animate. ([#4242](<https://github.com/tldraw/tldraw/pull/](https://github.com/tldraw/tldraw/pull/4042)>)
 
 #### API changes
 
@@ -502,25 +513,6 @@ Previously, `editor.mark(id)` accepted two additional boolean parameters: `onUnd
 - Trevor Dobbertin ([@Trevato](https://github.com/Trevato))
 
 ### [v2.1.4](/releases/v2.1.4)
-
-### Release Notes
-
-#### textfields: fix up flakiness in text selection and for unfilled geo shapes fix edit->edit (#3577) ([#3643](https://github.com/tldraw/tldraw/pull/3643))
-
-- Text labels: fix up regression to selection when clicking into a text shape. (was causing flaky selections)
-- Text labels: fix edit→edit not working as expected when unfilled geo shapes are on 'top' of other shapes.
-
----
-
-#### 🐛 Bug Fix
-
-- `@tldraw/editor`, `tldraw`
-  - textfields: fix up flakiness in text selection (#3578)
-  - textfields: for unfilled geo shapes fix edit->edit (#3577) [#3643](https://github.com/tldraw/tldraw/pull/3643) ([@mimecuvalo](https://github.com/mimecuvalo))
-
-#### Authors: 1
-
-- Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 
 ### [v2.1.3](/releases/v2.1.3)
 

--- a/apps/examples/src/examples/basic/README.md
+++ b/apps/examples/src/examples/basic/README.md
@@ -10,4 +10,4 @@ keywords: [basic, intro, simple, quick, start]
 
 The `Tldraw` component provides the tldraw editor as a regular React component. You can put this component anywhere in your React project. In this example, we make the component take up the height and width of the container.
 
-By default, the component does not persist between refreshes or sync locally between tabs. To keep your work after a refresh, check the [`persistenceKey`](/peristence-key) example.
+By default, the component does not persist between refreshes or sync locally between tabs. To keep your work after a refresh, check the [`persistenceKey`](https://tldraw.dev/examples/basic/peristence-key) example.

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -85,7 +85,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 
 	/**
 	 * Migrations allow you to make changes to a shape's props over time. Read the
-	 * {@link https://staging.tldraw.dev/docs/persistence#Shape-props-migrations | shape prop migrations}
+	 * {@link https://www.tldraw.dev/docs/persistence#Shape-props-migrations | shape prop migrations}
 	 * guide for more information.
 	 */
 	static migrations?: LegacyMigrations | TLPropsMigrations | MigrationSequence

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -48,7 +48,6 @@ export interface TLInstance extends BaseRecord<'instance', TLInstanceId> {
 	/**
 	 * This is whether the primary input mechanism includes a pointing device of limited accuracy,
 	 * such as a finger on a touchscreen.
-	 * See: https://developer.mozilla.org/en-US/docs/Web/CSS/\@media/pointer
 	 */
 	isCoarsePointer: boolean
 	/**


### PR DESCRIPTION
This PR fixes some broken links in the docs.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
