### PR TITLE
Make license debug helper return a cleanup function

### DIFF
--- a/apps/examples/src/examples/license-key/LicenseKeyExample.tsx
+++ b/apps/examples/src/examples/license-key/LicenseKeyExample.tsx
@@ -1,9 +1,11 @@
+import { useEffect } from 'react'
 import { Tldraw, debugEnableLicensing } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function LicenseKeyExample() {
 	// [1]
-	debugEnableLicensing()
+	useEffect(() => debugEnableLicensing(), [])
+
 	return (
 		<div className="tldraw__editor">
 			{/* [2] */}

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -562,7 +562,7 @@ export class CubicSpline2d extends Geometry2d {
 export function dataUrlToFile(url: string, filename: string, mimeType: string): Promise<File>;
 
 // @public (undocumented)
-export function debugEnableLicensing(): void;
+export function debugEnableLicensing(): () => void;
 
 // @internal (undocumented)
 export type DebugFlag<T> = DebugFlagDef<T> & Atom<T>;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -392,4 +392,7 @@ export { openWindow } from './lib/utils/window-open'
 /** @public */
 export function debugEnableLicensing() {
 	featureFlags.enableLicensing.set(true)
+	return () => {
+		featureFlags.enableLicensing.set(false)
+	}
 }


### PR DESCRIPTION
This PR adds a cleanup function to the license debug helper, so that our license example doesn't effect other examples.

### Change type

- [x] `other`
