### PR TITLE
Make docs site like 69x faster

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -30,6 +30,14 @@ export async function generateMetadata({
 	return metadata
 }
 
+const nonDocsPaths = ['/blog/', '/legal/']
+export async function generateStaticParams() {
+	const paths = await db.getAllPaths()
+	return paths
+		.filter((path) => !nonDocsPaths.some((nonDocsPath) => path.startsWith(nonDocsPath)))
+		.map((path) => ({ slug: path.slice(1).split('/') }))
+}
+
 export default async function Page({ params }: { params: { slug: string | string[] } }) {
 	const path = typeof params.slug === 'string' ? [params.slug] : params.slug
 	const content = await db.getPageContent(`/${path.join('/')}`)


### PR DESCRIPTION
Right now, we render the entire docs site dynamically for each request. It's really slow! This is what the timing waterfall looks like for just fetching the initial HTML of the editor reference page:
<img width="893" alt="Screenshot 2024-09-11 at 12 03 12" src="https://github.com/user-attachments/assets/2d200691-13f8-4f2b-9548-73a3b6131c30">

We don't need to do this, as the content is completely static and never changes between deploys. This diff uses `generateStaticParams` to make sure next pre-renders all of our content. Now, the waterfall graph looks like this:
<img width="890" alt="Screenshot 2024-09-11 at 12 03 21" src="https://github.com/user-attachments/assets/8c7f5837-9d6a-470d-9988-9f5ce11bd9f2">

8.37s -> 121ms is a speed up of about 69x. Nice!

### Change type

- [x] `other`
