### PR TITLE
text: followup to the followup of fix to locking text shapes

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -63,6 +63,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						// text tool.
 						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
+						currentNode.enter({}, currentNode.id)
 					}
 					editor.setCurrentTool('select.idle')
 					trackEvent('select-tool', { source, id: 'select' })

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -61,11 +61,14 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						// There's a quirk of select mode, where editing a shape is a sub-state of select.
 						// Because the text tool can be locked/sticky, we need to make sure we exit the
 						// text tool.
+						//
+						// psst, if you're changing this code, also change the code
+						// in strange-tools.test.ts! Sadly it's duplicated there.
 						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
 						currentNode.enter({}, currentNode.id)
 					}
-					editor.setCurrentTool('select.idle')
+					editor.setCurrentTool('select')
 					trackEvent('select-tool', { source, id: 'select' })
 				},
 			},

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -1,0 +1,68 @@
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+// This is copied from the "select" tool in the tools context
+// It's a bit of a hack to simulate the user clicking the select tool
+// Since there's no way of importing this code, it's copied here.
+function onSelectToolClick(editor: TestEditor) {
+	const currentNode = editor.root.getCurrent()!
+	currentNode.exit({}, currentNode.id)
+	currentNode.enter({}, currentNode.id)
+	editor.setCurrentTool('select')
+}
+
+describe('interaction between the select tool and the editing state', () => {
+	it('leaves editing when clicking the select tool', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown()
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('leaves cropping when clicking the select tool', () => {
+		editor
+			.createShape({ type: 'image', props: { w: 100, h: 100 } })
+			.pointerMove(50, 50)
+			.doubleClick()
+			.expectToBeIn('select.crop.idle')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('leaves editing while not tool locked', () => {
+		editor
+			.updateInstanceState({ isToolLocked: false })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+			.pointerMove(200, 200)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.idle')
+	})
+
+	it('leaves editing when clicking the select tool while tool locked', () => {
+		editor
+			.updateInstanceState({ isToolLocked: true })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+			.pointerMove(200, 200)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+})


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/4632 (which is a followup to https://github.com/tldraw/tldraw/pull/4569)

@steveruizok i saw you had removed this line but it's necessary because otherwise the Select tool doesn't work when switching to it... (clicking on shapes doesn't do anything)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix bug with text shape locking.