### PR TITLE
Fix an error with parsing embed urls.

### DIFF
--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -75,20 +75,6 @@ export type TLEmbedResult =
 	| undefined
 
 /**
- * Tests whether an URL supports embedding and returns the result.
- *
- * @param inputUrl - The URL to match
- * @public
- */
-export function getEmbedInfoUnsafely(
-	definitions: readonly TLEmbedDefinition[],
-	inputUrl: string
-): TLEmbedResult {
-	const result = matchUrl(definitions, inputUrl) ?? matchEmbedUrl(definitions, inputUrl)
-	return result
-}
-
-/**
  * Tests whether an URL supports embedding and returns the result. If we encounter an error, we
  * return undefined.
  *
@@ -99,12 +85,5 @@ export function getEmbedInfo(
 	definitions: readonly TLEmbedDefinition[],
 	inputUrl: string
 ): TLEmbedResult {
-	try {
-		return getEmbedInfoUnsafely(definitions, inputUrl)
-	} catch (e) {
-		// Don't throw here! We'll throw it from the embed shape's shape util
-		console.error(e)
-	}
-
-	return undefined
+	return matchUrl(definitions, inputUrl) ?? matchEmbedUrl(definitions, inputUrl)
 }

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -1,3 +1,4 @@
+import { safeParseUrl } from '@tldraw/editor'
 import { TLEmbedDefinition } from '../../defaultEmbedDefinitions'
 
 // https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js
@@ -13,7 +14,9 @@ function escapeStringRegexp(string: string) {
 
 /** @public */
 export function matchEmbedUrl(definitions: readonly TLEmbedDefinition[], url: string) {
-	const host = new URL(url).host.replace('www.', '')
+	const parsed = safeParseUrl(url)
+	if (!parsed) return
+	const host = parsed.host.replace('www.', '')
 	for (const localEmbedDef of definitions) {
 		if (checkHostnames(localEmbedDef.hostnames, host)) {
 			const originalUrl = localEmbedDef.fromEmbedUrl(url)
@@ -44,7 +47,9 @@ const checkHostnames = (hostnames: readonly string[], targetHostname: string) =>
 
 /** @public */
 export function matchUrl(definitions: readonly TLEmbedDefinition[], url: string) {
-	const host = new URL(url).host.replace('www.', '')
+	const parsed = safeParseUrl(url)
+	if (!parsed) return
+	const host = parsed.host.replace('www.', '')
 	for (const localEmbedDef of definitions) {
 		if (checkHostnames(localEmbedDef.hostnames, host)) {
 			const embedUrl = localEmbedDef.toEmbedUrl(url)

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -85,5 +85,9 @@ export function getEmbedInfo(
 	definitions: readonly TLEmbedDefinition[],
 	inputUrl: string
 ): TLEmbedResult {
-	return matchUrl(definitions, inputUrl) ?? matchEmbedUrl(definitions, inputUrl)
+	try {
+		return matchUrl(definitions, inputUrl) ?? matchEmbedUrl(definitions, inputUrl)
+	} catch (_e) {
+		return undefined
+	}
 }


### PR DESCRIPTION
Fix an issue with parsing embed urls. 

If you open the embed dialog, choose one of the embeds and start typing the url you'll see an error. After this change we handle the error correctly.

![CleanShot 2024-08-20 at 16 23 56](https://github.com/user-attachments/assets/bf9351a1-9e9a-4342-86ae-b4443e0c3370)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open embed dialog and choose one of the embeds.
2. Start typing an url.
3. You should no longer see an error.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix a bug with embed dialog throwing an error when entering an invalid url

### Breaking change
We have removed `getEmbedInfoUnsafely`. Use `getEmbedInfo` instead.