### PR TITLE
[infra] bump up skew protection time frame

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -386,10 +386,10 @@ async function coalesceWithPreviousAssets(assetsDir: string) {
 	}
 
 	// Always include the assets from the directly previous build, but also if there
-	// have been more deploys in the last two weeks, include those too.
-	const twoWeeks = 1000 * 60 * 60 * 24 * 14
+	// have been more deploys in the last six months, include those too.
+	const sixMonths = 1000 * 60 * 60 * 24 * 30 * 6
 	const recentOthers = others.filter(
-		(o) => (o.LastModified?.getTime() ?? 0) > Date.now() - twoWeeks
+		(o) => (o.LastModified?.getTime() ?? 0) > Date.now() - sixMonths
 	)
 	const objectsToFetch = [mostRecent, ...recentOthers]
 


### PR DESCRIPTION
For some reason I very conservatively set this value to two weeks. People keep browser tabs open for way longer than that.


### Change type

- [x] `other`
