### PR TITLE
Disable Pages UI when maxPages === 1

### DIFF
--- a/apps/examples/src/examples/disable-pages/DisablePagesExample.tsx
+++ b/apps/examples/src/examples/disable-pages/DisablePagesExample.tsx
@@ -1,0 +1,12 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// You can set the `maxPages` option to 1 to disable UI related to managing multiple pages.
+
+export default function DisablePagesExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="disable-pages" options={{ maxPages: 1 }} />
+		</div>
+	)
+}

--- a/apps/examples/src/examples/disable-pages/README.md
+++ b/apps/examples/src/examples/disable-pages/README.md
@@ -1,0 +1,13 @@
+---
+title: Disable Pages
+component: ./DisablePagesExample.tsx
+category: basic
+priority: 10
+keywords: [basic, intro, simple, quick, start, page]
+---
+
+Disabling page-related UI for single-page use cases.
+
+---
+
+You can set the `maxPages` option to `1` to disable the page selector and other UI related to managing pages.

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -409,6 +409,9 @@ export function createMediaAssetInfoSkeleton(file: File, assetId: TLAssetId, isI
 export function createShapesForAssets(editor: Editor, assets: TLAsset[], position: VecLike): Promise<TLShapeId[]>;
 
 // @public (undocumented)
+export function CursorChatItem(): JSX_2.Element | null;
+
+// @public (undocumented)
 export function CutMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
@@ -598,6 +601,9 @@ export function DuplicateMenuItem(): JSX_2.Element | null;
 
 // @public (undocumented)
 export function EditLinkMenuItem(): JSX_2.Element | null;
+
+// @public (undocumented)
+export function EditMenuSubmenu(): JSX_2.Element | null;
 
 // @public (undocumented)
 export function EditSubmenu(): JSX_2.Element;
@@ -3395,6 +3401,9 @@ export function useEditableText(id: TLShapeId, type: string, text: string): {
 export function useExportAs(): (ids: TLShapeId[], format: TLExportType | undefined, name: string | undefined) => void;
 
 // @public (undocumented)
+export function useIsMultiplayer(): boolean;
+
+// @public (undocumented)
 export function useIsToolSelected(tool: TLUiToolItem): boolean;
 
 // @public (undocumented)
@@ -3412,6 +3421,9 @@ export function useMenuClipboardEvents(): {
 
 // @public (undocumented)
 export function useMenuIsOpen(id: string, cb?: (isOpen: boolean) => void): readonly [boolean, (isOpen: boolean) => void];
+
+// @public (undocumented)
+export function useMultiplayerStatus(): "offline" | "online" | null;
 
 // @public (undocumented)
 export function useNativeClipboardEvents(): void;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -228,10 +228,12 @@ export {
 	ConvertToEmbedMenuItem,
 	CopyAsMenuGroup,
 	CopyMenuItem,
+	CursorChatItem,
 	CutMenuItem,
 	DeleteMenuItem,
 	DuplicateMenuItem,
 	EditLinkMenuItem,
+	EditMenuSubmenu,
 	FitFrameToContentMenuItem,
 	GroupMenuItem,
 	MoveToPageMenu,
@@ -391,6 +393,7 @@ export { useCanRedo, useCanUndo } from './lib/ui/hooks/menu-hooks'
 export { useMenuClipboardEvents, useNativeClipboardEvents } from './lib/ui/hooks/useClipboardEvents'
 export { useCopyAs } from './lib/ui/hooks/useCopyAs'
 export { useExportAs } from './lib/ui/hooks/useExportAs'
+export { useIsMultiplayer, useMultiplayerStatus } from './lib/ui/hooks/useIsMultiplayer'
 export { useKeyboardShortcuts } from './lib/ui/hooks/useKeyboardShortcuts'
 export { useLocalStorageState } from './lib/ui/hooks/useLocalStorageState'
 export { useMenuIsOpen } from './lib/ui/hooks/useMenuIsOpen'

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
@@ -22,6 +22,9 @@ export function DefaultContextMenuContent() {
 		() => editor.getCurrentToolId() === 'select',
 		[editor]
 	)
+	const isSinglePageMode = useValue('isSinglePageMode', () => editor.options.maxPages <= 1, [
+		editor,
+	])
 
 	if (!selectToolActive) return null
 
@@ -32,7 +35,7 @@ export function DefaultContextMenuContent() {
 				<EditMenuSubmenu />
 				<ArrangeMenuSubmenu />
 				<ReorderMenuSubmenu />
-				<MoveToPageMenu />
+				{!isSinglePageMode && <MoveToPageMenu />}
 			</TldrawUiMenuGroup>
 			<ClipboardMenuGroup />
 			<ConversionsMenuGroup />

--- a/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
@@ -1,3 +1,4 @@
+import { useEditor, useValue } from '@tldraw/editor'
 import { memo } from 'react'
 import { useBreakpoint } from '../context/breakpoints'
 import { useTldrawUiComponents } from '../context/components'
@@ -8,13 +9,18 @@ export const DefaultMenuPanel = memo(function MenuPanel() {
 
 	const { MainMenu, QuickActions, ActionsMenu, PageMenu } = useTldrawUiComponents()
 
+	const editor = useEditor()
+	const isSinglePageMode = useValue('isSinglePageMode', () => editor.options.maxPages <= 1, [
+		editor,
+	])
+
 	if (!MainMenu && !PageMenu && breakpoint < 6) return null
 
 	return (
 		<div className="tlui-menu-zone">
 			<div className="tlui-buttons__horizontal">
 				{MainMenu && <MainMenu />}
-				{PageMenu && <PageMenu />}
+				{PageMenu && !isSinglePageMode && <PageMenu />}
 				{breakpoint < 6 ? null : (
 					<>
 						{QuickActions && <QuickActions />}

--- a/packages/tldraw/src/lib/ui/hooks/useIsMultiplayer.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useIsMultiplayer.ts
@@ -1,10 +1,12 @@
 import { useEditor, useValue } from '@tldraw/editor'
 
+/** @public */
 export function useIsMultiplayer() {
 	const editor = useEditor()
 	return !!editor.store.props.multiplayerStatus
 }
 
+/** @public */
 export function useMultiplayerStatus() {
 	const editor = useEditor()
 	return useValue(


### PR DESCRIPTION
This PR makes it so that when you set `maxPages` to `1` it disables the UI related to pages

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Make the page management UI disappear when maxPages is 1