### PR TITLE
publish useAsset, tweak docs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,3 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\n"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
 git lfs pre-push "$@"

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -719,6 +719,7 @@ export const defaultTldrawOptions: {
     readonly maxPointsPerDrawShape: 500;
     readonly maxShapesPerPage: 4000;
     readonly multiClickDurationMs: 200;
+    readonly temporaryAssetPreviewLifetimeMs: 180000;
     readonly textShadowLod: 0.35;
 };
 
@@ -2748,6 +2749,7 @@ export interface TldrawOptions {
     readonly maxShapesPerPage: number;
     // (undocumented)
     readonly multiClickDurationMs: number;
+    readonly temporaryAssetPreviewLifetimeMs: number;
     // (undocumented)
     readonly textShadowLod: number;
 }

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7974,12 +7974,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/**
 	 * Register a temporary preview of an asset. This is useful for showing a ghost image of
-	 * something that is being uploaded. Returns an `RC` of the URL - call `.retain` to keep it in
-	 * memory, and `.release` when you're done with it.
+	 * something that is being uploaded. Retrieve the placeholder with
+	 * {@link Editor.getTemporaryAssetPreview}. Placeholders last for 3 minutes by default, but this
+	 * can be configured using
 	 *
 	 * @example
 	 * ```ts
-	 * editor.setTemporaryAssetPreview('someId', file)
+	 * editor.createTemporaryAssetPreview(assetId, file)
 	 * ```
 	 *
 	 * @param assetId - The asset's id.
@@ -7996,13 +7997,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.temporaryAssetPreview.set(assetId, objectUrl)
 
 		// eslint-disable-next-line no-restricted-globals -- we always want to revoke the asset and object URL
-		setTimeout(
-			() => {
-				this.temporaryAssetPreview.delete(assetId)
-				URL.revokeObjectURL(objectUrl)
-			},
-			3 * 60 * 1000 /* 3 minutes */
-		)
+		setTimeout(() => {
+			this.temporaryAssetPreview.delete(assetId)
+			URL.revokeObjectURL(objectUrl)
+		}, this.options.temporaryAssetPreviewLifetimeMs)
 
 		return objectUrl
 	}

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -52,6 +52,11 @@ export interface TldrawOptions {
 	readonly flattenImageBoundsPadding: number
 	readonly laserDelayMs: number
 	readonly maxExportDelayMs: number
+	/**
+	 * How long should previews created by {@link Editor.createTemporaryAssetPreview} last before
+	 * they expire? Defaults to 3 minutes.
+	 */
+	readonly temporaryAssetPreviewLifetimeMs: number
 }
 
 /** @public */
