### PR TITLE
Make e2e tests run in sequence within a file

### DIFF
--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -14,8 +14,10 @@ import path from 'path'
  */
 export default defineConfig({
 	testDir: './e2e',
-	/* Run tests in files in parallel */
-	fullyParallel: true,
+	// Run files in parallel, but tests within a file in sequence. This is important for certain
+	// tests that use shared system resources like the clipboard, which should all be kept in the
+	// same file.
+	fullyParallel: false,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */

--- a/apps/examples/e2e/playwright.config.ts
+++ b/apps/examples/e2e/playwright.config.ts
@@ -28,8 +28,10 @@ const config: PlaywrightTestConfig = {
 			threshold: 0.01,
 		},
 	},
-	/* Run tests in files in parallel */
-	fullyParallel: true,
+	// Run files in parallel, but tests within a file in sequence. This is important for certain
+	// tests that use shared system resources like the clipboard, which should all be kept in the
+	// same file.
+	fullyParallel: false,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: false, // !!process.env.CI,
 	/* Retry on CI only */


### PR DESCRIPTION
I think this was causing flakes with clipboard tests

### Change type
- [x] `other`
