### PR TITLE
Remove outlines from buttons until we fix radix-ui issues

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -110,7 +110,7 @@
 	--tl-font-sans: 'tldraw_sans', sans-serif;
 	--tl-font-serif: 'tldraw_serif', serif;
 	--tl-font-mono: 'tldraw_mono', monospace;
-	/* fext outline */
+	/* text outline */
 	--a: calc(min(0.5, 1 / var(--tl-zoom)) * 2px);
 	--b: calc(min(0.5, 1 / var(--tl-zoom)) * -2px);
 	--tl-text-outline-reference: 0 var(--b) 0 var(--color-background),

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -62,7 +62,9 @@
 }
 
 .tlui-button:focus-visible:not(:hover) {
-	outline: 1px solid var(--color-selected);
+	/* todo: fix the indicator errors in radix dropdown menus before restoring */
+	/* outline: 1px solid var(--color-selected); */
+	outline: none;
 	outline-offset: -4px;
 	border-radius: var(--radius-3);
 }


### PR DESCRIPTION
This PR removes focus outlines on buttons. There are persistent bugs with menu items that look cheap and bad and which we haven't been able to solve. If we solve them then we can bring back the outlines.

![Kapture 2024-11-05 at 09 29 41](https://github.com/user-attachments/assets/063cc2e4-032c-47b7-981a-761729b79951)

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with focus outlines appearing in menu items at the wrong time.