### PR TITLE
publish layout: enable some file actions even if readonly mode

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
@@ -54,7 +54,12 @@ export function TlaAccountMenu({
 				>
 					{auth.isSignedIn && (
 						<TldrawUiMenuGroup id="account-actions">
-							<TldrawUiMenuItem id="sign-out" label="Sign out" onSelect={handleSignout} />
+							<TldrawUiMenuItem
+								id="sign-out"
+								label="Sign out"
+								readonlyOk
+								onSelect={handleSignout}
+							/>
 						</TldrawUiMenuGroup>
 					)}
 					<TldrawUiMenuGroup id="account-links">

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -83,16 +83,29 @@ export function TlaFileMenu({
 		<>
 			<TldrawUiMenuGroup id="file-actions">
 				{/* todo: in published rooms, support copying link */}
-				<TldrawUiMenuItem label="Copy link" id="copy-link" onSelect={handleCopyLinkClick} />
-				{isOwner && <TldrawUiMenuItem label="Rename" id="copy-link" onSelect={onRenameAction} />}
+				<TldrawUiMenuItem
+					label="Copy link"
+					id="copy-link"
+					readonlyOk
+					onSelect={handleCopyLinkClick}
+				/>
+				{isOwner && (
+					<TldrawUiMenuItem label="Rename" id="copy-link" readonlyOk onSelect={onRenameAction} />
+				)}
 				{/* todo: in published rooms, support duplication / forking */}
-				<TldrawUiMenuItem label="Duplicate" id="copy-link" onSelect={handleDuplicateClick} />
+				<TldrawUiMenuItem
+					label="Duplicate"
+					id="copy-link"
+					readonlyOk
+					onSelect={handleDuplicateClick}
+				/>
 				{/* <TldrawUiMenuItem label="Star" id="copy-link" onSelect={handleStarLinkClick} /> */}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="file-delete">
 				<TldrawUiMenuItem
 					label={isOwner ? 'Delete' : 'Forget'}
 					id="delete"
+					readonlyOk
 					onSelect={handleDeleteClick}
 				/>
 			</TldrawUiMenuGroup>


### PR DESCRIPTION
this adds `readonlyOk` to a bunch of places. lemme know if there are concerns here but i think this should be ok, if we plan on keeping the sidebar around for published+logged in.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
