### PR TITLE
Fix parent transitions

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2332,6 +2332,8 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     getCurrent(): StateNode | undefined;
     // (undocumented)
     getCurrentToolIdMask(): string | undefined;
+    // (undocumented)
+    getDescendant<T extends StateNode>(path: string): T | undefined;
     getIsActive(): boolean;
     getPath(): string;
     // (undocumented)
@@ -2396,6 +2398,10 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     setCurrentToolIdMask(id: string | undefined): void;
     // (undocumented)
     shapeType?: string;
+    // (undocumented)
+    start(): void;
+    // (undocumented)
+    _started: boolean;
     transition(path: string, info?: any): this | undefined;
     // (undocumented)
     type: 'branch' | 'leaf' | 'root';

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2396,7 +2396,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     setCurrentToolIdMask(id: string | undefined): void;
     // (undocumented)
     shapeType?: string;
-    transition(id: string, info?: any): this;
+    transition(path: string, info?: any): this | undefined;
     // (undocumented)
     type: 'branch' | 'leaf' | 'root';
 }

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -720,11 +720,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			throw Error(`No state found for initialState "${initialState}".`)
 		}
 
-		this.root.enter(undefined, 'initial')
-
 		this.edgeScrollManager = new EdgeScrollManager(this)
 		this.focusManager = new FocusManager(this, autoFocus)
 		this.disposables.add(this.focusManager.dispose.bind(this.focusManager))
