### PR TITLE
watermark: go behind certain elements on the app

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -26,6 +26,7 @@
 	--layer-canvas-hidden: -999999;
 	--layer-canvas-background: 100;
 	--layer-canvas-grid: 150;
+	--layer-watermark: 200;
 	--layer-canvas-shapes: 300;
 	--layer-canvas-overlays: 500;
 	--layer-canvas-blocker: 10000;

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -114,7 +114,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		z-index: 2147483647 !important;
+		z-index: var(--layer-watermark) !important;
 		background-color: color-mix(in srgb, var(--color-background) 62%, transparent);
 		opacity: 1;
 		border-radius: 5px;


### PR DESCRIPTION
after:
<img width="431" alt="Screenshot 2024-10-03 at 14 49 45" src="https://github.com/user-attachments/assets/8fdbd9a4-18a8-4d6c-9555-adec747778d7">

before:
<img width="408" alt="Screenshot 2024-10-03 at 14 49 54" src="https://github.com/user-attachments/assets/1d89de2e-b24b-4631-9885-b892675fe52b">


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix issue with watermark and certain UI elements.