### PR TITLE
text: followup fix to locking text shapes

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -57,16 +57,15 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				kbd: 'v',
 				readonlyOk: true,
 				onSelect(source) {
-					const currentNode = editor.root.getCurrent()
-					if (currentNode) {
+					if (editor.isIn('select')) {
 						// There's a quirk of select mode, where editing a shape is a sub-state of select.
 						// Because the text tool can be locked/sticky, we need to make sure we exit the
 						// text tool.
+						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
 						currentNode.enter({}, currentNode.id)
 					}
 					editor.setCurrentTool('select.idle')
-
 					trackEvent('select-tool', { source, id: 'select' })
 				},
 			},

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -57,7 +57,16 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				kbd: 'v',
 				readonlyOk: true,
 				onSelect(source) {
+					const currentNode = editor.root.getCurrent()
+					if (currentNode) {
+						// There's a quirk of select mode, where editing a shape is a sub-state of select.
+						// Because the text tool can be locked/sticky, we need to make sure we exit the
+						// text tool.
+						currentNode.exit({}, currentNode.id)
+						currentNode.enter({}, currentNode.id)
+					}
 					editor.setCurrentTool('select.idle')
+
 					trackEvent('select-tool', { source, id: 'select' })
 				},
 			},

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -63,7 +63,6 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						// text tool.
 						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
-						currentNode.enter({}, currentNode.id)
 					}
 					editor.setCurrentTool('select.idle')
 					trackEvent('select-tool', { source, id: 'select' })


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/4569
Once the text shape is locked you can't click the Select tool to switch out. This addresses that (because the tool is masked at the time). If there's a better fix for this, I'm all ears, I wasn't sure how else to resolve this (I see you pulled it out in the other PR @steveruizok )

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix bug with text shape locking.