### PR TITLE
Lod Perf (effect scheduler)

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -947,7 +947,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         focusContainer?: boolean | undefined;
     }): this;
     getAncestorPageId(shape?: TLShape | TLShapeId): TLPageId | undefined;
-    getAsset<T extends TLAsset>(asset: T | T["id"]): T | undefined;
+    getAsset<T extends TLAsset>(asset: T | T['id']): T | undefined;
     getAssetForExternalContent(info: TLExternalAssetContent): Promise<TLAsset | undefined>;
     getAssets(): (TLBookmarkAsset | TLImageAsset | TLVideoAsset)[];
     getBaseZoom(): number;

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -947,7 +947,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         focusContainer?: boolean | undefined;
     }): this;
     getAncestorPageId(shape?: TLShape | TLShapeId): TLPageId | undefined;
-    getAsset(asset: TLAsset | TLAssetId): TLAsset | undefined;
+    getAsset<T extends TLAsset>(asset: T | T["id"]): T | undefined;
     getAssetForExternalContent(info: TLExternalAssetContent): Promise<TLAsset | undefined>;
     getAssets(): (TLBookmarkAsset | TLImageAsset | TLVideoAsset)[];
     getBaseZoom(): number;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4128,8 +4128,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public
 	 */
-	getAsset(asset: TLAssetId | TLAsset): TLAsset | undefined {
-		return this.store.get(typeof asset === 'string' ? asset : asset.id) as TLAsset | undefined
+	getAsset<T extends TLAsset>(asset: T | T['id']): T | undefined {
+		return this.store.get(typeof asset === 'string' ? asset : asset.id) as T | undefined
 	}
 
 	async resolveAssetUrl(

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -3682,9 +3682,9 @@ export function useActions(): TLUiActionsContextType;
 export function useAsset(options: {
     assetId: null | TLAssetId;
     shapeId: TLShapeId;
-    width: number;
 }): {
     asset: TLAsset | null | undefined;
+    isCulled: boolean;
     isPlaceholder: boolean;
     url: null | string;
 };

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -3679,13 +3679,11 @@ export function unwrapLabel(label?: TLUiActionItem['label'], menuType?: string):
 export function useActions(): TLUiActionsContextType;
 
 // @public
-export function useAsset(options: {
+export function useAsset({ shapeId, assetId }: {
     assetId: null | TLAssetId;
     shapeId: TLShapeId;
 }): {
-    asset: TLAsset | null | undefined;
-    isCulled: boolean;
-    isPlaceholder: boolean;
+    asset: (TLImageAsset | TLVideoAsset) | null;
     url: null | string;
 };
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -78,7 +78,7 @@ export {
 	LABEL_FONT_SIZES,
 	TEXT_PROPS,
 } from './lib/shapes/shared/default-shape-constants'
-export { useImageOrVideoAsset as useAsset } from './lib/shapes/shared/useAsset'
+export { useAsset } from './lib/shapes/shared/useAsset'
 export { useDefaultColorTheme } from './lib/shapes/shared/useDefaultColorTheme'
 export { useEditableText } from './lib/shapes/shared/useEditableText'
 export { TextShapeTool } from './lib/shapes/text/TextShapeTool'

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -78,7 +78,7 @@ export {
 	LABEL_FONT_SIZES,
 	TEXT_PROPS,
 } from './lib/shapes/shared/default-shape-constants'
-export { useAsset } from './lib/shapes/shared/useAsset'
+export { useImageOrVideoAsset as useAsset } from './lib/shapes/shared/useAsset'
 export { useDefaultColorTheme } from './lib/shapes/shared/useDefaultColorTheme'
 export { useEditableText } from './lib/shapes/shared/useEditableText'
 export { TextShapeTool } from './lib/shapes/text/TextShapeTool'

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -147,9 +147,7 @@ function BookmarkShapeComponent({
 						) : (
 							<div className="tl-bookmark__placeholder" />
 						)}
-						{asset?.props.image && (
-							<HyperlinkButton url={shape.props.url} zoomLevel={util.editor.getZoomLevel()} />
-						)}
+						{asset?.props.image && <HyperlinkButton url={shape.props.url} />}
 					</div>
 				)}
 				<div className="tl-bookmark__copy_container">

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -481,9 +481,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 						/>
 					</HTMLContainer>
 				)}
