### PR TITLE
Fix an issue with nearest point and lines that start and end at the same point

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Edge2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Edge2d.ts
@@ -35,7 +35,8 @@ export class Edge2d extends Geometry2d {
 	}
 
 	override nearestPoint(point: Vec): Vec {
-		const { start, end, u, ul: l } = this
+		const { start, end, d, u, ul: l } = this
+		if (d.len() === 0) return start // start and end are the same
 		if (l === 0) return start // no length in the unit vector
 		const k = Vec.Sub(point, start).dpr(u) / l
 		const cx = start.x + u.x * k

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1402,6 +1402,8 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
+    onBeforeCreate(next: TLLineShape): TLLineShape | void;
+    // (undocumented)
     onHandleDrag(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>): {
         id: TLShapeId;
         index: IndexKey;

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -117,6 +117,33 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		}
 	}
 
+	override onBeforeCreate(next: TLLineShape): void | TLLineShape {
+		const {
+			props: { points },
+		} = next
+		const pointKeys = Object.keys(points)
+
+		if (pointKeys.length < 2) {
+			return
+		}
+
+		const firstPoint = points[pointKeys[0]]
+		const allSame = pointKeys.every((key) => {
+			const point = points[key]
+			return point.x === firstPoint.x && point.y === firstPoint.y
+		})
+		if (allSame) {
+			const lastKey = pointKeys[pointKeys.length - 1]
+			points[lastKey] = {
+				...points[lastKey],
+				x: points[lastKey].x + 0.1,
+				y: points[lastKey].y + 0.1,
+			}
+			return next
+		}
+		return
+	}
+
 	override onHandleDrag(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>) {
 		// we should only ever be dragging vertex handles
 		if (handle.type !== 'vertex') return


### PR DESCRIPTION
This fixes an issue with getting the nearest point to a line for lines that start and end at the same point. 

Not sure how those lines got created though. Programatically we seem to allow that, so I also added a `onBeforeHandler` to line shape util that will nudge the end point just slightly if we try to create a line like that. We could also avoid creating it completely?

[Example sentry report](https://tldraw.sentry.io/issues/5936469482/?alert_rule_id=12855294&alert_timestamp=1727804797951&alert_type=email&environment=production&notification_uuid=3482b5d8-ad95-48ca-be09-40c77af5fcf2&project=4504203639193600&referrer=alert_email) for this issue.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a line shape programatically and make the start and end point be the same. Think it has to start and end at (0,0) but not sure.
2. Brush select.
3. This used to throw an error since we could not get the distance to line, but that should no longer be happening.

### Release notes

- Fix a bug with nearest points for lines that start and end at the same point.