### PR TITLE
Examples changes

### DIFF
--- a/apps/examples/src/examples.tsx
+++ b/apps/examples/src/examples.tsx
@@ -27,10 +27,6 @@ type Category =
 const getExamplesForCategory = (category: Category) =>
 	(Object.values(import.meta.glob('./examples/*/README.md', { eager: true })) as Example[])
 		.filter((e) => e.category === category)
-		.map((example) => ({
-			...example,
-			priority: example.priority ?? 5,
-		}))
 		.sort((a, b) => {
 			if (a.priority === b.priority) return a.title.localeCompare(b.title)
 			return a.priority - b.priority

--- a/apps/examples/src/examples.tsx
+++ b/apps/examples/src/examples.tsx
@@ -27,6 +27,10 @@ type Category =
 const getExamplesForCategory = (category: Category) =>
 	(Object.values(import.meta.glob('./examples/*/README.md', { eager: true })) as Example[])
 		.filter((e) => e.category === category)
+		.map((example) => ({
+			...example,
+			priority: example.priority ?? 5,
+		}))
 		.sort((a, b) => {
 			if (a.priority === b.priority) return a.title.localeCompare(b.title)
 			return a.priority - b.priority

--- a/apps/examples/src/examples/add-tool-to-toolbar/README.md
+++ b/apps/examples/src/examples/add-tool-to-toolbar/README.md
@@ -2,7 +2,7 @@
 title: Add a tool to the Toolbar
 component: ./ToolInToolbarExample.tsx
 category: ui
-priority: 1
+priority: 2
 keyword: [override, custom, icon]
 ---
 

--- a/apps/examples/src/examples/custom-ui/README.md
+++ b/apps/examples/src/examples/custom-ui/README.md
@@ -10,4 +10,4 @@ Replace tldraw's UI with your own.
 
 ---
 
-This UI has keyboard shortcuts and buttons for selecting tools.
+This UI has keyboard shortcuts and buttons for selecting tools. If you want to see the editor methods associated with every part of the ui, check out the ui events example.

--- a/apps/examples/src/examples/event-blocker/README.md
+++ b/apps/examples/src/examples/event-blocker/README.md
@@ -2,6 +2,7 @@
 title: Blocking events
 component: ./EventBlockerExample.tsx
 category: ui
+priority: 3
 keywords:
   - event
   - block

--- a/apps/examples/src/examples/external-ui-context/README.md
+++ b/apps/examples/src/examples/external-ui-context/README.md
@@ -2,6 +2,7 @@
 title: External UI (Context)
 component: ./ExternalUiContextExample.tsx
 category: ui
+priority: 2
 keywords: [outside, editor, context]
 ---
 

--- a/apps/examples/src/examples/external-ui/README.md
+++ b/apps/examples/src/examples/external-ui/README.md
@@ -2,6 +2,7 @@
 title: External UI
 component: ./ExternalUiExample.tsx
 category: ui
+priority: 2
 keywords: [outside, editor]
 ---
 

--- a/apps/examples/src/examples/layer-panel/README.md
+++ b/apps/examples/src/examples/layer-panel/README.md
@@ -2,6 +2,7 @@
 title: Layer Panel
 component: ./LayerPanelExample.tsx
 category: ui
+priority: 3
 keywords: []
 ---
 

--- a/apps/examples/src/examples/ui-events/README.md
+++ b/apps/examples/src/examples/ui-events/README.md
@@ -1,12 +1,12 @@
 ---
-title: Code x-ray for UI events
+title: UI events
 component: ./UiEventsExample.tsx
 category: editor-api
 priority: 0
-keywords: []
+keywords: [ui, events, api, x-ray]
 ---
 
-Listen to events from tldraw's UI.
+Useful if you want to build a custom ui. See which editor methods are triggered by ui events.
 
 ---
 


### PR DESCRIPTION
Various improvements to ordering and labelling of examples in the docs site, based on a conversation I had in the discord. Now, useful and important examples are being surfaced more optimally in the docs site.

This PR makes a few changes:

- Changes the title of the code x-ray example
- Adds tags for the code x-ray example
- References the code x-ray example from the custom ui example
- Adds priority fields to some of the examples
- Adds a default priority of 5 when sorting examples

For the future we might consider a lint rule to ensure all examples have tags and priority set.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

### Release notes

- Improved examples naming, tags and priority