### PR TITLE
Add zoom buttons to collapsed navigation panel on desktop.

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -320,9 +320,9 @@
 
 /* Zoom button */
 
-.tlui-zoom-menu__button__pct {
-	width: 60px;
-	min-width: 60px;
+.tlui-zoom-menu__button {
+	width: 56px;
+	min-width: 56px;
 	text-align: center;
 }
 

--- a/packages/tldraw/src/lib/ui/components/NavigationPanel/DefaultNavigationPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationPanel/DefaultNavigationPanel.tsx
@@ -34,7 +34,27 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 					<ZoomMenu />
 				) : collapsed ? (
 					<>
+						{breakpoint < PORTRAIT_BREAKPOINT.DESKTOP ? null : (
+							<TldrawUiButton
+								type="icon"
+								data-testid="minimap.zoom-out"
+								title={`${msg(unwrapLabel(actions['zoom-out'].label))} ${kbdStr(actions['zoom-out'].kbd!)}`}
+								onClick={() => actions['zoom-out'].onSelect('navigation-zone')}
+							>
+								<TldrawUiButtonIcon icon="minus" />
+							</TldrawUiButton>
+						)}
 						{ZoomMenu && <ZoomMenu />}
+						{breakpoint < PORTRAIT_BREAKPOINT.DESKTOP ? null : (
+							<TldrawUiButton
+								type="icon"
+								data-testid="minimap.zoom-in"
+								title={`${msg(unwrapLabel(actions['zoom-in'].label))} ${kbdStr(actions['zoom-in'].kbd!)}`}
+								onClick={() => actions['zoom-in'].onSelect('navigation-zone')}
+							>
+								<TldrawUiButtonIcon icon="plus" />
+							</TldrawUiButton>
+						)}
 						{Minimap && (
 							<TldrawUiButton
 								type="icon"
@@ -43,7 +63,7 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 								className="tlui-navigation-panel__toggle"
 								onClick={toggleMinimap}
 							>
-								<TldrawUiButtonIcon icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'} />
+								<TldrawUiButtonIcon icon={'chevrons-ne'} />
 							</TldrawUiButton>
 						)}
 					</>
@@ -74,7 +94,7 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 								className="tlui-navigation-panel__toggle"
 								onClick={toggleMinimap}
 							>
-								<TldrawUiButtonIcon icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'} />
+								<TldrawUiButtonIcon icon={'chevrons-sw'} />
 							</TldrawUiButton>
 						)}
 					</>

--- a/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
@@ -1,8 +1,6 @@
 import * as _Dropdown from '@radix-ui/react-dropdown-menu'
 import { useContainer, useEditor, useValue } from '@tldraw/editor'
 import { ReactNode, forwardRef, memo, useCallback } from 'react'
-import { PORTRAIT_BREAKPOINT } from '../../constants'
-import { useBreakpoint } from '../../context/breakpoints'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
@@ -50,7 +48,6 @@ export const DefaultZoomMenu = memo(function DefaultZoomMenu({ children }: TLUiZ
 const ZoomTriggerButton = forwardRef<HTMLButtonElement, any>(
 	function ZoomTriggerButton(props, ref) {
 		const editor = useEditor()
-		const breakpoint = useBreakpoint()
 		const zoom = useValue('zoom', () => editor.getZoomLevel(), [editor])
 		const msg = useTranslation()
 
@@ -67,16 +64,10 @@ const ZoomTriggerButton = forwardRef<HTMLButtonElement, any>(
 				type="icon"
 				title={`${msg('navigation-zone.zoom')}`}
 				data-testid="minimap.zoom-menu-button"
-				className={
-					breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM
-						? 'tlui-zoom-menu__button'
-						: 'tlui-zoom-menu__button__pct'
-				}
+				className={'tlui-zoom-menu__button'}
 				onDoubleClick={handleDoubleClick}
 			>
-				{breakpoint < PORTRAIT_BREAKPOINT.MOBILE ? null : (
-					<span style={{ flexGrow: 0, textAlign: 'center' }}>{Math.floor(zoom * 100)}%</span>
-				)}
+				<span style={{ flexGrow: 0, textAlign: 'center' }}>{Math.floor(zoom * 100)}%</span>
 			</TldrawUiButton>
 		)
 	}


### PR DESCRIPTION
This PR adds + and - buttons to the navigation panel when collapsed on the largest breakpoint (desktop). I'm pretty sure these would be useful for most people, but then again they're present on the default state of the navigation panel.

### Change type

- [x] `improvement`

### Test plan

1. On desktop, check the collapsed navigation panel.

### Release notes

- Adds zoom in and zoom out buttons on desktop.