### PR TITLE
Improve watermark tests

### DIFF
--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,3 +1,4 @@
+import { useValue } from '@tldraw/state-react'
 import { createContext, ReactNode, useContext, useState } from 'react'
 import { LicenseManager } from './LicenseManager'
 
@@ -17,4 +18,9 @@ export function LicenseProvider({
 }) {
 	const [licenseManager] = useState(() => new LicenseManager(licenseKey))
 	return <LicenseContext.Provider value={licenseManager}>{children}</LicenseContext.Provider>
+}
+
+/** @internal */
+export function useLicenseManagerState(licenseManager: LicenseManager) {
+	return useValue('watermarkState', () => licenseManager.state.get(), [licenseManager])
 }

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,4 +1,3 @@
-import { useValue } from '@tldraw/state-react'
 import { createContext, ReactNode, useContext, useState } from 'react'
 import { LicenseManager } from './LicenseManager'
 
@@ -18,9 +17,4 @@ export function LicenseProvider({
 }) {
 	const [licenseManager] = useState(() => new LicenseManager(licenseKey))
 	return <LicenseContext.Provider value={licenseManager}>{children}</LicenseContext.Provider>
-}
-
-/** @internal */
-export function useLicenseManagerState(licenseManager: LicenseManager) {
-	return useValue('watermarkState', () => licenseManager.state.get(), [licenseManager])
 }

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -8,25 +8,25 @@ jest.mock('../hooks/useLicenseManagerState', () => ({
 	useLicenseManagerState: () => mockLicenseState,
 }))
 
-async function renderWithMockedLicenseState() {
-	const result = await act(async () => render(<TldrawEditor />))
-	const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
-	return elm
-}
-
 describe('Watermark', () => {
 	it('Displays the watermark when the editor is unlicensed', async () => {
 		mockLicenseState = 'unlicensed'
-		expect(await renderWithMockedLicenseState()).not.toBeNull()
+		const result = await act(async () => render(<TldrawEditor />))
+		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
+		expect(elm).not.toBeNull()
 	})
 
 	it('Displays the watermark when the editor is licensed with watermark', async () => {
 		mockLicenseState = 'licensed-with-watermark'
-		expect(await renderWithMockedLicenseState()).not.toBeNull()
+		const result = await act(async () => render(<TldrawEditor />))
+		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
+		expect(elm).not.toBeNull()
 	})
 
 	it('Does not display the watermark when the editor is licensed', async () => {
 		mockLicenseState = 'licensed'
-		expect(await renderWithMockedLicenseState()).toBeNull()
+		const result = await act(async () => render(<TldrawEditor />))
+		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
+		expect(elm).toBeNull()
 	})
 })

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -8,25 +8,24 @@ jest.mock('../hooks/useLicenseManagerState', () => ({
 	useLicenseManagerState: () => mockLicenseState,
 }))
 
+async function renderEditorAndGetWatermarkElement() {
+	const result = await act(async () => render(<TldrawEditor />))
+	return await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
+}
+
 describe('Watermark', () => {
 	it('Displays the watermark when the editor is unlicensed', async () => {
 		mockLicenseState = 'unlicensed'
-		const result = await act(async () => render(<TldrawEditor />))
-		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
-		expect(elm).not.toBeNull()
+		expect(await renderEditorAndGetWatermarkElement()).not.toBeNull()
 	})
 
 	it('Displays the watermark when the editor is licensed with watermark', async () => {
 		mockLicenseState = 'licensed-with-watermark'
-		const result = await act(async () => render(<TldrawEditor />))
-		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
-		expect(elm).not.toBeNull()
+		expect(await renderEditorAndGetWatermarkElement()).not.toBeNull()
 	})
 
 	it('Does not display the watermark when the editor is licensed', async () => {
 		mockLicenseState = 'licensed'
-		const result = await act(async () => render(<TldrawEditor />))
-		const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
-		expect(elm).toBeNull()
+		expect(await renderEditorAndGetWatermarkElement()).toBeNull()
 	})
 })

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -4,7 +4,7 @@ import { LicenseManager } from './LicenseManager'
 
 let mockLicenseState = 'unlicensed'
 
