### PR TITLE
[sync] Allow doing CRUD directly on the server

### DIFF
--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -201,6 +201,18 @@ export interface RoomSnapshot {
     tombstones?: Record<string, number>;
 }
 
+// @public (undocumented)
+export interface RoomStoreMethods {
+    // (undocumented)
+    delete(recordOrId: string | UnknownRecord): void;
+    // (undocumented)
+    get(id: string): UnknownRecord;
+    // (undocumented)
+    getAll(): UnknownRecord[];
+    // (undocumented)
+    put(record: UnknownRecord): void;
+}
+
 // @internal (undocumented)
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void;
 
@@ -445,7 +457,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     });
     broadcastPatch({ diff, sourceSessionId }: {
         diff: NetworkDiff<R>;
-        sourceSessionId: string;
+        sourceSessionId?: string;
     }): this;
     // (undocumented)
     clock: number;
@@ -489,6 +501,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     }, unknown>;
     // (undocumented)
     tombstoneHistoryStartsAtClock: number;
+    // (undocumented)
+    updateStore(updater: (store: RoomStoreMethods) => Promise<void> | void): Promise<void>;
 }
 
 // @internal (undocumented)

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -202,15 +202,15 @@ export interface RoomSnapshot {
 }
 
 // @public (undocumented)
-export interface RoomStoreMethods {
+export interface RoomStoreMethods<R extends UnknownRecord = UnknownRecord> {
     // (undocumented)
-    delete(recordOrId: string | UnknownRecord): void;
+    delete(recordOrId: R | string): void;
     // (undocumented)
-    get(id: string): null | UnknownRecord;
+    get(id: string): null | R;
     // (undocumented)
-    getAll(): UnknownRecord[];
+    getAll(): R[];
     // (undocumented)
-    put(record: UnknownRecord): void;
+    put(record: R): void;
 }
 
 // @internal (undocumented)
@@ -503,7 +503,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     }, unknown>;
     // (undocumented)
     tombstoneHistoryStartsAtClock: number;
-    updateStore(updater: (store: RoomStoreMethods) => Promise<void> | void): Promise<void>;
+    updateStore(updater: (store: RoomStoreMethods<R>) => Promise<void> | void): Promise<void>;
 }
 
 // @internal (undocumented)

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -453,6 +453,7 @@ export interface TLSyncLog {
 export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     constructor(opts: {
         log?: TLSyncLog;
+        onDataChange?(): void;
         schema: StoreSchema<R, any>;
         snapshot?: RoomSnapshot;
     });

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -367,6 +367,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
         }) => void;
         schema?: StoreSchema<R, any>;
     };
+    updateStore(updater: (store: RoomStoreMethods) => Promise<void> | void): Promise<void>;
 }
 
 // @internal (undocumented)
@@ -501,7 +502,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     }, unknown>;
     // (undocumented)
     tombstoneHistoryStartsAtClock: number;