@@ -93,4 +98,5 @@ export const defaultTldrawOptions = {
 	flattenImageBoundsPadding: 16,
 	laserDelayMs: 1200,
 	maxExportDelayMs: 5000,
+	temporaryAssetPreviewLifetimeMs: 180000,
 } as const satisfies TldrawOptions

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -3719,6 +3719,13 @@ export function useEditableText(id: TLShapeId, type: string, text: string): {
 // @public (undocumented)
 export function useExportAs(): (ids: TLShapeId[], format: TLExportType | undefined, name: string | undefined) => void;
 
+// @public
+export function useImageAssetUrl(shapeId: TLShapeId, assetId: null | TLAssetId, width: number): {
+    asset: TLAsset | null | undefined;
+    isPlaceholder: boolean;
+    url: null | string;
+};
+
 // @public (undocumented)
 export function useIsToolSelected(tool: TLUiToolItem): boolean;
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -3640,6 +3640,17 @@ export function unwrapLabel(label?: TLUiActionItem['label'], menuType?: string):
 // @public (undocumented)
 export function useActions(): TLUiActionsContextType;
 
+// @public
+export function useAsset(options: {
+    assetId: null | TLAssetId;
+    shapeId: TLShapeId;
+    width: number;
+}): {
+    asset: TLAsset | null | undefined;
+    isPlaceholder: boolean;
+    url: null | string;
+};
+
 // @internal (undocumented)
 export function useAssetUrls(): TLUiAssetUrls;
 
@@ -3718,13 +3729,6 @@ export function useEditableText(id: TLShapeId, type: string, text: string): {
 
 // @public (undocumented)
 export function useExportAs(): (ids: TLShapeId[], format: TLExportType | undefined, name: string | undefined) => void;
-
-// @public
-export function useImageAssetUrl(shapeId: TLShapeId, assetId: null | TLAssetId, width: number): {
-    asset: TLAsset | null | undefined;
-    isPlaceholder: boolean;
-    url: null | string;
-};
 
 // @public (undocumented)
 export function useIsToolSelected(tool: TLUiToolItem): boolean;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -74,7 +74,7 @@ export {
 	LABEL_FONT_SIZES,
 	TEXT_PROPS,
 } from './lib/shapes/shared/default-shape-constants'
-export { useImageAssetUrl } from './lib/shapes/shared/useAsset'
+export { useAsset } from './lib/shapes/shared/useAsset'
 export { useDefaultColorTheme } from './lib/shapes/shared/useDefaultColorTheme'
 export { useEditableText } from './lib/shapes/shared/useEditableText'
 export { TextShapeTool } from './lib/shapes/text/TextShapeTool'

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -74,6 +74,7 @@ export {
 	LABEL_FONT_SIZES,
 	TEXT_PROPS,
 } from './lib/shapes/shared/default-shape-constants'
+export { useImageAssetUrl } from './lib/shapes/shared/useAsset'
 export { useDefaultColorTheme } from './lib/shapes/shared/useDefaultColorTheme'
 export { useEditableText } from './lib/shapes/shared/useEditableText'
 export { TextShapeTool } from './lib/shapes/text/TextShapeTool'

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -23,7 +23,7 @@ import { useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useImageAssetUrl } from '../shared/useAsset'
+import { useAsset } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 async function getDataURIFromURL(url: string): Promise<string> {
@@ -115,7 +115,11 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		const [staticFrameSrc, setStaticFrameSrc] = useState('')
 		const [loadedUrl, setLoadedUrl] = useState<null | string>(null)
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
-		const { asset, url } = useImageAssetUrl(shape.id, shape.props.assetId, shape.props.w)
+		const { asset, url } = useAsset({
+			shapeId: shape.id,
+			assetId: shape.props.assetId,
+			width: shape.props.w,
+		})
 
 		useEffect(() => {
 			if (url && this.isAnimated(shape)) {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -23,7 +23,7 @@ import { useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useAsset } from '../shared/useAsset'
+import { useImageAssetUrl } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 async function getDataURIFromURL(url: string): Promise<string> {
@@ -115,7 +115,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		const [staticFrameSrc, setStaticFrameSrc] = useState('')
 		const [loadedUrl, setLoadedUrl] = useState<null | string>(null)
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
-		const { asset, url } = useAsset(shape.id, shape.props.assetId, shape.props.w)
+		const { asset, url } = useImageAssetUrl(shape.id, shape.props.assetId, shape.props.w)
 
 		useEffect(() => {
 			if (url && this.isAnimated(shape)) {

--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -9,13 +9,17 @@ import {
 import { useEffect, useRef, useState } from 'react'
 
 /**
- * This is a handy helper hook that resolves an asset to a URL for a given shape. It takes care of fetching the asset.
- * This is used in particular for high-resolution images when you want lower and higher resolution depending
- * on the context.
+ * This is a handy helper hook that resolves an asset to an optimized URL for a given shape, or its
+ * {@link @tldraw/editor#Editor.createTemporaryAssetPreview | placeholder} if the asset is still
+ * uploading. This is used in particular for high-resolution images when you want lower and higher
+ * resolution depending on the context.
+ *
+ * For image scaling to work, you need to implement scaled URLs in
+ * {@link @tldraw/tlschema#TLAssetStore.resolve}.
  *
  * @public
  */
-export function useAsset(shapeId: TLShapeId, assetId: TLAssetId | null, width: number) {
+export function useImageAssetUrl(shapeId: TLShapeId, assetId: TLAssetId | null, width: number) {
 	const editor = useEditor()
 	const [url, setUrl] = useState<string | null>(null)
 	const [isPlaceholder, setIsPlaceholder] = useState(false)

--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -19,7 +19,12 @@ import { useEffect, useRef, useState } from 'react'
  *
  * @public
  */
-export function useImageAssetUrl(shapeId: TLShapeId, assetId: TLAssetId | null, width: number) {
+export function useAsset(options: {
+	shapeId: TLShapeId
+	assetId: TLAssetId | null
+	width: number
+}) {
+	const { shapeId, assetId, width } = options
 	const editor = useEditor()
 	const [url, setUrl] = useState<string | null>(null)
 	const [isPlaceholder, setIsPlaceholder] = useState(false)

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames'
 import { ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useImageAssetUrl } from '../shared/useAsset'
+import { useAsset } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -45,7 +45,11 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	component(shape: TLVideoShape) {
 		const { editor } = this
 		const showControls = editor.getShapeGeometry(shape).bounds.w * editor.getZoomLevel() >= 110
-		const { asset, url } = useImageAssetUrl(shape.id, shape.props.assetId, shape.props.w)
+		const { asset, url } = useAsset({
+			shapeId: shape.id,
+			assetId: shape.props.assetId,
+			width: shape.props.w,
+		})
 		const isEditing = useIsEditing(shape.id)
 		const prefersReducedMotion = usePrefersReducedMotion()
 		const { Spinner } = useEditorComponents()

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames'
 import { ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useAsset } from '../shared/useAsset'
+import { useImageAssetUrl } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -45,7 +45,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	component(shape: TLVideoShape) {
 		const { editor } = this
 		const showControls = editor.getShapeGeometry(shape).bounds.w * editor.getZoomLevel() >= 110
-		const { asset, url } = useAsset(shape.id, shape.props.assetId, shape.props.w)
+		const { asset, url } = useImageAssetUrl(shape.id, shape.props.assetId, shape.props.w)
 		const isEditing = useIsEditing(shape.id)
 		const prefersReducedMotion = usePrefersReducedMotion()
 		const { Spinner } = useEditorComponents()


### PR DESCRIPTION
This was hidden and some of the docs around it were out of date.

### Change type

- [x] `api`

### Release notes
- Publish the `useAsset` media asset helper