### PR TITLE
Fix VS Code `editorPath`

### DIFF
--- a/apps/vscode/extension/src/extension.ts
+++ b/apps/vscode/extension/src/extension.ts
@@ -16,8 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
 					vscode.commands.executeCommand('workbench.action.reloadWindow')
 				}
 			)
-			const result = path.dirname(__dirname).split(path.sep).slice(1, -1)
-			const editorpath = path.join(...result)
+			const dirname = path.dirname(__dirname)
+			const editorpath = dirname.slice(0, dirname.lastIndexOf(path.sep))
 			const editorWatcher = watch(
 				editorpath + '/editor/index.js',
 				{ persistent: false },


### PR DESCRIPTION
I'm not sure why the previous code was written the way it was, but it causes an error on my system that prevents the extension from running in development mode:

```
/home/vladh/sources/tldraw/apps/vscode/extension/dist
(9) ['', 'home', 'vladh', 'sources', 'tldraw', 'apps', 'vscode', 'extension', 'dist']
(7) ['home', 'vladh', 'sources', 'tldraw', 'apps', 'vscode', 'extension']
Error: ENOENT: no such file or directory, watch 'home/vladh/sources/tldraw/apps/vscode/extension/editor/index.js'
```

This is because the previous code was removing the leading slash from paths, which led the watcher to always fail. My solution fixes this, and does in a much simpler way what I believe the original code was trying to do, which is to remove the last path component.

Found while developing #4622.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Follow the development instructions in `apps/vscode/README.md`
2. When running “Start Debugging” in VS Code, an error message is shown and the extension crashes

### Release notes

- Fixed an incorrect path in the development tools of the VS Code extension