### PR TITLE
[experiment]: add captions to media

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1110,6 +1110,12 @@ input,
 	width: 100%;
 }
 
+.tl-shape[data-shape-type='image'] .tl-text-label,
+.tl-shape[data-shape-type='video'] .tl-text-label {
+	top: 100%;
+	height: fit-content;
+}
+
 .tl-text-label[data-hastext='false'][data-isediting='false'] > .tl-text-label__inner {
 	width: 40px;
 	height: 40px;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1302,11 +1302,15 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     canCrop(): boolean;
     // (undocumented)
+    canEdit(): boolean;
+    // (undocumented)
     component(shape: TLImageShape): JSX_2.Element;
     // (undocumented)
     getDefaultProps(): TLImageShape['props'];
     // (undocumented)
     getInterpolatedProps(startShape: TLImageShape, endShape: TLImageShape, t: number): TLImageShapeProps;
+    // (undocumented)
+    getText(shape: TLImageShape): string;
     // (undocumented)
     indicator(shape: TLImageShape): JSX_2.Element | null;
     // (undocumented)
@@ -3767,6 +3771,8 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     component(shape: TLVideoShape): JSX_2.Element;
     // (undocumented)
     getDefaultProps(): TLVideoShape['props'];
+    // (undocumented)
+    getText(shape: TLVideoShape): string;
     // (undocumented)
     indicator(shape: TLVideoShape): JSX_2.Element;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -75,18 +75,20 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 			w: 100,
 			h: 100,
 			geo: 'rectangle',
+			dash: 'draw',
+			growY: 0,
+			url: '',
+			scale: 1,
+
+			// Text properties
 			color: 'black',
 			labelColor: 'black',
 			fill: 'none',
-			dash: 'draw',
 			size: 'm',
 			font: 'draw',
 			text: '',
 			align: 'middle',
 			verticalAlign: 'middle',
-			growY: 0,
-			url: '',
-			scale: 1,
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -23,7 +23,10 @@ import { useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
+import { TextLabel } from '../shared/TextLabel'
+import { LABEL_FONT_SIZES, LABEL_PADDING, TEXT_PROPS } from '../shared/default-shape-constants'
 import { useAsset } from '../shared/useAsset'
+import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 async function getDataURIFromURL(url: string): Promise<string> {
@@ -44,6 +47,9 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	override canCrop() {
 		return true
 	}
+	override canEdit() {
+		return true
+	}
 
 	override getDefaultProps(): TLImageShape['props'] {
 		return {
@@ -55,7 +61,21 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 			crop: null,
 			flipX: false,
 			flipY: false,
+
+			// Text properties
+			color: 'black',
+			labelColor: 'black',
+			fill: 'none',
+			size: 'm',
+			font: 'draw',
+			text: '',
+			align: 'middle',
+			verticalAlign: 'middle',
 		}
+	}
+
+	override getText(shape: TLImageShape) {
+		return shape.props.text
 	}
 
 	override onResize(shape: TLImageShape, info: TLResizeInfo<TLImageShape>) {
@@ -116,6 +136,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		const [loadedUrl, setLoadedUrl] = useState<null | string>(null)
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 		const { asset, url } = useAsset(shape.id, shape.props.assetId, shape.props.w)
+		const theme = useDefaultColorTheme()
 
 		useEffect(() => {
 			if (url && this.isAnimated(shape)) {
@@ -190,6 +211,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		// We don't set crossOrigin for non-animated images because for Cloudflare we don't currently
 		// have that set up.
 		const crossOrigin = this.isAnimated(shape) ? 'anonymous' : undefined
+		const { fill, font, align, verticalAlign, size, text, color: labelColor } = shape.props
 
 		return (
 			<>
@@ -257,6 +279,22 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 						<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
 					)}
 				</HTMLContainer>
+
+				<TextLabel
+					id={shape.id}
+					type={shape.type}
+					font={font}
+					fontSize={LABEL_FONT_SIZES[size]}
+					lineHeight={TEXT_PROPS.lineHeight}
+					padding={LABEL_PADDING}
+					fill={fill}
+					align={align}
+					verticalAlign={verticalAlign}
+					text={text}
+					isSelected={isSelected}
+					labelColor={theme[labelColor].solid}
+					wrap
+				/>
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -13,7 +13,10 @@ import classNames from 'classnames'
 import { ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
+import { TextLabel } from '../shared/TextLabel'
+import { LABEL_FONT_SIZES, LABEL_PADDING, TEXT_PROPS } from '../shared/default-shape-constants'
 import { useAsset } from '../shared/useAsset'
+import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -37,7 +40,21 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 			time: 0,
 			playing: true,
 			url: '',
+
+			// Text properties
+			color: 'black',
+			labelColor: 'black',
+			fill: 'none',
+			size: 'm',
+			font: 'draw',
+			text: '',
+			align: 'middle',
+			verticalAlign: 'middle',
 		}
+	}
+
+	override getText(shape: TLVideoShape) {
+		return shape.props.text
 	}
 
 	component(shape: TLVideoShape) {
@@ -47,6 +64,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const isEditing = useIsEditing(shape.id)
 		const prefersReducedMotion = usePrefersReducedMotion()
 		const { Spinner } = useEditorComponents()
+		const theme = useDefaultColorTheme()
 
 		const rVideo = useRef<HTMLVideoElement>(null!)
 
@@ -68,18 +86,6 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 			setIsLoaded(true)
 		}, [])
 
-		// If the current time changes and we're not editing the video, update the video time
-		useEffect(() => {
-			const video = rVideo.current
-			if (!video) return
-
-			if (isEditing) {
-				if (document.activeElement !== video) {
-					video.focus()
-				}
-			}
-		}, [isEditing, isLoaded])
-
 		useEffect(() => {
 			if (prefersReducedMotion) {
 				const video = rVideo.current
@@ -88,6 +94,9 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 				video.currentTime = 0
 			}
 		}, [rVideo, prefersReducedMotion])
+
+		const { fill, font, align, verticalAlign, size, text, color: labelColor } = shape.props
+		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 
 		return (
 			<>
@@ -143,6 +152,22 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 				{'url' in shape.props && shape.props.url && (
 					<HyperlinkButton url={shape.props.url} zoomLevel={editor.getZoomLevel()} />
 				)}
+
+				<TextLabel
+					id={shape.id}
+					type={shape.type}
+					font={font}
+					fontSize={LABEL_FONT_SIZES[size]}
+					lineHeight={TEXT_PROPS.lineHeight}
+					padding={LABEL_PADDING}
+					fill={fill}
+					align={align}
+					verticalAlign={verticalAlign}
+					text={text}
+					isSelected={isSelected}
+					labelColor={theme[labelColor].solid}
+					wrap
+				/>
 			</>
 		)
 	}

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1052,19 +1052,35 @@ export interface TLImageShapeCrop {
 // @public (undocumented)
 export interface TLImageShapeProps {
     // (undocumented)
+    align: TLDefaultHorizontalAlignStyle;
+    // (undocumented)
     assetId: null | TLAssetId;
     // (undocumented)
+    color: TLDefaultColorStyle;
+    // (undocumented)
     crop: null | TLImageShapeCrop;
+    // (undocumented)
+    fill: TLDefaultFillStyle;
     // (undocumented)
     flipX: boolean;
     // (undocumented)
     flipY: boolean;
     // (undocumented)
+    font: TLDefaultFontStyle;
+    // (undocumented)
     h: number;
+    // (undocumented)
+    labelColor: TLDefaultColorStyle;
     // (undocumented)
     playing: boolean;
     // (undocumented)
+    size: TLDefaultSizeStyle;
+    // (undocumented)
+    text: string;
+    // (undocumented)
     url: string;
+    // (undocumented)
+    verticalAlign: TLDefaultVerticalAlignStyle;
     // (undocumented)
     w: number;
 }
@@ -1439,15 +1455,31 @@ export type TLVideoShape = TLBaseShape<'video', TLVideoShapeProps>;
 // @public (undocumented)
 export interface TLVideoShapeProps {
     // (undocumented)
+    align: TLDefaultHorizontalAlignStyle;
+    // (undocumented)
     assetId: null | TLAssetId;
+    // (undocumented)
+    color: TLDefaultColorStyle;
+    // (undocumented)
+    fill: TLDefaultFillStyle;
+    // (undocumented)
+    font: TLDefaultFontStyle;
     // (undocumented)
     h: number;
     // (undocumented)
+    labelColor: TLDefaultColorStyle;
+    // (undocumented)
     playing: boolean;
+    // (undocumented)
+    size: TLDefaultSizeStyle;
+    // (undocumented)
+    text: string;
     // (undocumented)
     time: number;
     // (undocumented)
     url: string;
+    // (undocumented)
+    verticalAlign: TLDefaultVerticalAlignStyle;
     // (undocumented)
     w: number;
 }

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -249,6 +249,28 @@ describe('Adding url props', () => {
 	}
 })
 
+describe('Adding text props', () => {
+	for (const [name, { up }] of [
+		['video shape', getTestMigration(videoShapeVersions.AddTextProps)],
+		['image shape', getTestMigration(imageShapeVersions.AddTextProps)],
+	] as const) {
+		test(`${name}: up works as expected`, () => {
+			expect(up({ props: {} })).toEqual({
+				props: {
+					color: 'black',
+					labelColor: 'black',
+					fill: 'none',
+					size: 'm',
+					font: 'draw',
+					text: '',
+					align: 'middle',
+					verticalAlign: 'middle',
+				},
+			})
+		})
+	}
+})
+
 describe('Bookmark null asset id', () => {
 	const { up } = getTestMigration(bookmarkShapeVersions.NullAssetId)
 	test('up works as expected', () => {

--- a/packages/tlschema/src/shapes/TLGeoShape.ts
+++ b/packages/tlschema/src/shapes/TLGeoShape.ts
@@ -54,20 +54,22 @@ export type TLGeoShapeGeoStyle = T.TypeOf<typeof GeoShapeGeoStyle>
 /** @public */
 export interface TLGeoShapeProps {
 	geo: TLGeoShapeGeoStyle
-	labelColor: TLDefaultColorStyle
-	color: TLDefaultColorStyle
-	fill: TLDefaultFillStyle
 	dash: TLDefaultDashStyle
-	size: TLDefaultSizeStyle
-	font: TLDefaultFontStyle
-	align: TLDefaultHorizontalAlignStyle
-	verticalAlign: TLDefaultVerticalAlignStyle
 	url: string
 	w: number
 	h: number
 	growY: number
-	text: string
 	scale: number
+
+	// Text properties
+	labelColor: TLDefaultColorStyle
+	color: TLDefaultColorStyle
+	fill: TLDefaultFillStyle
+	size: TLDefaultSizeStyle
+	font: TLDefaultFontStyle
+	align: TLDefaultHorizontalAlignStyle
+	verticalAlign: TLDefaultVerticalAlignStyle
+	text: string
 }
 
 /** @public */
@@ -76,20 +78,22 @@ export type TLGeoShape = TLBaseShape<'geo', TLGeoShapeProps>
 /** @public */
 export const geoShapeProps: RecordProps<TLGeoShape> = {
 	geo: GeoShapeGeoStyle,
-	labelColor: DefaultLabelColorStyle,
-	color: DefaultColorStyle,
-	fill: DefaultFillStyle,
 	dash: DefaultDashStyle,
-	size: DefaultSizeStyle,
-	font: DefaultFontStyle,
-	align: DefaultHorizontalAlignStyle,
-	verticalAlign: DefaultVerticalAlignStyle,
 	url: T.linkUrl,
 	w: T.nonZeroNumber,
 	h: T.nonZeroNumber,
 	growY: T.positiveNumber,
-	text: T.string,
 	scale: T.nonZeroNumber,
+
+	// Text properties
+	labelColor: DefaultLabelColorStyle,
+	color: DefaultColorStyle,
+	fill: DefaultFillStyle,
+	size: DefaultSizeStyle,
+	font: DefaultFontStyle,
+	align: DefaultHorizontalAlignStyle,
+	verticalAlign: DefaultVerticalAlignStyle,
+	text: T.string,
 }
 
 const geoShapeVersions = createShapePropsMigrationIds('geo', {

--- a/packages/tlschema/src/shapes/TLImageShape.ts
+++ b/packages/tlschema/src/shapes/TLImageShape.ts
@@ -4,6 +4,22 @@ import { VecModel, vecModelValidator } from '../misc/geometry-types'
 import { TLAssetId } from '../records/TLAsset'
 import { createShapePropsMigrationIds, createShapePropsMigrationSequence } from '../records/TLShape'
 import { RecordProps } from '../recordsWithProps'
+import {
+	DefaultColorStyle,
+	DefaultLabelColorStyle,
+	TLDefaultColorStyle,
+} from '../styles/TLColorStyle'
+import { DefaultFillStyle, TLDefaultFillStyle } from '../styles/TLFillStyle'
+import { DefaultFontStyle, TLDefaultFontStyle } from '../styles/TLFontStyle'
+import {
+	DefaultHorizontalAlignStyle,
+	TLDefaultHorizontalAlignStyle,
+} from '../styles/TLHorizontalAlignStyle'
+import { DefaultSizeStyle, TLDefaultSizeStyle } from '../styles/TLSizeStyle'
+import {
+	DefaultVerticalAlignStyle,
+	TLDefaultVerticalAlignStyle,
+} from '../styles/TLVerticalAlignStyle'
 import { TLBaseShape } from './TLBaseShape'
 
 /** @public */
@@ -28,6 +44,16 @@ export interface TLImageShapeProps {
 	crop: TLImageShapeCrop | null
 	flipX: boolean
 	flipY: boolean
+
+	// Text properties
+	labelColor: TLDefaultColorStyle
+	color: TLDefaultColorStyle
+	fill: TLDefaultFillStyle
+	size: TLDefaultSizeStyle
+	font: TLDefaultFontStyle
+	align: TLDefaultHorizontalAlignStyle
+	verticalAlign: TLDefaultVerticalAlignStyle
+	text: string
 }
 
 /** @public */
@@ -43,6 +69,16 @@ export const imageShapeProps: RecordProps<TLImageShape> = {
 	crop: ImageShapeCrop.nullable(),
 	flipX: T.boolean,
 	flipY: T.boolean,
+
+	// Text properties
+	labelColor: DefaultLabelColorStyle,
+	color: DefaultColorStyle,
+	fill: DefaultFillStyle,
+	size: DefaultSizeStyle,
+	font: DefaultFontStyle,
+	align: DefaultHorizontalAlignStyle,
+	verticalAlign: DefaultVerticalAlignStyle,
+	text: T.string,
 }
 
 const Versions = createShapePropsMigrationIds('image', {
@@ -50,6 +86,7 @@ const Versions = createShapePropsMigrationIds('image', {
 	AddCropProp: 2,
 	MakeUrlsValid: 3,
 	AddFlipProps: 4,
+	AddTextProps: 5,
 })
 
 export { Versions as imageShapeVersions }
@@ -93,6 +130,29 @@ export const imageShapeMigrations = createShapePropsMigrationSequence({
 			down: (props) => {
 				delete props.flipX
 				delete props.flipY
+			},
+		},
+		{
+			id: Versions.AddTextProps,
+			up: (props) => {
+				props.color = 'black'
+				props.labelColor = 'black'
+				props.fill = 'none'
+				props.size = 'm'
+				props.font = 'draw'
+				props.text = ''
+				props.align = 'middle'
+				props.verticalAlign = 'middle'
+			},
+			down: (_props) => {
+				delete _props.labelColor
+				delete _props.color
+				delete _props.fill
+				delete _props.size
+				delete _props.font
+				delete _props.align
+				delete _props.verticalAlign
+				delete _props.text
 			},
 		},
 	],

--- a/packages/tlschema/src/shapes/TLVideoShape.ts
+++ b/packages/tlschema/src/shapes/TLVideoShape.ts
@@ -3,6 +3,22 @@ import { assetIdValidator } from '../assets/TLBaseAsset'
 import { TLAssetId } from '../records/TLAsset'
 import { createShapePropsMigrationIds, createShapePropsMigrationSequence } from '../records/TLShape'
 import { RecordProps } from '../recordsWithProps'
+import {
+	DefaultColorStyle,
+	DefaultLabelColorStyle,
+	TLDefaultColorStyle,
+} from '../styles/TLColorStyle'
+import { DefaultFillStyle, TLDefaultFillStyle } from '../styles/TLFillStyle'
+import { DefaultFontStyle, TLDefaultFontStyle } from '../styles/TLFontStyle'
+import {
+	DefaultHorizontalAlignStyle,
+	TLDefaultHorizontalAlignStyle,
+} from '../styles/TLHorizontalAlignStyle'
+import { DefaultSizeStyle, TLDefaultSizeStyle } from '../styles/TLSizeStyle'
+import {
+	DefaultVerticalAlignStyle,
+	TLDefaultVerticalAlignStyle,
+} from '../styles/TLVerticalAlignStyle'
 import { TLBaseShape } from './TLBaseShape'
 
 /** @public */
@@ -13,6 +29,16 @@ export interface TLVideoShapeProps {
 	playing: boolean
 	url: string
 	assetId: TLAssetId | null
+
+	// Text properties
+	labelColor: TLDefaultColorStyle
+	color: TLDefaultColorStyle
+	fill: TLDefaultFillStyle
+	size: TLDefaultSizeStyle
+	font: TLDefaultFontStyle
+	align: TLDefaultHorizontalAlignStyle
+	verticalAlign: TLDefaultVerticalAlignStyle
+	text: string
 }
 
 /** @public */
@@ -26,11 +52,22 @@ export const videoShapeProps: RecordProps<TLVideoShape> = {
 	playing: T.boolean,
 	url: T.linkUrl,
 	assetId: assetIdValidator.nullable(),
+
+	// Text properties
+	labelColor: DefaultLabelColorStyle,
+	color: DefaultColorStyle,
+	fill: DefaultFillStyle,
+	size: DefaultSizeStyle,
+	font: DefaultFontStyle,
+	align: DefaultHorizontalAlignStyle,
+	verticalAlign: DefaultVerticalAlignStyle,
+	text: T.string,
 }
 
 const Versions = createShapePropsMigrationIds('video', {
 	AddUrlProp: 1,
 	MakeUrlsValid: 2,
+	AddTextProps: 3,
 })
 
 export { Versions as videoShapeVersions }
@@ -54,6 +91,29 @@ export const videoShapeMigrations = createShapePropsMigrationSequence({
 			},
 			down: (_props) => {
 				// noop
+			},
+		},
+		{
+			id: Versions.AddTextProps,
+			up: (props) => {
+				props.color = 'black'
+				props.labelColor = 'black'
+				props.fill = 'none'
+				props.size = 'm'
+				props.font = 'draw'
+				props.text = ''
+				props.align = 'middle'
+				props.verticalAlign = 'middle'
+			},
+			down: (_props) => {
+				delete _props.labelColor
+				delete _props.color
+				delete _props.fill
+				delete _props.size
+				delete _props.font
+				delete _props.align
+				delete _props.verticalAlign
+				delete _props.text
 			},
 		},
 	],


### PR DESCRIPTION
This adds captions for images and videos. For videos you can double-click but for images you'll have to hit Enter for now.
If we wanted this for real we'd have to figure out the tension between cropping and adding a caption. Also, we'd have to improve the hit targets to be able to re-edit a text label.

Fun though!

https://github.com/user-attachments/assets/4301ea6f-a4af-42fe-bb45-67f499720263

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Test adding/editing/deleting captions.

### Release notes

- Feature: add captions to videos and images.