### PR TITLE
[bugfix] respect camera constraints after switching page + setting constraints

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3887,6 +3887,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.run(
 			() => {
 				this.store.put([{ ...this.getInstanceState(), currentPageId: pageId }])
+				// ensure camera constraints are applied
+				this.setCamera(this.getCamera())
 			},
 			{ history: 'record-preserveRedoStack' }
 		)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2461,6 +2461,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
+		this.setCamera(this.getCamera(), { force: true })
 		return this
 	}
 
@@ -3888,7 +3889,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			() => {
 				this.store.put([{ ...this.getInstanceState(), currentPageId: pageId }])
 				// ensure camera constraints are applied
-				this.setCamera(this.getCamera())
+				this.setCamera(this.getCamera(), { force: true })
 			},
 			{ history: 'record-preserveRedoStack' }
 		)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2461,7 +2461,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
-		this.setCamera(this.getCamera(), { force: true })
+		this.setCamera(this.getCamera())
 		return this
 	}
 
@@ -3889,7 +3889,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			() => {
 				this.store.put([{ ...this.getInstanceState(), currentPageId: pageId }])
 				// ensure camera constraints are applied
-				this.setCamera(this.getCamera(), { force: true })
+				this.setCamera(this.getCamera())
 			},
 			{ history: 'record-preserveRedoStack' }
 		)

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -1045,3 +1045,33 @@ test('it animated towards the constrained viewport rather than the given viewpor
 		}
 	`)
 })
+
+test('calling setCameraOptions will apply the new constraints', () => {
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: {
+			...DEFAULT_CONSTRAINTS,
+		},
+	})
+	editor.setCamera(new Vec(-1000000, -1000000, 1))
+	const camera = editor.getCamera()
+	expect(camera).toMatchObject({ x: -1000000, y: -1000000, z: 1 })
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: {
+			...DEFAULT_CONSTRAINTS,
+			bounds: { x: 0, y: 0, w: 1600, h: 900 },
+			behavior: 'contain',
+		},
+	})
+	expect(editor.getCamera()).toMatchInlineSnapshot(`
+		{
+		  "id": "camera:page:page",
+		  "meta": {},
+		  "typeName": "camera",
+		  "x": 0,
+		  "y": 0,
+		  "z": 1,
+		}
+	`)
+})

--- a/packages/tldraw/src/test/commands/setCurrentPage.test.ts
+++ b/packages/tldraw/src/test/commands/setCurrentPage.test.ts
@@ -103,4 +103,23 @@ describe('setCurrentPage', () => {
 		editor.setCurrentPage(page2Id)
 		expect(editor.isIn('select.idle')).toBe(true)
 	})
+
+	it('applies camera constraints', () => {
+		const spy = jest.spyOn(editor, 'setCamera')
+
+		let currentPageId = editor.getCurrentPageId()
+		expect(currentPageId).toMatchInlineSnapshot(`"page:page"`)
+		spy.mockImplementation(() => {
+			currentPageId = editor.getCurrentPageId()
+			return editor
+		})
+
+		editor.createPage({ name: 'New Page 2', id: PageRecordType.createId('page2') })
+		expect(spy).toHaveBeenCalledTimes(0)
+		editor.setCurrentPage(PageRecordType.createId('page2'))
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(currentPageId).toMatchInlineSnapshot(`"page:page2"`)
+
+		expect(spy)
+	})
 })


### PR DESCRIPTION
1. When you call `editor.setCameraConstraints` it should immediately apply the camera constraints.
2. When you switch pages, the camera should be constrained.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug where camera constraints were not upheld after switching pages or setting new camera constraints.