### PR TITLE
Add an example of switching to the geo tool.

### DIFF
--- a/apps/examples/src/examples/external-ui-context/ExternalUiContextExample.tsx
+++ b/apps/examples/src/examples/external-ui-context/ExternalUiContextExample.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from 'react'
-import { Editor, Tldraw, useValue } from 'tldraw'
+import { Editor, GeoShapeGeoStyle, Tldraw, useValue } from 'tldraw'
 import 'tldraw/tldraw.css'
 import './external-ui.css'
 
@@ -52,6 +52,20 @@ const ExternalToolbar = () => {
 					onClick={() => editor.setCurrentTool('draw')}
 				>
 					Pencil
+				</button>
+				<button
+					className="external-button"
+					data-isactive={
+						currentToolId === 'geo' && editor?.getStyleForNextShape(GeoShapeGeoStyle) === 'oval'
+					}
+					onClick={() => {
+						editor.run(() => {
+							editor.setStyleForNextShapes(GeoShapeGeoStyle, 'oval')
+							editor.setCurrentTool('geo')
+						})
+					}}
+				>
+					Oval
 				</button>
 			</div>
 		</div>

--- a/apps/examples/src/examples/external-ui/ExternalUiExample.tsx
+++ b/apps/examples/src/examples/external-ui/ExternalUiExample.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Editor, Tldraw, useValue } from 'tldraw'
+import { Editor, GeoShapeGeoStyle, Tldraw, useValue } from 'tldraw'
 import 'tldraw/tldraw.css'
 import './external-ui.css'
 
@@ -37,6 +37,22 @@ export default function ExternalUiExample() {
 					>
 						Pencil
 					</button>
+					<button
+						className="external-button"
+						data-isactive={
+							currentToolId === 'geo' && editor?.getStyleForNextShape(GeoShapeGeoStyle) === 'oval'
+						}
+						onClick={() => {
+							if (!editor) return
+							editor.run(() => {
+								// [4]
+								editor.setStyleForNextShapes(GeoShapeGeoStyle, 'oval')
+								editor.setCurrentTool('geo')
+							})
+						}}
+					>
+						Oval
+					</button>
 				</div>
 			</div>
 		</div>
@@ -53,4 +69,9 @@ Use the `onMount` prop to get the editor instance and store it in state.
 [3]
 Use data from the editor instance or use the editor's methods to control the editor.
 Note that these callbacks also need to work if the editor isn't mounted yet.
+
+[4]
+The geo tool is a bit special since it controls the creation of many geo shapes (oval, rectangle, etc).
+This is why we first set the type of the shape we wish to add, then we set the tool to 'geo'.
+You can see all the available geo shapes in the `GeoShapeGeoStyle` enum.
 */


### PR DESCRIPTION
Setting the tool to the `geo` tool is a bit special, so it warrants being added to this example.

See #4540 

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Add an example of how you can set the current tool to a `geo` tool.