### PR TITLE
Add id for text shape

### DIFF
--- a/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -193,7 +193,8 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 					/>
 				</svg>
 				<TextLabel
-					id={id}
+					id={id + '-label'}
+					shapeId={id}
 					type={type}
 					font={font}
 					textWidth={shape.props.w}

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1769,8 +1769,6 @@ export const TextLabel: React_3.NamedExoticComponent<TextLabelProps>;
 // @public (undocumented)
 export interface TextLabelProps {
     // (undocumented)
-    addId?: boolean;
-    // (undocumented)
     align: TLDefaultHorizontalAlignStyle;
     // (undocumented)
     bounds?: Box;

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1783,7 +1783,7 @@ export interface TextLabelProps {
     // (undocumented)
     fontSize: number;
     // (undocumented)
-    id: TLShapeId;
+    id: string;
     // (undocumented)
     isNote?: boolean;
     // (undocumented)
@@ -1796,6 +1796,8 @@ export interface TextLabelProps {
     onKeyDown?(e: React_3.KeyboardEvent<HTMLTextAreaElement>): void;
     // (undocumented)
     padding?: number;
+    // (undocumented)
+    shapeId: TLShapeId;
     // (undocumented)
     style?: React_3.CSSProperties;
     // (undocumented)

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1769,6 +1769,8 @@ export const TextLabel: React_3.NamedExoticComponent<TextLabelProps>;
 // @public (undocumented)
 export interface TextLabelProps {
     // (undocumented)
+    addId?: boolean;
+    // (undocumented)
     align: TLDefaultHorizontalAlignStyle;
     // (undocumented)
     bounds?: Box;

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -617,7 +617,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				</SVGContainer>
 				{showArrowLabel && (
 					<TextLabel
-						id={shape.id}
+						id={shape.id + '-label'}
+						shapeId={shape.id}
 						classNamePrefix="tl-arrow"
 						type="arrow"
 						font={shape.props.font}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -465,7 +465,8 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 						}}
 					>
 						<TextLabel
-							id={id}
+							id={id + '-label'}
+							shapeId={id}
 							type={type}
 							font={font}
 							fontSize={LABEL_FONT_SIZES[size] * shape.props.scale}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -214,7 +214,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					}}
 				>
 					<TextLabel
-						id={id}
+						id={id + '-label'}
+						shapeId={id}
 						type={type}
 						font={font}
 						fontSize={(fontSizeAdjustment || LABEL_FONT_SIZES[size]) * scale}

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -34,6 +34,7 @@ export interface TextLabelProps {
 	textWidth?: number
 	textHeight?: number
 	padding?: number
+	addId?: boolean
 }
 
 /** @public @react */
@@ -55,6 +56,7 @@ export const TextLabel = React.memo(function TextLabel({
 	style,
 	textWidth,
 	textHeight,
+	addId = false,
 }: TextLabelProps) {
 	const { rInput, isEmpty, isEditing, isEditingAnything, ...editableTextRest } = useEditableText(
 		id,
@@ -81,6 +83,7 @@ export const TextLabel = React.memo(function TextLabel({
 	const cssPrefix = classNamePrefix || 'tl-text'
 	return (
 		<div
+			id={addId ? id : undefined}
 			className={`${cssPrefix}-label tl-text-wrapper`}
 			data-font={font}
 			data-align={align}

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -35,7 +35,6 @@ export interface TextLabelProps {
 	textWidth?: number
 	textHeight?: number
 	padding?: number
-	addId?: boolean
 }
 
 /** @public @react */

--- a/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/TextLabel.tsx
@@ -14,7 +14,8 @@ import { useEditableText } from './useEditableText'
 
 /** @public */
 export interface TextLabelProps {
-	id: TLShapeId
+	id: string
+	shapeId: TLShapeId
 	type: string
 	font: TLDefaultFontStyle
 	fontSize: number
@@ -40,6 +41,7 @@ export interface TextLabelProps {
 /** @public @react */
 export const TextLabel = React.memo(function TextLabel({
 	id,
+	shapeId,
 	type,
 	text,
 	labelColor,
@@ -56,10 +58,9 @@ export const TextLabel = React.memo(function TextLabel({
 	style,
 	textWidth,
 	textHeight,
-	addId = false,
 }: TextLabelProps) {
 	const { rInput, isEmpty, isEditing, isEditingAnything, ...editableTextRest } = useEditableText(
-		id,
+		shapeId,
 		type,
 		text
 	)
@@ -83,7 +84,7 @@ export const TextLabel = React.memo(function TextLabel({
 	const cssPrefix = classNamePrefix || 'tl-text'
 	return (
 		<div
-			id={addId ? id : undefined}
+			id={id}
 			className={`${cssPrefix}-label tl-text-wrapper`}
 			data-font={font}
 			data-align={align}

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -106,6 +106,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 				}}
 				wrap
 				onKeyDown={handleKeyDown}
+				addId={true}
 			/>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -88,6 +88,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return (
 			<TextLabel
 				id={id}
+				shapeId={id}
 				classNamePrefix="tl-text-shape"
 				type="text"
 				font={font}
@@ -106,7 +107,6 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 				}}
 				wrap
 				onKeyDown={handleKeyDown}
-				addId={true}
 			/>
 		)
 	}

--- a/packages/tldraw/src/test/TextLabel.test.tsx
+++ b/packages/tldraw/src/test/TextLabel.test.tsx
@@ -29,7 +29,7 @@ afterEach(() => {
 })
 
 describe('TextLabel', () => {
-	it('adds id attribute for TextShapeUtil', async () => {
+	it('sets id to shapeId for TextLabel in TextShapeUtil', async () => {
 		const id = createShapeId()
 
 		await act(async () => {
@@ -48,7 +48,7 @@ describe('TextLabel', () => {
 		expect(elements.length).toBe(1)
 	})
 
-	it('does not add id attribute for GeoShapeUtil', async () => {
+	it('sets id to {shapeId}-label for TextLabel in GeoShapeUtil', async () => {
 		const id = createShapeId()
 
 		await act(async () => {
@@ -63,8 +63,10 @@ describe('TextLabel', () => {
 
 		const escapedId = escapeId(id)
 
-		const elements = document.querySelectorAll(`#${escapedId}`)
-		// TextLabel is rendered inside the geo shape, so if it had an id, there would be multiple elements selected
-		expect(elements.length).toBe(1)
+		const shapeIdElements = document.querySelectorAll(`#${escapedId}`)
+		expect(shapeIdElements.length).toBe(1)
+
+		const shapeIdLabelElements = document.querySelectorAll(`#${escapedId}-label`)
+		expect(shapeIdLabelElements.length).toBe(1)
 	})
 })

--- a/packages/tldraw/src/test/TextLabel.test.tsx
+++ b/packages/tldraw/src/test/TextLabel.test.tsx
@@ -1,0 +1,70 @@
+import { act } from '@testing-library/react'
+import { createShapeId, Editor, TldrawEditor, TLGeoShape, TLTextShape } from '@tldraw/editor'
+import { defaultTools } from '../lib/defaultTools'
+import { GeoShapeUtil } from '../lib/shapes/geo/GeoShapeUtil'
+import { TextShapeUtil } from '../lib/shapes/text/TextShapeUtil'
+import { renderTldrawComponent } from './testutils/renderTldrawComponent'
+
+let editor: Editor
+
+// querySelector doesn't support colons in ids unless escaped
+const escapeId = (id: string) => id.replace(/([:])/g, '\\$1')
+
+beforeEach(async () => {
+	await renderTldrawComponent(
+		<TldrawEditor
+			shapeUtils={[GeoShapeUtil, TextShapeUtil]}
+			initialState="select"
+			tools={defaultTools}
+			onMount={(editorApp) => {
+				editor = editorApp
+			}}
+		/>,
+		{ waitForPatterns: false }
+	)
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+describe('TextLabel', () => {
+	it('adds id attribute for TextShapeUtil', async () => {
+		const id = createShapeId()
+
+		await act(async () => {
+			editor.createShape<TLTextShape>({
+				id,
+				type: 'text',
+				props: {
+					text: 'Hello!',
+				},
+			})
+		})
+
+		const escapedId = escapeId(id)
+
+		const elements = document.querySelectorAll(`#${escapedId}`)
+		expect(elements.length).toBe(1)
+	})
+
+	it('does not add id attribute for GeoShapeUtil', async () => {
+		const id = createShapeId()
+
+		await act(async () => {
+			editor.createShape<TLGeoShape>({
+				id,
+				type: 'geo',
+				props: {
+					text: 'Hello!',
+				},
+			})
+		})
+
+		const escapedId = escapeId(id)
+
+		const elements = document.querySelectorAll(`#${escapedId}`)
+		// TextLabel is rendered inside the geo shape, so if it had an id, there would be multiple elements selected
+		expect(elements.length).toBe(1)
+	})
+})


### PR DESCRIPTION
Resolves https://github.com/tldraw/tldraw/issues/4538

This PR adds an `id` for `TextShapeUtil`.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a text shape
2. Inspect the element with class `tl-text-wrapper`
3. It should have it's `shapeId` as it's `id` attribute

1. Create a geo shape
2. Inspect the element with class `tl-text-wrapper`
3. It should not have any `id` attribute — otherwise there would be duplicate elements with the same `id`

### Release notes

- Text shapes will now have an `id` of `shapeId`, similar to other shape types

### Evidence

|  GeoShapeUtil (no id on text wrapper) |  TextShapeUtil (has id on text wrapper) |
|---|---|
|  <img width="1417" alt="CleanShot 2024-09-17 at 17 52 49@2x" src="https://github.com/user-attachments/assets/ca13d204-5298-4b03-ac12-93b845df8625"> | <img width="1401" alt="CleanShot 2024-09-17 at 17 52 31@2x" src="https://github.com/user-attachments/assets/34af672e-bedf-4b3b-a265-90e88e1aa75a"> |
