### PR TITLE
Store all the published snapshots instead of only the last one

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/tla/publishFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/publishFile.ts
@@ -42,6 +42,11 @@ export async function publishFile(request: IRequest, env: Environment): Promise<
 			getR2KeyForRoom({ slug: `${roomId}/${file.publishedSlug}`, isApp: true }),
 			serializedSnapshot
 		)
+		const currentTime = new Date().toISOString()
+		await env.ROOM_SNAPSHOTS.put(
+			getR2KeyForRoom({ slug: `${roomId}/${file.publishedSlug}-${currentTime}`, isApp: true }),
+			serializedSnapshot
+		)
 
 		return new Response(JSON.stringify({ error: false }))
 	} catch (e: any) {


### PR DESCRIPTION
We store all the published snapshots so that we could expose published file history in the future. The way it works is:
* `/parentSlug/publishedSlug` aways contains the latest published snapshot
* we now also store the snapshot under `/parentSlug/publishedSlug-timeOfPublish` to keep track of all the published changes.


![image](https://github.com/user-attachments/assets/d72e8715-517b-4f9e-8c61-8d4ecf86b900)


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…