### PR TITLE
types: fix up some types from the i18n PR

### DIFF
--- a/apps/vscode/extension/src/TldrawDocument.ts
+++ b/apps/vscode/extension/src/TldrawDocument.ts
@@ -116,7 +116,7 @@ export class TLDrawDocument implements vscode.CustomDocument {
 
 	private async writeToResource(targetResource: vscode.Uri) {
 		const fileContents = Buffer.from(JSON.stringify(this.documentData, null, '\t'), 'utf8')
-		await vscode.workspace.fs.writeFile(targetResource, fileContents)
+		await vscode.workspace.fs.writeFile(targetResource, new Uint8Array(fileContents))
 	}
 
 	/** Called by VS Code when the user calls `revert` on a document. */

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -413,7 +413,7 @@ async function coalesceWithPreviousAssets(assetsDir: string) {
 		// and it will mess up the inline source viewer on sentry errors.
 		const out = tar.x({ cwd: assetsDir, 'keep-existing': true })
 		for await (const chunk of Body?.transformToWebStream() as any as AsyncIterable<Uint8Array>) {
-			out.write(Buffer.from(chunk.buffer))
+			out.write(new Uint8Array(Buffer.from(chunk.buffer)))
 		}
 		out.end()
 	}

--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -17,7 +17,7 @@ async function hasPackageChanged(pkg: PackageDetails) {
 			throw new Error(`Package not found at url ${url}: ${res.status}`)
 		}
 		const publishedTarballPath = `${dirPath}/published-package.tgz`
-		writeFileSync(publishedTarballPath, Buffer.from(await res.arrayBuffer()))
+		writeFileSync(publishedTarballPath, new Uint8Array(Buffer.from(await res.arrayBuffer())))
 		const publishedManifest = getTarballManifestSync(publishedTarballPath)
 
 		const localTarballPath = `${dirPath}/local-package.tgz`
@@ -41,7 +41,7 @@ function manifestsAreEqual(a: Record<string, Buffer>, b: Record<string, Buffer>)
 		if (!bKeys.includes(key)) {
 			return false
 		}
-		if (!a[key].equals(b[key])) {
+		if (!a[key].equals(new Uint8Array(b[key]))) {
 			return false
 		}
 	}
@@ -57,7 +57,7 @@ function getTarballManifestSync(tarballPath: string) {
 				// we could hash these to reduce memory but it's probably fine
 				const existing = manifest[entry.path]
 				if (existing) {
-					manifest[entry.path] = Buffer.concat([existing, data])
+					manifest[entry.path] = Buffer.concat([new Uint8Array(existing), new Uint8Array(data)])
 				} else {
 					manifest[entry.path] = data
 				}

--- a/internal/scripts/lib/file.ts
+++ b/internal/scripts/lib/file.ts
@@ -64,6 +64,7 @@ export async function writeStringFile(filePath: string, contents: string) {
 }
 
 export async function writeFile(filePath: string, contents: Buffer) {
+	const contentsArray = new Uint8Array(contents)
 	if (process.env.CI && !process.env.ALLOW_REFRESH_ASSETS_CHANGES) {
 		let existingContents: Buffer | null = null
 		try {
@@ -71,7 +72,7 @@ export async function writeFile(filePath: string, contents: Buffer) {
 		} catch {
 			// Ignore
 		}
-		if (existingContents && !existingContents.equals(contents)) {
+		if (existingContents && !existingContents.equals(contentsArray)) {
 			nicelog(
 				`Asset file ${relative(
 					REPO_ROOT,
@@ -86,7 +87,7 @@ export async function writeFile(filePath: string, contents: Buffer) {
 			process.exit(1)
 		}
 	}
-	await writeFileUnchecked(filePath, contents, 'utf-8')
+	await writeFileUnchecked(filePath, contentsArray, 'utf-8')
 }
 
 export async function writeJsonFile(filePath: string, contents: unknown) {

--- a/packages/tldraw/src/test/commands/clipboard.test.ts
+++ b/packages/tldraw/src/test/commands/clipboard.test.ts
@@ -33,6 +33,7 @@ const doMockClipboard = () => {
 		},
 	})
 
+	// @ts-ignore this is fine.
 	globalThis.ClipboardItem = jest.fn((payload: any) => payload)
 
 	return context

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -117,7 +117,7 @@ export function fpsThrottle(fn: {
 export function getErrorAnnotations(error: Error): ErrorAnnotations;
 
 // @public
-export function getFirstFromIterable<T = unknown>(set: Map<any, T> | Set<T>): T;
+export function getFirstFromIterable<T = unknown>(set: Map<any, T> | Set<T>): T | undefined;
 
 // @internal
 export function getFromLocalStorage(key: string): null | string;

--- a/packages/utils/src/lib/iterable.ts
+++ b/packages/utils/src/lib/iterable.ts
@@ -16,6 +16,6 @@
  * @param value - The iterable Set or Map.
  * @public
  */
-export function getFirstFromIterable<T = unknown>(set: Set<T> | Map<any, T>): T {
+export function getFirstFromIterable<T = unknown>(set: Set<T> | Map<any, T>): T | undefined {
 	return set.values().next().value
 }


### PR DESCRIPTION
After the `yarn dedupe` in the i18n PR https://github.com/tldraw/tldraw/pull/4719/
these new type issues crop up. I wanted to fix them up in a separate PR. This _should_ keep parity but sometimes this ArrayBuffer/UInt8Array stuff can be a little subtle.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
