### PR TITLE
Prevent unhandled promise rejection during strict mode

### DIFF
--- a/apps/examples/src/index.tsx
+++ b/apps/examples/src/index.tsx
@@ -1,4 +1,5 @@
 import { getAssetUrlsByMetaUrl } from '@tldraw/assets/urls'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import {
@@ -83,11 +84,13 @@ document.addEventListener('DOMContentLoaded', () => {
 	const rootElement = document.getElementById('root')!
 	const root = createRoot(rootElement!)
 	root.render(
-		<ErrorBoundary
-			fallback={(error) => <DefaultErrorFallback error={error} />}
-			onError={(error) => console.error(error)}
-		>
-			<RouterProvider router={router} />
-		</ErrorBoundary>
+		<StrictMode>
+			<ErrorBoundary
+				fallback={(error) => <DefaultErrorFallback error={error} />}
+				onError={(error) => console.error(error)}
+			>
+				<RouterProvider router={router} />
+			</ErrorBoundary>
+		</StrictMode>
 	)
 })

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -138,11 +138,19 @@ export class LocalIndexedDb {
 			assert(!this.isClosed, 'db is closed')
 			const db = await this.getDb()
 			const tx = db.transaction(names, mode)
+			// need to add a catch here early to prevent unhandled promise rejection
+			// during react-strict-mode where this tx.done promise can be rejected
+			// before we have a chance to await on it
+			const done = tx.done.catch((e: unknown) => {
+				if (!this.isClosed) {
+					throw e
+				}
+			})
 			try {
 				return await cb(tx)
 			} finally {
 				if (!this.isClosed) {
-					await tx.done
+					await done
 				} else {
 					tx.abort()
 				}


### PR DESCRIPTION
In react strict mode some folks have noticed that there's an unhandled promise rejection related to an idb transaction being aborted. This PR makes sure to handle such rejections so folks won't see an error in their console.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Prevented a harmless Unhandled Promise Rejection error message during dev time with React strict mode.