### PR TITLE
Only send updates to active users

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -18,6 +18,7 @@ const seed = `
 DROP TABLE IF EXISTS file_state;
 DROP TABLE IF EXISTS file;
 DROP TABLE IF EXISTS user;
+DROP TABLE IF EXISTS active_user;
 
 CREATE TABLE user (
 	id TEXT PRIMARY KEY,
@@ -35,6 +36,10 @@ CREATE TABLE file_state (
 	fileId TEXT NOT NULL,
 	json TEXT NOT NULL,
 	PRIMARY KEY (userId, fileId)
+);
+
+CREATE TABLE active_user (
+	id TEXT PRIMARY KEY
 );
 `
 
@@ -212,7 +217,8 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				this.getStubForUser(userId).onRowChange(
 					row,
 					event.relation.table as 'user' | 'file' | 'file_state',
-					event.command
+					event.command,
+					userId
 				)
 			}
 		}
@@ -239,7 +245,12 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				if (!files.length) break
 				const file = files[0] as any
 				if (row.userId !== file.ownerId) {
-					this.getStubForUser(row.userId).onRowChange(JSON.parse(file.json), 'file', 'delete')
+					this.getStubForUser(row.userId).onRowChange(
+						JSON.parse(file.json),
+						'file',
+						'delete',
+						row.userId
+					)
 				}
 
 				break
@@ -273,7 +284,12 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				} | null
 				if (!file) break
 				if (file.ownerId !== row.userId) {
-					this.getStubForUser(row.userId).onRowChange(JSON.parse(file.json), 'file', 'insert')
+					this.getStubForUser(row.userId).onRowChange(
+						JSON.parse(file.json),
+						'file',
+						'insert',
+						row.userId
+					)
 				}
 				break
 			}
@@ -281,14 +297,17 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	}
 
 	getImpactedUserIds(row: postgres.Row, event: postgres.ReplicationEvent): string[] {
+		let result: string[] = []
+
 		switch (event.relation.table) {
 			case 'user':
 				assert(row.id, 'row id is required')
-				return [row.id as string]
+				result = [row.id as string]
+				break
 			case 'file': {
 				assert(row.id, 'row id is required')
 				const file = this.sql.exec(`SELECT * FROM file WHERE id = ?`, row.id).toArray()[0]
-				return compact(
+				result = compact(
 					uniq([
 						...(this.sql
 							.exec(
@@ -301,14 +320,22 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 						file?.ownerId as string,
 					])
 				)
+				break
 			}
 
 			case 'file_state':
 				assert(row.userId, 'user id is required')
 				assert(row.fileId, 'file id is required')
-				return [row.userId as string]
+				result = [row.userId as string]
+				break
 		}
-		return []
+		if (result.length === 0) return []
+
+		const placeholders = result.map(() => '?').join(', ')
+		return this.sql
+			.exec(`SELECT * FROM active_users WHERE id IN (${placeholders})`, ...result)
+			.toArray()
+			.map((x) => x.id as string)
 	}
 
 	updateRow(_row: postgres.Row, event: postgres.ReplicationEvent) {
@@ -382,5 +409,13 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private getStubForUser(userId: string) {
 		const id = this.env.TL_USER.idFromName(userId)
 		return this.env.TL_USER.get(id) as any as TLUserDurableObject
+	}
+
+	registerUser(userId: string) {
+		this.sql.exec(`INSERT INTO active_users (id) VALUES (?) ON CONFLICT (id) DO NOTHING`, userId)
+	}
+
+	unregisterUser(userId: string) {
+		this.sql.exec(`DELETE FROM active_users WHERE id = ?`, userId)
 	}
 }


### PR DESCRIPTION
This adds user durable object registration so that we can track which users are active and only send updates to them.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Only send updates to active users.