### PR TITLE
Unify licenses.

### DIFF
--- a/apps/vscode/editor/LICENSE.md
+++ b/apps/vscode/editor/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 tldraw Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/vscode/editor/README.md
+++ b/apps/vscode/editor/README.md
@@ -8,7 +8,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 ## License
 
-The code in this folder is Copyright (c) 2024-present tldraw Inc. The tldraw SDK is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
+This project is provided under the MIT license found [here](https://github.com/tldraw/tldraw/blob/main/apps/vscode/editor/LICENSE.md). The tldraw SDK is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
 
 ## Trademarks
 

--- a/apps/vscode/editor/package.json
+++ b/apps/vscode/editor/package.json
@@ -8,7 +8,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "SEE LICENSE IN LICENSE.md",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/apps/vscode/extension/LICENSE.md
+++ b/apps/vscode/extension/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 tldraw Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/vscode/extension/README.md
+++ b/apps/vscode/extension/README.md
@@ -20,9 +20,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 ## License
 
-The code in this folder is Copyright (c) 2024-present tldraw Inc.
-
-The tldraw source code and its distributions are provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
+This project is provided under the MIT license found [here](https://github.com/tldraw/tldraw/blob/main/apps/vscode/extension/LICENSE.md). The tldraw SDK is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
 
 ## Trademarks
 

--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -7,6 +7,7 @@
 		"name": "tldraw Inc.",
 		"email": "hello@tldraw.com"
 	},
+	"license": "MIT",
 	"homepage": "https://tldraw.dev",
 	"repository": {
 		"type": "git",

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -7,7 +7,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "Apache-2.0",
+	"license": "MIT",
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",

--- a/templates/simple-server-example/package.json
+++ b/templates/simple-server-example/package.json
@@ -7,6 +7,7 @@
 		"name": "tldraw GB Ltd.",
 		"email": "hello@tldraw.com"
 	},
+	"license": "MIT",
 	"main": "./src/server/server.ts",
 	"scripts": {
 		"dev-node": "concurrently -n server,client -c red,blue \"yarn dev-server-node\" \"yarn dev-client\"",

--- a/templates/sync-cloudflare/package.json
+++ b/templates/sync-cloudflare/package.json
@@ -7,7 +7,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "Apache-2.0",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "concurrently --kill-others --names client,worker --prefix-colors blue,red yarn:dev:client yarn:dev:worker",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -7,7 +7,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "Apache-2.0",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
Unify the licenses. 

Also specify the license for the vs code extension. Without that the `vsce package` command erorrs out.

![CleanShot 2024-09-20 at 12 00 40@2x](https://github.com/user-attachments/assets/1689bd5c-326f-4c3e-9e48-e295f8cf8454)


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Unify templates licenses. Add back vs code extension license.