### PR TITLE
Disable debug mode in development by default

### DIFF
--- a/apps/docs/components/marketing/DemoTldraw.tsx
+++ b/apps/docs/components/marketing/DemoTldraw.tsx
@@ -17,8 +17,6 @@ export default function DemoTldraw({ hidden }: { hidden?: boolean }) {
 	useEffect(() => {
 		if (!editor) return
 		editor.focus({ focusContainer: false })
-		// don't want this at dev time
-		editor.updateInstanceState({ isDebugMode: false })
 		const handleClickOutside = (e: MouseEvent) => {
 			if (!wrapper.current?.contains(e.target as Node)) {
 				// prevent capturing scroll events on the landing page after clicking outside

--- a/apps/examples/src/examples/image-annotator/ImageAnnotationEditor.tsx
+++ b/apps/examples/src/examples/image-annotator/ImageAnnotationEditor.tsx
@@ -34,9 +34,6 @@ export function ImageAnnotationEditor({
 	useEffect(() => {
 		if (!editor) return
 
-		// Turn off debug mode
-		editor.updateInstanceState({ isDebugMode: false })
-
 		// Create the asset and image shape
 		const assetId = AssetRecordType.createId()
 		editor.createAssets([

--- a/apps/examples/src/examples/image-component/TldrawImageExample.tsx
+++ b/apps/examples/src/examples/image-component/TldrawImageExample.tsx
@@ -72,7 +72,6 @@ export default function TldrawImageExample() {
 						snapshot={snapshot}
 						onMount={(editor: Editor) => {
 							setEditor(editor)
-							editor.updateInstanceState({ isDebugMode: false })
 							editor.user.updateUserPreferences({ colorScheme: isDarkMode ? 'dark' : 'light' })
 							if (currentPageId) {
 								editor.setCurrentPage(currentPageId)

--- a/apps/examples/src/examples/inline-behavior/InlineBehavior.tsx
+++ b/apps/examples/src/examples/inline-behavior/InlineBehavior.tsx
@@ -103,7 +103,6 @@ function InlineBlock({ persistenceKey }: { persistenceKey: string }) {
 					setEditor(editor)
 					editor.setCurrentTool('hand')
 					editor.user.updateUserPreferences({ edgeScrollSpeed: 0 })
-					editor.updateInstanceState({ isDebugMode: false })
 				}}
 			/>
 		</div>

--- a/apps/examples/src/examples/inline/InlineExample.tsx
+++ b/apps/examples/src/examples/inline/InlineExample.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from 'react'
-import { Editor, Tldraw } from 'tldraw'
+import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 const FocusedEditorContext = createContext(
@@ -37,15 +37,11 @@ function InlineEditor({ width, height }: { width: number; height: number }) {
 
 	const title = `${width} x ${height}`
 
-	const handleMount = (editor: Editor) => {
-		editor.updateInstanceState({ isDebugMode: false })
-	}
-
 	return (
 		<div>
 			<h2>{title}</h2>
 			<div style={{ width, height }} onFocus={() => setFocusedEditor(title)}>
-				<Tldraw onMount={handleMount} autoFocus={focusedEditor === title} />
+				<Tldraw autoFocus={focusedEditor === title} />
 			</div>
 		</div>
 	)

--- a/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
+++ b/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
@@ -33,7 +33,6 @@ export function PdfEditor({ pdf }: { pdf: Pdf }) {
 	return (
 		<Tldraw
 			onMount={(editor) => {
-				editor.updateInstanceState({ isDebugMode: false })
 				editor.createAssets(
 					pdf.pages.map((page) => ({
 						id: page.assetId,

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -218,7 +218,7 @@ export function createInstanceRecordType(stylesById: Map<string, StyleProp<unkno
 			},
 			isFocusMode: false,
 			exportBackground: false,
-			isDebugMode: process.env.NODE_ENV === 'development',
+			isDebugMode: false,
 			isToolLocked: false,
 			screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
 			insets: [false, false, false, false],


### PR DESCRIPTION
fixes #4619

This was bad to inflict on our users, we can look at enabling it on dotcom for ourselves if people complain it's gone.

### Change type

- [x] `sdk`

### Release notes

- Turns off debug mode by default in local development.