### PR TITLE
Unify links for vs code.

### DIFF
--- a/apps/vscode/editor/src/Links.tsx
+++ b/apps/vscode/editor/src/Links.tsx
@@ -3,43 +3,42 @@ import { openUrl } from './utils/url'
 
 export function Links() {
 	return (
-		<TldrawUiMenuGroup id="links">
-			<TldrawUiMenuItem
-				id="github"
-				label="help-menu.github"
-				readonlyOk
-				icon="github"
-				onSelect={() => {
-					openUrl('https://github.com/tldraw/tldraw')
-				}}
-			/>
-			<TldrawUiMenuItem
-				id="twitter"
-				label="help-menu.twitter"
-				icon="twitter"
-				readonlyOk
-				onSelect={() => {
-					openUrl('https://twitter.com/tldraw')
-				}}
-			/>
-			<TldrawUiMenuItem
-				id="discord"
-				label="help-menu.discord"
-				icon="discord"
-				readonlyOk
-				onSelect={() => {
-					openUrl('https://discord.gg/SBBEVCA4PG')
-				}}
-			/>
-			<TldrawUiMenuItem
-				id="about"
-				label="help-menu.about"
-				icon="external-link"
-				readonlyOk
-				onSelect={() => {
-					openUrl('https://tldraw.dev')
-				}}
-			/>
-		</TldrawUiMenuGroup>
+		<>
+			<TldrawUiMenuGroup id="links">
+				<TldrawUiMenuItem
+					id="about"
+					label="help-menu.terms"
+					icon="external-link"
+					readonlyOk
+					onSelect={() => {
+						openUrl(
+							'https://github.com/tldraw/tldraw/blob/main/apps/dotcom/client/TERMS_OF_SERVICE.md'
+						)
+					}}
+				/>
+				<TldrawUiMenuItem
+					id="about"
+					label="help-menu.privacy"
+					icon="external-link"
+					readonlyOk
+					onSelect={() => {
+						openUrl(
+							'https://github.com/tldraw/tldraw/blob/main/apps/dotcom/client/PRIVACY_POLICY.md'
+						)
+					}}
+				/>
+			</TldrawUiMenuGroup>
+			<TldrawUiMenuGroup id="tldraw">
+				<TldrawUiMenuItem
+					id="about"
+					label="help-menu.about"
+					icon="external-link"
+					readonlyOk
+					onSelect={() => {
+						openUrl('https://tldraw.dev')
+					}}
+				/>
+			</TldrawUiMenuGroup>
+		</>
 	)
 }

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -2,7 +2,8 @@ import { useQuickReactor, useValue } from '@tldraw/state-react'
 import { memo, useState } from 'react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
-import { stopEventPropagation } from '../utils/dom'
+import { preventDefault, stopEventPropagation } from '../utils/dom'
+import { runtime } from '../utils/runtime'
 import { watermarkDesktopSvg, watermarkMobileSvg } from '../watermarks'
 import { LicenseManager } from './LicenseManager'
 import { useLicenseContext } from './LicenseProvider'
@@ -53,6 +54,7 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 	const events = useCanvasEvents()
 
 	const maskCss = `url('${src}') center 100% / 100% no-repeat`
+	const url = 'https://tldraw.dev'
 
 	return (
 		<div
@@ -64,11 +66,15 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 			{...events}
 		>
 			<a
-				href="https://tldraw.dev"
 				target="_blank"
+				href={url}
 				rel="noreferrer"
 				draggable={false}
-				onPointerDown={stopEventPropagation}
+				onPointerDown={(e) => {
+					stopEventPropagation(e)
+					preventDefault(e)
+				}}
+				onClick={() => runtime.openWindow(url, '_blank')}
 				style={{ mask: maskCss, WebkitMask: maskCss }}
 			/>
 		</div>


### PR DESCRIPTION
Unify links in vs code with the links on dotcom.

Also make the watermark link work. You can't use anchors in the vs code extension - we actually have a system for handling this with the `runtime` and vs code defines it's own runtime.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open vs code extension.
2. The links in the main menu should be the same as on dotcom. 
3. Clicking on the watermark should open tldraw.dev.

### Release notes

- Unify vs code extension links. Make the watermark link work in the vs code extension.