### PR TITLE
dotcom: use Inter font via a <link> for better Cloudflare optimization

### DIFF
--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -73,8 +73,9 @@
 		<meta name="msapplication-tap-highlight" content="no" />
 
 		<!-- $PRELOADED_FONTS -->
-		
-    <link rel="stylesheet"
+
+		<link
+			rel="stylesheet"
 			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
 		/>
 

--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -73,8 +73,10 @@
 		<meta name="msapplication-tap-highlight" content="no" />
 
 		<!-- $PRELOADED_FONTS -->
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		
+    <link rel="stylesheet"
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+		/>
 
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:url" content="https://www.tldraw.com/" />

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import url('tldraw/tldraw.css');
 
 .tldraw__editor {


### PR DESCRIPTION
talked with @SomeHats about this, following this PR: https://github.com/tldraw/tldraw/pull/4870
we're gonna turn on the Cloudflare optimization after this: https://developers.cloudflare.com/speed/optimization/content/fonts/
(Cloudflare wasn't doing the optimization correctly because we were using `@import` and it was stripping out the `preconnect` from the HTML on-demand)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
