### PR TITLE
[docs] remove useless subheadings

### DIFF
--- a/apps/docs/components/marketing/cta-section.tsx
+++ b/apps/docs/components/marketing/cta-section.tsx
@@ -6,16 +6,15 @@ export function CTASection() {
 	return (
 		<Section className="pb-24 md:pb-32 lg:pb-40">
 			<SectionHeading
-				subheading="Get Started"
 				heading="Get started today"
 				description="Follow our quick start guide and build something today with the tldraw SDK."
 			/>
-			{/* <div className="flex items-center gap-3 justify-center -mt-6 mb-12">
+			{/* <div className="flex items-center justify-center gap-3 mb-12 -mt-6">
                 <ul className="flex">
                     {avatars.map((avatar, index) => (
                         <li
                             key={index}
-                            className="relative size-8 sm:size-10 border-2 border-white rounded-full overflow-hidden -ml-2 first-of-type:ml-0"
+                            className="relative -ml-2 overflow-hidden border-2 border-white rounded-full size-8 sm:size-10 first-of-type:ml-0"
                         >
                             <Image
                                 src={avatar}
@@ -26,8 +25,8 @@ export function CTASection() {
                         </li>
                     ))}
                 </ul>
-                <div className="max-w-32 leading-tight text-xs sm:max-w-40 sm:text-sm sm:leading-tight">
-                    Loved by <span className="text-black font-semibold">5000+</span> developers and users.
+                <div className="text-xs leading-tight max-w-32 sm:max-w-40 sm:text-sm sm:leading-tight">
+                    Loved by <span className="font-semibold text-black">5000+</span> developers and users.
                 </div>
             </div> */}
 			<div className="flex flex-col items-center justify-center gap-4 -mt-4">

--- a/apps/docs/components/marketing/installation-section.tsx
+++ b/apps/docs/components/marketing/installation-section.tsx
@@ -7,13 +7,12 @@ export function InstallationSection() {
 	return (
 		<Section>
 			<SectionHeading
-				subheading="Features"
 				heading="Installation"
 				description="Install the tldraw package, import the styles, and render the component in your React app."
 			/>
-			<div className="flex flex-col items-center gap-8 mt-8 md:max-w-2xl mx-auto">
-				<CodeFiles files={[code.terminal]} hideTabs className="my-0 w-full" />
-				<CodeFiles files={[code.app]} className="my-0 w-full" />
+			<div className="flex flex-col items-center gap-8 mx-auto mt-8 md:max-w-2xl">
+				<CodeFiles files={[code.terminal]} hideTabs className="w-full my-0" />
+				<CodeFiles files={[code.app]} className="w-full my-0" />
 				<Button href="/quick-start" caption="Read our Quick Start guide" />
 			</div>
 		</Section>


### PR DESCRIPTION
Removes two of the subheadings on the landing page

Before
<img width="845" alt="image" src="https://github.com/user-attachments/assets/94d18f16-b6aa-46b3-ba8c-727ffc49e057">

After
<img width="814" alt="image" src="https://github.com/user-attachments/assets/c245f89c-d6f2-41a8-bdf8-3cbdd1b95fd6">

Before
<img width="563" alt="image" src="https://github.com/user-attachments/assets/909eebd6-408c-4874-bccc-0b3d076d8397">


After

<img width="499" alt="image" src="https://github.com/user-attachments/assets/ca740670-5425-4e7b-80ec-724ab456d70d">


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

closes INT-279