### PR TITLE
Fix shapes getting stuck in erasing state

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -56,6 +56,7 @@ export class Erasing extends StateNode {
 	}
 
 	override onExit() {
+		this.editor.setErasingShapes([])
 		this.editor.scribbles.stop(this.scribbleId)
 	}
 
@@ -131,13 +132,11 @@ export class Erasing extends StateNode {
 	complete() {
 		const { editor } = this
 		editor.deleteShapes(editor.getCurrentPageState().erasingShapeIds)
-		editor.setErasingShapes([])
 		this.parent.transition('idle')
 	}
 
 	cancel() {
 		const { editor } = this
-		editor.setErasingShapes([])
 		editor.bailToMark(this.markId)
 		this.parent.transition('idle', this.info)
 	}

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -55,6 +55,12 @@ export class Pointing extends StateNode {
 		this.startErasing(info)
 	}
 
+	override onExit(_info: any, to: string) {
+		if (to !== 'erasing') {
+			this.editor.setErasingShapes([])
+		}
+	}
+
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.isDragging) {
 			this.startErasing(info)
@@ -89,12 +95,10 @@ export class Pointing extends StateNode {
 			this.editor.deleteShapes(erasingShapeIds)
 		}
 
-		this.editor.setErasingShapes([])
 		this.parent.transition('idle')
 	}
 
 	cancel() {
-		this.editor.setErasingShapes([])
 		this.parent.transition('idle')
 	}
 }


### PR DESCRIPTION
This PR fixes shapes getting stuck in the 'erasing' state.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

See: https://github.com/tldraw/tldraw/issues/4860

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with shapes getting stuck in the translucent erasing state. 