### PR TITLE
Fix collaboration shape indicator showing a line through the arrow's label

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -933,7 +933,11 @@ const ArrowSvg = track(function ArrowSvg({
 
 	// NOTE: I know right setting `changeIndex` hacky-as right! But we need this because otherwise safari loses
 	// the mask, see <https://linear.app/tldraw/issue/TLD-1500/changing-arrow-color-makes-line-pass-through-text>
-	const maskId = (shape.id + '_clip_' + changeIndex).replace(':', '_')
+	const maskId = (
+		shape.id +
+		'_clip' +
+		(editor.environment.isSafari ? `_${changeIndex}` : '')
+	).replace(':', '_')
 
 	return (
 		<>


### PR DESCRIPTION
Masks for the collaborator indicators where somehow not getting correctly applied. First I played around with adding a random string to the end of the mask id which fixed it. But then I also found out this works.

I think there's some issue with ids for inline defined masks 🤷‍♂️ Was able to find a few similar issues online (but not exactly the same though).

Fixes #4562 

### Before

https://github.com/user-attachments/assets/6a6982d6-7984-4b4e-beb2-48c3094dce9d

### After

https://github.com/user-attachments/assets/0340fd96-c55e-4d61-a42d-8f1207b3c15c

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create an arrow with a label in a multiplayer project.
2. Select the arrow.
3. Open the same project in another browser / incognito.
4. The collaborator indicator should not be shown on top of the arrow's label.

### Release notes

- Fix an issue with arrow collaborator indicator showing on top of the arrow's label.