### PR TITLE
botcom: shareable by default

### DIFF
--- a/packages/dotcom-shared/src/tla-schema/TldrawAppFile.ts
+++ b/packages/dotcom-shared/src/tla-schema/TldrawAppFile.ts
@@ -91,7 +91,7 @@ export const TldrawAppFileRecordType = createRecordType<TldrawAppFile>('file', {
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		isEmpty: false,
-		shared: false,
+		shared: true,
 		sharedLinkType: 'edit',
 		published: false,
 		publishedSlug: uniqueId(),


### PR DESCRIPTION
this makes the rooms unlisted, not private by default. the ID is not guessable which gives privacy but doesn't ruin / complicate the UX flow of sharing the file with someone.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
