### PR TITLE
Use location hints to hopefully spawn replicator closer to the db

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -32,7 +32,7 @@ import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
 import { getAuth } from './utils/tla/getAuth'
-import { getPostgresReplicatorStub } from './utils/tla/getPostgresReplicatorStub'
+import { getPostgresReplicator } from './utils/tla/getPostgresReplicator'
 
 const MAX_CONNECTIONS = 50
 
@@ -298,7 +298,7 @@ export class TLDrawDurableObject extends DurableObject {
 
 	// this might return null if the file doesn't exist yet in the backend, or if it was deleted
 	async getAppFileRecord(): Promise<TlaFile | null> {
-		const stub = getPostgresReplicatorStub(this.env)
+		const stub = getPostgresReplicator(this.env)
 		try {
 			return await stub.getFileRecord(this.documentInfo.slug)
 		} catch (_e) {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -25,7 +25,6 @@ import { ExecutionQueue, createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { AlarmScheduler } from './AlarmScheduler'
-import type { TLPostgresReplicator } from './TLPostgresReplicator'
 import { PERSIST_INTERVAL_MS } from './config'
 import { getR2KeyForRoom } from './r2'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
@@ -33,6 +32,7 @@ import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
 import { getAuth } from './utils/tla/getAuth'
+import { getPostgresReplicatorStub } from './utils/tla/getPostgresReplicatorStub'
 
 const MAX_CONNECTIONS = 50
 
@@ -298,9 +298,7 @@ export class TLDrawDurableObject extends DurableObject {
 
 	// this might return null if the file doesn't exist yet in the backend, or if it was deleted
 	async getAppFileRecord(): Promise<TlaFile | null> {
-		const stub = this.env.TL_PG_REPLICATOR.get(
-			this.env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		const stub = getPostgresReplicatorStub(this.env)
 		try {
 			return await stub.getFileRecord(this.documentInfo.slug)
 		} catch (_e) {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -22,6 +22,7 @@ import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
 import { Environment } from './types'
 import { getCurrentSerializedRoomSnapshot } from './utils/tla/getCurrentSerializedRoomSnapshot'
+import { getPostgresReplicatorStub } from './utils/tla/getPostgresReplicatorStub'
 
 export class TLUserDurableObject extends DurableObject<Environment> {
 	db: ReturnType<typeof postgres>
@@ -41,9 +42,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		super(ctx, env)
 
 		this.sentry = createSentry(ctx, env)
-		this.replicator = this.env.TL_PG_REPLICATOR.get(
-			this.env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		this.replicator = getPostgresReplicatorStub(env)
 
 		this.db = postgres(env.BOTCOM_POSTGRES_CONNECTION_STRING)
 	}

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -22,7 +22,7 @@ import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
 import { Environment } from './types'
 import { getCurrentSerializedRoomSnapshot } from './utils/tla/getCurrentSerializedRoomSnapshot'
-import { getPostgresReplicatorStub } from './utils/tla/getPostgresReplicatorStub'
+import { getPostgresReplicator } from './utils/tla/getPostgresReplicator'
 
 export class TLUserDurableObject extends DurableObject<Environment> {
 	db: ReturnType<typeof postgres>
@@ -42,7 +42,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		super(ctx, env)
 
 		this.sentry = createSentry(ctx, env)
-		this.replicator = getPostgresReplicatorStub(env)
+		this.replicator = getPostgresReplicator(env)
 
 		this.db = postgres(env.BOTCOM_POSTGRES_CONNECTION_STRING)
 	}

--- a/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
@@ -3,7 +3,7 @@ import { RoomSnapshot } from '@tldraw/sync-core'
 import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../../r2'
 import { Environment } from '../../types'
-import { getPostgresReplicatorStub } from '../../utils/tla/getPostgresReplicatorStub'
+import { getPostgresReplicator } from '../../utils/tla/getPostgresReplicator'
 
 // Get a published file from a file's publishedSlug, if there is one.
 export async function getPublishedFile(request: IRequest, env: Environment): Promise<Response> {
@@ -17,7 +17,7 @@ export async function getPublishedFile(request: IRequest, env: Environment): Pro
 		if (!parentSlug) throw Error('not found')
 
 		console.log('parentSlug', parentSlug)
-		const replicator = getPostgresReplicatorStub(env)
+		const replicator = getPostgresReplicator(env)
 		const file = await replicator.getFileRecord(parentSlug)
 		console.log('roomId', roomId)
 

--- a/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import { RoomSnapshot } from '@tldraw/sync-core'
 import { IRequest } from 'itty-router'
-import { TLPostgresReplicator } from '../../TLPostgresReplicator'
 import { getR2KeyForRoom } from '../../r2'
 import { Environment } from '../../types'
+import { getPostgresReplicatorStub } from '../../utils/tla/getPostgresReplicatorStub'
 
 // Get a published file from a file's publishedSlug, if there is one.
 export async function getPublishedFile(request: IRequest, env: Environment): Promise<Response> {
@@ -17,10 +17,7 @@ export async function getPublishedFile(request: IRequest, env: Environment): Pro
 		if (!parentSlug) throw Error('not found')
 
 		console.log('parentSlug', parentSlug)
-
-		const replicator = env.TL_PG_REPLICATOR.get(
-			env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		const replicator = getPostgresReplicatorStub(env)
 		const file = await replicator.getFileRecord(parentSlug)
 		console.log('roomId', roomId)
 

--- a/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicator.ts
@@ -3,5 +3,6 @@ import { Environment } from '../../types'
 
 export function getPostgresReplicator(env: Environment) {
 	const id = env.TL_PG_REPLICATOR.idFromName('0')
+	// add a location hint so that the replicator lives closer to our db instance
 	return env.TL_PG_REPLICATOR.get(id, { locationHint: 'weur' }) as any as TLPostgresReplicator
 }

--- a/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicator.ts
@@ -1,7 +1,7 @@
 import { TLPostgresReplicator } from '../../TLPostgresReplicator'
 import { Environment } from '../../types'
 
-export function getPostgresReplicatorStub(env: Environment) {
+export function getPostgresReplicator(env: Environment) {
 	const id = env.TL_PG_REPLICATOR.idFromName('0')
 	return env.TL_PG_REPLICATOR.get(id, { locationHint: 'weur' }) as any as TLPostgresReplicator
 }

--- a/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicatorStub.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getPostgresReplicatorStub.ts
@@ -1,0 +1,7 @@
+import { TLPostgresReplicator } from '../../TLPostgresReplicator'
+import { Environment } from '../../types'
+
+export function getPostgresReplicatorStub(env: Environment) {
+	const id = env.TL_PG_REPLICATOR.idFromName('0')
+	return env.TL_PG_REPLICATOR.get(id, { locationHint: 'weur' }) as any as TLPostgresReplicator
+}

--- a/apps/dotcom/sync-worker/src/utils/tla/permissions.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/permissions.ts
@@ -2,19 +2,6 @@ import { IRequest } from 'itty-router'
 import { Environment } from '../../types'
 import { getAuth } from './getAuth'
 
-export type FileOwnerStatusError = 'unauthorized' | 'not-found' | 'forbidden'
-
-export function fileOwnerStatusErrorResponse(error: FileOwnerStatusError) {
-	switch (error) {
-		case 'forbidden':
-			return new Response(JSON.stringify({ error: true, message: 'Forbidden' }), { status: 403 })
-		case 'not-found':
-			return new Response(JSON.stringify({ error: true, message: 'Not found' }), { status: 404 })
-		case 'unauthorized':
-			return new Response(JSON.stringify({ error: true, message: 'Unauthorized' }), { status: 401 })
-	}
-}
-
 export async function getUserIdFromRequest(request: IRequest, env: Environment) {
 	const auth = await getAuth(request, env)
 	if (!auth) return null


### PR DESCRIPTION
Apparently the [first call ](https://developers.cloudflare.com/durable-objects/reference/data-location/#provide-a-location-hint) to `get` provides a location hint to where the DO should be located. Pulled out a helper function for getting the replicator and made all current uses go through that.

Looks like we created supabase databases in eu central, so west europe for the DO seemed best. We could [use a jurisdiction](https://developers.cloudflare.com/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) and make sure it's located in EU? (location hints are not a guarantee of the location).


We have many users in US, it might be better to move the supabase instances? OTOH having them in EU brings us closer to GDPR.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Pin 🙏  the postgres replicator close to the DB.