### PR TITLE
Add sleep fn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -199,15 +199,16 @@ module.exports = {
 			},
 		},
 		{
-			files: ['e2e/**/*'],
-			rules: {
-				'@typescript-eslint/no-empty-function': 'off',
-			},
-		},
-		{
 			files: 'scripts/**/*',
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+		{
+			files: ['apps/examples/**/*'],
+			rules: {
+				'no-restricted-syntax': 'off',
+				'local/no-at-internal': 'error',
 			},
 		},
 		{
@@ -217,13 +218,7 @@ module.exports = {
 				'no-restricted-globals': 'off',
 				'react/jsx-key': 'off',
 				'react/no-string-refs': 'off',
-			},
-		},
-		{
-			files: ['apps/examples/**/*'],
-			rules: {
-				'no-restricted-syntax': 'off',
-				'local/no-at-internal': 'error',
+				'local/no-at-internal': 'off',
 			},
 		},
 		{

--- a/apps/docs/components/docs/docs-feedback-widget.tsx
+++ b/apps/docs/components/docs/docs-feedback-widget.tsx
@@ -5,7 +5,7 @@ import { useLocalStorageState } from '@/utils/storage'
 import { Field, Label, Textarea } from '@headlessui/react'
 import { ArrowLongRightIcon, CheckCircleIcon, HandThumbDownIcon } from '@heroicons/react/20/solid'
 import { HandThumbUpIcon } from '@heroicons/react/24/solid'
-import { track } from '@vercel/analytics'
+import { sleep } from '@tldraw/utils'
 import { usePathname } from 'next/navigation'
 import { FormEventHandler, useCallback, useState } from 'react'
 
@@ -17,9 +17,8 @@ async function submitFeedback(
 	_feedback: 1 | -1 | 0,
 	_note: string
 ) {
-	const feedback: { value: number; message?: string } = { value: _feedback }
-	if (_note !== '') feedback.message = _note
-	track('Feedback', feedback)
+	// todo
+	await sleep(2000)
 	return
 }
 

--- a/apps/docs/utils/ContentVectorDatabase.ts
+++ b/apps/docs/utils/ContentVectorDatabase.ts
@@ -1,5 +1,6 @@
 import { connect } from '@/scripts/functions/connect'
 import { Article, ArticleHeading, ArticleHeadings } from '@/types/content-types'
+import { sleep } from '@tldraw/utils'
 import { config } from 'dotenv'
 import OpenAI from 'openai'
 import path from 'path'
@@ -139,7 +140,7 @@ export class ContentVectorDatabase {
 		}
 
 		// Sleep for 50ms or so to avoid rate limiting
-		await new Promise((r) => setTimeout(r, 35))
+		await sleep(35)
 
 		return
 	}

--- a/apps/examples/e2e/shared-e2e.ts
+++ b/apps/examples/e2e/shared-e2e.ts
@@ -1,10 +1,6 @@
 import { PlaywrightTestArgs, PlaywrightWorkerArgs } from '@playwright/test'
 import { Editor } from 'tldraw'
 
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 declare const editor: Editor
 
 export async function setup({ page }: PlaywrightTestArgs & PlaywrightWorkerArgs) {

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -1,5 +1,5 @@
 import { CDPSession, Page, expect } from '@playwright/test'
-import { Editor } from 'tldraw'
+import { Editor, sleep } from 'tldraw'
 import { setup } from '../shared-e2e'
 import test from './fixtures/fixtures'
 
@@ -77,10 +77,6 @@ const scrollZoom = async ({
 		zoomDirection === 'out' ? currentZoomLevel * 1.1 ** steps : currentZoomLevel / 1.1 ** steps
 
 	return expectedZoomLevel
-}
-
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 test.describe('camera', () => {

--- a/apps/examples/e2e/tests/test-clipboard.spec.ts
+++ b/apps/examples/e2e/tests/test-clipboard.spec.ts
@@ -1,10 +1,6 @@
 import test, { expect } from '@playwright/test'
-import { Editor } from 'tldraw'
+import { Editor, sleep } from 'tldraw'
 import { setup } from '../shared-e2e'
-
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 declare const editor: Editor
 

--- a/apps/examples/e2e/tests/test-shapes.spec.ts
+++ b/apps/examples/e2e/tests/test-shapes.spec.ts
@@ -2,10 +2,6 @@ import { expect } from '@playwright/test'
 import { getAllShapeTypes, setup } from '../shared-e2e'
 import test from './fixtures/fixtures'
 
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 const clickableShapeCreators = [
 	{ tool: 'draw', shape: 'draw' },
 	{ tool: 'frame', shape: 'frame' },

--- a/apps/examples/e2e/tests/test-smoke.spec.ts
+++ b/apps/examples/e2e/tests/test-smoke.spec.ts
@@ -3,10 +3,6 @@ import { Editor, TLGeoShape } from 'tldraw'
 import { getAllShapeTypes, setup } from '../shared-e2e'
 import test from './fixtures/fixtures'
 
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 declare const editor: Editor
 
 test.describe('smoke tests', () => {

--- a/apps/examples/e2e/tests/test-text.spec.ts
+++ b/apps/examples/e2e/tests/test-text.spec.ts
@@ -2,10 +2,6 @@ import test, { Page, expect } from '@playwright/test'
 import { BoxModel, Editor, TLNoteShape, TLShapeId } from 'tldraw'
 import { setupPage } from '../shared-e2e'
 
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 const measureTextOptions = {
 	maxWidth: null,
 	fontFamily: 'var(--tl-font-draw)',

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7947,7 +7947,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const objectUrl = URL.createObjectURL(file)
 		this.temporaryAssetPreview.set(assetId, objectUrl)
 
-		this.timers.setTimeout(
+		// eslint-disable-next-line no-restricted-globals -- we always want to revoke the asset and object URL
+		setTimeout(
 			() => {
 				this.temporaryAssetPreview.delete(assetId)
 				URL.revokeObjectURL(objectUrl)

--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -1,4 +1,4 @@
-import { bind } from '@tldraw/utils'
+import { bind, sleep } from '@tldraw/utils'
 
 /**
  * Export delay is a helper class that allows you to wait for a set of promises to resolve before
@@ -32,16 +32,12 @@ export class ExportDelay {
 			await Promise.allSettled(this.promisesToWaitFor)
 
 			// wait for a cycle of the event loop to allow any of those promises to add more if needed.
-			// eslint-disable-next-line no-restricted-globals
-			await new Promise((r) => setTimeout(r, 0))
+			await sleep(0)
 		}
 	}
 
 	async resolve() {
-		const timeoutPromise = new Promise<'timeout'>((r) =>
-			// eslint-disable-next-line no-restricted-globals
-			setTimeout(() => r('timeout'), this.maxDelayTimeMs)
-		)
+		const timeoutPromise = sleep(this.maxDelayTimeMs).then(() => 'timeout' as const)
 		const resolvePromise = this.resolvePromises().then(() => 'resolved' as const)
 
 		const result = await Promise.race([timeoutPromise, resolvePromise])

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { fetch } from '@tldraw/utils'
+import { fetch, sleep } from '@tldraw/utils'
 import React, { useEffect, useState } from 'react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
@@ -35,12 +35,7 @@ async function getWatermarkUrl(forceLocal: boolean): Promise<string> {
 			})(),
 
 			// but if that's taking a long time (>3s) just show the local one anyway
-			new Promise<string>((resolve) => {
-				// eslint-disable-next-line no-restricted-globals
-				setTimeout(() => {
-					resolve(WATERMARK_LOCAL_SRC)
-				}, 3_000)
-			}),
+			sleep(3_000).then(() => WATERMARK_LOCAL_SRC),
 		])
 	}
 

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -1,4 +1,4 @@
-import { TLRecord } from 'tldraw'
+import { TLRecord, sleep } from 'tldraw'
 import { ClientWebSocketAdapter, INACTIVE_MIN_DELAY } from './ClientWebSocketAdapter'
 // NOTE: there is a hack in apps/dotcom/jestResolver.js to make this import work
 import { WebSocketServer, WebSocket as WsWebSocket } from 'ws'
@@ -13,7 +13,7 @@ async function waitFor(predicate: () => boolean) {
 		try {
 			jest.runAllTimers()
 			jest.useRealTimers()
-			await new Promise((resolve) => setTimeout(resolve, 10))
+			await sleep(10)
 		} finally {
 			jest.useFakeTimers()
 		}

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -7,6 +7,7 @@ import {
 	TLShapeId,
 	debugFlags,
 	exhaustiveSwitchError,
+	sleep,
 } from '@tldraw/editor'
 import { clampToBrowserMaxCanvasSize } from '../../shapes/shared/getBrowserCanvasMaxSize'
 import { TLExportType } from './exportAs'
@@ -48,7 +49,7 @@ export async function getSvgAsImage(
 			// there doesn't seem to be any better solution for now :( see
 			// https://bugs.webkit.org/show_bug.cgi?id=219770
 			if (editor.environment.isSafari) {
-				await new Promise((resolve) => editor.timers.setTimeout(resolve, 250))
+				await sleep(250)
 			}
 
 			const canvas = document.createElement('canvas') as HTMLCanvasElement

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -389,6 +389,9 @@ export function setInLocalStorage(key: string, value: string): void;
 // @internal
 export function setInSessionStorage(key: string, value: string): void;
 
+// @internal (undocumented)
+export function sleep(ms: number): Promise<void>;
+
 // @public (undocumented)
 export function sortById<T extends {
     id: any;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,6 +20,7 @@ export {
 	assertExists,
 	exhaustiveSwitchError,
 	promiseWithResolve,
+	sleep,
 	type ErrorResult,
 	type OkResult,
 } from './lib/control'

--- a/packages/utils/src/lib/control.ts
+++ b/packages/utils/src/lib/control.ts
@@ -64,3 +64,9 @@ export function promiseWithResolve<T>(): Promise<T> & {
 		reject: reject!,
 	})
 }
+
+/** @internal */
+export function sleep(ms: number): Promise<void> {
+	// eslint-disable-next-line no-restricted-globals
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/worker-shared/src/createPersistQueue.ts
+++ b/packages/worker-shared/src/createPersistQueue.ts
@@ -1,3 +1,5 @@
+import { sleep } from '@tldraw/utils'
+
 // Save the room to supabase
 export function createPersistQueue(persist: () => Promise<void>, timeout: number) {
 	let persistAgain = false
@@ -15,7 +17,7 @@ export function createPersistQueue(persist: () => Promise<void>, timeout: number
 					do {
 						if (persistAgain) {
 							if (timeout > 0) {
-								await new Promise((resolve) => setTimeout(resolve, timeout))
+								await sleep(timeout)
 							}
 							persistAgain = false
 						}


### PR DESCRIPTION
There are a bunch of places we do something like `await new Promise(resolve => setTimeout(resolve, 1000))`. Most of the time, these places have to come with an eslint disable. We have a rule enforcing that timers come from `editor.timers`, but in those cases this won't do what you would expect: when the editor is disposed, those timers will never resolve, which isn't really what you want if you're using the timers for control-flow around more expensive resources that need to be disposed of.

For example:
```tsx
const thing = createAnExpensiveResourceThatNeedsToBeExplicitlyDestroyed()
try {
    await doSomethingWithIt(thing)
    await new Promise(r => editor.timers.setTimeout(r, 100))
} finally {
    thing.dispose()
}
```

In this example, if the editor is disposed, then the `setTimeout` callback is never called, and the promise never resolves. The code in the finally block never runs, and the memory for `thing` leaks. 

### Change type

- [x] `other`

### Release notes

(internal-only change)