### PR TITLE
[dotcom] Add dialogs

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -19,6 +19,7 @@
 		"test": "yarn run -T jest"
 	},
 	"dependencies": {
+		"@radix-ui/react-alert-dialog": "^1.1.1",
 		"@radix-ui/react-dialog": "^1.0.5",
 		"@radix-ui/react-dropdown-menu": "^2.0.6",
 		"@radix-ui/react-popover": "^1.0.7",

--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -19,6 +19,7 @@
 		"test": "yarn run -T jest"
 	},
 	"dependencies": {
+		"@radix-ui/react-dialog": "^1.0.5",
 		"@radix-ui/react-dropdown-menu": "^2.0.6",
 		"@radix-ui/react-popover": "^1.0.7",
 		"@sentry/integrations": "^7.34.0",

--- a/apps/dotcom/client/src/tla/components/TlaDialog.tsx/TlaDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaDialog.tsx/TlaDialog.tsx
@@ -1,0 +1,32 @@
+import * as Dialogs from '@radix-ui/react-dialog'
+import { useCallback } from 'react'
+import { dialogsAtom, TldrawAppDialog } from '../../providers/TlaDialogsProvider'
+import styles from './dialog.module.css'
+
+export function TlaDialog({ dialog }: { dialog: TldrawAppDialog }) {
+	const handleOpenChange = useCallback(
+		(open: boolean) => {
+			if (!open) {
+				dialogsAtom.update((dialogs) => dialogs.filter((d) => d.id !== dialog.id))
+				dialog.onClose?.()
+			}
+		},
+		[dialog]
+	)
+
+	return (
+		<Dialogs.Root onOpenChange={handleOpenChange} modal open>
+			<Dialogs.Overlay className={styles.overlay} />
+			<Dialogs.Content
+				className={styles.container}
+				onPointerDownOutside={() => {
+					handleOpenChange(false)
+				}}
+			>
+				<div className={styles.containerInner}>
+					<dialog.Component />
+				</div>
+			</Dialogs.Content>
+		</Dialogs.Root>
+	)
+}

--- a/apps/dotcom/client/src/tla/components/TlaDialog.tsx/dialog.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaDialog.tsx/dialog.module.css
@@ -1,0 +1,33 @@
+.overlay {
+	position: absolute;
+	inset: 0px;
+	background-color: var(--tla-color-overlay);
+	z-index: 2000;
+}
+
+.container {
+	outline: none;
+	display: flex;
+	align-self: center;
+	justify-self: center;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 2200;
+}
+
+.containerInner {
+	position: relative;
+	width: 100%;
+	max-width: 360px;
+	height: fit-content;
+	padding: 12px;
+	z-index: 2200;
+	color: var(--tla-color-text-1);
+	background-color: var(--tla-color-panel);
+	pointer-events: all;
+}

--- a/apps/dotcom/client/src/tla/components/TlaDialog.tsx/dialog.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaDialog.tsx/dialog.module.css
@@ -3,6 +3,16 @@
 	inset: 0px;
 	background-color: var(--tla-color-overlay);
 	z-index: 2000;
+	animation: fade-in forwards 0.12s;
+}
+
+@keyframes fade-in {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
 }
 
 .container {
@@ -16,18 +26,21 @@
 	position: absolute;
 	top: 50%;
 	left: 50%;
+	width: 100%;
+	max-width: 360px;
 	transform: translate(-50%, -50%);
 	z-index: 2200;
 }
 
 .containerInner {
 	position: relative;
-	width: 100%;
-	max-width: 360px;
 	height: fit-content;
+	width: 100%;
 	padding: 12px;
 	z-index: 2200;
 	color: var(--tla-color-text-1);
 	background-color: var(--tla-color-panel);
 	pointer-events: all;
+	border-radius: 9px;
+	box-shadow: var(--tla-shadow-3);
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -13,6 +13,7 @@ import { getFileUrl, getShareableFileUrl } from '../../utils/urls'
 import { TlaAvatar } from '../TlaAvatar/TlaAvatar'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
 import { TlaSpacer } from '../TlaSpacer/TlaSpacer'
+import { TlaRenameFileDialog } from '../dialogs/TlaRenameFileDialog'
 import styles from './sidebar.module.css'
 
 export function TlaSidebar() {
@@ -234,12 +235,10 @@ function TlaSidebarFileLinkMenu({ fileId }: { fileId: TldrawAppFile['id'] }) {
 			...d,
 			{
 				id: 'rename',
-				Component: () => {
-					return <div>hello!!!!!!</div>
-				},
+				Component: () => <TlaRenameFileDialog fileId={fileId} />,
 			},
 		])
-	}, [])
+	}, [fileId])
 
 	const handleDuplicateLinkClick = useCallback(() => {
 		// duplicate file

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -4,10 +4,12 @@ import { useCallback } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { TldrawUiButton, TldrawUiButtonLabel, TldrawUiDropdownMenuTrigger, useValue } from 'tldraw'
 import { useApp } from '../../hooks/useAppState'
+import { dialogsAtom } from '../../providers/TlaDialogsProvider'
 import { TldrawApp } from '../../utils/TldrawApp'
+import { copyTextToClipboard } from '../../utils/copy'
 import { TldrawAppFile, TldrawAppFileRecordType } from '../../utils/schema/TldrawAppFile'
 import { getCleanId } from '../../utils/tldrawAppSchema'
-import { getFileUrl } from '../../utils/urls'
+import { getFileUrl, getShareableFileUrl } from '../../utils/urls'
 import { TlaAvatar } from '../TlaAvatar/TlaAvatar'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
 import { TlaSpacer } from '../TlaSpacer/TlaSpacer'
@@ -218,15 +220,25 @@ function TlaSidebarFileLink({ file }: { file: TldrawAppFile }) {
 
 /* ---------------------- Menu ---------------------- */
 
-function TlaSidebarFileLinkMenu(_props: { fileId: TldrawAppFile['id'] }) {
+function TlaSidebarFileLinkMenu({ fileId }: { fileId: TldrawAppFile['id'] }) {
 	// const app = useApp()
 
 	const handleCopyLinkClick = useCallback(() => {
-		// copy file url
-	}, [])
+		const url = getShareableFileUrl(fileId)
+		copyTextToClipboard(url)
+	}, [fileId])
 
 	const handleRenameLinkClick = useCallback(() => {
 		// open rename dialog
+		dialogsAtom.update((d) => [
+			...d,
+			{
+				id: 'rename',
+				Component: () => {
+					return <div>hello!!!!!!</div>
+				},
+			},
+		])
 	}, [])
 
 	const handleDuplicateLinkClick = useCallback(() => {

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaRenameFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaRenameFileDialog.tsx
@@ -1,0 +1,58 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { useCallback, useRef } from 'react'
+import { useValue } from 'tldraw'
+import { useApp } from '../../hooks/useAppState'
+import { TldrawAppFileId } from '../../utils/schema/TldrawAppFile'
+import { TlaButton } from '../TlaButton/TlaButton'
+import { TlaFormGroup, TlaFormInput, TlaFormItem, TlaFormLabel } from '../tla-form/tla-form'
+import styles from './dialogs.module.css'
+
+export function TlaRenameFileDialog({ fileId }: { fileId: TldrawAppFileId }) {
+	const app = useApp()
+	const ref = useRef<HTMLInputElement>(null)
+
+	const fileName = useValue(
+		'file name',
+		() => {
+			const file = app.store.get(fileId)
+			if (!file) throw Error('expected a file')
+			return file.name
+		},
+		[app]
+	)
+
+	const handleClose = useCallback(() => {
+		// rename the file
+		const file = app.store.get(fileId)
+		if (!file) return
+		const elm = ref.current
+		if (!elm) return
+		const name = elm.value.trim() || fileName
+		app.store.put([{ ...file, name }])
+	}, [app, fileId, fileName])
+
+	return (
+		<>
+			<TlaFormGroup>
+				<TlaFormItem>
+					<Dialog.DialogTitle asChild>
+						<TlaFormLabel>Rename file</TlaFormLabel>
+					</Dialog.DialogTitle>
+					<TlaFormInput ref={ref} defaultValue={fileName} />
+				</TlaFormItem>
+			</TlaFormGroup>
+			<TlaFormGroup className={styles.actionGroup}>
+				<Dialog.Close asChild>
+					<TlaButton className={styles.actionButton} variant="secondary">
+						Cancel
+					</TlaButton>
+				</Dialog.Close>
+				<Dialog.Close asChild>
+					<TlaButton className={styles.actionButton} onClick={handleClose}>
+						Save
+					</TlaButton>
+				</Dialog.Close>
+			</TlaFormGroup>
+		</>
+	)
+}

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -1,0 +1,8 @@
+.actionGroup {
+	flex-direction: row;
+	justify-content: flex-end;
+}
+
+.actionButton {
+	width: fit-content;
+}

--- a/apps/dotcom/client/src/tla/components/tla-form/tla-form.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-form/tla-form.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames'
 import {
 	FormHTMLAttributes,
+	forwardRef,
 	HTMLAttributes,
 	HTMLProps,
 	InputHTMLAttributes,
 	LabelHTMLAttributes,
-	ReactNode,
 } from 'react'
 import styles from './form.module.css'
 
@@ -13,12 +13,12 @@ export function TlaForm(props: FormHTMLAttributes<HTMLFormElement>) {
 	return <form {...props} className={classNames(styles.form, props.className)} />
 }
 
-export function TlaFormGroup({ children }: { children: ReactNode }) {
-	return <div className={styles.group}>{children}</div>
+export function TlaFormGroup(props: HTMLAttributes<HTMLDivElement>) {
+	return <div {...props} className={classNames(styles.group, props.className)} />
 }
 
-export function TlaFormItem({ children }: { children: ReactNode }) {
-	return <div className={styles.item}>{children}</div>
+export function TlaFormItem(props: HTMLAttributes<HTMLDivElement>) {
+	return <div {...props} className={classNames(styles.item, props.className)} />
 }
 
 // A label mostly for an input
@@ -30,14 +30,17 @@ export function TlaFormLabel({ children, ...props }: LabelHTMLAttributes<HTMLLab
 	)
 }
 
-export function TlaFormInput(props: InputHTMLAttributes<HTMLInputElement>) {
-	return (
-		<input
-			{...props}
-			className={classNames(styles.input, 'tla-text_ui__regular', props.className)}
-		/>
-	)
-}
+export const TlaFormInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+	function TlaFormInput(props, ref) {
+		return (
+			<input
+				{...props}
+				ref={ref}
+				className={classNames(styles.input, 'tla-text_ui__regular', props.className)}
+			/>
+		)
+	}
+)
 
 export function TlaFormCheckbox({ children, ...props }: HTMLProps<HTMLInputElement>) {
 	return (

--- a/apps/dotcom/client/src/tla/layouts/TlaAnonLayout/TlaAnonLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaAnonLayout/TlaAnonLayout.tsx
@@ -1,21 +1,12 @@
 import classNames from 'classnames'
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { useValue } from 'tldraw'
 import { TlaButton } from '../../components/TlaButton/TlaButton'
-import { useApp } from '../../hooks/useAppState'
 import styles from './anon.module.css'
 
 export function TlaAnonLayout({ children }: { children: ReactNode }) {
-	const app = useApp()
-	const theme = useValue('theme', () => app.getSessionState().theme, [app])
 	return (
-		<div
-			className={classNames(
-				styles.loggedOut,
-				`tla tl-container ${theme === 'light' ? 'tla-theme__light tl-theme__light' : 'tla-theme__dark tl-theme__dark'}`
-			)}
-		>
+		<div className={classNames(styles.loggedOut)}>
 			<div className={styles.header}>
 				<Link to="/">
 					<img src="/tla/tldraw-logo-2.svg" style={{ height: 20, width: 'auto' }} />

--- a/apps/dotcom/client/src/tla/layouts/TlaErrorLayout/TlaErrorLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaErrorLayout/TlaErrorLayout.tsx
@@ -1,20 +1,13 @@
 import { ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useValue } from 'tldraw'
 import { TlaCloseButton } from '../../components/TlaCloseButton/TlaCloseButton'
-import { useApp } from '../../hooks/useAppState'
 import styles from './error-layout.module.css'
 
 export function TlaErrorLayout({ children }: { children: ReactNode }) {
-	const app = useApp()
-	const theme = useValue('theme', () => app.getSessionState().theme, [app])
 	const navigate = useNavigate()
 
 	return (
-		<div
-			className={`tla tl-container ${theme === 'light' ? 'tla-theme__light' : 'tla-theme__dark'} `}
-			data-sidebar="false"
-		>
+		<div data-sidebar="false">
 			<TlaCloseButton onClose={() => navigate('/q/')} />
 			<div className={styles.page}>{children}</div>
 		</div>

--- a/apps/dotcom/client/src/tla/layouts/TlaPageLayout/TlaPageLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaPageLayout/TlaPageLayout.tsx
@@ -1,16 +1,9 @@
-import classNames from 'classnames'
 import { ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useValue } from 'tldraw'
 import { TlaCloseButton } from '../../components/TlaCloseButton/TlaCloseButton'
-import { useApp } from '../../hooks/useAppState'
 import styles from './page.module.css'
 
 export function TlaPageLayout({ children }: { children: ReactNode }) {
-	const app = useApp()
-
-	const theme = useValue('theme', () => app.getSessionState().theme, [app])
-
 	const navigate = useNavigate()
 
 	const handleCloseClick = useCallback(() => {
@@ -18,12 +11,7 @@ export function TlaPageLayout({ children }: { children: ReactNode }) {
 	}, [navigate])
 
 	return (
-		<div
-			className={classNames(
-				`tla tl-container ${theme === 'light' ? 'tla-theme__light tl-theme__light' : 'tla-theme__dark tl-theme__dark'}`,
-				styles.container
-			)}
-		>
+		<div className={styles.container}>
 			<TlaCloseButton onClose={handleCloseClick} />
 			<div className={styles.page}>{children}</div>
 		</div>

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { ReactNode } from 'react'
 import { useValue } from 'tldraw'
 import { TlaSidebar } from '../../components/TlaSidebar/TlaSidebar'
@@ -13,13 +12,9 @@ export function TlaSidebarLayout({ children }: { children: ReactNode; collapsabl
 		() => app.getSessionState().isSidebarOpenMobile,
 		[app]
 	)
-	const theme = useValue('theme', () => app.getSessionState().theme, [app])
 	return (
 		<div
-			className={classNames(
-				`tla tl-container ${theme === 'light' ? 'tla-theme__light tl-theme__light' : 'tla-theme__dark tl-theme__dark'}`,
-				styles.layout
-			)}
+			className={styles.layout}
 			data-sidebar={isSidebarOpen}
 			data-sidebarmobile={isSidebarOpenMobile}
 		>

--- a/apps/dotcom/client/src/tla/providers/TlaAppProvider.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaAppProvider.tsx
@@ -1,11 +1,28 @@
 import { Outlet } from 'react-router-dom'
-import { AppStateProvider } from '../hooks/useAppState'
+import { useValue } from 'tldraw'
+import { AppStateProvider, useApp } from '../hooks/useAppState'
 import '../styles/tla.css'
+import { TlaDialogsProvider } from './TlaDialogsProvider'
 
 export function Component() {
 	return (
 		<AppStateProvider>
-			<Outlet />
+			<Inner />
 		</AppStateProvider>
+	)
+}
+
+function Inner() {
+	const app = useApp()
+	const theme = useValue('theme', () => app.getSessionState().theme, [app])
+
+	return (
+		<div
+			className={`tla tl-container ${theme === 'light' ? 'tla-theme__light tl-theme__light' : 'tla-theme__dark tl-theme__dark'}`}
+		>
+			<TlaDialogsProvider>
+				<Outlet />
+			</TlaDialogsProvider>
+		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/providers/TlaDialogsProvider.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaDialogsProvider.tsx
@@ -1,6 +1,8 @@
 import { JSX, ReactNode } from 'react'
 import { atom, useValue } from 'tldraw'
 import { TlaDialog } from '../components/TlaDialog.tsx/TlaDialog'
+import { TlaRenameFileDialog } from '../components/dialogs/TlaRenameFileDialog'
+import { TldrawAppFileRecordType } from '../utils/schema/TldrawAppFile'
 
 export interface TldrawAppDialog {
 	id: string
@@ -8,7 +10,14 @@ export interface TldrawAppDialog {
 	Component(props: { onClose?(): void }): JSX.Element
 }
 
-export const dialogsAtom = atom<TldrawAppDialog[]>('dialogs', [])
+export const dialogsAtom = atom<TldrawAppDialog[]>('dialogs', [
+	{
+		id: 'rename',
+		Component: () => {
+			return <TlaRenameFileDialog fileId={TldrawAppFileRecordType.createId('0')} />
+		},
+	},
+])
 
 export function TlaDialogsProvider({ children }: { children: ReactNode }) {
 	const dialogs = useValue('dialogs', () => dialogsAtom.get(), [])

--- a/apps/dotcom/client/src/tla/providers/TlaDialogsProvider.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaDialogsProvider.tsx
@@ -1,0 +1,24 @@
+import { JSX, ReactNode } from 'react'
+import { atom, useValue } from 'tldraw'
+import { TlaDialog } from '../components/TlaDialog.tsx/TlaDialog'
+
+export interface TldrawAppDialog {
+	id: string
+	onClose?(): void
+	Component(props: { onClose?(): void }): JSX.Element
+}
+
+export const dialogsAtom = atom<TldrawAppDialog[]>('dialogs', [])
+
+export function TlaDialogsProvider({ children }: { children: ReactNode }) {
+	const dialogs = useValue('dialogs', () => dialogsAtom.get(), [])
+
+	return (
+		<>
+			{children}
+			{dialogs.map((dialog) => (
+				<TlaDialog key={dialog.id} dialog={dialog} />
+			))}
+		</>
+	)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,6 +3747,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-alert-dialog@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-alert-dialog@npm:1.1.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.0"
+    "@radix-ui/react-dialog": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-slot": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 5049255a4b31b2d65c36235c32016c54234f7580778639b416c3c169af545a2522f9f452d6eb1d9d31c0d2e4d9ca2ae36cac4876bec31f5cc422e92acba5557c
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-arrow@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-arrow@npm:1.0.3"
@@ -3972,7 +3996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.0.5":
+"@radix-ui/react-dialog@npm:1.1.1, @radix-ui/react-dialog@npm:^1.0.5":
   version: 1.1.1
   resolution: "@radix-ui/react-dialog@npm:1.1.1"
   dependencies:
@@ -11220,6 +11244,7 @@ __metadata:
   resolution: "dotcom@workspace:apps/dotcom/client"
   dependencies:
     "@jest/globals": "npm:30.0.0-alpha.2"
+    "@radix-ui/react-alert-dialog": "npm:^1.1.1"
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-dropdown-menu": "npm:^2.0.6"
     "@radix-ui/react-popover": "npm:^1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11220,6 +11220,7 @@ __metadata:
   resolution: "dotcom@workspace:apps/dotcom/client"
   dependencies:
     "@jest/globals": "npm:30.0.0-alpha.2"
+    "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-dropdown-menu": "npm:^2.0.6"
     "@radix-ui/react-popover": "npm:^1.0.7"
     "@sentry/cli": "npm:^2.25.0"


### PR DESCRIPTION
This PR adds some quick app-level dialogs. I'm not wed to the design here, and we could bring in the dialog system from the editor as we've discussed.

<img width="1345" alt="Screenshot 2024-09-29 at 00 20 18" src="https://github.com/user-attachments/assets/4f56baed-64e8-456b-ab67-6607055e8c2e">

For comparison, here's an example of the editor dialog:
<img width="1345" alt="Screenshot 2024-09-29 at 00 19 44" src="https://github.com/user-attachments/assets/e147aeaa-c250-4d82-ac94-02ba6724cb6b">

### Change type

- [x] `other`
