### PR TITLE
ui: suppress aria warning about desc in dialogs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"version": "3.3.0"
 }

--- a/packages/tldraw/src/lib/ui/components/Dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/components/Dialogs.tsx
@@ -36,7 +36,7 @@ const TldrawUiDialog = ({ id, component: ModalContent, onClose }: TLUiDialog) =>
 						if (e.target === e.currentTarget) handleOpenChange(false)
 					}}
 				>
-					<_Dialog.Content dir="ltr" className="tlui-dialog__content">
+					<_Dialog.Content dir="ltr" className="tlui-dialog__content" aria-describedby={undefined}>
 						<ModalContent onClose={() => handleOpenChange(false)} />
 					</_Dialog.Content>
 				</_Dialog.Overlay>


### PR DESCRIPTION
small little tweak - noisy in dev logs. if in the future if we add descriptions for dialogs we can make this an optional parameter

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
