### PR TITLE
allow loading the sync URI dynamically

### DIFF
--- a/packages/sync/api-report.md
+++ b/packages/sync/api-report.md
@@ -49,7 +49,7 @@ export interface UseSyncOptions {
     trackAnalyticsEvent?(name: string, data: {
         [key: string]: any;
     }): void;
-    uri: string;
+    uri: (() => Promise<string> | string) | string;
     userInfo?: Signal<TLSyncUserInfo> | TLSyncUserInfo;
 }
 

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -109,8 +109,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		)
 
 		const socket = new ClientWebSocketAdapter(async () => {
+			const uriString = typeof uri === 'string' ? uri : await uri()
+
 			// set sessionId as a query param on the uri
-			const withParams = new URL(uri)
+			const withParams = new URL(uriString)
 			if (withParams.searchParams.has('sessionId')) {
 				throw new Error(
 					'useSync. "sessionId" is a reserved query param name. Please use a different name'
@@ -236,9 +238,14 @@ export interface UseSyncOptions {
 	 *
 	 *   e.g. `wss://server.example.com/my-room` or `ws://localhost:5858/my-room`.
 	 *
-	 * Note that the protocol can also be `https` or `http` and it will upgrade to a websocket connection.
+	 * Note that the protocol can also be `https` or `http` and it will upgrade to a websocket
+	 * connection.
+	 *
+	 * Optionally, you can pass a function which will be called each time a connection is
+	 * established to get the URI. This is useful if you need to include e.g. a short-lived session
+	 * token for authentication.
 	 */
-	uri: string
+	uri: string | (() => string | Promise<string>)
 	/**
 	 * A signal that contains the user information needed for multiplayer features.
 	 * This should be synchronized with the `userPreferences` configuration for the main `<Tldraw />` component.


### PR DESCRIPTION
In teach, we get short-lived JWTs for auth. We want to verify these on the server. We can send them with the URI, but they go out of date quickly. Luckily, our websocket client already supports dynamically generating the URI, this exposes that option via the `useSync` hook too.

### Change type

- [x] `api`