### PR TITLE
[api] Widen snapshots pit of success

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -3247,27 +3247,27 @@ export type TLSelectionHandle = RotateCorner | SelectionCorner | SelectionEdge;
 // @public
 export interface TLSessionStateSnapshot {
     // (undocumented)
-    currentPageId: TLPageId;
+    currentPageId?: TLPageId;
     // (undocumented)
-    exportBackground: boolean;
+    exportBackground?: boolean;
     // (undocumented)
-    isDebugMode: boolean;
+    isDebugMode?: boolean;
     // (undocumented)
-    isFocusMode: boolean;
+    isFocusMode?: boolean;
     // (undocumented)
-    isGridMode: boolean;
+    isGridMode?: boolean;
     // (undocumented)
-    isToolLocked: boolean;
+    isToolLocked?: boolean;
     // (undocumented)
-    pageStates: Array<{
-        camera: {
+    pageStates?: Array<{
+        camera?: {
             x: number;
             y: number;
             z: number;
         };
-        focusedGroupId: null | TLShapeId;
+        focusedGroupId?: null | TLShapeId;
         pageId: TLPageId;
-        selectedShapeIds: TLShapeId[];
+        selectedShapeIds?: TLShapeId[];
     }>;
     // (undocumented)
     version: number;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1132,7 +1132,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     isShapeOrAncestorLocked(shape?: TLShape): boolean;
     // (undocumented)
     isShapeOrAncestorLocked(id?: TLShapeId): boolean;
-    loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot): this;
+    loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot, opts?: TLLoadSnapshotOptions): this;
     // @deprecated
     mark(markId?: string): this;
     markHistoryStoppingPoint(name?: string): string;
@@ -1732,10 +1732,10 @@ export interface LoadingScreenProps {
 }
 
 // @public
-export function loadSessionStateSnapshotIntoStore(store: TLStore, snapshot: TLSessionStateSnapshot): void;
+export function loadSessionStateSnapshotIntoStore(store: TLStore, snapshot: TLSessionStateSnapshot, opts?: TLLoadSessionStateSnapshotOptions): void;
 
 // @public
-export function loadSnapshot(store: TLStore, _snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot): void;
+export function loadSnapshot(store: TLStore, _snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot, opts?: TLLoadSnapshotOptions): void;
 
 // @public (undocumented)
 export function loopToHtmlElement(elm: Element): HTMLElement;
@@ -3084,6 +3084,16 @@ export type TLKeyboardEventInfo = TLBaseEventInfo & {
 
 // @public (undocumented)
 export type TLKeyboardEventName = 'key_down' | 'key_repeat' | 'key_up';
+
+// @public
+export interface TLLoadSessionStateSnapshotOptions {
+    forceOverwrite?: boolean;
+}
+
+// @public
+export interface TLLoadSnapshotOptions {
+    forceOverwriteSessionState?: boolean;
+}
 
 // @public (undocumented)
 export interface TLMeasureTextSpanOpts {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -109,12 +109,18 @@ export {
 } from './lib/components/default-components/DefaultSnapIndictor'
 export { DefaultSpinner } from './lib/components/default-components/DefaultSpinner'
 export { DefaultSvgDefs } from './lib/components/default-components/DefaultSvgDefs'
-export { getSnapshot, loadSnapshot, type TLEditorSnapshot } from './lib/config/TLEditorSnapshot'
+export {
+	getSnapshot,
+	loadSnapshot,
+	type TLEditorSnapshot,
+	type TLLoadSnapshotOptions,
+} from './lib/config/TLEditorSnapshot'
 export {
 	TAB_ID,
 	createSessionStateSnapshotSignal,
 	extractSessionStateFromLegacySnapshot,
 	loadSessionStateSnapshotIntoStore,
+	type TLLoadSessionStateSnapshotOptions,
 	type TLSessionStateSnapshot,
 } from './lib/config/TLSessionStateSnapshot'
 export {

--- a/packages/editor/src/lib/config/TLEditorSnapshot.test.ts
+++ b/packages/editor/src/lib/config/TLEditorSnapshot.test.ts
@@ -1,4 +1,4 @@
-import { PageRecordType, TLStore } from '@tldraw/tlschema'
+import { PageRecordType, TLStore, createShapeId } from '@tldraw/tlschema'
 import { IndexKey } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 import { Box } from '../primitives/Box'
@@ -223,5 +223,22 @@ describe('loadSnapshot', () => {
 		// and because we updated the page1 camera after the snapshot was taken, it should still be the same
 		editor.setCurrentPage(page1Id)
 		expect(editor.getCamera()).toMatchObject({ x: 1, y: 2, z: 3 })
+	})
+
+	it('cleans up references to missing shapes from page state', () => {
+		const store = createTLStore({})
+		const editor = createEditor(store)
+
+		const shapeA = createShapeId('a')
+		editor.createShape({ type: 'group', id: shapeA })
+
+		const snapshot = getSnapshot(store)
+
+		const shapeB = createShapeId('b')
+		editor.createShape({ type: 'group', id: shapeB }).select(shapeB, shapeA)
+
+		loadSnapshot(store, snapshot.document)
+
+		expect(editor.getCurrentPageState().selectedShapeIds).toEqual([shapeA])
 	})
 })

--- a/packages/editor/src/lib/config/TLEditorSnapshot.test.ts
+++ b/packages/editor/src/lib/config/TLEditorSnapshot.test.ts
@@ -76,6 +76,7 @@ describe('getSnapshot', () => {
 const page2Id = PageRecordType.createId('page2')
 function addPage2(snapshot: TLEditorSnapshot) {
 	// sneakily add a page
+	snapshot = structuredClone(snapshot)
 	snapshot.document.store[page2Id] = PageRecordType.create({
 		id: page2Id,
 		name: 'my lovely page',
@@ -84,6 +85,7 @@ function addPage2(snapshot: TLEditorSnapshot) {
 
 	// and set the current page id
 	snapshot.session.currentPageId = page2Id
+	return snapshot
 }
 
 describe('loadSnapshot', () => {
@@ -91,9 +93,7 @@ describe('loadSnapshot', () => {
 		const store = createTLStore({})
 		const editor = createEditor(store)
 
-		const snapshot = getSnapshot(store)
-
-		addPage2(snapshot)
+		const snapshot = addPage2(getSnapshot(store))
 
 		loadSnapshot(store, snapshot)
 
@@ -110,13 +110,11 @@ describe('loadSnapshot', () => {
 		const store = createTLStore({})
 		const editor = createEditor(store)
 
-		const snapshot = getSnapshot(store)
+		const snapshot = addPage2(getSnapshot(store))
 
 		expect(editor.getViewportScreenBounds()).not.toEqual(new Box(0, 0, 100, 100))
 		editor.updateViewportScreenBounds(new Box(0, 0, 100, 100))
 		expect(editor.getViewportScreenBounds()).toEqual(new Box(0, 0, 100, 100))
-
-		addPage2(snapshot)
 
 		loadSnapshot(store, snapshot)
 
@@ -127,9 +125,7 @@ describe('loadSnapshot', () => {
 		const store = createTLStore({})
 		const editor = createEditor(store)
 
-		const snapshot = getSnapshot(store)
-
-		addPage2(snapshot)
+		const snapshot = addPage2(getSnapshot(store))
 
 		loadSnapshot(store, snapshot.document)
 
@@ -146,9 +142,7 @@ describe('loadSnapshot', () => {
 		const store = createTLStore({})
 		const editor = createEditor(store)
 
-		const snapshot = getSnapshot(store)
-
-		addPage2(snapshot)
+		const snapshot = addPage2(getSnapshot(store))
 
 		loadSnapshot(store, { document: snapshot.document })
 
@@ -165,9 +159,7 @@ describe('loadSnapshot', () => {
 		const store = createTLStore({})
 		const editor = createEditor(store)
 
-		const snapshot = getSnapshot(store)
-
-		addPage2(snapshot)
+		const snapshot = addPage2(getSnapshot(store))
 
 		loadSnapshot(store, snapshot.document)
 
@@ -181,5 +173,55 @@ describe('loadSnapshot', () => {
 
 		loadSnapshot(store, { session: snapshot.session })
 		expect(editor.getCurrentPageId()).toBe('page:page2')
+	})
+
+	it('preserves session stuff if no session snapshot is provided', () => {
+		const store = createTLStore({})
+		const editor = createEditor(store)
+
+		const snapshot = getSnapshot(store)
+
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
+
+		editor.setCamera({ x: 1, y: 2, z: 3 })
+
+		loadSnapshot(store, snapshot.document)
+
+		expect(editor.getCamera()).toMatchObject({ x: 1, y: 2, z: 3 })
+
+		loadSnapshot(store, { document: snapshot.document })
+
+		expect(editor.getCamera()).toMatchObject({ x: 1, y: 2, z: 3 })
+
+		loadSnapshot(store, snapshot)
+
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
+	})
+
+	it('preserves session stuff if only a partial session snapshot is provided', () => {
+		const store = createTLStore({})
+		const editor = createEditor(store)
+		const page1Id = editor.getCurrentPageId()
+
+		const page2Id = PageRecordType.createId('page2')
+		editor.createPage({ id: page2Id })
+		editor.setCurrentPage(PageRecordType.createId('page2'))
+
+		const snapshot = getSnapshot(store)
+
+		delete snapshot.session.pageStates
+
+		editor.setCurrentPage(page1Id)
+		editor.setCamera({ x: 1, y: 2, z: 3 })
+
+		loadSnapshot(store, snapshot)
+
+		// the page should have switched back to page2 with the default camera
+		expect(editor.getCurrentPageId()).toBe(page2Id)
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
+
+		// and because we updated the page1 camera after the snapshot was taken, it should still be the same
+		editor.setCurrentPage(page1Id)
+		expect(editor.getCamera()).toMatchObject({ x: 1, y: 2, z: 3 })
 	})
 })

--- a/packages/editor/src/lib/config/TLEditorSnapshot.ts
+++ b/packages/editor/src/lib/config/TLEditorSnapshot.ts
@@ -44,6 +44,9 @@ export function loadSnapshot(
 	// We need to preserve a bunch of instance state properties that the Editor sets
 	// to avoid breaking the editor or causing jarring changes when loading a snapshot.
 	const preservingInstanceState = pluckPreservingValues(store.get(TLINSTANCE_ID))
+	const preservingSessionState = sessionStateCache
+		.get(store, createSessionStateSnapshotSignal)
+		.get()
 
 	store.atomic(() => {
 		// first load the document state (this will wipe the store if it happens)
@@ -55,6 +58,10 @@ export function loadSnapshot(
 		// this is a noop if the document state wasn't loaded above
 		if (preservingInstanceState) {
 			store.update(TLINSTANCE_ID, (r) => ({ ...r, ...preservingInstanceState }))
+		}
+		if (preservingSessionState) {
+			// there's some duplication here with the instanceState but it's fine
+			loadSessionStateSnapshotIntoStore(store, preservingSessionState)
 		}
 
 		// finally reinstate the UI state

--- a/packages/editor/src/lib/config/TLEditorSnapshot.ts
+++ b/packages/editor/src/lib/config/TLEditorSnapshot.ts
@@ -14,12 +14,26 @@ export interface TLEditorSnapshot {
 }
 
 /**
+ * Options for {@link loadSnapshot}
+ * @public
+ */
+export interface TLLoadSnapshotOptions {
+	/**
+	 * By default, some session state flags like `isDebugMode` are not overwritten when loading a snapshot.
+	 * These are usually considered "sticky" by users while the document data is not.
+	 * If you want to overwrite these flags, set this to `true`.
+	 */
+	forceOverwriteSessionState?: boolean
+}
+
+/**
  * Loads a snapshot into a store.
  * @public
  */
 export function loadSnapshot(
 	store: TLStore,
-	_snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot
+	_snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot,
+	opts?: TLLoadSnapshotOptions
 ) {
 	let snapshot: Partial<TLEditorSnapshot> = {}
 	if ('store' in _snapshot) {
@@ -66,7 +80,9 @@ export function loadSnapshot(
 
 		// finally reinstate the UI state
 		if (snapshot.session) {
-			loadSessionStateSnapshotIntoStore(store, snapshot.session)
+			loadSessionStateSnapshotIntoStore(store, snapshot.session, {
+				forceOverwrite: opts?.forceOverwriteSessionState,
+			})
 		}
 	})
 }

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -85,7 +85,12 @@ import {
 import EventEmitter from 'eventemitter3'
 import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
-import { TLEditorSnapshot, getSnapshot, loadSnapshot } from '../config/TLEditorSnapshot'
+import {
+	TLEditorSnapshot,
+	TLLoadSnapshotOptions,
+	getSnapshot,
+	loadSnapshot,
+} from '../config/TLEditorSnapshot'
 import { TLUser, createTLUser } from '../config/createTLUser'
 import { TLAnyBindingUtilConstructor, checkBindings } from '../config/defaultBindings'
 import { TLAnyShapeUtilConstructor, checkShapesAndAddCore } from '../config/defaultShapes'
@@ -8783,8 +8788,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @param snapshot - the snapshot to load
 	 * @returns
 	 */
-	loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot) {
-		loadSnapshot(this.store, snapshot)
+	loadSnapshot(
+		snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot,
+		opts?: TLLoadSnapshotOptions
+	) {
+		loadSnapshot(this.store, snapshot, opts)
 		return this
 	}
 

--- a/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
+++ b/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
@@ -46,7 +46,7 @@ describe('createSessionStateSnapshotSignal', () => {
 
 		react('', () => {
 			isGridMode = $snapshot.get()?.isGridMode ?? false
-			numPages = $snapshot.get()?.pageStates.length ?? 0
+			numPages = $snapshot.get()?.pageStates?.length ?? 0
 		})
 
 		expect(isGridMode).toBe(false)
@@ -77,8 +77,8 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 		snapshot = JSON.parse(JSON.stringify(snapshot)) as TLSessionStateSnapshot
 
 		snapshot.isGridMode = true
-		snapshot.pageStates[0].camera.x = 1
-		snapshot.pageStates[0].camera.y = 2
+		snapshot.pageStates![0].camera!.x = 1
+		snapshot.pageStates![0].camera!.y = 2
 
 		loadSessionStateSnapshotIntoStore(editor.store, snapshot)
 

--- a/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
+++ b/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
@@ -80,7 +80,7 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 		snapshot.pageStates![0].camera!.x = 1
 		snapshot.pageStates![0].camera!.y = 2
 
-		loadSessionStateSnapshotIntoStore(editor.store, snapshot)
+		loadSessionStateSnapshotIntoStore(editor.store, snapshot, { forceOverwrite: true })
 
 		expect(editor.getInstanceState().isGridMode).toBe(true)
 		expect(editor.getCamera().x).toBe(1)

--- a/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
+++ b/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
@@ -76,15 +76,59 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 
 		snapshot = JSON.parse(JSON.stringify(snapshot)) as TLSessionStateSnapshot
 
-		snapshot.isGridMode = true
 		snapshot.pageStates![0].camera!.x = 1
 		snapshot.pageStates![0].camera!.y = 2
 
-		loadSessionStateSnapshotIntoStore(editor.store, snapshot, { forceOverwrite: true })
+		loadSessionStateSnapshotIntoStore(editor.store, snapshot)
 
-		expect(editor.getInstanceState().isGridMode).toBe(true)
 		expect(editor.getCamera().x).toBe(1)
 		expect(editor.getCamera().y).toBe(2)
+	})
+
+	it('preserves existing UI flags by default', () => {
+		expect(editor.getInstanceState()).toMatchObject({
+			isGridMode: false,
+			isFocusMode: false,
+			isDebugMode: false,
+			isToolLocked: false,
+		})
+		const snapshot = createSessionStateSnapshotSignal(editor.store).get()
+		editor.updateInstanceState({
+			isGridMode: true,
+			isFocusMode: true,
+			isDebugMode: true,
+			isToolLocked: true,
+		})
+		loadSessionStateSnapshotIntoStore(editor.store, snapshot!)
+		expect(editor.getInstanceState()).toMatchObject({
+			isGridMode: true,
+			isFocusMode: true,
+			isDebugMode: true,
+			isToolLocked: true,
+		})
+	})
+
+	it('overrides existing UI flags if you say so', () => {
+		expect(editor.getInstanceState()).toMatchObject({
+			isGridMode: false,
+			isFocusMode: false,
+			isDebugMode: false,
+			isToolLocked: false,
+		})
+		const snapshot = createSessionStateSnapshotSignal(editor.store).get()
+		editor.updateInstanceState({
+			isGridMode: true,
+			isFocusMode: true,
+			isDebugMode: true,
+			isToolLocked: true,
+		})
+		loadSessionStateSnapshotIntoStore(editor.store, snapshot!, { forceOverwrite: true })
+		expect(editor.getInstanceState()).toMatchObject({
+			isGridMode: false,
+			isFocusMode: false,
+			isDebugMode: false,
+			isToolLocked: false,
+		})
 	})
 })
 


### PR DESCRIPTION
This PR makes the snapshot loader preserve page states that are not explicitly overridden so that, e.g. you can load a previous snapshot version of a document without switching page or resetting camera simply by omitting the session state option.

The goal is to provide a nice and robust version of the solution mentioned in #4381 

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

- [x] Unit tests


### Release notes

- Improved loadSnapshot to preserve page state like camera position and current page if no session snapshot is provided.