### PR TITLE
Fix footer link in docs.

### DIFF
--- a/apps/docs/components/navigation/footer.tsx
+++ b/apps/docs/components/navigation/footer.tsx
@@ -35,7 +35,7 @@ const menus = [
 		items: [
 			{ caption: 'Trademarks', href: '/legal/trademarks' },
 			{ caption: 'CLA', href: '/legal/cla' },
-			{ caption: 'License', href: '/legal/license' },
+			{ caption: 'License', href: '/legal/tldraw-license' },
 		],
 	},
 ]

--- a/apps/docs/content/community/license.mdx
+++ b/apps/docs/content/community/license.mdx
@@ -14,6 +14,6 @@ For more information, visit [tldraw.dev](https://tldraw.dev/#pricing).
 
 ## Trademarks
 
-While the copyright to our software is licensed under the tldraw license, our trademarks appearing in or on the software are the exclusive property of tldraw. Our default (non-commercial) license does not include a license to use our trademarks.
+While the copyright to our software is licensed under the tldraw license, our trademarks appearing in or on the software are the exclusive property of tldraw. Our default license does not include a license to use our trademarks.
 
 Please see our [trademark policy](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for more information.

--- a/apps/docs/content/legal/tldraw-license.mdx
+++ b/apps/docs/content/legal/tldraw-license.mdx
@@ -1,5 +1,5 @@
 ---
-title: License
+title: tldraw SDK License
 status: published
 author: steveruizok
 ---
@@ -53,4 +53,4 @@ tldraw reserves all rights not expressly granted to you in this License. tldraw 
 
 ## Alternative License
 
-For alternative licensing, please contact sales@tldraw.com. If you wish to use the tldraw SDK without displaying the Watermark, please visit https://tldraw.dev/#pricing to purchase a Business License.
+For alternative licensing, please contact sales@tldraw.com. If you wish to use the tldraw SDK without displaying the Watermark, please visit (https://tldraw.dev/#pricing)[https://tldraw.dev/#pricing] to purchase a Business License.

--- a/apps/docs/scripts/lib/generateSection.ts
+++ b/apps/docs/scripts/lib/generateSection.ts
@@ -15,6 +15,11 @@ import { CONTENT_DIR } from './utils'
 export function generateSection(section: InputSection, articles: Articles, index: number): Section {
 	const { id: sectionId, sidebar_behavior, categories: sectionCategories } = section
 
+	function assignToArticles(key: string, article: Article) {
+		if (articles[key]) throw Error(`Duplicate article key: ${key}`)
+		articles[key] = article
+	}
+
 	const isExamplesSection = sectionId === 'examples'
 	const isReferenceSection = sectionId === 'reference'
 	const skipUnpublishedArticles = process.env.NODE_ENV !== 'development' && !isExamplesSection
@@ -63,7 +68,7 @@ export function generateSection(section: InputSection, articles: Articles, index
 			// The article is an index page, ie docs/docs
 			article.categoryIndex = -1
 			article.sectionIndex = -1
-			articles[section.id + '_index'] = article
+			assignToArticles(section.id + '_index', article)
 		} else {
 			// If the article is in a category and that category exists...
 			if (article.categoryId && sectionCategoryArticles[article.categoryId]) {
@@ -71,7 +76,7 @@ export function generateSection(section: InputSection, articles: Articles, index
 				if (article.id === article.categoryId) {
 					article.categoryIndex = -1
 					article.sectionIndex = -1
-					articles[article.categoryId + '_index'] = article
+					assignToArticles(article.categoryId + '_index', article)
 				} else {
 					// Otherwise, add it to the category's list of articles
 					sectionCategoryArticles[article.categoryId].push(article)
@@ -121,7 +126,7 @@ export function generateSection(section: InputSection, articles: Articles, index
 		categoryArticles.sort(sortArticles).forEach((article, i) => {
 			article.categoryIndex = i
 			article.sectionIndex = articleSectionIndex
-			articles[article.id] = article
+			assignToArticles(article.id, article)
 			articleSectionIndex++
 		})
 	})


### PR DESCRIPTION
This PR fixes the footer link in the docs. It also adds a check to prevent a bug with double naming.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`