### PR TITLE
Fix icon button width

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1416,6 +1416,10 @@
 	}
 }
 
+.tlui-button__icon {
+	padding: 0px;
+}
+
 .tlui-page-menu__item__button .tlui-button__icon {
 	margin-right: 4px;
 }


### PR DESCRIPTION
This PR fixes a bug that caused our icon buttons to be 42px wide instead of 40.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with the width of icon buttons.