+
+		this.root.start()
 
 		if (this.getInstanceState().followingUserId) {
 			this.stopFollowingUser()
@@ -1380,16 +1380,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	getStateDescendant<T extends StateNode>(path: string): T | undefined {
-		const ids = path.split('.').reverse()
-		let state = this.root as StateNode
-		while (ids.length > 0) {
-			const id = ids.pop()
-			if (!id) return state as T
-			const childState = state.children?.[id]
-			if (!childState) return undefined
-			state = childState
-		}
-		return state as T
+		return this.root.getDescendant(path)
 	}
 
 	/* ---------------- Document Settings --------------- */

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -136,20 +136,32 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	 * ```ts
 	 * parentState.transition('childStateA')
 	 * parentState.transition('childStateB', { myData: 4 })
+	 * parentState.transition('childStateA.childStateAB.childStateABC')
 	 *```
 	 *
-	 * @param id - The id of the child state node to transition to.
+	 * @param path - The path of child state nodes to transition to.
 	 * @param info - Any data to pass to the `onEnter` and `onExit` handlers.
 	 *
 	 * @public
 	 */
-	transition(id: string, info: any = {}) {
-		const path = id.split('.')
+	transition(path: string, info: any = {}) {
+		const pathIds = path.split('.')
 
 		let currState = this as StateNode
 
-		for (let i = 0; i < path.length; i++) {
-			const id = path[i]
+		const currentPath = this.getPath().split('root.')[1]
+		// todo: if the transition is to a parent of the current path, we should exit the current path
+		if (currentPath === path) {
+			return
+		}
+
+		if (currentPath?.includes(path)) {
+			this.exit(info, this.id)
+			this.enter(info, this.id)
+		}
+
+		for (let i = 0; i < pathIds.length; i++) {
+			const id = pathIds[i]
 			const prevChildState = currState.getCurrent()
 			const nextChildState = currState.children?.[id]
 

--- a/packages/editor/src/lib/test/states.test.ts
+++ b/packages/editor/src/lib/test/states.test.ts
@@ -1,0 +1,233 @@
+import { StateNode } from '../editor/tools/StateNode'
+import { TestEditor } from './TestEditor'
+
+const editor = new TestEditor()
+
+let root: StateNode
+
+let eventLog: string[] = []
+
+const flyingEnter = jest.fn(() => eventLog.push('flyingEnter'))
+const flyingExit = jest.fn(() => eventLog.push('flyingExit'))
+class Flying extends StateNode {
+	static override id = 'flying'
+	onEnter() {
+		flyingEnter()
+	}
+	onExit() {
+		flyingExit()
+	}
+}
+
+const fallingEnter = jest.fn(() => eventLog.push('fallingEnter'))
+const fallingExit = jest.fn(() => eventLog.push('fallingExit'))
+class Falling extends StateNode {
+	static override id = 'falling'
+	onEnter() {
+		fallingEnter()
+	}
+	onExit() {
+		fallingExit()
+	}
+}
+
+const dreamingEnter = jest.fn(() => eventLog.push('dreamingEnter'))
+const dreamingExit = jest.fn(() => eventLog.push('dreamingExit'))
+class Dreaming extends StateNode {
+	static override id = 'dreaming'
+	static override initial = 'flying'
+	static override children() {
+		return [Flying, Falling]
+	}
+	onEnter() {
+		dreamingEnter()
+	}
+	onExit() {
+		dreamingExit()
+	}
+}
+
+const restingEnter = jest.fn(() => eventLog.push('restingEnter'))
+const restingExit = jest.fn(() => eventLog.push('restingExit'))
+class Resting extends StateNode {
+	static override id = 'resting'
+	onEnter() {
+		restingEnter()
+	}
+	onExit() {
+		restingExit()
+	}
+}
+
+const asleepEnter = jest.fn(() => eventLog.push('asleepEnter'))
+const asleepExit = jest.fn(() => eventLog.push('asleepExit'))
+class Asleep extends StateNode {
+	static override id = 'asleep'
+	static override initial = 'resting'
+	static override children() {
+		return [Dreaming, Resting]
+	}
+	onEnter() {
+		asleepEnter()
+	}
+	onExit() {
+		asleepExit()
+	}
+}
+
+class Eating extends StateNode {
+	static override id = 'eating'
+}
+
+const workingEnter = jest.fn(() => eventLog.push('workingEnter'))
+const workingExit = jest.fn(() => eventLog.push('workingExit'))
+class Working extends StateNode {
+	static override id = 'working'
+	onEnter() {
+		workingEnter()
+	}
+	onExit() {
+		workingExit()
+	}
+}
+
+const awakeEnter = jest.fn(() => eventLog.push('awakeEnter'))
+const awakeExit = jest.fn(() => eventLog.push('awakeExit'))
+class Awake extends StateNode {
+	static override id = 'awake'
+	static override initial = 'working'
+	static override children() {
+		return [Eating, Working]
+	}
+	onEnter() {
+		awakeEnter()
+	}
+	onExit() {
+		awakeExit()
+	}
+}
+
+class Root extends StateNode {
+	static override id = 'root'
+	static override initial = 'awake'
+	static override children() {
+		return [Awake, Asleep]
+	}
+}
+
+beforeEach(() => {
+	root = new Root(editor)
+	root.start()
+	eventLog = []
+})
+
+afterEach(() => {
+	jest.clearAllMocks()
+})
+
+describe('states', () => {
+	it('has the state tree with the correct initial path', () => {
+		expect(root.getPath()).toBe('root.awake.working')
+		expect(root.getCurrent()!.getIsActive()).toBe(true)
+		expect(root.getCurrent()!.getCurrent()!.getIsActive()).toBe(true)
+
+		expect(root.getDescendant('awake.working')).toBe(root.getCurrent()!.getCurrent())
+	})
+
+	it('does not fire enter events when loaded', () => {
+		expect(awakeEnter).toHaveBeenCalledTimes(1)
+		expect(workingEnter).toHaveBeenCalledTimes(1)
+	})
+
+	it('transitions from root and picks up initial state', () => {
+		expect(root.getIsActive()).toBe(true)
+		expect(root.getDescendant('awake')!.getIsActive()).toBe(true)
+		expect(root.getDescendant('awake.working')!.getIsActive()).toBe(true)
+
+		root.transition('asleep')
+		expect(root.getPath()).toBe('root.asleep.resting')
+
+		// Everything happened in the right order
+		expect(eventLog).toEqual(['awakeExit', 'workingExit', 'asleepEnter', 'restingEnter'])
+
+		// exits the current states...
+		expect(awakeExit).toHaveBeenCalledTimes(1)
+		expect(workingExit).toHaveBeenCalledTimes(1)
+
+		// enters the next states...
+		expect(asleepEnter).toHaveBeenCalledTimes(1)
+		expect(restingEnter).toHaveBeenCalledTimes(1)
+	})
+
+	it('transitions with deep path', () => {
+		root.transition('asleep.dreaming.falling')
+		expect(root.getPath()).toBe('root.asleep.dreaming.falling')
+
+		expect(eventLog).toEqual([
+			'awakeExit',
+			'workingExit',
+			'asleepEnter',
+			'dreamingEnter',
+			'fallingEnter',
+		])
+
+		// exits the current states...
+		expect(awakeExit).toHaveBeenCalledTimes(1)
+		expect(workingExit).toHaveBeenCalledTimes(1)
+
+		// enters the next states...
+		expect(asleepEnter).toHaveBeenCalledTimes(1)
+		expect(dreamingEnter).toHaveBeenCalledTimes(1)
+		expect(fallingEnter).toHaveBeenCalledTimes(1)
+	})
+
+	it.only('transitions from child to parent', () => {
+		root.transition('asleep.dreaming.falling')
+		expect(root.getPath()).toBe('root.asleep.dreaming.falling')
+
+		expect(eventLog).toEqual([
+			'awakeExit',
+			'workingExit',
+			'asleepEnter',
+			'dreamingEnter',
+			'fallingEnter',
+		])
+
+		root.transition('asleep.dreaming')
+		expect(root.getPath()).toBe('root.asleep.dreaming.flying')
+
+		expect(eventLog).toEqual([
+			'awakeExit',
+			'workingExit',
+			'asleepEnter',
+			'dreamingEnter',
+			'fallingEnter',
+			// ...
+			'asleepExit',
+			'dreamingExit',
+			'fallingExit',
+			'awakeEnter',
+			'workingEnter',
+			'awakeExit',
+			'workingExit',
+			'asleepEnter',
+			'dreamingEnter',
+			'flyingEnter',
+		])
+
+		// exits the current states...
+		expect(awakeExit).toHaveBeenCalledTimes(2)
+		expect(workingExit).toHaveBeenCalledTimes(2)
+
+		// enters the next states...
+		expect(asleepEnter).toHaveBeenCalledTimes(2)
+		expect(dreamingEnter).toHaveBeenCalledTimes(2)
+		expect(fallingEnter).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('state events', () => {
+	it('fires enter events when loaded', () => {
+		expect(workingEnter).toHaveBeenCalledTimes(1)
+	})
+})

--- a/packages/editor/src/lib/test/states.test.ts
+++ b/packages/editor/src/lib/test/states.test.ts
@@ -181,7 +181,7 @@ describe('states', () => {
 		expect(fallingEnter).toHaveBeenCalledTimes(1)
 	})
 
-	it.only('transitions from child to parent', () => {
+	it('transitions from child to parent', () => {
 		root.transition('asleep.dreaming.falling')
 		expect(root.getPath()).toBe('root.asleep.dreaming.falling')
 

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -27,6 +27,7 @@ export function registerDefaultSideEffects(editor: Editor) {
 							// then create the shape with a flag that will let it know to
 							// go back to the text tool once the edit is complete.
 							const shape = editor.getEditingShape()
+
 							if (
 								shape &&
 								shape.type === 'text' &&

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
@@ -24,13 +24,7 @@ export class Idle extends StateNode {
 				onlySelectedShape &&
 				this.editor.getShapeUtil(onlySelectedShape).canEdit(onlySelectedShape)
 			) {
-				this.editor.setCurrentTool('select')
-				this.editor.setEditingShape(onlySelectedShape.id)
-				this.editor.root.getCurrent()?.transition('editing_shape', {
-					...info,
-					target: 'shape',
-					shape: onlySelectedShape,
-				})
+				this.editor.setEditingShape(onlySelectedShape.id) // will transition to 'select.editing_shape'
 			}
 		}
 	}

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -21,13 +21,7 @@ export class Idle extends StateNode {
 				onlySelectedShape &&
 				this.editor.getShapeUtil(onlySelectedShape).canEdit(onlySelectedShape)
 			) {
-				this.editor.setCurrentTool('select')
-				this.editor.setEditingShape(onlySelectedShape.id)
-				this.editor.root.getCurrent()?.transition('editing_shape', {
-					...info,
-					target: 'shape',
-					shape: onlySelectedShape,
-				})
+				this.editor.setEditingShape(onlySelectedShape.id) // will transition to 'select.editing_shape'
 			}
 		}
 	}

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -72,8 +72,7 @@ export class Pointing extends StateNode {
 				isCreating: true,
 				creatingMarkId: this.markId,
 				onCreate: () => {
-					this.editor.setEditingShape(this.shape.id)
-					this.editor.setCurrentTool('select.editing_shape')
+					this.editor.setEditingShape(this.shape.id) // will transition to 'select.editing_shape'
 				},
 			})
 		}
@@ -100,12 +99,7 @@ export class Pointing extends StateNode {
 			if (this.editor.getInstanceState().isToolLocked) {
 				this.parent.transition('idle')
 			} else {
-				this.editor.setEditingShape(this.shape.id)
-				this.editor.setCurrentTool('select.editing_shape', {
-					...this.info,
-					target: 'shape',
-					shape: this.shape,
-				})
+				this.editor.setEditingShape(this.shape.id) // will transition to 'select.editing_shape'
 			}
 		}
 	}

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -34,13 +34,7 @@ export class Idle extends StateNode {
 				onlySelectedShape &&
 				this.editor.getShapeUtil(onlySelectedShape).canEdit(onlySelectedShape)
 			) {
-				this.editor.setCurrentTool('select')
-				this.editor.setEditingShape(onlySelectedShape.id)
-				this.editor.root.getCurrent()?.transition('editing_shape', {
-					...info,
-					target: 'shape',
-					shape: onlySelectedShape,
-				})
+				this.editor.setEditingShape(onlySelectedShape.id) // will transition to 'select.editing_shape'
 			}
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -81,8 +81,5 @@ export class SelectTool extends StateNode {
 
 	override onExit() {
 		this.reactor?.()
-		if (this.editor.getCurrentPageState().editingShapeId) {
-			this.editor.setEditingShape(null)
-		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -533,8 +533,7 @@ export class Idle extends StateNode {
 	) {
 		if (this.editor.isShapeOrAncestorLocked(shape) && shape.type !== 'embed') return
 		this.editor.markHistoryStoppingPoint('editing shape')
-		startEditingShapeWithLabel(this.editor, shape, shouldSelectAll)
-		this.parent.transition('editing_shape', info)
+		startEditingShapeWithLabel(this.editor, shape, shouldSelectAll) // will transition to 'select.editing_shape'
 	}
 
 	isDarwin = window.navigator.userAgent.toLowerCase().indexOf('mac') > -1
@@ -594,9 +593,8 @@ export class Idle extends StateNode {
 			}
 		}
 
-		this.editor.setEditingShape(id)
 		this.editor.select(id)
-		this.parent.transition('editing_shape', info)
+		this.editor.setEditingShape(id) // will transition to 'select.editing_shape'
 	}
 
 	private nudgeSelectedShapes(ephemeral = false) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -236,7 +236,7 @@ export class Idle extends StateNode {
 				}
 
 				if (!this.editor.inputs.shiftKey) {
-					this.handleDoubleClickOnCanvas(info)
+					this.handleDoubleClickOnCanvas()
 				}
 				break
 			}
@@ -319,7 +319,7 @@ export class Idle extends StateNode {
 					// If the shape's double click handler has not created a change,
 					// and if the shape cannot edit, then create a text shape and
 					// begin editing the text shape
-					this.handleDoubleClickOnCanvas(info)
+					this.handleDoubleClickOnCanvas()
 				}
 				break
 			}
@@ -560,7 +560,7 @@ export class Idle extends StateNode {
 		return false
 	}
 
-	handleDoubleClickOnCanvas(info: TLClickEventInfo) {
+	handleDoubleClickOnCanvas() {
 		// Create text shape and transition to editing_shape
 		if (this.editor.getInstanceState().isReadonly) return
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -115,9 +115,7 @@ export class PointingArrowLabel extends StateNode {
 		if (this.didDrag || !this.wasAlreadySelected) {
 			this.complete()
 		} else {
-			// Go into edit mode.
-			this.editor.setEditingShape(shape.id)
-			this.editor.setCurrentTool('select.editing_shape')
+			this.editor.setEditingShape(shape.id) // will transition to 'select.editing_shape'
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -153,8 +153,7 @@ export class PointingShape extends StateNode {
 											}
 										}
 
-										this.editor.setEditingShape(selectingShape.id)
-										this.editor.setCurrentTool('select.editing_shape')
+										this.editor.setEditingShape(selectingShape.id) // will transition to 'select.editing_shape'
 
 										if (this.isDoubleClick) {
 											this.editor.emit('select-all-text', { shapeId: selectingShape.id })

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -118,11 +118,7 @@ export function getOccludedChildren(editor: Editor, parent: TLShape) {
 export function startEditingShapeWithLabel(editor: Editor, shape: TLShape, selectAll = false) {
 	// Finish this shape and start editing the next one
 	editor.select(shape)
-	editor.setEditingShape(shape)
-	editor.setCurrentTool('select.editing_shape', {
-		target: 'shape',
-		shape: shape,
-	})
+	editor.setEditingShape(shape) // will transition to 'select.editing_shape'
 	if (selectAll) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -57,17 +57,6 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				kbd: 'v',
 				readonlyOk: true,
 				onSelect(source) {
-					if (editor.isIn('select')) {
-						// There's a quirk of select mode, where editing a shape is a sub-state of select.
-						// Because the text tool can be locked/sticky, we need to make sure we exit the
-						// text tool.
-						//
-						// psst, if you're changing this code, also change the code
-						// in strange-tools.test.ts! Sadly it's duplicated there.
-						const currentNode = editor.root.getCurrent()!
-						currentNode.exit({}, currentNode.id)
-						currentNode.enter({}, currentNode.id)
-					}
 					editor.setCurrentTool('select')
 					trackEvent('select-tool', { source, id: 'select' })
 				},

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -63,6 +63,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						// text tool.
 						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
+						currentNode.enter({}, currentNode.id)
 					}
 					editor.setCurrentTool('select.idle')
 					trackEvent('select-tool', { source, id: 'select' })

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -61,11 +61,14 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						// There's a quirk of select mode, where editing a shape is a sub-state of select.
 						// Because the text tool can be locked/sticky, we need to make sure we exit the
 						// text tool.
+						//
+						// psst, if you're changing this code, also change the code
+						// in strange-tools.test.ts! Sadly it's duplicated there.
 						const currentNode = editor.root.getCurrent()!
 						currentNode.exit({}, currentNode.id)
 						currentNode.enter({}, currentNode.id)
 					}
-					editor.setCurrentTool('select.idle')
+					editor.setCurrentTool('select')
 					trackEvent('select-tool', { source, id: 'select' })
 				},
 			},

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1644,6 +1644,7 @@ describe('scribble brushes to add to the selection', () => {
 		editor.pointerMove(-50, -50)
 		editor.keyDown('Alt')
 		editor.pointerDown()
+		editor.expectToBeIn('select.pointing_canvas')
 		editor.pointerMove(-1, -1)
 		editor.expectToBeIn('select.scribble_brushing')
 		expect(editor.getSelectedShapeIds()).toEqual([])

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -1,0 +1,68 @@
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+// This is copied from the "select" tool in the tools context
+// It's a bit of a hack to simulate the user clicking the select tool
+// Since there's no way of importing this code, it's copied here.
+function onSelectToolClick(editor: TestEditor) {
+	const currentNode = editor.root.getCurrent()!
+	currentNode.exit({}, currentNode.id)
+	currentNode.enter({}, currentNode.id)
+	editor.setCurrentTool('select')
+}
+
+describe('interaction between the select tool and the editing state', () => {
+	it('leaves editing when clicking the select tool', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown()
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('leaves cropping when clicking the select tool', () => {
+		editor
+			.createShape({ type: 'image', props: { w: 100, h: 100 } })
+			.pointerMove(50, 50)
+			.doubleClick()
+			.expectToBeIn('select.crop.idle')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('leaves editing while not tool locked', () => {
+		editor
+			.updateInstanceState({ isToolLocked: false })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+			.pointerMove(200, 200)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.idle')
+	})
+
+	it('leaves editing when clicking the select tool while tool locked', () => {
+		editor
+			.updateInstanceState({ isToolLocked: true })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+			.pointerMove(200, 200)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+		onSelectToolClick(editor)
+		editor.expectToBeIn('select.idle')
+	})
+})

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -59,6 +59,7 @@ describe('interaction between the select tool and the editing state', () => {
 			.pointerDown()
 			.pointerUp()
 			.expectToBeIn('select.editing_shape')
+
 		onSelectToolClick(editor)
 		editor.expectToBeIn('select.idle')
 	})

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -10,9 +10,6 @@ beforeEach(() => {
 // It's a bit of a hack to simulate the user clicking the select tool
 // Since there's no way of importing this code, it's copied here.
 function onSelectToolClick(editor: TestEditor) {
-	const currentNode = editor.root.getCurrent()!
-	currentNode.exit({}, currentNode.id)
-	currentNode.enter({}, currentNode.id)
 	editor.setCurrentTool('select')
 }
 


### PR DESCRIPTION
While working on #4644, we ran into this curious problem where transitioning from a child state (like `select.editing_shape`) to a parent state (like `select`) did not cause the `select.editing_shape` to exit. It turns out there were a few issues with the state chart:

  1. Parent transitions had no effect on active children, were basically noops
  2. Transitioning to a partial branch did not exit the lower branch. For example, `a.b.c` to `a.x` did not exit `c`.

This PR aims to solve all that.

Everything seems to work alright, however there are a few things discovered along the way:
- creating transitions in a node's `onExit` adds a lot of complexity
- the side effects we've created around `editingShape` and `croppingShape` add a lot of complexity

In this PR, transitions to parents (e.g. from `a.b.c` to `a`) will exit the whole tree and re-enter it.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed several rare bugs with state transitions.