### PR TITLE
Fix label wrapping

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -817,6 +817,7 @@ input,
 	text-shadow: inherit;
 	text-transform: none;
 	white-space: pre-wrap;
+	line-break: normal;
 	word-spacing: 0px;
 	word-wrap: break-word;
 	writing-mode: horizontal-tb !important;
@@ -831,7 +832,6 @@ input,
 	width: max-content;
 	box-sizing: border-box;
 	pointer-events: none;
-	line-break: normal;
 	white-space: pre-wrap;
 	word-wrap: break-word;
 	overflow-wrap: break-word;

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -607,8 +607,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const isEditing = this.editor.getEditingShapeId() === shape.id
 		const showArrowLabel = isEditing || shape.props.text
 
-		console.log(labelPosition.box.w)
-
 		return (
 			<>
 				<SVGContainer id={shape.id} style={{ minWidth: 50, minHeight: 50 }}>

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -38,7 +38,7 @@ import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
 import { ShapeFill } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
-import { STROKE_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
+import { ARROW_LABEL_PADDING, STROKE_SIZES, TEXT_PROPS } from '../shared/default-shape-constants'
 import {
 	getFillDefForCanvas,
 	getFillDefForExport,
@@ -607,6 +607,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const isEditing = this.editor.getEditingShapeId() === shape.id
 		const showArrowLabel = isEditing || shape.props.text
 
+		console.log(labelPosition.box.w)
+
 		return (
 			<>
 				<SVGContainer id={shape.id} style={{ minWidth: 50, minHeight: 50 }}>
@@ -627,7 +629,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 						verticalAlign="middle"
 						text={shape.props.text}
 						labelColor={theme[shape.props.labelColor].solid}
-						textWidth={labelPosition.box.w}
+						textWidth={labelPosition.box.w - ARROW_LABEL_PADDING * 2 * shape.props.scale}
 						isSelected={isSelected}
 						padding={0}
 						style={{
@@ -788,8 +790,10 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 					verticalAlign="middle"
 					text={shape.props.text}
 					labelColor={theme[shape.props.labelColor].solid}
-					bounds={getArrowLabelPosition(this.editor, shape).box}
-					padding={4 * shape.props.scale}
+					bounds={getArrowLabelPosition(this.editor, shape)
+						.box.clone()
+						.expandBy(-ARROW_LABEL_PADDING * shape.props.scale)}
+					padding={0}
 				/>
 			</g>
 		)

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -56,6 +56,7 @@ function getLabelSizeCache(editor: Editor) {
 
 				const fontSize = getArrowLabelFontSize(shape)
 
+				// First we measure the text with no constraints
 				const { w, h } = editor.textMeasure.measureText(shape.props.text, {
 					...TEXT_PROPS,
 					fontFamily: FONT_FAMILIES[shape.props.font],
@@ -66,33 +67,25 @@ function getLabelSizeCache(editor: Editor) {
 				width = w
 				height = h
 
+				let shouldSquish = false
+
+				// If the text is wider than the body, we need to squish it
 				if (bodyBounds.width > bodyBounds.height) {
 					width = Math.max(Math.min(w, 64), Math.min(bodyBounds.width - 64, w))
-
-					const { w: squishedWidth, h: squishedHeight } = editor.textMeasure.measureText(
-						shape.props.text,
-						{
-							...TEXT_PROPS,
-							fontFamily: FONT_FAMILIES[shape.props.font],
-							fontSize,
-							maxWidth: width,
-						}
-					)
-
-					width = squishedWidth
-					height = squishedHeight
+					shouldSquish = true
+				} else if (width > 16 * fontSize) {
+					width = 16 * fontSize
+					shouldSquish = true
 				}
 
-				if (width > 16 * fontSize) {
-					width = 16 * fontSize
-
+				if (shouldSquish) {
 					const { w: squishedWidth, h: squishedHeight } = editor.textMeasure.measureText(
 						shape.props.text,
 						{
 							...TEXT_PROPS,
 							fontFamily: FONT_FAMILIES[shape.props.font],
 							fontSize,
-							maxWidth: width,
+							maxWidth: Math.ceil(width),
 						}
 					)
 
@@ -101,7 +94,10 @@ function getLabelSizeCache(editor: Editor) {
 				}
 			}
 
-			return new Vec(width, height).addScalar(ARROW_LABEL_PADDING * 2 * shape.props.scale)
+			// return new Vec(width, height)
+			return new Vec(Math.ceil(width), Math.ceil(height)).addScalar(
+				ARROW_LABEL_PADDING * 2 * shape.props.scale
+			)
 		})
 	})
 }

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -85,7 +85,7 @@ function getLabelSizeCache(editor: Editor) {
 							...TEXT_PROPS,
 							fontFamily: FONT_FAMILIES[shape.props.font],
 							fontSize,
-							maxWidth: Math.ceil(width),
+							maxWidth: width,
 						}
 					)
 
@@ -94,10 +94,7 @@ function getLabelSizeCache(editor: Editor) {
 				}
 			}
 
-			// return new Vec(width, height)
-			return new Vec(Math.ceil(width), Math.ceil(height)).addScalar(
-				ARROW_LABEL_PADDING * 2 * shape.props.scale
-			)
+			return new Vec(width, height).addScalar(ARROW_LABEL_PADDING * 2 * shape.props.scale)
 		})
 	})
 }


### PR DESCRIPTION
This PR fixes a bug that was causing broken wrapping on arrow labels.

We were calculating the bounds of the arrow label with an included padding when measuring the arrow label, but not removing that padding from the arrow label text.

Before:
<img width="257" alt="image" src="https://github.com/user-attachments/assets/498abb3f-c5b3-4ab6-a407-710c205b249a">

After:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/11389205-b5e2-4c9d-bf08-e0aafdb719bf">

### Change type

- [x] `bugfix`

### Test plan

1. Use the text arrow labels
2. Check for weird line breaks

### Release notes

- Fixed a bug with arrow label text measurements.