### PR TITLE
consistent function style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,11 @@ module.exports = {
 				selector: 'Identifier[name=sessionStorage]',
 				message: 'Use the getFromSessionStorage/setInSessionStorage helpers instead',
 			},
+			{
+				selector:
+					'ExportNamedDeclaration > VariableDeclaration[kind=const] > VariableDeclarator[init.type=ArrowFunctionExpression]',
+				message: 'Use a function declaration instead of an arrow function here.',
+			},
 		],
 		'no-restricted-globals': [
 			'error',

--- a/apps/docs/components/blog/blog-authors.tsx
+++ b/apps/docs/components/blog/blog-authors.tsx
@@ -3,7 +3,7 @@ import { getAuthor } from '@/utils/get-author'
 import Image from 'next/image'
 import Link from 'next/link'
 
-export const BlogAuthors: React.FC<{ article: Article }> = ({ article }) => {
+export function BlogAuthors({ article }: { article: Article }) {
 	// @ts-ignore
 	const authors = article.authorId.split(',').map((id: string) => getAuthor(id.trim()))
 

--- a/apps/docs/components/blog/blog-category-menu.tsx
+++ b/apps/docs/components/blog/blog-category-menu.tsx
@@ -13,7 +13,7 @@ const icons = {
 	'all-posts': RectangleStackIcon,
 }
 
-export const BlogCategoryMenu = ({ categories }: { categories: Category[] }) => {
+export function BlogCategoryMenu({ categories }: { categories: Category[] }) {
 	const pathname = usePathname()
 
 	return (

--- a/apps/docs/components/blog/blog-category-page.tsx
+++ b/apps/docs/components/blog/blog-category-page.tsx
@@ -7,12 +7,17 @@ import { Article, Section } from '@/types/content-types'
 import { NewsletterSignup } from '../common/newsletter-signup'
 import { SearchButton } from '../search/button'
 
-export const BlogCategoryPage: React.FC<{
+export function BlogCategoryPage({
+	title,
+	description,
+	section,
+	articles,
+}: {
 	title: string
 	description: string | null
 	section: Section
 	articles: Article[]
-}> = ({ title, description, section, articles }) => {
+}) {
 	return (
 		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-16 isolate">
 			<BlogSidebar>

--- a/apps/docs/components/blog/blog-mobile-sidebar.tsx
+++ b/apps/docs/components/blog/blog-mobile-sidebar.tsx
@@ -4,7 +4,7 @@ import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { Bars3Icon } from '@heroicons/react/16/solid'
 import { XMarkIcon } from '@heroicons/react/20/solid'
 
-export const BlogMobileSidebar: React.FC = async () => {
+export async function BlogMobileSidebar() {
 	const db = await getDb()
 	const categories = await db.getCategoriesForSection('blog')
 	return (

--- a/apps/docs/components/blog/blog-post-header.tsx
+++ b/apps/docs/components/blog/blog-post-header.tsx
@@ -6,7 +6,7 @@ import { Article } from '@/types/content-types'
 import { getDb } from '@/utils/ContentDatabase'
 import { format } from 'date-fns'
 
-export const BlogPostHeader: React.FC<{ article: Article }> = async ({ article }) => {
+export async function BlogPostHeader({ article }: { article: Article }) {
 	const db = await getDb()
 	const category = await db.getCategory(article.categoryId)
 	const section = await db.getSection(article.sectionId)

--- a/apps/docs/components/blog/blog-post-page.tsx
+++ b/apps/docs/components/blog/blog-post-page.tsx
@@ -6,9 +6,7 @@ import { Content } from '@/components/content'
 import { Article } from '@/types/content-types'
 import { NewsletterSignup } from '../common/newsletter-signup'
 
-export const BlogPostPage: React.FC<{
-	article: Article
-}> = ({ article }) => {
+export function BlogPostPage({ article }: { article: Article }) {
 	return (
 		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-16 isolate">
 			<BlogSidebar>

--- a/apps/docs/components/blog/blog-post-preview.tsx
+++ b/apps/docs/components/blog/blog-post-preview.tsx
@@ -2,9 +2,8 @@ import { getAuthor } from '@/utils/get-author'
 import { format } from 'date-fns'
 import Image from 'next/image'
 import Link from 'next/link'
-import React from 'react'
 
-export const BlogPostPreview: React.FC<{ article: any }> = ({ article }) => {
+export function BlogPostPreview({ article }: { article: any }) {
 	const authors = article.authorId.split(',').map((id: string) => getAuthor(id.trim()))
 
 	return (

--- a/apps/docs/components/blog/blog-search-bar.tsx
+++ b/apps/docs/components/blog/blog-search-bar.tsx
@@ -3,7 +3,7 @@
 import { SearchButton } from '@/components/search/button'
 import { motion, useScroll, useTransform } from 'framer-motion'
 
-export const BlogSearchBar = () => {
+export function BlogSearchBar() {
 	const { scrollY } = useScroll()
 	const width = useTransform(scrollY, [0, 32], ['100%', '60%'])
 	const offset = useTransform(scrollY, [0, 32], ['15rem', '0rem'])

--- a/apps/docs/components/blog/blog-sidebar.tsx
+++ b/apps/docs/components/blog/blog-sidebar.tsx
@@ -2,7 +2,7 @@ import { BlogCategoryMenu } from '@/components/blog/blog-category-menu'
 import { Aside } from '@/components/common/aside'
 import { getDb } from '@/utils/ContentDatabase'
 
-export const BlogSidebar: React.FC<{ children?: React.ReactNode }> = async ({ children }) => {
+export async function BlogSidebar({ children }: { children?: React.ReactNode }) {
 	const db = await getDb()
 	const categories = await db.getCategoriesForSection('blog')
 

--- a/apps/docs/components/blog/blog-table-of-contents.tsx
+++ b/apps/docs/components/blog/blog-table-of-contents.tsx
@@ -6,7 +6,7 @@ import { HeadingsMenu } from '@/components/navigation/headings-menu'
 import { Article } from '@/types/content-types'
 import { getDb } from '@/utils/ContentDatabase'
 
-export const BlogTableOfContents: React.FC<{ article: Article }> = async ({ article }) => {
+export async function BlogTableOfContents({ article }: { article: Article }) {
 	const db = await getDb()
 	const headings = await db.getArticleHeadings(article.id)
 

--- a/apps/docs/components/common/aside.tsx
+++ b/apps/docs/components/common/aside.tsx
@@ -3,10 +3,7 @@
 import { cn } from '@/utils/cn'
 import { motion, useScroll, useTransform } from 'framer-motion'
 
-export const Aside: React.FC<{ className?: string; children: React.ReactNode }> = ({
-	className,
-	children,
-}) => {
+export function Aside({ className, children }: { className?: string; children: React.ReactNode }) {
 	const { scrollY } = useScroll()
 	const offset = useTransform(scrollY, [0, 80], [80, 0])
 

--- a/apps/docs/components/common/back-to-top-button.tsx
+++ b/apps/docs/components/common/back-to-top-button.tsx
@@ -3,7 +3,7 @@
 import { ArrowLongUpIcon } from '@heroicons/react/20/solid'
 import { useEffect, useState } from 'react'
 
-export const BackToTopButton = () => {
+export function BackToTopButton() {
 	const [showButton, setShowButton] = useState<boolean>(false)
 
 	useEffect(() => {

--- a/apps/docs/components/common/breadcrumbs.tsx
+++ b/apps/docs/components/common/breadcrumbs.tsx
@@ -3,11 +3,15 @@ import { cn } from '@/utils/cn'
 import { ChevronRightIcon } from '@heroicons/react/20/solid'
 import Link from 'next/link'
 
-export const Breadcrumbs: React.FC<{
+export async function Breadcrumbs({
+	section,
+	category,
+	className,
+}: {
 	section?: Section
 	category?: Category
 	className?: string
-}> = async ({ section, category, className }) => {
+}) {
 	const items = [section, category].filter(Boolean) as (Section | Category)[]
 
 	return (

--- a/apps/docs/components/common/button.tsx
+++ b/apps/docs/components/common/button.tsx
@@ -8,20 +8,7 @@ import { MouseEventHandler } from 'react'
 import { useFormStatus } from 'react-dom'
 import { Loader } from './loader'
 
-export const Button: React.FC<{
-	href?: string
-	newTab?: boolean
-	onClick?: MouseEventHandler<HTMLButtonElement>
-	submit?: boolean
-	caption: string
-	icon?: IconName
-	arrow?: 'left' | 'right'
-	className?: string
-	size?: 'xs' | 'sm' | 'base' | 'lg'
-	type?: 'primary' | 'secondary' | 'tertiary' | 'black'
-	darkRingOffset?: boolean
-	loading?: boolean
-}> = ({
+export function Button({
 	href,
 	newTab,
 	onClick,
@@ -34,7 +21,20 @@ export const Button: React.FC<{
 	type = 'primary',
 	darkRingOffset,
 	loading,
-}) => {
+}: {
+	href?: string
+	newTab?: boolean
+	onClick?: MouseEventHandler<HTMLButtonElement>
+	submit?: boolean
+	caption: string
+	icon?: IconName
+	arrow?: 'left' | 'right'
+	className?: string
+	size?: 'xs' | 'sm' | 'base' | 'lg'
+	type?: 'primary' | 'secondary' | 'tertiary' | 'black'
+	darkRingOffset?: boolean
+	loading?: boolean
+}) {
 	const { pending } = useFormStatus()
 	const iconSizes = { xs: 'h-3', sm: 'h-3.5', base: 'h-4', lg: 'h-5' }
 	className = cn(

--- a/apps/docs/components/common/icon/discord.tsx
+++ b/apps/docs/components/common/icon/discord.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const DiscordIcon: React.FC<{ className: string }> = ({ className }) => {
+export function DiscordIcon({ className }: { className: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/components/common/icon/github.tsx
+++ b/apps/docs/components/common/icon/github.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const GithubIcon: React.FC<{ className: string }> = ({ className }) => {
+export function GithubIcon({ className }: { className: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/components/common/icon/index.tsx
+++ b/apps/docs/components/common/icon/index.tsx
@@ -18,7 +18,7 @@ const icons = {
 
 export type IconName = keyof typeof icons
 
-export const Icon: React.FC<{ icon: IconName; className: string }> = ({ icon, className }) => {
+export function Icon({ icon, className }: { icon: IconName; className: string }) {
 	const IconComponent = icons[icon]
 	return <IconComponent className={className} />
 }

--- a/apps/docs/components/common/icon/tldraw.tsx
+++ b/apps/docs/components/common/icon/tldraw.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const TldrawIcon: React.FC<{ className: string }> = ({ className }) => {
+export function TldrawIcon({ className }: { className: string }) {
 	return (
 		<svg
 			width="14"

--- a/apps/docs/components/common/icon/twitter.tsx
+++ b/apps/docs/components/common/icon/twitter.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const TwitterIcon: React.FC<{ className: string }> = ({ className }) => {
+export function TwitterIcon({ className }: { className: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/components/common/loader.tsx
+++ b/apps/docs/components/common/loader.tsx
@@ -1,6 +1,4 @@
-import { FC } from 'react'
-
-export const Loader: FC<{ className?: string }> = ({ className }) => {
+export function Loader({ className }: { className?: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/components/common/logo.tsx
+++ b/apps/docs/components/common/logo.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const Logo: React.FC<{ className: string }> = ({ className }) => {
+export function Logo({ className }: { className: string }) {
 	return (
 		<svg
 			viewBox="0 0 96 24"

--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -6,12 +6,12 @@ import { cn } from '@/utils/cn'
 import { useLocalStorageState } from '@/utils/storage'
 import { Field, Input, Label } from '@headlessui/react'
 import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/20/solid'
-import { FC, FormEventHandler, useCallback, useState } from 'react'
+import { FormEventHandler, useCallback, useState } from 'react'
 
 // when debugging is true, the form will always show (even if the user has submitted)
 const DEBUGGING = false
 
-export const NewsletterSignup: FC<{ size?: 'small' | 'large' }> = ({ size = 'large' }) => {
+export function NewsletterSignup({ size = 'large' }: { size?: 'small' | 'large' }) {
 	// If the user has submitted their email, we don't show the form anymore
 	const [didSubmit, setDidSubmit] = useLocalStorageState('dev_did_submit_newsletter', false)
 

--- a/apps/docs/components/common/page-title.tsx
+++ b/apps/docs/components/common/page-title.tsx
@@ -1,9 +1,12 @@
 import { cn } from '@/utils/cn'
 
-export const PageTitle: React.FC<{ children: React.ReactNode; className?: string }> = ({
+export function PageTitle({
 	children,
 	className,
-}) => {
+}: {
+	children: React.ReactNode
+	className?: string
+}) {
 	return (
 		<h1 className={cn('font-black text-black dark:text-white text-3xl sm:text-4xl', className)}>
 			{children}

--- a/apps/docs/components/common/share-button.tsx
+++ b/apps/docs/components/common/share-button.tsx
@@ -2,13 +2,17 @@
 
 import { cn } from '@/utils/cn'
 import { CheckIcon, ShareIcon } from '@heroicons/react/20/solid'
-import React, { useState } from 'react'
+import { useState } from 'react'
 
-export const ShareButton: React.FC<{
+export function ShareButton({
+	url,
+	size = 'small',
+	className,
+}: {
 	url: string
 	size?: 'small' | 'base'
 	className?: string
-}> = ({ url, size = 'small', className }) => {
+}) {
 	const [copied, setCopied] = useState<boolean>(false)
 
 	return (

--- a/apps/docs/components/common/theme-switch.tsx
+++ b/apps/docs/components/common/theme-switch.tsx
@@ -11,7 +11,7 @@ const themes = [
 	{ id: 'system', name: 'System Preference', icon: Cog6ToothIcon },
 ]
 
-export const ThemeSwitch = () => {
+export function ThemeSwitch() {
 	const { theme: initialTheme, setTheme: persistTheme } = useTheme()
 	const [theme, setTheme] = useState<string>()
 	const Icon = themes.find((t) => t.id === theme)?.icon ?? SunIcon

--- a/apps/docs/components/content/api-heading.tsx
+++ b/apps/docs/components/content/api-heading.tsx
@@ -1,3 +1,3 @@
-export const ApiHeading = (props: any) => {
+export function ApiHeading(props: any) {
 	return <h4 className="!-mb-4 !mt-8 uppercase text-sm font-semibold" {...props} />
 }

--- a/apps/docs/components/content/blockquote.tsx
+++ b/apps/docs/components/content/blockquote.tsx
@@ -1,5 +1,5 @@
 import { Callout } from './callout'
 
-export const Blockquote = (props: any) => {
+export function Blockquote(props: any) {
 	return <Callout>{props.children}</Callout>
 }

--- a/apps/docs/components/content/callout.tsx
+++ b/apps/docs/components/content/callout.tsx
@@ -5,10 +5,13 @@ import {
 	InformationCircleIcon,
 } from '@heroicons/react/20/solid'
 
-export const Callout: React.FC<{
+export function Callout({
+	type = 'info',
+	children,
+}: {
 	type?: 'info' | 'warning' | 'critical'
 	children: React.ReactNode
-}> = ({ type = 'info', children }) => {
+}) {
 	return (
 		<div
 			className={cn(

--- a/apps/docs/components/content/code-files.tsx
+++ b/apps/docs/components/content/code-files.tsx
@@ -2,12 +2,16 @@ import { cn } from '@/utils/cn'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import hljs from 'highlight.js/lib/common'
 
-export const CodeFiles: React.FC<{
+export function CodeFiles({
+	files,
+	hideTabs,
+	className,
+}: {
 	files: { name: string; content: any }[]
 	hideCopyButton?: boolean
 	hideTabs?: boolean
 	className?: string
-}> = ({ files, hideTabs, className }) => {
+}) {
 	return (
 		<TabGroup
 			className={cn(

--- a/apps/docs/components/content/embed.tsx
+++ b/apps/docs/components/content/embed.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const Embed = (props: any) => {
+export function Embed(props: any) {
 	return (
 		<div>
 			<div className="bg-zinc-100 dark:bg-zinc-700 py-1 md:rounded-2xl -mx-5 md:-mx-1 md:px-1">

--- a/apps/docs/components/content/example.tsx
+++ b/apps/docs/components/content/example.tsx
@@ -2,7 +2,7 @@ import { CodeFiles } from '@/components/content/code-files'
 import { Embed } from '@/components/content/embed'
 import { Article } from '@/types/content-types'
 
-export const Example: React.FC<{ article: Article }> = ({ article }) => {
+export function Example({ article }: { article: Article }) {
 	const server = 'https://examples.tldraw.com'
 	const additionalFiles = JSON.parse(article.componentCodeFiles ?? '')
 	const files = [

--- a/apps/docs/components/content/image.tsx
+++ b/apps/docs/components/content/image.tsx
@@ -1,4 +1,4 @@
-export const Image = (props: any) => {
+export function Image(props: any) {
 	return (
 		<span className="block">
 			<span className="block bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:mx-0 md:px-1">

--- a/apps/docs/components/content/index.tsx
+++ b/apps/docs/components/content/index.tsx
@@ -20,7 +20,7 @@ import rehypeHighlight from 'rehype-highlight'
 import rehypeSlug from 'rehype-slug-custom-id'
 import remarkGfm from 'remark-gfm'
 
-export const Content: React.FC<{ mdx: string; type?: string }> = ({ mdx, type }) => {
+export function Content({ mdx, type }: { mdx: string; type?: string }) {
 	return (
 		<section
 			className={cn(

--- a/apps/docs/components/content/parameters-table-description.tsx
+++ b/apps/docs/components/content/parameters-table-description.tsx
@@ -1,5 +1,3 @@
-export const ParametersTableDescription: React.FC<{ children: React.ReactNode }> = ({
-	children,
-}) => {
+export function ParametersTableDescription({ children }: { children: React.ReactNode }) {
 	return <td>{children}</td>
 }

--- a/apps/docs/components/content/parameters-table-name.tsx
+++ b/apps/docs/components/content/parameters-table-name.tsx
@@ -1,3 +1,3 @@
-export const ParametersTableName: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export function ParametersTableName({ children }: { children: React.ReactNode }) {
 	return <td>{children}</td>
 }

--- a/apps/docs/components/content/parameters-table-row.tsx
+++ b/apps/docs/components/content/parameters-table-row.tsx
@@ -1,3 +1,3 @@
-export const ParametersTableRow: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export function ParametersTableRow({ children }: { children: React.ReactNode }) {
 	return <tr>{children}</tr>
 }

--- a/apps/docs/components/content/parameters-table.tsx
+++ b/apps/docs/components/content/parameters-table.tsx
@@ -1,4 +1,4 @@
-export const ParametersTable: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export function ParametersTable({ children }: { children: React.ReactNode }) {
 	return (
 		<div className="prose-p:my-0 prose-pre:hidden prose-code:!bg-zinc-200 dark:prose-code:!bg-zinc-800">
 			<table>

--- a/apps/docs/components/content/pre.tsx
+++ b/apps/docs/components/content/pre.tsx
@@ -3,17 +3,15 @@
 import { cn } from '@/utils/cn'
 import { DetailedHTMLProps, HTMLAttributes } from 'react'
 
-export const Pre = (props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>) => {
+export function Pre(props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>) {
 	// const container = useRef<HTMLPreElement>(null)
 	// const [copied, setCopied] = useState<boolean>(false)
-
 	// const copy = () => {
 	// 	const code: string = container.current?.innerText ?? ''
 	// 	navigator.clipboard.writeText(code)
 	// 	setCopied(true)
 	// 	setTimeout(() => setCopied(false), 1500)
 	// }
-
 	return (
 		<div
 			className={cn(
@@ -31,12 +29,12 @@ export const Pre = (props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTM
 				{props.children}
 			</pre>
 			{/* <Button
-				onClick={copy}
-				caption={copied ? 'Copied' : 'Copy'}
-				icon={copied ? 'check' : 'paperclip'}
-				size="xs"
-				className="absolute -top-2 right-4 opacity-0 translate-y-4 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-100"
-			/> */}
+                onClick={copy}
+                caption={copied ? 'Copied' : 'Copy'}
+                icon={copied ? 'check' : 'paperclip'}
+                size="xs"
+                className="absolute -top-2 right-4 opacity-0 translate-y-4 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-100"
+            /> */}
 		</div>
 	)
 }

--- a/apps/docs/components/content/title-with-source-link.tsx
+++ b/apps/docs/components/content/title-with-source-link.tsx
@@ -3,17 +3,23 @@ import { ArrowRightIcon } from '@heroicons/react/16/solid'
 import { CodeBracketIcon } from '@heroicons/react/20/solid'
 import Link from 'next/link'
 
-const Tag: React.FC<{ children: React.ReactNode; tag: string }> = ({ children }) => {
+function Tag({ children }: { children: React.ReactNode; tag: string }) {
 	return <span className="border border-zinc-800 rounded-full px-1.5 text-xs">{children}</span>
 }
 
-export const TitleWithSourceLink: React.FC<{
+export function TitleWithSourceLink({
+	children,
+	source,
+	tags,
+	inherited,
+	large,
+}: {
 	children: React.ReactNode
 	source?: string | null
 	large?: boolean
 	tags?: string[]
 	inherited?: { name: string; link: string }
-}> = ({ children, source, tags, inherited, large }) => {
+}) {
 	return (
 		<>
 			<div className="flex items-end gap-2 prose-headings:mb-0">

--- a/apps/docs/components/content/video.tsx
+++ b/apps/docs/components/content/video.tsx
@@ -1,8 +1,12 @@
-export const Video: React.FC<{ src: string; thumbnail?: string; caption?: string }> = ({
+export function Video({
 	src,
 	thumbnail,
 	caption,
-}) => {
+}: {
+	src: string
+	thumbnail?: string
+	caption?: string
+}) {
 	return (
 		<span className="block mb-5">
 			<span className="block bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:mx-0 md:px-1">

--- a/apps/docs/components/content/youtube.tsx
+++ b/apps/docs/components/content/youtube.tsx
@@ -1,4 +1,4 @@
-export const YouTube: React.FC<{ src: string; caption?: string }> = ({ src, caption }) => {
+export function YouTube({ src, caption }: { src: string; caption?: string }) {
 	return (
 		<span className="block mb-5">
 			<span className="block bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:mx-0 md:px-1">

--- a/apps/docs/components/docs/docs-article-info.tsx
+++ b/apps/docs/components/docs/docs-article-info.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 const githubContentRoot = 'https://github.com/tldraw/tldraw/blob/main/apps/docs/content/'
 
-export const DocsArticleInfo: React.FC<{ article: Article }> = ({ article }) => {
+export function DocsArticleInfo({ article }: { article: Article }) {
 	return (
 		<div className="shrink-0 text-xs flex flex-col gap-1">
 			{article.date && <p>Last edited on {format(new Date(article.date), 'MMM dd, yyyy')}</p>}

--- a/apps/docs/components/docs/docs-category-menu.tsx
+++ b/apps/docs/components/docs/docs-category-menu.tsx
@@ -28,7 +28,7 @@ const categoryLinks = [
 	},
 ]
 
-export const DocsCategoryMenu = () => {
+export function DocsCategoryMenu() {
 	const pathname = usePathname()
 	return (
 		<ul className="shrink-0 flex flex-col gap-3">

--- a/apps/docs/components/docs/docs-feedback-widget.tsx
+++ b/apps/docs/components/docs/docs-feedback-widget.tsx
@@ -23,7 +23,7 @@ async function submitFeedback(
 	return
 }
 
-export const DocsFeedbackWidget: React.FC<{ className?: string }> = ({ className }) => {
+export function DocsFeedbackWidget({ className }: { className?: string }) {
 	const pathname = usePathname()
 
 	const [didSubmit, setDidSubmit] = useLocalStorageState(pathname + '-feedback-submitted', false)
@@ -85,7 +85,6 @@ export const DocsFeedbackWidget: React.FC<{ className?: string }> = ({ className
 	)
 
 	// todo, improve this so that thumbs ups and thumbs downs are also captured
-
 	if (didSubmit && !(DEBUGGING && process.env.NODE_ENV === 'development')) return null
 
 	return (

--- a/apps/docs/components/docs/docs-footer.tsx
+++ b/apps/docs/components/docs/docs-footer.tsx
@@ -3,7 +3,7 @@ import { getDb } from '@/utils/ContentDatabase'
 import { ArrowLongLeftIcon, ArrowLongRightIcon } from '@heroicons/react/20/solid'
 import Link from 'next/link'
 
-export const DocsFooter: React.FC<{ article: Article }> = async ({ article }) => {
+export async function DocsFooter({ article }: { article: Article }) {
 	const db = await getDb()
 	const links = await db.getArticleLinks(article)
 

--- a/apps/docs/components/docs/docs-header.tsx
+++ b/apps/docs/components/docs/docs-header.tsx
@@ -5,7 +5,7 @@ import { Article } from '@/types/content-types'
 import { getDb } from '@/utils/ContentDatabase'
 import { cn } from '@/utils/cn'
 
-export const DocsHeader: React.FC<{ article: Article }> = async ({ article }) => {
+export async function DocsHeader({ article }: { article: Article }) {
 	const db = await getDb()
 	const section = await db.getSection(article.sectionId)
 	const category = await db.getCategory(article.categoryId)

--- a/apps/docs/components/docs/docs-mobile-sidebar.tsx
+++ b/apps/docs/components/docs/docs-mobile-sidebar.tsx
@@ -5,11 +5,15 @@ import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { Bars3Icon } from '@heroicons/react/16/solid'
 import { XMarkIcon } from '@heroicons/react/20/solid'
 
-export const DocsMobileSidebar: React.FC<{
+export async function DocsMobileSidebar({
+	sectionId,
+	categoryId,
+	articleId,
+}: {
 	sectionId?: string
 	categoryId?: string
 	articleId?: string
-}> = async ({ sectionId, categoryId, articleId }) => {
+}) {
 	const db = await getDb()
 	const sidebar = await db.getSidebarContentList({ sectionId, categoryId, articleId })
 	const skipFirstLevel = ['reference', 'examples'].includes(sectionId ?? '')

--- a/apps/docs/components/docs/docs-search-bar.tsx
+++ b/apps/docs/components/docs/docs-search-bar.tsx
@@ -3,7 +3,7 @@
 import { SearchButton } from '@/components/search/button'
 import { motion, useScroll, useTransform } from 'framer-motion'
 
-export const DocsSearchBar = () => {
+export function DocsSearchBar() {
 	const { scrollY } = useScroll()
 	const width = useTransform(scrollY, [0, 32], ['100%', '60%'])
 	const offset = useTransform(scrollY, [0, 32], ['15rem', '0rem'])

--- a/apps/docs/components/docs/docs-sidebar-menu.tsx
+++ b/apps/docs/components/docs/docs-sidebar-menu.tsx
@@ -7,7 +7,10 @@ import { ChevronRightIcon } from '@heroicons/react/16/solid'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
-export const DocsSidebarMenu: React.FC<{
+export function DocsSidebarMenu({
+	title,
+	elements,
+}: {
 	title: string
 	elements: {
 		type: string
@@ -16,7 +19,7 @@ export const DocsSidebarMenu: React.FC<{
 		url: string
 		groupId: string | null
 	}[]
-}> = ({ title, elements }) => {
+}) {
 	const pathname = usePathname()
 	const groups = elements.some((e) => e.groupId) ? Object.values(APIGroup) : null
 

--- a/apps/docs/components/docs/docs-sidebar-menus.tsx
+++ b/apps/docs/components/docs/docs-sidebar-menus.tsx
@@ -6,7 +6,7 @@ import { UIEventHandler, useEffect, useRef } from 'react'
 
 let scrollPosition = 0
 
-export const DocsSidebarMenus = ({ menus }: { menus: any }) => {
+export function DocsSidebarMenus({ menus }: { menus: any }) {
 	const container = useRef<HTMLDivElement>(null)
 	const pathname = usePathname()
 

--- a/apps/docs/components/docs/docs-sidebar.tsx
+++ b/apps/docs/components/docs/docs-sidebar.tsx
@@ -3,11 +3,15 @@ import { DocsCategoryMenu } from '@/components/docs/docs-category-menu'
 import { DocsSidebarMenus } from '@/components/docs/docs-sidebar-menus'
 import { getDb } from '@/utils/ContentDatabase'
 
-export const DocsSidebar: React.FC<{
+export async function DocsSidebar({
+	sectionId,
+	categoryId,
+	articleId,
+}: {
 	sectionId?: string
 	categoryId?: string
 	articleId?: string
-}> = async ({ sectionId, categoryId, articleId }) => {
+}) {
 	const db = await getDb()
 	const sidebar = await db.getSidebarContentList({ sectionId, categoryId, articleId })
 	const skipFirstLevel = ['reference', 'examples'].includes(sectionId ?? '')

--- a/apps/docs/components/docs/docs-table-of-contents.tsx
+++ b/apps/docs/components/docs/docs-table-of-contents.tsx
@@ -5,7 +5,7 @@ import { HeadingsMenu } from '@/components/navigation/headings-menu'
 import { Article } from '@/types/content-types'
 import { getDb } from '@/utils/ContentDatabase'
 
-export const DocsTableOfContents: React.FC<{ article: Article }> = async ({ article }) => {
+export async function DocsTableOfContents({ article }: { article: Article }) {
 	const db = await getDb()
 	const headings = await db.getArticleHeadings(article.id)
 

--- a/apps/docs/components/marketing/arrow-down.tsx
+++ b/apps/docs/components/marketing/arrow-down.tsx
@@ -3,11 +3,15 @@
 import { cn } from '@/utils/cn'
 import { motion } from 'framer-motion'
 
-export const ArrowDown: React.FC<{
+export function ArrowDown({
+	className,
+	animationDelay = 0,
+	animationDuration = 0.15,
+}: {
 	className?: string
 	animationDelay?: number
 	animationDuration?: number
-}> = ({ className, animationDelay = 0, animationDuration = 0.15 }) => {
+}) {
 	return (
 		<svg
 			viewBox="0 0 24 60"

--- a/apps/docs/components/marketing/arrow-up.tsx
+++ b/apps/docs/components/marketing/arrow-up.tsx
@@ -1,8 +1,6 @@
 import { cn } from '@/utils/cn'
 
-export const ArrowUp: React.FC<{
-	className?: string
-}> = ({ className }) => {
+export function ArrowUp({ className }: { className?: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/components/marketing/card.tsx
+++ b/apps/docs/components/marketing/card.tsx
@@ -1,10 +1,14 @@
 import { cn } from '@/utils/cn'
 
-export const Card: React.FC<{
+export function Card({
+	children,
+	className,
+	darker,
+}: {
 	children: React.ReactNode
 	className?: string
 	darker?: boolean
-}> = ({ children, className, darker }) => {
+}) {
 	return (
 		<div
 			className={cn(

--- a/apps/docs/components/marketing/case-studies-section.tsx
+++ b/apps/docs/components/marketing/case-studies-section.tsx
@@ -14,7 +14,7 @@ import PlaygroundLogo from '../../public/images/case-studies/playground-logo.png
 import Playground from '../../public/images/case-studies/playground.jpg'
 import { Card } from './card'
 
-export const CaseStudiesSection = () => {
+export function CaseStudiesSection() {
 	return (
 		<Section>
 			<SectionHeading

--- a/apps/docs/components/marketing/cta-section.tsx
+++ b/apps/docs/components/marketing/cta-section.tsx
@@ -2,7 +2,7 @@ import { Section } from '@/components/marketing/section'
 import { SectionHeading } from '@/components/marketing/section-heading'
 import { Button } from '../common/button'
 
-export const CTASection = () => {
+export function CTASection() {
 	return (
 		<Section className="pb-24 md:pb-32 lg:pb-40">
 			<SectionHeading
@@ -11,25 +11,25 @@ export const CTASection = () => {
 				description="Follow our quick start guide and build something today with the tldraw SDK."
 			/>
 			{/* <div className="flex items-center gap-3 justify-center -mt-6 mb-12">
-				<ul className="flex">
-					{avatars.map((avatar, index) => (
-						<li
-							key={index}
-							className="relative size-8 sm:size-10 border-2 border-white rounded-full overflow-hidden -ml-2 first-of-type:ml-0"
-						>
-							<Image
-								src={avatar}
-								alt={`Tldraw user ${index}`}
-								fill
-								className="object-cover object-center"
-							/>
-						</li>
-					))}
-				</ul>
-				<div className="max-w-32 leading-tight text-xs sm:max-w-40 sm:text-sm sm:leading-tight">
-					Loved by <span className="text-black font-semibold">5000+</span> developers and users.
-				</div>
-			</div> */}
+                <ul className="flex">
+                    {avatars.map((avatar, index) => (
+                        <li
+                            key={index}
+                            className="relative size-8 sm:size-10 border-2 border-white rounded-full overflow-hidden -ml-2 first-of-type:ml-0"
+                        >
+                            <Image
+                                src={avatar}
+                                alt={`Tldraw user ${index}`}
+                                fill
+                                className="object-cover object-center"
+                            />
+                        </li>
+                    ))}
+                </ul>
+                <div className="max-w-32 leading-tight text-xs sm:max-w-40 sm:text-sm sm:leading-tight">
+                    Loved by <span className="text-black font-semibold">5000+</span> developers and users.
+                </div>
+            </div> */}
 			<div className="flex flex-col items-center justify-center gap-4 -mt-4">
 				<div className="flex flex-row items-center justify-center gap-4">
 					<Button href="/quick-start" caption="Read the docs" type="black" />
@@ -42,13 +42,13 @@ export const CTASection = () => {
 					/>
 				</div>
 				{/* <Link
-					href="https://forms.gle/PmS4wNzngnbD3fb89"
-					className="font-semibold text-blue-500 hover:text-blue-600"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Ask about a commercial license
-				</Link> */}
+                href="https://forms.gle/PmS4wNzngnbD3fb89"
+                className="font-semibold text-blue-500 hover:text-blue-600"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Ask about a commercial license
+            </Link> */}
 			</div>
 		</Section>
 	)

--- a/apps/docs/components/marketing/customization-section.tsx
+++ b/apps/docs/components/marketing/customization-section.tsx
@@ -12,7 +12,7 @@ import {
 import Link from 'next/link'
 import { ArrowUp } from './arrow-up'
 
-export const CustomizationSection = async () => {
+export async function CustomizationSection() {
 	return (
 		<Section>
 			<SectionHeading

--- a/apps/docs/components/marketing/demo.tsx
+++ b/apps/docs/components/marketing/demo.tsx
@@ -10,7 +10,7 @@ import SmBc from '../../public/images/ui-placeholder/sm-bc.jpg'
 import SmTl from '../../public/images/ui-placeholder/sm-tl.jpg'
 import { Button } from '../common/button'
 
-export const Demo = () => {
+export function Demo() {
 	const [showCanvas, setShowCanvas] = useState<boolean>(false)
 
 	return (

--- a/apps/docs/components/marketing/details-section.tsx
+++ b/apps/docs/components/marketing/details-section.tsx
@@ -7,7 +7,7 @@ import {
 import { Section } from './section'
 import { SectionHeading } from './section-heading'
 
-export const DetailsSection = () => {
+export function DetailsSection() {
 	return (
 		<Section>
 			<SectionHeading

--- a/apps/docs/components/marketing/example-placeholder.tsx
+++ b/apps/docs/components/marketing/example-placeholder.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 import CustomUI from '../../public/images/ui-placeholder/custom-ui.jpg'
 
-export const ExamplePlaceholder: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export function ExamplePlaceholder({ children }: { children: React.ReactNode }) {
 	const container = useRef<HTMLDivElement>(null)
 	const inView = useInView(container, { amount: 1 })
 	const [placeholder, setPlaceholder] = useState(true)

--- a/apps/docs/components/marketing/example.tsx
+++ b/apps/docs/components/marketing/example.tsx
@@ -2,10 +2,13 @@ import { getPageContent } from '@/utils/get-page-content'
 import { CodeFiles } from '../content/code-files'
 import { ExamplePlaceholder } from './example-placeholder'
 
-export const Example: React.FC<{ path: string; showPlaceholder?: boolean }> = async ({
+export async function Example({
 	path,
 	showPlaceholder,
-}) => {
+}: {
+	path: string
+	showPlaceholder?: boolean
+}) {
 	const content = await getPageContent(path)
 	if (!content || content.type !== 'article') return null
 	const server = 'https://examples.tldraw.com'

--- a/apps/docs/components/marketing/faq-section.tsx
+++ b/apps/docs/components/marketing/faq-section.tsx
@@ -4,7 +4,7 @@ import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react
 import { MinusIcon, PlusIcon } from '@heroicons/react/20/solid'
 import Link from 'next/link'
 
-export const FAQSection = () => {
+export function FAQSection() {
 	return (
 		<Section id="faq">
 			<SectionHeading

--- a/apps/docs/components/marketing/features-section.tsx
+++ b/apps/docs/components/marketing/features-section.tsx
@@ -9,7 +9,7 @@ import FeaturesShapes from '@/public/images/features/shapes.png'
 import Image from 'next/image'
 import Link from 'next/link'
 
-export const FeaturesSection = () => {
+export function FeaturesSection() {
 	return (
 		<Section id="features">
 			<SectionHeading

--- a/apps/docs/components/marketing/hero-section.tsx
+++ b/apps/docs/components/marketing/hero-section.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/common/button'
 import { Demo } from '@/components/marketing/demo'
 
-export const HeroSection = () => {
+export function HeroSection() {
 	return (
 		<section className="w-full max-w-screen-xl mx-auto md:px-5 flex flex-col items-center pt-8 sm:pt-16">
 			<div className="relative">
@@ -11,35 +11,35 @@ export const HeroSection = () => {
 					for React developers
 				</h1>
 				{/* <Underline
-					className={cn(
-						'pointer-events-none text-blue-500 absolute',
-						'w-64 left-2 top-[4.1rem]',
-						'sm:w-80 sm:left-auto sm:right-2 sm:top-8',
-						'md:w-[26rem] md:right-4 md:top-11'
-					)}
-				/> */}
+                className={cn(
+                    'pointer-events-none text-blue-500 absolute',
+                    'w-64 left-2 top-[4.1rem]',
+                    'sm:w-80 sm:left-auto sm:right-2 sm:top-8',
+                    'md:w-[26rem] md:right-4 md:top-11'
+                )}
+            /> */}
 			</div>
 			{/* <div className="mt-5 sm:mt-8 flex items-center gap-3">
-				<ul className="flex">
-					{avatars.map((avatar, index) => (
-						<li
-							key={index}
-							className="relative size-8 sm:size-10 border-2 border-white dark:border-zinc-950 rounded-full overflow-hidden -ml-2 first-of-type:ml-0"
-						>
-							<Image
-								src={avatar}
-								alt={`Tldraw user ${index}`}
-								fill
-								className="object-cover object-center"
-							/>
-						</li>
-					))}
-				</ul>
-				<div className="max-w-32 leading-tight text-xs sm:max-w-40 sm:text-sm sm:leading-tight">
-					Loved by <span className="text-black dark:text-white font-semibold">5000+</span>{' '}
-					developers and users.
-				</div>
-			</div> */}
+                <ul className="flex">
+                    {avatars.map((avatar, index) => (
+                        <li
+                            key={index}
+                            className="relative size-8 sm:size-10 border-2 border-white dark:border-zinc-950 rounded-full overflow-hidden -ml-2 first-of-type:ml-0"
+                        >
+                            <Image
+                                src={avatar}
+                                alt={`Tldraw user ${index}`}
+                                fill
+                                className="object-cover object-center"
+                            />
+                        </li>
+                    ))}
+                </ul>
+                <div className="max-w-32 leading-tight text-xs sm:max-w-40 sm:text-sm sm:leading-tight">
+                    Loved by <span className="text-black dark:text-white font-semibold">5000+</span>{' '}
+                    developers and users.
+                </div>
+            </div> */}
 			<p className="mt-5 sm:mt-8 px-5 text-center text-zinc-800 dark:text-zinc-200 sm:text-lg max-w-xl">
 				Whether you need a drop in whiteboard or an engine for your web canvas, the{' '}
 				<b>tldraw SDK</b> provides the components, APIs, and services to get you there.
@@ -55,9 +55,9 @@ export const HeroSection = () => {
 					newTab
 				/>
 				{/* <div className="pt-2">
-					<div className="font-hand text-blue-500 text-lg">or try here</div>
-					<ArrowDown className="h-14 text-blue-500 ml-auto -mt-2 -mr-6" animationDelay={1.2} />
-				</div> */}
+                <div className="font-hand text-blue-500 text-lg">or try here</div>
+                <ArrowDown className="h-14 text-blue-500 ml-auto -mt-2 -mr-6" animationDelay={1.2} />
+            </div> */}
 			</div>
 			<Demo />
 		</section>

--- a/apps/docs/components/marketing/installation-section.tsx
+++ b/apps/docs/components/marketing/installation-section.tsx
@@ -3,7 +3,7 @@ import { Section } from '@/components/marketing/section'
 import { SectionHeading } from '@/components/marketing/section-heading'
 import { Button } from '../common/button'
 
-export const InstallationSection = () => {
+export function InstallationSection() {
 	return (
 		<Section>
 			<SectionHeading

--- a/apps/docs/components/marketing/logo-section.tsx
+++ b/apps/docs/components/marketing/logo-section.tsx
@@ -1,4 +1,4 @@
-export const LogoSection = () => {
+export function LogoSection() {
 	return (
 		<section className="w-full max-w-screen-xl mx-auto px-5 pt-16 sm:pt-20 text-sm sm:text-base">
 			<h2 className="text-center mb-8">Trusted by great teams around the globe:</h2>

--- a/apps/docs/components/marketing/pricing-section.tsx
+++ b/apps/docs/components/marketing/pricing-section.tsx
@@ -3,7 +3,7 @@ import { Section } from '@/components/marketing/section'
 import { SectionHeading } from '@/components/marketing/section-heading'
 import { CheckBadgeIcon } from '@heroicons/react/20/solid'
 
-export const PricingSection = () => {
+export function PricingSection() {
 	return (
 		<div className="bg-zinc-50 dark:bg-zinc-900 mt-16 sm:mt-24 md:mt-32 lg:mt-40">
 			<Section id="pricing" className="pb-24 md:pb-32 lg:pb-40">

--- a/apps/docs/components/marketing/request-form.tsx
+++ b/apps/docs/components/marketing/request-form.tsx
@@ -7,7 +7,7 @@ import { XMarkIcon } from '@heroicons/react/16/solid'
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 import { useFormState } from 'react-dom'
 
-export const RequestForm = () => {
+export function RequestForm() {
 	const formState = { error: '', success: false }
 	const [state, action] = useFormState(submitLicenseForm, formState)
 

--- a/apps/docs/components/marketing/section-heading.tsx
+++ b/apps/docs/components/marketing/section-heading.tsx
@@ -1,10 +1,14 @@
 import { cn } from '@/utils/cn'
 
-export const SectionHeading: React.FC<{
+export function SectionHeading({
+	heading,
+	subheading,
+	description,
+}: {
 	heading: string
 	subheading?: string
 	description?: React.ReactNode
-}> = ({ heading, subheading, description }) => {
+}) {
 	return (
 		<>
 			{subheading && (

--- a/apps/docs/components/marketing/section.tsx
+++ b/apps/docs/components/marketing/section.tsx
@@ -1,10 +1,14 @@
 import { cn } from '@/utils/cn'
 
-export const Section: React.FC<{ id?: string; children: React.ReactNode; className?: string }> = ({
+export function Section({
 	id,
 	children,
 	className,
-}) => {
+}: {
+	id?: string
+	children: React.ReactNode
+	className?: string
+}) {
 	return (
 		<section
 			id={id}

--- a/apps/docs/components/marketing/testimonials-section.tsx
+++ b/apps/docs/components/marketing/testimonials-section.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import { Section } from './section'
 import { SectionHeading } from './section-heading'
 
-export const TestimonialsSection = () => {
+export function TestimonialsSection() {
 	return (
 		<Section>
 			<SectionHeading

--- a/apps/docs/components/marketing/underline.tsx
+++ b/apps/docs/components/marketing/underline.tsx
@@ -3,7 +3,7 @@
 import { cn } from '@/utils/cn'
 import { motion } from 'framer-motion'
 
-export const Underline: React.FC<{ className?: string }> = ({ className }) => {
+export function Underline({ className }: { className?: string }) {
 	return (
 		<svg
 			viewBox="0 0 407 24"

--- a/apps/docs/components/navigation/close-on-navigation.tsx
+++ b/apps/docs/components/navigation/close-on-navigation.tsx
@@ -2,7 +2,7 @@ import { useClose } from '@headlessui/react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 
-export const CloseOnNavigation = () => {
+export function CloseOnNavigation() {
 	const pathname = usePathname()
 	const searchParams = useSearchParams()
 	const close = useClose()

--- a/apps/docs/components/navigation/footer.tsx
+++ b/apps/docs/components/navigation/footer.tsx
@@ -38,7 +38,7 @@ const menus = [
 	},
 ]
 
-export const Footer = () => {
+export function Footer() {
 	return (
 		<footer className="bg-zinc-50 dark:bg-zinc-900 py-12 md:py-16">
 			<div className="w-full max-w-screen-xl mx-auto px-5 flex flex-col sm:flex-row sm:justify-between gap-12">

--- a/apps/docs/components/navigation/header.tsx
+++ b/apps/docs/components/navigation/header.tsx
@@ -61,7 +61,7 @@ const socialLinks = [
 	},
 ]
 
-export const Header = () => {
+export function Header() {
 	const pathname = usePathname()
 	const { scrollY } = useScroll()
 	const navOpacity = useTransform(scrollY, [0, 32], [1, 0])

--- a/apps/docs/components/navigation/headings-menu.tsx
+++ b/apps/docs/components/navigation/headings-menu.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/utils/cn'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
-export const HeadingsMenu: React.FC<{ headings: ArticleHeadings }> = ({ headings }) => {
+export function HeadingsMenu({ headings }: { headings: ArticleHeadings }) {
 	const [activeSlug, setActiveSlug] = useState('')
 
 	useEffect(() => {

--- a/apps/docs/components/navigation/link.tsx
+++ b/apps/docs/components/navigation/link.tsx
@@ -12,14 +12,21 @@ import { ChevronDownIcon } from '@heroicons/react/16/solid'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
 
-export const NavigationLink: React.FC<{
+export function NavigationLink({
+	caption,
+	icon,
+	href,
+	children,
+	active,
+	closeOnClick = true,
+}: {
 	caption: string
 	icon?: any
 	href?: string
 	children?: { caption: string; href: string }[]
 	active: boolean
 	closeOnClick?: boolean
-}> = ({ caption, icon, href, children, active, closeOnClick = true }) => {
+}) {
 	const Icon = icon
 
 	if (children)

--- a/apps/docs/components/navigation/mobile-menu.tsx
+++ b/apps/docs/components/navigation/mobile-menu.tsx
@@ -9,7 +9,10 @@ import { usePathname } from 'next/navigation'
 import { ThemeSwitch } from '../common/theme-switch'
 import { CloseOnNavigation } from './close-on-navigation'
 
-export const MobileMenu: React.FC<{
+export function MobileMenu({
+	main,
+	social,
+}: {
 	main: {
 		caption: string
 		href?: string
@@ -17,7 +20,7 @@ export const MobileMenu: React.FC<{
 		active(pathname: string): boolean
 	}[]
 	social: { caption: string; icon: IconName; href: string }[]
-}> = ({ main, social }) => {
+}) {
 	const pathname = usePathname()
 
 	return (

--- a/apps/docs/components/navigation/social-link.tsx
+++ b/apps/docs/components/navigation/social-link.tsx
@@ -1,11 +1,15 @@
 import { Icon, IconName } from '@/components/common/icon'
 import Link from 'next/link'
 
-export const SocialLink: React.FC<{ caption: string; icon: IconName; href: string }> = ({
+export function SocialLink({
 	caption,
 	icon,
 	href,
-}) => {
+}: {
+	caption: string
+	icon: IconName
+	href: string
+}) {
 	return (
 		<Link href={href} target="_blank" rel="noreferrer">
 			<span className="sr-only">{caption}</span>

--- a/apps/docs/components/search/button.tsx
+++ b/apps/docs/components/search/button.tsx
@@ -11,11 +11,15 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { Search } from '.'
 
-export const SearchButton: React.FC<{
+export function SearchButton({
+	type,
+	layout,
+	className,
+}: {
 	type: 'docs' | 'blog'
 	layout: 'mobile' | 'desktop'
 	className?: string
-}> = ({ type, layout, className }) => {
+}) {
 	const [open, setOpen] = useState(false)
 	const pathname = usePathname()
 

--- a/apps/docs/components/search/hits.tsx
+++ b/apps/docs/components/search/hits.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation'
 import { Fragment } from 'react'
 import { Highlight, useHits } from 'react-instantsearch'
 
-export const Hits = () => {
+export function Hits() {
 	const { items } = useHits()
 	const router = useRouter()
 	let section = ''

--- a/apps/docs/components/search/index.tsx
+++ b/apps/docs/components/search/index.tsx
@@ -12,7 +12,7 @@ const searchClient = algoliasearch(
 	process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_KEY!
 )
 
-export const Search: React.FC<{ type: 'blog' | 'docs' }> = ({ type }) => {
+export function Search({ type }: { type: 'blog' | 'docs' }) {
 	return (
 		<InstantSearch indexName={type} searchClient={searchClient}>
 			<Command

--- a/apps/docs/components/search/input.tsx
+++ b/apps/docs/components/search/input.tsx
@@ -4,7 +4,7 @@ import { Command } from 'cmdk'
 import { useEffect, useState } from 'react'
 import { useSearchBox } from 'react-instantsearch'
 
-export const SearchInput = () => {
+export function SearchInput() {
 	const { refine } = useSearchBox()
 	const [search, setSearch] = useState('')
 

--- a/apps/docs/scripts/submit-newsletter-signup.ts
+++ b/apps/docs/scripts/submit-newsletter-signup.ts
@@ -1,6 +1,6 @@
 'use server'
 
-export const submitNewsletterSignup = async (email: string) => {
+export async function submitNewsletterSignup(email: string) {
 	const res = await fetch('https://api.sendgrid.com/v3/marketing/contacts', {
 		method: 'PUT',
 		headers: {

--- a/apps/docs/utils/cn.ts
+++ b/apps/docs/utils/cn.ts
@@ -1,6 +1,6 @@
 import { ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
-export const cn = (...inputs: ClassValue[]) => {
+export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
 }

--- a/apps/docs/utils/get-all-articles.ts
+++ b/apps/docs/utils/get-all-articles.ts
@@ -1,7 +1,7 @@
 import { getDb } from './ContentDatabase'
 import { replaceMarkdownLinks } from './replace-md-links'
 
-export const getAllArticles = async () => {
+export async function getAllArticles() {
 	const db = await getDb()
 
 	const articles = await db.db.all(

--- a/apps/docs/utils/get-all-paths.ts
+++ b/apps/docs/utils/get-all-paths.ts
@@ -1,6 +1,6 @@
 import { getDb } from './ContentDatabase'
 
-export const getAllPaths = async () => {
+export async function getAllPaths() {
 	const db = await getDb()
 	const articles = await db.db.all(`SELECT path FROM articles`)
 	return articles.map((article) => article.path)

--- a/apps/docs/utils/get-author.ts
+++ b/apps/docs/utils/get-author.ts
@@ -1,5 +1,5 @@
 import authors from '@/content/authors.json'
 
-export const getAuthor = (id: string) => {
+export function getAuthor(id: string) {
 	return authors.find((author) => author.id === id)
 }

--- a/apps/docs/utils/get-page-content.ts
+++ b/apps/docs/utils/get-page-content.ts
@@ -1,14 +1,14 @@
 import { Article, Category, Section } from '@/types/content-types'
 import { getDb } from '@/utils/ContentDatabase'
 
-export const getPageContent = async (
+export async function getPageContent(
 	path: string
 ): Promise<
 	| { type: 'section'; section: Section }
 	| { type: 'category'; category: Category }
 	| { type: 'article'; article: Article }
 	| undefined
-> => {
+> {
 	const db = await getDb()
 
 	const section = await db.db.get(`SELECT * FROM sections WHERE sections.path = ?`, path)

--- a/apps/docs/utils/replace-md-links.ts
+++ b/apps/docs/utils/replace-md-links.ts
@@ -1,4 +1,4 @@
-export const replaceMarkdownLinks = (text: string) => {
+export function replaceMarkdownLinks(text: string) {
 	const links = text.match(/\[.*?\)/g)
 	if (links !== null && links.length > 0) {
 		for (const link of links) {

--- a/apps/docs/utils/search-api.ts
+++ b/apps/docs/utils/search-api.ts
@@ -3,7 +3,9 @@ export const SEARCH_RESULTS = {
 	apiDocs: [],
 	examples: [],
 }
-export const searchBucket = (sectionId: string) =>
-	sectionId === 'examples' ? 'examples' : sectionId === 'reference' ? 'apiDocs' : 'articles'
-export const sectionTypeBucket = (sectionId: string) =>
-	['examples', 'reference'].includes(sectionId) ? sectionId : 'docs'
+export function searchBucket(sectionId: string) {
+	return sectionId === 'examples' ? 'examples' : sectionId === 'reference' ? 'apiDocs' : 'articles'
+}
+export function sectionTypeBucket(sectionId: string) {
+	return ['examples', 'reference'].includes(sectionId) ? sectionId : 'docs'
+}

--- a/apps/dotcom/src/utils/iFrame.ts
+++ b/apps/dotcom/src/utils/iFrame.ts
@@ -1,4 +1,4 @@
-export const isInIframe = () => {
+export function isInIframe() {
 	return typeof window !== 'undefined' && (window !== window.top || window.self !== window.parent)
 }
 

--- a/apps/dotcom/vite.config.ts
+++ b/apps/dotcom/vite.config.ts
@@ -6,7 +6,7 @@ config({
 	path: './.env.local',
 })
 
-export const getMultiplayerServerURL = () => {
+export function getMultiplayerServerURL() {
 	return process.env.MULTIPLAYER_SERVER?.replace(/^ws/, 'http')
 }
 

--- a/apps/huppy/pages/deliveries.tsx
+++ b/apps/huppy/pages/deliveries.tsx
@@ -1,5 +1,5 @@
 import { assert } from '@tldraw/utils'
-import { GetServerSideProps } from 'next'
+import { GetServerSidePropsContext } from 'next'
 import { useEffect, useState } from 'react'
 import { getAppOctokit } from '../src/octokit'
 
@@ -20,7 +20,7 @@ interface Props {
 	cursor: string | null
 }
 
-export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
 	assert(process.env.NODE_ENV !== 'production')
 
 	const gh = getAppOctokit()

--- a/apps/vscode/editor/src/ChangeResponder.tsx
+++ b/apps/vscode/editor/src/ChangeResponder.tsx
@@ -11,7 +11,7 @@ import type { VscodeMessage } from '../../messages'
 import '../public/index.css'
 import { vscode } from './utils/vscode'
 
-export const ChangeResponder = () => {
+export function ChangeResponder() {
 	const editor = useEditor()
 	const { addToast, clearToasts, msg } = useDefaultHelpers()
 

--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -64,7 +64,7 @@ export function WrappedTldrawEditor() {
 	)
 }
 
-export const TldrawWrapper = () => {
+export function TldrawWrapper() {
 	const [tldrawInnerProps, setTldrawInnerProps] = useState<TLDrawInnerProps | null>(null)
 
 	useEffect(() => {

--- a/apps/vscode/extension/src/utils.ts
+++ b/apps/vscode/extension/src/utils.ts
@@ -1,6 +1,6 @@
 const DEBUG_EVENTS = false
 
-export const nicelog = (...args: any[]) => {
+export function nicelog(...args: any[]) {
 	if (process.env.NODE_ENV !== 'production' && DEBUG_EVENTS) {
 		// eslint-disable-next-line no-console
 		console.log(...args)

--- a/packages/state/api-report.md
+++ b/packages/state/api-report.md
@@ -128,7 +128,7 @@ export function isAtom(value: unknown): value is Atom<unknown>;
 export function isSignal(value: any): value is Signal<any>;
 
 // @public
-export const isUninitialized: (value: any) => value is typeof UNINITIALIZED;
+export function isUninitialized(value: any): value is UNINITIALIZED;
 
 // @public
 export function react(name: string, fn: (lastReactedEpoch: number) => any, options?: EffectSchedulerOptions): () => void;

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -40,7 +40,7 @@ export type UNINITIALIZED = typeof UNINITIALIZED
  * @param value - The value to check.
  * @public
  */
-export const isUninitialized = (value: any): value is UNINITIALIZED => {
+export function isUninitialized(value: any): value is UNINITIALIZED {
 	return value === UNINITIALIZED
 }
 

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -36,7 +36,7 @@ export function haveParentsChanged(child: Child) {
  * @param parent The parent to detach from.
  * @param child The child to detach.
  */
-export const detach = (parent: Signal<any>, child: Child) => {
+export function detach(parent: Signal<any>, child: Child) {
 	// If the child is not attached to the parent, do nothing.
 	if (!parent.children.remove(child)) {
 		return
@@ -56,7 +56,7 @@ export const detach = (parent: Signal<any>, child: Child) => {
  * @param parent The parent to attach to.
  * @param child The child to attach.
  */
-export const attach = (parent: Signal<any>, child: Child) => {
+export function attach(parent: Signal<any>, child: Child) {
 	// If the child is already attached to the parent, do nothing.
 	if (!parent.children.add(child)) {
 		return

--- a/packages/store/api-report.md
+++ b/packages/store/api-report.md
@@ -536,13 +536,7 @@ export interface StoreSchemaOptions<R extends UnknownRecord, P> {
     // (undocumented)
     migrations?: MigrationSequence[];
     // (undocumented)
-    onValidationFailure?(data: {
-        error: unknown;
-        phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord';
-        record: R;
-        recordBefore: null | R;
-        store: Store<R>;
-    }): R;
+    onValidationFailure?(data: StoreValidationFailure<R>): R;
 }
 
 // @public
@@ -604,6 +598,20 @@ export interface StoreSnapshot<R extends UnknownRecord> {
     schema: SerializedSchema;
     // (undocumented)
     store: SerializedStore<R>;
+}
+
+// @public (undocumented)
+export interface StoreValidationFailure<R extends UnknownRecord> {
+    // (undocumented)
+    error: unknown;
+    // (undocumented)
+    phase: 'createRecord' | 'initialize' | 'tests' | 'updateRecord';
+    // (undocumented)
+    record: R;
+    // (undocumented)
+    recordBefore: null | R;
+    // (undocumented)
+    store: Store<R>;
 }
 
 // @public (undocumented)

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -31,7 +31,7 @@ export type {
 	StoreValidators,
 } from './lib/Store'
 export { StoreQueries, type RSIndex, type RSIndexDiff, type RSIndexMap } from './lib/StoreQueries'
-export { StoreSchema } from './lib/StoreSchema'
+export { StoreSchema, type StoreValidationFailure } from './lib/StoreSchema'
 export type {
 	SerializedSchema,
 	SerializedSchemaV1,

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -74,16 +74,19 @@ export function upgradeSchema(schema: SerializedSchema): Result<SerializedSchema
 }
 
 /** @public */
+export interface StoreValidationFailure<R extends UnknownRecord> {
+	error: unknown
+	store: Store<R>
+	record: R
+	phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests'
+	recordBefore: R | null
+}
+
+/** @public */
 export interface StoreSchemaOptions<R extends UnknownRecord, P> {
 	migrations?: MigrationSequence[]
 	/** @public */
-	onValidationFailure?(data: {
-		error: unknown
-		store: Store<R>
-		record: R
-		phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests'
-		recordBefore: R | null
-	}): R
+	onValidationFailure?(data: StoreValidationFailure<R>): R
 	/** @internal */
 	createIntegrityChecker?(store: Store<R, P>): void
 }

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -83,7 +83,7 @@ export class DocumentState<R extends UnknownRecord> {
 }
 
 // @internal
-export const getNetworkDiff: <R extends UnknownRecord>(diff: RecordsDiff<R>) => NetworkDiff<R> | null;
+export function getNetworkDiff<R extends UnknownRecord>(diff: RecordsDiff<R>): NetworkDiff<R> | null;
 
 // @internal (undocumented)
 export function getTlsyncProtocolVersion(): number;

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -36,9 +36,9 @@ export interface NetworkDiff<R extends UnknownRecord> {
  *
  *@internal
  */
-export const getNetworkDiff = <R extends UnknownRecord>(
+export function getNetworkDiff<R extends UnknownRecord>(
 	diff: RecordsDiff<R>
-): NetworkDiff<R> | null => {
+): NetworkDiff<R> | null {
 	let res: NetworkDiff<R> | null = null
 
 	for (const [k, v] of objectMapEntries(diff.added)) {

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -129,11 +129,11 @@ export function createBindingValidator<Type extends string, Props extends JsonOb
 }): T.ObjectValidator<Expand<    { [P in T.ExtractRequiredKeys<TLBaseBinding<Type, Props>>]: TLBaseBinding<Type, Props>[P]; } & { [P_1 in T.ExtractOptionalKeys<TLBaseBinding<Type, Props>>]?: TLBaseBinding<Type, Props>[P_1] | undefined; }>>;
 
 // @public
-export const createPresenceStateDerivation: ($user: Signal<{
+export function createPresenceStateDerivation($user: Signal<{
     color: string;
     id: string;
     name: string;
-}>, instanceId?: TLInstancePresence['id']) => (store: TLStore) => Signal<null | TLInstancePresence>;
+}>, instanceId?: TLInstancePresence['id']): (store: TLStore) => Signal<null | TLInstancePresence>;
 
 // @public (undocumented)
 export function createShapeId(id?: string): TLShapeId;
@@ -501,7 +501,7 @@ export const PageRecordType: RecordType<TLPage, "index" | "name">;
 export const parentIdValidator: T.Validator<TLParentId>;
 
 // @internal (undocumented)
-export const pluckPreservingValues: (val?: null | TLInstance) => null | Partial<TLInstance>;
+export function pluckPreservingValues(val?: null | TLInstance): null | Partial<TLInstance>;
 
 // @public (undocumented)
 export const PointerRecordType: RecordType<TLPointer, never>;

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -3,8 +3,8 @@ import {
 	SerializedStore,
 	Store,
 	StoreSchema,
-	StoreSchemaOptions,
 	StoreSnapshot,
+	StoreValidationFailure,
 } from '@tldraw/store'
 import { IndexKey, annotateError, structuredClone } from '@tldraw/utils'
 import { TLAsset } from './records/TLAsset'
@@ -108,10 +108,12 @@ export interface TLStoreProps {
 export type TLStore = Store<TLRecord, TLStoreProps>
 
 /** @public */
-export const onValidationFailure: StoreSchemaOptions<
-	TLRecord,
-	TLStoreProps
->['onValidationFailure'] = ({ error, phase, record, recordBefore }): TLRecord => {
+export function onValidationFailure({
+	error,
+	phase,
+	record,
+	recordBefore,
+}: StoreValidationFailure<TLRecord>): TLRecord {
 	const isExistingValidationIssue =
 		// if we're initializing the store for the first time, we should
 		// allow invalid records so people can load old buggy data:

--- a/packages/tlschema/src/createPresenceStateDerivation.ts
+++ b/packages/tlschema/src/createPresenceStateDerivation.ts
@@ -10,12 +10,11 @@ import { InstancePresenceRecordType, TLInstancePresence } from './records/TLPres
  * Creates a derivation that represents the current presence state of the current user.
  * @public
  */
-export const createPresenceStateDerivation =
-	(
-		$user: Signal<{ id: string; color: string; name: string }>,
-		instanceId?: TLInstancePresence['id']
-	) =>
-	(store: TLStore): Signal<TLInstancePresence | null> => {
+export function createPresenceStateDerivation(
+	$user: Signal<{ id: string; color: string; name: string }>,
+	instanceId?: TLInstancePresence['id']
+) {
+	return (store: TLStore): Signal<TLInstancePresence | null> => {
 		return computed('instancePresence', () => {
 			const instance = store.get(TLINSTANCE_ID)
 			const pageState = store.get(InstancePageStateRecordType.createId(instance?.currentPageId))
@@ -54,3 +53,4 @@ export const createPresenceStateDerivation =
 			})
 		})
 	}
+}

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -109,12 +109,13 @@ export const shouldKeyBePreservedBetweenSessions = {
 } as const satisfies { [K in keyof TLInstance]: boolean }
 
 /** @internal */
-export const pluckPreservingValues = (val?: TLInstance | null): null | Partial<TLInstance> =>
-	val
+export function pluckPreservingValues(val?: TLInstance | null): null | Partial<TLInstance> {
+	return val
 		? (filterEntries(val, (key) => {
 				return shouldKeyBePreservedBetweenSessions[key as keyof TLInstance]
 			}) as Partial<TLInstance>)
 		: null
+}
 
 /** @public */
 export type TLInstanceId = RecordId<TLInstance>


### PR DESCRIPTION
`const doSomething = () => {...}` won't produce as nice documentation as `function doSomething() {}`. This diff enforces function declaration style when function are written in export position.

### Change type

- [x] `other`
