### PR TITLE
[sync] Set instance.isReadonly automatically 

### DIFF
--- a/apps/dotcom/client/src/components/DocumentName/DocumentName.tsx
+++ b/apps/dotcom/client/src/components/DocumentName/DocumentName.tsx
@@ -64,7 +64,7 @@ export const DocumentNameInner = track(function DocumentNameInner() {
 	const msg = useTranslation()
 	const toasts = useToasts()
 	const trackEvent = useUiEvents()
-	const isReadonly = editor.getInstanceState().isReadonly
+	const isReadonly = editor.getIsReadonly()
 
 	return (
 		<div className="tlui-document-name__inner">
@@ -73,7 +73,7 @@ export const DocumentNameInner = track(function DocumentNameInner() {
 				<TldrawUiDropdownMenuTrigger>
 					<TldrawUiButton
 						type="icon"
-						className="tlui-document-name__menu tlui-menu__trigger flex-none"
+						className="flex-none tlui-document-name__menu tlui-menu__trigger"
 					>
 						<TldrawUiButtonIcon icon="chevron-down" />
 					</TldrawUiButton>
@@ -96,10 +96,7 @@ export const DocumentNameInner = track(function DocumentNameInner() {
 								type="menu"
 								onClick={async () => {
 									trackEvent('copy-link', { source: 'document-name' })
-									const shareLink = await getShareUrl(
-										window.location.href,
-										editor.getInstanceState().isReadonly
-									)
+									const shareLink = await getShareUrl(window.location.href, editor.getIsReadonly())
 									shareLink && navigator.clipboard.writeText(shareLink)
 									toasts.addToast({
 										title: msg('share-menu.copied'),

--- a/apps/dotcom/client/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/client/src/components/MultiplayerEditor.tsx
@@ -142,9 +142,6 @@ export function MultiplayerEditor({
 				;(window as any).app = editor
 				;(window as any).editor = editor
 			}
-			editor.updateInstanceState({
-				isReadonly,
-			})
 			editor.registerExternalAssetHandler('url', createAssetFromUrl)
 		},
 		[isReadonly]

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1007,6 +1007,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     getIsFocused(): boolean;
     // @deprecated (undocumented)
     getIsMenuOpen(): boolean;
+    // (undocumented)
+    getIsReadonly(): boolean;
     // @internal
     getMarkIdMatching(idSubstring: string): null | string;
     getOnlySelectedShape(): null | TLShape;
@@ -3490,6 +3492,7 @@ export type TLStoreEventInfo = HistoryEntry<TLRecord>;
 // @public (undocumented)
 export type TLStoreOptions = TLStoreBaseOptions & {
     collaboration?: {
+        mode?: null | Signal<'readonly' | 'readwrite'>;
         status: null | Signal<'offline' | 'online'>;
     };
     id?: string;

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -50,6 +50,7 @@ export type TLStoreOptions = TLStoreBaseOptions & {
 	/** Collaboration options for the store. */
 	collaboration?: {
 		status: Signal<'online' | 'offline'> | null
+		mode?: Signal<'readonly' | 'readwrite'> | null
 	}
 } & TLStoreSchemaOptions
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -738,6 +738,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 
 		this.performanceTracker = new PerformanceTracker()
+
+		if (this.store.props.collaboration?.mode) {
+			const mode = this.store.props.collaboration.mode
+			this.disposables.add(
+				react('update collaboration mode', () => {
+					this.store.put([{ ...this.getInstanceState(), isReadonly: mode.get() === 'readonly' }])
+				})
+			)
+		}
 	}
 
 	private readonly _isShapeHiddenPredicate?: (shape: TLShape, editor: Editor) => boolean
@@ -3879,7 +3888,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	updatePage(partial: RequiredKeys<Partial<TLPage>, 'id'>): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const prev = this.getPage(partial.id)
 		if (!prev) return this
@@ -3902,7 +3911,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	createPage(page: Partial<TLPage>): this {
 		this.run(() => {
-			if (this.getInstanceState().isReadonly) return
+			if (this.getIsReadonly()) return
 			if (this.getPages().length >= this.options.maxPages) return
 			const pages = this.getPages()
 
@@ -3944,7 +3953,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	deletePage(page: TLPageId | TLPage): this {
 		const id = typeof page === 'string' ? page : page.id
 		this.run(() => {
-			if (this.getInstanceState().isReadonly) return
+			if (this.getIsReadonly()) return
 			const pages = this.getPages()
 			if (pages.length === 1) return
 
@@ -4013,7 +4022,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	renamePage(page: TLPageId | TLPage, name: string) {
 		const id = typeof page === 'string' ? page : page.id
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		this.updatePage({ id, name })
 		return this
 	}
@@ -4047,7 +4056,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	createAssets(assets: TLAsset[]): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (assets.length <= 0) return this
 		this.run(() => this.store.put(assets), { history: 'ignore' })
 		return this
@@ -4066,7 +4075,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	updateAssets(assets: TLAssetPartial[]): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (assets.length <= 0) return this
 		this.run(
 			() => {
@@ -4095,7 +4104,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	deleteAssets(assets: TLAssetId[] | TLAsset[]): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const ids =
 			typeof assets[0] === 'string'
@@ -5856,7 +5865,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				: (shapes as TLShape[]).map((s) => s.id)
 
 		if (ids.length === 0) return this
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const currentPageId = this.getCurrentPageId()
 
@@ -5919,7 +5928,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly || ids.length === 0) return this
+		if (this.getIsReadonly() || ids.length === 0) return this
 
 		let allLocked = true,
 			allUnlocked = true
@@ -6067,7 +6076,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		let shapesToFlip = compact(ids.map((id) => this.getShape(id)))
 
@@ -6137,7 +6146,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const shapesToStack = ids
 			.map((id) => this.getShape(id)) // always fresh shapes
@@ -6274,7 +6283,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (ids.length < 2) return this
 
 		const shapesToPack = ids
@@ -6430,7 +6439,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (ids.length < 2) return this
 
 		const shapesToAlign = compact(ids.map((id) => this.getShape(id))) // always fresh shapes
@@ -6506,7 +6515,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (ids.length < 3) return this
 
 		const len = ids.length
@@ -6585,7 +6594,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (ids.length < 2) return this
 
 		const shapesToStretch = compact(ids.map((id) => this.getShape(id))) // always fresh shapes
@@ -6659,7 +6668,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	resizeShape(shape: TLShapeId | TLShape, scale: VecLike, opts: TLResizeShapeOptions = {}): this {
 		const id = typeof shape === 'string' ? shape : shape.id
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		if (!Number.isFinite(scale.x)) scale = new Vec(1, scale.y)
 		if (!Number.isFinite(scale.y)) scale = new Vec(scale.x, 1)
@@ -6963,7 +6972,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!Array.isArray(shapes)) {
 			throw Error('Editor.createShapes: must provide an array of shapes or shape partials')
 		}
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 		if (shapes.length <= 0) return this
 
 		const currentPageShapeIds = this.getCurrentPageShapeIds()
@@ -7292,7 +7301,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!Array.isArray(shapes)) {
 			throw Error('Editor.groupShapes: must provide an array of shapes or shape ids')
 		}
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const ids =
 			typeof shapes[0] === 'string'
@@ -7368,7 +7377,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	ungroupShapes(ids: TLShapeId[], opts?: Partial<{ select: boolean }>): this
 	ungroupShapes(shapes: TLShape[], opts?: Partial<{ select: boolean }>): this
 	ungroupShapes(shapes: TLShapeId[] | TLShape[], opts = {} as Partial<{ select: boolean }>) {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		const { select = true } = opts
 		const ids =
@@ -7500,7 +7509,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/** @internal */
 	_updateShapes(_partials: (TLShapePartial | null | undefined)[]) {
-		if (this.getInstanceState().isReadonly) return
+		if (this.getIsReadonly()) return
 
 		this.run(() => {
 			const updates = []
@@ -7555,7 +7564,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	deleteShapes(ids: TLShapeId[]): this
 	deleteShapes(shapes: TLShape[]): this
 	deleteShapes(_ids: TLShapeId[] | TLShape[]): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		if (!Array.isArray(_ids)) {
 			throw Error('Editor.deleteShapes: must provide an array of shapes or shapeIds')
@@ -8195,7 +8204,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			preserveIds?: boolean
 		} = {}
 	): this {
-		if (this.getInstanceState().isReadonly) return this
+		if (this.getIsReadonly()) return this
 
 		// todo: make this able to support putting content onto any page, not just the current page
 
@@ -8793,6 +8802,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	@computed getIsFocused() {
 		return this.getInstanceState().isFocused
+	}
+
+	/**
+	 * @public
+	 * @returns true if the editor is in readonly mode
+	 */
+	@computed getIsReadonly() {
+		return this.getInstanceState().isReadonly
 	}
 
 	/**

--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -396,6 +396,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> = {
     connectRequestId: string;
     diff: NetworkDiff<R>;
     hydrationType: 'wipe_all' | 'wipe_presence';
+    isReadonly: boolean;
     protocolVersion: number;
     schema: SerializedSchema;
     serverClock: number;
@@ -417,7 +418,9 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> = {
 export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>> {
     constructor(config: {
         didCancel?(): boolean;
-        onAfterConnect?(self: TLSyncClient<R, S>, isNew: boolean): void;
+        onAfterConnect?(self: TLSyncClient<R, S>, details: {
+            isReadonly: boolean;
+        }): void;
         onLoad(self: TLSyncClient<R, S>): void;
         onLoadError(error: Error): void;
         onSyncError(reason: TLIncompatibilityReason): void;
@@ -437,7 +440,9 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
     lastPushedPresenceState: null | R;
     // (undocumented)
     latestConnectRequestId: null | string;
-    readonly onAfterConnect?: (self: TLSyncClient<R, S>, isNew: boolean) => void;
+    readonly onAfterConnect?: (self: this, details: {
+        isReadonly: boolean;
+    }) => void;
     // (undocumented)
     readonly onSyncError: (reason: TLIncompatibilityReason) => void;
     // (undocumented)

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -115,7 +115,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * Called immediately after a connect acceptance has been received and processed Use this to make
 	 * any changes to the store that are required to keep it operational
 	 */
-	public readonly onAfterConnect?: (self: TLSyncClient<R, S>, isNew: boolean) => void
+	public readonly onAfterConnect?: (self: this, details: { isReadonly: boolean }) => void
 	public readonly onSyncError: (reason: TLIncompatibilityReason) => void
 
 	private isDebugging = false
@@ -137,7 +137,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		onLoad(self: TLSyncClient<R, S>): void
 		onLoadError(error: Error): void
 		onSyncError(reason: TLIncompatibilityReason): void
-		onAfterConnect?(self: TLSyncClient<R, S>, isNew: boolean): void
+		onAfterConnect?(self: TLSyncClient<R, S>, details: { isReadonly: boolean }): void
 		didCancel?(): boolean
 	}) {
 		this.didCancel = config.didCancel
@@ -363,8 +363,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			// this.store.applyDiff(stashedChanges, false)
 
 			this.store.ensureStoreIsUsable()
-			// TODO: reinstate isNew
-			this.onAfterConnect?.(this, false)
+			this.onAfterConnect?.(this, { isReadonly: event.isReadonly })
 		})
 
 		this.lastServerClock = event.serverClock

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -779,6 +779,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					schema: this.schema.serialize(),
 					serverClock: this.clock,
 					diff: migrated.value,
+					isReadonly: session.isReadonly,
 				})
 			} else {
 				// calculate the changes since the time the client last saw
@@ -827,6 +828,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					protocolVersion: getTlsyncProtocolVersion(),
 					serverClock: this.clock,
 					diff: migrated.value,
+					isReadonly: session.isReadonly,
 				})
 			}
 		})

--- a/packages/sync-core/src/lib/protocol.ts
+++ b/packages/sync-core/src/lib/protocol.ts
@@ -32,6 +32,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 			schema: SerializedSchema
 			diff: NetworkDiff<R>
 			serverClock: number
+			isReadonly: boolean
 	  }
 	| {
 			type: 'incompatibility_error'

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -439,7 +439,8 @@ test('v5 special case should allow connections', () => {
 		},
 		serverClock: 1,
 		type: 'connect',
-	})
+		isReadonly: false,
+	} satisfies TLSocketServerSentEvent<RV2>)
 })
 
 test('clients using a too-new protocol will receive compatibility errors', () => {

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -591,6 +591,7 @@ describe('when the client is too old', () => {
 			protocolVersion: getTlsyncProtocolVersion(),
 			schema: schemaV2.serialize(),
 			serverClock: 10,
+			isReadonly: false,
 		} satisfies TLSocketServerSentEvent<RV2>)
 
 		expect(v1SendMessage).toHaveBeenCalledWith({
@@ -601,6 +602,7 @@ describe('when the client is too old', () => {
 			protocolVersion: getTlsyncProtocolVersion(),
 			schema: schemaV2.serialize(),
 			serverClock: 10,
+			isReadonly: false,
 		} satisfies TLSocketServerSentEvent<RV2>)
 
 		v2SendMessage.mockClear()
@@ -748,6 +750,7 @@ describe('when the client is the same version', () => {
 			protocolVersion: getTlsyncProtocolVersion(),
 			schema: schemaV2.serialize(),
 			serverClock: 10,
+			isReadonly: false,
 		} satisfies TLSocketServerSentEvent<RV2>)
 
 		expect(bSocket.sendMessage).toHaveBeenCalledWith({
@@ -758,6 +761,7 @@ describe('when the client is the same version', () => {
 			protocolVersion: getTlsyncProtocolVersion(),
 			schema: schemaV2.serialize(),
 			serverClock: 10,
+			isReadonly: false,
 		} satisfies TLSocketServerSentEvent<RV2>)
 		;(aSocket.sendMessage as jest.Mock).mockClear()
 		;(bSocket.sendMessage as jest.Mock).mockClear()

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -596,7 +596,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				'select.dragging_handle',
 				'select.translating',
 				'arrow.dragging'
-			) && !this.editor.getInstanceState().isReadonly
+			) && !this.editor.getIsReadonly()
 
 		const info = getArrowInfo(this.editor, shape)
 		if (!info?.isValid) return null

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.ts
@@ -17,7 +17,7 @@ export class Idle extends StateNode {
 
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.getIsReadonly()) return null
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it
 			if (

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -13,7 +13,7 @@ export class Idle extends StateNode {
 
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.getIsReadonly()) return null
 
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -27,7 +27,7 @@ export class Idle extends StateNode {
 
 	override onKeyDown(info: TLKeyboardEventInfo) {
 		if (info.key === 'Enter') {
-			if (this.editor.getInstanceState().isReadonly) return null
+			if (this.editor.getIsReadonly()) return null
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			// If the only selected shape is editable, start editing it
 			if (

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
@@ -39,7 +39,7 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	private startCropping() {
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 		this.parent.transition('cropping', {
 			...this.info,
 			onInteractionEnd: this.info.onInteractionEnd,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -60,7 +60,7 @@ export class EditingShape extends StateNode {
 		// In the case where on pointer down we hit a shape's label, we need to check if the user is dragging.
 		// and if they are, we need to transition to translating instead.
 		if (this.hitShapeForPointerUp && this.editor.inputs.isDragging) {
-			if (this.editor.getInstanceState().isReadonly) return
+			if (this.editor.getIsReadonly()) return
 			if (this.hitShapeForPointerUp.isLocked) return
 			this.editor.select(this.hitShapeForPointerUp)
 			this.parent.transition('translating', info)
@@ -153,7 +153,7 @@ export class EditingShape extends StateNode {
 		const util = this.editor.getShapeUtil(hitShape)
 		if (hitShape.isLocked) return
 
-		if (this.editor.getInstanceState().isReadonly) {
+		if (this.editor.getIsReadonly()) {
 			if (!util.canEditInReadOnly(hitShape)) {
 				this.parent.transition('pointing_shape', info)
 				return

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -110,7 +110,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'handle': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.getIsReadonly()) break
 				if (this.editor.inputs.altKey) {
 					this.parent.transition('pointing_shape', info)
 				} else {
@@ -247,7 +247,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'selection': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.getIsReadonly()) break
 
 				const onlySelectedShape = this.editor.getOnlySelectedShape()
 
@@ -294,12 +294,7 @@ export class Idle extends StateNode {
 				const util = this.editor.getShapeUtil(shape)
 
 				// Allow playing videos and embeds
-				if (
-					shape.type !== 'video' &&
-					shape.type !== 'embed' &&
-					this.editor.getInstanceState().isReadonly
-				)
-					break
+				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
 				if (util.onDoubleClick) {
 					// Call the shape's double click handler
@@ -330,7 +325,7 @@ export class Idle extends StateNode {
 				break
 			}
 			case 'handle': {
-				if (this.editor.getInstanceState().isReadonly) break
+				if (this.editor.getIsReadonly()) break
 				const { shape, handle } = info
 
 				const util = this.editor.getShapeUtil(shape)
@@ -567,7 +562,7 @@ export class Idle extends StateNode {
 
 	handleDoubleClickOnCanvas(info: TLClickEventInfo) {
 		// Create text shape and transition to editing_shape
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 
 		this.editor.markHistoryStoppingPoint('creating text shape')
 
@@ -592,7 +587,7 @@ export class Idle extends StateNode {
 		if (!shape) return
 
 		const util = this.editor.getShapeUtil(shape)
-		if (this.editor.getInstanceState().isReadonly) {
+		if (this.editor.getIsReadonly()) {
 			if (!util.canEditInReadOnly(shape)) {
 				return
 			}
@@ -642,7 +637,7 @@ export class Idle extends StateNode {
 	}
 
 	private canInteractWithShapeInReadOnly(shape: TLShape) {
-		if (!this.editor.getInstanceState().isReadonly) return true
+		if (!this.editor.getIsReadonly()) return true
 		const util = this.editor.getShapeUtil(shape)
 		if (util.canEditInReadOnly(shape)) return true
 		return false

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -121,7 +121,7 @@ export class PointingArrowLabel extends StateNode {
 
 		if (this.didDrag || !this.wasAlreadySelected) {
 			this.complete()
-		} else {
+		} else if (!this.editor.getIsReadonly()) {
 			// Go into edit mode.
 			this.editor.setEditingShape(shape.id)
 			this.editor.setCurrentTool('select.editing_shape')

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -76,7 +76,7 @@ export class PointingHandle extends StateNode {
 
 	private startDraggingHandle() {
 		const { editor } = this
-		if (editor.getInstanceState().isReadonly) return
+		if (editor.getIsReadonly()) return
 		const { shape, handle } = this.info
 
 		if (editor.isShapeOfType<TLNoteShape>(shape, 'note')) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -50,7 +50,7 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	private startResizing() {
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 		this.parent.transition('resizing', this.info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -39,7 +39,7 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	private startRotating() {
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 		this.parent.transition('rotating', this.info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
@@ -28,7 +28,7 @@ export class PointingSelection extends StateNode {
 	}
 
 	private startTranslating(info: TLPointerEventInfo) {
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 		this.parent.transition('translating', info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -153,7 +153,7 @@ export class PointingShape extends StateNode {
 										this.editor.select(selectingShape.id)
 
 										const util = this.editor.getShapeUtil(selectingShape)
-										if (this.editor.getInstanceState().isReadonly) {
+										if (this.editor.getIsReadonly()) {
 											if (!util.canEditInReadOnly(selectingShape)) {
 												return
 											}
@@ -218,7 +218,7 @@ export class PointingShape extends StateNode {
 	}
 
 	private startTranslating(info: TLPointerEventInfo) {
-		if (this.editor.getInstanceState().isReadonly) return
+		if (this.editor.getIsReadonly()) return
 
 		// Re-focus the editor, just in case the text label of the shape has stolen focus
 		this.editor.focus()

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -63,7 +63,7 @@ export function useKeyboardShortcuts() {
 		}
 
 		for (const tool of Object.values(tools)) {
-			if (!tool.kbd || (!tool.readonlyOk && editor.getInstanceState().isReadonly)) {
+			if (!tool.kbd || (!tool.readonlyOk && editor.getIsReadonly())) {
 				continue
 			}
 

--- a/packages/tldraw/src/lib/ui/hooks/useReadonly.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useReadonly.ts
@@ -3,5 +3,5 @@ import { useMaybeEditor, useValue } from '@tldraw/editor'
 /** @public */
 export function useReadonly() {
 	const editor = useMaybeEditor()
-	return useValue('isReadonlyMode', () => !!editor?.getInstanceState().isReadonly, [editor])
+	return useValue('isReadonlyMode', () => !!editor?.getIsReadonly(), [editor])
 }

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -824,3 +824,25 @@ describe('isShapeHidden', () => {
 		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
 	})
 })
+
+describe('instance.isReadonly', () => {
+	it('updates in accordance with collaboration.mode', () => {
+		const mode = atom<'readonly' | 'readwrite'>('', 'readonly')
+		const editor = new TestEditor(
+			{},
+			{
+				collaboration: {
+					mode,
+					status: atom('', 'online'),
+				},
+			}
+		)
+
+		expect(editor.getIsReadonly()).toBe(true)
+
+		mode.set('readwrite')
+		expect(editor.getIsReadonly()).toBe(false)
+		mode.set('readonly')
+		expect(editor.getIsReadonly()).toBe(true)
+	})
+})

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -509,7 +509,7 @@ describe('When in readonly mode', () => {
 	it('Begins editing embed when double clicked', () => {
 		expect(editor.getEditingShapeId()).toBe(null)
 		expect(editor.getSelectedShapeIds().length).toBe(0)
-		expect(editor.getInstanceState().isReadonly).toBe(true)
+		expect(editor.getIsReadonly()).toBe(true)
 
 		const shape = editor.getShape(ids.embed1)
 		editor.doubleClick(100, 100, { target: 'shape', shape })
@@ -519,7 +519,7 @@ describe('When in readonly mode', () => {
 	it('Begins editing embed when pressing Enter on a selected embed', () => {
 		expect(editor.getEditingShapeId()).toBe(null)
 		expect(editor.getSelectedShapeIds().length).toBe(0)
-		expect(editor.getInstanceState().isReadonly).toBe(true)
+		expect(editor.getIsReadonly()).toBe(true)
 
 		editor.setSelectedShapes([ids.embed1])
 		expect(editor.getSelectedShapeIds().length).toBe(1)

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -21,6 +21,7 @@ import {
 	TLShape,
 	TLShapeId,
 	TLShapePartial,
+	TLStoreOptions,
 	TLWheelEventInfo,
 	Vec,
 	VecLike,
@@ -63,7 +64,10 @@ declare global {
 }
 
 export class TestEditor extends Editor {
-	constructor(options: Partial<Omit<TLEditorOptions, 'store'>> = {}) {
+	constructor(
+		options: Partial<Omit<TLEditorOptions, 'store'>> = {},
+		storeOptions: Partial<TLStoreOptions> = {}
+	) {
 		const elm = document.createElement('div')
 		const bounds = {
 			x: 0,
@@ -93,6 +97,7 @@ export class TestEditor extends Editor {
 			store: createTLStore({
 				shapeUtils: shapeUtilsWithDefaults,
 				bindingUtils: bindingUtilsWithDefaults,
+				...storeOptions,
 			}),
 			getContainer: () => elm,
 			initialState: 'select',

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -1380,6 +1380,7 @@ export interface TLStoreProps {
     assets: Required<TLAssetStore>;
     // (undocumented)
     collaboration?: {
+        mode?: null | Signal<'readonly' | 'readwrite'>;
         status: null | Signal<'offline' | 'online'>;
     };
     // (undocumented)

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -101,6 +101,7 @@ export interface TLStoreProps {
 	onMount(editor: unknown): void | (() => void)
 	collaboration?: {
 		status: Signal<'online' | 'offline'> | null
+		mode?: Signal<'readonly' | 'readwrite'> | null
 	}
 }
 


### PR DESCRIPTION
Follow up to #4648 , extracted from #4660 

This PR adds a TLStore prop that contains a signal for setting the readonly mode. This allows the readonlyness to change on the fly, which is necessary for botcom. it's also just nice for tlsync users to be able to decide on the server whether something is readonly.

### Change type

- [x] `improvement`

### Release notes

- Puts the editor into readonly mode automatically when the tlsync server responds in readonly mode.
- Adds the `editor.getIsReadonly()` method.
- Fixes a bug where arrow labels could be edited in readonly mode.