### PR TITLE
[sync] refine error handling + room.closeSession method

### DIFF
--- a/apps/bemo-worker/src/BemoDO.ts
+++ b/apps/bemo-worker/src/BemoDO.ts
@@ -1,5 +1,10 @@
 import { AnalyticsEngineDataset } from '@cloudflare/workers-types'
-import { RoomSnapshot, TLCloseEventCode, TLSocketRoom } from '@tldraw/sync-core'
+import {
+	RoomSnapshot,
+	TLSocketRoom,
+	TLSyncErrorCloseEventCode,
+	TLSyncErrorCloseEventReason,
+} from '@tldraw/sync-core'
 import { TLRecord } from '@tldraw/tlschema'
 import { throttle } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
@@ -114,7 +119,7 @@ export class BemoDO extends DurableObject<Environment> {
 			return new Response(null, { status: 101, webSocket: clientWebSocket })
 		} catch (e) {
 			if (e === ROOM_NOT_FOUND) {
-				serverWebSocket.close(TLCloseEventCode.NOT_FOUND, 'Room not found')
+				serverWebSocket.close(TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason.NOT_FOUND)
 				return new Response(null, { status: 101, webSocket: clientWebSocket })
 			}
 			throw e

--- a/apps/dotcom/client/src/components/StoreErrorScreen.tsx
+++ b/apps/dotcom/client/src/components/StoreErrorScreen.tsx
@@ -1,5 +1,4 @@
-import { TLIncompatibilityReason, TLRemoteSyncError } from '@tldraw/sync-core'
-import { exhaustiveSwitchError } from 'tldraw'
+import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
 import { ErrorPage } from './ErrorPage/ErrorPage'
 
 export function StoreErrorScreen({ error }: { error: Error }) {
@@ -7,7 +6,7 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 	let message = ''
 	if (error instanceof TLRemoteSyncError) {
 		switch (error.reason) {
-			case TLIncompatibilityReason.ClientTooOld: {
+			case TLSyncErrorCloseEventReason.CLIENT_TOO_OLD: {
 				return (
 					<ErrorPage
 						icon={
@@ -27,33 +26,30 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 					/>
 				)
 			}
-			case TLIncompatibilityReason.ServerTooOld: {
+			case TLSyncErrorCloseEventReason.SERVER_TOO_OLD: {
 				message =
 					'The multiplayer server is out of date. Please reload the page. If the problem persists contact the system administrator.'
 				break
 			}
-			case TLIncompatibilityReason.InvalidRecord: {
+			case TLSyncErrorCloseEventReason.INVALID_RECORD: {
 				message =
 					'Your changes were rejected by the server. Please reload the page. If the problem persists contact the system administrator.'
 				break
 			}
-			case TLIncompatibilityReason.InvalidOperation: {
-				message =
-					'Your changes were rejected by the server. Please reload the page. If the problem persists contact the system administrator.'
-				break
-			}
-			case TLIncompatibilityReason.RoomNotFound: {
+			case TLSyncErrorCloseEventReason.NOT_FOUND: {
 				header = 'Room not found'
 				message = 'The room you are trying to connect to does not exist.'
 				break
 			}
-			case TLIncompatibilityReason.Forbidden: {
+			case TLSyncErrorCloseEventReason.NOT_AUTHENTICATED:
+			case TLSyncErrorCloseEventReason.FORBIDDEN: {
 				header = 'Unauthorized'
 				message = 'You need to be authorized to view this room.'
 				break
 			}
-			default:
-				exhaustiveSwitchError(error.reason)
+			default: {
+				console.error('Unhandled sync error', error)
+			}
 		}
 	}
 

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -5,7 +5,7 @@ import {
 	ROOM_PREFIX,
 	SNAPSHOT_PREFIX,
 } from '@tldraw/dotcom-shared'
-import { TLIncompatibilityReason, TLRemoteSyncError } from '@tldraw/sync-core'
+import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
 import { useEffect } from 'react'
 import { Route, createRoutesFromElements, useRouteError } from 'react-router-dom'
 import { DefaultErrorFallback } from './components/DefaultErrorFallback/DefaultErrorFallback'
@@ -23,12 +23,13 @@ export const router = createRoutesFromElements(
 				'Please try refreshing the page. Still having trouble? Let us know at hello@tldraw.com.'
 			if (error instanceof TLRemoteSyncError) {
 				switch (error.reason) {
-					case TLIncompatibilityReason.RoomNotFound: {
+					case TLSyncErrorCloseEventReason.NOT_FOUND: {
 						header = 'Not found'
 						para1 = 'The file you are looking for does not exist.'
 						break
 					}
-					case TLIncompatibilityReason.Forbidden: {
+					case TLSyncErrorCloseEventReason.NOT_AUTHENTICATED:
+					case TLSyncErrorCloseEventReason.FORBIDDEN: {
 						header = 'Unauthorized'
 						para1 = 'You need to be authorized to view this file.'
 						break

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -326,7 +326,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
         schema?: StoreSchema<R, any>;
     });
     close(): void;
-    evictSession(sessionId: string, fatalReason?: string | TLSyncErrorCloseEventReason): void;
+    closeSession(sessionId: string, fatalReason?: string | TLSyncErrorCloseEventReason): void;
     getCurrentDocumentClock(): number;
     getCurrentSnapshot(): RoomSnapshot;
     getNumActiveSessions(): number;

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -5,11 +5,14 @@ export type { WebSocketMinimal } from './lib/ServerSocketAdapter'
 export { TLRemoteSyncError } from './lib/TLRemoteSyncError'
 export { TLSocketRoom, type OmitVoid, type TLSyncLog } from './lib/TLSocketRoom'
 export {
-	TLCloseEventCode,
 	TLSyncClient,
+	TLSyncErrorCloseEventCode,
+	TLSyncErrorCloseEventReason,
 	type SubscribingFn,
 	type TLPersistentClientSocket,
 	type TLPersistentClientSocketStatus,
+	type TLSocketStatusListener,
+	type TlSocketStatusChangeEvent,
 } from './lib/TLSyncClient'
 export {
 	DocumentState,
@@ -35,6 +38,7 @@ export {
 	type ValueOp,
 } from './lib/diff'
 export {
+	// eslint-disable-next-line deprecation/deprecation
 	TLIncompatibilityReason,
 	getTlsyncProtocolVersion,
 	type TLConnectRequest,

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -4,9 +4,11 @@ import { assert, warnOnce } from '@tldraw/utils'
 import { chunk } from './chunk'
 import { TLSocketClientSentEvent, TLSocketServerSentEvent } from './protocol'
 import {
-	TLCloseEventCode,
 	TLPersistentClientSocket,
 	TLPersistentClientSocketStatus,
+	TLSocketStatusListener,
+	TLSyncErrorCloseEventCode,
+	TLSyncErrorCloseEventReason,
 } from './TLSyncClient'
 
 function listenTo<T extends EventTarget>(target: T, event: string, handler: () => void) {
@@ -39,7 +41,6 @@ function debug(...args: any[]) {
 //       they don't seem to be surfaced in browser APIs and can't be relied on. Therefore,
 //       pings need to be implemented one level up, on the application API side, which for our
 //       codebase means whatever code that uses ClientWebSocketAdapter.
-
 /** @internal */
 export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord> {
 	_ws: WebSocket | null = null
@@ -66,7 +67,7 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 		debug('handleConnect')
 
 		this._connectionStatus.set('online')
-		this.statusListeners.forEach((cb) => cb('online'))
+		this.statusListeners.forEach((cb) => cb({ status: 'online' }))
 
 		this._reconnectManager.connected()
 	}
@@ -74,8 +75,11 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 	private _handleDisconnect(
 		reason: 'closed' | 'error' | 'manual',
 		closeCode?: number,
-		didOpen?: boolean
+		didOpen?: boolean,
+		closeReason?: string
 	) {
+		closeReason = closeReason || TLSyncErrorCloseEventReason.UNKNOWN_ERROR
+
 		debug('handleDisconnect', {
 			currentStatus: this.connectionStatus,
 			closeCode,
@@ -85,14 +89,11 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 		let newStatus: 'offline' | 'error'
 		switch (reason) {
 			case 'closed':
-				if (closeCode === TLCloseEventCode.NOT_FOUND) {
+				if (closeCode === TLSyncErrorCloseEventCode) {
 					newStatus = 'error'
-					break
-				} else if (closeCode === TLCloseEventCode.FORBIDDEN) {
-					newStatus = 'error'
-					break
+				} else {
+					newStatus = 'offline'
 				}
-				newStatus = 'offline'
 				break
 			case 'error':
 				newStatus = 'error'
@@ -115,7 +116,9 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 			!(newStatus === 'error' && this.connectionStatus === 'offline')
 		) {
 			this._connectionStatus.set(newStatus)
-			this.statusListeners.forEach((cb) => cb(newStatus, closeCode))
+			this.statusListeners.forEach((cb) =>
+				cb(newStatus === 'error' ? { status: 'error', reason: closeReason } : { status: newStatus })
+			)
 		}
 
 		this._reconnectManager.disconnected()
@@ -148,7 +151,7 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 		ws.onclose = (event: CloseEvent) => {
 			debug('ws.onclose', event)
 			if (this._ws === ws) {
-				this._handleDisconnect('closed', event.code, didOpen)
+				this._handleDisconnect('closed', event.code, didOpen, event.reason)
 			} else {
 				debug('ignoring onclose for an orphaned socket')
 			}
@@ -219,10 +222,8 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
 		}
 	}
 
-	private statusListeners = new Set<
-		(status: TLPersistentClientSocketStatus, closeCode?: number) => void
-	>()
-	onStatusChange(cb: (val: TLPersistentClientSocketStatus, closeCode?: number) => void) {
+	private statusListeners = new Set<TLSocketStatusListener>()
+	onStatusChange(cb: TLSocketStatusListener) {
 		assert(!this.isDisposed, 'Tried to add status listener on a disposed socket')
 
 		this.statusListeners.add(cb)

--- a/packages/sync-core/src/lib/RoomSession.ts
+++ b/packages/sync-core/src/lib/RoomSession.ts
@@ -26,6 +26,7 @@ export type RoomSession<R extends UnknownRecord, Meta> =
 			sessionStartTime: number
 			meta: Meta
 			isReadonly: boolean
+			requiresLegacyRejection: boolean
 	  }
 	| {
 			state: typeof RoomSessionState.AwaitingRemoval
@@ -35,6 +36,7 @@ export type RoomSession<R extends UnknownRecord, Meta> =
 			cancellationTime: number
 			meta: Meta
 			isReadonly: boolean
+			requiresLegacyRejection: boolean
 	  }
 	| {
 			state: typeof RoomSessionState.Connected
@@ -47,4 +49,5 @@ export type RoomSession<R extends UnknownRecord, Meta> =
 			outstandingDataMessages: TLSocketServerSentDataEvent<R>[]
 			meta: Meta
 			isReadonly: boolean
+			requiresLegacyRejection: boolean
 	  }

--- a/packages/sync-core/src/lib/ServerSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ServerSocketAdapter.ts
@@ -22,7 +22,7 @@ export interface WebSocketMinimal {
 	// eslint-disable-next-line @typescript-eslint/method-signature-style
 	send: (data: string) => void
 	// eslint-disable-next-line @typescript-eslint/method-signature-style
-	close: () => void
+	close: (code?: number, reason?: string) => void
 	readyState: number
 }
 
@@ -46,7 +46,7 @@ export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocke
 		this.opts.onBeforeSendMessage?.(msg, message)
 		this.opts.ws.send(message)
 	}
-	close() {
-		this.opts.ws.close()
+	close(code?: number, reason?: string) {
+		this.opts.ws.close(code, reason)
 	}
 }

--- a/packages/sync-core/src/lib/TLRemoteSyncError.ts
+++ b/packages/sync-core/src/lib/TLRemoteSyncError.ts
@@ -1,9 +1,9 @@
-import { TLIncompatibilityReason } from './protocol'
+import { TLSyncErrorCloseEventReason } from './TLSyncClient'
 
-/** @internal */
+/** @public */
 export class TLRemoteSyncError extends Error {
 	override name = 'RemoteSyncError'
-	constructor(public readonly reason: TLIncompatibilityReason) {
-		super(`remote sync error: ${reason}`)
+	constructor(public readonly reason: TLSyncErrorCloseEventReason | string) {
+		super(`sync error: ${reason}`)
 	}
 }

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -3,6 +3,7 @@ import { TLStoreSnapshot, createTLSchema } from '@tldraw/tlschema'
 import { objectMapValues, structuredClone } from '@tldraw/utils'
 import { RoomSessionState } from './RoomSession'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
+import { TLSyncErrorCloseEventReason } from './TLSyncClient'
 import { RoomSnapshot, RoomStoreMethods, TLSyncRoom } from './TLSyncRoom'
 import { JsonChunkAssembler } from './chunk'
 import { TLSocketServerSentEvent } from './protocol'
@@ -194,16 +195,9 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 			}
 		} catch (e) {
 			this.log?.error?.(e)
-			const socket = this.sessions.get(sessionId)?.socket
-			if (socket) {
-				socket.send(
-					JSON.stringify({
-						type: 'error',
-						error: typeof e?.toString === 'function' ? e.toString() : e,
-					} satisfies TLSocketServerSentEvent<R>)
-				)
-				socket.close()
-			}
+			// here we use rejectSession rather than removeSession to support legacy clients
+			// that use the old incompatibility_error close event
+			this.room.rejectSession(sessionId, TLSyncErrorCloseEventReason.UNKNOWN_ERROR)
 		}
 	}
 
@@ -338,6 +332,20 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 */
 	async updateStore(updater: (store: RoomStoreMethods) => void | Promise<void>) {
 		return this.room.updateStore(updater)
+	}
+
+	/**
+	 * Immediately remove a session from the room, and close its socket if not already closed.
+	 *
+	 * If no `fatalReason` parameter is supplied, the client will attempt to reconnect.
+	 *
+	 * The `fatalReason` parameter will be available in the return value of the `useSync` hook as `useSync().error.reason`.
+	 *
+	 * @param sessionId - The id of the session to remove
+	 * @param fatalReason - The reason message to use when calling .close on the underlying websocket
+	 */
+	evictSession(sessionId: string, fatalReason?: TLSyncErrorCloseEventReason | string) {
+		this.room.rejectSession(sessionId, fatalReason)
 	}
 
 	/**

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -337,14 +337,14 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	/**
 	 * Immediately remove a session from the room, and close its socket if not already closed.
 	 *
-	 * If no `fatalReason` parameter is supplied, the client will attempt to reconnect.
+	 * The client will attempt to reconnect unless you provide a `fatalReason` parameter.
 	 *
 	 * The `fatalReason` parameter will be available in the return value of the `useSync` hook as `useSync().error.reason`.
 	 *
 	 * @param sessionId - The id of the session to remove
 	 * @param fatalReason - The reason message to use when calling .close on the underlying websocket
 	 */
-	evictSession(sessionId: string, fatalReason?: TLSyncErrorCloseEventReason | string) {
+	closeSession(sessionId: string, fatalReason?: TLSyncErrorCloseEventReason | string) {
 		this.room.rejectSession(sessionId, fatalReason)
 	}
 

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -12,7 +12,6 @@ import isEqual from 'lodash.isequal'
 import { NetworkDiff, RecordOpType, applyObjectDiff, diffRecord, getNetworkDiff } from './diff'
 import { interval } from './interval'
 import {
-	TLIncompatibilityReason,
 	TLPushRequest,
 	TLSocketClientSentEvent,
 	TLSocketServerSentDataEvent,
@@ -24,16 +23,55 @@ import {
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void
 
 /**
- * These are our private codes to be sent from server-\>client.
- * They are in the private range of the websocket code range.
- * See: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+ * This the close code that we use on the server to signal to a socket that
+ * the connection is being closed because of a non-recoverable error.
  *
+ * You should use this if you need to close a connection.
+ *
+ * @example
+ * ```ts
+ * socket.close(TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason.NOT_FOUND)
+ * ```
+ *
+ * The `reason` parameter that you pass to `socket.close()` will be made available at `useSync().error.reason`
+ *
+ * @public
+ */
+export const TLSyncErrorCloseEventCode = 4099 as const
+
+/**
+ * The set of reasons that a connection can be closed by the server
+ * @public
+ */
+export const TLSyncErrorCloseEventReason = {
+	NOT_FOUND: 'NOT_FOUND',
+	FORBIDDEN: 'FORBIDDEN',
+	NOT_AUTHENTICATED: 'NOT_AUTHENTICATED',
+	UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+	CLIENT_TOO_OLD: 'CLIENT_TOO_OLD',
+	SERVER_TOO_OLD: 'SERVER_TOO_OLD',
+	INVALID_RECORD: 'INVALID_RECORD',
+} as const
+/**
+ * The set of reasons that a connection can be closed by the server
+ * @public
+ */
+export type TLSyncErrorCloseEventReason =
+	(typeof TLSyncErrorCloseEventReason)[keyof typeof TLSyncErrorCloseEventReason]
+
+/**
  * @internal
  */
-export const TLCloseEventCode = {
-	NOT_FOUND: 4099,
-	FORBIDDEN: 4100,
-} as const
+export type TlSocketStatusChangeEvent =
+	| {
+			status: 'online' | 'offline'
+	  }
+	| {
+			status: 'error'
+			reason: string
+	  }
+/** @internal */
+export type TLSocketStatusListener = (params: TlSocketStatusChangeEvent) => void
 
 /** @internal */
 export type TLPersistentClientSocketStatus = 'online' | 'offline' | 'error'
@@ -52,7 +90,7 @@ export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecor
 	/** Attach a listener for messages sent by the server */
 	onReceiveMessage: SubscribingFn<TLSocketServerSentEvent<R>>
 	/** Attach a listener for connection status changes */
-	onStatusChange: SubscribingFn<TLPersistentClientSocketStatus>
+	onStatusChange: SubscribingFn<TlSocketStatusChangeEvent>
 	/** Restart the connection */
 	restart(): void
 }
@@ -116,7 +154,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * any changes to the store that are required to keep it operational
 	 */
 	public readonly onAfterConnect?: (self: this, details: { isReadonly: boolean }) => void
-	public readonly onSyncError: (reason: TLIncompatibilityReason) => void
 
 	private isDebugging = false
 	private debug(...args: any[]) {
@@ -135,8 +172,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		socket: TLPersistentClientSocket<R>
 		presence: Signal<R | null>
 		onLoad(self: TLSyncClient<R, S>): void
-		onLoadError(error: Error): void
-		onSyncError(reason: TLIncompatibilityReason): void
+		onSyncError(reason: string): void
 		onAfterConnect?(self: TLSyncClient<R, S>, details: { isReadonly: boolean }): void
 		didCancel?(): boolean
 	}) {
@@ -150,7 +186,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.store = config.store
 		this.socket = config.socket
 		this.onAfterConnect = config.onAfterConnect
-		this.onSyncError = config.onSyncError
 
 		let didLoad = false
 
@@ -177,27 +212,21 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				// one of the load callbacks
 				if (!didLoad) {
 					didLoad = true
-					if (msg.type === 'error') {
-						config.onLoadError(msg.error)
-					} else {
-						config.onLoad(this)
-					}
+					config.onLoad(this)
 				}
 			}),
 			// handle switching between online and offline
-			this.socket.onStatusChange((status) => {
+			this.socket.onStatusChange((ev) => {
 				if (this.didCancel?.()) return this.close()
-				this.debug('socket status changed', status)
-				if (status === 'online') {
+				this.debug('socket status changed', ev.status)
+				if (ev.status === 'online') {
 					this.sendConnectMessage()
 				} else {
 					this.resetConnection()
-					// if we reached here before connecting to the server
-					// it's a socket error, mostly likely the server is down or
-					// it's the wrong url.
-					if (status === 'error' && !didLoad) {
+					if (ev.status === 'error') {
 						didLoad = true
-						config.onLoadError(new Error('socket error'))
+						config.onSyncError(ev.reason)
+						this.close()
 					}
 				}
 			}),
@@ -380,11 +409,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			case 'connect':
 				this.didReconnect(event)
 				break
-			case 'error':
-				console.error('Server error', event.error)
-				console.error('Restarting socket')
-				this.socket.restart()
-				break
 			// legacy v4 events
 			case 'patch':
 			case 'push_result':
@@ -399,7 +423,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				this.scheduleRebase()
 				break
 			case 'incompatibility_error':
-				this.onSyncError(event.reason)
+				// legacy unrecoverable errors
+				console.error('incompatibility error is legacy and should no longer be sent by the server')
 				break
 			case 'pong':
 				// noop, we only use ping/pong to set lastSeverInteractionTimestamp

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -690,6 +690,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	rejectSession(sessionId: string, fatalReason?: TLSyncErrorCloseEventReason | string) {
 		const session = this.sessions.get(sessionId)
 		if (!session) return
+		if (!fatalReason) {
+			this.removeSession(sessionId)
+			return
+		}
 		if (session.requiresLegacyRejection) {
 			try {
 				if (session.socket.isOpen) {

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -31,6 +31,7 @@ import {
 	SESSION_START_WAIT_TIME,
 } from './RoomSession'
 import { TLSyncLog } from './TLSocketRoom'
+import { TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason } from './TLSyncClient'
 import {
 	NetworkDiff,
 	ObjectDiff,
@@ -53,7 +54,7 @@ import {
 export interface TLRoomSocket<R extends UnknownRecord> {
 	isOpen: boolean
 	sendMessage(msg: TLSocketServerSentEvent<R>): void
-	close(): void
+	close(code?: number, reason?: string): void
 }
 
 // the max number of tombstones to keep in the store
@@ -480,7 +481,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		}
 	}
 
-	private removeSession(sessionId: string) {
+	/** @internal */
+	private removeSession(sessionId: string, fatalReason?: string) {
 		const session = this.sessions.get(sessionId)
 		if (!session) {
 			this.log?.warn?.('Tried to remove unknown session')
@@ -493,7 +495,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 
 		try {
 			if (session.socket.isOpen) {
-				session.socket.close()
+				if (fatalReason) {
+					session.socket.close(TLSyncErrorCloseEventCode, fatalReason)
+				} else {
+					session.socket.close()
+				}
 			}
 		} catch (_e) {
 			// noop
@@ -537,6 +543,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			cancellationTime: Date.now(),
 			meta: session.meta,
 			isReadonly: session.isReadonly,
+			requiresLegacyRejection: session.requiresLegacyRejection,
 		})
 	}
 
@@ -560,10 +567,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			if (!res.ok) {
 				// disconnect client and send incompatibility error
 				this.rejectSession(
-					session,
+					session.sessionId,
 					res.error === MigrationFailureReason.TargetVersionTooNew
-						? TLIncompatibilityReason.ServerTooOld
-						: TLIncompatibilityReason.ClientTooOld
+						? TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+						: TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
 				)
 				return
 			}
@@ -599,6 +606,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			sessionStartTime: Date.now(),
 			meta,
 			isReadonly: isReadonly ?? false,
+			// this gets set later during handleConnectMessage
+			requiresLegacyRejection: false,
 		})
 		return this
 	}
@@ -678,18 +687,44 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}
 
 	/** If the client is out of date, or we are out of date, we need to let them know */
-	private rejectSession(session: RoomSession<R, SessionMeta>, reason: TLIncompatibilityReason) {
-		try {
-			if (session.socket.isOpen) {
-				session.socket.sendMessage({
-					type: 'incompatibility_error',
-					reason,
-				})
+	rejectSession(sessionId: string, fatalReason?: TLSyncErrorCloseEventReason | string) {
+		const session = this.sessions.get(sessionId)
+		if (!session) return
+		if (session.requiresLegacyRejection) {
+			try {
+				if (session.socket.isOpen) {
+					// eslint-disable-next-line deprecation/deprecation
+					let legacyReason: TLIncompatibilityReason
+					switch (fatalReason) {
+						case TLSyncErrorCloseEventReason.CLIENT_TOO_OLD:
+							// eslint-disable-next-line deprecation/deprecation
+							legacyReason = TLIncompatibilityReason.ClientTooOld
+							break
+						case TLSyncErrorCloseEventReason.SERVER_TOO_OLD:
+							// eslint-disable-next-line deprecation/deprecation
+							legacyReason = TLIncompatibilityReason.ServerTooOld
+							break
+						case TLSyncErrorCloseEventReason.INVALID_RECORD:
+							// eslint-disable-next-line deprecation/deprecation
+							legacyReason = TLIncompatibilityReason.InvalidRecord
+							break
+						default:
+							// eslint-disable-next-line deprecation/deprecation
+							legacyReason = TLIncompatibilityReason.InvalidOperation
+							break
+					}
+					session.socket.sendMessage({
+						type: 'incompatibility_error',
+						reason: legacyReason,
+					})
+				}
+			} catch (e) {
+				// noop
+			} finally {
+				this.removeSession(sessionId)
 			}
-		} catch (e) {
-			// noop
-		} finally {
-			this.removeSession(session.sessionId)
+		} else {
+			this.removeSession(sessionId, fatalReason)
 		}
 	}
 
@@ -705,23 +740,28 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		if (theirProtocolVersion === 5) {
 			theirProtocolVersion = 6
 		}
+		// 6 is almost the same as 7
+		session.requiresLegacyRejection = theirProtocolVersion === 6
+		if (theirProtocolVersion === 6) {
+			theirProtocolVersion++
+		}
 		if (theirProtocolVersion == null || theirProtocolVersion < getTlsyncProtocolVersion()) {
-			this.rejectSession(session, TLIncompatibilityReason.ClientTooOld)
+			this.rejectSession(session.sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			return
 		} else if (theirProtocolVersion > getTlsyncProtocolVersion()) {
-			this.rejectSession(session, TLIncompatibilityReason.ServerTooOld)
+			this.rejectSession(session.sessionId, TLSyncErrorCloseEventReason.SERVER_TOO_OLD)
 			return
 		}
 		// If the client's store is at a different version to ours, it could cause corruption.
 		// We should disconnect the client and ask them to refresh.
 		if (message.schema == null) {
-			this.rejectSession(session, TLIncompatibilityReason.ClientTooOld)
+			this.rejectSession(session.sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			return
 		}
 		const migrations = this.schema.getMigrationsSince(message.schema)
 		// if the client's store is at a different version to ours, we can't support them
 		if (!migrations.ok || migrations.value.some((m) => m.scope === 'store' || !m.down)) {
-			this.rejectSession(session, TLIncompatibilityReason.ClientTooOld)
+			this.rejectSession(session.sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			return
 		}
 
@@ -741,6 +781,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				outstandingDataMessages: [],
 				meta: session.meta,
 				isReadonly: session.isReadonly,
+				requiresLegacyRejection: session.requiresLegacyRejection,
 			})
 			this.sendMessage(session.sessionId, msg)
 		}
@@ -764,10 +805,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				if (!migrated.ok) {
 					rollback()
 					this.rejectSession(
-						session,
+						session.sessionId,
 						migrated.error === MigrationFailureReason.TargetVersionTooNew
-							? TLIncompatibilityReason.ServerTooOld
-							: TLIncompatibilityReason.ClientTooOld
+							? TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+							: TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
 					)
 					return
 				}
@@ -812,10 +853,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				if (!migrated.ok) {
 					rollback()
 					this.rejectSession(
-						session,
+						session.sessionId,
 						migrated.error === MigrationFailureReason.TargetVersionTooNew
-							? TLIncompatibilityReason.ServerTooOld
-							: TLIncompatibilityReason.ClientTooOld
+							? TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+							: TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
 					)
 					return
 				}
@@ -866,15 +907,18 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				changes.diff[id] = op
 			}
 
-			const fail = (reason: TLIncompatibilityReason): Result<void, void> => {
+			const fail = (
+				reason: TLSyncErrorCloseEventReason,
+				underlyingError?: Error
+			): Result<void, void> => {
 				rollback()
 				if (session) {
-					this.rejectSession(session, reason)
+					this.rejectSession(session.sessionId, reason)
 				} else {
-					throw new Error('failed to apply changes: ' + reason)
+					throw new Error('failed to apply changes: ' + reason, underlyingError)
 				}
 				if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') {
-					this.log?.error?.('failed to apply push', reason, message)
+					this.log?.error?.('failed to apply push', reason, message, underlyingError)
 				}
 				return Result.err(undefined)
 			}
@@ -886,8 +930,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				if (res.type === 'error') {
 					return fail(
 						res.reason === MigrationFailureReason.TargetVersionTooOld // target version is our version
-							? TLIncompatibilityReason.ServerTooOld
-							: TLIncompatibilityReason.ClientTooOld
+							? TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+							: TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
 					)
 				}
 				const { value: state } = res
@@ -900,7 +944,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					// but propagate a diff rather than the entire value
 					const diff = doc.replaceState(state, this.clock)
 					if (!diff.ok) {
-						return fail(TLIncompatibilityReason.InvalidRecord)
+						return fail(TLSyncErrorCloseEventReason.INVALID_RECORD)
 					}
 					if (diff.value) {
 						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
@@ -910,7 +954,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					// create the document and propagate the put op
 					const result = this.addDocument(id, state, this.clock)
 					if (!result.ok) {
-						return fail(TLIncompatibilityReason.InvalidRecord)
+						return fail(TLSyncErrorCloseEventReason.INVALID_RECORD)
 					}
 					propagateOp(changes, id, [RecordOpType.Put, state])
 				}
@@ -932,14 +976,14 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					? this.schema.migratePersistedRecord(doc.state, session.serializedSchema, 'down')
 					: { type: 'success' as const, value: doc.state }
 				if (downgraded.type === 'error') {
-					return fail(TLIncompatibilityReason.ClientTooOld)
+					return fail(TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 				}
 
 				if (downgraded.value === doc.state) {
 					// If the versions are compatible, apply the patch and propagate the patch op
 					const diff = doc.mergeDiff(patch, this.clock)
 					if (!diff.ok) {
-						return fail(TLIncompatibilityReason.InvalidRecord)
+						return fail(TLSyncErrorCloseEventReason.INVALID_RECORD)
 					}
 					if (diff.value) {
 						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
@@ -955,12 +999,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 						: { type: 'success' as const, value: patched }
 					// If the client's version is too old, we'll hit an error
 					if (upgraded.type === 'error') {
-						return fail(TLIncompatibilityReason.ClientTooOld)
+						return fail(TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 					}
 					// replace the state with the upgraded version and propagate the patch op
 					const diff = doc.replaceState(upgraded.value, this.clock)
 					if (!diff.ok) {
-						return fail(TLIncompatibilityReason.InvalidRecord)
+						return fail(TLSyncErrorCloseEventReason.INVALID_RECORD)
 					}
 					if (diff.value) {
 						propagateOp(changes, id, [RecordOpType.Patch, diff.value])
@@ -1007,7 +1051,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 							// Try to add the document.
 							// If we're putting a record with a type that we don't recognize, fail
 							if (!this.documentTypes.has(op[1].typeName)) {
-								return fail(TLIncompatibilityReason.InvalidRecord)
+								return fail(TLSyncErrorCloseEventReason.INVALID_RECORD)
 							}
 							const res = addDocument(docChanges, id, op[1])
 							// if res.ok is false here then we already called `fail` and we should stop immediately
@@ -1026,11 +1070,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 							if (!doc) {
 								// If the doc was already deleted, don't do anything, no need to propagate a delete op
 								continue
-							}
-
-							// If the doc is not a type that we recognize, fail
-							if (!this.documentTypes.has(doc.state.typeName)) {
-								return fail(TLIncompatibilityReason.InvalidOperation)
 							}
 
 							// Delete the document and propagate the delete op
@@ -1086,8 +1125,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					if (!migrateResult.ok) {
 						return fail(
 							migrateResult.error === MigrationFailureReason.TargetVersionTooNew
-								? TLIncompatibilityReason.ServerTooOld
-								: TLIncompatibilityReason.ClientTooOld
+								? TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+								: TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
 						)
 					}
 					// If the migration worked, send the rebased diff to the client

--- a/packages/sync-core/src/lib/protocol.ts
+++ b/packages/sync-core/src/lib/protocol.ts
@@ -1,25 +1,30 @@
 import { SerializedSchema, UnknownRecord } from '@tldraw/store'
 import { NetworkDiff, ObjectDiff, RecordOpType } from './diff'
 
-const TLSYNC_PROTOCOL_VERSION = 6
+const TLSYNC_PROTOCOL_VERSION = 7
 
 /** @internal */
 export function getTlsyncProtocolVersion() {
 	return TLSYNC_PROTOCOL_VERSION
 }
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated Replaced by websocket .close status/reason
+ */
 export const TLIncompatibilityReason = {
 	ClientTooOld: 'clientTooOld',
 	ServerTooOld: 'serverTooOld',
 	InvalidRecord: 'invalidRecord',
 	InvalidOperation: 'invalidOperation',
-	RoomNotFound: 'roomNotFound',
-	Forbidden: 'forbidden',
 } as const
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated replaced by websocket .close status/reason
+ */
 export type TLIncompatibilityReason =
+	// eslint-disable-next-line deprecation/deprecation
 	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
 /** @internal */
@@ -36,11 +41,8 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	  }
 	| {
 			type: 'incompatibility_error'
+			// eslint-disable-next-line deprecation/deprecation
 			reason: TLIncompatibilityReason
-	  }
-	| {
-			type: 'error'
-			error?: any
 	  }
 	| {
 			type: 'pong'

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -451,7 +451,7 @@ describe('TLSyncRoom.updateStore', () => {
 				page.index = 34 as any
 				store.put(page)
 			})
-		).rejects.toMatchInlineSnapshot(`[Error: failed to apply changes: invalidRecord]`)
+		).rejects.toMatchInlineSnapshot(`[Error: failed to apply changes: INVALID_RECORD]`)
 	})
 
 	test('changes in multiple transaction are isolated from one another', async () => {

--- a/packages/sync-core/src/test/TestServer.ts
+++ b/packages/sync-core/src/test/TestServer.ts
@@ -24,7 +24,7 @@ export class TestServer<R extends UnknownRecord, P = unknown> {
 			this.room.handleClose(socketPair.id)
 		}
 
-		socketPair.callbacks.onStatusChange?.('online')
+		socketPair.callbacks.onStatusChange?.({ status: 'online' })
 	}
 
 	flushDebouncingMessages() {

--- a/packages/sync-core/src/test/TestSocketPair.ts
+++ b/packages/sync-core/src/test/TestSocketPair.ts
@@ -1,6 +1,6 @@
 import { UnknownRecord } from '@tldraw/store'
 import { structuredClone } from '@tldraw/utils'
-import { TLPersistentClientSocket, TLPersistentClientSocketStatus } from '../lib/TLSyncClient'
+import { TLPersistentClientSocket, TLSocketStatusListener } from '../lib/TLSyncClient'
 import { TLRoomSocket } from '../lib/TLSyncRoom'
 import { TLSocketClientSentEvent, TLSocketServerSentEvent } from '../lib/protocol'
 import { TestServer } from './TestServer'
@@ -78,7 +78,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 
 	callbacks = {
 		onReceiveMessage: null as null | ((msg: TLSocketServerSentEvent<R>) => void),
-		onStatusChange: null as null | ((status: TLPersistentClientSocketStatus) => void),
+		onStatusChange: null as null | TLSocketStatusListener,
 	}
 
 	// eslint-disable-next-line no-restricted-syntax
@@ -94,7 +94,7 @@ export class TestSocketPair<R extends UnknownRecord> {
 		this.clientSocket.connectionStatus = 'offline'
 		this.serverSentEventQueue = []
 		this.clientSentEventQueue = []
-		this.callbacks.onStatusChange?.('offline')
+		this.callbacks.onStatusChange?.({ status: 'offline' })
 		this.clientDisconnected?.()
 	}
 

--- a/packages/sync-core/src/test/syncFuzz.test.ts
+++ b/packages/sync-core/src/test/syncFuzz.test.ts
@@ -83,9 +83,6 @@ class FuzzTestInstance extends RandomSource {
 			onLoad: () => {
 				this.editor = new FuzzEditor(this.id, this.seed, this.store)
 			},
-			onLoadError: (e) => {
-				throw new Error('onLoadError', e)
-			},
 			presence: createPresenceStateDerivation(
 				computed('', () => ({
 					id: this.id,

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -187,9 +187,6 @@ class TestInstance {
 			onLoad: () => {
 				this.hasLoaded = true
 			},
-			onLoadError: (e) => {
-				throw new Error('onLoadError', e)
-			},
 			onSyncError: jest.fn((reason) => {
 				throw new Error('onSyncError: ' + reason)
 			}),
@@ -201,9 +198,6 @@ class TestInstance {
 			socket: this.newSocketPair.clientSocket,
 			onLoad: () => {
 				this.hasLoaded = true
-			},
-			onLoadError: (e) => {
-				throw new Error('onLoadError', e)
 			},
 			onSyncError: jest.fn((reason) => {
 				throw new Error('onSyncError: ' + reason)
@@ -375,6 +369,7 @@ test('out-of-date clients will receive incompatibility errors', () => {
 
 	expect(socket.sendMessage).toHaveBeenCalledWith({
 		type: 'incompatibility_error',
+		// eslint-disable-next-line deprecation/deprecation
 		reason: TLIncompatibilityReason.ClientTooOld,
 	})
 })
@@ -399,6 +394,7 @@ test('clients using an out-of-date protocol will receive compatibility errors', 
 
 		expect(socket.sendMessage).toHaveBeenCalledWith({
 			type: 'incompatibility_error',
+			// eslint-disable-next-line deprecation/deprecation
 			reason: TLIncompatibilityReason.ClientTooOld,
 		})
 	} finally {
@@ -460,6 +456,7 @@ test('clients using a too-new protocol will receive compatibility errors', () =>
 
 	expect(socket.sendMessage).toHaveBeenCalledWith({
 		type: 'incompatibility_error',
+		// eslint-disable-next-line deprecation/deprecation
 		reason: TLIncompatibilityReason.ServerTooOld,
 	})
 })

--- a/packages/sync-core/src/test/validation.test.ts
+++ b/packages/sync-core/src/test/validation.test.ts
@@ -1,6 +1,6 @@
 import { computed } from '@tldraw/state'
 import { RecordId, Store, StoreSchema, UnknownRecord, createRecordType } from '@tldraw/store'
-import { TLSyncClient } from '../lib/TLSyncClient'
+import { TLSyncClient, TLSyncErrorCloseEventReason } from '../lib/TLSyncClient'
 import { RecordOpType } from '../lib/diff'
 import { TestServer } from './TestServer'
 import { TestSocketPair } from './TestSocketPair'
@@ -107,7 +107,7 @@ it('rejects invalid put operations that create a new document', async () => {
 	await flush()
 
 	expect(onSyncError).toHaveBeenCalledTimes(1)
-	expect(onSyncError).toHaveBeenLastCalledWith('invalidRecord')
+	expect(onSyncError).toHaveBeenLastCalledWith(TLSyncErrorCloseEventReason.INVALID_RECORD)
 	expect(server.room.getSnapshot().documents).toStrictEqual(prevServerDocs)
 })
 
@@ -141,7 +141,7 @@ it('rejects invalid put operations that replace an existing document', async () 
 	await flush()
 
 	expect(onSyncError).toHaveBeenCalledTimes(1)
-	expect(onSyncError).toHaveBeenLastCalledWith('invalidRecord')
+	expect(onSyncError).toHaveBeenLastCalledWith(TLSyncErrorCloseEventReason.INVALID_RECORD)
 	expect(server.room.getSnapshot().documents).toStrictEqual(prevServerDocs)
 })
 
@@ -175,6 +175,6 @@ it('rejects invalid update operations', async () => {
 	])
 	await flush()
 	expect(onSyncError).toHaveBeenCalledTimes(1)
-	expect(onSyncError).toHaveBeenLastCalledWith('invalidRecord')
+	expect(onSyncError).toHaveBeenLastCalledWith(TLSyncErrorCloseEventReason.INVALID_RECORD)
 	expect(server.room.getSnapshot().documents).toStrictEqual(prevServerDocs)
 })

--- a/packages/sync-core/src/test/validation.test.ts
+++ b/packages/sync-core/src/test/validation.test.ts
@@ -68,13 +68,13 @@ async function makeTestInstance() {
 			socketPair.flushServerSentEvents()
 		}
 	}
-	const onSyncError = jest.fn()
+	let onSyncError = jest.fn()
 	const client = await new Promise<TLSyncClient<Book | Presence>>((resolve, reject) => {
+		onSyncError = jest.fn(reject)
 		const client = new TLSyncClient({
 			store: new Store<Book | Presence, unknown>({ schema: schemaWithoutValidator, props: {} }),
 			socket: socketPair.clientSocket as any,
 			onLoad: resolve,
-			onLoadError: reject,
 			onSyncError,
 			presence: computed('', () => null),
 		})


### PR DESCRIPTION
- refine and consolidate error handling, using `socket.close(code, reason)` for unrecoverable errors instead of the message protocol.
- allow SDK users to evict sessions from a room, either terminally (by supplying a reason which gets passed to socket.close) or just to force them to reconnect.

### Change type

- [x] `improvement`
- [x] `api`

### Release notes

- Adds a `closeSession` to the `TLSocketRoom` class, for terminating or restarting a client's socket connection.