### PR TITLE
[sync] Expose sessions and individual records on TLSocketRoom

### DIFF
--- a/packages/sync-core/api-report.md
+++ b/packages/sync-core/api-report.md
@@ -334,6 +334,13 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     getCurrentDocumentClock(): number;
     getCurrentSnapshot(): RoomSnapshot;
     getNumActiveSessions(): number;
+    getRecord(id: string): R;
+    getSessions(): Array<{
+        isConnected: boolean;
+        isReadonly: boolean;
+        meta: SessionMeta;
+        sessionId: string;
+    }>;
     handleSocketClose(sessionId: string): void;
     handleSocketConnect(opts: {
         isReadonly?: boolean;

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -1,6 +1,7 @@
 import type { StoreSchema, UnknownRecord } from '@tldraw/store'
 import { TLStoreSnapshot, createTLSchema } from '@tldraw/tlschema'
-import { objectMapValues } from '@tldraw/utils'
+import { objectMapValues, structuredClone } from '@tldraw/utils'
+import { RoomSessionState } from './RoomSession'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
 import { RoomSnapshot, RoomStoreMethods, TLSyncRoom } from './TLSyncRoom'
 import { JsonChunkAssembler } from './chunk'
@@ -233,6 +234,34 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 */
 	getCurrentDocumentClock() {
 		return this.room.documentClock
+	}
+
+	/**
+	 * Returns a deeply cloned record from the store, if available.
+	 * @param id - The id of the record
+	 * @returns the cloned record
+	 */
+	getRecord(id: string) {
+		return structuredClone(this.room.state.get().documents[id]?.state)
+	}
+
+	/**
+	 * Returns a list of the sessions in the room.
+	 */
+	getSessions(): Array<{
+		sessionId: string
+		isConnected: boolean
+		isReadonly: boolean
+		meta: SessionMeta
+	}> {
+		return [...this.room.sessions.values()].map((session) => {
+			return {
+				sessionId: session.sessionId,
+				isConnected: session.state === RoomSessionState.Connected,
+				isReadonly: session.isReadonly,
+				meta: session.meta,
+			}
+		})
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a couple of tiny helpers for getting useful data from a sync room.

- `getRecord` - for getting an individual record
- `getSessions` - for getting a list of the active sessions


### Change type

- [x] `api`

### Release notes

- [sync] Adds a couple of new methods to the TLSocketRoom class:
  - `getRecord` - for getting an individual record
  - `getSessions` - for getting a list of the active sessions
