### PR TITLE
[botcom] fix inline renaming

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -151,9 +151,9 @@ function TlaFileNameEditor({
 	)
 
 	useEffect(() => {
-		if (isRenaming !== undefined && isRenaming !== isEditing) {
+		if (isRenaming && !isEditing) {
 			// Wait a tick, otherwise the blur event immediately exits the input.
-			setTimeout(() => setIsEditing(isRenaming), 0)
+			setTimeout(() => setIsEditing(true), 0)
 		}
 	}, [isRenaming, isEditing])
 


### PR DESCRIPTION
Clicking the name to rename was broken

### Change type

- [x] `other`
