### PR TITLE
links: fix link indicator on stickies

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1062,6 +1062,7 @@ input,
 	border: none;
 	outline: none;
 	pointer-events: all;
+	z-index: 1;
 }
 
 .tl-hyperlink-button::after {


### PR DESCRIPTION
you couldn't see the external link UI on stickies, not sure when this regresed

<img width="354" alt="Screenshot 2024-10-11 at 09 53 24" src="https://github.com/user-attachments/assets/a4ed3ca8-506c-4fc3-8c88-ee316fedf0d0">


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix link indicator in sticky notes.