### PR TITLE
Don't upload a snapshot from the snapshots page

### DIFF
--- a/apps/dotcom/client/src/components/ExportMenu.tsx
+++ b/apps/dotcom/client/src/components/ExportMenu.tsx
@@ -1,24 +1,23 @@
 import * as Popover from '@radix-ui/react-popover'
-import React, { useState } from 'react'
+import React from 'react'
 import {
 	TldrawUiMenuContextProvider,
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
-	unwrapLabel,
 	useActions,
 	useContainer,
 	useEditor,
 	useTranslation,
 } from 'tldraw'
 import { useShareMenuIsOpen } from '../hooks/useShareMenuOpen'
-import { SHARE_PROJECT_ACTION, SHARE_SNAPSHOT_ACTION } from '../utils/sharing'
+import { SHARE_PROJECT_ACTION } from '../utils/sharing'
 import { getSaveFileCopyAction } from '../utils/useFileSystem'
 import { useHandleUiEvents } from '../utils/useHandleUiEvent'
 import { ShareButton } from './ShareButton'
+import { SnapshotLinkCopy } from './SnapshotLinkCopy'
 
 export const ExportMenu = React.memo(function ExportMenu() {
-	const { [SHARE_PROJECT_ACTION]: shareProject, [SHARE_SNAPSHOT_ACTION]: shareSnapshot } =
-		useActions()
+	const { [SHARE_PROJECT_ACTION]: shareProject } = useActions()
 	const container = useContainer()
 	const msg = useTranslation()
 	const handleUiEvent = useHandleUiEvents()
@@ -28,9 +27,6 @@ export const ExportMenu = React.memo(function ExportMenu() {
 		handleUiEvent,
 		msg('document.default-name')
 	)
-	const [didCopySnapshotLink, setDidCopySnapshotLink] = useState(false)
-	const [isUploadingSnapshot, setIsUploadingSnapshot] = useState(false)
-
 	const [isOpen, onOpenChange] = useShareMenuIsOpen()
 
 	return (
@@ -53,25 +49,7 @@ export const ExportMenu = React.memo(function ExportMenu() {
 								{msg('share-menu.fork-note')}
 							</p>
 						</TldrawUiMenuGroup>
-						<TldrawUiMenuGroup id="snapshot">
-							<TldrawUiMenuItem
-								id="copy-to-clipboard"
-								readonlyOk
-								icon={didCopySnapshotLink ? 'clipboard-copied' : 'clipboard-copy'}
-								label={unwrapLabel(shareSnapshot.label)}
-								onSelect={async () => {
-									setIsUploadingSnapshot(true)
-									await shareSnapshot.onSelect('share-menu')
-									setIsUploadingSnapshot(false)
-									setDidCopySnapshotLink(true)
-									setTimeout(() => setDidCopySnapshotLink(false), 1000)
-								}}
-								spinner={isUploadingSnapshot}
-							/>
-							<p className="tlui-menu__group tlui-share-zone__details">
-								{msg('share-menu.snapshot-link-note')}
-							</p>
-						</TldrawUiMenuGroup>
+						<SnapshotLinkCopy />
 						<TldrawUiMenuGroup id="save">
 							<TldrawUiMenuItem {...saveFileCopyAction} />
 							<p className="tlui-menu__group tlui-share-zone__details">

--- a/apps/dotcom/client/src/components/ShareMenu.tsx
+++ b/apps/dotcom/client/src/components/ShareMenu.tsx
@@ -11,7 +11,6 @@ import {
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
 	fetch,
-	unwrapLabel,
 	useActions,
 	useContainer,
 	useEditor,
@@ -22,6 +21,7 @@ import { useShareMenuIsOpen } from '../hooks/useShareMenuOpen'
 import { createQRCodeImageDataString } from '../utils/qrcode'
 import { SHARE_PROJECT_ACTION, SHARE_SNAPSHOT_ACTION } from '../utils/sharing'
 import { ShareButton } from './ShareButton'
+import { SnapshotLinkCopy } from './SnapshotLinkCopy'
 
 const SHARE_CURRENT_STATE = {
 	OFFLINE: 'offline',
@@ -119,7 +119,6 @@ export const ShareMenu = React.memo(function ShareMenu() {
 	const [shareState, setShareState] = useState(getFreshShareState)
 
 	const [isUploading, setIsUploading] = useState(false)
-	const [isUploadingSnapshot, setIsUploadingSnapshot] = useState(false)
 	const isReadOnlyLink = shareState.state === SHARE_CURRENT_STATE.SHARED_READ_ONLY
 	const currentShareLinkUrl = isReadOnlyLink ? shareState.readonlyUrl : shareState.url
 	const currentQrCodeUrl = isReadOnlyLink
@@ -248,22 +247,7 @@ export const ShareMenu = React.memo(function ShareMenu() {
 										{msg('share-menu.copy-readonly-link-note')}
 									</p>
 								</TldrawUiMenuGroup>
-
-								<TldrawUiMenuGroup id="snapshot">
-									<TldrawUiMenuItem
-										{...shareSnapshot}
-										icon="clipboard-copy"
-										onSelect={async () => {
-											setIsUploadingSnapshot(true)
-											await shareSnapshot.onSelect('share-menu')
-											setIsUploadingSnapshot(false)
-										}}
-										spinner={isUploadingSnapshot}
-									/>
-									<p className="tlui-menu__group tlui-share-zone__details">
-										{msg('share-menu.snapshot-link-note')}
-									</p>
-								</TldrawUiMenuGroup>
+								<SnapshotLinkCopy />
 							</>
 						) : (
 							<>
@@ -292,23 +276,7 @@ export const ShareMenu = React.memo(function ShareMenu() {
 										)}
 									</p>
 								</TldrawUiMenuGroup>
-								<TldrawUiMenuGroup id="copy-snapshot-link">
-									<TldrawUiMenuItem
-										id="copy-snapshot-link"
-										readonlyOk
-										icon="clipboard-copy"
-										label={unwrapLabel(shareSnapshot.label)}
-										onSelect={async () => {
-											setIsUploadingSnapshot(true)
-											await shareSnapshot.onSelect('share-menu')
-											setIsUploadingSnapshot(false)
-										}}
-										spinner={isUploadingSnapshot}
-									/>
-									<p className="tlui-menu__group tlui-share-zone__details">
-										{msg('share-menu.snapshot-link-note')}
-									</p>
-								</TldrawUiMenuGroup>
+								<SnapshotLinkCopy />
 							</>
 						)}
 					</TldrawUiMenuContextProvider>

--- a/apps/dotcom/client/src/components/SnapshotLinkCopy.tsx
+++ b/apps/dotcom/client/src/components/SnapshotLinkCopy.tsx
@@ -1,0 +1,50 @@
+import { SNAPSHOT_PREFIX } from '@tldraw/dotcom-shared'
+import React, { useCallback, useState } from 'react'
+import {
+	TldrawUiMenuGroup,
+	TldrawUiMenuItem,
+	unwrapLabel,
+	useActions,
+	useTranslation,
+} from 'tldraw'
+import { writeToClipboard } from '../utils/clipboard'
+import { SHARE_SNAPSHOT_ACTION } from '../utils/sharing'
+
+/** @internal */
+export const SnapshotLinkCopy = React.memo(function SnapshotLinkCopy() {
+	const { [SHARE_SNAPSHOT_ACTION]: shareSnapshot } = useActions()
+	const msg = useTranslation()
+	const [didCopySnapshotLink, setDidCopySnapshotLink] = useState(false)
+	const [isUploadingSnapshot, setIsUploadingSnapshot] = useState(false)
+
+	const handleSnapshotLinkCopy = useCallback(async () => {
+		if (window.location.pathname.startsWith(`/${SNAPSHOT_PREFIX}/`)) {
+			const result = new Promise<Blob>((resolve) => {
+				resolve(new Blob([window.location.href], { type: 'text/plain' }))
+			})
+			writeToClipboard(result)
+			setDidCopySnapshotLink(true)
+			return
+		}
+		setIsUploadingSnapshot(true)
+		await shareSnapshot.onSelect('share-menu')
+		setIsUploadingSnapshot(false)
+		setDidCopySnapshotLink(true)
+	}, [shareSnapshot])
+
+	return (
+		<TldrawUiMenuGroup id="snapshot">
+			<TldrawUiMenuItem
+				id="copy-to-clipboard"
+				readonlyOk
+				icon={didCopySnapshotLink ? 'clipboard-copied' : 'clipboard-copy'}
+				label={unwrapLabel(shareSnapshot.label)}
+				onSelect={handleSnapshotLinkCopy}
+				spinner={isUploadingSnapshot}
+			/>
+			<p className="tlui-menu__group tlui-share-zone__details">
+				{msg('share-menu.snapshot-link-note')}
+			</p>
+		</TldrawUiMenuGroup>
+	)
+})

--- a/apps/dotcom/client/src/utils/clipboard.ts
+++ b/apps/dotcom/client/src/utils/clipboard.ts
@@ -1,0 +1,14 @@
+/** @internal */
+export async function writeToClipboard(result: Promise<Blob | ''>) {
+	if (navigator?.clipboard?.write) {
+		await navigator.clipboard.write([
+			new ClipboardItem({
+				'text/plain': result,
+			}),
+		])
+	} else if (navigator?.clipboard?.writeText) {
+		const link = await result
+		if (link === '') return
+		navigator.clipboard.writeText(await link.text())
+	}
+}

--- a/apps/dotcom/client/src/utils/sharing.ts
+++ b/apps/dotcom/client/src/utils/sharing.ts
@@ -23,6 +23,7 @@ import {
 	fetch,
 	isShape,
 } from 'tldraw'
+import { writeToClipboard } from './clipboard'
 import { cloneAssetForShare } from './cloneAssetForShare'
 import { getParentOrigin, isInIframe } from './iFrame'
 import { shouldLeaveSharedProject } from './shouldLeaveSharedProject'
@@ -165,18 +166,9 @@ export function useSharing(): TLUiOverrides {
 					label: 'share-menu.create-snapshot-link',
 					readonlyOk: true,
 					onSelect: async (source) => {
+						console.log('SHARE_SNAPSHOT_ACTION')
 						const result = getSnapshotLink(source, editor, handleUiEvent, addToast, msg, roomId)
-						if (navigator?.clipboard?.write) {
-							await navigator.clipboard.write([
-								new ClipboardItem({
-									'text/plain': result,
-								}),
-							])
-						} else if (navigator?.clipboard?.writeText) {
-							const link = await result
-							if (link === '') return
-							navigator.clipboard.writeText(await link.text())
-						}
+						writeToClipboard(result)
 						addToast({
 							title: msg('share-menu.copied'),
 							severity: 'success',


### PR DESCRIPTION
This prevents uploading a snapshot when we are on a snapshot page. We can just use the current link instead of generating a new one.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Share a snapshot.
2. Open the snapshot.
3. Copy the share link. This should not upload the current snapshot to the server and should result copy the current url to the clipboard.

### Release notes

- Copying a snapshot link from a snapshot page now just returns the current url.