### PR TITLE
Add option to disable text creation on double click

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -690,6 +690,7 @@ export const defaultTldrawOptions: {
     readonly collaboratorCheckIntervalMs: 1200;
     readonly collaboratorIdleTimeoutMs: 3000;
     readonly collaboratorInactiveTimeoutMs: 60000;
+    readonly createTextOnCanvasDoubleClick: true;
     readonly defaultSvgPadding: 32;
     readonly doubleClickDurationMs: 450;
     readonly dragDistanceSquared: 16;
@@ -2766,6 +2767,8 @@ export interface TldrawOptions {
     readonly collaboratorIdleTimeoutMs: number;
     // (undocumented)
     readonly collaboratorInactiveTimeoutMs: number;
+    // (undocumented)
+    readonly createTextOnCanvasDoubleClick: boolean;
     // (undocumented)
     readonly defaultSvgPadding: number;
     // (undocumented)

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -58,6 +58,7 @@ export interface TldrawOptions {
 	 */
 	readonly temporaryAssetPreviewLifetimeMs: number
 	readonly actionShortcutsLocation: 'menu' | 'toolbar' | 'swap'
+	readonly createTextOnCanvasDoubleClick: boolean
 }
 
 /** @public */
@@ -101,4 +102,5 @@ export const defaultTldrawOptions = {
 	maxExportDelayMs: 5000,
 	temporaryAssetPreviewLifetimeMs: 180000,
 	actionShortcutsLocation: 'swap',
+	createTextOnCanvasDoubleClick: true,
 } as const satisfies TldrawOptions

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -562,6 +562,8 @@ export class Idle extends StateNode {
 		// Create text shape and transition to editing_shape
 		if (this.editor.getIsReadonly()) return
 
+		if (!this.editor.options.createTextOnCanvasDoubleClick) return
+
 		this.editor.markHistoryStoppingPoint('creating text shape')
 
 		const id = createShapeId()


### PR DESCRIPTION
This was asked on discord https://discord.com/channels/859816885297741824/1298916572093612062/1298916572093612062 

let's let people turn off text creation on double click?

### Change type


- [x] `feature`


### Release notes

- Add option to disable text creation on double click `createTextOnCanvasDoubleClick`