### PR TITLE
Fix examples link quick-start.mdx

### DIFF
--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -139,6 +139,6 @@ Now that you've seen how the tldraw canvas works, you can:
 - Customize the [user interface](/docs/user-interface)
 - Learn more about the [editor](/docs/editor)
 
-You can do a lot with the tldraw SDK. In addition to our long-form docs, we have dozens of examples in our [examples section](/examples) that cover more of its functionality. You can run these locally with the tldraw [GitHub repository](https://github.com/tldraw/tldraw).
+You can do a lot with the tldraw SDK. In addition to our long-form docs, we have dozens of examples in our [examples section](/examples/basic/basic) that cover more of its functionality. You can run these locally with the tldraw [GitHub repository](https://github.com/tldraw/tldraw).
 
 Remember: if you build something incredible, please share it with us in our [#show-and-tell](https://discord.com/invite/SBBEVCA4PG) channel on Discord. Good luck!


### PR DESCRIPTION
The link to the examples page on quick-start in the dev docs was broken. The incorrect link `/examples` has been replaced with `/examples/basic/basic`

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Navigate to `/quick-start` in the dev docs. Click the `examples` link in the second-last paragraph and ensure you are directed to `examples/basic/basic`

### Release notes

- Updated examples link in quick-start guide to go to the correct page instead of a 404