### PR TITLE
Make default color theme light.

### DIFF
--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -13,6 +13,8 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence - approximately monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible, but tldraw is actively evolving as we add new features. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
+
+
 {/* START AUTO-GENERATED CHANGELOG */}
 
 ## Current release: [v3.4.0](/releases/v3.4.0)
@@ -56,7 +58,7 @@ Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in o
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
-
+						
 ## Previous releases
 
 - [v3.3.0](/releases/v3.3.0)
@@ -78,3 +80,5 @@ Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in o
 - [v2.0.0](/releases/v2.0.0)
 
 {/* END AUTO-GENERATED CHANGELOG */}
+
+

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -13,8 +13,6 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence - approximately monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible, but tldraw is actively evolving as we add new features. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
-
-
 {/* START AUTO-GENERATED CHANGELOG */}
 
 ## Current release: [v3.4.0](/releases/v3.4.0)
@@ -58,7 +56,7 @@ Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in o
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
-						
+
 ## Previous releases
 
 - [v3.3.0](/releases/v3.3.0)
@@ -80,5 +78,3 @@ Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in o
 - [v2.0.0](/releases/v2.0.0)
 
 {/* END AUTO-GENERATED CHANGELOG */}
-
-

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -15,87 +15,51 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
-## Current release: [v3.3.0](/releases/v3.3.0)
+## Current release: [v3.4.0](/releases/v3.4.0)
 
