### PR TITLE
csp: turn on; also, add data: for connect-src

### DIFF
--- a/apps/dotcom/scripts/build.ts
+++ b/apps/dotcom/scripts/build.ts
@@ -15,7 +15,7 @@ const commonSecurityHeaders = {
 	'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
 	'X-Content-Type-Options': 'nosniff',
 	'Referrer-Policy': 'no-referrer-when-downgrade',
-	'Content-Security-Policy-Report-Only': csp,
+	'Content-Security-Policy': csp,
 }
 
 // We load the list of routes that should be forwarded to our SPA's index.html here.

--- a/apps/dotcom/src/utils/csp.ts
+++ b/apps/dotcom/src/utils/csp.ts
@@ -5,6 +5,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`ws:`,
 		`wss:`,
 		'blob:',
+		'data:',
 		'http://localhost:8788',
 		`https://assets.tldraw.xyz`,
 		`https://*.tldraw.workers.dev`,


### PR DESCRIPTION
Turn on CSP for dotcom. Also, I found another case where `connect-src` needs to have `data:` added so that we can paste those types of images from other sites.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
