### PR TITLE
fix getArcInfo

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -388,7 +388,7 @@ export function getCurvedArrowInfo(
  */
 function getArcInfo(a: VecLike, b: VecLike, c: VecLike): TLArcInfo {
 	// find a circle from the three points
-	const center = centerOfCircleFromThreePoints(a, b, c)!
+	const center = centerOfCircleFromThreePoints(a, b, c) ?? Vec.Med(a, b)
 
 	const radius = Vec.Dist(center, a)
 


### PR DESCRIPTION
This PR removes a bang operator to fix a sentry issue in the latest release noticed by @MitjaBezensek 

https://tldraw.sentry.io/issues/?project=4504203639193600&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+Cannot+read+properties+of+null+%28reading+%27y%27%29&referrer=issue-list&statsPeriod=14d

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
