### PR TITLE
feat: Able to pass disable to the Icon when UiMenuContext is in mode 'toolbar'

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -229,6 +229,7 @@ export function TldrawUiMenuItem<
 						}}
 						data-testid={`tools.more.${id}`}
 						title={titleStr}
+						disabled={disabled}
 						role="radio"
 						aria-checked={isSelected ? 'true' : 'false'}
 						data-value={id}

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -206,6 +206,7 @@ export function TldrawUiMenuItem<
 					data-value={id}
 					onClick={() => onSelect('toolbar')}
 					title={titleStr}
+					disabled={disabled}
 					onTouchStart={(e) => {
 						preventDefault(e)
 						onSelect('toolbar')


### PR DESCRIPTION
Simple change - unable to pass disabled prop to an icon when the UIMenuContext type is set to 'toolbar'

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

