### PR TITLE
Imported wrong css

### DIFF
--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -74,7 +74,7 @@ Next, import the `useSyncDemo` hook from the `@tldraw/sync` package. Call it in 
 ```tsx
 import { Tldraw } from 'tldraw'
 import { useSyncDemo } from '@tldraw/sync'
-import './index.css'
+import 'tldraw/tldraw.css'
 
 export default function App() {
 	const store = useSyncDemo({ roomId: 'myapp-abc123' })
@@ -101,7 +101,7 @@ For simplicity's sake, let's roll back our persistence and sync code. We can the
 
 ```tsx
 import { Tldraw } from 'tldraw'
-import './index.css'
+import 'tldraw/tldraw.css'
 
 export default function App() {
 	const handleMount = (editor) => {


### PR DESCRIPTION
Fix the imported css in the docs.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

No tests added

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with tutorial documentation QuickStart. It did not import 'tldraw/tldraw.css' in the code snippet