### PR TITLE
Fix an issue with canceling the page name and presence name changes.

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -30,7 +30,6 @@ import { MigrationSequence } from '@tldraw/editor';
 import { NamedExoticComponent } from 'react';
 import { Polygon2d } from '@tldraw/editor';
 import { Polyline2d } from '@tldraw/editor';
-import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React_2 from 'react';
 import { default as React_3 } from 'react';
 import { ReactElement } from 'react';
@@ -2949,7 +2948,7 @@ export interface TLUiPopoverContentProps {
     // (undocumented)
     children: React_3.ReactNode;
     // (undocumented)
-    onEscapeKeyDown?: PopoverPrimitive.PopoverContentProps['onEscapeKeyDown'];
+    onEscapeKeyDown?(event: KeyboardEvent): void;
     // (undocumented)
     side: 'bottom' | 'left' | 'right' | 'top';
     // (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -30,6 +30,7 @@ import { MigrationSequence } from '@tldraw/editor';
 import { NamedExoticComponent } from 'react';
 import { Polygon2d } from '@tldraw/editor';
 import { Polyline2d } from '@tldraw/editor';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React_2 from 'react';
 import { default as React_3 } from 'react';
 import { ReactElement } from 'react';
@@ -1578,7 +1579,7 @@ export interface OverflowingToolbarProps {
 }
 
 // @public (undocumented)
-export const PageItemInput: ({ name, id, isCurrentPage, }: PageItemInputProps) => JSX_2.Element;
+export const PageItemInput: ({ name, id, isCurrentPage, onCancel, }: PageItemInputProps) => JSX_2.Element;
 
 // @public (undocumented)
 export interface PageItemInputProps {
@@ -1588,6 +1589,8 @@ export interface PageItemInputProps {
     isCurrentPage: boolean;
     // (undocumented)
     name: string;
+    // (undocumented)
+    onCancel(): void;
 }
 
 // @public (undocumented)
@@ -2160,7 +2163,7 @@ export function TldrawUiMenuToolItem({ toolId, ...rest }: TLUiMenuToolItemProps)
 export function TldrawUiPopover({ id, children, onOpenChange, open }: TLUiPopoverProps): JSX_2.Element;
 
 // @public (undocumented)
-export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, }: TLUiPopoverContentProps): JSX_2.Element;
+export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, onEscapeKeyDown, }: TLUiPopoverContentProps): JSX_2.Element;
 
 // @public (undocumented)
 export function TldrawUiPopoverTrigger({ children }: TLUiPopoverTriggerProps): JSX_2.Element;
@@ -2945,6 +2948,8 @@ export interface TLUiPopoverContentProps {
     alignOffset?: number;
     // (undocumented)
     children: React_3.ReactNode;
+    // (undocumented)
+    onEscapeKeyDown?: PopoverPrimitive.PopoverContentProps['onEscapeKeyDown'];
     // (undocumented)
     side: 'bottom' | 'left' | 'right' | 'top';
     // (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2162,7 +2162,7 @@ export function TldrawUiMenuToolItem({ toolId, ...rest }: TLUiMenuToolItemProps)
 export function TldrawUiPopover({ id, children, onOpenChange, open }: TLUiPopoverProps): JSX_2.Element;
 
 // @public (undocumented)
-export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, onEscapeKeyDown, }: TLUiPopoverContentProps): JSX_2.Element;
+export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, disableEscapeKeyDown, }: TLUiPopoverContentProps): JSX_2.Element;
 
 // @public (undocumented)
 export function TldrawUiPopoverTrigger({ children }: TLUiPopoverTriggerProps): JSX_2.Element;
