### PR TITLE
Call ensureStoreIsUsable after mergeRemoteChanges

### DIFF
--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -184,14 +184,16 @@ export class TLLocalSyncClient {
 					return
 				}
 
-				// 3. Merge the changes into the REAL STORE
-				this.store.mergeRemoteChanges(() => {
-					// Calling put will validate the records!
-					this.store.put(
-						Object.values(migrationResult.value).filter((r) => this.documentTypes.has(r.typeName)),
-						'initialize'
-					)
-				})
+				const records = Object.values(migrationResult.value).filter((r) =>
+					this.documentTypes.has(r.typeName)
+				)
+				if (records.length > 0) {
+					// 3. Merge the changes into the REAL STORE
+					this.store.mergeRemoteChanges(() => {
+						// Calling put will validate the records!
+						this.store.put(records, 'initialize')
+					})
+				}
 
 				if (sessionStateSnapshot) {
 					loadSessionStateSnapshotIntoStore(this.store, sessionStateSnapshot)
@@ -237,7 +239,6 @@ export class TLLocalSyncClient {
 					transact(() => {
 						this.store.mergeRemoteChanges(() => {
 							this.store.applyDiff(msg.changes as any)
-							this.store.ensureStoreIsUsable()
 						})
 					})
 				}

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -697,6 +697,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			transact(fn)
 		} finally {
 			this.isMergingRemoteChanges = false
+			this.ensureStoreIsUsable()
 		}
 	}
 

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -391,7 +391,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			// this.isConnectedToRoom = true
 			// this.store.applyDiff(stashedChanges, false)
 
-			this.store.ensureStoreIsUsable()
 			this.onAfterConnect?.(this, { isReadonly: event.isReadonly })
 		})
 
@@ -645,7 +644,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 					this.resetConnection()
 				}
 			})
-			this.store.ensureStoreIsUsable()
 			this.lastServerClock = diffs.at(-1)?.serverClock ?? this.lastServerClock
 		} catch (e) {
 			console.error(e)


### PR DESCRIPTION
`ensureStoreIsUsable` is marked internal and should probably stay that way? But it makes sense to always call it after `mergeRemoteChanges` (which we already do)

### Change type


- [x] `improvement`

### Release notes

- Add store consistency checks during `mergeRemoteChanges`