-    // (undocumented)
     updateStore(updater: (store: RoomStoreMethods) => Promise<void> | void): Promise<void>;
 }
 

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -206,7 +206,7 @@ export interface RoomStoreMethods {
     // (undocumented)
     delete(recordOrId: string | UnknownRecord): void;
     // (undocumented)
-    get(id: string): UnknownRecord;
+    get(id: string): null | UnknownRecord;
     // (undocumented)
     getAll(): UnknownRecord[];
     // (undocumented)

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -11,7 +11,13 @@ export {
 	type TLPersistentClientSocket,
 	type TLPersistentClientSocketStatus,
 } from './lib/TLSyncClient'
-export { DocumentState, TLSyncRoom, type RoomSnapshot, type TLRoomSocket } from './lib/TLSyncRoom'
+export {
+	DocumentState,
+	TLSyncRoom,
+	type RoomSnapshot,
+	type RoomStoreMethods,
+	type TLRoomSocket,
+} from './lib/TLSyncRoom'
 export { chunk } from './lib/chunk'
 export {
 	RecordOpType,

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -283,7 +283,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 * Allow applying changes to the store inside of a transaction.
 	 *
 	 * You can get values from the store by id with `store.get(id)`.
-	 * These values are safe to mutate, but to commit the changes you must call `store.set(...)` with the updated value.
+	 * These values are safe to mutate, but to commit the changes you must call `store.put(...)` with the updated value.
 	 * You can get all values in the store with `store.getAll()`.
 	 * You can also delete values with `store.delete(id)`.
 	 *

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -2,7 +2,7 @@ import type { StoreSchema, UnknownRecord } from '@tldraw/store'
 import { TLStoreSnapshot, createTLSchema } from '@tldraw/tlschema'
 import { objectMapValues } from '@tldraw/utils'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
-import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
+import { RoomSnapshot, RoomStoreMethods, TLSyncRoom } from './TLSyncRoom'
 import { JsonChunkAssembler } from './chunk'
 import { TLSocketServerSentEvent } from './protocol'
 
@@ -285,6 +285,32 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 		// replace room with new one and kick out all the clients
 		this.room = newRoom
 		oldRoom.close()
+	}
+
+	/**
+	 * Allow applying changes to the store inside of a transaction.
+	 *
+	 * You can get values from the store by id with `store.get(id)`.
+	 * These values are safe to mutate, but to commit the changes you must call `store.set(...)` with the updated value.
+	 * You can get all values in the store with `store.getAll()`.
+	 * You can also delete values with `store.delete(id)`.
+	 *
+	 * @example
+	 * ```ts
+	 * room.updateStore(store => {
+	 *   const shape = store.get('shape:abc123')
+	 *   shape.meta.approved = true
+	 *   store.put(shape)
+	 * })
+	 * ```
+	 *
+	 * Changes to the store inside the callback are isolated from changes made by other clients until the transaction commits.
+	 *
+	 * @param updater - A function that will be called with a store object that can be used to make changes.
+	 * @returns A promise that resolves when the transaction is complete.
+	 */
+	async updateStore(updater: (store: RoomStoreMethods) => void | Promise<void>) {
+		return this.room.updateStore(updater)
 	}
 
 	/**

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -7,24 +7,37 @@ import {
 	TLArrowShape,
 	TLArrowShapeProps,
 	TLBaseShape,
+	TLDOCUMENT_ID,
+	TLDocument,
+	TLPage,
 	TLRecord,
 	TLShapeId,
 	createTLSchema,
 } from '@tldraw/tlschema'
-import { ZERO_INDEX_KEY, sortById } from '@tldraw/utils'
+import { IndexKey, ZERO_INDEX_KEY, sortById } from '@tldraw/utils'
 import {
 	MAX_TOMBSTONES,
 	RoomSnapshot,
+	TLRoomSocket,
 	TLSyncRoom,
 	TOMBSTONE_PRUNE_BUFFER_SIZE,
 } from '../lib/TLSyncRoom'
+import {
+	TLConnectRequest,
+	TLSocketServerSentEvent,
+	getTlsyncProtocolVersion,
+} from '../lib/protocol'
 
 const schema = createTLSchema()
 const compareById = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id)
 
 const records = [
-	DocumentRecordType.create({}),
-	PageRecordType.create({ index: ZERO_INDEX_KEY, name: 'page 2' }),
+	DocumentRecordType.create({ id: TLDOCUMENT_ID }),
+	PageRecordType.create({
+		index: ZERO_INDEX_KEY,
+		name: 'page 2',
+		id: PageRecordType.createId('page_2'),
+	}),
 ].sort(compareById)
 
 const makeSnapshot = (records: TLRecord[], others: Partial<RoomSnapshot> = {}) => ({
@@ -151,5 +164,276 @@ describe('TLSyncRoom', () => {
 				.documents.map((r) => r.state)
 				.sort(sortById)
 		).toEqual(records)
+	})
+})
+
+type MockSocket = TLRoomSocket<any> & { __lastMessage: null | TLSocketServerSentEvent<any> }
+function makeSocket(): MockSocket {
+	const socket: MockSocket = {
+		__lastMessage: null,
+		sendMessage: jest.fn((msg) => {
+			socket.__lastMessage = msg
+		}),
+		close() {
+			socket.isOpen = false
+		},
+		isOpen: true,
+	}
+	return socket
+}
+
+describe('TLSyncRoom.updateStore', () => {
+	const sessionAId = 'sessionA'
+	const sessionBId = 'sessionB'
+	let room = new TLSyncRoom<TLRecord, undefined>({ schema, snapshot: makeSnapshot(records) })
+	let socketA = makeSocket()
+	let socketB = makeSocket()
+	function init(snapshot?: RoomSnapshot) {
+		room = new TLSyncRoom<TLRecord, undefined>({
+			schema,
+			snapshot: snapshot ?? makeSnapshot(records),
+		})
+		socketA = makeSocket()
+		socketB = makeSocket()
+		room.handleNewSession(sessionAId, socketA, null as any)
+		room.handleNewSession(sessionBId, socketB, null as any)
+		room.handleMessage(sessionAId, {
+			connectRequestId: 'connectRequestId' + sessionAId,
+			lastServerClock: 0,
+			protocolVersion: getTlsyncProtocolVersion(),
+			schema: room.serializedSchema,
+			type: 'connect',
+		} satisfies TLConnectRequest)
+		room.handleMessage(sessionBId, {
+			connectRequestId: 'connectRequestId' + sessionBId,
+			lastServerClock: 0,
+			protocolVersion: getTlsyncProtocolVersion(),
+			schema: room.serializedSchema,
+			type: 'connect',
+		} satisfies TLConnectRequest)
+		expect(room.sessions.get(sessionAId)?.state).toBe('connected')
+		expect(room.sessions.get(sessionBId)?.state).toBe('connected')
+		socketA.__lastMessage = null
+		socketB.__lastMessage = null
+	}
+	beforeEach(() => {
+		init()
+	})
+
+	test('it allows updating records', async () => {
+		const clock = room.clock
+		const documentClock = room.documentClock
+		await room.updateStore((store) => {
+			const document = store.get('document:document') as TLDocument
+			document.name = 'My lovely document'
+			store.put(document)
+		})
+		expect(
+			(room.getSnapshot().documents.find((r) => r.state.id === 'document:document')?.state as any)
+				.name
+		).toBe('My lovely document')
+		expect(clock).toBeLessThan(room.clock)
+		expect(documentClock).toBeLessThan(room.documentClock)
+	})
+
+	test('it does not update unless you call .set', () => {
+		const documentClock = room.documentClock
+		room.updateStore((store) => {
+			const document = store.get('document:document') as TLDocument
+			document.name = 'My lovely document'
+		})
+		expect(
+			(room.getSnapshot().documents.find((r) => r.state.id === 'document:document')?.state as any)
+				.name
+		).toBe('')
+		expect(documentClock).toBe(room.documentClock)
+	})
+
+	test('after the change it sends a patch to all clients', async () => {
+		const clock = room.clock
+		const documentClock = room.documentClock
+		await room.updateStore((store) => {
+			const document = store.get('document:document') as TLDocument
+			document.name = 'My lovely document'
+			store.put(document)
+		})
+
+		expect(clock).toBeLessThan(room.clock)
+		expect(documentClock).toBeLessThan(room.documentClock)
+
+		expect(socketA.__lastMessage).toMatchInlineSnapshot(`
+		{
+		  "data": [
+		    {
+		      "diff": {
+		        "document:document": [
+		          "patch",
+		          {
+		            "name": [
+		              "put",
+		              "My lovely document",
+		            ],
+		          },
+		        ],
+		      },
+		      "serverClock": 1,
+		      "type": "patch",
+		    },
+		  ],
+		  "type": "data",
+		}
+	`)
+		expect(socketB.__lastMessage).toEqual(socketA.__lastMessage)
+	})
+
+	test('it allows adding new records', async () => {
+		const id = PageRecordType.createId('page_3')
+		await room.updateStore((store) => {
+			const page = PageRecordType.create({ id, name: 'page 3', index: 'a0' as IndexKey })
+			store.put(page)
+		})
+
+		expect(socketA.__lastMessage).toMatchInlineSnapshot(`
+		{
+		  "data": [
+		    {
+		      "diff": {
+		        "page:page_3": [
+		          "put",
+		          {
+		            "id": "page:page_3",
+		            "index": "a0",
+		            "meta": {},
+		            "name": "page 3",
+		            "typeName": "page",
+		          },
+		        ],
+		      },
+		      "serverClock": 1,
+		      "type": "patch",
+		    },
+		  ],
+		  "type": "data",
+		}
+	`)
+		expect(socketB.__lastMessage).toEqual(socketA.__lastMessage)
+		expect(room.getSnapshot().documents.find((r) => r.state.id === id)?.state).toBeTruthy()
+	})
+
+	test('it allows deleting records', async () => {
+		await room.updateStore((store) => {
+			store.delete('page:page_2')
+		})
+
+		expect(socketA.__lastMessage).toMatchInlineSnapshot(`
+		{
+		  "data": [
+		    {
+		      "diff": {
+		        "page:page_2": [
+		          "remove",
+		        ],
+		      },
+		      "serverClock": 1,
+		      "type": "patch",
+		    },
+		  ],
+		  "type": "data",
+		}
+	`)
+		expect(socketB.__lastMessage).toEqual(socketA.__lastMessage)
+		expect(room.getSnapshot().documents.find((r) => r.state.id === 'page:page_2')).toBeFalsy()
+	})
+
+	test('it wont do anything if your changes are no-ops', async () => {
+		const documentClock = room.documentClock
+		await room.updateStore((store) => {
+			const newPage = PageRecordType.create({ name: 'page 3', index: 'a0' as IndexKey })
+			store.put(newPage)
+			store.delete(newPage.id)
+		})
+
+		expect(room.documentClock).toBe(documentClock)
+		expect(socketA.__lastMessage).toBeNull()
+		expect(socketB.__lastMessage).toBeNull()
+
+		await room.updateStore((store) => {
+			const page = store.get('page:page_2')
+			store.delete(page)
+			store.put(page)
+		})
+
+		expect(room.documentClock).toBe(documentClock)
+		expect(socketA.__lastMessage).toBeNull()
+		expect(socketB.__lastMessage).toBeNull()
+
+		await room.updateStore((store) => {
+			let page = store.get('page:page_2') as TLPage
+			page.name = 'my lovely page'
+			store.put(page)
+			page = store.get('page:page_2') as TLPage
+			store.delete(page)
+			page.name = 'page 2'
+			store.put(page)
+		})
+
+		expect(room.documentClock).toBe(documentClock)
+		expect(socketA.__lastMessage).toBeNull()
+		expect(socketB.__lastMessage).toBeNull()
+	})
+
+	test('it returns all records if you ask for them', async () => {
+		let allRecords
+		await room.updateStore((store) => {
+			allRecords = store.getAll()
+		})
+		expect(allRecords!.sort(compareById)).toEqual(records)
+		await room.updateStore((store) => {
+			const page3 = PageRecordType.create({ name: 'page 3', index: 'a0' as IndexKey })
+			store.put(page3)
+			allRecords = store.getAll()
+			expect(allRecords.sort(compareById)).toEqual([...records, page3].sort(compareById))
+			store.delete(page3)
+			allRecords = store.getAll()
+		})
+		expect(allRecords!.sort(compareById)).toEqual(records)
+	})
+
+	test('all operations fail after the store is closed', async () => {
+		let store
+		await room.updateStore((s) => {
+			store = s
+		})
+		expect(() => {
+			store!.put(PageRecordType.create({ name: 'page 3', index: 'a0' as IndexKey }))
+		}).toThrowErrorMatchingInlineSnapshot(`"StoreUpdateContext is closed"`)
+		expect(() => {
+			store!.delete('page:page_2')
+		}).toThrowErrorMatchingInlineSnapshot(`"StoreUpdateContext is closed"`)
+		expect(() => {
+			store!.getAll()
+		}).toThrowErrorMatchingInlineSnapshot(`"StoreUpdateContext is closed"`)
+		expect(() => {
+			store!.get('page:page_2')
+		}).toThrowErrorMatchingInlineSnapshot(`"StoreUpdateContext is closed"`)
+	})
+
+	test('it fails if the room is closed', () => {
+		room.close()
+		expect(
+			room.updateStore(() => {
+				// noop
+			})
+		).rejects.toMatchInlineSnapshot(`[Error: Cannot update store on a closed room]`)
+	})
+
+	test('it fails if you try to add bad data', () => {
+		expect(
+			room.updateStore((store) => {
+				const page = store.get('page:page_2') as TLPage
+				page.index = 34 as any
+				store.put(page)
+			})
+		).rejects.toMatchInlineSnapshot(`[Error: failed to apply changes: invalidRecord]`)
 	})
 })


### PR DESCRIPTION
We've had a couple of requests for the ability to update the room data directly on the server, which totally make sense when implementing any kind of workflow that involves talking to an external service.

This PR adds a simple helper that gives you an async transactional context in which to perform updates that will be committed at the end, and which are isolated from any other concurrent updates happening in the server due to client activity or even other transactions. At the end of a transaction, the generated diff is calculated as if it were on a client and 'sent' to the room via a push request.

### Change type

- [x] `feature`
- [x] `api`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Adds the `updateStore` method to the `TLSocketRoom` class, to allow updating room data directly on the server.