### PR TITLE
Don't pipe out webserver stuff.

### DIFF
--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: 'html',
+	reporter: process.env.CI ? [['list'], ['github'], ['html', { open: 'never' }]] : 'list',
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -82,7 +82,6 @@ export default defineConfig({
 	webServer: {
 		command: 'yarn dev-app',
 		url: 'http://localhost:3000',
-		stdout: 'pipe',
 		reuseExistingServer: !process.env.CI,
 		cwd: path.join(__dirname, '../../../'),
 	},


### PR DESCRIPTION
Declutter the printout in CI.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Declutter the printout for e2e tests in CI.