### PR TITLE
assets: no need for the setTimeout 0 anymore after deep links

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -72,10 +72,17 @@ export function useAsset(shapeId: TLShapeId, assetId: TLAssetId | null, width: n
 		}
 
 		// If we already resolved the URL, debounce fetching potentially multiple image variations.
-		const timer = editor.timers.setTimeout(resolve, didAlreadyResolve.current ? 500 : 0)
-		return () => {
-			clearTimeout(timer)
-			isCancelled = true
+		if (didAlreadyResolve.current) {
+			const timer = editor.timers.setTimeout(resolve, 500)
+			return () => {
+				clearTimeout(timer)
+				isCancelled = true
+			}
+		} else {
+			resolve()
+			return () => {
+				isCancelled = true
+			}
 		}
 	}, [assetId, asset?.props.src, isCulled, screenScale, editor, isExport, isReady])
 


### PR DESCRIPTION
After David's Deep links PR https://github.com/tldraw/tldraw/pull/4333 the camera doesn't get set twice on page load (first at 1, and then at the actual zoom specified by the url). Because of this, we can drop this setTimeout 0 which was addressing that issue.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
