### PR TITLE
Add center option to rotateShapesBy

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -95,7 +95,8 @@ import { whyAmIRunning } from '@tldraw/state';
 export function angleDistance(fromAngle: number, toAngle: number, direction: number): number;
 
 // @internal (undocumented)
-export function applyRotationToSnapshotShapes({ delta, editor, snapshot, stage, }: {
+export function applyRotationToSnapshotShapes({ delta, editor, snapshot, stage, centerOverride, }: {
+    centerOverride?: VecLike;
     delta: number;
     editor: Editor;
     snapshot: TLRotationSnapshot;
@@ -1162,7 +1163,9 @@ export class Editor extends EventEmitter<TLEventMap> {
         shouldResolveToOriginal?: boolean;
     }): Promise<null | string>;
     readonly root: StateNode;
-    rotateShapesBy(shapes: TLShape[] | TLShapeId[], delta: number): this;
+    rotateShapesBy(shapes: TLShape[] | TLShapeId[], delta: number, opts?: {
+        center?: VecLike;
+    }): this;
     run(fn: () => void, opts?: TLEditorRunOptions): this;
     screenToPage(point: VecLike): Vec;
     readonly scribbles: ScribbleManager;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5603,7 +5603,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @param shapes - The shapes (or shape ids) of the shapes to move.
 	 * @param delta - The delta in radians to apply to the selection rotation.
 	 */
-	rotateShapesBy(shapes: TLShapeId[] | TLShape[], delta: number): this {
+	rotateShapesBy(
+		shapes: TLShapeId[] | TLShape[],
+		delta: number,
+		opts?: { center?: VecLike }
+	): this {
 		const ids =
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
@@ -5613,7 +5617,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const snapshot = getRotationSnapshot({ editor: this, ids })
 		if (!snapshot) return this
-		applyRotationToSnapshotShapes({ delta, snapshot, editor: this, stage: 'one-off' })
+		applyRotationToSnapshotShapes({
+			delta,
+			snapshot,
+			editor: this,
+			stage: 'one-off',
+			centerOverride: opts?.center,
+		})
 
 		return this
 	}

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -3,7 +3,7 @@ import { compact } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 import { Mat } from '../primitives/Mat'
 import { canonicalizeRotation } from '../primitives/utils'
-import { Vec } from '../primitives/Vec'
+import { Vec, VecLike } from '../primitives/Vec'
 
 /** @internal */
 export function getRotationSnapshot({
@@ -58,11 +58,13 @@ export function applyRotationToSnapshotShapes({
 	editor,
 	snapshot,
 	stage,
+	centerOverride,
 }: {
 	delta: number
 	snapshot: TLRotationSnapshot
 	editor: Editor
 	stage: 'start' | 'update' | 'end' | 'one-off'
+	centerOverride?: VecLike
 }) {
 	const { pageCenter, shapeSnapshots } = snapshot
 
@@ -75,7 +77,7 @@ export function applyRotationToSnapshotShapes({
 				? editor.getShapePageTransform(shape.parentId)!
 				: Mat.Identity()
 
-			const newPagePoint = Vec.RotWith(initialPagePoint, pageCenter, delta)
+			const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? pageCenter, delta)
 
 			const newLocalPoint = Mat.applyToPoint(
 				// use the current parent transform in case it has moved/resized since the start

--- a/packages/tldraw/src/test/commands/rotateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/rotateShapes.test.ts
@@ -114,4 +114,18 @@ describe('editor.rotateShapesBy', () => {
 			.expectShapeToMatch({ id: ids.box1, rotation: Math.PI })
 			.expectShapeToMatch({ id: ids.box2, rotation: Math.PI / 2 })
 	})
+
+	it('allows to customize the rotation center', () => {
+		editor.select(ids.box1, ids.box2)
+
+		editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI, { center: { x: 0, y: 0 } })
+
+		editor
+			.expectShapeToMatch({ id: ids.box1, rotation: Math.PI })
+			.expectShapeToMatch({ id: ids.box2, rotation: Math.PI })
+
+		// Are the centers the same?
+		expect(editor.getShapePageBounds(ids.box1)).toCloselyMatchObject({ x: -110, y: -110 })
+		expect(editor.getShapePageBounds(ids.box2)).toCloselyMatchObject({ x: -300, y: -300 })
+	})
 })


### PR DESCRIPTION
rotateShapesBy is hard-coded to use the center of the selected shapes as the rotation origin, but it's useful to be able to override that to make some rotation operations much easier.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add option to Editor.rotateShapesBy to specify the rotation center point.