### PR TITLE
search: turn back on in production

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -36,7 +36,7 @@
 		"check-links": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/check-broken-links.ts",
 		"create-api-markdown": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/create-api-markdown.ts",
 		"refresh-content": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/refresh-content.ts",
-		"refresh-everything": "yarn fetch-api-source && yarn fetch-releases && yarn create-api-markdown && yarn refresh-content && yarn format",
+		"refresh-everything": "yarn fetch-api-source && yarn fetch-releases && yarn create-api-markdown && yarn refresh-content && yarn format && yarn update-algolia-index",
 		"update-algolia-index": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/update-algolia-index.ts",
 		"clean": "rm -rf node_modules .yarn",
 		"format": "yarn run -T prettier --write .",


### PR DESCRIPTION
looks like it was accidentally disabled in https://github.com/tldraw/tldraw/pull/4494

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
