### PR TITLE
Snap to grid when creating shapes

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1908,6 +1908,9 @@ export interface MatModel {
 }
 
 // @public
+export function maybeSnapToGrid(point: Vec, editor: Editor): Vec;
+
+// @public
 export function MenuClickCapture(): false | JSX_2.Element;
 
 // @internal (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -192,6 +192,7 @@ export { GroupShapeUtil } from './lib/editor/shapes/group/GroupShapeUtil'
 export { getPerfectDashProps } from './lib/editor/shapes/shared/getPerfectDashProps'
 export { resizeBox, type ResizeBoxOptions } from './lib/editor/shapes/shared/resizeBox'
 export { BaseBoxShapeTool } from './lib/editor/tools/BaseBoxShapeTool/BaseBoxShapeTool'
+export { maybeSnapToGrid } from './lib/editor/tools/BaseBoxShapeTool/children/Pointing'
 export { StateNode, type TLStateNodeConstructor } from './lib/editor/tools/StateNode'
 export {
 	useDelaySvgExport,

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -143,6 +143,6 @@ export class Pointing extends StateNode {
 export function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
 	const isGridMode = editor.getInstanceState().isGridMode
 	const gridSize = editor.getDocumentSettings().gridSize
-	if (isGridMode) return point.snapToGrid(gridSize)
-	return point
+	if (isGridMode) return point.clone().snapToGrid(gridSize)
+	return point.clone()
 }

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -1,6 +1,7 @@
 import { TLShape, createShapeId } from '@tldraw/tlschema'
 import { structuredClone } from '@tldraw/utils'
 import { Vec } from '../../../../primitives/Vec'
+import { Editor } from '../../../Editor'
 import { TLBaseBoxShape } from '../../../shapes/BaseBoxShapeUtil'
 import { TLPointerEventInfo } from '../../../types/event-types'
 import { StateNode } from '../../StateNode'
@@ -108,8 +109,9 @@ export class Pointing extends StateNode {
 		}
 
 		const next = structuredClone(shape)
-		next.x = shape.x - delta.x
-		next.y = shape.y - delta.y
+		const newPoint = maybeSnapToGrid(new Vec(shape.x - delta.x, shape.y - delta.y), this.editor)
+		next.x = newPoint.x
+		next.y = newPoint.y
 		next.props.w = w
 		next.props.h = h
 
@@ -131,4 +133,11 @@ export class Pointing extends StateNode {
 	cancel() {
 		this.parent.transition('idle')
 	}
+}
+
+function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
+	const isGridMode = editor.getInstanceState().isGridMode
+	const gridSize = editor.getDocumentSettings().gridSize
+	if (isGridMode) return point.snapToGrid(gridSize)
+	return point
 }

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -135,7 +135,12 @@ export class Pointing extends StateNode {
 	}
 }
 
-function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
+/**
+ * Checks if grid mode is enabled and snaps a point to the grid if so
+ *
+ * @public
+ */
+export function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
 	const isGridMode = editor.getInstanceState().isGridMode
 	const gridSize = editor.getDocumentSettings().gridSize
 	if (isGridMode) return point.snapToGrid(gridSize)

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -19,14 +19,14 @@ export class Pointing extends StateNode {
 			const id = createShapeId()
 
 			const creatingMarkId = this.editor.markHistoryStoppingPoint(`creating_box:${id}`)
-
+			const newPoint = maybeSnapToGrid(originPagePoint, this.editor)
 			this.editor
 				.createShapes<TLBaseBoxShape>([
 					{
 						id,
 						type: shapeType,
-						x: originPagePoint.x,
-						y: originPagePoint.y,
+						x: newPoint.x,
+						y: newPoint.y,
 						props: {
 							w: 1,
 							h: 1,

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -19,6 +19,7 @@ import {
 	fetch,
 	getHashForBuffer,
 	getHashForString,
+	maybeSnapToGrid,
 } from '@tldraw/editor'
 import { EmbedDefinition } from './defaultEmbedDefinitions'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
@@ -586,6 +587,7 @@ export async function createShapesForAssets(
 
 		// Re-position shapes so that the center of the group is at the provided point
 		centerSelectionAroundPoint(editor, position)
+		maybeSnapSelectionToGrid(editor)
 	})
 
 	return partials.map((p) => p.id)
@@ -628,6 +630,29 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 	if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {
 		editor.zoomToSelection({ animation: { duration: editor.options.animationMediumMs } })
 	}
+}
+
+function maybeSnapSelectionToGrid(editor: Editor) {
+	const selectionPageBounds = editor.getSelectionPageBounds()
+	if (!selectionPageBounds) return
+	const topLeft = new Vec(selectionPageBounds.minX, selectionPageBounds.minY)
+	const newPoint = maybeSnapToGrid(topLeft, editor)
+	const delta = topLeft.sub(newPoint)
+
+	if (delta.equals(new Vec(0, 0))) return
+
+	editor.updateShapes(
+		editor.getSelectedShapes().map((shape) => {
+			const localRotation = editor.getShapeParentTransform(shape).decompose().rotation
+			const localDelta = Vec.Rot(delta, -localRotation)
+			return {
+				id: shape.id,
+				type: shape.type,
+				x: shape.x! - localDelta.x,
+				y: shape.y! - localDelta.y,
+			}
+		})
+	)
 }
 
 export function createEmptyBookmarkShape(

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -622,7 +622,25 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 			})
 		)
 	}
