### PR TITLE
docs: revert to system monospace font for code

### DIFF
--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -6,7 +6,9 @@ module.exports = {
 		extend: {
 			fontFamily: {
 				sans: ['var(--font-geist-sans)'],
-				mono: ['var(--font-geist-mono)'],
+				mono: [
+					'"Fira Mono", "DejaVu Sans Mono", Menlo, Consolas, "Liberation Mono", Monaco, "Lucida Console", monospace',
+				],
 				hand: ['var(--font-shantell-sans)'],
 			},
 		},


### PR DESCRIPTION
revert back to what we had before, i would agree that the original font is slightly more readable than the Geist Mono.
@steveruizok you probably have an opinion here :)

Before
<img width="718" alt="Screenshot 2024-09-10 at 18 08 45" src="https://github.com/user-attachments/assets/498dd8c2-4ddd-47b6-8347-6abc7ce1aca4">


After
<img width="671" alt="Screenshot 2024-09-10 at 18 09 21" src="https://github.com/user-attachments/assets/05eab605-d4db-4bd7-93e5-cbaf689ff281">


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