@@ -2948,7 +2948,7 @@ export interface TLUiPopoverContentProps {
     // (undocumented)
     children: React_3.ReactNode;
     // (undocumented)
-    onEscapeKeyDown?(event: KeyboardEvent): void;
+    disableEscapeKeyDown?: boolean;
     // (undocumented)
     side: 'bottom' | 'left' | 'right' | 'top';
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -295,7 +295,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 				side="bottom"
 				align="start"
 				sideOffset={6}
-				disableEscapeKeyDown={true}
+				disableEscapeKeyDown={isEditing}
 			>
 				<div className="tlui-page-menu__wrapper">
 					<div className="tlui-page-menu__header">

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -291,7 +291,14 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 					<TldrawUiButtonIcon icon="chevron-down" small />
 				</TldrawUiButton>
 			</TldrawUiPopoverTrigger>
-			<TldrawUiPopoverContent side="bottom" align="start" sideOffset={6}>
+			<TldrawUiPopoverContent
+				side="bottom"
+				align="start"
+				sideOffset={6}
+				onEscapeKeyDown={(e) => {
+					e.preventDefault()
+				}}
+			>
 				<div className="tlui-page-menu__wrapper">
 					<div className="tlui-page-menu__header">
 						<div className="tlui-page-menu__header__title">{msg('page-menu.title')}</div>
@@ -384,6 +391,10 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 												id={page.id}
 												name={page.name}
 												isCurrentPage={page.id === currentPage.id}
+												onCancel={() => {
+													setIsEditing(false)
+													editor.clearOpenMenus()
+												}}
 											/>
 										</div>
 									)}

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -295,9 +295,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 				side="bottom"
 				align="start"
 				sideOffset={6}
-				onEscapeKeyDown={(e) => {
-					e.preventDefault()
-				}}
+				disableEscapeKeyDown={true}
 			>
 				<div className="tlui-page-menu__wrapper">
 					<div className="tlui-page-menu__header">

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
@@ -8,6 +8,7 @@ export interface PageItemInputProps {
 	name: string
 	id: TLPageId
 	isCurrentPage: boolean
+	onCancel(): void
 }
 
 /** @public @react */
