### PR TITLE
Pin replicator close to supabase

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -3,9 +3,9 @@ import type { TLUserDurableObject } from '../TLUserDurableObject'
 import { Environment } from '../types'
 
 export function getReplicator(env: Environment) {
-	return env.TL_PG_REPLICATOR.get(
-		env.TL_PG_REPLICATOR.idFromName('0')
-	) as any as TLPostgresReplicator
+	return env.TL_PG_REPLICATOR.get(env.TL_PG_REPLICATOR.idFromName('0'), {
+		locationHint: 'weur',
+	}) as any as TLPostgresReplicator
 }
 
 export function getUserDurableObject(env: Environment, userId: string) {


### PR DESCRIPTION
Apparently the [first call ](https://developers.cloudflare.com/durable-objects/reference/data-location/#provide-a-location-hint) to `get` provides a location hint to where the DO should be located. Pulled out a helper function for getting the replicator and made all current uses go through that.

Looks like we created supabase databases in eu central, so west europe for the DO seemed best. We could [use a jurisdiction](https://developers.cloudflare.com/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) and make sure it's located in EU? (location hints are not a guarantee of the location).

We have many users in US, it might be better to move the supabase instances? OTOH having them in EU brings us closer to GDPR.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Pin 🙏  the postgres replicator close to the DB.