### PR TITLE
[infra] limit skew protection to one month

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -387,9 +387,9 @@ async function coalesceWithPreviousAssets(assetsDir: string) {
 
 	// Always include the assets from the directly previous build, but also if there
 	// have been more deploys in the last six months, include those too.
-	const sixMonths = 1000 * 60 * 60 * 24 * 30 * 6
+	const oneMonth = 1000 * 60 * 60 * 24 * 30
 	const recentOthers = others.filter(
-		(o) => (o.LastModified?.getTime() ?? 0) > Date.now() - sixMonths
+		(o) => (o.LastModified?.getTime() ?? 0) > Date.now() - oneMonth
 	)
 	const objectsToFetch = [mostRecent, ...recentOthers]
 


### PR DESCRIPTION
vercel has a 15,000 file limit that we were exceeding by 300 or so

maybe it's time to ship assets to s3

### Change type

- [x] `other`
