### PR TITLE
[docs] tighten up header whitespace on desktop

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -29,21 +29,21 @@ export default async function Page({ params }: { params: { slug: string | string
 	if (!content || content.type !== 'article') notFound()
 
 	return (
-		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-16 isolate">
+		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-8 isolate">
 			<DocsSidebar
 				sectionId={content.article.sectionId}
 				categoryId={content.article.categoryId}
 				articleId={content.article.id}
 			/>
-			<div className="fixed w-full h-12 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between px-5 bg-white dark:bg-zinc-950 backdrop-blur md:hidden z-10">
+			<div className="fixed z-10 flex items-center justify-between w-full h-12 px-5 bg-white border-b border-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 backdrop-blur md:hidden">
 				<DocsMobileSidebar
 					sectionId={content.article.sectionId}
 					categoryId={content.article.categoryId}
 					articleId={content.article.id}
 				/>
-				<SearchButton type="docs" layout="mobile" className="hidden sm:block -mr-2" />
+				<SearchButton type="docs" layout="mobile" className="hidden -mr-2 sm:block" />
 			</div>
-			<main className="relative shrink w-full max-w-3xl px-5 md:pr-0 lg:pl-12 xl:pr-12 pt-24 md:pt-0">
+			<main className="relative w-full max-w-3xl px-5 pt-24 shrink md:pr-0 lg:pl-12 xl:pr-12 md:pt-0">
 				<DocsHeader article={content.article} />
 				<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />
 				{content.article.sectionId === 'examples' && <Example article={content.article} />}

--- a/apps/docs/app/legal/[slug]/page.tsx
+++ b/apps/docs/app/legal/[slug]/page.tsx
@@ -23,8 +23,8 @@ export default async function Page({ params }: { params: { slug: string | string
 	if (!content || content.type !== 'article' || content.article.sectionId !== 'legal') notFound()
 
 	return (
-		<main className="w-full max-w-3xl mx-auto px-5 md:pr-0 lg:pl-12 xl:pr-12 py-24 md:pt-16">
-			<div className="pb-6 mb-6 md:mb-12 md:pb-12 border-b border-zinc-100 dark:border-zinc-800">
+		<main className="w-full max-w-3xl px-5 py-24 mx-auto md:pr-0 lg:pl-12 xl:pr-12 md:pt-8">
+			<div className="pb-6 mb-6 border-b md:mb-12 md:pb-12 border-zinc-100 dark:border-zinc-800">
 				<PageTitle className="text-center">{content.article.title}</PageTitle>
 			</div>
 			<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />

--- a/apps/docs/components/blog/blog-category-page.tsx
+++ b/apps/docs/components/blog/blog-category-page.tsx
@@ -19,20 +19,20 @@ export function BlogCategoryPage({
 	articles: Article[]
 }) {
 	return (
-		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-16 isolate">
+		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-8 isolate">
 			<BlogSidebar>
 				<NewsletterSignup size="small" />
 			</BlogSidebar>
-			<div className="fixed w-full h-12 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between px-5 bg-white dark:bg-zinc-950 backdrop-blur md:hidden z-10">
+			<div className="fixed z-10 flex items-center justify-between w-full h-12 px-5 bg-white border-b border-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 backdrop-blur md:hidden">
 				<BlogMobileSidebar />
-				<SearchButton type="blog" layout="mobile" className="hidden sm:block -mr-2" />
+				<SearchButton type="blog" layout="mobile" className="hidden -mr-2 sm:block" />
 			</div>
-			<main className="relative shrink w-full md:overflow-x-hidden px-5 md:pr-0 lg:pl-12 py-24 md:pt-0">
-				<section className="pb-6 mb-6 md:mb-12 md:pb-12 border-b border-zinc-100 dark:border-zinc-800">
+			<main className="relative w-full px-5 py-24 shrink md:overflow-x-hidden md:pr-0 lg:pl-12 md:pt-0">
+				<section className="pb-6 mb-6 border-b md:mb-8 md:pb-8 border-zinc-100 dark:border-zinc-800">
 					<Breadcrumbs section={section} className="mb-2" />
 					<PageTitle>{title}</PageTitle>
 					{description && (
-						<p className="mt-4 text-zinc-800 dark:text-zinc-200 text-lg max-w-2xl">{description}</p>
+						<p className="max-w-2xl mt-4 text-lg text-zinc-800 dark:text-zinc-200">{description}</p>
 					)}
 				</section>
 				<section className="space-y-12">
@@ -42,7 +42,7 @@ export function BlogCategoryPage({
 							<BlogPostPreview key={index} article={article} />
 						))}
 				</section>
-				<section className="mt-16 py-16 border-t border-zinc-100 dark:border-zinc-800">
+				<section className="py-16 mt-16 border-t border-zinc-100 dark:border-zinc-800">
 					<NewsletterSignup />
 				</section>
 			</main>

--- a/apps/docs/components/blog/blog-post-header.tsx
+++ b/apps/docs/components/blog/blog-post-header.tsx
@@ -12,13 +12,13 @@ export async function BlogPostHeader({ article }: { article: Article }) {
 	const section = await db.getSection(article.sectionId)
 
 	return (
-		<section className="pb-6 mb-6 md:mb-12 md:pb-12 border-b border-zinc-100 dark:border-zinc-800">
+		<section className="pb-6 mb-6 border-b md:mb-8 md:pb-8 border-zinc-100 dark:border-zinc-800">
 			<Breadcrumbs section={section} category={category} className="mb-2" />
 			<PageTitle>{article.title}</PageTitle>
-			<p className="mt-4 text-zinc-800 dark:text-zinc-200 md:text-lg max-w-2xl">
+			<p className="max-w-2xl mt-4 text-zinc-800 dark:text-zinc-200 md:text-lg">
 				{article.description}
 			</p>
-			<div className="text-sm mt-4 mb-8 flex flex-col sm:flex-row gap-y-2 justify-between">
+			<div className="flex flex-col justify-between mt-4 mb-8 text-sm sm:flex-row gap-y-2">
 				<span>{format(new Date(article.date ?? new Date()), 'MMMM dd, yyyy')}</span>
 				<ShareButton url={`https://tldraw.dev${article.path}`} size="base" />
 			</div>

--- a/apps/docs/components/blog/blog-post-page.tsx
+++ b/apps/docs/components/blog/blog-post-page.tsx
@@ -8,17 +8,17 @@ import { NewsletterSignup } from '../common/newsletter-signup'
 
 export function BlogPostPage({ article }: { article: Article }) {
 	return (
-		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-16 isolate">
+		<div className="w-full max-w-screen-xl mx-auto md:px-5 md:flex md:pt-8 isolate">
 			<BlogSidebar>
 				<NewsletterSignup size="small" />
 			</BlogSidebar>
-			<div className="fixed w-full h-12 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between px-5 bg-white dark:bg-zinc-950 backdrop-blur md:hidden z-10">
+			<div className="fixed z-10 flex items-center justify-between w-full h-12 px-5 bg-white border-b border-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 backdrop-blur md:hidden">
 				<BlogMobileSidebar />
 			</div>
-			<main className="relative shrink w-full md:overflow-x-hidden px-5 md:pr-0 lg:pl-12 xl:pr-12 py-24 md:pt-0">
+			<main className="relative w-full px-5 py-24 shrink md:overflow-x-hidden md:pr-0 lg:pl-12 xl:pr-12 md:pt-0">
 				<BlogPostHeader article={article} />
 				<Content mdx={article.content ?? ''} type={article.sectionId} />
-				<section className="mt-16 py-16 border-t border-zinc-100">
+				<section className="py-16 mt-16 border-t border-zinc-100">
 					<NewsletterSignup />
 				</section>
 			</main>

--- a/apps/docs/components/docs/docs-header.tsx
+++ b/apps/docs/components/docs/docs-header.tsx
@@ -14,7 +14,7 @@ export async function DocsHeader({ article }: { article: Article }) {
 			className={cn(
 				article.sectionId === 'reference'
 					? ''
-					: 'pb-6 mb-6 md:mb-12 md:pb-12 border-b border-zinc-100 dark:border-zinc-800'
+					: 'pb-6 mb-6 md:mb-8 md:pb-8 border-b border-zinc-100 dark:border-zinc-800'
 			)}
 		>
 			<Breadcrumbs section={section} category={category} className="mb-2" />


### PR DESCRIPTION
before

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/008ec518-3485-4d09-a442-41eefbe002e4">


after

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/0103d365-1128-4245-86a0-68a17b833d6f">


- [x] `other`