-
+	selectionPageBounds = editor.getSelectionPageBounds()
+	// align selection with the grid if necessary
+	if (selectionPageBounds && editor.getInstanceState().isGridMode) {
+		const gridSize = editor.getDocumentSettings().gridSize
+		const topLeft = new Vec(selectionPageBounds.minX, selectionPageBounds.minY)
+		const gridSnappedPoint = topLeft.clone().snapToGrid(gridSize)
+		const delta = Vec.Sub(topLeft, gridSnappedPoint)
+		editor.updateShapes(
+			editor.getSelectedShapes().map((shape) => {
+				const newPoint = { x: shape.x! - delta.x, y: shape.y! - delta.y }
+				return {
+					id: shape.id,
+					type: shape.type,
+					x: newPoint.x,
+					y: newPoint.y,
+				}
+			})
+		)
+	}
 	// Zoom out to fit the shapes, if necessary
 	selectionPageBounds = editor.getSelectionPageBounds()
 	if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -19,7 +19,6 @@ import {
 	fetch,
 	getHashForBuffer,
 	getHashForString,
-	maybeSnapToGrid,
 } from '@tldraw/editor'
 import { EmbedDefinition } from './defaultEmbedDefinitions'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
@@ -587,7 +586,6 @@ export async function createShapesForAssets(
 
 		// Re-position shapes so that the center of the group is at the provided point
 		centerSelectionAroundPoint(editor, position)
-		maybeSnapSelectionToGrid(editor)
 	})
 
 	return partials.map((p) => p.id)
@@ -630,29 +628,6 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 	if (selectionPageBounds && !viewportPageBounds.contains(selectionPageBounds)) {
 		editor.zoomToSelection({ animation: { duration: editor.options.animationMediumMs } })
 	}
