### PR TITLE
Smart bringForward/sendBackward

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -835,7 +835,9 @@ export class Editor extends EventEmitter<TLEventMap> {
     blur({ blurContainer }?: {
         blurContainer?: boolean | undefined;
     }): this;
-    bringForward(shapes: TLShape[] | TLShapeId[]): this;
+    bringForward(shapes: TLShape[] | TLShapeId[], opts?: {
+        considerAllShapes?: boolean;
+    }): this;
     bringToFront(shapes: TLShape[] | TLShapeId[]): this;
     // (undocumented)
     canBindShapes({ fromShape, toShape, binding, }: {
@@ -1215,7 +1217,9 @@ export class Editor extends EventEmitter<TLEventMap> {
     select(...shapes: TLShape[] | TLShapeId[]): this;
     selectAll(): this;
     selectNone(): this;
-    sendBackward(shapes: TLShape[] | TLShapeId[]): this;
+    sendBackward(shapes: TLShape[] | TLShapeId[], opts?: {
+        considerAllShapes?: boolean;
+    }): this;
     sendToBack(shapes: TLShape[] | TLShapeId[]): this;
     // @internal (undocumented)
     _setAltKeyTimeout(): void;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6008,6 +6008,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shapes - The shapes (or shape ids) to move.
+	 * @param opts - The options for the backward operation.
 	 *
 	 * @public
 	 */

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5983,7 +5983,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
-		const changes = getReorderingShapesChanges(this, 'toBack', ids as TLShapeId[])
+		const changes = getReorderingShapesChanges(this, 'toBack', ids as TLShapeId[], {
+			considerAllShapes: true,
+		})
 		if (changes) this.updateShapes(changes)
 		return this
 	}
@@ -5997,16 +5999,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.sendBackward([box1, box2])
 	 * ```
 	 *
+	 * By default, the operation will only consider overlapping shapes.
+	 * To consider all shapes, pass `{ considerAllShapes: true }` in the options.
+	 *
+	 * @example
+	 * ```ts
+	 * editor.sendBackward(['id1', 'id2'], { considerAllShapes: true })
+	 * ```
+	 *
 	 * @param shapes - The shapes (or shape ids) to move.
 	 *
 	 * @public
 	 */
-	sendBackward(shapes: TLShapeId[] | TLShape[]): this {
+	sendBackward(shapes: TLShapeId[] | TLShape[], opts: { considerAllShapes?: boolean } = {}): this {
 		const ids =
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
-		const changes = getReorderingShapesChanges(this, 'backward', ids as TLShapeId[])
+		const changes = getReorderingShapesChanges(this, 'backward', ids as TLShapeId[], opts)
 		if (changes) this.updateShapes(changes)
 		return this
 	}
@@ -6020,16 +6030,25 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * editor.bringForward(box1,  box2)
 	 * ```
 	 *
+	 * By default, the operation will only consider overlapping shapes.
+	 * To consider all shapes, pass `{ considerAllShapes: true }` in the options.
+	 *
+	 * @example
+	 * ```ts
+	 * editor.bringForward(['id1', 'id2'], { considerAllShapes: true })
+	 * ```
+	 *
 	 * @param shapes - The shapes (or shape ids) to move.
+	 * @param opts - The options for the forward operation.
 	 *
 	 * @public
 	 */
-	bringForward(shapes: TLShapeId[] | TLShape[]): this {
+	bringForward(shapes: TLShapeId[] | TLShape[], opts: { considerAllShapes?: boolean } = {}): this {
 		const ids =
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
-		const changes = getReorderingShapesChanges(this, 'forward', ids as TLShapeId[])
+		const changes = getReorderingShapesChanges(this, 'forward', ids as TLShapeId[], opts)
 		if (changes) this.updateShapes(changes)
 		return this
 	}

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -178,6 +178,7 @@ function filterOverlappingShapes(editor: Editor, moving: Set<TLShape>, children:
 /**
  * Reorders the moving shapes forward in the parent's children.
  *
+ * @param editor The editor
  * @param moving The set of shapes that are moving
  * @param children The parent's children
  * @param changes The changes array to push changes to
@@ -228,6 +229,7 @@ function reorderForward(
 /**
  * Reorders the moving shapes backward in the parent's children.
  *
+ * @param editor The editor
  * @param moving The set of shapes that are moving
  * @param children The parent's children
  * @param changes The changes array to push changes to

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -188,6 +188,7 @@ function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
  * @param moving The set of shapes that are moving
  * @param children The parent's children
  * @param changes The changes array to push changes to
+ * @param opts The options
  */
 function reorderForward(
 	editor: Editor,
@@ -246,6 +247,7 @@ function reorderForward(
  * @param moving The set of shapes that are moving
  * @param children The parent's children
  * @param changes The changes array to push changes to
+ * @param opts The options
  */
 function reorderBackward(
 	editor: Editor,

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -7,7 +7,8 @@ import { polygonsIntersect } from '../primitives/intersect'
 export function getReorderingShapesChanges(
 	editor: Editor,
 	operation: 'toBack' | 'toFront' | 'forward' | 'backward',
-	ids: TLShapeId[]
+	ids: TLShapeId[],
+	opts?: { considerAllShapes?: boolean }
 ) {
 	if (ids.length === 0) return []
 
@@ -39,11 +40,15 @@ export function getReorderingShapesChanges(
 			break
 		}
 		case 'forward': {
-			parents.forEach(({ moving, children }) => reorderForward(editor, moving, children, changes))
+			parents.forEach(({ moving, children }) =>
+				reorderForward(editor, moving, children, changes, opts)
+			)
 			break
 		}
 		case 'backward': {
-			parents.forEach(({ moving, children }) => reorderBackward(editor, moving, children, changes))
+			parents.forEach(({ moving, children }) =>
+				reorderBackward(editor, moving, children, changes, opts)
+			)
 			break
 		}
 	}
@@ -188,7 +193,8 @@ function reorderForward(
 	editor: Editor,
 	moving: Set<TLShape>,
 	children: TLShape[],
-	changes: TLShapePartial[]
+	changes: TLShapePartial[],
+	opts?: { considerAllShapes?: boolean }
 ) {
 	const isOverlapping = getOverlapChecker(editor, moving)
 
@@ -214,7 +220,7 @@ function reorderForward(
 			}
 			case 'selecting': {
 				if (isMoving) continue
-				if (!isOverlapping(children[i])) continue
+				if (!opts?.considerAllShapes && !isOverlapping(children[i])) continue
 				// if we find a non-moving and overlapping shape while selecting, move all selected
 				// shapes in front of the not moving shape; and start skipping
 				const { selectIndex } = state
@@ -245,7 +251,8 @@ function reorderBackward(
 	editor: Editor,
 	moving: Set<TLShape>,
 	children: TLShape[],
-	changes: TLShapePartial[]
+	changes: TLShapePartial[],
+	opts?: { considerAllShapes?: boolean }
 ) {
 	const isOverlapping = getOverlapChecker(editor, moving)
 
@@ -270,7 +277,7 @@ function reorderBackward(
 			}
 			case 'selecting': {
 				if (isMoving) continue
-				if (!isOverlapping(children[i])) continue
+				if (!opts?.considerAllShapes && !isOverlapping(children[i])) continue
 				// if we find a non-moving and overlapping shape while selecting, move all selected
 				// shapes in behind of the not moving shape; and start skipping
 				getIndicesBetween(children[i - 1]?.index, children[i].index, state.selectIndex - i).forEach(

--- a/packages/tldraw/src/test/commands/reorderShapes.test.ts
+++ b/packages/tldraw/src/test/commands/reorderShapes.test.ts
@@ -949,7 +949,7 @@ test('When only two shapes exist', () => {
 	expectShapesInOrder(editor, ids['A'], ids['B'])
 })
 
-test.only("bringForward ignores shapes that don't overlap", () => {
+test("bringForward ignores shapes that don't overlap", () => {
 	editor = new TestEditor()
 
 	// a and c overlap but a and b do not and neither do a and d

--- a/packages/tldraw/src/test/commands/reorderShapes.test.ts
+++ b/packages/tldraw/src/test/commands/reorderShapes.test.ts
@@ -948,3 +948,89 @@ test('When only two shapes exist', () => {
 
 	expectShapesInOrder(editor, ids['A'], ids['B'])
 })
+
+test.only("bringForward ignores shapes that don't overlap", () => {
+	editor = new TestEditor()
+
+	// a and c overlap but a and b do not and neither do a and d
+	editor.createShapes([
+		{
+			id: ids['A'],
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['B'],
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['C'],
+			type: 'geo',
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['D'],
+			type: 'geo',
+			x: 110,
+			y: 110,
+			props: { w: 100, h: 100 },
+		},
+	])
+
+	expectShapesInOrder(editor, ids['A'], ids['B'], ids['C'], ids['D'])
+
+	editor.bringForward([ids['A']])
+
+	// a should now be in front of c but behind d
+	expectShapesInOrder(editor, ids['B'], ids['C'], ids['A'], ids['D'])
+})
+
+test("sendBackwards ignores shapes that don't overlap", () => {
+	editor = new TestEditor()
+
+	// d overlaps with b but not a or c
+	editor.createShapes([
+		{
+			id: ids['A'],
+			type: 'geo',
+			x: -110,
+			y: -110,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['B'],
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['C'],
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['D'],
+			type: 'geo',
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		},
+	])
+
+	expectShapesInOrder(editor, ids['A'], ids['B'], ids['C'], ids['D'])
+
+	editor.sendBackward([ids['D']])
+
+	// d should now be behind b
+	expectShapesInOrder(editor, ids['A'], ids['D'], ids['B'], ids['C'])
+})

--- a/packages/tldraw/src/test/commands/reorderShapes.test.ts
+++ b/packages/tldraw/src/test/commands/reorderShapes.test.ts
@@ -949,7 +949,7 @@ test('When only two shapes exist', () => {
 	expectShapesInOrder(editor, ids['A'], ids['B'])
 })
 
-test("bringForward ignores shapes that don't overlap", () => {
+test("bringForward ignores shapes that don't overlap by default", () => {
 	editor = new TestEditor()
 
 	// a and c overlap but a and b do not and neither do a and d
@@ -992,7 +992,50 @@ test("bringForward ignores shapes that don't overlap", () => {
 	expectShapesInOrder(editor, ids['B'], ids['C'], ids['A'], ids['D'])
 })
 
-test("sendBackwards ignores shapes that don't overlap", () => {
+test("bringForward does not ignore shapes that don't overlap with considerAllShapes", () => {
+	editor = new TestEditor()
+
+	// a and c overlap but a and b do not and neither do a and d
+	editor.createShapes([
+		{
+			id: ids['A'],
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['B'],
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['C'],
+			type: 'geo',
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['D'],
+			type: 'geo',
+			x: 110,
+			y: 110,
+			props: { w: 100, h: 100 },
+		},
+	])
+
+	expectShapesInOrder(editor, ids['A'], ids['B'], ids['C'], ids['D'])
+
+	editor.bringForward([ids['A']], { considerAllShapes: true })
+
+	// a should now be in front of c but behind d
+	expectShapesInOrder(editor, ids['B'], ids['A'], ids['C'], ids['D'])
+})
+
+test("sendBackwards ignores shapes that don't overlap by default", () => {
 	editor = new TestEditor()
 
 	// d overlaps with b but not a or c
@@ -1033,4 +1076,47 @@ test("sendBackwards ignores shapes that don't overlap", () => {
 
 	// d should now be behind b
 	expectShapesInOrder(editor, ids['A'], ids['D'], ids['B'], ids['C'])
+})
+
+test("sendBackwards does not ignore shapes that don't overlap with considerAllShapes", () => {
+	editor = new TestEditor()
+
+	// d overlaps with b but not a or c
+	editor.createShapes([
+		{
+			id: ids['A'],
+			type: 'geo',
+			x: -110,
+			y: -110,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['B'],
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['C'],
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: ids['D'],
+			type: 'geo',
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		},
+	])
+
+	expectShapesInOrder(editor, ids['A'], ids['B'], ids['C'], ids['D'])
+
+	editor.sendBackward([ids['D']], { considerAllShapes: true })
+
+	// d should now be behind b
+	expectShapesInOrder(editor, ids['A'], ids['B'], ids['D'], ids['C'])
 })


### PR DESCRIPTION
This PR makes it so that only overlapping shapes are considered when moving forward/backward incrementally. It feels great.
Before
![Kapture 2024-11-04 at 12 36 22](https://github.com/user-attachments/assets/98808a29-fe04-4458-82d5-1f9c9b07082f)

After
![Kapture 2024-11-04 at 12 36 22](https://github.com/user-attachments/assets/182f9428-7e13-4702-9803-06ee8ce32008)

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Improved the 'bring forward' and 'send backward' actions by making them only consider nearby overlapping shapes when deciding the next ordering.