### PR TITLE
Limit the page name length in the move to page menu.

### DIFF
--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -437,7 +437,7 @@ export function MoveToPageMenu() {
 						id={page.id}
 						key={page.id}
 						disabled={currentPageId === page.id}
-						label={page.name}
+						label={page.name.length > 30 ? `${page.name.slice(0, 30)}\u2026` : page.name}
 						onSelect={() => {
 							editor.markHistoryStoppingPoint('move_shapes_to_page')
 							editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId)

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -437,7 +437,7 @@ export function MoveToPageMenu() {
 						id={page.id}
 						key={page.id}
 						disabled={currentPageId === page.id}
-						label={page.name.length > 30 ? `${page.name.slice(0, 30)}\u2026` : page.name}
+						label={page.name.length > 30 ? `${page.name.slice(0, 30)}…` : page.name}
 						onSelect={() => {
 							editor.markHistoryStoppingPoint('move_shapes_to_page')
 							editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId)


### PR DESCRIPTION
Resolves [#4746](https://github.com/tldraw/tldraw/issues/4746)

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a page with a really long name.
2. Go to a different page, select a shape, right click to open context menu, then go to move to page. The page name should be shortened.


### Release notes

- Limit the length of the page names in the move to page menu.