### PR TITLE
[docs] better icon for 'Reference' nav item

### DIFF
--- a/apps/docs/components/docs/docs-category-menu.tsx
+++ b/apps/docs/components/docs/docs-category-menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { NavigationLink } from '@/components/navigation/link'
-import { AcademicCapIcon, BookOpenIcon, PlayIcon } from '@heroicons/react/20/solid'
+import { AcademicCapIcon, CommandLineIcon, PlayIcon } from '@heroicons/react/20/solid'
 import { usePathname } from 'next/navigation'
 
 const categoryLinks = [
@@ -16,7 +16,7 @@ const categoryLinks = [
 	},
 	{
 		caption: 'Reference',
-		icon: BookOpenIcon,
+		icon: CommandLineIcon,
 		href: '/reference/editor/Editor',
 		active: (pathname: string) => pathname.startsWith('/reference'),
 	},
@@ -31,7 +31,7 @@ const categoryLinks = [
 export function DocsCategoryMenu() {
 	const pathname = usePathname()
 	return (
-		<ul className="shrink-0 flex flex-col gap-3">
+		<ul className="flex flex-col gap-3 shrink-0">
 			{categoryLinks.map((item, index) => (
 				<li key={index}>
 					<NavigationLink {...item} active={item.active(pathname)} />


### PR DESCRIPTION
This looked a bit too much like play/pause in a media player.

Before
<img width="220" alt="image" src="https://github.com/user-attachments/assets/9eac3bf4-4fa6-4228-a20f-c7b3d218ac15">

After
<img width="185" alt="image" src="https://github.com/user-attachments/assets/1491fca7-4049-4958-ada3-9c01a5e0a3d7">


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
