### PR TITLE
kbd shortcuts: fix up wrong size dialog on desktop

### DIFF
--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -136,7 +136,14 @@ function SneakyLocalSaveWarning() {
 							</TldrawUiDialogTitle>
 							<TldrawUiDialogCloseButton />
 						</TldrawUiDialogHeader>
-						<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+						<TldrawUiDialogBody
+							style={{
+								maxWidth: 350,
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 'var(--space-4)',
+							}}
+						>
 							<p>
 								Did you know that your tldraw project is being saved to your own computer? This
 								means that if you clear your browser cache, you will also lose your project here.

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -809,9 +809,6 @@
 	color: var(--color-text-1);
 	user-select: all;
 	-webkit-user-select: text;
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-4);
 }
 .tlui-dialog__body a {
 	color: var(--color-selected);


### PR DESCRIPTION
strange we didn't notice this but regression since this PR https://github.com/tldraw/tldraw/pull/4469

Before:
<img width="1480" alt="Screenshot 2024-10-25 at 23 49 01" src="https://github.com/user-attachments/assets/22242d78-d331-457b-9472-62ee46d2232b">

After:
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/8cd9d0c8-ddd1-4fff-bf90-83a5f7b47831">

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix keyboard shortcuts dialog being narrow on desktop.