### PR TITLE
seo: add canonical url for rooms

### DIFF
--- a/apps/dotcom/src/components/Head/CanonicalUrl.tsx
+++ b/apps/dotcom/src/components/Head/CanonicalUrl.tsx
@@ -1,0 +1,12 @@
+import { Helmet } from 'react-helmet-async'
+import { useLocation } from 'react-router-dom'
+
+export function CanonicalUrl() {
+	const location = useLocation()
+
+	return (
+		<Helmet>
+			<link rel="canonical" href={`${window.location.origin}${location.pathname}`} />
+		</Helmet>
+	)
+}

--- a/apps/dotcom/src/pages/public-multiplayer.tsx
+++ b/apps/dotcom/src/pages/public-multiplayer.tsx
@@ -1,6 +1,7 @@
 import { ROOM_OPEN_MODE } from '@tldraw/dotcom-shared'
 import { useParams } from 'react-router-dom'
 import '../../styles/globals.css'
+import { CanonicalUrl } from '../components/Head/CanonicalUrl'
 import { IFrameProtector, ROOM_CONTEXT } from '../components/IFrameProtector'
 import { MultiplayerEditor } from '../components/MultiplayerEditor'
 
@@ -8,6 +9,7 @@ export function Component() {
 	const id = useParams()['roomId'] as string
 	return (
 		<IFrameProtector slug={id} context={ROOM_CONTEXT.PUBLIC_MULTIPLAYER}>
+			<CanonicalUrl />
 			<MultiplayerEditor roomOpenMode={ROOM_OPEN_MODE.READ_WRITE} roomSlug={id} />
 		</IFrameProtector>
 	)

--- a/apps/dotcom/src/pages/public-readonly-legacy.tsx
+++ b/apps/dotcom/src/pages/public-readonly-legacy.tsx
@@ -1,6 +1,7 @@
 import { ROOM_OPEN_MODE } from '@tldraw/dotcom-shared'
 import { useParams } from 'react-router-dom'
 import '../../styles/globals.css'
+import { CanonicalUrl } from '../components/Head/CanonicalUrl'
 import { IFrameProtector, ROOM_CONTEXT } from '../components/IFrameProtector'
 import { MultiplayerEditor } from '../components/MultiplayerEditor'
 
@@ -8,6 +9,7 @@ export function Component() {
 	const id = useParams()['roomId'] as string
 	return (
 		<IFrameProtector slug={id} context={ROOM_CONTEXT.PUBLIC_READONLY}>
+			<CanonicalUrl />
 			<MultiplayerEditor roomOpenMode={ROOM_OPEN_MODE.READ_ONLY_LEGACY} roomSlug={id} />
 		</IFrameProtector>
 	)

--- a/apps/dotcom/src/pages/public-readonly.tsx
+++ b/apps/dotcom/src/pages/public-readonly.tsx
@@ -1,6 +1,7 @@
 import { ROOM_OPEN_MODE } from '@tldraw/dotcom-shared'
 import { useParams } from 'react-router-dom'
 import '../../styles/globals.css'
+import { CanonicalUrl } from '../components/Head/CanonicalUrl'
 import { IFrameProtector, ROOM_CONTEXT } from '../components/IFrameProtector'
 import { MultiplayerEditor } from '../components/MultiplayerEditor'
 
@@ -8,6 +9,7 @@ export function Component() {
 	const id = useParams()['roomId'] as string
 	return (
 		<IFrameProtector slug={id} context={ROOM_CONTEXT.PUBLIC_READONLY}>
+			<CanonicalUrl />
 			<MultiplayerEditor roomOpenMode={ROOM_OPEN_MODE.READ_ONLY} roomSlug={id} />
 		</IFrameProtector>
 	)

--- a/apps/dotcom/src/pages/public-snapshot.tsx
+++ b/apps/dotcom/src/pages/public-snapshot.tsx
@@ -1,5 +1,6 @@
 import { SerializedSchema, TLRecord, fetch } from 'tldraw'
 import '../../styles/globals.css'
+import { CanonicalUrl } from '../components/Head/CanonicalUrl'
 import { IFrameProtector, ROOM_CONTEXT } from '../components/IFrameProtector'
 import { SnapshotsEditor } from '../components/SnapshotsEditor'
 import { defineLoader } from '../utils/defineLoader'
@@ -25,6 +26,7 @@ export function Component() {
 	const { roomId, records, schema } = result
 	return (
 		<IFrameProtector slug={roomId} context={ROOM_CONTEXT.PUBLIC_SNAPSHOT}>
+			<CanonicalUrl />
 			<SnapshotsEditor records={records} schema={schema} />
 		</IFrameProtector>
 	)


### PR DESCRIPTION
I need to test this with the Google Search tool but I believe this should consolidate URLs for googlebot. It happens after page load, not on server side, but I think it should still work. 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