@@ -15,14 +16,16 @@ export const PageItemInput = function PageItemInput({
 	name,
 	id,
 	isCurrentPage,
+	onCancel,
 }: PageItemInputProps) {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()
 
 	const rInput = useRef<HTMLInputElement | null>(null)
+	const rMark = useRef<string | null>(null)
 
 	const handleFocus = useCallback(() => {
-		editor.markHistoryStoppingPoint('rename page')
+		rMark.current = editor.markHistoryStoppingPoint('rename page')
 	}, [editor])
 
 	const handleChange = useCallback(
@@ -33,12 +36,20 @@ export const PageItemInput = function PageItemInput({
 		[editor, id, trackEvent]
 	)
 
+	const handleCancel = useCallback(() => {
+		if (rMark.current) {
+			editor.bailToMark(rMark.current)
+		}
+		onCancel()
+	}, [editor, onCancel])
+
 	return (
 		<TldrawUiInput
 			className="tlui-page-menu__item__input"
 			ref={(el) => (rInput.current = el)}
 			defaultValue={name}
 			onValueChange={handleChange}
+			onCancel={handleCancel}
 			onFocus={handleFocus}
 			shouldManuallyMaintainScrollPositionWhenFocused
 			autoFocus={isCurrentPage}

--- a/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
@@ -54,6 +54,7 @@ export const PeopleMenu = track(function PeopleMenu({ children }: PeopleMenuProp
 					side="bottom"
 					sideOffset={2}
 					alignOffset={-5}
+					onEscapeKeyDown={(e) => e.preventDefault()}
 				>
 					<div className="tlui-people-menu__wrapper">
 						<div className="tlui-people-menu__section">

--- a/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceEditor.tsx
@@ -36,6 +36,12 @@ export function UserPresenceEditor() {
 		rOriginalName.current = rCurrentName.current
 	}, [trackEvent])
 
+	const handleCancel = useCallback(() => {
+		setIsEditingName(false)
+		editor.user.updateUserPreferences({ name: rOriginalName.current })
+		editor.clearOpenMenus()
+	}, [editor])
+
 	return (
 		<div className="tlui-people-menu__user">
 			<UserPresenceColorPicker />
@@ -45,7 +51,7 @@ export function UserPresenceEditor() {
 					defaultValue={userName}
 					onValueChange={handleValueChange}
 					onComplete={toggleEditingName}
-					onCancel={toggleEditingName}
+					onCancel={handleCancel}
 					onBlur={handleBlur}
 					shouldManuallyMaintainScrollPositionWhenFocused
 					autoFocus

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
@@ -104,9 +104,9 @@ export const TldrawUiInput = React.forwardRef<HTMLInputElement, TLUiInputProps>(
 					}
 					case 'Escape': {
 						e.currentTarget.value = rInitialValue.current
+						onCancel?.(e.currentTarget.value)
 						e.currentTarget.blur()
 						stopEventPropagation(e)
-						onCancel?.(e.currentTarget.value)
 						break
 					}
 				}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -46,6 +46,7 @@ export interface TLUiPopoverContentProps {
 	align?: 'start' | 'center' | 'end'
 	alignOffset?: number
 	sideOffset?: number
+	onEscapeKeyDown?: PopoverPrimitive.PopoverContentProps['onEscapeKeyDown']
 }
 
 /** @public @react */
@@ -55,6 +56,7 @@ export function TldrawUiPopoverContent({
 	align = 'center',
 	sideOffset = 8,
 	alignOffset = 0,
+	onEscapeKeyDown,
 }: TLUiPopoverContentProps) {
 	const container = useContainer()
 	return (
@@ -66,6 +68,7 @@ export function TldrawUiPopoverContent({
 				align={align}
 				alignOffset={alignOffset}
 				dir="ltr"
+				onEscapeKeyDown={onEscapeKeyDown}
 			>
 				{children}
 				{/* <StyledArrow /> */}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -46,7 +46,7 @@ export interface TLUiPopoverContentProps {
 	align?: 'start' | 'center' | 'end'
 	alignOffset?: number
 	sideOffset?: number
-	onEscapeKeyDown?(event: KeyboardEvent): void
+	disableEscapeKeyDown?: boolean
 }
 
 /** @public @react */
@@ -56,7 +56,7 @@ export function TldrawUiPopoverContent({
 	align = 'center',
 	sideOffset = 8,
 	alignOffset = 0,
-	onEscapeKeyDown,
+	disableEscapeKeyDown = false,
 }: TLUiPopoverContentProps) {
 	const container = useContainer()
 	return (
@@ -68,7 +68,7 @@ export function TldrawUiPopoverContent({
 				align={align}
 				alignOffset={alignOffset}
 				dir="ltr"
-				onEscapeKeyDown={onEscapeKeyDown}
+				onEscapeKeyDown={(e) => disableEscapeKeyDown && e.preventDefault()}
 			>
 				{children}
 				{/* <StyledArrow /> */}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -46,7 +46,7 @@ export interface TLUiPopoverContentProps {
 	align?: 'start' | 'center' | 'end'
 	alignOffset?: number
 	sideOffset?: number
-	onEscapeKeyDown?: PopoverPrimitive.PopoverContentProps['onEscapeKeyDown']
+	onEscapeKeyDown?(event: KeyboardEvent): void
 }
 
 /** @public @react */


### PR DESCRIPTION
You can now use escape to cancel the changes to page name and presence name changes.

There was an issue with using Escape to cancel the page name or presence name changes. The problem was that Escape key event (on key down) was captured by the popover component (radix) which closed the popover. This meant that the `onKeyUp` in `TldrawUiInput` never triggered when Escape was pressed so the `onCancel` callback was never called.
We now prevent the direct closing of the popover on Escape which means that we do have to close it manually.

Could maybe also cause the `onCancel` to be called on key down, might be better?

### Before

https://github.com/user-attachments/assets/151a980e-0a24-44cb-a1eb-89e384883ef9

### After
https://github.com/user-attachments/assets/601a5830-1ea8-4849-b489-e2077e746e97



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix an issue with not being able to cancel out changing of page names and user presence names.