### PR TITLE
docs: fix up horz. scrolling and slow search typing

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -32,4 +32,14 @@ html {
 	input[type='search']::-webkit-search-results-decoration {
 		-webkit-appearance: none;
 	}
+
+	@media (max-width: 768px) {
+		.prose table {
+			table-layout: fixed;
+		}
+
+		.prose td {
+			word-break: break-word;
+		}
+	}
 }

--- a/apps/docs/components/search/index.tsx
+++ b/apps/docs/components/search/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SearchEntry, SearchIndexName, getSearchIndexName } from '@/utils/algolia'
+import { debounce } from '@/utils/debounce'
 import algoliasearch from 'algoliasearch/lite'
 import { useRouter } from 'next/navigation'
 import { InstantSearch, useHits, useSearchBox } from 'react-instantsearch'
@@ -28,11 +29,12 @@ function InstantSearchInner({ onClose }: { onClose(): void }) {
 		router.push(path)
 		onClose()
 	}
+	const handleInputChange = debounce((query: string) => refine(query), 200)
 
 	return (
 		<SearchAutocomplete
 			items={items}
-			onInputChange={(query: string) => refine(query)}
+			onInputChange={handleInputChange}
 			onChange={handleChange}
 			onClose={onClose}
 		/>


### PR DESCRIPTION
we had some horz. scrolling issues from tables being too big on mobile.
also, the search wasn't being debounced which made typing on mobile strained.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
