### PR TITLE
Fix an issue with firefox

### DIFF
--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -56,6 +56,7 @@ async function migrateLegacyAssetDbIfNeeded(persistenceKey: string) {
 			}
 		},
 	})
+	if (!oldAssetDb.objectStoreNames.contains('assets')) return
 
 	const oldTx = oldAssetDb.transaction(['assets'], 'readonly')
 	const oldAssetStore = oldTx.objectStore('assets')


### PR DESCRIPTION
For me the assets table didn't get created in the upgrade callback (a few lines above the diff), so it doesn't exists when we try to access it a few lines later.

![image](https://github.com/user-attachments/assets/2b0bf49a-0e67-40d5-9851-15fd262a965e)
![image](https://github.com/user-attachments/assets/90ef3e6c-4d1c-4023-bb7f-59d8cbf16a23)


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix an issue with migrating legacy assets in Firefox.