### PR TITLE
Fix dragging on frame headings

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -38,6 +38,8 @@ export const FrameHeading = function FrameHeading({
 			const event = getPointerInfo(e)
 			e.preventDefault()
 
+			e.currentTarget.setPointerCapture(e.pointerId)
+
 			// If we're editing the frame label, we shouldn't hijack the pointer event
 			if (editor.getEditingShapeId() === id) return
 
@@ -51,6 +53,10 @@ export const FrameHeading = function FrameHeading({
 		},
 		[editor, id]
 	)
+
+	const handlePointerUp = useCallback((e: React.PointerEvent) => {
+		e.currentTarget.releasePointerCapture(e.pointerId)
+	}, [])
 
 	useEffect(() => {
 		const el = rInput.current
@@ -98,6 +104,7 @@ export const FrameHeading = function FrameHeading({
 				transform: `${labelTranslate} scale(var(--tl-scale)) translateX(calc(-1 * var(--space-3))`,
 			}}
 			onPointerDown={handlePointerDown}
+			onPointerUp={handlePointerUp}
 		>
 			<div className="tl-frame-heading-hit-area">
 				<FrameLabelInput ref={rInput} id={id} name={name} isEditing={isEditing} />


### PR DESCRIPTION
This PR fixes a bug where frame headings would not capture the pointer.

![Kapture 2024-10-26 at 11 21 53](https://github.com/user-attachments/assets/bb656d09-8c47-47e5-a793-34c71a67c8f3)

### Change type

- [x] `bugfix`

### Test plan

1. Drag a frame by its heading
2. Move your cursor outside of the window
3. The frame should move with your cursor, even when the cursor is outside of the window

### Release notes

- Fixed a bug with dragging frames by their heading.