### PR TITLE
Use base zoom and zoom steps to calculate min and max zoom for pinch gesture

### DIFF
--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -300,7 +300,12 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 		pinch: {
 			from: () => [editor.getZoomLevel(), 0], // Return the camera z to use when pinch starts
 			scaleBounds: () => {
-				return { from: editor.getZoomLevel(), max: 8, min: 0.05 }
+				const baseZoom = editor.getBaseZoom()
+				const zoomSteps = editor.getCameraOptions().zoomSteps
+				const zoomMin = zoomSteps[0] * baseZoom
+				const zoomMax = zoomSteps[zoomSteps.length - 1] * baseZoom
+
+				return { from: editor.getZoomLevel(), max: zoomMax, min: zoomMin }
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #4426.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Tested locally, see [video](https://vimeo.com/1003367979?share=copy). Pinch gestures currently do not have any unit test coverage that I could find.


### Release notes

- Fixed issue where pinch gestures on Safari would snap camera at low zoom levels