### PR TITLE
Add canvas mask example

### DIFF
--- a/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
+++ b/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
@@ -44,11 +44,10 @@ export default function LayerPanelExample() {
 	)
 }
 
-/**
- * Guide:
- *
- * 1. Here we override the `InFrontOfTheCanvas` component with a custom component that renders a simple layer panel.
- * 2. We pass the root ids of the current page to the recursive ShapeList component. (see ShapeList.tsx)
- * 3. This is a function that determines whether a shape is hidden. We use this to hide shapes that have the `hidden` meta property set to true.
- *
- */
+/*
+Guide:
+
+1. Here we override the `InFrontOfTheCanvas` component with a custom component that renders a simple layer panel.
+2. We pass the root ids of the current page to the recursive ShapeList component. (see ShapeList.tsx)
+3. This is a function that determines whether a shape is hidden. We use this to hide shapes that have the `hidden` meta property set to true.
+*/

--- a/apps/examples/src/examples/mask-window/MaskWindowExample.tsx
+++ b/apps/examples/src/examples/mask-window/MaskWindowExample.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react'
+import { TLComponents, TLShape, Tldraw, createShapeId, useEditor, useQuickReactor } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './mask-window.css'
+
+function MaskWindow() {
+	const editor = useEditor()
+	const ref = useRef<HTMLDivElement>(null)
+
+	useQuickReactor(
+		'clip',
+		() => {
+			const elm = ref.current
+			if (!elm) return
+
+			const rotation = editor.getSelectionRotation()
+			const box = editor.getSelectionRotatedScreenBounds()
+
+			if (!box) {
+				// If there's nothing selected, clear the clip path
+				elm.style.clipPath = ''
+				return
+			}
+
+			// Expand the box and get the corners
+			const { corners } = box.clone().expandBy(20)
+
+			// Account for rotation by rotating the points of the rectangle
+			const [tl, tr, br, bl] = corners.map((p) => p.rotWith(box.point, rotation))
+
+			// Since there's no reliable "reverse clip path", we wind around the corners in order to turn our clip into a mask
+			elm.style.clipPath = `polygon(0% 0%, ${tl.x}px 0%, ${tl.x}px ${tl.y}px, ${bl.x}px ${bl.y}px, ${br.x}px ${br.y}px, ${tr.x}px ${tr.y}px, ${tl.x}px ${tl.y}px, ${tl.x}px 0%, 100% 0%, 100% 100%, 0% 100%)`
+		},
+		[editor]
+	)
+
+	useExtraBonusStuff()
+
+	return <div ref={ref} className="mask-fg" />
+}
+
+const components: TLComponents = {
+	InFrontOfTheCanvas: () => {
+		return <MaskWindow />
+	},
+}
+
+export default function MaskWindowExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="mask" components={components} />
+		</div>
+	)
+}
+
+// Some extra stuff that isnt necessary but good for this demo
+function useExtraBonusStuff() {
+	const editor = useEditor()
+
+	useEffect(() => {
+		if (editor.getCurrentPageShapeIds().size === 0) {
+			const vpb = editor.getViewportPageBounds()
+
+			// if the canvas is empty, create some shapes for the demo
+			for (let i = 0; i < 50; i++) {
+				const x = vpb.x + Math.random() * vpb.w
+				const y = vpb.y + Math.random() * vpb.h
+				editor.createShape({ type: 'geo', x, y })
+			}
+
+			const id = createShapeId()
+			const { center } = editor.getViewportPageBounds()
+			editor.createShape({
+				id,
+				type: 'geo',
+				x: center.x - 100,
+				y: center.y - 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+			editor.select(id)
+		}
+
+		// As a (fragile) treat, press J to save positions for the selected shape, then press Ctrl+J to animate between positions
+		const positions: TLShape[] = []
+
+		const handleKeydown = (e: any) => {
+			if (e.key === 'j') {
+				e.preventDefault()
+				e.stopPropagation()
+				if (e.metaKey || e.ctrlKey) {
+					const shape = positions.shift()
+					if (!shape) return
+					editor.animateShape(shape, { animation: { duration: 1000 } })
+				} else {
+					const shape = editor.getOnlySelectedShape()
+					if (!shape) return
+					positions.push(shape)
+				}
+			}
+		}
+		document.addEventListener('keydown', handleKeydown)
+		return () => {
+			document.removeEventListener('keydown', handleKeydown)
+		}
+	}, [editor])
+}

--- a/apps/examples/src/examples/mask-window/README.md
+++ b/apps/examples/src/examples/mask-window/README.md
@@ -1,0 +1,12 @@
+---
+title: Canvas mask
+component: ./MaskWindowExample.tsx
+category: use-cases
+keywords: [mask, window, clip]
+---
+
+This example shows how you can mask the canvas.
+
+---
+
+The canvas has a white overlay. When you have a shape selected, the shape's bounds will be used as a mask through the overlay.

--- a/apps/examples/src/examples/mask-window/mask-window.css
+++ b/apps/examples/src/examples/mask-window/mask-window.css
@@ -1,0 +1,21 @@
+.mask-svg {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+}
+
+.mask-fg {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	background-color: rgba(255, 255, 255, 0.9);
+	/* -webkit-mask:
+		url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" preserveAspectRatio="none"><rect x="100" y="100" width="20" height="20"/></svg>')
+			0/100% 100%,
+		linear-gradient(#fff, #fff);
+	-webkit-mask-composite: destination-out;
+	mask-composite: exclude; */
+}


### PR DESCRIPTION
This PR adds a canvas mask example.

![Kapture 2024-09-28 at 20 25 20](https://github.com/user-attachments/assets/897483cf-b1b0-4c4d-9dcd-fd2a94a0e597)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
