### PR TITLE
Add eslint rule to check that tsdoc params match with function params

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,10 +56,10 @@ module.exports = {
 			{ fixMixedExportsWithInlineTypeSpecifier: true },
 		],
 		'local/no-export-star': 'error',
-		'local/tsdoc-param-matching': 'error',
 		'local/no-internal-imports': 'error',
 		'local/tagged-components': 'error',
 		'local/prefer-class-methods': 'error',
+		'local/tsdoc-param-matching': 'error',
 		'no-only-tests/no-only-tests': 'error',
 		'no-restricted-syntax': [
 			'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
 			{ fixMixedExportsWithInlineTypeSpecifier: true },
 		],
 		'local/no-export-star': 'error',
+		'local/tsdoc-param-matching': 'error',
 		'local/no-internal-imports': 'error',
 		'local/tagged-components': 'error',
 		'local/prefer-class-methods': 'error',

--- a/internal/scripts/lib/eslint-plugin.ts
+++ b/internal/scripts/lib/eslint-plugin.ts
@@ -536,6 +536,7 @@ exports.rules = {
 		},
 	}),
 }
+
 function checkParams(
 	context: RuleContext<'paramMismatch' | 'paramMissing', []>,
 	node:

--- a/internal/scripts/lib/eslint-plugin.ts
+++ b/internal/scripts/lib/eslint-plugin.ts
@@ -560,7 +560,7 @@ function checkParams(
 				context.report({
 					node,
 					messageId: 'paramMismatch',
-					data: { paramName: param, name }, // Include name in the message
+					data: { paramName: param, name },
 				})
 			}
 		})
@@ -572,7 +572,7 @@ function checkParams(
 				context.report({
 					node,
 					messageId: 'paramMissing',
-					data: { paramName: param, name }, // Include name in the message
+					data: { paramName: param, name },
 				})
 			}
 		})

--- a/internal/scripts/lib/eslint-plugin.ts
+++ b/internal/scripts/lib/eslint-plugin.ts
@@ -491,7 +491,7 @@ exports.rules = {
 				description: 'Ensure TSDoc @param tags match function parameters',
 				recommended: 'error',
 			},
-			schema: [], // No options for now
+			schema: [],
 			messages: {
 				paramMismatch:
 					"Parameter '{{ paramName }}' is documented but not present in function definition (in {{ name }}).",

--- a/internal/scripts/lib/eslint-plugin.ts
+++ b/internal/scripts/lib/eslint-plugin.ts
@@ -6,6 +6,8 @@
 import ts = require('typescript')
 // @ts-ignore - no import/require
 import utils = require('@typescript-eslint/utils')
+import { TSDocParser } from '@microsoft/tsdoc'
+import { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint'
 
 const { isReassignmentTarget } = require('tsutils') as typeof import('tsutils')
 
@@ -482,4 +484,146 @@ exports.rules = {
 		},
 		defaultOptions: [],
 	}),
