### PR TITLE
fix context toolbar example container width

### DIFF
--- a/apps/examples/src/examples/context-toolbar/ContextToolbar.tsx
+++ b/apps/examples/src/examples/context-toolbar/ContextToolbar.tsx
@@ -40,7 +40,7 @@ const ContextToolbarComponent = track(() => {
 				left: Math.max(16, pageCoordinates.x),
 				pointerEvents: 'all',
 				// [3]
-				width: selectionRotatedPageBounds.width,
+				width: selectionRotatedPageBounds.width * editor.getZoomLevel(),
 			}}
 			// [4]
 			onPointerDown={(e) => e.stopPropagation()}


### PR DESCRIPTION
before
![Kapture 2024-09-02 at 08 48 23](https://github.com/user-attachments/assets/a5cb5fa5-a97b-4842-81b3-860ca0f0a414)


after
![Kapture 2024-09-02 at 08 47 30](https://github.com/user-attachments/assets/1438aaae-25f5-40f3-af55-9748c69388d4)

thanks to #4431 for pointing out this was broken

### Change type

- [x] `bugfix`

