### PR TITLE
fix dev postgres setup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -30,3 +30,5 @@ apps/docs/content/reference/**/*
 apps/dotcom/client/public/**/*.*
 
 **/.clasp.json
+
+apps/dotcom/zero-cache/docker/docker-compose.yml

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -38,6 +38,9 @@ binding = "MEASURE"
 [env.dev]
 name = "dev-tldraw-multiplayer"
 
+[env.dev.vars]
+BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
+
 # we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.
 
 # staging is the same as a preview on main:

--- a/apps/dotcom/zero-cache/docker/docker-compose.yml
+++ b/apps/dotcom/zero-cache/docker/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       -c max_replication_slots=5 
       -c hot_standby=on 
       -c hot_standby_feedback=on
-      # Uncomment the following line to enable query logging
-      # -c config_file=/etc/postgresql/postgresql.conf
+#       Uncomment the following line to enable query logging
+#       -c config_file=/etc/postgresql/postgresql.conf
     volumes:
       - zstart_pgdata:/var/lib/postgresql/data
       - ./:/docker-entrypoint-initdb.d


### PR DESCRIPTION
- fix the docker-compose.yml
- add a dev var for postgres connection string so folks don't need to add it themselves in dev.vars
- [x] `other`
