### PR TITLE
Allow the users to programmatically disable the context menu.

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2377,6 +2377,8 @@ export interface TLUiComponentsProviderProps {
 export interface TLUiContextMenuProps {
     // (undocumented)
     children?: ReactNode;
+    // (undocumented)
+    disabled?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
@@ -8,11 +8,13 @@ import { DefaultContextMenuContent } from './DefaultContextMenuContent'
 /** @public */
 export interface TLUiContextMenuProps {
 	children?: ReactNode
+	disabled?: boolean
 }
 
 /** @public @react */
 export const DefaultContextMenu = memo(function DefaultContextMenu({
 	children,
+	disabled = false,
 }: TLUiContextMenuProps) {
 	const editor = useEditor()
 
@@ -67,7 +69,7 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 
 	return (
 		<_ContextMenu.Root dir="ltr" onOpenChange={handleOpenChange} modal={false}>
-			<_ContextMenu.Trigger onContextMenu={undefined} dir="ltr">
+			<_ContextMenu.Trigger onContextMenu={undefined} dir="ltr" disabled={disabled}>
 				{Canvas ? <Canvas /> : null}
 			</_ContextMenu.Trigger>
 			{isOpen && (


### PR DESCRIPTION
Resolves #4417 

We just expose a `disabled` prop and pass it to the radix' `Trigger` component. After this change you can do something like this to conditionally render the context menu:
```ts
function CustomContextMenu(props: TLUiContextMenuProps) {
	const editor = useEditor()
	const disabled = useValue('disabled', () => editor.getSelectedShapeIds().length === 0, [editor])

	return <DefaultContextMenu disabled={disabled} {...props} />
}
```

 A bit more info in the [discord discussion](https://discord.com/channels/859816885297741824/1276478006285565954/1276478006285565954).

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improves the customisability of the context menu. You can now conditionally disable it.