### PR TITLE
[fix] Meta key bug

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9164,7 +9164,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	@bind
 	_setMetaKeyTimeout() {
-		this.inputs.shiftKey = false
+		this.inputs.metaKey = false
 		this.dispatch({
 			type: 'keyboard',
 			name: 'key_up',


### PR DESCRIPTION
This PR solves an infinite timer loop caused by pressing the meta key. Let's get this hotfixed asap.

### Change type

- [x] `bugfix`
