### PR TITLE
Fix escape bug

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -111,13 +111,15 @@ export function useDocumentEvents() {
 					// should we allow escape to do its normal thing.
 
 					if (editor.getEditingShape() || editor.getSelectedShapeIds().length > 0) {
-						e.preventDefault()
+						preventDefault(e)
 					}
 
 					// Don't do anything if we open menus open
 					if (editor.getOpenMenus().length > 0) return
 
-					if (!editor.inputs.keys.has('Escape')) {
+					if (editor.inputs.keys.has('Escape')) {
+						// noop
+					} else {
 						editor.inputs.keys.add('Escape')
 
 						editor.cancel()
@@ -126,7 +128,7 @@ export function useDocumentEvents() {
 						// will break additional shortcuts. We need to
 						// refocus the container in order to keep these
 						// shortcuts working.
-						editor.focus()
+						container.focus()
 					}
 					return
 				}

--- a/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
@@ -1,5 +1,12 @@
 import * as Popover from '@radix-ui/react-popover'
-import { track, useContainer, useEditor, usePeerIds, useValue } from '@tldraw/editor'
+import {
+	preventDefault,
+	track,
+	useContainer,
+	useEditor,
+	usePeerIds,
+	useValue,
+} from '@tldraw/editor'
 import { ReactNode } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -54,7 +61,7 @@ export const PeopleMenu = track(function PeopleMenu({ children }: PeopleMenuProp
 					side="bottom"
 					sideOffset={2}
 					alignOffset={-5}
-					onEscapeKeyDown={(e) => e.preventDefault()}
+					onEscapeKeyDown={preventDefault}
 				>
 					<div className="tlui-people-menu__wrapper">
 						<div className="tlui-people-menu__section">


### PR DESCRIPTION
The editor was already "focused", so it wasn't refocusing the container. The container needed to be focused.

To reproduce: create a text shape, press escape, press enter to re-edit, press escape to blur again.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
