### PR TITLE
Lazy replicator

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -52,6 +52,7 @@ export class Database {
 `.execute()
 
 			await sql`DELETE FROM public.file WHERE "ownerId" = ${id}`.execute()
+			// await fetch(`http://localhost:3000/api/app/__test__/user/${id}/reboot`)
 		} catch (e) {
 			console.error('Error', e)
 		}

--- a/apps/dotcom/client/e2e/fixtures/tla-test.ts
+++ b/apps/dotcom/client/e2e/fixtures/tla-test.ts
@@ -53,14 +53,12 @@ export const test = base.extend<TlaFixtures, TlaWorkerFixtures>({
 			// Make sure we don't get marked as a bot
 			// https://clerk.com/docs/testing/playwright/overview
 			await setupClerkTestingToken({ page })
+			await database.reset()
 
 			await homePage.goto()
 			await homePage.isLoaded()
 
 			await testUse()
-
-			// All the code after testUse is run after each test
-			await database.reset()
 		},
 		{ auto: true },
 	],

--- a/apps/dotcom/client/scripts/wait-for-docker.sh
+++ b/apps/dotcom/client/scripts/wait-for-docker.sh
@@ -7,7 +7,7 @@ for i in {1..30}; do
 		echo "Postgres is healthy"
 		break
 	fi
-	sleep 10
+	sleep 1
 done
 
 if [ "$STATUS" != "\"healthy\"" ]; then

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -270,12 +270,6 @@ export class TldrawApp {
 				...file,
 				shared: !file.shared,
 			})
-
-			// if it was shared, remove all shared links
-			// TODO: move this to the backend after read permissions are implemented
-			for (const fileState of this.getUserFileStates().filter((f) => f.fileId === fileId)) {
-				tx.file_state.delete(fileState)
-			}
 		})
 	}
 