+	'tsdoc-param-matching': ESLintUtils.RuleCreator.withoutDocs({
+		meta: {
+			type: 'problem',
+			docs: {
+				description: 'Ensure TSDoc @param tags match function parameters',
+				recommended: 'error',
+			},
+			schema: [], // No options for now
+			messages: {
+				paramMismatch:
+					"Parameter '{{ paramName }}' is documented but not present in function definition (in {{ name }}).",
+				paramMissing:
+					"Parameter '{{ paramName }}' is defined but missing from TSDoc @param (in {{ name }}).",
+			},
+		},
+		defaultOptions: [],
+		create(context) {
+			return {
+				FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+					checkParams(context, node, node.params, node.id?.name || 'anonymous function')
+				},
+				MethodDefinition(node: TSESTree.MethodDefinition) {
+					if (node.value.type === utils.AST_NODE_TYPES.FunctionExpression) {
+						checkParams(
+							context,
+							node,
+							node.value.params,
+							node.key.type === 'Identifier' ? node.key.name : 'anonymous method'
+						)
+					}
+				},
+				TSAbstractMethodDefinition(node: TSESTree.TSAbstractMethodDefinition) {
+					checkParams(
+						context,
+						node,
+						node.value.params,
+						node.key.type === 'Identifier' ? node.key.name : 'anonymous method'
+					)
+				},
+				Property(node: TSESTree.Property) {
+					if (
+						(node.value.type === 'FunctionExpression' ||
+							node.value.type === 'ArrowFunctionExpression') &&
+						node.key.type === 'Identifier'
+					) {
+						checkParams(context, node, node.value.params, node.key.name)
+					}
+				},
+			}
+		},
+	}),
+}
+function checkParams(
+	context: RuleContext<'paramMismatch' | 'paramMissing', []>,
+	node:
+		| TSESTree.FunctionDeclaration
+		| TSESTree.TSAbstractMethodDefinition
+		| TSESTree.MethodDefinition
+		| TSESTree.Property,
+	params: TSESTree.Parameter[],
+	name: string
+) {
+	const tsDocComment = getTSDocComment(context, node)
+	if (tsDocComment) {
+		const docParams = getTSDocParams(tsDocComment)
+		if (docParams.length === 0) return
+
+		const funcParams = params.map((param) => getParamName(param)).filter(Boolean) as string[]
+
+		docParams.forEach((param) => {
+			// We have to check if the function is using the parameter name with or without the _
+			if (!funcParams.includes(param) && !funcParams.includes(`_${param}`)) {
+				context.report({
+					node,
+					messageId: 'paramMismatch',
+					data: { paramName: param, name }, // Include name in the message
+				})
+			}
+		})
+
+		// Some abstract methods use _param names, so we need to adjust the doc params to match
+		const adjustedDocsParams = new Set(docParams.flatMap((param) => [param, `_${param}`]))
+		funcParams.forEach((param) => {
+			if (!adjustedDocsParams.has(param)) {
+				context.report({
+					node,
+					messageId: 'paramMissing',
+					data: { paramName: param, name }, // Include name in the message
+				})
+			}
+		})
+	}
+}
+
+function getTSDocComment(
+	context: RuleContext<'paramMismatch' | 'paramMissing', []>,
+	node:
+		| TSESTree.FunctionDeclaration
+		| TSESTree.TSAbstractMethodDefinition
+		| TSESTree.MethodDefinition
+		| TSESTree.Property
+): string | null {
+	const sourceCode = context.getSourceCode()
+
+	const leadingComments = sourceCode.getCommentsBefore(node)
+
+	for (let i = leadingComments.length - 1; i >= 0; i--) {
+		const comment = leadingComments[i]
+		const isBlockComment = comment.type === 'Block' && comment.value.includes('* @param')
+		const isDirectlyBeforeNode = comment.loc.end.line === node.loc.start.line - 1
+
+		if (isBlockComment && isDirectlyBeforeNode) {
+			return '/*' + comment.value + '*/'
+		}
+	}
+
+	return null
+}
+
+function getTSDocParams(tsDocComment: string): string[] {
+	const parser = new TSDocParser()
+	const docComment = parser.parseString(tsDocComment)
+	return docComment.docComment.params.blocks.map((paramBlock) => paramBlock.parameterName)
+}
+
+function getParamName(param: TSESTree.Parameter): string | null {
+	switch (param.type) {
+		case 'Identifier':
+			return param.name
+		case 'AssignmentPattern':
+			if (param.left.type === 'Identifier') {
+				return param.left.name
+			}
+			return getParamName(param.left)
+		case 'RestElement':
+			if (param.argument.type === 'Identifier') {
+				return param.argument.name
+			}
+			return null
+		default:
+			return null
+	}
 }

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -874,8 +874,8 @@ export class Editor extends EventEmitter<TLEventMap> {
         };
     };
     createPage(page: Partial<TLPage>): this;
-    createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>, select?: boolean): this;
-    createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[], select?: boolean): this;
+    createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this;
+    createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this;
     createTemporaryAssetPreview(assetId: TLAssetId, file: File): string | undefined;
     // (undocumented)
     _decayCameraStateTimeout(elapsed: number): void;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1078,7 +1078,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         select: boolean;
     }>): this;
     // (undocumented)
-    groupShapes(ids: TLShapeId[], options?: Partial<{
+    groupShapes(ids: TLShapeId[], opts?: Partial<{
         groupId: TLShapeId;
         select: boolean;
     }>): this;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -874,8 +874,8 @@ export class Editor extends EventEmitter<TLEventMap> {
         };
     };
     createPage(page: Partial<TLPage>): this;
-    createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this;
-    createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this;
+    createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>, select?: boolean): this;
+    createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[], select?: boolean): this;
     createTemporaryAssetPreview(assetId: TLAssetId, file: File): string | undefined;
     // (undocumented)
     _decayCameraStateTimeout(elapsed: number): void;
@@ -1073,7 +1073,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getViewportScreenBounds(): Box;
     getViewportScreenCenter(): Vec;
     getZoomLevel(): number;
