### PR TITLE
Fix style menu vertical align button

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -53,7 +53,7 @@ function _DropdownPicker<T extends string>({
 		<TldrawUiDropdownMenuRoot id={`style panel ${id}`}>
 			<TldrawUiDropdownMenuTrigger>
 				<TldrawUiButton type={type} data-testid={`style.${uiType}`} title={titleStr}>
-					<TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>
+					{labelStr && <TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>}
 					<TldrawUiButtonIcon icon={(icon as TLUiIconType) ?? 'mixed'} />
 				</TldrawUiButton>
 			</TldrawUiDropdownMenuTrigger>


### PR DESCRIPTION
This PR fixes a design regression in the vertical alignment submenu in the style panel.

Before:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/7c10a5c1-8556-46f5-99c3-5cfe1dd21e53">

After:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/f9aa3527-5d2c-4233-af9c-2fdde3c2e0ca">

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with the vertical alignment button in the style panel.