### PR TITLE
Fix file name when exporting a single unnamed frame

### DIFF
--- a/packages/tldraw/src/lib/utils/export/exportAs.ts
+++ b/packages/tldraw/src/lib/utils/export/exportAs.ts
@@ -28,7 +28,7 @@ export async function exportAs(
 		if (ids.length === 1) {
 			const first = editor.getShape(ids[0])!
 			if (editor.isShapeOfType<TLFrameShape>(first, 'frame')) {
-				name = first.props.name ?? 'frame'
+				name = first.props.name || 'frame'
 			} else {
 				name = `${sanitizeId(first.id)} at ${getTimestamp()}`
 			}


### PR DESCRIPTION
If you have a frame without a name, select it and export it, the name before the extension would end up as an empty string. So the final name would just be a period and the extension (e.g. `.svg`). This would cause the SVG file to be downloaded as `svg.txt` with Chrome and as just `svg` with Firefox (and equivalent for JSON files, but PNG files would be named `png.png`).

With this change they will be named `frame.<extension>` instead.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a frame, don't name it.
2. Select the frame.
3. Right click and select export as SVG or JSON.
4. Observe that the downloaded file doesn't have the correct extension before this fix.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix file name when exporting a single unnamed frame