### PR TITLE
hand tool: remove lockable attr

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1231,6 +1231,8 @@ export class HandTool extends StateNode {
     // (undocumented)
     static initial: string;
     // (undocumented)
+    static isLockable: boolean;
+    // (undocumented)
     onDoubleClick(info: TLClickEventInfo): void;
     // (undocumented)
     onQuadrupleClick(info: TLClickEventInfo): void;

--- a/packages/tldraw/src/lib/tools/HandTool/HandTool.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/HandTool.ts
@@ -7,6 +7,7 @@ import { Pointing } from './childStates/Pointing'
 export class HandTool extends StateNode {
 	static override id = 'hand'
 	static override initial = 'idle'
+	static override isLockable = false
 	static override children(): TLStateNodeConstructor[] {
 		return [Idle, Pointing, Dragging]
 	}


### PR DESCRIPTION
noticed this in the How To meeting. i think this is an oversight, locking/unlocking the hand tool doesn't do anything.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix Hand tool being lockable when it already is.