-jest.mock('../hooks/useLicenseManagerState', () => ({
+jest.mock('./useLicenseManagerState', () => ({
 	useLicenseManagerState: () => mockLicenseState,
 }))
 

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -2,10 +2,10 @@ import { act, render, waitFor } from '@testing-library/react'
 import { TldrawEditor } from '../TldrawEditor'
 import { LicenseManager } from './LicenseManager'
 
-let licenseState = 'unlicensed'
+let mockLicenseState = 'unlicensed'
 
 jest.mock('../hooks/useLicenseManagerState', () => ({
-	useLicenseManagerState: () => licenseState,
+	useLicenseManagerState: () => mockLicenseState,
 }))
 
 async function renderWithMockedLicenseState() {
@@ -16,17 +16,17 @@ async function renderWithMockedLicenseState() {
 
 describe('Watermark', () => {
 	it('Displays the watermark when the editor is unlicensed', async () => {
-		licenseState = 'unlicensed'
+		mockLicenseState = 'unlicensed'
 		expect(await renderWithMockedLicenseState()).not.toBeNull()
 	})
 
 	it('Displays the watermark when the editor is licensed with watermark', async () => {
-		licenseState = 'licensed-with-watermark'
+		mockLicenseState = 'licensed-with-watermark'
 		expect(await renderWithMockedLicenseState()).not.toBeNull()
 	})
 
 	it('Does not display the watermark when the editor is licensed', async () => {
-		licenseState = 'licensed'
+		mockLicenseState = 'licensed'
 		expect(await renderWithMockedLicenseState()).toBeNull()
 	})
 })

--- a/packages/editor/src/lib/license/Watermark.test.tsx
+++ b/packages/editor/src/lib/license/Watermark.test.tsx
@@ -1,78 +1,32 @@
 import { act, render, waitFor } from '@testing-library/react'
+import { TldrawEditor } from '../TldrawEditor'
 import { LicenseManager } from './LicenseManager'
-import { Watermark } from './Watermark'
 
-// Mocking useEditor and licenseContext
-jest.mock('../hooks/useEditor', () => ({
-	useEditor: () => ({
-		getViewportScreenBounds: jest.fn().mockReturnValue({ width: 800 }),
-		getInstanceState: jest.fn().mockReturnValue({ isDebugMode: false }),
-		menus: {
-			hasAnyOpenMenus: jest.fn().mockReturnValue(false),
-		},
-		getIsMenuOpen: jest.fn().mockReturnValue(false),
-		environment: jest.fn().mockReturnValue({
-			isSafari: true,
-			isIos: false,
-			isChromeForIos: false,
-			isFirefox: false,
-			isAndroid: false,
-			isWebview: false,
-		}),
-	}),
+let licenseState = 'unlicensed'
+
+jest.mock('../hooks/useLicenseManagerState', () => ({
+	useLicenseManagerState: () => licenseState,
 }))
 
-let mockLicenseState = 'unlicensed'
-jest.mock('./LicenseProvider', () => ({
-	useLicenseContext: jest.fn().mockReturnValue({
-		state: { get: () => mockLicenseState },
-		async getWatermarkUrl() {
-			return ['watermark-desktop.svg', 'watermark-mobile.svg']
-		},
-	}),
-}))
-
-jest.useFakeTimers()
-
-export async function renderComponent() {
-	const result = render(<Watermark />)
-	jest.advanceTimersByTime(3000)
-	return result
+async function renderWithMockedLicenseState() {
+	const result = await act(async () => render(<TldrawEditor />))
+	const elm = await waitFor(() => result.container.querySelector(`.${LicenseManager.className}`))
+	return elm
 }
 
 describe('Watermark', () => {
-	beforeEach(() => {
-		jest.mock('./LicenseProvider', () => ({
-			useLicenseContext: jest.fn().mockReturnValue({ state: { get: () => mockLicenseState } }),
-		}))
-	})
-
 	it('Displays the watermark when the editor is unlicensed', async () => {
-		const result = await act(renderComponent)
-
-		// Don't wanna put a data-testid here - makes it too easy to querySelect on.
-		await waitFor(() =>
-			expect((result.container.firstChild! as Element)!.nextElementSibling!.className).toBe(
-				LicenseManager.className
-			)
-		)
+		licenseState = 'unlicensed'
+		expect(await renderWithMockedLicenseState()).not.toBeNull()
 	})
 
 	it('Displays the watermark when the editor is licensed with watermark', async () => {
-		mockLicenseState = 'licensed-with-watermark'
-		const result = await act(renderComponent)
-
-		// Don't wanna put a data-testid here - makes it too easy to querySelect on.
-		await waitFor(() =>
-			expect((result.container.firstChild! as Element)!.nextElementSibling!.className).toBe(
-				LicenseManager.className
-			)
-		)
+		licenseState = 'licensed-with-watermark'
+		expect(await renderWithMockedLicenseState()).not.toBeNull()
 	})
 
 	it('Does not display the watermark when the editor is licensed', async () => {
-		mockLicenseState = 'licensed'
-		const result = await renderComponent()
-		expect(result.container.firstChild).toBeNull()
+		licenseState = 'licensed'
+		expect(await renderWithMockedLicenseState()).toBeNull()
 	})
 })

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -1,8 +1,9 @@
 import { useValue } from '@tldraw/state-react'
-import { memo } from 'react'
+import { memo, useRef } from 'react'
 import { tlenv } from '../globals/environment'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
+import { usePassThroughWheelEvents } from '../hooks/usePassThroughWheelEvents'
 import { preventDefault, stopEventPropagation } from '../utils/dom'
 import { runtime } from '../utils/runtime'
 import { watermarkDesktopSvg, watermarkMobileSvg } from '../watermarks'
@@ -41,11 +42,15 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 	])
 	const events = useCanvasEvents()
 
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+
 	const maskCss = `url('${src}') center 100% / 100% no-repeat`
 	const url = 'https://tldraw.dev'
 
 	return (
 		<div
+			ref={ref}
 			className={LicenseManager.className}
 			data-debug={isDebugMode}
 			data-menu={isMenuOpen}

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -1,5 +1,5 @@
-import { useQuickReactor, useValue } from '@tldraw/state-react'
-import { memo, useState } from 'react'
+import { useValue } from '@tldraw/state-react'
+import { memo } from 'react'
 import { tlenv } from '../globals/environment'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
@@ -7,7 +7,7 @@ import { preventDefault, stopEventPropagation } from '../utils/dom'
 import { runtime } from '../utils/runtime'
 import { watermarkDesktopSvg, watermarkMobileSvg } from '../watermarks'
 import { LicenseManager } from './LicenseManager'
-import { useLicenseContext } from './LicenseProvider'
+import { useLicenseContext, useLicenseManagerState } from './LicenseProvider'
 
 const WATERMARK_DESKTOP_LOCAL_SRC = `data:image/svg+xml;utf8,${encodeURIComponent(watermarkDesktopSvg)}`
 const WATERMARK_MOBILE_LOCAL_SRC = `data:image/svg+xml;utf8,${encodeURIComponent(watermarkMobileSvg)}`
@@ -19,28 +19,15 @@ export const Watermark = memo(function Watermark() {
 	const isMobile = useValue('is mobile', () => editor.getViewportScreenBounds().width < 700, [
 		editor,
 	])
-	const [src, setSrc] = useState<string | null>(null)
 
-	useQuickReactor(
-		'set watermark src',
-		async () => {
-			const showWatermark = ['licensed-with-watermark', 'unlicensed'].includes(
-				licenseManager.state.get()
-			)
+	const licenseManagerState = useLicenseManagerState(licenseManager)
 
-			if (showWatermark) {
-				setSrc(isMobile ? WATERMARK_MOBILE_LOCAL_SRC : WATERMARK_DESKTOP_LOCAL_SRC)
-			}
-		},
-		[licenseManager, isMobile]
-	)
-
-	if (!src) return null
+	if (!['licensed-with-watermark', 'unlicensed'].includes(licenseManagerState)) return null
 
 	return (
 		<>
 			<LicenseStyles />
-			<WatermarkInner src={src} />
+			<WatermarkInner src={isMobile ? WATERMARK_MOBILE_LOCAL_SRC : WATERMARK_DESKTOP_LOCAL_SRC} />
 		</>
 	)
 })

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -8,7 +8,8 @@ import { preventDefault, stopEventPropagation } from '../utils/dom'
 import { runtime } from '../utils/runtime'
 import { watermarkDesktopSvg, watermarkMobileSvg } from '../watermarks'
 import { LicenseManager } from './LicenseManager'
-import { useLicenseContext, useLicenseManagerState } from './LicenseProvider'
+import { useLicenseContext } from './LicenseProvider'
+import { useLicenseManagerState } from './useLicenseManagerState'
 
 const WATERMARK_DESKTOP_LOCAL_SRC = `data:image/svg+xml;utf8,${encodeURIComponent(watermarkDesktopSvg)}`
 const WATERMARK_MOBILE_LOCAL_SRC = `data:image/svg+xml;utf8,${encodeURIComponent(watermarkMobileSvg)}`

--- a/packages/editor/src/lib/license/useLicenseManagerState.ts
+++ b/packages/editor/src/lib/license/useLicenseManagerState.ts
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { LicenseManager } from '../license/LicenseManager'
+import { LicenseManager } from './LicenseManager'
 
 /** @internal */
 export function useLicenseManagerState(licenseManager: LicenseManager) {


### PR DESCRIPTION
This PR improves the tests for our watermark.

The `Watermark.test.tsx` file includes three unit tests that check whether the watermark is displayed or not displayed depending on whether the editor is licensed, unlicensed, or licensed with watermark. Previously, we were testing just the `Watermark` component on its own, which necessitated mocking the Editor and any other hooks used in the component.

In this PR, we instead test with the full Editor. I've created a custom hook, `useLicenseManagerState`, that returns the license manager state. In our tests, we now mock _only_ this hook, returning the result we wish to test and then checking whether the watermark component is in the document.

## Pros

No more mocking random parts of the Editor.

## Cons

An extra hook.

## One more thing

It's also possible to test this with the actual license keys, however that added some extra complexity in exchange for duplicating tests already covered by `LicenseManager.test.ts`.

### Change type

- [x] `other`
