### PR TITLE
[fix] build caching i.e. "You have multiple versions of tldraw libraries installed"

### DIFF
--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -8,6 +8,7 @@ const config = {
 			'<rootDir>/lazy.config.ts',
 			'<rootDir>/config/**/*',
 			'<rootDir>/scripts/**/*',
+			'package.json',
 		],
 		exclude: [
 			'<allWorkspaceDirs>/coverage/**/*',


### PR DESCRIPTION
fixes https://discord.com/channels/859816885297741824/1284451614400188458/1284451614400188458

the package.json files in workspace dirs were not forming part of the build task's cache key so it wasn't rebuilding after the code changed since alex's new version number checking thingy.

(during publish each package is built twice, once to check whether it has changed, and again during the actual publish step)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed the "You have multiple versions of tldraw libraries installed" problem on 3.0.1