### PR TITLE
Update READMEs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3006,7 +3006,7 @@ Add `newMenuItem` creation in "Toolbar and Menus" example
 
 - fix typo in hideRotateHandle method
 
-#### Maintain bindings whilst translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
+#### Maintain bindings while translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
 
 - You can now move arrows without them becoming unattached the shapes they're pointing to
 
@@ -3155,7 +3155,7 @@ Add `newMenuItem` creation in "Toolbar and Menus" example
   - debug: add FPS counter [#2558](https://github.com/tldraw/tldraw/pull/2558) ([@mimecuvalo](https://github.com/mimecuvalo) [@steveruizok](https://github.com/steveruizok))
   - [improvement] better comma control for pointer [#2568](https://github.com/tldraw/tldraw/pull/2568) ([@steveruizok](https://github.com/steveruizok))
   - Allow snapping of shapes to the frame when dragging inside the frame. [#2520](https://github.com/tldraw/tldraw/pull/2520) ([@MitjaBezensek](https://github.com/MitjaBezensek))
-  - Maintain bindings whilst translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+  - Maintain bindings while translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
   - [improvement] update dark mode [#2468](https://github.com/tldraw/tldraw/pull/2468) ([@steveruizok](https://github.com/steveruizok))
 - `@tldraw/editor`, `@tldraw/tldraw`, `@tldraw/tlschema`
   - arrows: add ability to change label placement [#2557](https://github.com/tldraw/tldraw/pull/2557) ([@mimecuvalo](https://github.com/mimecuvalo) [@steveruizok](https://github.com/steveruizok) [@SomeHats](https://github.com/SomeHats))

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -140,7 +140,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/apps/examples/README.md
+++ b/apps/examples/README.md
@@ -14,7 +14,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/apps/examples/src/examples/after-create-update-shape/AfterCreateUpdateShapeExample.tsx
+++ b/apps/examples/src/examples/after-create-update-shape/AfterCreateUpdateShapeExample.tsx
@@ -38,7 +38,7 @@ export default function AfterCreateUpdateShapeExample() {
 				onMount={(editor) => {
 					// we can run our `ensureOnlyOneRedShape` function after any shape is created or
 					// changed. this means we can enforce our "only one red shape at a time" rule,
-					// whilst making sure that the shape most recently set to red is the one that
+					// while making sure that the shape most recently set to red is the one that
 					// stays red.
 					editor.sideEffects.registerAfterCreateHandler('shape', (shape) => {
 						ensureOnlyOneRedShape(editor, shape.id)

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -103,7 +103,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/apps/vscode/extension/README.md
+++ b/apps/vscode/extension/README.md
@@ -24,7 +24,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -16,7 +16,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1172,7 +1172,7 @@ The `canBind` flag now accepts an options object instead of just the shape in qu
 
 - fix typo in hideRotateHandle method
 
-#### Maintain bindings whilst translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
+#### Maintain bindings while translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
 
 - You can now move arrows without them becoming unattached the shapes they're pointing to
 
@@ -1201,7 +1201,7 @@ The `canBind` flag now accepts an options object instead of just the shape in qu
 - arrows: add ability to change label placement [#2557](https://github.com/tldraw/tldraw/pull/2557) ([@mimecuvalo](https://github.com/mimecuvalo) [@steveruizok](https://github.com/steveruizok) [@SomeHats](https://github.com/SomeHats))
 - [improvement] better comma control for pointer [#2568](https://github.com/tldraw/tldraw/pull/2568) ([@steveruizok](https://github.com/steveruizok))
 - Allow snapping of shapes to the frame when dragging inside the frame. [#2520](https://github.com/tldraw/tldraw/pull/2520) ([@MitjaBezensek](https://github.com/MitjaBezensek))
-- Maintain bindings whilst translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+- Maintain bindings while translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 - [improvement] update dark mode [#2468](https://github.com/tldraw/tldraw/pull/2468) ([@steveruizok](https://github.com/steveruizok))
 - [improvement] account for coarse pointers / insets in edge scrolling [#2401](https://github.com/tldraw/tldraw/pull/2401) ([@steveruizok](https://github.com/steveruizok))
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -14,7 +14,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -35,7 +35,7 @@ function debug(...args: any[]) {
 //       we might not be able to detect the websocket connection going down in a timely manner
 //       (it will probably time out on outgoing data packets at some point).
 //
-//       This is by design. Whilst the Websocket protocol specifies protocol-level pings,
+//       This is by design. While the Websocket protocol specifies protocol-level pings,
 //       they don't seem to be surfaced in browser APIs and can't be relied on. Therefore,
 //       pings need to be implemented one level up, on the application API side, which for our
 //       codebase means whatever code that uses ClientWebSocketAdapter.

--- a/packages/tldraw/CHANGELOG.md
+++ b/packages/tldraw/CHANGELOG.md
@@ -1505,7 +1505,7 @@ Fix textbox direction when it contains both RTL and LTR languages
 
 - Fix first `yarn dev` experience.
 
-#### Maintain bindings whilst translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
+#### Maintain bindings while translating arrows ([#2424](https://github.com/tldraw/tldraw/pull/2424))
 
 - You can now move arrows without them becoming unattached the shapes they're pointing to
 
@@ -1546,7 +1546,7 @@ Fix textbox direction when it contains both RTL and LTR languages
 - arrows: add ability to change label placement [#2557](https://github.com/tldraw/tldraw/pull/2557) ([@mimecuvalo](https://github.com/mimecuvalo) [@steveruizok](https://github.com/steveruizok) [@SomeHats](https://github.com/SomeHats))
 - [improvement] better comma control for pointer [#2568](https://github.com/tldraw/tldraw/pull/2568) ([@steveruizok](https://github.com/steveruizok))
 - Allow snapping of shapes to the frame when dragging inside the frame. [#2520](https://github.com/tldraw/tldraw/pull/2520) ([@MitjaBezensek](https://github.com/MitjaBezensek))
-- Maintain bindings whilst translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+- Maintain bindings while translating arrows [#2424](https://github.com/tldraw/tldraw/pull/2424) ([@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 - [improvement] update dark mode [#2468](https://github.com/tldraw/tldraw/pull/2468) ([@steveruizok](https://github.com/steveruizok))
 - [improvement] account for coarse pointers / insets in edge scrolling [#2401](https://github.com/tldraw/tldraw/pull/2401) ([@steveruizok](https://github.com/steveruizok))
 

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -215,7 +215,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 				>
 					<div className={classNames('tl-image-container')} style={containerStyle}>
 						{/* We have two images: the currently loaded image, and the next image that
-						we're waiting to load. we keep the loaded image mounted whilst we're waiting
+						we're waiting to load. we keep the loaded image mounted while we're waiting
 						for the next one by storing the loaded URL in state. We use `key` props with
 						the src of the image so that when the next image is ready, the previous one will
 						be unmounted and the next will be shown with the browser having to remount a

--- a/packages/tlschema/README.md
+++ b/packages/tlschema/README.md
@@ -78,7 +78,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -16,7 +16,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -16,7 +16,7 @@ The tldraw source code and its distributions are provided under the [tldraw lice
 
 ## Trademarks
 
-Copyright (c) 2023-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
 ## Contact
 

--- a/templates/nextjs/LICENSE
+++ b/templates/nextjs/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 tldraw GB Ltd.
+Copyright (c) 2024 tldraw GB Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -5,11 +5,18 @@
 	</picture>
 </div>
 
-This repo contains a very basic example of how to use [tldraw](https://github.com/tldraw/tldraw) in a [Next.js](https://nextjs.org/) app using the src directory and App router.
+This repo contains a template for using [tldraw](https://github.com/tldraw/tldraw) with the [Next.js](https://nextjs.org/) framework.
+
+## Local development
+
+Install dependencies with `yarn` or `npm install`.
+
+Run the development server with `yarn dev` or `npm run dev`.
+
+Open `http://localhost:3000/` in your browser to see the app.
 
 ## License
 
-Whilst the code in this template is available under the MIT license, `tldraw` and `@tldraw/sync` are
-under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not
-allow their use for commercial purposes. To purchase an alternative license for commercial use,
-contact [sales@tldraw.com](mailto:sales@tldraw.com).
+The code in this template is available under the MIT license.
+
+Note that the `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -19,4 +19,4 @@ Open `http://localhost:3000/` in your browser to see the app.
 
 The code in this template is available under the MIT license.
 
-Note that the `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).
+The `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).

--- a/templates/sync-cloudflare/LICENSE
+++ b/templates/sync-cloudflare/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 tldraw GB Ltd.
+Copyright (c) 2024 tldraw GB Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -12,13 +12,12 @@ This is a production-ready backend for [tldraw sync](https://tldraw.dev/docs/syn
   R2](https://developers.cloudflare.com/r2/) bucket.
 - Although unreliated to tldraw sync, this server also includes a component to fetch link previews
   for URLs added to the canvas.
-
-This is a minimal setup of the same system that powers multiplayer collaboration for hundreds of
-thousands of rooms & users on www.tldraw.com. Because durable objects effectively create a mini
-server instance for every single active room, we've never needed to worry about scale. Cloudflare
-handles the tricky infrastructure work of ensuring there's only ever one instance of each room, and
-making sure that every user gets connected to that instance. We've found that with this approach,
-each room is able to handle about 30 simultaneous collaborators.
+  This is a minimal setup of the same system that powers multiplayer collaboration for hundreds of
+  thousands of rooms & users on www.tldraw.com. Because durable objects effectively create a mini
+  server instance for every single active room, we've never needed to worry about scale. Cloudflare
+  handles the tricky infrastructure work of ensuring there's only ever one instance of each room, and
+  making sure that every user gets connected to that instance. We've found that with this approach,
+  each room is able to handle about 30 simultaneous collaborators.
 
 ## Overview
 
@@ -66,7 +65,7 @@ The frontend client is under [`client`](./client):
 - **[`client/getBookmarkPreview.tsx`](./client/getBookmarkPreview.tsx):** how does the client fetch
   bookmark previews from the worker?
 
-## Custom shapes
+  ## Custom shapes
 
 To add support for custom shapes, see the [tldraw sync custom shapes
 docs](https://tldraw.dev/docs/sync#Custom-shapes--bindings).
@@ -108,7 +107,6 @@ your document across devices.
 
 ## License
 
-Whilst the code in this template is available under the MIT license, `tldraw` and `@tldraw/sync` are
-under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not
-allow their use for commercial purposes. To purchase an alternative license for commercial use,
-contact [sales@tldraw.com](mailto:sales@tldraw.com).
+The code in this template is available under the MIT license.
+
+The `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -22,7 +22,7 @@ const schema = createTLSchema({
 // handles websocket connections. periodically, it persists the room state to the R2 bucket.
 export class TldrawDurableObject {
 	private r2: R2Bucket
-	// the room ID will be missing whilst the room is being initialized
+	// the room ID will be missing while the room is being initialized
 	private roomId: string | null = null
 	// when we load the room from the R2 bucket, we keep it here. it's a promise so we only ever
 	// load it once.

--- a/templates/vite/LICENSE
+++ b/templates/vite/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 tldraw GB Ltd.
+Copyright (c) 2024 tldraw GB Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/vite/README.md
+++ b/templates/vite/README.md
@@ -19,4 +19,4 @@ Open `http://localhost:5173/` in your browser to see the app.
 
 The code in this template is available under the MIT license.
 
-Note that the `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).
+The `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).

--- a/templates/vite/README.md
+++ b/templates/vite/README.md
@@ -5,11 +5,18 @@
 	</picture>
 </div>
 
-This repo contains a template you can copy for using [tldraw](https://github.com/tldraw/tldraw) in a vite application.
+This repo contains a template you can copy for using [tldraw](https://github.com/tldraw/tldraw) with the [Vite](https://vitejs.dev/) development environment.
+
+## Local development
+
+Install dependencies with `yarn` or `npm install`.
+
+Run the development server with `yarn dev` or `npm run dev`.
+
+Open `http://localhost:5173/` in your browser to see the app.
 
 ## License
 
-Whilst the code in this template is available under the MIT license, `tldraw` and `@tldraw/sync` are
-under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not
-allow their use for commercial purposes. To purchase an alternative license for commercial use,
-contact [sales@tldraw.com](mailto:sales@tldraw.com).
+The code in this template is available under the MIT license.
+
+Note that the `tldraw` library is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md) which does not allow their use for commercial purposes. To purchase an alternative license for commercial use, contact [sales@tldraw.com](mailto:sales@tldraw.com).


### PR DESCRIPTION
This PR:
- updates the descriptions for our Nextjs and Vite templates
- adds some licensing information
- replaces the word whilst with while
- updates copyright notices to 2024

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
