### PR TITLE
Add dev website as an option.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,7 @@ body:
       options:
         - The developer package
         - The tldraw.com website
+        - The tldraw.dev website
         - The makereal.tldraw.com website
     validations:
       required: true


### PR DESCRIPTION
Updates the bug template to include the tldraw.dev website. Would help with issues like this one https://github.com/tldraw/tldraw/issues/4886

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Add tldraw.dev as an option for bug reports.