### PR TITLE
[botcom] Double click sidebar item to edit inline

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -230,6 +230,7 @@ function TlaSidebarFileLink({ item }: { item: RecentFile }) {
 			className={classNames(styles.link, styles.hoverable)}
 			data-active={isActive}
 			data-element="file-link"
+			onDoubleClick={handleRenameAction}
 		>
 			<div className={styles.linkContent}>
 				<div className={classNames(styles.label, 'tla-text_ui__regular')}>
@@ -270,20 +271,14 @@ function TlaRenameInline({ fileId, onClose }: { fileId: TldrawAppFile['id']; onC
 				handleSave()
 			}
 		}
-		function handleKeyDown(e: KeyboardEvent) {
-			if (e.key === 'Escape') {
-				onClose()
-			}
-		}
 
 		// We wait a tick because we don't want to immediately close the input.
 		setTimeout(() => {
 			document.addEventListener('click', handleClick, { capture: true })
-			document.addEventListener('keydown', handleKeyDown)
 		}, 0)
+
 		return () => {
 			document.removeEventListener('click', handleClick, { capture: true })
-			document.removeEventListener('keydown', handleKeyDown)
 		}
 	}, [handleSave, onClose])
 
@@ -294,6 +289,7 @@ function TlaRenameInline({ fileId, onClose }: { fileId: TldrawAppFile['id']; onC
 				className={classNames(styles.rename, 'tla-text_ui__regular')}
 				defaultValue={app.getFileName(fileId)}
 				onComplete={handleSave}
+				onCancel={onClose}
 				autoSelect
 				autoFocus
 			/>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -291,6 +291,11 @@
 	z-index: 2;
 }
 
+.renameWrapper {
+	outline: 1px solid var(--color-primary);
+	outline-offset: -2px;
+}
+
 .renameWrapper > div {
 	height: 36px;
 	padding: 0px 8px 0px 8px;


### PR DESCRIPTION
This PR allows double clicking the sidebar item to edit its name inline. It fixes a bug with the Escape key to cancel the edit.

### Change type

- [x] `improvement`
