### PR TITLE
File save warning

### DIFF
--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -1,5 +1,5 @@
 import { getLicenseKey } from '@tldraw/dotcom-shared'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import {
 	DefaultDebugMenu,
 	DefaultDebugMenuContent,
@@ -13,9 +13,20 @@ import {
 	PreferencesGroup,
 	TLComponents,
 	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiDialogBody,
+	TldrawUiDialogCloseButton,
+	TldrawUiDialogFooter,
+	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
 	TldrawUiMenuActionItem,
 	TldrawUiMenuGroup,
 	ViewSubmenu,
+	getFromLocalStorage,
+	setInLocalStorage,
+	useDialogs,
+	useEditor,
 } from 'tldraw'
 import { assetUrls } from '../utils/assetUrls'
 import { createAssetFromUrl } from '../utils/createAssetFromUrl'
@@ -100,7 +111,69 @@ export function LocalEditor() {
 				<LocalMigration />
 				<SneakyOnDropOverride isMultiplayer={false} />
 				<ThemeUpdater />
+				<SneakyLocalSaveWarning />
 			</Tldraw>
 		</div>
 	)
+}
+
+function SneakyLocalSaveWarning() {
+	const editor = useEditor()
+	const { addDialog } = useDialogs()
+
+	useEffect(() => {
+		const hasConfirmedLocalSave = getFromLocalStorage('local save warning dismissed 1')
+
+		console.log(editor.store.allRecords().length)
+		if (hasConfirmedLocalSave) return
+		if (editor.store.allRecords().length > 500) {
+			// tell the user to save to the cloud or to desktop
+
+			addDialog({
+				component: ({ onClose }) => (
+					<>
+						<TldrawUiDialogHeader>
+							<TldrawUiDialogTitle>
+								<b>{`Don't forget to save!`}</b>
+							</TldrawUiDialogTitle>
+							<TldrawUiDialogCloseButton />
+						</TldrawUiDialogHeader>
+						<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+							<p>
+								Did you know that your tldraw project is being saved to your own computer? This
+								means that if you clear your browser cache, you will also lose your project here.
+							</p>
+							<p>To keep things safe, you can either:</p>
+							<ol>
+								<li>
+									Save your project as a .tldr file. From the Menu, choose <b>File</b> {`>`}{' '}
+									<b>Save a copy</b>. You can open it back up again later with <b>File</b> {`>`}{' '}
+									<b>Open file</b>.
+								</li>
+								<li>
+									Share your project by clicking the <b>Share</b> button at the top right of your
+									screen. Shared projects are hosted on the cloud for free. Just be sure to bookmark
+									the new hosted project so that you can come back to it later.
+								</li>
+							</ol>
+							<p>
+								Have fun with tldraw! Have questions?{' '}
+								<a href="https://discord.gg/rhsyWMUJxd">Ask here!</a>
+							</p>
+						</TldrawUiDialogBody>
+						<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+							<TldrawUiButton type="primary" onClick={() => onClose()}>
+								<TldrawUiButtonLabel>Got it!</TldrawUiButtonLabel>
+							</TldrawUiButton>
+						</TldrawUiDialogFooter>
+					</>
+				),
+				onClose() {
+					setInLocalStorage('local save warning dismissed', 'true')
+				},
+			})
+		}
+	}, [editor, addDialog])
+
+	return null
 }

--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -126,7 +126,7 @@ function SneakyLocalSaveWarning() {
 
 		if (hasConfirmedLocalSave) return
 
-		if (editor.store.allRecords().length > 500) {
+		if (editor.store.allRecords().length > 128) {
 			// tell the user to save to the cloud or to desktop
 
 			addDialog({

--- a/apps/dotcom/src/components/LocalEditor.tsx
+++ b/apps/dotcom/src/components/LocalEditor.tsx
@@ -124,8 +124,8 @@ function SneakyLocalSaveWarning() {
 	useEffect(() => {
 		const hasConfirmedLocalSave = getFromLocalStorage('local save warning dismissed 1')
 
-		console.log(editor.store.allRecords().length)
 		if (hasConfirmedLocalSave) return
+
 		if (editor.store.allRecords().length > 500) {
 			// tell the user to save to the cloud or to desktop
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -806,6 +806,20 @@
 	color: var(--color-text-1);
 	user-select: all;
 	-webkit-user-select: text;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-4);
+}
+.tlui-dialog__body a {
+	color: var(--color-selected);
+}
+
+.tlui-dialog__body ul,
+.tlui-dialog__body ol {
+	padding-left: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-4);
 }
 
 .tlui-dialog__footer {


### PR DESCRIPTION
This PR adds a one-time warning about files in tldraw. It's only shown when the user loads a project with >500 records in the store. Hopefully this cuts down on the number of people who accidentally delete their local project. It is only shown once and will be dismissed once closed.

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/c6cac01d-34e3-4b70-a0d6-a4dfcbbdc56d">

We could also pair this with a "local" chip in the top zone that pops up a screen like this.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Adds save warning.