### PR TITLE
[state] fix error 'cannot change atoms during reaction cycle' bug

### DIFF
--- a/packages/state/src/lib/__tests__/transactions.test.ts
+++ b/packages/state/src/lib/__tests__/transactions.test.ts
@@ -305,6 +305,13 @@ test('it should be possible to run a transaction during a reaction', () => {
 	a.set(1)
 
 	expect(b.get()).toBe(2)
+
+	transaction(() => {
+		a.set(2)
+		expect(b.get()).toBe(2)
+	})
+
+	expect(b.get()).toBe(3)
 })
 
 test('it should be possible to abort a transaction during a reaction', () => {
@@ -325,20 +332,72 @@ test('it should be possible to abort a transaction during a reaction', () => {
 	unsub()
 
 	react('', () => {
-		try {
-			transaction(() => {
-				b.set(a.get() + 1)
-				throw new Error('oops')
-			})
-		} catch (e: any) {
-			expect(e.message).toBe('oops')
-		} finally {
-			expect(b.get()).toBe(0)
-		}
+		transaction(() => {
+			b.set(3)
+			try {
+				transaction(() => {
+					b.set(a.get() + 1)
+					throw new Error('oops')
+				})
+			} catch (e: any) {
+				expect(e.message).toBe('oops')
+			} finally {
+				expect(b.get()).toBe(3)
+			}
+		})
+		expect(b.get()).toBe(3)
 	})
 
 	expect(a.get()).toBe(0)
-	expect(b.get()).toBe(0)
+	expect(b.get()).toBe(3)
 
-	expect.assertions(7)
+	expect.assertions(8)
+})
+
+it('should defer all side effects until the end of the outer transaction', () => {
+	const a = atom('', 0)
+	const b = atom('', 0)
+	const c = atom('', 0)
+
+	const aChanged = jest.fn()
+	const bChanged = jest.fn()
+	const cChanged = jest.fn()
+
+	react('', () => {
+		a.get()
+		aChanged()
+	})
+
+	react('', () => {
+		transaction(() => {
+			a.set(b.get() + 1)
+		})
+		bChanged()
+	})
+
+	react('', () => {
+		transaction(() => {
+			b.set(c.get() + 1)
+		})
+		cChanged()
+	})
+
+	expect(aChanged).toHaveBeenCalledTimes(3)
+	expect(bChanged).toHaveBeenCalledTimes(2)
+	expect(cChanged).toHaveBeenCalledTimes(1)
+
+	expect(a.__unsafe__getWithoutCapture()).toBe(2)
+
+	cChanged.mockImplementationOnce(() => {
+		// b was .set() during c's reaction
+		expect(b.__unsafe__getWithoutCapture()).toBe(2)
+		// a was not yet set because the effect was deferred
+		// util the end of the reaction
+		expect(a.__unsafe__getWithoutCapture()).toBe(2)
+	})
+
+	c.set(1)
+
+	expect(a.__unsafe__getWithoutCapture()).toBe(3)
+	expect(cChanged).toHaveBeenCalledTimes(2)
 })

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -24,7 +24,13 @@ class Transaction {
 	 * @public
 	 */
 	commit() {
-		if (this.isRoot) {
+		if (inst.globalIsReacting) {
+			// if we're committing during a reaction we actually need to
+			// use the 'cleanup' reactors set to ensure we re-run effects if necessary
+			for (const atom of this.initialAtomValues.keys()) {
+				traverseAtomForCleanup(atom)
+			}
+		} else if (this.isRoot) {
 			// For root transactions, flush changed atoms
 			flushChanges(this.initialAtomValues.keys())
 		} else {
@@ -100,10 +106,13 @@ function traverse(reactors: Set<EffectScheduler<unknown>>, child: Child) {
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {
-		throw new Error('cannot change atoms during reaction cycle')
+		throw new Error('flushChanges cannot be called during a reaction')
 	}
 
+	const outerTxn = inst.currentTransaction
 	try {
+		// clear the transaction stack
+		inst.currentTransaction = null
 		inst.globalIsReacting = true
 		inst.reactionEpoch = inst.globalEpoch
 
@@ -133,6 +142,7 @@ function flushChanges(atoms: Iterable<_Atom>) {
 	} finally {
 		inst.cleanupReactors = null
 		inst.globalIsReacting = false
+		inst.currentTransaction = outerTxn
 	}
 }
 
@@ -145,21 +155,28 @@ function flushChanges(atoms: Iterable<_Atom>) {
  * @internal
  */
 export function atomDidChange(atom: _Atom, previousValue: any) {
-	if (inst.globalIsReacting) {
-		// If the atom changed during the reaction phase of flushChanges
-		// then we are past the point where a transaction can be aborted
-		// so we don't need to note down the previousValue.
-		const rs = (inst.cleanupReactors ??= new Set())
-		atom.children.visit((child) => traverse(rs, child))
-	} else if (!inst.currentTransaction) {
-		// If there is no transaction, flush the changes immediately.
-		flushChanges([atom])
-	} else if (!inst.currentTransaction.initialAtomValues.has(atom)) {
+	if (inst.currentTransaction) {
 		// If we are in a transaction, then all we have to do is preserve
 		// the value of the atom at the start of the transaction in case
 		// we need to roll back.
-		inst.currentTransaction.initialAtomValues.set(atom, previousValue)
+		if (!inst.currentTransaction.initialAtomValues.has(atom)) {
+			inst.currentTransaction.initialAtomValues.set(atom, previousValue)
+		}
+	} else if (inst.globalIsReacting) {
+		// If the atom changed during the reaction phase of flushChanges
+		// (and there are no transactions started inside the reaction phase)
+		// then we are past the point where a transaction can be aborted
+		// so we don't need to note down the previousValue.
+		traverseAtomForCleanup(atom)
+	} else {
+		// If there is no transaction, flush the changes immediately.
+		flushChanges([atom])
 	}
+}
+
+function traverseAtomForCleanup(atom: _Atom) {
+	const rs = (inst.cleanupReactors ??= new Set())
+	atom.children.visit((child) => traverse(rs, child))
 }
 
 export function advanceGlobalEpoch() {


### PR DESCRIPTION
Small error related to running a transaction inside a reaction, which would fail if the transaction was triggered by an atom change that was _not_ inside a transaction.

reported on discord https://discord.com/channels/859816885297741824/1290915672095985664/1290915672095985664

### Change type

- [x] `bugfix`


### Release notes

- Fixed a bug that was manifesting as `Error('cannot change atoms during reaction cycle')`