### PR TITLE
Add editor option for quick actions placement.

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -677,6 +677,7 @@ export const DefaultSvgDefs: () => null;
 
 // @public (undocumented)
 export const defaultTldrawOptions: {
+    readonly actionShortcutsLocation: "swap";
     readonly adjacentShapeMargin: 10;
     readonly animationMediumMs: 320;
     readonly cameraMovingTimeoutMs: 64;
@@ -2725,6 +2726,8 @@ export interface TldrawEditorWithStoreProps {
 
 // @public
 export interface TldrawOptions {
+    // (undocumented)
+    readonly actionShortcutsLocation: 'menu' | 'swap' | 'toolbar';
     // (undocumented)
     readonly adjacentShapeMargin: number;
     // (undocumented)

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -57,6 +57,7 @@ export interface TldrawOptions {
 	 * they expire? Defaults to 3 minutes.
 	 */
 	readonly temporaryAssetPreviewLifetimeMs: number
+	readonly actionShortcutsLocation: 'menu' | 'toolbar' | 'swap'
 }
 
 /** @public */
@@ -99,4 +100,5 @@ export const defaultTldrawOptions = {
 	laserDelayMs: 1200,
 	maxExportDelayMs: 5000,
 	temporaryAssetPreviewLifetimeMs: 180000,
+	actionShortcutsLocation: 'swap',
 } as const satisfies TldrawOptions

--- a/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
@@ -20,7 +20,7 @@ export const DefaultMenuPanel = memo(function MenuPanel() {
 			? true
 			: editor.options.actionShortcutsLocation === 'toolbar'
 				? false
-				: breakpoint < PORTRAIT_BREAKPOINT.TABLET
+				: breakpoint >= PORTRAIT_BREAKPOINT.TABLET
 
 	if (!MainMenu && !PageMenu && !showQuickActions) return null
 

--- a/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
@@ -1,5 +1,6 @@
 import { useEditor, useValue } from '@tldraw/editor'
 import { memo } from 'react'
+import { PORTRAIT_BREAKPOINT } from '../constants'
 import { useBreakpoint } from '../context/breakpoints'
 import { useTldrawUiComponents } from '../context/components'
 
@@ -14,19 +15,26 @@ export const DefaultMenuPanel = memo(function MenuPanel() {
 		editor,
 	])
 
-	if (!MainMenu && !PageMenu && breakpoint < 6) return null
+	const showQuickActions =
+		editor.options.actionShortcutsLocation === 'menu'
+			? true
+			: editor.options.actionShortcutsLocation === 'toolbar'
+				? false
+				: breakpoint < PORTRAIT_BREAKPOINT.TABLET
+
+	if (!MainMenu && !PageMenu && !showQuickActions) return null
 
 	return (
 		<div className="tlui-menu-zone">
 			<div className="tlui-buttons__horizontal">
 				{MainMenu && <MainMenu />}
 				{PageMenu && !isSinglePageMode && <PageMenu />}
-				{breakpoint < 6 ? null : (
+				{showQuickActions ? (
 					<>
 						{QuickActions && <QuickActions />}
 						{ActionsMenu && <ActionsMenu />}
 					</>
-				)}
+				) : null}
 			</div>
 		</div>
 	)

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
@@ -30,17 +30,20 @@ export const DefaultToolbar = memo(function DefaultToolbar({ children }: Default
 
 	const { ActionsMenu, QuickActions } = useTldrawUiComponents()
 
+	const showQuickActions =
+		editor.options.actionShortcutsLocation === 'menu'
+			? false
+			: editor.options.actionShortcutsLocation === 'toolbar'
+				? true
+				: breakpoint < PORTRAIT_BREAKPOINT.TABLET
+
 	return (
 		<div className="tlui-toolbar">
 			<div className="tlui-toolbar__inner">
 				<div className="tlui-toolbar__left">
 					{!isReadonlyMode && (
 						<div className="tlui-toolbar__extras">
-							{(editor.options.actionShortcutsLocation === 'menu'
-								? false
-								: editor.options.actionShortcutsLocation === 'toolbar'
-									? true
-									: breakpoint < PORTRAIT_BREAKPOINT.TABLET) && (
+							{showQuickActions && (
 								<div className="tlui-toolbar__extras__controls tlui-buttons__horizontal">
 									{QuickActions && <QuickActions />}
 									{ActionsMenu && <ActionsMenu />}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
@@ -36,7 +36,11 @@ export const DefaultToolbar = memo(function DefaultToolbar({ children }: Default
 				<div className="tlui-toolbar__left">
 					{!isReadonlyMode && (
 						<div className="tlui-toolbar__extras">
-							{breakpoint < PORTRAIT_BREAKPOINT.TABLET && (
+							{(editor.options.actionShortcutsLocation === 'menu'
+								? false
+								: editor.options.actionShortcutsLocation === 'toolbar'
+									? true
+									: breakpoint < PORTRAIT_BREAKPOINT.TABLET) && (
 								<div className="tlui-toolbar__extras__controls tlui-buttons__horizontal">
 									{QuickActions && <QuickActions />}
 									{ActionsMenu && <ActionsMenu />}


### PR DESCRIPTION
This PR adds an Editor option, `actionShortcutsLocation`, that allows for control over whether the action shortcuts are always in the menu, always in the toolbar, or (the default mode) swapping between the two based on breakpoint.

### Change type

- [x] `improvement`

### Release notes

- Adds an editor option to control the placement of quick action shortcuts.