### PR TITLE
Prevent some draw shape rerenders when changing the zoom

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -139,7 +139,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 		const scaleFactor = 1 / shape.props.scale
 		return (
 			<g transform={`scale(${scaleFactor})`}>
-				<DrawShapeSvg shape={shape} use100PercentZoom />
+				<DrawShapeSvg shape={shape} zoomLevel={1} />
 			</g>
 		)
 	}
@@ -201,13 +201,7 @@ function getIsDot(shape: TLDrawShape) {
 	return shape.props.segments.length === 1 && shape.props.segments[0].points.length < 2
 }
 
-function DrawShapeSvg({
-	shape,
-	use100PercentZoom = false,
-}: {
-	shape: TLDrawShape
-	use100PercentZoom?: boolean
-}) {
+function DrawShapeSvg({ shape, zoomLevel }: { shape: TLDrawShape; zoomLevel?: number }) {
 	const theme = useDefaultColorTheme()
 	const editor = useEditor()
 
@@ -219,22 +213,21 @@ function DrawShapeSvg({
 	const forceSolid = useValue(
 		'force solid',
 		() => {
-			if (use100PercentZoom) return false
-			const zoomLevel = editor.getZoomLevel()
-			return zoomLevel < 0.5 && zoomLevel < 1.5 / sw
+			const z = zoomLevel ?? editor.getZoomLevel()
+			return z < 0.5 && z < 1.5 / sw
 		},
-		[editor, sw, use100PercentZoom]
+		[editor, sw, zoomLevel]
 	)
 
 	const dotAdjustment = useValue(
 		'dot adjustment',
 		() => {
-			if (use100PercentZoom) return 0.1
+			const z = zoomLevel ?? editor.getZoomLevel()
 			// If we're zoomed way out (10%), then we need to make the dotted line go to 9 instead 0.1
 			// Chrome doesn't render anything otherwise.
-			return editor.getZoomLevel() < 0.2 ? 0 : 0.1
+			return z < 0.2 ? 0 : 0.1
 		},
-		[editor, use100PercentZoom]
+		[editor, zoomLevel]
 	)
 
 	if (

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -139,7 +139,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 		const scaleFactor = 1 / shape.props.scale
 		return (
 			<g transform={`scale(${scaleFactor})`}>
-				<DrawShapeSvg shape={shape} zoomLevel={1} />
+				<DrawShapeSvg shape={shape} zoomOverride={1} />
 			</g>
 		)
 	}
@@ -201,7 +201,7 @@ function getIsDot(shape: TLDrawShape) {
 	return shape.props.segments.length === 1 && shape.props.segments[0].points.length < 2
 }
 
-function DrawShapeSvg({ shape, zoomLevel }: { shape: TLDrawShape; zoomLevel?: number }) {
+function DrawShapeSvg({ shape, zoomOverride }: { shape: TLDrawShape; zoomOverride?: number }) {
 	const theme = useDefaultColorTheme()
 	const editor = useEditor()
 
@@ -213,21 +213,21 @@ function DrawShapeSvg({ shape, zoomLevel }: { shape: TLDrawShape; zoomLevel?: nu
 	const forceSolid = useValue(
 		'force solid',
 		() => {
-			const z = zoomLevel ?? editor.getZoomLevel()
-			return z < 0.5 && z < 1.5 / sw
+			const zoomLevel = zoomOverride ?? editor.getZoomLevel()
+			return zoomLevel < 0.5 && zoomLevel < 1.5 / sw
 		},
-		[editor, sw, zoomLevel]
+		[editor, sw, zoomOverride]
 	)
 
 	const dotAdjustment = useValue(
 		'dot adjustment',
 		() => {
-			const z = zoomLevel ?? editor.getZoomLevel()
+			const zoomLevel = zoomOverride ?? editor.getZoomLevel()
 			// If we're zoomed way out (10%), then we need to make the dotted line go to 9 instead 0.1
 			// Chrome doesn't render anything otherwise.
-			return z < 0.2 ? 0 : 0.1
+			return zoomLevel < 0.2 ? 0 : 0.1
 		},
-		[editor, zoomLevel]
+		[editor, zoomOverride]
 	)
 
 	if (

--- a/packages/tldraw/src/lib/shapes/draw/getPath.ts
+++ b/packages/tldraw/src/lib/shapes/draw/getPath.ts
@@ -122,14 +122,12 @@ export function getPointsFromSegments(segments: TLDrawShapeSegment[]) {
 export function getDrawShapeStrokeDashArray(
 	shape: TLDrawShape,
 	strokeWidth: number,
-	zoomLevel: number
+	dotAdjustment: number
 ) {
 	return {
 		draw: 'none',
 		solid: `none`,
-		// If we're zoomed way out (10%), then we need to make the dotted line go to 9 instead 0.1
-		// Chrome doesn't render anything otherwise.
-		dotted: `${zoomLevel < 0.2 ? 0 : 0.1} ${strokeWidth * 2}`,
+		dotted: `${dotAdjustment} ${strokeWidth * 2}`,
 		dashed: `${strokeWidth * 2} ${strokeWidth * 2}`,
 	}[shape.props.dash]
 }


### PR DESCRIPTION
Any zoom change caused a rerender of draw shapes. Now we will only rerender when the conditions for the change in `forceSolid` or `dotAdjustment` are met.

[Related conversation](https://discord.com/channels/859816885297741824/1290589596417003571/1290963510963994626).

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a draw shape.
2. Change the zoom.
3. We shouldn't see renrenders for every change, only at certain zoom level changes (like going for 10 -> 20%)

### Release notes

- Reduce the number of times the draw shape has to rerender due to the zoom changes.