### PR TITLE
Make rotateShapesBy work on any shapes

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1037,6 +1037,12 @@ export class Editor extends EventEmitter<TLEventMap> {
         hitInside?: boolean | undefined;
         margin?: number | undefined;
     }): TLShape[];
+    // @internal (undocumented)
+    getShapesPageBounds(shapeIds: TLShapeId[]): Box | null;
+    // @internal (undocumented)
+    getShapesRotatedPageBounds(shapeIds: TLShapeId[]): Box | undefined;
+    // @internal (undocumented)
+    getShapesSharedRotation(shapeIds: TLShapeId[]): number;
     // (undocumented)
     getShapeStyleIfExists<T>(shape: TLShape, style: StyleProp<T>): T | undefined;
     getShapeUtil<S extends TLUnknownShape>(shape: S | TLShapePartial<S>): ShapeUtil<S>;
@@ -1482,8 +1488,9 @@ export function getPointsOnArc(startPoint: VecLike, endPoint: VecLike, center: n
 export function getPolygonVertices(width: number, height: number, sides: number): Vec[];
 
 // @internal (undocumented)
-export function getRotationSnapshot({ editor }: {
+export function getRotationSnapshot({ editor, ids, }: {
     editor: Editor;
+    ids: TLShapeId[];
 }): null | TLRotationSnapshot;
 
 // @public (undocumented)
@@ -3189,14 +3196,14 @@ export type TLResizeShapeOptions = Partial<{
     skipStartAndEndCallbacks: boolean;
 }>;
 
-// @public
+// @internal (undocumented)
 export interface TLRotationSnapshot {
     // (undocumented)
     initialCursorAngle: number;
     // (undocumented)
-    initialSelectionRotation: number;
+    initialShapesRotation: number;
     // (undocumented)
-    selectionPageCenter: Vec;
+    pageCenter: Vec;
     // (undocumented)
     shapeSnapshots: {
         initialPagePoint: Vec;

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -1,57 +1,51 @@
-import { isShapeId, TLShape, TLShapePartial } from '@tldraw/tlschema'
-import { structuredClone } from '@tldraw/utils'
+import { isShapeId, TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
+import { compact } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 import { Mat } from '../primitives/Mat'
 import { canonicalizeRotation } from '../primitives/utils'
 import { Vec } from '../primitives/Vec'
 
 /** @internal */
-export function getRotationSnapshot({ editor }: { editor: Editor }): TLRotationSnapshot | null {
-	const selectedShapes = editor.getSelectedShapes()
-	const selectionRotation = editor.getSelectionRotation()
-	const selectionBounds = editor.getSelectionRotatedPageBounds()
-	const {
-		inputs: { originPagePoint },
-	} = editor
+export function getRotationSnapshot({
+	editor,
+	ids,
+}: {
+	editor: Editor
+	ids: TLShapeId[]
+}): TLRotationSnapshot | null {
+	const shapes = compact(ids.map((id) => editor.getShape(id)))
+	const rotation = editor.getShapesSharedRotation(ids)
+	const rotatedPageBounds = editor.getShapesRotatedPageBounds(ids)
 
 	// todo: this assumes we're rotating the selected shapes
 	// if we try to rotate shapes that aren't selected, this
 	// will produce the wrong results
 
 	// Return null if there are no selected shapes
-	if (!selectionBounds) {
+	if (!rotatedPageBounds) {
 		return null
 	}
 
-	const selectionPageCenter = selectionBounds.center
-		.clone()
-		.rotWith(selectionBounds.point, selectionRotation)
+	const pageCenter = rotatedPageBounds.center.clone().rotWith(rotatedPageBounds.point, rotation)
 
 	return {
-		selectionPageCenter: selectionPageCenter,
-		initialCursorAngle: selectionPageCenter.angle(originPagePoint),
-		initialSelectionRotation: selectionRotation,
-		shapeSnapshots: selectedShapes.map((shape) => ({
-			shape: structuredClone(shape),
+		pageCenter,
+		initialCursorAngle: pageCenter.angle(editor.inputs.originPagePoint),
+		initialShapesRotation: rotation,
+		shapeSnapshots: shapes.map((shape) => ({
+			shape,
 			initialPagePoint: editor.getShapePageTransform(shape.id)!.point(),
 		})),
 	}
 }
 
 /**
- * Info about a rotation that can be applied to the editor's selected shapes.
- *
- * @param selectionPageCenter - The center of the selection in page coordinates
- * @param initialCursorAngle - The angle of the cursor relative to the selection center when the rotation started
- * @param initialSelectionRotation - The rotation of the selection when the rotation started
- * @param shapeSnapshots - Info about each shape that is being rotated
- *
- * @public
+ * @internal
  **/
 export interface TLRotationSnapshot {
-	selectionPageCenter: Vec
+	pageCenter: Vec
 	initialCursorAngle: number
-	initialSelectionRotation: number
+	initialShapesRotation: number
 	shapeSnapshots: {
 		shape: TLShape
 		initialPagePoint: Vec
@@ -70,7 +64,7 @@ export function applyRotationToSnapshotShapes({
 	editor: Editor
 	stage: 'start' | 'update' | 'end' | 'one-off'
 }) {
-	const { selectionPageCenter, shapeSnapshots } = snapshot
+	const { pageCenter, shapeSnapshots } = snapshot
 
 	editor.updateShapes(
 		shapeSnapshots.map(({ shape, initialPagePoint }) => {
@@ -81,7 +75,7 @@ export function applyRotationToSnapshotShapes({
 				? editor.getShapePageTransform(shape.parentId)!
 				: Mat.Identity()
 
-			const newPagePoint = Vec.RotWith(initialPagePoint, selectionPageCenter, delta)
+			const newPagePoint = Vec.RotWith(initialPagePoint, pageCenter, delta)
 
 			const newLocalPoint = Mat.applyToPoint(
 				// use the current parent transform in case it has moved/resized since the start

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -30,7 +30,10 @@ export class Rotating extends StateNode {
 
 		this.markId = this.editor.markHistoryStoppingPoint('rotate start')
 
-		const snapshot = getRotationSnapshot({ editor: this.editor })
+		const snapshot = getRotationSnapshot({
+			editor: this.editor,
+			ids: this.editor.getSelectedShapeIds(),
+		})
 		if (!snapshot) return this.parent.transition('idle', this.info)
 		this.snapshot = snapshot
 
@@ -49,7 +52,7 @@ export class Rotating extends StateNode {
 		// Update cursor
 		this.editor.setCursor({
 			type: CursorTypeMap[this.info.handle as RotateCorner],
-			rotation: newSelectionRotation + this.snapshot.initialSelectionRotation,
+			rotation: newSelectionRotation + this.snapshot.initialShapesRotation,
 		})
 	}
 
@@ -101,7 +104,7 @@ export class Rotating extends StateNode {
 		// Update cursor
 		this.editor.setCursor({
 			type: CursorTypeMap[this.info.handle as RotateCorner],
-			rotation: newSelectionRotation + this.snapshot.initialSelectionRotation,
+			rotation: newSelectionRotation + this.snapshot.initialShapesRotation,
 		})
 	}
 
@@ -138,9 +141,9 @@ export class Rotating extends StateNode {
 		const {
 			inputs: { shiftKey, currentPagePoint },
 		} = this.editor
-		const { initialCursorAngle, initialSelectionRotation } = this.snapshot
+		const { initialCursorAngle, initialShapesRotation } = this.snapshot
 
-		if (!selectionBounds) return initialSelectionRotation
+		if (!selectionBounds) return initialShapesRotation
 
 		const selectionPageCenter = selectionBounds.center
 			.clone()
@@ -148,7 +151,7 @@ export class Rotating extends StateNode {
 
 		// The delta is the difference between the current angle and the initial angle
 		const preSnapRotationDelta = selectionPageCenter.angle(currentPagePoint) - initialCursorAngle
-		let newSelectionRotation = initialSelectionRotation + preSnapRotationDelta
+		let newSelectionRotation = initialShapesRotation + preSnapRotationDelta
 
 		if (shiftKey) {
 			newSelectionRotation = snapAngle(newSelectionRotation, 24)
@@ -164,6 +167,6 @@ export class Rotating extends StateNode {
 			}
 		}
 
-		return newSelectionRotation - initialSelectionRotation
+		return newSelectionRotation - initialShapesRotation
 	}
 }

--- a/packages/tldraw/src/test/commands/rotateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/rotateShapes.test.ts
@@ -39,21 +39,23 @@ beforeEach(() => {
 	])
 })
 
-describe('editor.rotateShapes', () => {
-	it('Rotates shapes and fires events', () => {
+describe('editor.rotateShapesBy', () => {
+	let fnStart = jest.fn()
+	let fnChange = jest.fn()
+	let fnEnd = jest.fn()
+
+	beforeEach(() => {
 		// Set start / change / end events on only the geo shape
 		const util = editor.getShapeUtil('geo')
 
 		// Bad! who did this (did I do this)
-		const fnStart = jest.fn()
-		util.onRotateStart = fnStart
+		util.onRotateStart = fnStart = jest.fn()
 
-		const fnChange = jest.fn()
-		util.onRotate = fnChange
+		util.onRotate = fnChange = jest.fn()
 
-		const fnEnd = jest.fn()
-		util.onRotateEnd = fnEnd
-
+		util.onRotateEnd = fnEnd = jest.fn()
+	})
+	it('Rotates shapes and fires events', () => {
 		// Select the shape...
 		editor.select(ids.box1, ids.box2)
 
@@ -78,5 +80,38 @@ describe('editor.rotateShapes', () => {
 
 		// Are the centers the same?
 		expect(selectionPageCenter).toCloselyMatchObject(editor.getSelectionPageCenter()!)
+	})
+
+	it('rotates the shapes you pass in only, regardless of selection', () => {
+		// Select the shape...
+		editor.select(ids.box1, ids.box2)
+
+		// Rotate the shape...
+		editor.rotateShapesBy([], Math.PI)
+
+		expect(fnStart).toHaveBeenCalledTimes(0)
+		expect(fnChange).toHaveBeenCalledTimes(0)
+		expect(fnEnd).toHaveBeenCalledTimes(0)
+
+		editor.rotateShapesBy([ids.box1], Math.PI)
+		expect(fnStart).toHaveBeenCalledTimes(1)
+		expect(fnChange).toHaveBeenCalledTimes(1)
+		expect(fnEnd).toHaveBeenCalledTimes(1)
+
+		// Are the shapes rotated?
+		editor
+			.expectShapeToMatch({ id: ids.box1, rotation: Math.PI })
+			.expectShapeToMatch({ id: ids.box2, rotation: 0 })
+
+		editor.selectNone()
+
+		editor.rotateShapesBy([ids.box2], Math.PI / 2)
+		expect(fnStart).toHaveBeenCalledTimes(2)
+		expect(fnChange).toHaveBeenCalledTimes(2)
+		expect(fnEnd).toHaveBeenCalledTimes(2)
+
+		editor
+			.expectShapeToMatch({ id: ids.box1, rotation: Math.PI })
+			.expectShapeToMatch({ id: ids.box2, rotation: Math.PI / 2 })
 	})
 })


### PR DESCRIPTION
Since the earliest days `rotateShapesBy` has been hard-coded to use the selected shape ids.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`


### Release notes

- Make `rotateShapesBy` work with any shapes, not just the currently selected shapes.
- BREAKING CHANGE - removes the `TLRotationSnapshot` type.