-}
-
-function maybeSnapSelectionToGrid(editor: Editor) {
-	const selectionPageBounds = editor.getSelectionPageBounds()
-	if (!selectionPageBounds) return
-	const topLeft = new Vec(selectionPageBounds.minX, selectionPageBounds.minY)
-	const newPoint = maybeSnapToGrid(topLeft, editor)
-	const delta = topLeft.sub(newPoint)
-
-	if (delta.equals(new Vec(0, 0))) return
-
-	editor.updateShapes(
-		editor.getSelectedShapes().map((shape) => {
-			const localRotation = editor.getShapeParentTransform(shape).decompose().rotation
-			const localDelta = Vec.Rot(delta, -localRotation)
-			return {
-				id: shape.id,
-				type: shape.type,
-				x: shape.x! - localDelta.x,
-				y: shape.y! - localDelta.y,
-			}
-		})
-	)
 }
 
 export function createEmptyBookmarkShape(

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -36,6 +36,7 @@ import {
 } from '@tldraw/editor'
 import React from 'react'
 import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
+import { maybeSnapToGrid } from '../../utils/shapes/shapes'
 import { ShapeFill } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'
@@ -253,10 +254,10 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		if (!target) {
 			// todo: maybe double check that this isn't equal to the other handle too?
 			removeArrowBinding(this.editor, shape, handleId)
-
+			const newPoint = maybeSnapToGrid(new Vec(handle.x, handle.y), this.editor)
 			update.props![handleId] = {
-				x: handle.x,
-				y: handle.y,
+				x: newPoint.x,
+				y: newPoint.y,
 			}
 			return update
 		}

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -26,6 +26,7 @@ import {
 	getPerfectDashProps,
 	lerp,
 	mapObjectMapValues,
+	maybeSnapToGrid,
 	structuredClone,
 	toDomPrecision,
 	track,
@@ -36,7 +37,7 @@ import {
 } from '@tldraw/editor'
 import React from 'react'
 import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
-import { maybeSnapToGrid } from '../../utils/shapes/shapes'
+
 import { ShapeFill } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'
 import { TextLabel } from '../shared/TextLabel'

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -1,5 +1,4 @@
-import { StateNode, TLArrowShape, createShapeId } from '@tldraw/editor'
-import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
+import { StateNode, TLArrowShape, createShapeId, maybeSnapToGrid } from '@tldraw/editor'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.ts
@@ -1,4 +1,5 @@
 import { StateNode, TLArrowShape, createShapeId } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -90,12 +91,12 @@ export class Pointing extends StateNode {
 		const id = createShapeId()
 
 		this.markId = this.editor.markHistoryStoppingPoint(`creating_arrow:${id}`)
-
+		const newPoint = maybeSnapToGrid(originPagePoint, this.editor)
 		this.editor.createShape<TLArrowShape>({
 			id,
 			type: 'arrow',
-			x: originPagePoint.x,
-			y: originPagePoint.y,
+			x: newPoint.x,
+			y: newPoint.y,
 			props: {
 				scale: this.editor.user.getIsDynamicResizeMode() ? 1 / this.editor.getZoomLevel() : 1,
 			},

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -5,8 +5,8 @@ import {
 	TLPointerEventInfo,
 	Vec,
 	createShapeId,
+	maybeSnapToGrid,
 } from '@tldraw/editor'
-import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -6,6 +6,7 @@ import {
 	Vec,
 	createShapeId,
 } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -102,13 +103,13 @@ export class Pointing extends StateNode {
 		const delta = new Vec(w / 2, h / 2).mul(scale)
 		const parentTransform = this.editor.getShapeParentTransform(shape)
 		if (parentTransform) delta.rot(-parentTransform.rotation())
-
+		const newPoint = maybeSnapToGrid(new Vec(shape.x - delta.x, shape.y - delta.y), this.editor)
 		this.editor.select(id)
 		this.editor.updateShape<TLGeoShape>({
 			id: shape.id,
 			type: 'geo',
-			x: shape.x - delta.x,
-			y: shape.y - delta.y,
+			x: newPoint.x,
+			y: newPoint.y,
 			props: {
 				geo: this.editor.getStyleForNextShape(GeoShapeGeoStyle),
 				w: w * scale,

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -22,14 +22,14 @@ export class Pointing extends StateNode {
 			const id = createShapeId()
 
 			const creatingMarkId = this.editor.markHistoryStoppingPoint(`creating_geo:${id}`)
-
+			const newPoint = maybeSnapToGrid(originPagePoint, this.editor)
 			this.editor
 				.createShapes<TLGeoShape>([
 					{
 						id,
 						type: 'geo',
-						x: originPagePoint.x,
-						y: originPagePoint.y,
+						x: newPoint.x,
+						y: newPoint.y,
 						props: {
 							w: 1,
 							h: 1,

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -21,10 +21,10 @@ import {
 	lineShapeMigrations,
 	lineShapeProps,
 	mapObjectMapValues,
+	maybeSnapToGrid,
 	sortByIndex,
 } from '@tldraw/editor'
 
-import { maybeSnapToGrid } from '../../utils/shapes/shapes'
 import { STROKE_SIZES } from '../arrow/shared'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 import { getLineDrawPath, getLineIndicatorPath } from './components/getLinePath'

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -24,6 +24,7 @@ import {
 	sortByIndex,
 } from '@tldraw/editor'
 
+import { maybeSnapToGrid } from '../../utils/shapes/shapes'
 import { STROKE_SIZES } from '../arrow/shared'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 import { getLineDrawPath, getLineIndicatorPath } from './components/getLinePath'
@@ -147,14 +148,14 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	override onHandleDrag(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>) {
 		// we should only ever be dragging vertex handles
 		if (handle.type !== 'vertex') return
-
+		const newPoint = maybeSnapToGrid(new Vec(handle.x, handle.y), this.editor)
 		return {
 			...shape,
 			props: {
 				...shape.props,
 				points: {
 					...shape.props.points,
-					[handle.id]: { id: handle.id, index: handle.index, x: handle.x, y: handle.y },
+					[handle.id]: { id: handle.id, index: handle.index, x: newPoint.x, y: newPoint.y },
 				},
 			},
 		}

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -10,6 +10,7 @@ import {
 	sortByIndex,
 	structuredClone,
 } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 const MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES = 2
 
@@ -45,8 +46,8 @@ export class Pointing extends StateNode {
 				this.editor.getShapeParentTransform(this.shape)!,
 				new Vec(this.shape.x, this.shape.y)
 			)
-
-			const nextPoint = Vec.Sub(currentPagePoint, shapePagePoint).addXY(0.1, 0.1)
+			const nudgedPoint = Vec.Sub(currentPagePoint, shapePagePoint).addXY(0.1, 0.1)
+			const nextPoint = maybeSnapToGrid(nudgedPoint, this.editor)
 			const points = structuredClone(this.shape.props.points)
 
 			if (
@@ -85,12 +86,13 @@ export class Pointing extends StateNode {
 
 			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${id}`)
 
+			const newPoint = maybeSnapToGrid(currentPagePoint, this.editor)
 			this.editor.createShapes<TLLineShape>([
 				{
 					id,
 					type: 'line',
-					x: currentPagePoint.x,
-					y: currentPagePoint.y,
+					x: newPoint.x,
+					y: newPoint.y,
 					props: {
 						scale: this.editor.user.getIsDynamicResizeMode() ? 1 / this.editor.getZoomLevel() : 1,
 					},

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -7,10 +7,10 @@ import {
 	createShapeId,
 	getIndexAbove,
 	last,
+	maybeSnapToGrid,
 	sortByIndex,
 	structuredClone,
 } from '@tldraw/editor'
-import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 const MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES = 2
 
@@ -46,6 +46,7 @@ export class Pointing extends StateNode {
 				this.editor.getShapeParentTransform(this.shape)!,
 				new Vec(this.shape.x, this.shape.y)
 			)
+			// nudge the point slightly to avoid zero-length lines
 			const nudgedPoint = Vec.Sub(currentPagePoint, shapePagePoint).addXY(0.1, 0.1)
 			const nextPoint = maybeSnapToGrid(nudgedPoint, this.editor)
 			const points = structuredClone(this.shape.props.points)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
@@ -133,7 +133,7 @@ describe('When in the pointing state', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(1)
 	})
 
-	it('Creates a frame and returns to frame.idle on pointer up if tool lock is enabled', () => {
+	it('Creates a note and returns to note.idle on pointer up if tool lock is enabled', () => {
 		editor.updateInstanceState({ isToolLocked: true })
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 		editor.setCurrentTool('note')
@@ -144,7 +144,7 @@ describe('When in the pointing state', () => {
 	})
 })
 
-describe('Grid placement helpers', () => {
+describe('Adjacent note position helpers (sticky pits)', () => {
 	it('Creates a new sticky note outside of a sticky pit', () => {
 		editor.createShape({ type: 'note', x: 0, y: 0 })
 
@@ -270,5 +270,24 @@ describe('Grid placement helpers', () => {
 				y: 320,
 			})
 			.undo()
+	})
+	it('Prefers snapping to adjacent note position over the grid', () => {
+		editor.updateInstanceState({ isGridMode: true })
+
+		editor.createShape({ type: 'note', x: 2, y: 0 })
+
+		const pit = { x: 322, y: 100 }
+
+		editor
+			.setCurrentTool('note')
+			.pointerDown(0, 0)
+			.pointerMove(pit.x, pit.y)
+			.pointerUp()
+			.expectShapeToMatch({
+				...editor.getLastCreatedShape(),
+				x: pit.x - 100,
+				y: pit.y - 100,
+			})
+		expect(editor.getLastCreatedShape().x).not.toBe(220)
 	})
 })

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -6,8 +6,9 @@ import {
 	TLShapeId,
 	Vec,
 	createShapeId,
+	maybeSnapToGrid,
 } from '@tldraw/editor'
-import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
+
 import {
 	NOTE_ADJACENT_POSITION_SNAP_RADIUS,
 	getAvailableNoteAdjacentPositions,

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -7,6 +7,7 @@ import {
 	Vec,
 	createShapeId,
 } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 import {
 	NOTE_ADJACENT_POSITION_SNAP_RADIUS,
 	getAvailableNoteAdjacentPositions,
@@ -110,12 +111,13 @@ export function getNoteShapeAdjacentPositionOffset(editor: Editor, center: Vec, 
 }
 
 export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
+	const newPoint = maybeSnapToGrid(center, editor)
 	editor
 		.createShape({
 			id,
 			type: 'note',
-			x: center.x,
-			y: center.y,
+			x: newPoint.x,
+			y: newPoint.y,
 			props: {
 				scale: editor.user.getIsDynamicResizeMode() ? 1 / editor.getZoomLevel() : 1,
 			},

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -6,6 +6,7 @@ import {
 	Vec,
 	createShapeId,
 	isShapeId,
+	maybeSnapToGrid,
 } from '@tldraw/editor'
 
 export class Pointing extends StateNode {
@@ -169,22 +170,22 @@ export class Pointing extends StateNode {
 			delta.rot(-transform.rotation())
 		}
 
-		this.editor.updateShape({
-			...shape,
-			x: shape.x + delta.x,
-			y: shape.y + delta.y,
-		})
-
+		const shapeX = shape.x + delta.x
+		const shapeY = shape.y + delta.y
 		if (this.editor.getInstanceState().isGridMode) {
-			const newShape = this.editor.getShape(shape) as TLTextShape
-			const gridSize = this.editor.getDocumentSettings().gridSize
-			const topLeft = new Vec(newShape.x, newShape.y)
-			const gridSnappedPoint = topLeft.clone().snapToGrid(gridSize)
+			const topLeft = new Vec(shapeX, shapeY)
+			const gridSnappedPoint = maybeSnapToGrid(topLeft, this.editor)
 			const gridDelta = Vec.Sub(topLeft, gridSnappedPoint)
 			this.editor.updateShape({
-				...newShape,
-				x: newShape.x - gridDelta.x,
-				y: newShape.y - gridDelta.y,
+				...shape,
+				x: shapeX - gridDelta.x,
+				y: shapeY - gridDelta.y,
+			})
+		} else {
+			this.editor.updateShape({
+				...shape,
+				x: shapeX,
+				y: shapeY,
 			})
 		}
 

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -7,7 +7,6 @@ import {
 	createShapeId,
 	isShapeId,
 } from '@tldraw/editor'
-import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -169,12 +168,22 @@ export class Pointing extends StateNode {
 			const transform = this.editor.getShapeParentTransform(shape)
 			delta.rot(-transform.rotation())
 		}
-		const newPoint = maybeSnapToGrid(new Vec(shape.x, shape.y), this.editor)
-		this.editor.updateShape({
-			...shape,
-			x: newPoint.x,
-			y: newPoint.y,
-		})
+		const isGridMode = this.editor.getInstanceState().isGridMode
+		if (isGridMode) {
+			const gridSize = this.editor.getDocumentSettings().gridSize
+			const newPoint = new Vec(shape.x, shape.y).snapToGrid(gridSize)
+			this.editor.updateShape({
+				...shape,
+				x: newPoint.x,
+				y: newPoint.y,
+			})
+		} else {
+			this.editor.updateShape({
+				...shape,
+				x: shape.x + delta.x,
+				y: shape.y + delta.y,
+			})
+		}
 
 		return shape
 	}

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -7,6 +7,7 @@ import {
 	createShapeId,
 	isShapeId,
 } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -120,11 +121,12 @@ export class Pointing extends StateNode {
 	}
 
 	private createTextShape(id: TLShapeId, point: Vec, autoSize: boolean, width: number) {
+		const newPoint = maybeSnapToGrid(point, this.editor)
 		this.editor.createShape<TLTextShape>({
 			id,
 			type: 'text',
-			x: point.x,
-			y: point.y,
+			x: newPoint.x,
+			y: newPoint.y,
 			props: {
 				text: '',
 				autoSize,

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -168,20 +168,23 @@ export class Pointing extends StateNode {
 			const transform = this.editor.getShapeParentTransform(shape)
 			delta.rot(-transform.rotation())
 		}
-		const isGridMode = this.editor.getInstanceState().isGridMode
-		if (isGridMode) {
+
+		this.editor.updateShape({
+			...shape,
+			x: shape.x + delta.x,
+			y: shape.y + delta.y,
+		})
+
+		if (this.editor.getInstanceState().isGridMode) {
+			const newShape = this.editor.getShape(shape) as TLTextShape
 			const gridSize = this.editor.getDocumentSettings().gridSize
-			const newPoint = new Vec(shape.x, shape.y).snapToGrid(gridSize)
+			const topLeft = new Vec(newShape.x, newShape.y)
+			const gridSnappedPoint = topLeft.clone().snapToGrid(gridSize)
+			const gridDelta = Vec.Sub(topLeft, gridSnappedPoint)
 			this.editor.updateShape({
-				...shape,
-				x: newPoint.x,
-				y: newPoint.y,
-			})
-		} else {
-			this.editor.updateShape({
-				...shape,
-				x: shape.x + delta.x,
-				y: shape.y + delta.y,
+				...newShape,
+				x: newShape.x - gridDelta.x,
+				y: newShape.y - gridDelta.y,
 			})
 		}
 

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -1,6 +1,4 @@
 import {
-	Box,
-	Editor,
 	StateNode,
 	TLPointerEventInfo,
 	TLShapeId,
@@ -9,6 +7,7 @@ import {
 	createShapeId,
 	isShapeId,
 } from '@tldraw/editor'
+import { maybeSnapToGrid } from '../../../utils/shapes/shapes'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
@@ -170,7 +169,7 @@ export class Pointing extends StateNode {
 			const transform = this.editor.getShapeParentTransform(shape)
 			delta.rot(-transform.rotation())
 		}
-		const newPoint = maybeSnapTextToGrid(new Vec(shape.x, shape.y), this.editor, bounds)
+		const newPoint = maybeSnapToGrid(new Vec(shape.x, shape.y), this.editor)
 		this.editor.updateShape({
 			...shape,
 			x: newPoint.x,
@@ -179,23 +178,4 @@ export class Pointing extends StateNode {
 
 		return shape
 	}
-}
-
-function maybeSnapTextToGrid(point: Vec, editor: Editor, bounds: Box) {
-	const isGridMode = editor.getInstanceState().isGridMode
-	const gridSize = editor.getDocumentSettings().gridSize
-	const topLeft = new Vec(bounds.x, bounds.y)
-	editor.createShape({ type: 'geo', x: topLeft.x, y: topLeft.y, props: { h: 1, w: 1 } })
-	if (isGridMode) {
-		const snappedPoint = topLeft.clone().snapToGrid(gridSize)
-
-		const deltaX = snappedPoint.x - topLeft.x
-		const deltaY = snappedPoint.y - topLeft.y
-
-		const adjustedPoint = new Vec(point.x + deltaX, point.y + deltaY)
-		console.log({ deltaX, deltaY })
-		return adjustedPoint
-	}
-
-	return point
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -502,7 +502,6 @@ export function moveShapesToPoint({
 
 	// we don't want to snap to the grid if we're holding the ctrl key, if we've already snapped into a pit, or if we're showing snapping indicators
 	const snapIndicators = editor.snaps.getIndicators()
-	console.log(snapIndicators)
 	if (isGridMode && !inputs.ctrlKey && !snappedToPit && snapIndicators.length === 0) {
 		averageSnappedPoint.snapToGrid(gridSize)
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -459,6 +459,7 @@ export function moveShapesToPoint({
 
 	// If the user isn't moving super quick
 	const isSnapping = editor.user.getIsSnapMode() ? !inputs.ctrlKey : inputs.ctrlKey
+	let snappedToPit = false
 	if (isSnapping && editor.inputs.pointerVelocity.len() < 0.5) {
 		// snapping
 		const { nudge } = editor.snaps.shapeBounds.snapTranslateShapes({
@@ -487,6 +488,8 @@ export function moveShapesToPoint({
 				const deltaToPit = Vec.Sub(pageCenter, pit)
 				const dist = deltaToPit.len()
 				if (dist < min) {
+					console.log('in a pit')
+					snappedToPit = true
 					min = dist
 					offset = deltaToPit
 				}
@@ -498,7 +501,7 @@ export function moveShapesToPoint({
 
 	const averageSnappedPoint = Vec.Add(averagePagePoint, delta)
 
-	if (isGridMode && !inputs.ctrlKey) {
+	if (isGridMode && !inputs.ctrlKey && !snappedToPit) {
 		averageSnappedPoint.snapToGrid(gridSize)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -500,7 +500,10 @@ export function moveShapesToPoint({
 
 	const averageSnappedPoint = Vec.Add(averagePagePoint, delta)
 
-	if (isGridMode && !inputs.ctrlKey && !snappedToPit) {
+	// we don't want to snap to the grid if we're holding the ctrl key, if we've already snapped into a pit, or if we're showing snapping indicators
+	const snapIndicators = editor.snaps.getIndicators()
+	console.log(snapIndicators)
+	if (isGridMode && !inputs.ctrlKey && !snappedToPit && snapIndicators.length === 0) {
 		averageSnappedPoint.snapToGrid(gridSize)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -488,7 +488,6 @@ export function moveShapesToPoint({
 				const deltaToPit = Vec.Sub(pageCenter, pit)
 				const dist = deltaToPit.len()
 				if (dist < min) {
-					console.log('in a pit')
 					snappedToPit = true
 					min = dist
 					offset = deltaToPit

--- a/packages/tldraw/src/lib/utils/shapes/shapes.ts
+++ b/packages/tldraw/src/lib/utils/shapes/shapes.ts
@@ -1,4 +1,4 @@
-import { Editor, Geometry2d, Group2d, Vec } from '@tldraw/editor'
+import { Geometry2d, Group2d } from '@tldraw/editor'
 
 /**
  * Return all the text labels in a geometry.
@@ -17,11 +17,4 @@ export function getTextLabels(geometry: Geometry2d) {
 	}
 
 	return []
-}
-
-export function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
-	const isGridMode = editor.getInstanceState().isGridMode
-	const gridSize = editor.getDocumentSettings().gridSize
-	if (isGridMode) return point.snapToGrid(gridSize)
-	return point
 }

--- a/packages/tldraw/src/lib/utils/shapes/shapes.ts
+++ b/packages/tldraw/src/lib/utils/shapes/shapes.ts
@@ -1,4 +1,4 @@
-import { Geometry2d, Group2d } from '@tldraw/editor'
+import { Editor, Geometry2d, Group2d, Vec } from '@tldraw/editor'
 
 /**
  * Return all the text labels in a geometry.
@@ -17,4 +17,11 @@ export function getTextLabels(geometry: Geometry2d) {
 	}
 
 	return []
+}
+
+export function maybeSnapToGrid(point: Vec, editor: Editor): Vec {
+	const isGridMode = editor.getInstanceState().isGridMode
+	const gridSize = editor.getDocumentSettings().gridSize
+	if (isGridMode) return point.snapToGrid(gridSize)
+	return point
 }

--- a/packages/tldraw/src/test/grid-align-on-create.test.ts
+++ b/packages/tldraw/src/test/grid-align-on-create.test.ts
@@ -10,10 +10,14 @@ import { NOTE_SIZE } from '../lib/shapes/note/noteHelpers'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
+let gridSize: number
+let gridNudge: number
 
 beforeEach(() => {
 	editor = new TestEditor()
 	editor.updateInstanceState({ isGridMode: true })
+	gridSize = editor.getDocumentSettings().gridSize
+	gridNudge = gridSize / 5
 })
 const expectedPoints = {
 	a1: {
@@ -37,13 +41,20 @@ const expectedPoints = {
 }
 describe('when creating a shape...', () => {
 	it('aligns arrow points with the grid', () => {
-		editor.setCurrentTool('arrow').pointerDown(4, 4).pointerMove(32, 32).pointerUp()
+		editor
+			.setCurrentTool('arrow')
+			.pointerDown(0 + gridNudge, 0 + gridNudge)
+			.pointerMove(30 + gridNudge, 30 + gridNudge)
+			.pointerUp()
 		const shape = editor.selectAll().getOnlySelectedShape() as TLArrowShape
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: 0, y: 0 })
 		expect(shape.props.end).toMatchObject({ x: 30, y: 30 })
 	})
 	it('aligns base box shapes with the grid', () => {
-		editor.setCurrentTool('frame').pointerDown(4, 4).pointerUp()
+		editor
+			.setCurrentTool('frame')
+			.pointerDown(0 + gridNudge, 0 + gridNudge)
+			.pointerUp()
 		const shape = editor.getLastCreatedShape() as TLFrameShape
 		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
 		expect({ x: shape.x, y: shape.y }).toMatchObject({
@@ -52,7 +63,10 @@ describe('when creating a shape...', () => {
 		})
 	})
 	it('aligns geo shapes with the grid', () => {
-		editor.setCurrentTool('geo').pointerDown(4, 4).pointerUp()
+		editor
+			.setCurrentTool('geo')
+			.pointerDown(0 + gridNudge, 0 + gridNudge)
+			.pointerUp()
 		const shape = editor.getLastCreatedShape() as TLGeoShape
 		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -defaultProps.w, y: -defaultProps.h })
@@ -61,12 +75,12 @@ describe('when creating a shape...', () => {
 		editor.keyDown('Shift')
 		editor
 			.setCurrentTool('line')
-			.pointerDown(4, 4)
+			.pointerDown(0 + gridNudge, 0 + gridNudge)
 			.pointerUp()
-			.pointerMove(28, 28)
+			.pointerMove(30 + gridNudge, 30 + gridNudge)
 			.pointerDown()
 			.pointerUp()
-			.pointerMove(-31, -31)
+			.pointerMove(-30 + gridNudge, -30 + gridNudge)
 			.pointerDown()
 			.pointerUp()
 		const shape = editor.getLastCreatedShape() as TLLineShape
@@ -77,15 +91,18 @@ describe('when creating a shape...', () => {
 		})
 	})
 	it('aligns notes with the grid', () => {
-		editor.setCurrentTool('note').pointerDown(4, 4).pointerUp()
+		editor
+			.setCurrentTool('note')
+			.pointerDown(0 + gridNudge, 0 + gridNudge)
+			.pointerUp()
 		const shape = editor.getLastCreatedShape() as TLNoteShape
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -NOTE_SIZE / 2, y: -NOTE_SIZE / 2 })
 	})
 	it('aligns text shapes with the grid', () => {
-		editor.setCurrentTool('text').pointerDown(4, 4).pointerUp()
+		editor.setCurrentTool('text').pointerDown(gridNudge, gridNudge).pointerUp()
 		const shape = editor.getLastCreatedShape()! as TLTextShape
 		const bounds = editor.getShapePageBounds(shape)!
-		expect(Math.abs(bounds.minX % 10)).toBe(0)
-		expect(Math.abs(bounds.minY % 10)).toBe(0)
+		expect(Math.abs(bounds.minX % gridSize)).toBe(0)
+		expect(Math.abs(bounds.minY % gridSize)).toBe(0)
 	})
 })

--- a/packages/tldraw/src/test/grid-align-on-create.test.ts
+++ b/packages/tldraw/src/test/grid-align-on-create.test.ts
@@ -1,4 +1,11 @@
-import { TLArrowShape, TLFrameShape, TLGeoShape, TLLineShape, TLNoteShape } from '@tldraw/editor'
+import {
+	TLArrowShape,
+	TLFrameShape,
+	TLGeoShape,
+	TLLineShape,
+	TLNoteShape,
+	TLTextShape,
+} from '@tldraw/editor'
 import { NOTE_SIZE } from '../lib/shapes/note/noteHelpers'
 import { TestEditor } from './TestEditor'
 
@@ -73,5 +80,10 @@ describe('when creating a shape...', () => {
 		editor.setCurrentTool('note').pointerDown(4, 4).pointerUp()
 		const shape = editor.selectAll().getOnlySelectedShape() as TLNoteShape
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -NOTE_SIZE / 2, y: -NOTE_SIZE / 2 })
+	})
+	it('aligns text shapes with the grid', () => {
+		editor.setCurrentTool('text').pointerDown(4, 4).pointerUp()
+		const shape = editor.selectAll().getOnlySelectedShape() as TLTextShape
+		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: 0, y: 0 })
 	})
 })

--- a/packages/tldraw/src/test/grid-align-on-create.test.ts
+++ b/packages/tldraw/src/test/grid-align-on-create.test.ts
@@ -37,14 +37,14 @@ const expectedPoints = {
 }
 describe('when creating a shape...', () => {
 	it('aligns arrow points with the grid', () => {
-		editor.setCurrentTool('arrow').pointerDown(4, 4).pointerMove(28, 28).pointerUp(28, 28)
+		editor.setCurrentTool('arrow').pointerDown(4, 4).pointerMove(32, 32).pointerUp()
 		const shape = editor.selectAll().getOnlySelectedShape() as TLArrowShape
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: 0, y: 0 })
 		expect(shape.props.end).toMatchObject({ x: 30, y: 30 })
 	})
 	it('aligns base box shapes with the grid', () => {
 		editor.setCurrentTool('frame').pointerDown(4, 4).pointerUp()
-		const shape = editor.selectAll().getOnlySelectedShape() as TLFrameShape
+		const shape = editor.getLastCreatedShape() as TLFrameShape
 		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
 		expect({ x: shape.x, y: shape.y }).toMatchObject({
 			x: -defaultProps.w / 2,
@@ -53,7 +53,7 @@ describe('when creating a shape...', () => {
 	})
 	it('aligns geo shapes with the grid', () => {
 		editor.setCurrentTool('geo').pointerDown(4, 4).pointerUp()
-		const shape = editor.selectAll().getOnlySelectedShape() as TLGeoShape
+		const shape = editor.getLastCreatedShape() as TLGeoShape
 		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -defaultProps.w, y: -defaultProps.h })
 	})
@@ -69,7 +69,7 @@ describe('when creating a shape...', () => {
 			.pointerMove(-31, -31)
 			.pointerDown()
 			.pointerUp()
-		const shape = editor.selectAll().getOnlySelectedShape() as TLLineShape
+		const shape = editor.getLastCreatedShape() as TLLineShape
 		expect({ x: shape.x, y: shape.y, points: shape.props.points }).toMatchObject({
 			x: 0,
 			y: 0,
@@ -78,12 +78,14 @@ describe('when creating a shape...', () => {
 	})
 	it('aligns notes with the grid', () => {
 		editor.setCurrentTool('note').pointerDown(4, 4).pointerUp()
-		const shape = editor.selectAll().getOnlySelectedShape() as TLNoteShape
+		const shape = editor.getLastCreatedShape() as TLNoteShape
 		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -NOTE_SIZE / 2, y: -NOTE_SIZE / 2 })
 	})
 	it('aligns text shapes with the grid', () => {
 		editor.setCurrentTool('text').pointerDown(4, 4).pointerUp()
-		const shape = editor.selectAll().getOnlySelectedShape() as TLTextShape
-		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: 0, y: 0 })
+		const shape = editor.getLastCreatedShape()! as TLTextShape
+		const bounds = editor.getShapePageBounds(shape)!
+		expect(Math.abs(bounds.minX % 10)).toBe(0)
+		expect(Math.abs(bounds.minY % 10)).toBe(0)
 	})
 })

--- a/packages/tldraw/src/test/grid-align-on-create.test.ts
+++ b/packages/tldraw/src/test/grid-align-on-create.test.ts
@@ -1,0 +1,77 @@
+import { TLArrowShape, TLFrameShape, TLGeoShape, TLLineShape, TLNoteShape } from '@tldraw/editor'
+import { NOTE_SIZE } from '../lib/shapes/note/noteHelpers'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.updateInstanceState({ isGridMode: true })
+})
+const expectedPoints = {
+	a1: {
+		id: 'a1',
+		index: 'a1',
+		x: 0,
+		y: 0,
+	},
+	a2: {
+		id: 'a2',
+		index: 'a2',
+		x: 30,
+		y: 30,
+	},
+	a3: {
+		id: 'a3',
+		index: 'a3',
+		x: -30,
+		y: -30,
+	},
+}
+describe('when creating a shape...', () => {
+	it('aligns arrow points with the grid', () => {
+		editor.setCurrentTool('arrow').pointerDown(4, 4).pointerMove(28, 28).pointerUp(28, 28)
+		const shape = editor.selectAll().getOnlySelectedShape() as TLArrowShape
+		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: 0, y: 0 })
+		expect(shape.props.end).toMatchObject({ x: 30, y: 30 })
+	})
+	it('aligns base box shapes with the grid', () => {
+		editor.setCurrentTool('frame').pointerDown(4, 4).pointerUp()
+		const shape = editor.selectAll().getOnlySelectedShape() as TLFrameShape
+		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
+		expect({ x: shape.x, y: shape.y }).toMatchObject({
+			x: -defaultProps.w / 2,
+			y: -defaultProps.h / 2,
+		})
+	})
+	it('aligns geo shapes with the grid', () => {
+		editor.setCurrentTool('geo').pointerDown(4, 4).pointerUp()
+		const shape = editor.selectAll().getOnlySelectedShape() as TLGeoShape
+		const defaultProps = editor.getShapeUtil(shape).getDefaultProps()
+		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -defaultProps.w, y: -defaultProps.h })
+	})
+	it('aligns line points with the grid', () => {
+		editor.keyDown('Shift')
+		editor
+			.setCurrentTool('line')
+			.pointerDown(4, 4)
+			.pointerUp()
+			.pointerMove(28, 28)
+			.pointerDown()
+			.pointerUp()
+			.pointerMove(-31, -31)
+			.pointerDown()
+			.pointerUp()
+		const shape = editor.selectAll().getOnlySelectedShape() as TLLineShape
+		expect({ x: shape.x, y: shape.y, points: shape.props.points }).toMatchObject({
+			x: 0,
+			y: 0,
+			points: expectedPoints,
+		})
+	})
+	it('aligns notes with the grid', () => {
+		editor.setCurrentTool('note').pointerDown(4, 4).pointerUp()
+		const shape = editor.selectAll().getOnlySelectedShape() as TLNoteShape
+		expect({ x: shape.x, y: shape.y }).toMatchObject({ x: -NOTE_SIZE / 2, y: -NOTE_SIZE / 2 })
+	})
+})


### PR DESCRIPTION
TLD-2817

TLD-2816

This PR makes sure that shapes snap to the grid when created. It adds a ```maybeSnapToGrid``` function, which can be used to push a shape onto the grid if grid mode is enabled, both when click-creating and when drag-creating.

1. Any shapes using the basebox shape tool (i.e frames)
2. Geo shapes
3. Both arrow handles
4. Line shapes, including shift-clicking
5. Note shapes (when translating, note shapes prefer adjacent note positions over grid)
6. Text shapes
7. Aligns uploaded assets using the top left of the selection bounds.
8. Does not snap to the grid when snap indicators are being shown

It also adds tests for this behaviour

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Enable grid
9. Click-create a note shape off the grid
10. It should snap to the grid
11. Add an asset, it should align with the grid

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Shapes snap to grid on creation, or when adding points.