-				{shape.props.url && (
-					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
-				)}
+				{shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -26,7 +26,7 @@ import { useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useImageOrVideoAsset } from '../shared/useAsset'
+import { useAsset } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 async function getDataURIFromURL(url: string): Promise<string> {
@@ -253,7 +253,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 function ImageShape({ shape }: { shape: TLImageShape }) {
 	const editor = useEditor()
 
-	const { asset, url } = useImageOrVideoAsset({
+	const { asset, url } = useAsset({
 		shapeId: shape.id,
 		assetId: shape.props.assetId,
 	})

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -20,9 +20,10 @@ import {
 	structuredClone,
 	toDomPrecision,
 	useEditor,
+	useValue,
 } from '@tldraw/editor'
 import classNames from 'classnames'
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
@@ -250,7 +251,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	}
 }
 
-function ImageShape({ shape }: { shape: TLImageShape }) {
+const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) {
 	const editor = useEditor()
 
 	const { asset, url } = useAsset({
@@ -258,11 +259,9 @@ function ImageShape({ shape }: { shape: TLImageShape }) {
 		assetId: shape.props.assetId,
 	})
 
-	const isCropping = editor.getCroppingShapeId() === shape.id
 	const prefersReducedMotion = usePrefersReducedMotion()
 	const [staticFrameSrc, setStaticFrameSrc] = useState('')
 	const [loadedUrl, setLoadedUrl] = useState<null | string>(null)
-	const isSelected = shape.id === editor.getOnlySelectedShapeId()
 
 	const isAnimated = getIsAnimated(editor, shape)
 
@@ -298,7 +297,14 @@ function ImageShape({ shape }: { shape: TLImageShape }) {
 		throw Error("Bookmark assets can't be rendered as images")
 	}
 
-	const showCropPreview = isSelected && isCropping && editor.isIn('select.crop')
+	const showCropPreview = useValue(
+		'show crop preview',
+		() =>
+			shape.id === editor.getOnlySelectedShapeId() &&
+			editor.getCroppingShapeId() === shape.id &&
+			editor.isIn('select.crop'),
+		[editor, shape.id]
+	)
 
 	// We only want to reduce motion for mimeTypes that have motion
 	const reduceMotion =
@@ -391,7 +397,7 @@ function ImageShape({ shape }: { shape: TLImageShape }) {
 			</HTMLContainer>
 		</>
 	)
-}
+})
 
 function getIsAnimated(editor: Editor, shape: TLImageShape) {
 	const asset = shape.props.assetId ? editor.getAsset(shape.props.assetId) : undefined

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import {
 	BaseBoxShapeUtil,
 	Editor,

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -293,10 +293,6 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 		}
 	}, [editor, isAnimated, prefersReducedMotion, url])
 
-	if (asset?.type === 'bookmark') {
-		throw Error("Bookmark assets can't be rendered as images")
-	}
-
 	const showCropPreview = useValue(
 		'show crop preview',
 		() =>

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -230,9 +230,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						onKeyDown={handleKeyDown}
 					/>
 				</div>
-				{'url' in shape.props && shape.props.url && (
-					<HyperlinkButton url={shape.props.url} zoomLevel={this.editor.getZoomLevel()} />
-				)}
+				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>
 		)
 	}

--- a/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
@@ -1,14 +1,16 @@
-import { stopEventPropagation } from '@tldraw/editor'
+import { stopEventPropagation, useEditor, useValue } from '@tldraw/editor'
 import classNames from 'classnames'
 
 const LINK_ICON =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' fill='none'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 5H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6M19 5h6m0 0v6m0-6L13 17'/%3E%3C/svg%3E"
 
-export function HyperlinkButton({ url, zoomLevel }: { url: string; zoomLevel: number }) {
+export function HyperlinkButton({ url }: { url: string }) {
+	const editor = useEditor()
+	const hideButton = useValue('zoomLevel', () => editor.getZoomLevel() < 0.32, [editor])
 	return (
 		<a
 			className={classNames('tl-hyperlink-button', {
-				'tl-hyperlink-button__hidden': zoomLevel < 0.32,
+				'tl-hyperlink-button__hidden': hideButton,
 			})}
 			href={url}
 			target="_blank"

--- a/packages/tldraw/src/lib/shapes/shared/useAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useAsset.ts
@@ -1,15 +1,15 @@
 import {
-	debounce,
 	Editor,
 	TLAssetId,
 	TLImageShape,
 	TLShapeId,
 	TLVideoShape,
+	debounce,
+	react,
 	useDelaySvgExport,
 	useEditor,
 	useSvgExportContext,
 } from '@tldraw/editor'
-import { react } from '@tldraw/state'
 import { useEffect, useRef, useState } from 'react'
 
 /**
@@ -23,7 +23,7 @@ import { useEffect, useRef, useState } from 'react'
  *
  * @public
  */
-export function useImageOrVideoAsset(options: { shapeId: TLShapeId; assetId: TLAssetId | null }) {
+export function useAsset(options: { shapeId: TLShapeId; assetId: TLAssetId | null }) {
 	const { shapeId, assetId } = options
 
 	const editor = useEditor()

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames'
 import { ReactEventHandler, memo, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useImageOrVideoAsset } from '../shared/useAsset'
+import { useAsset } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -44,7 +44,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	}
 
 	component(shape: TLVideoShape) {
-		const { asset, url } = useImageOrVideoAsset({
+		const { asset, url } = useAsset({
 			shapeId: shape.id,
 			assetId: shape.props.assetId,
 		})

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames'
 import { ReactEventHandler, memo, useCallback, useEffect, useRef, useState } from 'react'
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
-import { useAsset } from '../shared/useAsset'
+import { useImageOrVideoAsset } from '../shared/useAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
 /** @public */
@@ -44,10 +44,9 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	}
 
 	component(shape: TLVideoShape) {
-		const { asset, url } = useAsset({
+		const { asset, url } = useImageOrVideoAsset({
 			shapeId: shape.id,
 			assetId: shape.props.assetId,
-			width: shape.props.w,
 		})
 
 		return <VideoShape editor={this.editor} shape={shape} asset={asset} url={url} />
@@ -172,9 +171,7 @@ const VideoShape = memo(function VideoShape({
 					</div>
 				</div>
 			</HTMLContainer>
-			{'url' in shape.props && shape.props.url && (
-				<HyperlinkButton url={shape.props.url} zoomLevel={editor.getZoomLevel()} />
-			)}
+			{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 		</>
 	)
 })


### PR DESCRIPTION
This PR aims to improve on the LOD performance of image and video elements. Its main goal is to reduce the number of renders caused by the hooks in `useAsset`. It does this by moving the majority of the logic into an effect scheduler (via our `react`), keeping the result (url and asset) in React state, and only updating the result it has actually changed. We also debounce subsequent renders

### Change type

- [x] `improvement`

### Release notes

- The `useAssets` hook now is now specifically for `TLImageAsset`- or `TLVideoAsset`-type assets.