### PR TITLE
Fix watermark link opening twice when clicking on the watermark.

### DIFF
--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -2,7 +2,7 @@ import { useQuickReactor, useValue } from '@tldraw/state-react'
 import { memo, useState } from 'react'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
-import { preventDefault, stopEventPropagation } from '../utils/dom'
+import { stopEventPropagation } from '../utils/dom'
 import { runtime } from '../utils/runtime'
 import { watermarkDesktopSvg, watermarkMobileSvg } from '../watermarks'
 import { LicenseManager } from './LicenseManager'
@@ -69,7 +69,6 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 				draggable={false}
 				role="button"
 				onPointerDown={(e) => {
-					preventDefault(e)
 					stopEventPropagation(e)
 					runtime.openWindow(url, '_blank')
 				}}

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -66,15 +66,13 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 			{...events}
 		>
 			<a
-				target="_blank"
-				href={url}
-				rel="noreferrer"
 				draggable={false}
+				role="button"
 				onPointerDown={(e) => {
-					stopEventPropagation(e)
 					preventDefault(e)
+					stopEventPropagation(e)
+					runtime.openWindow(url, '_blank')
 				}}
-				onClick={() => runtime.openWindow(url, '_blank')}
 				style={{ mask: maskCss, WebkitMask: maskCss }}
 			/>
 		</div>


### PR DESCRIPTION
Fix the link opening twice in FF.

Related #4622

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Start the app.
2. Click on the watermark. It should only open one new tab.
3. Try different browsers.

### Release notes

- Fix a bug with watermark link opening twice in FF.