### PR TITLE
Use custom mime types in useInsertMedia hook

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -3618,7 +3618,7 @@ export function useSelectionEvents(handle: TLSelectionHandle): {
 };
 
 // @internal (undocumented)
-export function useShallowArrayIdentity<T>(arr: readonly T[]): readonly T[];
+export function useShallowArrayIdentity<T extends null | readonly any[] | undefined>(arr: T): T;
 
 // @internal (undocumented)
 export function useShallowObjectIdentity<T extends null | object | undefined>(obj: T): T;

--- a/packages/editor/src/lib/hooks/useIdentity.tsx
+++ b/packages/editor/src/lib/hooks/useIdentity.tsx
@@ -10,9 +10,24 @@ function useIdentity<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
 	return value
 }
 
+const areNullableArraysShallowEqual = (
+	a: readonly any[] | null | undefined,
+	b: readonly any[] | null | undefined
+) => {
+	a ??= null
+	b ??= null
+	if (a === b) {
+		return true
+	}
+	if (!a || !b) {
+		return false
+	}
+	return areArraysShallowEqual(a, b)
+}
+
 /** @internal */
-export function useShallowArrayIdentity<T>(arr: readonly T[]): readonly T[] {
-	return useIdentity(arr, areArraysShallowEqual)
+export function useShallowArrayIdentity<T extends readonly any[] | null | undefined>(arr: T): T {
+	return useIdentity(arr, areNullableArraysShallowEqual)
 }
 
 const areNullableObjectsShallowEqual = (

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2070,7 +2070,7 @@ export const TldrawUiButtonPicker: <T extends string>(props: TLUiButtonPickerPro
 export function TldrawUiComponentsProvider({ overrides, children, }: TLUiComponentsProviderProps): JSX_2.Element;
 
 // @public (undocumented)
-export function TldrawUiContextProvider({ overrides, components, assetUrls, onUiEvent, forceMobile, children, }: TldrawUiContextProviderProps): JSX_2.Element;
+export function TldrawUiContextProvider({ overrides, components, assetUrls, onUiEvent, forceMobile, mediaMimeTypes, children, }: TldrawUiContextProviderProps): JSX_2.Element;
 
 // @public (undocumented)
 export interface TldrawUiContextProviderProps {
@@ -2078,6 +2078,7 @@ export interface TldrawUiContextProviderProps {
     children?: ReactNode;
     components?: TLUiComponents;
     forceMobile?: boolean;
+    mediaMimeTypes?: string[];
     onUiEvent?: TLUiEventHandler;
     overrides?: TLUiOverrides | TLUiOverrides[];
 }

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -122,6 +122,18 @@ export function Tldraw(props: TldrawProps) {
 		[_tools]
 	)
 
+	const _imageMimeTypes = useShallowArrayIdentity(
+		acceptedImageMimeTypes ?? DEFAULT_SUPPORTED_IMAGE_TYPES
+	)
+	const _videoMimeTypes = useShallowArrayIdentity(
+		acceptedVideoMimeTypes ?? DEFAULT_SUPPORT_VIDEO_TYPES
+	)
+
+	const mediaMimeTypes = useMemo(
+		() => [..._imageMimeTypes, ..._videoMimeTypes],
+		[_imageMimeTypes, _videoMimeTypes]
+	)
+
 	const assets = useDefaultEditorAssetsWithOverrides(rest.assetUrls)
 	const { done: preloadingComplete, error: preloadingError } = usePreloadAssets(assets)
 	if (preloadingError) {
@@ -144,7 +156,7 @@ export function Tldraw(props: TldrawProps) {
 			bindingUtils={bindingUtilsWithDefaults}
 			tools={toolsWithDefaults}
 		>
-			<TldrawUi {...rest} components={componentsWithDefault}>
+			<TldrawUi {...rest} components={componentsWithDefault} mediaMimeTypes={mediaMimeTypes}>
 				<InsideOfEditorAndUiContext
 					maxImageDimension={maxImageDimension}
 					maxAssetSize={maxAssetSize}

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -160,8 +160,8 @@ export function Tldraw(props: TldrawProps) {
 				<InsideOfEditorAndUiContext
 					maxImageDimension={maxImageDimension}
 					maxAssetSize={maxAssetSize}
-					acceptedImageMimeTypes={acceptedImageMimeTypes}
-					acceptedVideoMimeTypes={acceptedVideoMimeTypes}
+					acceptedImageMimeTypes={_imageMimeTypes}
+					acceptedVideoMimeTypes={_videoMimeTypes}
 					onMount={onMount}
 					embeds={embeds}
 				/>

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -275,7 +275,7 @@ export function registerDefaultExternalContentHandlers(
 					severity: 'error',
 				})
 
-				console.warn(`${file.name} not loaded - Extension not allowed.`)
+				console.warn(`${file.name} not loaded - Mime type not allowed ${file.type}.`)
 				continue
 			}
 

--- a/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
+++ b/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
@@ -1,6 +1,7 @@
 import { RecursivePartial } from '@tldraw/editor'
 import { ReactNode } from 'react'
 import { TLUiAssetUrls, useDefaultUiAssetUrlsWithOverrides } from '../assetUrls'
+import { MimeTypeContext } from '../hooks/useInsertMedia'
 import { ToolsProvider } from '../hooks/useTools'
 import { TranslationProvider } from '../hooks/useTranslation/useTranslation'
 import { TLUiOverrides, useMergedOverrides, useMergedTranslationOverrides } from '../overrides'
@@ -43,6 +44,11 @@ export interface TldrawUiContextProviderProps {
 	 * The component's children.
 	 */
 	children?: ReactNode
+
+	/**
+	 * Supported mime types for media files.
+	 */
+	mediaMimeTypes?: string[]
 }
 
 /** @public @react */
@@ -52,24 +58,27 @@ export function TldrawUiContextProvider({
 	assetUrls,
 	onUiEvent,
 	forceMobile,
+	mediaMimeTypes,
 	children,
 }: TldrawUiContextProviderProps) {
 	return (
-		<AssetUrlsProvider assetUrls={useDefaultUiAssetUrlsWithOverrides(assetUrls)}>
-			<TranslationProvider overrides={useMergedTranslationOverrides(overrides)}>
-				<UiEventsProvider onEvent={onUiEvent}>
-					<ToastsProvider>
-						<DialogsProvider>
-							<BreakPointProvider forceMobile={forceMobile}>
-								<TldrawUiComponentsProvider overrides={components}>
-									<InternalProviders overrides={overrides}>{children}</InternalProviders>
-								</TldrawUiComponentsProvider>
-							</BreakPointProvider>
-						</DialogsProvider>
-					</ToastsProvider>
-				</UiEventsProvider>
-			</TranslationProvider>
-		</AssetUrlsProvider>
+		<MimeTypeContext.Provider value={mediaMimeTypes}>
+			<AssetUrlsProvider assetUrls={useDefaultUiAssetUrlsWithOverrides(assetUrls)}>
+				<TranslationProvider overrides={useMergedTranslationOverrides(overrides)}>
+					<UiEventsProvider onEvent={onUiEvent}>
+						<ToastsProvider>
+							<DialogsProvider>
+								<BreakPointProvider forceMobile={forceMobile}>
+									<TldrawUiComponentsProvider overrides={components}>
+										<InternalProviders overrides={overrides}>{children}</InternalProviders>
+									</TldrawUiComponentsProvider>
+								</BreakPointProvider>
+							</DialogsProvider>
+						</ToastsProvider>
+					</UiEventsProvider>
+				</TranslationProvider>
+			</AssetUrlsProvider>
+		</MimeTypeContext.Provider>
 	)
 }
 

--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -1,14 +1,21 @@
-import { DEFAULT_SUPPORTED_MEDIA_TYPE_LIST, useEditor } from '@tldraw/editor'
-import { useCallback, useEffect, useRef } from 'react'
+import {
+	DEFAULT_SUPPORTED_MEDIA_TYPE_LIST,
+	useEditor,
+	useShallowArrayIdentity,
+} from '@tldraw/editor'
+import React, { useCallback, useEffect, useRef } from 'react'
+
+export const MimeTypeContext = React.createContext<string[] | undefined>([])
 
 export function useInsertMedia() {
 	const editor = useEditor()
 	const inputRef = useRef<HTMLInputElement>()
+	const mimeTypes = useShallowArrayIdentity(React.useContext(MimeTypeContext))
 
 	useEffect(() => {
 		const input = window.document.createElement('input')
 		input.type = 'file'
-		input.accept = DEFAULT_SUPPORTED_MEDIA_TYPE_LIST
+		input.accept = mimeTypes?.join(',') ?? DEFAULT_SUPPORTED_MEDIA_TYPE_LIST
 		input.multiple = true
 		inputRef.current = input
 		async function onchange(e: Event) {
@@ -28,7 +35,7 @@ export function useInsertMedia() {
 			inputRef.current = undefined
 			input.removeEventListener('change', onchange)
 		}
-	}, [editor])
+	}, [editor, mimeTypes])
 
 	return useCallback(() => {
 		inputRef.current?.click()


### PR DESCRIPTION
Before this PR, the `useInsertMedia` hook was hard-coded to use our default list of supported mime types for uploads. This fixes that by passing the user-given list down through context

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Make the 'insert media' action use custom mime type configurations to restrict which files can be selected in the picker.