### PR TITLE
Preserve focus search param

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -337,7 +337,7 @@ const TldrawEditorWithLoadingStore = memo(function TldrawEditorBeforeLoading({
 	return <TldrawEditorWithReadyStore {...rest} store={store.store} user={user} />
 })
 
-const noAutoFocus = () => document.location.search.includes('preserveFocus')
+const noAutoFocus = () => document.location.search.includes('tldraw_preserveFocus')
 
 function TldrawEditorWithReadyStore({
 	onMount,
@@ -438,7 +438,7 @@ function TldrawEditorWithReadyStore({
 	)
 
 	// For our examples site, we want autoFocus to be true on the examples site, but not
-	// when embedded in our docs site. If present, the `preserveFocus` search param
+	// when embedded in our docs site. If present, the `tldraw_preserveFocus` search param
 	// overrides the `autoFocus` prop and prevents the editor from focusing immediately,
 	// however here we also add some logic to focus the editor when the user clicks
 	// on it and unfocus it when the user clicks away from it.

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -421,36 +421,6 @@ function TldrawEditorWithReadyStore({
 		}
 	}, [editor, cameraOptions])
 
-	useEffect(
-		function handleFocusOnPointerDownForPreserveFocusMode() {
-			if (!editor) return
-
-			function handleFocusOnPointerDown() {
-				if (!editor) return
-				editor.focus()
-			}
-
-			function handleBlurOnPointerDown() {
-				if (!editor) return
-				editor.blur()
-			}
-
-			// If the user wants to autofocus the editor but prevent it (by force), then
-			// focus when the user clicks on the editor and unfocus it when the user clicks
-			// on the body (ie anything outside the editor).
-			if (autoFocus && noAutoFocus()) {
-				editor.getContainer().addEventListener('pointerdown', handleFocusOnPointerDown)
-				document.body.addEventListener('pointerdown', handleBlurOnPointerDown)
-
-				return () => {
-					editor.getContainer()?.removeEventListener('pointerdown', handleFocusOnPointerDown)
-					document.body.removeEventListener('pointerdown', handleBlurOnPointerDown)
-				}
-			}
-		},
-		[editor, autoFocus]
-	)
-
 	const crashingError = useSyncExternalStore(
 		useCallback(
 			(onStoreChange) => {
@@ -465,6 +435,38 @@ function TldrawEditorWithReadyStore({
 			[editor]
 		),
 		() => editor?.getCrashingError() ?? null
+	)
+
+	// For our examples site, we want autoFocus to be true on the examples site, but not
+	// when embedded in our docs site. If present, the `preserveFocus` search param
+	// overrides the `autoFocus` prop and prevents the editor from focusing immediately,
+	// however here we also add some logic to focus the editor when the user clicks
+	// on it and unfocus it when the user clicks away from it.
+	useEffect(
+		function handleFocusOnPointerDownForPreserveFocusMode() {
+			if (!editor) return
+
+			function handleFocusOnPointerDown() {
+				if (!editor) return
+				editor.focus()
+			}
+
+			function handleBlurOnPointerDown() {
+				if (!editor) return
+				editor.blur()
+			}
+
+			if (autoFocus && noAutoFocus()) {
+				editor.getContainer().addEventListener('pointerdown', handleFocusOnPointerDown)
+				document.body.addEventListener('pointerdown', handleBlurOnPointerDown)
+
+				return () => {
+					editor.getContainer()?.removeEventListener('pointerdown', handleFocusOnPointerDown)
+					document.body.removeEventListener('pointerdown', handleBlurOnPointerDown)
+				}
+			}
+		},
+		[editor, autoFocus]
 	)
 
 	const { Canvas } = useEditorComponents()

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -337,7 +337,7 @@ const TldrawEditorWithLoadingStore = memo(function TldrawEditorBeforeLoading({
 	return <TldrawEditorWithReadyStore {...rest} store={store.store} user={user} />
 })
 
-const noAutoFocus = () => document.location.search.includes('tldraw_preserveFocus')
+const noAutoFocus = () => document.location.search.includes('tldraw_preserve_focus')
 
 function TldrawEditorWithReadyStore({
 	onMount,
@@ -438,7 +438,7 @@ function TldrawEditorWithReadyStore({
 	)
 
 	// For our examples site, we want autoFocus to be true on the examples site, but not
-	// when embedded in our docs site. If present, the `tldraw_preserveFocus` search param
+	// when embedded in our docs site. If present, the `tldraw_preserve_focus` search param
 	// overrides the `autoFocus` prop and prevents the editor from focusing immediately,
 	// however here we also add some logic to focus the editor when the user clicks
 	// on it and unfocus it when the user clicks away from it.

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8690,9 +8690,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	focus({ focusContainer = true } = {}): this {
-		if (focusContainer) {
-			this.focusManager.focus()
-		}
+		if (this.getIsFocused()) return this
+		if (focusContainer) this.focusManager.focus()
 		this.updateInstanceState({ isFocused: true })
 		return this
 	}


### PR DESCRIPTION
This PR adds a kinda-secret "preserve focus" mode using the `preserveFocus` search param, along with the behavior for handling focus in that state.

In many of our examples, we want `autoFocus` to be true. However, in our docs site, we want each example's `autoFocus` to be false, and for the editor to be focused only when clicked on and blurred when clicking away.

One solution, which this PR implements, is to use a search parameter that says "if the URL has a `preserveFocus` search parameter, then even if `autoFocus` is true, start unfocused`. It also implements that "click to focus, click away to blur" behavior.

We could add support via a prop, however I'm not entirely sure about this feature so would prefer to keep it internal for now. Either way, we would want our docs examples to all use `preserveFocus` routes.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Visit the examples page in our docs.
2. The example should not have focus. Kbds should not work.
3. Click on the example to give it focus. Kbds should work.
4. Click away to blur the editor. Kbds should not work.
