### PR TITLE
[botcom] fix random remounting

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -79,6 +79,7 @@ export class Sidebar {
 	async setLanguage(languageButtonText: string, language: string) {
 		await this.openLanguageMenu(languageButtonText)
 		await this.page.getByRole('menuitemcheckbox', { name: language }).click()
+		await this.page.keyboard.press('Escape')
 	}
 
 	@step


### PR DESCRIPTION
Not sure why this started happening today, but clerk's useAuth started emitting updates sometimes on certain window interactions like tab switching and opening the share menu (??) even though the user session hadn't changed, which caused our useUser hook to emit updates, which caused our useSync to restart from scratch, which caused the editor to disappear momentarily.

### Change type


- [x] `other`
