### PR TITLE
fonts: fix up preconnect in index.html

### DIFF
--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -73,8 +73,8 @@
 		<meta name="msapplication-tap-highlight" content="no" />
 
 		<!-- $PRELOADED_FONTS -->
-		<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:url" content="https://www.tldraw.com/" />


### PR DESCRIPTION
Reverting a bit of https://github.com/tldraw/tldraw/pull/4842
Have to have the CORS headers match.

<img width="1495" alt="Screenshot 2024-11-06 at 15 45 16" src="https://github.com/user-attachments/assets/c73137f3-b660-49b3-9642-4b0b015a27f8">


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
