### PR TITLE
Fix copying of snapshot links

### DIFF
--- a/apps/dotcom/client/src/utils/sharing.ts
+++ b/apps/dotcom/client/src/utils/sharing.ts
@@ -174,7 +174,7 @@ export function useSharing(): TLUiOverrides {
 							msg,
 							roomId
 						)
-						writeToClipboard(new Promise(() => result))
+						writeToClipboard(new Promise((resolve) => resolve(result)))
 						addToast({
 							title: msg('share-menu.copied'),
 							severity: 'success',


### PR DESCRIPTION
Looks like links did not get copied to the clipboard.

Resolves https://github.com/tldraw/tldraw/issues/4744

Related PR https://github.com/tldraw/tldraw/pull/4695

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix copying of snapshot links.