### PR TITLE
Improve submenu open indicators appearance

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -997,12 +997,12 @@
 }
 
 .tlui-menu__submenu__trigger[data-state='open']:not(:hover)::after {
-	border-radius: var(--radius-1);
+	border-radius: 0px;
 	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
 .tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
-	border-radius: var(--radius-1);
+	border-radius: 0px;
 	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -156,7 +156,7 @@ export interface TLUiDropdownMenuSubContentProps {
 export function TldrawUiDropdownMenuSubContent({
 	id,
 	alignOffset = -1,
-	sideOffset = -4,
+	sideOffset = -6,
 	size = 'small',
 	children,
 }: TLUiDropdownMenuSubContentProps) {


### PR DESCRIPTION
This PR improves the appearance of the open submenu indicators.

Current:
![image](https://github.com/user-attachments/assets/63d6d674-ece2-4cb9-8f10-b7cc51633242)

New:
![image](https://github.com/user-attachments/assets/6992fb50-054a-49ae-84a6-11120e846dda)

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improved appearance of submenu items when submenus are open.