### PR TITLE
[Fix] Toolbar button outline border radius

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -214,7 +214,7 @@
 }
 
 .tlui-button__tool:focus-visible:not(:hover) {
-	border-radius: var(--radius-4);
+	border-radius: 12px;
 }
 
 .tlui-button__tool:nth-of-type(1) {


### PR DESCRIPTION
This PR fixes the outline border radius on toolbar tools.

Before:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/00c78f5e-c84b-4e86-834a-16e245989868">

After:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/3ab3845b-ca28-4943-a9bb-4b385ae13dcd">

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with the border radius on toolbar button outlines.