### PR TITLE
refactor: specify type at bbox

### DIFF
--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -54,7 +54,7 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 		.filter(({ id }) => shapeIdsToInclude.has(id))
 
 	// --- Common bounding box of all shapes
-	let bbox = null
+	let bbox: null | Box = null
 	if (opts.bounds) {
 		bbox = opts.bounds
 	} else {


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.
I found that bbox's type is any.
Bbox is let variable, so I thought it would be good to improve.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. yarn run test
- Just I change the type, so logic is not changed. It just checks to see if there are any type errors.

- [ ] Unit tests
- [ ] End to end tests

### Release notes
- When I see the code in `packages/editor/src/lib/exports/getSvgJsx.tsx`, Improvements were found.
```
// L57
let bbox: = null // any type
```
- This is declared as `let`, but it is `any` type.
- I felt this was a risk for future maintenance.
- So I specify the type of `bbox`.
```
let bbox: null | Box = null
```