@@ -512,6 +506,8 @@ export class TldrawApp {
 
 		const { id: _id, name: _name, color: _color, ...restOfPreferences } = getUserPreferences()
 		const app = new TldrawApp(opts.userId, opts.getToken)
+		// @ts-expect-error
+		window.app = app
 		await app.preload({
 			id: opts.userId,
 			name: opts.fullName,

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -30,7 +30,6 @@ export class Zero {
 					break
 				case 'update':
 					this.store.updateCommittedData(msg.update)
-
 					break
 				case 'commit':
 					{

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -151,17 +151,17 @@ export class Zero {
 					{
 						table: 'file_state',
 						event: 'insert',
-						row: { fileId: data.id, userId: store.user.id },
+						row: { fileId: data.id, userId: store.user.id } as any,
 					},
 				])
 			},
 			update: (data: Partial<TlaFile> & { id: TlaFile['id'] }) => {
 				const existing = this.store.getFullData()?.files.find((f) => f.id === data.id)
 				if (!existing) throw new Error('file not found')
-				this.makeOptimistic([{ table: 'file', event: 'update', row: data }])
+				this.makeOptimistic([{ table: 'file', event: 'update', row: data as any }])
 			},
 			delete: (data: { id: TlaFile['id'] }) => {
-				this.makeOptimistic([{ table: 'file', event: 'delete', row: data }])
+				this.makeOptimistic([{ table: 'file', event: 'delete', row: data as any }])
 			},
 		},
 		file_state: {
@@ -180,18 +180,18 @@ export class Zero {
 					.getFullData()
 					?.fileStates.find((f) => f.fileId === data.fileId && f.userId === data.userId)
 				if (!existing) throw new Error('file state not found')
-				this.makeOptimistic([{ table: 'file_state', event: 'update', row: data }])
+				this.makeOptimistic([{ table: 'file_state', event: 'update', row: data as any }])
 			},
 			delete: (data: { fileId: TlaFileState['fileId']; userId: TlaFileState['userId'] }) => {
-				this.makeOptimistic([{ table: 'file_state', event: 'delete', row: data }])
+				this.makeOptimistic([{ table: 'file_state', event: 'delete', row: data as any }])
 			},
 		},
 		user: {
 			create: (data: TlaUser) => {
-				this.makeOptimistic([{ table: 'user', event: 'insert', row: data }])
+				this.makeOptimistic([{ table: 'user', event: 'insert', row: data as any }])
 			},
 			update: (data: Partial<TlaUser>) => {
-				this.makeOptimistic([{ table: 'user', event: 'update', row: data }])
+				this.makeOptimistic([{ table: 'user', event: 'update', row: data as any }])
 			},
 			delete: () => {
 				throw new Error('no')

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -325,7 +325,6 @@ export class TLDrawDurableObject extends DurableObject {
 		serverWebSocket.accept()
 
 		const closeSocket = (reason: TLSyncErrorCloseEventReason) => {
-			console.error('CLOSING SOCKET', reason, new Error().stack)
 			serverWebSocket.close(TLSyncErrorCloseEventCode, reason)
 			return new Response(null, { status: 101, webSocket: clientWebSocket })
 		}

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -25,11 +25,11 @@ import { ExecutionQueue, createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { AlarmScheduler } from './AlarmScheduler'
-import type { TLPostgresReplicator } from './TLPostgresReplicator'
 import { PERSIST_INTERVAL_MS } from './config'
 import { getR2KeyForRoom } from './r2'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
 import { createSupabaseClient } from './utils/createSupabaseClient'
+import { getReplicator } from './utils/durableObjects'
 import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
@@ -299,9 +299,7 @@ export class TLDrawDurableObject extends DurableObject {
 
 	// this might return null if the file doesn't exist yet in the backend, or if it was deleted
 	async getAppFileRecord(): Promise<TlaFile | null> {
-		const stub = this.env.TL_PG_REPLICATOR.get(
-			this.env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		const stub = getReplicator(this.env)
 		try {
 			return await stub.getFileRecord(this.documentInfo.slug)
 		} catch (_e) {

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -1,4 +1,4 @@
-import { ROOM_PREFIX, TlaFile } from '@tldraw/dotcom-shared'
+import { ROOM_PREFIX, TlaFile, ZTable } from '@tldraw/dotcom-shared'
 import { assert, promiseWithResolve, sleep, uniqueId } from '@tldraw/utils'
 import { ExecutionQueue, createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
@@ -82,11 +82,11 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private debug(...args: any[]) {
 		// uncomment for dev time debugging
-		// console.log(...args)
+		// console.log('[TLPostgresReplicator]:', ...args)
 		if (this.sentry) {
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.sentry.addBreadcrumb({
-				message: args.join(' '),
+				message: `[TLPostgresReplicator]: ${args.join(' ')}`,
 			})
 		}
 	}
@@ -279,7 +279,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 					this.messageUser(userId, {
 						type: 'row_update',
 						row: row as any,
-						table: event.relation.table as 'user' | 'file' | 'file_state',
+						table: event.relation.table as ZTable,
 						event: event.command,
 						sequenceId: this.state.sequenceId,
 						userId,

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -29,6 +29,7 @@ type BootState =
 	| {
 			type: 'init'
 			promise: PromiseWithResolve
+			sequenceId: string
 	  }
 	| {
 			type: 'connecting'
@@ -48,6 +49,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	state: BootState = {
 		type: 'init',
 		promise: promiseWithResolve(),
+		sequenceId: uniqueId(),
 	}
 
 	sentry
@@ -288,7 +290,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	}
 
 	async ping() {
-		return 'pong'
+		return { sequenceId: this.state.sequenceId }
 	}
 
 	async waitUntilConnected() {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -76,7 +76,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		)
 		this.debug('cache', !!this.cache)
 		await this.cache.waitUntilConnected()
-		this.replicator.registerUser(this.userId!)
 	}
 
 	// Handle a request to the Durable Object.
@@ -160,11 +159,11 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private debug(...args: any[]) {
 		// uncomment for dev time debugging
-		// console.log(...args)
+		// console.log('[TLUserDurableObject]: ', ...args)
 		if (this.sentry) {
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.sentry.addBreadcrumb({
-				message: args.join(' '),
+				message: `[TLUserDurableObject]: ${args.join(' ')}`,
 			})
 		}
 	}
@@ -241,7 +240,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				throw new ZMutationError(
 					ZErrorCode.forbidden,
 					'Cannot update file that is not our own and not shared in edit mode' +
-						` user id ${this.userId} ownerId ${nextFile.ownerId}`
+						` user id ${this.userId} ownerId ${prevFile.ownerId}`
 				)
 			}
 			case 'file_state': {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -20,6 +20,7 @@ import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
 import { Environment } from './types'
 import { UserDataSyncer, ZReplicationEvent } from './UserDataSyncer'
+import { getReplicator } from './utils/durableObjects'
 import { isRateLimited } from './utils/rateLimit'
 import { getCurrentSerializedRoomSnapshot } from './utils/tla/getCurrentSerializedRoomSnapshot'
 
@@ -42,9 +43,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		super(ctx, env)
 
 		this.sentry = createSentry(ctx, env)
-		this.replicator = this.env.TL_PG_REPLICATOR.get(
-			this.env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		this.replicator = getReplicator(env)
 
 		this.db = getPostgres(env)
 		this.debug('created')

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -33,7 +33,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		this.sentry?.captureException(exception, eventHint) as any
 		if (!this.sentry) {
-			console.error(exception)
+			console.error(`[TLUserDurableObject]: `, exception)
 		}
 	}
 

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -145,7 +145,6 @@ export class UserDataSyncer {
 		assert(this.state.type === 'connecting', 'state should be connecting')
 		if (this.state.didGetBootId && this.state.data) {
 			// we got everything, so we can set the state to connected and apply any buffered events
-			assert(this.state.type === 'connecting', 'state should be connecting')
 			const promise = this.state.promise
 			const bufferedEvents = this.state.bufferedEvents
 			const data = this.state.data

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -20,6 +20,7 @@ import {
 } from './getFetchEverythingSql'
 import { getPostgres } from './getPostgres'
 import { Environment } from './types'
+import { getReplicator } from './utils/durableObjects'
 type PromiseWithResolve = ReturnType<typeof promiseWithResolve>
 
 export interface ZRowUpdateEvent {
@@ -106,9 +107,7 @@ export class UserDataSyncer {
 		private broadcast: (message: ZServerSentMessage) => void
 	) {
 		this.sentry = createSentry(ctx, env)
-		this.replicator = env.TL_PG_REPLICATOR.get(
-			env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		this.replicator = getReplicator(env)
 		this.db = getPostgres(env)
 		this.reboot(false)
 	}

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -1,0 +1,301 @@
+import {
+	OptimisticAppStore,
+	TlaRow,
+	ZEvent,
+	ZServerSentMessage,
+	ZStoreData,
+	ZTable,
+} from '@tldraw/dotcom-shared'
+import { assert, promiseWithResolve, sleep, uniqueId } from '@tldraw/utils'
+import { ExecutionQueue, createSentry } from '@tldraw/worker-shared'
+import postgres from 'postgres'
+import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
+import { TLPostgresReplicator } from './TLPostgresReplicator'
+import {
+	fileKeys,
+	fileStateKeys,
+	getFetchUserDataSql,
+	parseResultRow,
+	userKeys,
+} from './getFetchEverythingSql'
+import { Environment } from './types'
+type PromiseWithResolve = ReturnType<typeof promiseWithResolve>
+
+export interface ZRowUpdateEvent {
+	type: 'row_update'
+	userId: string
+	// A unique id for the replicator's unbroken sequence of events.
+	// If the replicator fails and restarts, this id will change.
+	// And in that case the user DO should reboot.
+	sequenceId: string
+	row: TlaRow
+	table: ZTable
+	event: ZEvent
+}
+
+export interface ZBootCompleteEvent {
+	type: 'boot_complete'
+	userId: string
+	sequenceId: string
+	bootId: string
+}
+
+export interface ZMutationCommit {
+	type: 'mutation_commit'
+	userId: string
+	mutationNumber: number
+	sequenceId: string
+}
+
+export type ZReplicationEvent = ZRowUpdateEvent | ZBootCompleteEvent | ZMutationCommit
+
+type BootState =
+	| {
+			type: 'init'
+			promise: PromiseWithResolve
+	  }
+	| {
+			type: 'connecting'
+			bootId: string
+			sequenceId: string
+			promise: PromiseWithResolve
+			bufferedEvents: Array<ZReplicationEvent>
+			didGetBootId: boolean
+			data: null | ZStoreData
+	  }
+	| {
+			type: 'connected'
+			bootId: string
+			sequenceId: string
+	  }
+
+export class UserDataSyncer {
+	state: BootState = {
+		type: 'init',
+		promise: promiseWithResolve(),
+	}
+	replicator: TLPostgresReplicator
+	db: postgres.Sql
+
+	store = new OptimisticAppStore()
+
+	sentry
+	// eslint-disable-next-line local/prefer-class-methods
+	private captureException = (exception: unknown, eventHint?: EventHint) => {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		this.sentry?.captureException(exception, eventHint) as any
+		if (!this.sentry) {
+			console.error(exception)
+		}
+	}
+
+	constructor(
+		private ctx: DurableObjectState,
+		private env: Environment,
+		private userId: string,
+		private broadcast: (message: ZServerSentMessage) => void
+	) {
+		this.sentry = createSentry(ctx, env)
+		this.replicator = env.TL_PG_REPLICATOR.get(
+			env.TL_PG_REPLICATOR.idFromName('0')
+		) as any as TLPostgresReplicator
+		this.db = postgres(this.env.BOTCOM_POSTGRES_CONNECTION_STRING, {
+			types: {
+				bigint: {
+					from: [20], // PostgreSQL OID for BIGINT
+					parse: (value: string) => Number(value), // Convert string to number
+					to: 20,
+					serialize: (value: number) => String(value), // Convert number to string
+				},
+			},
+		})
+		this.reboot(false)
+	}
+
+	private debug(...args: any[]) {
+		// uncomment for dev time debugging
+		// console.log(...args)
+		if (this.sentry) {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			this.sentry.addBreadcrumb({
+				message: args.join(' '),
+			})
+		}
+	}
+
+	private queue = new ExecutionQueue()
+
+	private async reboot(delay = true) {
+		// TODO: set up analytics and alerts for this
+		this.debug('rebooting')
+		await this.queue.push(async () => {
+			if (delay) {
+				await sleep(1000)
+			}
+			try {
+				await this.boot()
+			} catch (e) {
+				this.captureException(e)
+				this.reboot()
+			}
+		})
+	}
+
+	private updateStateAfterBootStep() {
+		assert(this.state.type === 'connecting', 'state should be connecting')
+		if (this.state.didGetBootId && this.state.data) {
+			// we got everything, so we can set the state to connected and apply any buffered events
+			assert(this.state.type === 'connecting', 'state should be connecting')
+			const promise = this.state.promise
+			const bufferedEvents = this.state.bufferedEvents
+			const data = this.state.data
+			this.state = {
+				type: 'connected',
+				bootId: this.state.bootId,
+				sequenceId: this.state.sequenceId,
+			}
+			this.store.initialize(data)
+			if (bufferedEvents.length > 0) {
+				bufferedEvents.forEach((event) => this.handleReplicationEvent(event))
+			}
+			promise.resolve(null)
+			this.broadcast({
+				type: 'initial_data',
+				initialData: data,
+			})
+		}
+		return this.state
+	}
+
+	private async boot() {
+		this.debug('booting')
+		// todo: clean up old resources if necessary?
+		const start = Date.now()
+		const sequenceId = await this.replicator.registerUser(this.userId)
+		this.state = {
+			type: 'connecting',
+			// preserve the promise so any awaiters do eventually get resolved
+			// TODO: set a timeout on the promise?
+			promise: 'promise' in this.state ? this.state.promise : promiseWithResolve(),
+			bootId: uniqueId(),
+			sequenceId,
+			bufferedEvents: [],
+			didGetBootId: false,
+			data: null,
+		}
+		/**
+		 * BOOTUP SEQUENCE
+		 * 1. Generate a unique boot id
+		 * 2. Subscribe to all changes
+		 * 3. Fetch all data and write the boot id in a transaction
+		 * 4. If we receive events before the boot id update comes through, ignore them
+		 * 5. If we receive events after the boot id comes through but before we've finished
+		 *    fetching all data, buffer them and apply them after we've finished fetching all data.
+		 *    (not sure this is possible, but just in case)
+		 * 6. Once we've finished fetching all data, apply any buffered events
+		 */
+
+		// if the bootId changes during the boot process, we should stop silently
+		const bootId = this.state.bootId
+
+		const promise = this.state.promise
+
+		const sql = getFetchUserDataSql(this.userId, bootId)
+		const initialData: ZStoreData = {
+			user: null as any,
+			files: [],
+			fileStates: [],
+		}
+		// sync initial data
+		await this.db.begin(async (db) => {
+			return db
+				.unsafe(sql, [], { prepare: false })
+				.simple()
+				.forEach((row: any) => {
+					switch (row.table) {
+						case 'user':
+							initialData.user = parseResultRow(userKeys, row)
+							break
+						case 'file':
+							initialData.files.push(parseResultRow(fileKeys, row))
+							break
+						case 'file_state':
+							initialData.fileStates.push(parseResultRow(fileStateKeys, row))
+							break
+					}
+				})
+		})
+
+		this.state.data = initialData
+		// do an unnecessary assign here to tell typescript that the state might have changed
+		this.debug('got initial data')
+		this.state = this.updateStateAfterBootStep()
+		// this will prevent more events from being added to the buffer
+
+		await promise
+		const end = Date.now()
+		this.debug('boot time', end - start, 'ms')
+		assert(this.state.type === 'connected', 'state should be connected after boot')
+	}
+
+	// It is important that this method is synchronous!!!!
+	// We need to make sure that events are handled in-order.
+	// If we make this asynchronous for whatever reason we should
+	// make sure to uphold this invariant.
+	private handleRowUpdateEvent(event: ZRowUpdateEvent) {
+		try {
+			assert(this.state.type === 'connected', 'state should be connected in handleEvent')
+			if (event.table !== 'user' && event.table !== 'file' && event.table !== 'file_state') {
+				throw new Error(`Unhandled table: ${event.table}`)
+			}
+			this.store.updateCommittedData(event)
+			this.broadcast({
+				type: 'update',
+				update: {
+					// reference the properties individually because the
+					// event might have extra properties that we don't want to send
+					event: event.event,
+					row: event.row,
+					table: event.table,
+				},
+			})
+		} catch (e) {
+			this.captureException(e)
+			this.reboot()
+		}
+	}
+
+	handleReplicationEvent(event: ZReplicationEvent) {
+		assert(this.state.type !== 'init', 'state should not be init')
+		if (this.state.sequenceId !== event.sequenceId) {
+			// the replicator has restarted, so we need to reboot
+			this.reboot()
+			return
+		}
+
+		if (this.state.type === 'connected') {
+			assert(event.type === 'row_update', `event type should be row_update got ${event.type}`)
+			this.handleRowUpdateEvent(event)
+			return
+		}
+
+		assert(this.state.type === 'connecting')
+		this.debug('got event', event, this.state.didGetBootId, this.state.bootId)
+		if (this.state.didGetBootId) {
+			// we've already got the boot id, so just shove things into
+			// a buffer until the state is set to 'connecting'
+			this.state.bufferedEvents.push(event)
+		} else if (event.type === 'boot_complete' && event.bootId === this.state.bootId) {
+			this.state.didGetBootId = true
+			this.debug('got boot id')
+			this.updateStateAfterBootStep()
+		}
+		// ignore other events until we get the boot id
+	}
+
+	async waitUntilConnected() {
+		while (this.state.type !== 'connected') {
+			await this.state.promise
+		}
+	}
+}

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -18,6 +18,7 @@ import {
 	parseResultRow,
 	userKeys,
 } from './getFetchEverythingSql'
+import { getPostgres } from './getPostgres'
 import { Environment } from './types'
 type PromiseWithResolve = ReturnType<typeof promiseWithResolve>
 
@@ -99,16 +100,7 @@ export class UserDataSyncer {
 		this.replicator = env.TL_PG_REPLICATOR.get(
 			env.TL_PG_REPLICATOR.idFromName('0')
 		) as any as TLPostgresReplicator
-		this.db = postgres(this.env.BOTCOM_POSTGRES_CONNECTION_STRING, {
-			types: {
-				bigint: {
-					from: [20], // PostgreSQL OID for BIGINT
-					parse: (value: string) => Number(value), // Convert string to number
-					to: 20,
-					serialize: (value: number) => String(value), // Convert number to string
-				},
-			},
-		})
+		this.db = getPostgres(env)
 		this.reboot(false)
 	}
 
@@ -172,6 +164,7 @@ export class UserDataSyncer {
 		// todo: clean up old resources if necessary?
 		const start = Date.now()
 		const sequenceId = await this.replicator.registerUser(this.userId)
+		this.debug('registered user', sequenceId)
 		this.state = {
 			type: 'connecting',
 			// preserve the promise so any awaiters do eventually get resolved

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -98,7 +98,7 @@ export class UserDataSyncer {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		this.sentry?.captureException(exception, eventHint) as any
 		if (!this.sentry) {
-			console.error(exception)
+			console.error(`[UserDataSyncer]: `, exception)
 		}
 	}
 
@@ -116,11 +116,11 @@ export class UserDataSyncer {
 
 	private debug(...args: any[]) {
 		// uncomment for dev time debugging
-		// console.log(...args)
+		// console.log('[UserDataSyncer]:',...args)
 		if (this.sentry) {
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.sentry.addBreadcrumb({
-				message: args.join(' '),
+				message: `[UserDataSyncer]: ${args.join(' ')}`,
 			})
 		}
 	}
@@ -185,7 +185,7 @@ export class UserDataSyncer {
 		// todo: clean up old resources if necessary?
 		const start = Date.now()
 		const sequenceId = await this.replicator.registerUser(this.userId)
-		this.debug('registered user', sequenceId)
+		this.debug('registered user, sequenceId:', sequenceId)
 		this.state = {
 			type: 'connecting',
 			// preserve the promise so any awaiters do eventually get resolved

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -268,12 +268,15 @@ export class UserDataSyncer {
 	}
 
 	handleReplicationEvent(event: ZReplicationEvent) {
-		assert(this.state.type !== 'init', 'state should not be init')
-		if (event.type === 'force_reboot' || this.state.sequenceId !== event.sequenceId) {
+		if (
+			event.type === 'force_reboot' ||
+			('sequenceId' in this.state && this.state.sequenceId !== event.sequenceId)
+		) {
 			// the replicator has restarted, so we need to reboot
 			this.reboot()
 			return
 		}
+		assert(this.state.type !== 'init', 'state should not be init: ' + event.type)
 
 		if (this.state.type === 'connected') {
 			assert(event.type === 'row_update', `event type should be row_update got ${event.type}`)

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -45,10 +45,19 @@ export interface ZMutationCommit {
 	type: 'mutation_commit'
 	userId: string
 	mutationNumber: number
+	// if the sequence id changes make sure we still handle the mutation commit
+	sequenceId: string
+}
+export interface ZForceReboot {
+	type: 'force_reboot'
 	sequenceId: string
 }
 
-export type ZReplicationEvent = ZRowUpdateEvent | ZBootCompleteEvent | ZMutationCommit
+export type ZReplicationEvent =
+	| ZRowUpdateEvent
+	| ZBootCompleteEvent
+	| ZMutationCommit
+	| ZForceReboot
 
 type BootState =
 	| {
@@ -260,7 +269,7 @@ export class UserDataSyncer {
 
 	handleReplicationEvent(event: ZReplicationEvent) {
 		assert(this.state.type !== 'init', 'state should not be init')
-		if (this.state.sequenceId !== event.sequenceId) {
+		if (event.type === 'force_reboot' || this.state.sequenceId !== event.sequenceId) {
 			// the replicator has restarted, so we need to reboot
 			this.reboot()
 			return

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -117,7 +117,7 @@ export class UserDataSyncer {
 
 	private queue = new ExecutionQueue()
 
-	private async reboot(delay = true) {
+	async reboot(delay = true) {
 		// TODO: set up analytics and alerts for this
 		this.debug('rebooting')
 		await this.queue.push(async () => {

--- a/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
+++ b/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
@@ -45,7 +45,7 @@ export function getFetchUserDataSql(userId: string, bootId: string) {
 INSERT INTO public.user_boot_id ("userId", "bootId") VALUES ('${userId}', '${bootId}') ON CONFLICT ("userId") DO UPDATE SET "bootId" = '${bootId}';
 SELECT 'user' AS "table", ${userColumns.concat(fileNulls).concat(fileStateNulls)} FROM public.user WHERE "id" = '${userId}'
 UNION
-SELECT 'file' AS "table", ${userNulls.concat(fileColumns).concat(fileStateNulls)} FROM public.file WHERE "ownerId" = '${userId}' OR EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${userId}' AND public.file_state."fileId" = public.file.id) 
+SELECT 'file' AS "table", ${userNulls.concat(fileColumns).concat(fileStateNulls)} FROM public.file WHERE "ownerId" = '${userId}' OR "shared" = true AND EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${userId}' AND public.file_state."fileId" = public.file.id) 
 UNION
 SELECT 'file_state' AS "table", ${userNulls.concat(fileNulls).concat(fileStateColumns)} FROM public.file_state WHERE "userId" = '${userId}';
 `

--- a/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
+++ b/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
@@ -40,10 +40,9 @@ const userColumns = userKeys.map((c) => `${c.reference} as "${c.alias}"`)
 const fileColumns = fileKeys.map((c) => `${c.reference} as "${c.alias}"`)
 const fileStateColumns = fileStateKeys.map((c) => `${c.reference} as "${c.alias}"`)
 
-//
-export function getFetchUserDataSql(replicatorId: string, userId: string, bootId: string) {
+export function getFetchUserDataSql(userId: string, bootId: string) {
 	return `
-INSERT INTO public.replicator_user_boot_id ("replicatorId", "userId", "bootId") VALUES ('${replicatorId}', '${userId}', '${bootId}') ON CONFLICT ("replicatorId", "userId") DO UPDATE SET "bootId" = '${bootId}';
+INSERT INTO public.user_boot_id ("userId", "bootId") VALUES ('${userId}', '${bootId}') ON CONFLICT ("userId") DO UPDATE SET "bootId" = '${bootId}';
 SELECT 'user' AS "table", ${userColumns.concat(fileNulls).concat(fileStateNulls)} FROM public.user WHERE "id" = '${userId}'
 UNION
 SELECT 'file' AS "table", ${userNulls.concat(fileColumns).concat(fileStateNulls)} FROM public.file WHERE "ownerId" = '${userId}' OR EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${userId}' AND public.file_state."fileId" = public.file.id) 

--- a/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
+++ b/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
@@ -40,14 +40,15 @@ const userColumns = userKeys.map((c) => `${c.reference} as "${c.alias}"`)
 const fileColumns = fileKeys.map((c) => `${c.reference} as "${c.alias}"`)
 const fileStateColumns = fileStateKeys.map((c) => `${c.reference} as "${c.alias}"`)
 
-export function getFetchEverythingSql(replicatorId: string, bootId: string) {
+//
+export function getFetchUserDataSql(replicatorId: string, userId: string, bootId: string) {
 	return `
-insert into public.replicator_boot_id ("replicatorId", "bootId") values ('${replicatorId}', '${bootId}') ON CONFLICT ("replicatorId") DO UPDATE SET "bootId" = '${bootId}';
-select 'user' as "table", ${userColumns.concat(fileNulls).concat(fileStateNulls)} from public.user
-union
-select 'file' as "table", ${userNulls.concat(fileColumns).concat(fileStateNulls)} from public.file
-union
-select 'file_state' as "table", ${userNulls.concat(fileNulls).concat(fileStateColumns)} from public.file_state;
+INSERT INTO public.replicator_user_boot_id ("replicatorId", "userId", "bootId") VALUES ('${replicatorId}', '${userId}', '${bootId}') ON CONFLICT ("replicatorId", "userId") DO UPDATE SET "bootId" = '${bootId}';
+SELECT 'user' AS "table", ${userColumns.concat(fileNulls).concat(fileStateNulls)} FROM public.user WHERE "id" = '${userId}'
+UNION
+SELECT 'file' AS "table", ${userNulls.concat(fileColumns).concat(fileStateNulls)} FROM public.file WHERE "ownerId" = '${userId}' OR EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${userId}' AND public.file_state."fileId" = public.file.id) 
+UNION
+SELECT 'file_state' AS "table", ${userNulls.concat(fileNulls).concat(fileStateColumns)} FROM public.file_state WHERE "userId" = '${userId}';
 `
 }
 

--- a/apps/dotcom/sync-worker/src/getPostgres.ts
+++ b/apps/dotcom/sync-worker/src/getPostgres.ts
@@ -1,0 +1,15 @@
+import postgres from 'postgres'
+import { Environment } from './types'
+
+export function getPostgres(env: Environment) {
+	return postgres(env.BOTCOM_POSTGRES_CONNECTION_STRING, {
+		types: {
+			bigint: {
+				from: [20], // PostgreSQL OID for BIGINT
+				parse: (value: string) => Number(value), // Convert string to number
+				to: 20,
+				serialize: (value: number) => String(value), // Convert number to string
+			},
+		},
+	})
+}

--- a/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
@@ -1,8 +1,8 @@
 import { RoomSnapshot } from '@tldraw/sync-core'
 import { IRequest } from 'itty-router'
-import { TLPostgresReplicator } from '../../TLPostgresReplicator'
 import { getR2KeyForRoom } from '../../r2'
 import { Environment } from '../../types'
+import { getReplicator } from '../../utils/durableObjects'
 
 // Get a published file from a file's publishedSlug, if there is one.
 export async function getPublishedFile(request: IRequest, env: Environment): Promise<Response> {
@@ -15,9 +15,7 @@ export async function getPublishedFile(request: IRequest, env: Environment): Pro
 		const parentSlug = await env.SNAPSHOT_SLUG_TO_PARENT_SLUG.get(roomId)
 		if (!parentSlug) throw Error('not found')
 
-		const replicator = env.TL_PG_REPLICATOR.get(
-			env.TL_PG_REPLICATOR.idFromName('0')
-		) as any as TLPostgresReplicator
+		const replicator = getReplicator(env)
 		const file = await replicator.getFileRecord(parentSlug)
 
 		if (!file) throw Error('not found')

--- a/apps/dotcom/sync-worker/src/testRoutes.ts
+++ b/apps/dotcom/sync-worker/src/testRoutes.ts
@@ -1,0 +1,32 @@
+import { createRouter, notFound } from '@tldraw/worker-shared'
+import type { Environment } from './types'
+import { getReplicator, getUserDurableObject } from './utils/durableObjects'
+
+export const testRoutes = createRouter<Environment>()
+	.all('/app/__test__/*', (_, env) => {
+		if (env.IS_LOCAL !== 'true') return notFound()
+		return undefined
+	})
+	.get('/app/__test__/replicator/reboot', (_, env) => {
+		getReplicator(env).__test__forceReboot()
+		return new Response('ok')
+	})
+	.get('/app/__test__/replicator/panic', (_, env) => {
+		getReplicator(env).__test__panic()
+		return new Response('ok')
+	})
+	.get('/app/__test__/user/:userId/reboot', (req, env) => {
+		getUserDurableObject(env, req.params.userId).handleReplicationEvent({
+			type: 'force_reboot',
+			sequenceId: 'test',
+		})
+		return new Response('ok')
+	})
+	.get('/app/__test__/user/:userId/panic', (req, env) => {
+		getUserDurableObject(env, req.params.userId).handleReplicationEvent({
+			type: 'force_reboot',
+			sequenceId: 'test',
+		})
+		return new Response('ok')
+	})
+	.all('*', notFound)

--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -1,0 +1,13 @@
+import type { TLPostgresReplicator } from '../TLPostgresReplicator'
+import type { TLUserDurableObject } from '../TLUserDurableObject'
+import { Environment } from '../types'
+
+export function getReplicator(env: Environment) {
+	return env.TL_PG_REPLICATOR.get(
+		env.TL_PG_REPLICATOR.idFromName('0')
+	) as any as TLPostgresReplicator
+}
+
+export function getUserDurableObject(env: Environment, userId: string) {
+	return env.TL_USER.get(env.TL_USER.idFromName(userId)) as any as TLUserDurableObject
+}

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -22,6 +22,7 @@ import { createFiles } from './routes/tla/createFiles'
 import { deleteFile } from './routes/tla/deleteFile'
 import { forwardRoomRequest } from './routes/tla/forwardRoomRequest'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
+import { testRoutes } from './testRoutes'
 import { Environment } from './types'
 import { getAuth } from './utils/tla/getAuth'
 // export { TLAppDurableObject } from './TLAppDurableObject'
@@ -70,6 +71,7 @@ const router = createRouter<Environment>()
 	.get('/app/file/:roomId', forwardRoomRequest)
 	.get('/app/publish/:roomId', getPublishedFile)
 	.delete('/app/file/:roomId', deleteFile)
+	.all('/app/__test__/*', testRoutes.fetch)
 	// end app
 	.all('*', notFound)
 

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -24,6 +24,7 @@ import { forwardRoomRequest } from './routes/tla/forwardRoomRequest'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
 import { testRoutes } from './testRoutes'
 import { Environment } from './types'
+import { getUserDurableObject } from './utils/durableObjects'
 import { getAuth } from './utils/tla/getAuth'
 // export { TLAppDurableObject } from './TLAppDurableObject'
 export { TLDrawDurableObject } from './TLDrawDurableObject'
@@ -64,7 +65,7 @@ const router = createRouter<Environment>()
 			console.log('auth not found')
 			return notFound()
 		}
-		const stub = env.TL_USER.get(env.TL_USER.idFromName(auth.userId))
+		const stub = getUserDurableObject(env, auth.userId)
 		return stub.fetch(req)
 	})
 	.post('/app/tldr', createFiles)

--- a/apps/dotcom/zero-cache/docker/002_add_user_id.sql
+++ b/apps/dotcom/zero-cache/docker/002_add_user_id.sql
@@ -1,8 +1,6 @@
-CREATE TABLE "replicator_user_boot_id" (
-	"replicatorId" VARCHAR NOT NULL,
-  "userId" VARCHAR NOT NULL,
-	"bootId" VARCHAR NOT NULL,
-  PRIMARY KEY ("replicatorId", "userId")
+CREATE TABLE "user_boot_id" (
+  "userId" VARCHAR NOT NULL PRIMARY KEY,
+	"bootId" VARCHAR NOT NULL
 );
 
--- drop the old table later
+-- drop the replicator_boot table later

--- a/apps/dotcom/zero-cache/docker/002_add_user_id.sql
+++ b/apps/dotcom/zero-cache/docker/002_add_user_id.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "replicator_user_boot_id" (
+	"replicatorId" VARCHAR NOT NULL,
+  "userId" VARCHAR NOT NULL,
+	"bootId" VARCHAR NOT NULL,
+  PRIMARY KEY ("replicatorId", "userId")
+);
+
+-- drop the old table later

--- a/apps/dotcom/zero-cache/docker/002_add_user_id.sql
+++ b/apps/dotcom/zero-cache/docker/002_add_user_id.sql
@@ -4,3 +4,6 @@ CREATE TABLE "user_boot_id" (
 );
 
 -- drop the replicator_boot table later
+
+CREATE INDEX file_owner_index ON public.file ("ownerId");
+CREATE INDEX file_shared_index ON public.file ("shared");

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -118,6 +118,15 @@ class SizeReporter {
 			'--minify',
 			'--watch',
 			'--external:cloudflare:*',
+			// need to list out node packages that are used in the worker.
+			// otherwise, if we user platform=node, the bundle size is not reported correctly
+			'--external:os',
+			'--external:crypto',
+			'--external:stream',
+			'--external:net',
+			'--external:fs',
+			'--external:perf_hooks',
+			'--external:tls',
 			'--target=esnext',
 			'--format=esm',
 		])

--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -58,9 +58,8 @@ export class OptimisticAppStore {
 	commitMutations(mutationIds: string[]) {
 		this._optimisticStore.update((prev) => {
 			if (!prev) return prev
-			return prev.filter((p) => {
-				return !mutationIds.includes(p.mutationId)
-			})
+			const highestIndex = prev.findLastIndex((p) => mutationIds.includes(p.mutationId))
+			return prev.slice(highestIndex + 1)
 		})
 	}
 

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -130,6 +130,8 @@ export type TlaFile = SchemaToRow<typeof tlaFileSchema>
 export type TlaFileState = SchemaToRow<typeof tlaFileStateSchema>
 export type TlaUser = SchemaToRow<typeof tlaUserSchema>
 
+export type TlaRow = TlaFile | TlaFileState | TlaUser
+
 const immutableColumns: Record<string, Set<string>> = {
 	user: new Set<keyof TlaUser>(['id', 'email', 'createdAt']),
 	file: new Set<keyof TlaFile>(['id', 'ownerId', 'createdAt']),

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -75,7 +75,7 @@ export interface ZStoreData {
 }
 
 export interface ZRowUpdate {
-	row: object
+	row: TlaFile | TlaFileState | TlaUser
 	table: 'file' | 'file_state' | 'user'
 	event: 'insert' | 'update' | 'delete'
 }


### PR DESCRIPTION
- the pg replicator only stores data for the users who are currently active
- even then it only stores the users' ids, along with any guest file ids they have access to.
- each user DO fetches their replica directly from postgres, and syncs via messages from the pg replicator
- user DOs keep their replica in memory rather than sqlite, since they are so small.

still need to debug and stress test this, but it should be a lot more scalable than the current thing.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…