### PR TITLE
[docs] remove overflow from article body

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -29,7 +29,7 @@ export default async function Page({ params }: { params: { slug: string | string
 				/>
 				<SearchButton type="docs" layout="mobile" className="hidden sm:block -mr-2" />
 			</div>
-			<main className="relative shrink w-full max-w-3xl md:overflow-x-hidden px-5 md:pr-0 lg:pl-12 xl:pr-12 pt-24 md:pt-0">
+			<main className="relative shrink w-full max-w-3xl px-5 md:pr-0 lg:pl-12 xl:pr-12 pt-24 md:pt-0">
 				<DocsHeader article={content.article} />
 				<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />
 				{content.article.sectionId === 'examples' && <Example article={content.article} />}


### PR DESCRIPTION
There are a few intentional negative margins and overflows on the article body, but they're clipped due to the overflow. Not sure if this had any other purpose?

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
