### PR TITLE
[botcom] fix copy for forbidden state

### DIFF
--- a/apps/dotcom/client/src/components/StoreErrorScreen.tsx
+++ b/apps/dotcom/client/src/components/StoreErrorScreen.tsx
@@ -47,8 +47,8 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 				return <LoginRedirectPage />
 			}
 			case TLSyncErrorCloseEventReason.FORBIDDEN: {
-				header = 'Forbidden'
-				message = 'You are forbidden to view this room.'
+				header = 'Not authorized'
+				message = 'You do not have permission to view this room.'
 				break
 			}
 			default: {

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -41,8 +41,8 @@ export const router = createRoutesFromElements(
 						)
 					}
 					case TLSyncErrorCloseEventReason.FORBIDDEN: {
-						header = 'Forbidden'
-						para1 = 'You are forbidden to view this file.'
+						header = 'Not authorized'
+						para1 = 'You do not have permission to view this file.'
 						break
 					}
 				}


### PR DESCRIPTION
Just reverting this copy change. 'Forbidden' is too archaic and too strong a word to be user-facing here. It's like an old bible word. cc @mimecuvalo 

### Change type

- [x] `other`