-Welcome to the 3.3.0 release of the tldraw sdk. This release includes a number of new features and bug fixes.
+Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in our user interface, improves performance around images and videos, and even improves our very secret ability to accept pasted content from [Excalidraw](https://excalidraw.com/). See below for the full list of changes.
 
-Special thanks to new contributors [@nayounsang](https://github.com/nayounsang) and [@vladh](https://github.com/vladh)!
+#### Breaking changes
 
-## Whats's new
+- The `id` attribute that was present on some shapes in the dom has been removed. There's now a data-shape-id attribute on every shape wrapper that can be used instead. ([#4694](https://github.com/tldraw/tldraw/pull/4694))
 
-### tldraw sync updates
+#### Improvements
 
-We've been working on [tldraw sync](https://tldraw.dev/docs/sync) to improve the developer experience and enable common use cases.
+- Clearer tooltip wording in the style panel. ([#4750](https://github.com/tldraw/tldraw/pull/4750))
+- Arrow labels no longer have their indictors showing behind them. ([#4749](https://github.com/tldraw/tldraw/pull/4749))
+- Limit the page name length in the move to page menu. ([#4747](https://github.com/tldraw/tldraw/pull/4747))
+- Improve performance of image/video rendering. ([#4659](https://github.com/tldraw/tldraw/pull/4659))
 
-#### New 'readonly' mode
+#### API changes
 
-When adding a socket to a room, you can now specify whether the client should be in readonly mode.
+- Add `labelColor` to note shapes. ([#4724](https://github.com/tldraw/tldraw/pull/4724))
+- There are a new set of APIs for working with unique DOM IDs in tldraw components: [`useUniqueSafeId`](https://staging.tldraw.dev/reference/editor/useUniqueSafeId) & [`useSharedSafeId`](https://staging.tldraw.dev/reference/editor/useSharedSafeId). ([#4694](https://github.com/tldraw/tldraw/pull/4694))
 
-```ts
-room.handleNewSession({
-	sessionId,
-	socket,
-	isReadonly: !(await canUserEdit(userId, roomId)),
-})
-```
+#### Bug fixes
 
-Users in readonly mode:
+- Writing `options` inline in the Tldraw component will no longer cause re-render loops. ([#4762](https://github.com/tldraw/tldraw/pull/4762))
+- Make sure toolbar button outlines match the border-radius of the button. ([#4759](https://github.com/tldraw/tldraw/pull/4759))
+- Make sure content pasted from Excalidraw keeps the correct color. ([#4752](https://github.com/tldraw/tldraw/pull/4752))
+- Don't highlight menu triggers that dont have their submenus open. ([#4710](https://github.com/tldraw/tldraw/pull/4710))
+- Pass through the correct event type for drag events. ([#4739](https://github.com/tldraw/tldraw/pull/4739))
+- Prevent multiple images accidentally being created when you drop one onto the canvas. ([#4704](https://github.com/tldraw/tldraw/pull/4704))
+- Make sure the link indicator is visible on sticky notes. ([#4708](https://github.com/tldraw/tldraw/pull/4708))
+- The insert embed dialog now parses URLs correctly. ([#4709](https://github.com/tldraw/tldraw/pull/4709))
+- Exports and other tldraw instances no longer can affect how each other are rendered. ([#4694](https://github.com/tldraw/tldraw/pull/4694))
+- Show the correct set of menu options in read-only mode. ([#4696](https://github.com/tldraw/tldraw/pull/4696))
 
-- Will see a reduced UI, to hide tools and actions they can't make use of.
-- Will not be able to make changes to the document. This is now enforced by the server.
-- Will still send presence updates (cursor position, name, etc) to the server which will be broadcast to other users.
-
-([#4648](https://github.com/tldraw/tldraw/pull/4648)) ([#4673](https://github.com/tldraw/tldraw/pull/4673))
-
-#### New methods on TLSocketRoom
-
-We've added a few new methods to the TLSocketRoom class:
-
-- `closeSession` - for terminating or restarting a client's socket connection.
-- `getRecord` - for getting an individual record.
-- `getSessions` - for getting a list of the active sessions.
-
-([#4677](https://github.com/tldraw/tldraw/pull/4677)) ([#4660](https://github.com/tldraw/tldraw/pull/4660))
-
-## Breaking Changes
-
-No breaking changes in this release 🎉
-
-## Improvements
-
-- Allow wheel events to pass through certain user interface elements like toolbars, to enable scrolling and zooming even when your cursor is not directly over the canvas. ([#4662](https://github.com/tldraw/tldraw/pull/4662))
-- Allow holding `cmd`/`ctrl` modifier keys to add multiple shapes to the selection. Previously only `shift` worked. ([#4570](https://github.com/tldraw/tldraw/pull/4570))
-- Allow the text tool to be locked ([#4569](https://github.com/tldraw/tldraw/pull/4569)) ([#4632](https://github.com/tldraw/tldraw/pull/4632)) ([#4644](https://github.com/tldraw/tldraw/pull/4644))
-- Improve draw shape rendering performance during zoom interactions. ([#4647](https://github.com/tldraw/tldraw/pull/4647))
-- Disable debug mode in development by default. ([#4629](https://github.com/tldraw/tldraw/pull/4629))
-
-## Api Changes
-
-- Adds an editor option to control the placement of quick action shortcuts (undo, redo, delete, etc). ([#4666](https://github.com/tldraw/tldraw/pull/4666))
-- Adds an `editor.getIsReadonly()` helper method. ([#4673](https://github.com/tldraw/tldraw/pull/4673))
-
-## Bug fixes
-
-- Fix icon button width ([#4663](https://github.com/tldraw/tldraw/pull/4663))
-- Fixed a bug where dropping images or other things on user interface elements would navigate away from the canvas ([#4651](https://github.com/tldraw/tldraw/pull/4651))
-- Work around a Safari performance bug affecting arrows at certain zoom levels. ([#4636](https://github.com/tldraw/tldraw/pull/4636))
-- Fix a bug that affected some geometry calculations for lines that start and end at the same point ([#4650](https://github.com/tldraw/tldraw/pull/4650)).
-- Fix layer ordering issue with the watermark. ([#4656](https://github.com/tldraw/tldraw/pull/4656))
-- Fixed a signals transaction bug that was manifesting as `Error('cannot change atoms during reaction cycle')` ([#4645](https://github.com/tldraw/tldraw/pull/4645))
-- Fix a bug where the watermark link would open twice ([#4622](https://github.com/tldraw/tldraw/pull/4622))
-- Fixed a bug where camera constraints were not upheld after switching pages or setting new camera constraints. ([#4628](https://github.com/tldraw/tldraw/pull/4628))
-- Fixes a bug where arrow labels could be edited in readonly mode. ([#4673](https://github.com/tldraw/tldraw/pull/4673))
-
-## Authors
+#### Authors
 
 - [@nayounsang](https://github.com/nayounsang)
+- alex ([@SomeHats](https://github.com/SomeHats))
 - David Sheldrick ([@ds300](https://github.com/ds300))
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
-- Vlad-Stefan Harbuz ([@vladh](https://github.com/vladh))
 
 ## Previous releases
+
+- [v3.3.0](/releases/v3.3.0)
 
 - [v3.2.0](/releases/v3.2.0)
 

--- a/apps/dotcom/client/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
+++ b/apps/dotcom/client/src/components/BoardHistorySnapshot/BoardHistorySnapshot.tsx
@@ -62,7 +62,6 @@ export function BoardHistorySnapshot({
 						})
 					}}
 					overrides={[fileSystemUiOverrides]}
-					inferDarkMode
 				/>
 			</div>
 			<div className="board-history__restore">

--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -103,7 +103,6 @@ export function LocalEditor() {
 				overrides={[sharingUiOverrides, fileSystemUiOverrides]}
 				onUiEvent={handleUiEvent}
 				components={components}
-				inferDarkMode
 			>
 				<SneakyOnDropOverride isMultiplayer={false} />
 				<ThemeUpdater />

--- a/apps/dotcom/client/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/client/src/components/MultiplayerEditor.tsx
@@ -163,7 +163,6 @@ export function MultiplayerEditor({
 				onUiEvent={handleUiEvent}
 				components={components}
 				deepLinks
-				inferDarkMode
 			>
 				<SneakyOnDropOverride isMultiplayer />
 				<ThemeUpdater />

--- a/apps/dotcom/client/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/client/src/components/SnapshotsEditor.tsx
@@ -85,7 +85,6 @@ export function SnapshotsEditor({ schema, records }: SnapshotEditorProps) {
 				}}
 				components={components}
 				deepLinks
-				inferDarkMode
 			/>
 		</div>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
@@ -73,7 +73,6 @@ export function TlaPublishEditor({ schema, records }: TlaPublishEditorProps) {
 				}}
 				components={components}
 				deepLinks
-				inferDarkMode
 			>
 				<ThemeUpdater />
 				<SneakyDarkModeSync />

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -735,7 +735,7 @@ export const defaultTldrawOptions: {
 export const defaultUserPreferences: Readonly<{
     animationSpeed: 0 | 1;
     color: "#02B1CC" | "#11B3A3" | "#39B178" | "#55B467" | "#7B66DC" | "#9D5BD2" | "#BD54C6" | "#E34BA9" | "#EC5E41" | "#F04F88" | "#F2555A" | "#FF802B";
-    colorScheme: "system";
+    colorScheme: "light";
     edgeScrollSpeed: 1;
     isDynamicSizeMode: false;
     isPasteAtCursorMode: false;

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -143,7 +143,7 @@ export const defaultUserPreferences = Object.freeze({
 	isWrapMode: false,
 	isDynamicSizeMode: false,
 	isPasteAtCursorMode: false,
-	colorScheme: 'system',
+	colorScheme: 'light',
 }) satisfies Readonly<Omit<TLUserPreferences, 'id'>>
 
 /** @public */

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager.ts
@@ -12,7 +12,7 @@ export class UserPreferencesManager {
 		if (typeof window === 'undefined' || !('matchMedia' in window)) return
 
 		const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-		if (this.getUserPreferences().colorScheme === 'system' && darkModeMediaQuery?.matches) {
+		if (inferDarkMode && darkModeMediaQuery?.matches) {
 			this.systemColorScheme.set('dark')
 		}
 		darkModeMediaQuery?.addEventListener('change', (e) => {

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager.ts
@@ -12,14 +12,16 @@ export class UserPreferencesManager {
 		if (typeof window === 'undefined' || !('matchMedia' in window)) return
 
 		const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-		if (darkModeMediaQuery?.matches) {
+		if (this.getUserPreferences().colorScheme === 'system' && darkModeMediaQuery?.matches) {
 			this.systemColorScheme.set('dark')
 		}
 		darkModeMediaQuery?.addEventListener('change', (e) => {
-			if (e.matches) {
-				this.systemColorScheme.set('dark')
-			} else {
-				this.systemColorScheme.set('light')
+			if (this.getUserPreferences().colorScheme === 'system') {
+				if (e.matches) {
+					this.systemColorScheme.set('dark')
+				} else {
+					this.systemColorScheme.set('light')
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This PR:
- makes the default user preference light, rather than system
- updates the theme when the media theme changes only if the user has selected system

## Rationale

Our light theme is better and presents a better initial experience of the app.
Our logged out pages only support light mode and we don't want to show a dark editor on a light page.
Our docs landing page has light mode as its default and we don't want to show a dark editor on a light page.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Sets the default color theme to light.