-    groupShapes(shapes: TLShape[], options?: Partial<{
+    groupShapes(shapes: TLShape[], opts?: Partial<{
         groupId: TLShapeId;
         select: boolean;
     }>): this;
@@ -1141,7 +1141,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     pageToScreen(point: VecLike): Vec;
     pageToViewport(point: VecLike): Vec;
     popFocusedGroupId(): this;
-    putContentOntoCurrentPage(content: TLContent, options?: {
+    putContentOntoCurrentPage(content: TLContent, opts?: {
         point?: VecLike;
         preserveIds?: boolean;
         preservePosition?: boolean;
@@ -1159,7 +1159,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     renamePage(page: TLPage | TLPageId, name: string): this;
     reparentShapes(shapes: TLShape[] | TLShapeId[], parentId: TLParentId, insertIndex?: IndexKey): this;
     resetZoom(point?: Vec, opts?: TLCameraMoveOptions): this;
-    resizeShape(shape: TLShape | TLShapeId, scale: VecLike, options?: TLResizeShapeOptions): this;
+    resizeShape(shape: TLShape | TLShapeId, scale: VecLike, opts?: TLResizeShapeOptions): this;
     // (undocumented)
     resolveAssetsInContent(content: TLContent | undefined): Promise<TLContent | undefined>;
     // (undocumented)
@@ -1182,7 +1182,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal (undocumented)
     _setAltKeyTimeout(): void;
     setCamera(point: VecLike, opts?: TLCameraMoveOptions): this;
-    setCameraOptions(options: Partial<TLCameraOptions>): this;
+    setCameraOptions(opts: Partial<TLCameraOptions>): this;
     setCroppingShape(shape: null | TLShape | TLShapeId): this;
     // @internal (undocumented)
     _setCtrlKeyTimeout(): void;
@@ -1230,11 +1230,11 @@ export class Editor extends EventEmitter<TLEventMap> {
     readonly timers: Timers;
     toggleLock(shapes: TLShape[] | TLShapeId[]): this;
     undo(): this;
-    ungroupShapes(ids: TLShapeId[], options?: Partial<{
+    ungroupShapes(ids: TLShapeId[], opts?: Partial<{
         select: boolean;
     }>): this;
     // (undocumented)
-    ungroupShapes(shapes: TLShape[], options?: Partial<{
+    ungroupShapes(shapes: TLShape[], opts?: Partial<{
         select: boolean;
     }>): this;
     updateAssets(assets: TLAssetPartial[]): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7175,7 +7175,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			this.store.put(shapeRecordsToCreate)
 
-			if (select) {
+			if (select && shapeRecordsToCreate.length) {
 				this.setSelectedShapes(shapeRecordsToCreate.map((s) => s.id))
 			}
 		})

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3849,7 +3849,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * const idsOnPage2 = editor.getPageShapeIds(myPage2)
 	 * ```
 	 *
-	 * @param page - The page (or the page id) to get.
+	 * @param page - The page (or the page id) to get the shape ids for.
 	 *
 	 * @public
 	 **/

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3962,7 +3962,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.deletePage('page1')
 	 * ```
 	 *
-	 * @param page - The page (or page id) to delete.
+	 * @param page - The page (or the page id) to delete.
 	 *
 	 * @public
 	 */
@@ -3989,7 +3989,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Duplicate a page.
 	 *
-	 * @param page - The page (or the page id) of the page to duplicate. Defaults to the current page.
+	 * @param page - The page (or the page id) to duplicate. Defaults to the current page.
 	 * @param createId - The id of the new page. Defaults to a new id.
 	 *
 	 * @public
@@ -4485,7 +4485,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape (or shape id) to get the ancestors for.
-	 * @param acc - The
+	 * @param acc - The accumulator.
 	 *
 	 * @public
 	 */
@@ -7319,12 +7319,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	groupShapes(shapes: TLShape[], opts?: Partial<{ groupId: TLShapeId; select: boolean }>): this
-	groupShapes(ids: TLShapeId[], options?: Partial<{ groupId: TLShapeId; select: boolean }>): this
+	groupShapes(ids: TLShapeId[], opts?: Partial<{ groupId: TLShapeId; select: boolean }>): this
 	groupShapes(
 		shapes: TLShapeId[] | TLShape[],
-		options = {} as Partial<{ groupId: TLShapeId; select: boolean }>
+		opts = {} as Partial<{ groupId: TLShapeId; select: boolean }>
 	): this {
-		const { groupId = createShapeId(), select = true } = options
+		const { groupId = createShapeId(), select = true } = opts
 
 		if (!Array.isArray(shapes)) {
 			throw Error('Editor.groupShapes: must provide an array of shapes or shape ids')

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1430,6 +1430,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Update the instance's state.
 	 *
 	 * @param partial - A partial object to update the instance state with.
+	 * @param historyOptions - History batch options.
 	 *
 	 * @public
 	 */
@@ -1561,9 +1562,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Set the cursor.
 	 *
-	 * @param type - The cursor type.
-	 * @param rotation - The cursor rotation.
-	 *
+	 * @param cursor - The cursor to set.
 	 * @public
 	 */
 	setCursor(cursor: Partial<TLCursor>) {
@@ -1657,7 +1656,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.setSelectedShapes(['id1', 'id2'])
 	 * ```
 	 *
-	 * @param ids - The ids to select.
+	 * @param shapes - The shape (or shape ids) to select.
 	 *
 	 * @public
 	 */
@@ -1679,7 +1678,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Determine whether or not any of a shape's ancestors are selected.
 	 *
-	 * @param id - The id of the shape to check.
+	 * @param shape - The shape (or shape id) of the shape to check.
 	 *
 	 * @public
 	 */
@@ -1700,7 +1699,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.select('id1', 'id2')
 	 * ```
 	 *
-	 * @param ids - The ids to select.
+	 * @param shapes - The shape (or the shape ids) to select.
 	 *
 	 * @public
 	 */
@@ -2080,7 +2079,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.setHoveredShape(myShape.id)
 	 * ```
 	 *
-	 * @param shapes - The shape (or shape id) to set as hovered.
+	 * @param shape - The shape (or shape id) to set as hovered.
 	 *
 	 * @public
 	 */
@@ -2451,13 +2450,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.setCamera(editor.getCamera())
 	 * ```
 	 *
-	 * @param options - The camera options to set.
+	 * @param opts - The camera options to set.
 	 *
 	 * @public */
-	setCameraOptions(options: Partial<TLCameraOptions>) {
+	setCameraOptions(opts: Partial<TLCameraOptions>) {
 		const next = structuredClone({
 			...this._cameraOptions.__unsafe__getWithoutCapture(),
-			...options,
+			...opts,
 		})
 		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
@@ -2750,7 +2749,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param point - The point in the current page space to center on.
-	 * @param animation - The camera move options.
+	 * @param opts - The camera move options.
 	 *
 	 * @public
 	 */
@@ -2924,7 +2923,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.zoomToSelection({ animation: { duration: 200 } })
 	 * ```
 	 *
-	 * @param animation - The camera move options.
+	 * @param opts - The camera move options.
 	 *
 	 * @public
 	 */
@@ -3230,6 +3229,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.updateViewportScreenBounds(new Box(0, 0, 1280, 1024), true)
 	 * ```
 	 *
+	 * @param screenBounds - The new screen bounds of the viewport.
 	 * @param center - Whether to preserve the viewport page center as the viewport changes.
 	 *
 	 * @public
@@ -3439,7 +3439,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param userId - The id of the user to follow.
-	 * @param opts - Options for starting to follow a user.
 	 *
 	 * @public
 	 */
@@ -3808,7 +3807,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.getPage(myPage)
 	 * ```
 	 *
-	 * @param page - The page (or page id) to get.
+	 * @param page - The page (or the page id) to get.
 	 *
 	 * @public
 	 */
@@ -3850,7 +3849,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * const idsOnPage2 = editor.getPageShapeIds(myPage2)
 	 * ```
 	 *
-	 * @param page - The page (or page id) to get.
+	 * @param page - The page (or the page id) to get.
 	 *
 	 * @public
 	 **/
@@ -3869,7 +3868,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.setCurrentPage(myPage1)
 	 * ```
 	 *
-	 * @param page - The page (or page id) to set as the current page.
+	 * @param page - The page (or the page id) to set as the current page.
 	 *
 	 * @public
 	 */
@@ -3963,7 +3962,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.deletePage('page1')
 	 * ```
 	 *
-	 * @param id - The id of the page to delete.
+	 * @param page - The page (or page id) to delete.
 	 *
 	 * @public
 	 */
@@ -3990,7 +3989,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Duplicate a page.
 	 *
-	 * @param id - The id of the page to duplicate. Defaults to the current page.
+	 * @param page - The page (or the page id) of the page to duplicate. Defaults to the current page.
 	 * @param createId - The id of the new page. Defaults to a new id.
 	 *
 	 * @public
@@ -4032,7 +4031,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.renamePage('page1', 'My Page')
 	 * ```
 	 *
-	 * @param id - The id of the page to rename.
+	 * @param page - The page (or the id) of the page to rename.
 	 * @param name - The new name.
 	 *
 	 * @public
@@ -4116,7 +4115,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.deleteAssets(['asset1', 'asset2'])
 	 * ```
 	 *
-	 * @param ids - The assets to delete.
+	 * @param assets - The assets (or asset ids) to delete.
 	 *
 	 * @public
 	 */
@@ -4428,7 +4427,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * const pageMask = editor.getShapeMask(shape.id)
 	 * ```
 	 *
-	 * @param id - The id of the shape to get the mask for.
+	 * @param shape - The shape (or the shape id) of the shape to get the mask for.
 	 *
 	 * @returns The mask for the shape.
 	 *
@@ -4486,6 +4485,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape (or shape id) to get the ancestors for.
+	 * @param acc - The
 	 *
 	 * @public
 	 */
@@ -4516,6 +4516,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape to check the ancestors for.
+	 * @param predicate - The predicate to match.
 	 *
 	 * @public
 	 */
@@ -4876,6 +4877,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param point - The page point to test.
+	 * @param opts - The options for the hit point testing.
 	 *
 	 * @public
 	 */
@@ -4899,7 +4901,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @param shape - The shape to test against.
 	 * @param point - The page point to test (in the current page space).
-	 * @param hitInside - Whether to count as a hit if the point is inside of a closed shape.
+	 * @param opts - The options for the hit point testing.
 	 *
 	 * @public
 	 */
@@ -5043,7 +5045,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.getShape('box1')
 	 * ```
 	 *
-	 * @param id - The id of the shape to get.
+	 * @param shape - The shape (or the id of the shape) to get.
 	 *
 	 * @public
 	 */
@@ -5274,7 +5276,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Get the index above the highest child of a given parent.
 	 *
-	 * @param parentId - The id of the parent.
+	 * @param parent - The parent (or the id) of the parent.
 	 *
 	 * @returns The index.
 	 *
@@ -5299,7 +5301,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.getSortedChildIdsForParent('frame1')
 	 * ```
 	 *
-	 * @param parentId - The id of the parent shape.
+	 * @param parent - The parent (or the id) of the parent shape.
 	 *
 	 * @public
 	 */
@@ -5318,7 +5320,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.visitDescendants('frame1', myCallback)
 	 * ```
 	 *
-	 * @param parentId - The id of the parent shape.
+	 * @param parent - The parent (or the id) of the parent shape.
 	 * @param visitor - The visitor function.
 	 *
 	 * @public
@@ -5640,6 +5642,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @param shapes - The shapes (or shape ids) of the shapes to move.
 	 * @param delta - The delta in radians to apply to the selection rotation.
+	 * @param opts - The options for the rotation.
 	 */
 	rotateShapesBy(
 		shapes: TLShapeId[] | TLShape[],
@@ -5704,8 +5707,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shapes - The shapes (or shape ids) to move.
-	 * @param direction - The direction in which to move the shapes.
-	 * @param historyOptions - The history options for the change.
+	 * @param offset - The offset to apply to the shapes.
 	 */
 	nudgeShapes(shapes: TLShapeId[] | TLShape[], offset: VecLike): this {
 		const ids =
@@ -6674,31 +6676,27 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Resize a shape.
 	 *
-	 * @param id - The id of the shape to resize.
+	 * @param shape - The shape (or the shape id of the shape) to resize.
 	 * @param scale - The scale factor to apply to the shape.
-	 * @param options - Additional options.
+	 * @param opts - Additional options.
 	 *
 	 * @public
 	 */
-	resizeShape(
-		shape: TLShapeId | TLShape,
-		scale: VecLike,
-		options: TLResizeShapeOptions = {}
-	): this {
+	resizeShape(shape: TLShapeId | TLShape, scale: VecLike, opts: TLResizeShapeOptions = {}): this {
 		const id = typeof shape === 'string' ? shape : shape.id
 		if (this.getInstanceState().isReadonly) return this
 
 		if (!Number.isFinite(scale.x)) scale = new Vec(1, scale.y)
 		if (!Number.isFinite(scale.y)) scale = new Vec(scale.x, 1)
 
-		const initialShape = options.initialShape ?? this.getShape(id)
+		const initialShape = opts.initialShape ?? this.getShape(id)
 		if (!initialShape) return this
 
-		const scaleOrigin = options.scaleOrigin ?? this.getShapePageBounds(id)?.center
+		const scaleOrigin = opts.scaleOrigin ?? this.getShapePageBounds(id)?.center
 		if (!scaleOrigin) return this
 
-		const pageTransform = options.initialPageTransform
-			? Mat.Cast(options.initialPageTransform)
+		const pageTransform = opts.initialPageTransform
+			? Mat.Cast(opts.initialPageTransform)
 			: this.getShapePageTransform(id)
 		if (!pageTransform) return this
 
@@ -6706,15 +6704,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (pageRotation == null) return this
 
-		const scaleAxisRotation = options.scaleAxisRotation ?? pageRotation
+		const scaleAxisRotation = opts.scaleAxisRotation ?? pageRotation
 
-		const initialBounds = options.initialBounds ?? this.getShapeGeometry(id).bounds
+		const initialBounds = opts.initialBounds ?? this.getShapeGeometry(id).bounds
 
 		if (!initialBounds) return this
 
 		const isAspectRatioLocked =
-			options.isAspectRatioLocked ??
-			this.getShapeUtil(initialShape).isAspectRatioLocked(initialShape)
+			opts.isAspectRatioLocked ?? this.getShapeUtil(initialShape).isAspectRatioLocked(initialShape)
 
 		if (!areAnglesCompatible(pageRotation, scaleAxisRotation)) {
 			// shape is awkwardly rotated, keep the aspect ratio locked and adopt the scale factor
@@ -6722,7 +6719,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// than the bounds of the selection
 			// const minScale = Math.min(Math.abs(scale.x), Math.abs(scale.y))
 			return this._resizeUnalignedShape(id, scale, {
-				...options,
+				...opts,
 				initialBounds,
 				scaleOrigin,
 				scaleAxisRotation,
@@ -6773,7 +6770,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const { x, y } = this.getPointInParentSpace(initialShape.id, initialPagePoint)
 
 			let workingShape = initialShape
-			if (!options.skipStartAndEndCallbacks) {
+			if (!opts.skipStartAndEndCallbacks) {
 				workingShape = applyPartialToRecordWithProps(
 					initialShape,
 					util.onResizeStart?.(initialShape) ?? undefined
@@ -6789,9 +6786,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 					{ ...initialShape, x, y },
 					{
 						newPoint: newLocalPoint,
-						handle: options.dragHandle ?? 'bottom_right',
+						handle: opts.dragHandle ?? 'bottom_right',
 						// don't set isSingle to true for children
-						mode: options.mode ?? 'scale_shape',
+						mode: opts.mode ?? 'scale_shape',
 						scaleX: myScale.x,
 						scaleY: myScale.y,
 						initialBounds,
@@ -6800,7 +6797,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				),
 			})
 
-			if (!options.skipStartAndEndCallbacks) {
+			if (!opts.skipStartAndEndCallbacks) {
 				workingShape = applyPartialToRecordWithProps(
 					workingShape,
 					util.onResizeEnd?.(initialShape, workingShape) ?? undefined
@@ -7195,7 +7192,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param partial - The shape partial to update.
-	 * @param options - The animation's options.
+	 * @param opts - The animation's options.
 	 *
 	 * @public
 	 */
@@ -7216,7 +7213,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param partials - The shape partials to update.
-	 * @param options - The animation's options.
+	 * @param opts - The animation's options.
 	 *
 	 * @public
 	 */
@@ -7317,11 +7314,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shapes - The shapes (or shape ids) to group. Defaults to the selected shapes.
-	 * @param options - An options object.
+	 * @param opts - An options object.
 	 *
 	 * @public
 	 */
-	groupShapes(shapes: TLShape[], options?: Partial<{ groupId: TLShapeId; select: boolean }>): this
+	groupShapes(shapes: TLShape[], opts?: Partial<{ groupId: TLShapeId; select: boolean }>): this
 	groupShapes(ids: TLShapeId[], options?: Partial<{ groupId: TLShapeId; select: boolean }>): this
 	groupShapes(
 		shapes: TLShapeId[] | TLShape[],
@@ -7401,16 +7398,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shapes - The group shapes (or shape ids) to ungroup.
-	 * @param options - An options object.
+	 * @param opts - An options object.
 	 *
 	 * @public
 	 */
-	ungroupShapes(ids: TLShapeId[], options?: Partial<{ select: boolean }>): this
-	ungroupShapes(shapes: TLShape[], options?: Partial<{ select: boolean }>): this
-	ungroupShapes(shapes: TLShapeId[] | TLShape[], options = {} as Partial<{ select: boolean }>) {
+	ungroupShapes(ids: TLShapeId[], opts?: Partial<{ select: boolean }>): this
+	ungroupShapes(shapes: TLShape[], opts?: Partial<{ select: boolean }>): this
+	ungroupShapes(shapes: TLShapeId[] | TLShape[], opts = {} as Partial<{ select: boolean }>) {
 		if (this.getInstanceState().isReadonly) return this
 
-		const { select = true } = options
+		const { select = true } = opts
 		const ids =
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
@@ -7889,7 +7886,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @param style - The style to set.
 	 * @param value - The value to set.
-	 * @param historyOptions - The history options for the change.
 	 *
 	 * @public
 	 */
@@ -8223,13 +8219,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Place content into the editor.
 	 *
 	 * @param content - The content.
-	 * @param options - Options for placing the content.
+	 * @param opts - Options for placing the content.
 	 *
 	 * @public
 	 */
 	putContentOntoCurrentPage(
 		content: TLContent,
-		options: {
+		opts: {
 			point?: VecLike
 			select?: boolean
 			preservePosition?: boolean
@@ -8244,8 +8240,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			throw Error('Could not put content:\ncontent is missing a schema.')
 		}
 
-		const { select = false, preserveIds = false, preservePosition = false } = options
-		let { point = undefined } = options
+		const { select = false, preserveIds = false, preservePosition = false } = opts
+		let { point = undefined } = opts
 
 		// decide on a parent for the put shapes; if the parent is among the put shapes(?) then use its parent
 
@@ -8561,7 +8557,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Get an exported SVG element of the given shapes.
 	 *
-	 * @param ids - The shapes (or shape ids) to export.
+	 * @param shapes - The shapes (or shape ids) to export.
 	 * @param opts - Options for the export.
 	 *
 	 * @returns The SVG element.
@@ -8582,7 +8578,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Get an exported SVG string of the given shapes.
 	 *
-	 * @param ids - The shapes (or shape ids) to export.
+	 * @param shapes - The shapes (or shape ids) to export.
 	 * @param opts - Options for the export.
 	 *
 	 * @returns The SVG element.
@@ -8844,7 +8840,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/**
 	 * Loads a snapshot into the editor.
-	 * @param snapshot - the snapshot to load
+	 * @param snapshot - The snapshot to load.
+	 * @param opts - The options for loading the snapshot.
 	 * @returns
 	 */
 	loadSnapshot(

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4031,7 +4031,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.renamePage('page1', 'My Page')
 	 * ```
 	 *
-	 * @param page - The page (or the id) of the page to rename.
+	 * @param page - The page (or the page id) to rename.
 	 * @param name - The new name.
 	 *
 	 * @public

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6963,15 +6963,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape (or shape partial) to create.
-	 * @param select - Whether to select the created shapes. Defaults to false.
 	 *
 	 * @public
 	 */
-	createShape<T extends TLUnknownShape>(
-		shape: OptionalKeys<TLShapePartial<T>, 'id'>,
-		select = false
-	): this {
-		this.createShapes([shape], select)
+	createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this {
+		this.createShapes([shape])
 		return this
 	}
 
@@ -6985,14 +6981,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shapes - The shapes (or shape partials) to create.
-	 * @param select - Whether to select the created shapes. Defaults to false.
 	 *
 	 * @public
 	 */
-	createShapes<T extends TLUnknownShape>(
-		shapes: OptionalKeys<TLShapePartial<T>, 'id'>[],
-		select = false
-	): this {
+	createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this {
 		if (!Array.isArray(shapes)) {
 			throw Error('Editor.createShapes: must provide an array of shapes or shape partials')
 		}
@@ -7171,10 +7163,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			})
 
 			this.store.put(shapeRecordsToCreate)
-
-			if (select && shapeRecordsToCreate.length) {
-				this.setSelectedShapes(shapeRecordsToCreate.map((s) => s.id))
-			}
 		})
 
 		return this

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6966,11 +6966,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape (or shape partial) to create.
+	 * @param select - Whether to select the created shapes. Defaults to false.
 	 *
 	 * @public
 	 */
-	createShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'>): this {
-		this.createShapes([shape])
+	createShape<T extends TLUnknownShape>(
+		shape: OptionalKeys<TLShapePartial<T>, 'id'>,
+		select = false
+	): this {
+		this.createShapes([shape], select)
 		return this
 	}
 
@@ -6988,7 +6992,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	createShapes<T extends TLUnknownShape>(shapes: OptionalKeys<TLShapePartial<T>, 'id'>[]): this {
+	createShapes<T extends TLUnknownShape>(
+		shapes: OptionalKeys<TLShapePartial<T>, 'id'>[],
+		select = false
+	): this {
 		if (!Array.isArray(shapes)) {
 			throw Error('Editor.createShapes: must provide an array of shapes or shape partials')
 		}
@@ -7167,6 +7174,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			})
 
 			this.store.put(shapeRecordsToCreate)
+
+			if (select) {
+				this.setSelectedShapes(shapeRecordsToCreate.map((s) => s.id))
+			}
 		})
 
 		return this

--- a/packages/editor/src/lib/editor/managers/EdgeScrollManager.ts
+++ b/packages/editor/src/lib/editor/managers/EdgeScrollManager.ts
@@ -52,6 +52,9 @@ export class EdgeScrollManager {
 	 * Helper function to get the scroll proximity factor for a given position.
 	 * @param position - The mouse position on the axis.
 	 * @param dimension - The component dimension on the axis.
+	 * @param isCoarse - Whether the pointer is coarse.
+	 * @param insetStart - Whether the pointer is inset at the start of the axis.
+	 * @param insetEnd - Whether the pointer is inset at the end of the axis.
 	 * @internal
 	 */
 	private getEdgeProximityFactors(

--- a/packages/editor/src/lib/editor/managers/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager.ts
@@ -65,7 +65,10 @@ export class ScribbleManager {
 	/**
 	 * Set the scribble's next point.
 	 *
-	 * @param point - The point to add.
+	 * @param id - The id of the scribble to add a point to.
+	 * @param x - The x coordinate of the point.
+	 * @param y - The y coordinate of the point.
+	 * @param z - The z coordinate of the point.
 	 * @public
 	 */
 	addPoint(id: ScribbleItem['id'], x: number, y: number, z = 0.5) {

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -299,6 +299,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	/**
 	 * Get whether the shape can receive children of a given type.
 	 *
+	 * @param shape - The shape.
 	 * @param type - The shape type.
 	 * @public
 	 */

--- a/packages/state/src/lib/HistoryBuffer.ts
+++ b/packages/state/src/lib/HistoryBuffer.ts
@@ -52,7 +52,7 @@ export class HistoryBuffer<Diff> {
 	/**
 	 * Get the diffs since the given epoch.
 	 *
-	 * @param epoch - The epoch to get diffs since.
+	 * @param sinceEpoch - The epoch to get diffs since.
 	 * @returns An array of diffs or a flag to reset the history buffer.
 	 */
 	getChangesSince(sinceEpoch: number): RESET_VALUE | Diff[] {

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -96,7 +96,7 @@ function traverse(reactors: Set<EffectScheduler<unknown>>, child: Child) {
 /**
  * Collect all of the reactors that need to run for an atom and run them.
  *
- * @param atoms The atoms to flush changes for.
+ * @param atoms - The atoms to flush changes for.
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -96,7 +96,7 @@ function traverse(reactors: Set<EffectScheduler<unknown>>, child: Child) {
 /**
  * Collect all of the reactors that need to run for an atom and run them.
  *
- * @param atom The atom to flush changes for.
+ * @param atoms The atoms to flush changes for.
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {

--- a/packages/store/src/lib/RecordType.ts
+++ b/packages/store/src/lib/RecordType.ts
@@ -190,7 +190,7 @@ export class RecordType<
 	 * const deadAuthorType = authorType.withDefaultProperties({ living: false })
 	 * ```
 	 *
-	 * @param fn - A function that returns the default properties of the new RecordType.
+	 * @param createDefaultProperties - A function that returns the default properties of the new RecordType.
 	 * @returns The new RecordType.
 	 */
 	withDefaultProperties<DefaultProps extends Omit<Partial<R>, 'typeName' | 'id'>>(

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -280,6 +280,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	/**
 	 * Filters out non-document changes from a diff. Returns null if there are no changes left.
 	 * @param change - the records diff
+	 * @param scope - the records scope
 	 * @returns
 	 */
 	filterChangesByScope(change: RecordsDiff<R>, scope: RecordScope) {
@@ -322,6 +323,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * Add some records to the store. It's an error if they already exist.
 	 *
 	 * @param records - The records to add.
+	 * @param phaseOverride - The phase override.
 	 * @public
 	 */
 	put(records: R[], phaseOverride?: 'initialize'): void {
@@ -760,6 +762,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 *
 	 * @param name - The name of the derivation cache.
 	 * @param derive - A function used to derive the value of the cache.
+	 * @param isEqual - A function that determins equality between two records.
 	 * @public
 	 */
 	createComputedCache<Result, Record extends R = R>(

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -457,7 +457,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
         schema: StoreSchema<R, any>;
         snapshot?: RoomSnapshot;
     });
-    broadcastPatch({ diff, sourceSessionId }: {
+    broadcastPatch(message: {
         diff: NetworkDiff<R>;
         sourceSessionId?: string;
     }): this;

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -543,9 +543,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * Broadcast a message to all connected clients except the one with the sessionId provided.
 	 *
 	 * @param message - The message to broadcast.
-	 * @param sourceSessionId - The session to exclude.
 	 */
-	broadcastPatch({ diff, sourceSessionId }: { diff: NetworkDiff<R>; sourceSessionId?: string }) {
+	broadcastPatch(message: { diff: NetworkDiff<R>; sourceSessionId?: string }) {
+		const { diff, sourceSessionId } = message
 		this.sessions.forEach((session) => {
 			if (session.state !== RoomSessionState.Connected) return
 			if (sourceSessionId === session.sessionId) return
@@ -582,6 +582,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 *
 	 * @param sessionId - The session of the client that connected to the room.
 	 * @param socket - Their socket.
+	 * @param meta - Any metadata associated with the session.
 	 */
 	handleNewSession(sessionId: string, socket: TLRoomSocket<R>, meta: SessionMeta) {
 		const existing = this.sessions.get(sessionId)

--- a/packages/utils/src/lib/file.ts
+++ b/packages/utils/src/lib/file.ts
@@ -26,7 +26,7 @@ export class FileHelpers {
 	 * const A = FileHelpers.toDataUrl(myImageFile)
 	 * ```
 	 *
-	 * @param value - The file as a blob.
+	 * @param file - The file as a blob.
 	 */
 	static async blobToDataUrl(file: Blob): Promise<string> {
 		return await new Promise((resolve, reject) => {
@@ -49,7 +49,7 @@ export class FileHelpers {
 	 * const A = FileHelpers.fileToDataUrl(myTextFile)
 	 * ```
 	 *
-	 * @param value - The file as a blob.
+	 * @param file - The file as a blob.
 	 */
 	static async blobToText(file: Blob): Promise<string> {
 		return await new Promise((resolve, reject) => {

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -136,7 +136,7 @@ export class MediaHelpers {
 	/**
 	 * Get the size of a video blob
 	 *
-	 * @param src - A SharedBlob containing the video
+	 * @param blob - A SharedBlob containing the video
 	 * @public
 	 */
 	static async getVideoSize(blob: Blob): Promise<{ w: number; h: number }> {
@@ -149,7 +149,7 @@ export class MediaHelpers {
 	/**
 	 * Get the size of an image blob
 	 *
-	 * @param dataURL - A Blob containing the image.
+	 * @param blob - A Blob containing the image.
 	 * @public
 	 */
 	static async getImageSize(blob: Blob): Promise<{ w: number; h: number }> {


### PR DESCRIPTION
After this [conversation](https://discord.com/channels/859816885297741824/859816885801713728/1289133853822423050) I noticed that our tsdocs `@params` and our function / method definitions don't always match. We often miss tsdoc params or have outdated names for them.

This PR:
- Adds an eslint rule to check whether the tsdoc params and the function params / method arguments match. It allows for using `_` in function params (you can specifiy `@param shapes` in the tsdocs but use `_shapes: SomeType` in function. This helps with some functions that get overriden, like [this one](https://github.com/tldraw/tldraw/blob/a19c8f73898d59500accd87d416b4ae9a7a82ece/packages/editor/src/lib/editor/shapes/ShapeUtil.ts#L299-L308).
- It fixes the issues that the new rule found.
- Also adds the `select` argument back to the `createShape` and `createShapes` methods. We could also go the other way and remove the docs instead of adding the argument.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Add lint rules to check for discrepancies between tsdoc params and function params and fix all the discovered issues.