### PR TITLE
bug: fix rendering issues on new MacOS 15 / iOS 18

### DIFF
--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -2,12 +2,11 @@
 @import url('tldraw/tldraw.css');
 @import url('./z-board.css');
 
+/* NB: If we did position: fixed, Safari on iOS 18 and MacOS 15 would
+ * have several rendering issues. This must stay position: absolute. */
 .tldraw__editor {
-	position: fixed;
-	top: 0px;
-	left: 0px;
-	bottom: 0px;
-	right: 0px;
+	position: absolute;
+	inset: 0;
 	width: 100%;
 	height: 100%;
 	overflow: hidden;

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -40,6 +40,8 @@ html,
 	box-sizing: border-box;
 }
 
+/* NB: If we did position: fixed, Safari on iOS 18 and MacOS 15 would
+ * have several rendering issues. This must stay position: absolute. */
 .tldraw__editor {
 	position: absolute;
 	inset: 0px;


### PR DESCRIPTION
Various rendering issues on MacOS 15 and iOS 18. It can be caused when erasing shapes or with selecting shapes or just generally interacting with them.

We noticed that this wasn't happening on the Examples app and @SomeHats discovered that we use `position: absolute` there whilst on .com we use `position: fixed` 🤦 

Examples in action:
- https://x.com/rafalfilipek/status/1836845121406652423
- another example:

https://github.com/user-attachments/assets/f5d7ff09-c7b1-4271-896f-ca33f7dab505



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix rendering issues on new MacOS 15 / iOS 18