### PR TITLE
make options object stable

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -222,6 +222,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 	components,
 	className,
 	user: _user,
+	options: _options,
 	...rest
 }: TldrawEditorProps) {
 	const [container, setContainer] = useState<HTMLElement | null>(null)
@@ -239,6 +240,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 		bindingUtils: rest.bindingUtils ?? EMPTY_BINDING_UTILS_ARRAY,
 		tools: rest.tools ?? EMPTY_TOOLS_ARRAY,
 		components,
+		options: useShallowObjectIdentity(_options),
 	}
 
 	return (

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import {
 	BaseBoxShapeTool,
 	BaseBoxShapeUtil,
@@ -122,13 +122,14 @@ describe('<TldrawEditor />', () => {
 	it('Accepts fresh versions of store and calls `onMount` for each one', async () => {
 		const initialStore = createTLStore({ shapeUtils: [] })
 		const onMount = jest.fn()
-		const rendered = render(
+		const rendered = await renderTldrawComponent(
 			<TldrawEditor
 				initialState="select"
 				tools={defaultTools}
 				store={initialStore}
 				onMount={onMount}
-			/>
+			/>,
+			{ waitForPatterns: false }
 		)
 		const initialEditor = onMount.mock.lastCall[0]
 		jest.spyOn(initialEditor, 'dispose')
@@ -333,7 +334,9 @@ describe('<TldrawEditor />', () => {
 			{ waitForPatterns: true }
 		)
 
-		expect(editor.selectAll().getSelectedShapes()).toMatchObject([
+		act(() => editor.selectAll())
+
+		expect(editor.getSelectedShapes()).toMatchObject([
 			{
 				id: 'shape:SxHfVyCVdM4Ryl27eJNRD',
 				type: 'geo',
@@ -373,6 +376,22 @@ describe('<TldrawEditor />', () => {
 		)
 
 		expect(editor.store.props.assets.upload).toBe(myUploadFn)
+	})
+
+	it('will not re-create the editor if re-rendered with identical options', async () => {
+		const onMount = jest.fn()
+
+		const renderer = await renderTldrawComponent(
+			<TldrawEditor onMount={onMount} options={{ maxPages: 1 }} />,
+			{
+				waitForPatterns: false,
+			}
+		)
+
+		expect(onMount).toHaveBeenCalledTimes(1)
+
+		renderer.rerender(<TldrawEditor onMount={onMount} options={{ maxPages: 1 }} />)
+		expect(onMount).toHaveBeenCalledTimes(1)
 	})
 })
 


### PR DESCRIPTION
If you write code like `<Tldraw options={{maxPages: 1}} />` that also e.g. sets state on mount or otherwise re-renders, getting a fresh options object will cause the editor to reload even though the options are the same. You have to memoize options, or specify them outside of your component.

This diff uses `useShallowObjectIdentity` to stop identical sets of options from causing the editor to get recreated.

### Change type

- [x] `api`

### Release notes

- Writing `options` inline in the Tldraw component will no longer cause re-render loops