### PR TITLE
Fix issues with resizing cropped images

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1063,8 +1063,6 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     onResize(shape: TLImageShape, info: TLResizeInfo<TLImageShape>): TLImageShape;
     // (undocumented)
-    previousScale: null | VecModel;
-    // (undocumented)
     static props: RecordProps<TLImageShape>;
     // (undocumented)
     toSvg(shape: TLImageShape): Promise<JSX_2.Element | null>;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1063,6 +1063,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     onResize(shape: TLImageShape, info: TLResizeInfo<TLImageShape>): TLImageShape;
     // (undocumented)
+    previousScale: null | VecModel;
+    // (undocumented)
     static props: RecordProps<TLImageShape>;
     // (undocumented)
     toSvg(shape: TLImageShape): Promise<JSX_2.Element | null>;

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -188,7 +188,11 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 				{showCropPreview && loadedSrc && (
 					<div style={containerStyle}>
 						<img
-							className="tl-image"
+							className={classNames('tl-image', {
+								'tl-flip-x': shape.props.flipX && !shape.props.flipY,
+								'tl-flip-y': shape.props.flipY && !shape.props.flipX,
+								'tl-flip-xy': shape.props.flipY && shape.props.flipX,
+							})}
 							crossOrigin={crossOrigin}
 							src={loadedSrc}
 							referrerPolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
While working on #4337 I also discovered two other issues:
* Preview of the whole image (including the cropped out part) was incorrect when shapes were flipped. We weren't applying the scaling styles to the preview. 
* When resizing the shapes via the handles the same issue as in #4337 could occur. We also need to flip if resizing causes the image to flip.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create an image with a crop.
2. Use resizing handles to make it flip. The cropped part should stay the same.
3. Also check the preview of the cropped area when the image is flipped. It should also be flipped.

### Release notes

- Fix a bug with cropped and flipped images and their previews.