### PR TITLE
Use sign up here.

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSignUpButton/TlaSignUpButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSignUpButton/TlaSignUpButton.tsx
@@ -1,0 +1,20 @@
+import { SignUpButton } from '@clerk/clerk-react'
+import { ComponentProps } from 'react'
+import { useLocation } from 'react-router-dom'
+import { F } from '../../app/i18n'
+import { TlaButton } from '../TlaButton/TlaButton'
+
+export function TlaSignUpButton({ children, ...props }: ComponentProps<typeof TlaButton>) {
+	const location = useLocation()
+	return (
+		<SignUpButton
+			mode="modal"
+			forceRedirectUrl={location.pathname + location.search}
+			signInForceRedirectUrl={location.pathname + location.search}
+		>
+			<TlaButton data-testid="tla-sign-up-button" {...props}>
+				{children ?? <F defaultMessage="Sign up" />}
+			</TlaButton>
+		</SignUpButton>
+	)
+}

--- a/apps/dotcom/client/src/tla/layouts/TlaAnonLayout/TlaAnonLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaAnonLayout/TlaAnonLayout.tsx
@@ -6,6 +6,7 @@ import { defineMessages, F, useIntl } from '../../app/i18n'
 import { TlaAccountMenu } from '../../components/TlaAccountMenu/TlaAccountMenu'
 import { TlaIcon } from '../../components/TlaIcon/TlaIcon'
 import { TlaSignInButton } from '../../components/TlaSignInButton/TlaSignInButton'
+import { TlaSignUpButton } from '../../components/TlaSignUpButton/TlaSignUpButton'
 import { usePreventAccidentalDrops } from '../../hooks/usePreventAccidentalDrops'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import styles from './anon.module.css'
@@ -47,12 +48,12 @@ export function TlaAnonLayout({ children }: { children: ReactNode }) {
 						>
 							<F defaultMessage="Sign in" />
 						</TlaSignInButton>
-						<TlaSignInButton
+						<TlaSignUpButton
 							onClick={() => trackEvent('sign-up-clicked', { source: 'anon-landing-page' })}
 							data-testid="tla-signup-button"
 						>
 							<F defaultMessage="Sign up" />
-						</TlaSignInButton>
+						</TlaSignUpButton>
 					</SignedOut>
 				</div>
 			</div>


### PR DESCRIPTION
Looks like we used the same form for both buttons, now added the sign up for the sign up button.

Fixes INT-489

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Sign up button now opens the sign up form.