### PR TITLE
Don't index multiplayer rooms, snapshots, history.

### DIFF
--- a/apps/dotcom/client/public/robots.txt
+++ b/apps/dotcom/client/public/robots.txt
@@ -1,11 +1,2 @@
 User-agent: *
-Disallow: /r
-
-User-agent: *
-Disallow: /v
-
-User-agent: *
-Disallow: /s
-
-User-agent: *
 Allow: /

--- a/apps/dotcom/client/src/pages/noindex.tsx
+++ b/apps/dotcom/client/src/pages/noindex.tsx
@@ -5,7 +5,7 @@ export function Component() {
 	return (
 		<>
 			<Helmet>
-				<meta name="robots" content="noindex" />
+				<meta name="robots" content="noindex, noimageindex, nofollow" />
 			</Helmet>
 			<Outlet />
 		</>

--- a/apps/dotcom/client/src/pages/noindex.tsx
+++ b/apps/dotcom/client/src/pages/noindex.tsx
@@ -1,0 +1,13 @@
+import { Helmet } from 'react-helmet-async'
+import { Outlet } from 'react-router-dom'
+
+export function Component() {
+	return (
+		<>
+			<Helmet>
+				<meta name="robots" content="noindex" />
+			</Helmet>
+			<Outlet />
+		</>
+	)
+}

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -41,21 +41,30 @@ export const router = createRoutesFromElements(
 	>
 		<Route errorElement={<DefaultErrorFallback />}>
 			<Route path="/" lazy={() => import('./pages/root')} />
-			<Route path={`/${ROOM_PREFIX}`} lazy={() => import('./pages/new')} />
-			<Route path="/new" lazy={() => import('./pages/new')} />
-			<Route path={`/ts-side`} lazy={() => import('./pages/public-touchscreen-side-panel')} />
-			<Route path={`/${ROOM_PREFIX}/:roomId`} lazy={() => import('./pages/public-multiplayer')} />
-			<Route path={`/${ROOM_PREFIX}/:boardId/history`} lazy={() => import('./pages/history')} />
-			<Route
-				path={`/${ROOM_PREFIX}/:boardId/history/:timestamp`}
-				lazy={() => import('./pages/history-snapshot')}
-			/>
-			<Route path={`/${SNAPSHOT_PREFIX}/:roomId`} lazy={() => import('./pages/public-snapshot')} />
-			<Route
-				path={`/${READ_ONLY_LEGACY_PREFIX}/:roomId`}
-				lazy={() => import('./pages/public-readonly-legacy')}
-			/>
-			<Route path={`/${READ_ONLY_PREFIX}/:roomId`} lazy={() => import('./pages/public-readonly')} />
+			{/* We don't want to index multiplayer rooms */}
+			<Route lazy={() => import('./pages/noindex')}>
+				<Route path={`/${ROOM_PREFIX}`} lazy={() => import('./pages/new')} />
+				<Route path="/new" lazy={() => import('./pages/new')} />
+				<Route path={`/ts-side`} lazy={() => import('./pages/public-touchscreen-side-panel')} />
+				<Route path={`/${ROOM_PREFIX}/:roomId`} lazy={() => import('./pages/public-multiplayer')} />
+				<Route path={`/${ROOM_PREFIX}/:boardId/history`} lazy={() => import('./pages/history')} />
+				<Route
+					path={`/${ROOM_PREFIX}/:boardId/history/:timestamp`}
+					lazy={() => import('./pages/history-snapshot')}
+				/>
+				<Route
+					path={`/${SNAPSHOT_PREFIX}/:roomId`}
+					lazy={() => import('./pages/public-snapshot')}
+				/>
+				<Route
+					path={`/${READ_ONLY_LEGACY_PREFIX}/:roomId`}
+					lazy={() => import('./pages/public-readonly-legacy')}
+				/>
+				<Route
+					path={`/${READ_ONLY_PREFIX}/:roomId`}
+					lazy={() => import('./pages/public-readonly')}
+				/>
+			</Route>
 		</Route>
 		{/* begin tla */}
 		<Route lazy={() => import('./tla/providers/TlaProvider')}>


### PR DESCRIPTION
Prevent indexing of multiplayer rooms, snapshots, new room route (it just redirects), history, etc

This only touches current dotcom. Logged in experience will be hidden behind auth so should not be discoverable by search bots.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Prevent indexing of multiplayer rooms, snapshots, new room route (it just redirects), history, etc