### PR TITLE
Add assetUrls option to TldrawImage

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2027,6 +2027,7 @@ export const TldrawImage: NamedExoticComponent<TldrawImageProps>;
 
 // @public (undocumented)
 export interface TldrawImageProps extends TLImageExportOptions {
+    assetUrls?: TLUiAssetUrlOverrides;
     bindingUtils?: readonly TLAnyBindingUtilConstructor[];
     format?: 'png' | 'svg';
     licenseKey?: string;

--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -15,6 +15,7 @@ import {
 import { memo, useLayoutEffect, useMemo, useState } from 'react'
 import { defaultBindingUtils } from './defaultBindingUtils'
 import { defaultShapeUtils } from './defaultShapeUtils'
+import { TLUiAssetUrlOverrides } from './ui/assetUrls'
 import { usePreloadAssets } from './ui/hooks/usePreloadAssets'
 import { getSvgAsImage } from './utils/export/export'
 import { useDefaultEditorAssetsWithOverrides } from './utils/static-assets/assetUrls'
@@ -48,6 +49,10 @@ export interface TldrawImageProps extends TLImageExportOptions {
 	 * The license key.
 	 */
 	licenseKey?: string
+	/**
+	 * Asset URL overrides.
+	 */
+	assetUrls?: TLUiAssetUrlOverrides
 }
 
 /**
@@ -81,7 +86,7 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 	)
 	const store = useTLStore({ snapshot: props.snapshot, shapeUtils: shapeUtilsWithDefaults })
 
-	const assets = useDefaultEditorAssetsWithOverrides()
+	const assets = useDefaultEditorAssetsWithOverrides(props.assetUrls)
 	const { done: preloadingComplete, error: preloadingError } = usePreloadAssets(assets)
 
 	const {


### PR DESCRIPTION
API oversight on our part. fixes #4464

### Change type

- [x] `api`

### Release notes

- Allow the `<TldrawImage />` component to accept custom asset URLs.