### PR TITLE
Allow publishing PR branches to npm for testing

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -1,0 +1,54 @@
+name: Publish branch packages
+
+on:
+  pull_request:
+    types: [labeled]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: 'Publish branch packages'
+    environment: npm deploy
+    timeout-minutes: 60
+    runs-on: ubuntu-latest-16-cores-open
+    if: github.event.label.name == 'publish-packages'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Remove the update-snapshots label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: publish-packages
+
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run our setup
+        uses: ./.github/actions/setup
+
+      - name: Publish Canary Packages
+        run: yarn tsx ./scripts/publish-prerelease.ts internal
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_ACCESS_KEY_SECRET }}
+          TLDRAW_BEMO_URL: https://canary-demo.tldraw.xyz
+
+      - name: Extract published version
+        id: extract_version
+        run: echo "::set-output name=version::$(node -e 'console.log(require("./packages/tldraw/package.json").version)')"
+
+      - name: Tell user released version
+        uses: actions-ecosystem/action-create-comment@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Published version ${{ steps.extract_version.outputs.version }} to npm.

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Remove the update-snapshots label
+      - name: Remove the publish-packages label
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: publish-packages

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Publish Canary Packages
-        run: yarn tsx ./scripts/publish-canary.ts
+        run: yarn tsx ./scripts/publish-prerelease.ts canary
         env:
           GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/publish-prerelease.ts
+++ b/scripts/publish-prerelease.ts
@@ -2,7 +2,7 @@ import { exec } from './lib/exec'
 import { getLatestVersion, publish, setAllVersions } from './lib/publishing'
 import { uploadStaticAssets } from './upload-static-assets'
 
-async function main() {
+async function main(releaseTag: string) {
 	const sha = (await exec('git', ['rev-parse', 'HEAD'])).trim().slice(0, 12)
 
 	async function setCanaryVersions() {
@@ -12,7 +12,8 @@ async function main() {
 			? // if the package is in prerelease mode, we want to release a canary for the current version rather than bumping
 				latestVersion
 			: latestVersion?.inc('minor')
-		const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-canary.${sha}`
+
+		const versionString = `${nextVersion.major}.${nextVersion.minor}.${nextVersion.patch}-${releaseTag}.${sha}`
 
 		await setAllVersions(versionString)
 		return versionString
@@ -22,7 +23,15 @@ async function main() {
 
 	const versionString = await setCanaryVersions()
 	await uploadStaticAssets(versionString)
-	await publish('canary')
+	await publish(releaseTag)
 }
 
-main()
+const args = process.argv.slice(2)
+if (args.length === 0) {
+	throw new Error('Usage: publish-prerelease.ts <releaseTag>')
+}
+const releaseTag = args[0]
+if (releaseTag !== 'canary' && releaseTag !== 'latest') {
+	throw new Error('releaseTag must be "canary" or "latest"')
+}
+main(releaseTag)

--- a/scripts/publish-prerelease.ts
+++ b/scripts/publish-prerelease.ts
@@ -31,7 +31,7 @@ if (args.length === 0) {
 	throw new Error('Usage: publish-prerelease.ts <releaseTag>')
 }
 const releaseTag = args[0]
-if (releaseTag !== 'canary' && releaseTag !== 'latest') {
-	throw new Error('releaseTag must be "canary" or "latest"')
+if (releaseTag !== 'canary' && releaseTag !== 'internal') {
+	throw new Error('releaseTag must be "canary" or "internal"')
 }
 main(releaseTag)


### PR DESCRIPTION
If you add the `publish-packages` label to a PR, we'll publish it to npm under the `internal` release tag.

### Change type

- [x] `other`