### PR TITLE
[wip] Make sure we migrate first

### DIFF
--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -113,7 +113,6 @@ export function parseTldrawJsonFile({
 				// junk data in the migration
 				return Result.err({ type: 'invalidRecords', cause: e })
 			}
-
 			// if the migration failed, we can't open the file
 			if (migrationResult.type === 'error') {
 				return Result.err({ type: 'migrationFailed', reason: migrationResult.reason })

--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -136,11 +136,9 @@ export function parseTldrawJsonFile({
 				return Result.err({ type: 'invalidRecords', cause: e })
 			}
 		}
-		case 'v1File': {
-			return Result.err({ type: 'v1File', data: result.data })
-		}
+		case 'v1File':
 		case 'notATldrawFile':
-			return Result.err({ type: 'notATldrawFile', cause: result.cause })
+			return Result.err(result)
 	}
 }
 

--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -67,11 +67,10 @@ function parseFile(json: any) {
 		} else if (isV1File(data)) {
 			return { type: 'v1File' as const, data }
 		}
+		return { type: 'notATldrawFile' as const, cause: null }
 	} catch (e) {
 		return { type: 'notATldrawFile' as const, cause: e }
 	}
-
-	return { type: 'notATldrawFile' as const, cause: null }
 }
 
 /** @public */


### PR DESCRIPTION
This is a followup to #4502, where we always try to migrate results before validating.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improve loading of files.