### PR TITLE
drag: passthrough correct event type for drag events

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -30,7 +30,7 @@ export function useDocumentEvents() {
 			stopEventPropagation(e)
 			const cvs = container.querySelector('.tl-canvas')
 			if (!cvs) return
-			const newEvent = new DragEvent('drop', e)
+			const newEvent = new DragEvent(e.type, e)
 			;(newEvent as any).isSpecialRedispatchedEvent = true
 			cvs.dispatchEvent(newEvent)
 		}


### PR DESCRIPTION

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix bug with passing correct event type for drag events