### PR TITLE
Fix parsing of older tldraw v2 documents

### DIFF
--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -93,6 +93,20 @@ export type TldrawFileParseError =
 	| { type: 'migrationFailed'; reason: MigrationFailureReason }
 	| { type: 'invalidRecords'; cause: unknown }
 
+function parseAndRemoveOldRecordTypes(json: string) {
+	const document = JSON.parse(json)
+	const recordTypesToRemove = ['user', 'user_presence', 'user_document']
+	if (document.records) {
+		document.records = document.records.filter((record: any) => {
+			if (record && recordTypesToRemove.includes(record.typeName)) {
+				return false
+			}
+			return true
+		})
+	}
+	return document
+}
+
 /** @public */
 export function parseTldrawJsonFile({
 	json,
@@ -105,7 +119,8 @@ export function parseTldrawJsonFile({
 	// a tldraw file
 	let data
 	try {
-		data = tldrawFileValidator.validate(JSON.parse(json))
+		const document = parseAndRemoveOldRecordTypes(json)
+		data = tldrawFileValidator.validate(document)
 	} catch (e) {
 		// could be a v1 file!
 		try {


### PR DESCRIPTION
Parsing of some old files failed due to some record types that are no longer present in our store. 

See PRs that removed them: https://github.com/tldraw/tldraw/pull/1493/ ([user_document](https://github.com/tldraw/tldraw/pull/1493/files#diff-4a4bcc8b6ed0eb5c124a153c3d6e4de7a467ebc0a4d65ff4b18c74dd54fb3dd8R55)) and https://github.com/tldraw/tldraw/pull/1435/ ([user and user_presence](https://github.com/tldraw/tldraw/pull/1435/files#diff-901095d4d90bdb975afedd77a3b456547bb365634d99460d5a1b74d20955ee14R42)).

We could also migrate the records (just like we do a bit lower), but I guess we can't be certain if we even have a v2 document at this point 🤷‍♂️ 

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix a but with opening older v2 tldraw files.