### PR TITLE
Fix links.

### DIFF
--- a/apps/docs/content/blog/announcing-tldraw-sync.mdx
+++ b/apps/docs/content/blog/announcing-tldraw-sync.mdx
@@ -25,7 +25,7 @@ We’ve designed tldraw sync to be self-hosted.
 To use tldraw sync in production, first deploy the **sync server** on your backend of choice, configure it to work with your storage solution, and then connect to the server from your client application.
 
 - We recommend starting from our [Cloudflare template](https://github.com/tldraw/tldraw-sync-cloudflare)
-- For Node or Bun runtimes, check out our [generic server template](https://github.com/tldraw/tldraw/tree/main/apps/simple-server-example)
+- For Node or Bun runtimes, check out our [generic server template](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example)
 
 While we don’t offer a hosted version of tldraw sync for production, we do host a **demo server** that you can connect to immediately from any tldraw project. It’s our recommended way to explore collaboration in tldraw, develop your own multi-user features, and compare tldraw sync with alternative backends.
 

--- a/apps/docs/content/docs/assets.mdx
+++ b/apps/docs/content/docs/assets.mdx
@@ -37,6 +37,6 @@ While we're working on docs for this part of the project, please refer to the ex
 - [Handling pasted / dropped external
   content](/examples/data/assets/external-content-sources)
 - [A simple asset store that uploads content to a remote
-  server](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/client/App.tsx)
+  server](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/client/App.tsx)
 - [A more complex asset store that optimizes images when retrieving
   them](https://github.com/tldraw/tldraw/blob/main/packages/sync/src/useSyncDemo.ts#L87)

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -50,7 +50,7 @@ Make sure you also read the section below about [deployment concerns](#deploymen
 
 The `@tldraw/sync-core` library can be used to integrate tldraw sync into any JavaScript server environment that supports WebSockets.
 
-We have a [simple server example](https://github.com/tldraw/tldraw/tree/main/apps/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
+We have a [simple server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
 
 ## What does a tldraw sync backend do?
 
@@ -99,7 +99,7 @@ function registerUrlHandler(editor: Editor) {
 }
 ```
 
-And [here's a full working example](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/client/App.tsx) of the client-side code.
+And [here's a full working example](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/client/App.tsx) of the client-side code.
 
 ### WebSocket server
 
@@ -118,7 +118,7 @@ The `@tldraw/sync-core` package exports a class called [`TLSocketRoom`](?) that 
 	tldraw.com.
 </Callout>
 
-Read the reference docs for [`TLSocketRoom`](?), and see an example of how to use it in the [simple server example](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/server/rooms.ts).
+Read the reference docs for [`TLSocketRoom`](?), and see an example of how to use it in the [simple server example](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/server/rooms.ts).
 
 ### Asset storage
 

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -149,7 +149,7 @@ This should be registered with the [`Editor`](?) when it loads.
 />
 ```
 
-Refer to the simple server example for example [client](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/client/App.tsx) and [server](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/src/server/unfurl.ts) code.
+Refer to the simple server example for example [client](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/client/App.tsx) and [server](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/server/unfurl.ts) code.
 
 ## Using tldraw sync in your app
 

--- a/apps/dotcom/src/components/Links.tsx
+++ b/apps/dotcom/src/components/Links.tsx
@@ -14,7 +14,7 @@ export function Links() {
 					readonlyOk
 					onSelect={() => {
 						openAndTrack(
-							'https://github.com/tldraw/tldraw/blob/main/apps/dotcom/TERMS_OF_SERVICE.md'
+							'https://github.com/tldraw/tldraw/blob/main/apps/dotcom/client/TERMS_OF_SERVICE.md'
 						)
 					}}
 				/>
@@ -24,7 +24,9 @@ export function Links() {
 					icon="external-link"
 					readonlyOk
 					onSelect={() => {
-						openAndTrack('https://github.com/tldraw/tldraw/blob/main/apps/dotcom/PRIVACY_POLICY.md')
+						openAndTrack(
+							'https://github.com/tldraw/tldraw/blob/main/apps/dotcom/client/PRIVACY_POLICY.md'
+						)
 					}}
 				/>
 			</TldrawUiMenuGroup>


### PR DESCRIPTION
Fix privacy and terms links. Our folder shuffle made these point to files that no longer exist.

Also updated the docs links for the `simple-example-server` which got moved from apps to templates.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix privacy and T&C links.
- Fix docs links for 