### PR TITLE
[botcom] simplify replicator dispatch logic

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -313,6 +313,7 @@ export class TldrawApp {
 					lastEditAt: null,
 					lastSessionState: null,
 					lastVisitAt: null,
+					isFileOwner: true,
 				})
 			}
 		})
@@ -443,6 +444,9 @@ export class TldrawApp {
 				lastEditAt: null,
 				lastSessionState: null,
 				lastVisitAt: null,
+				// doesn't really matter what this is because it is
+				// overwritten by postgres
+				isFileOwner: this.isFileOwner(fileId),
 			})
 		}
 		fileState = this.getFileState(fileId)

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -185,7 +185,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 					this.handleBootEvent(row, event)
 					return
 				case 'user_mutation_number':
-					this.handleMutationEvent(row, event)
+					this.handleMutationConfirmationEvent(row, event)
 					return
 				case 'file_state':
 					this.handleFileStateEvent(row, event)
@@ -216,7 +216,10 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		})
 	}
 
-	private handleMutationEvent(row: postgres.Row | null, event: postgres.ReplicationEvent) {
+	private handleMutationConfirmationEvent(
+		row: postgres.Row | null,
+		event: postgres.ReplicationEvent
+	) {
 		if (event.command === 'delete') return
 		assert(typeof row?.mutationNumber === 'number', 'mutationNumber is required')
 		this.messageUser(row.userId, {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -163,7 +163,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		if (this.sentry) {
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.sentry.addBreadcrumb({
-				message: `[TLUserDurableObject]: ${args.join(' ')}`,
+				message: `[TLUserDurableObject]: ${args.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' ')}`,
 			})
 		}
 	}
@@ -390,11 +390,15 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			isApp: true,
 		})
 		const publishedHistory = await listAllObjectKeys(this.env.ROOM_SNAPSHOTS, publishedPrefixKey)
-		await this.env.ROOM_SNAPSHOTS.delete(publishedHistory)
+		if (publishedHistory.length > 0) {
+			await this.env.ROOM_SNAPSHOTS.delete(publishedHistory)
+		}
 		// remove edit history
 		const r2Key = getR2KeyForRoom({ slug: id, isApp: true })
 		const editHistory = await listAllObjectKeys(this.env.ROOMS_HISTORY_EPHEMERAL, r2Key)
-		await this.env.ROOMS_HISTORY_EPHEMERAL.delete(editHistory)
+		if (editHistory.length > 0) {
+			await this.env.ROOMS_HISTORY_EPHEMERAL.delete(editHistory)
+		}
 		// remove main file
 		await this.env.ROOMS.delete(r2Key)
 	}

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -325,7 +325,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								await sql`delete from public.file_state where "fileId" = ${fileId} and "userId" = ${userId}`
 							} else {
 								const { id } = update.row as any
-								await sql`delete from ${sql('public.' + update.table)} where id = ${id}`
+								const deleteQ = `delete from public."${update.table}" where id = '${id}'`
+								await sql.unsafe(deleteQ)
 							}
 							if (update.table === 'file') {
 								const { id } = update.row as TlaFile

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -266,7 +266,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	private async handleMutate(msg: ZClientSentMessage) {
 		this.assertCache()
 		try {
-			;(await this.db.begin(async (sql) => {
+			await this.db.begin(async (sql) => {
 				for (const update of msg.updates) {
 					await this.assertValidMutation(update)
 					switch (update.event) {
@@ -336,7 +336,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 					}
 					this.cache.store.updateOptimisticData([update], msg.mutationId)
 				}
-			})) as any
+			})
 
 			// TODO: We should probably handle a case where the above operation succeeds but the one below fails
 			const result = await this

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -325,8 +325,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								await sql`delete from public.file_state where "fileId" = ${fileId} and "userId" = ${userId}`
 							} else {
 								const { id } = update.row as any
-								const deleteQ = `delete from public."${update.table}" where id = '${id}'`
-								await sql.unsafe(deleteQ)
+								await sql`delete from ${sql('public.' + update.table)} where id = ${id}`
 							}
 							if (update.table === 'file') {
 								const { id } = update.row as TlaFile

--- a/apps/dotcom/zero-cache/docker/004_guest_column_on_file_state.sql
+++ b/apps/dotcom/zero-cache/docker/004_guest_column_on_file_state.sql
@@ -1,0 +1,37 @@
+-- This file adds a column to the file_state table that indicates whether the user is the owner of the file.
+-- To make sure it is always up to date, we add two triggers that update the column when the file or file_state table is updated.
+
+BEGIN;
+
+ALTER TABLE file_state
+ADD COLUMN "isFileOwner" BOOLEAN;
+
+CREATE OR REPLACE FUNCTION update_is_file_owner() RETURNS TRIGGER AS $$
+BEGIN
+  NEW."isFileOwner" := (NEW."userId" = (SELECT "ownerId" FROM file WHERE file.id = NEW."fileId"));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_is_file_owner
+BEFORE INSERT OR UPDATE ON file_state
+FOR EACH ROW EXECUTE FUNCTION update_is_file_owner();
+
+CREATE OR REPLACE FUNCTION update_file_state_on_file_change() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE file_state
+  SET "isFileOwner" = (file_state."userId" = NEW."ownerId")
+  WHERE file_state."fileId" = NEW.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_file_state_on_file_change
+AFTER UPDATE ON file
+FOR EACH ROW EXECUTE FUNCTION update_file_state_on_file_change();
+
+-- popluating the isFileOwner column with no-op update
+UPDATE file_state
+SET "userId" = file_state."userId";
+
+COMMIT;

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -79,6 +79,7 @@ export const tlaFileStateSchema = {
 		lastEditAt: { type: 'number', optional: true },
 		lastSessionState: { type: 'string', optional: true },
 		lastVisitAt: { type: 'number', optional: true },
+		isFileOwner: { type: 'boolean', optional: true },
 	},
 	primaryKey: ['userId', 'fileId'],
 	relationships: {
@@ -135,7 +136,7 @@ export type TlaRow = TlaFile | TlaFileState | TlaUser
 const immutableColumns: Record<string, Set<string>> = {
 	user: new Set<keyof TlaUser>(['id', 'email', 'createdAt']),
 	file: new Set<keyof TlaFile>(['id', 'ownerId', 'createdAt']),
-	file_state: new Set<keyof TlaFileState>(['userId', 'fileId', 'firstVisitAt']),
+	file_state: new Set<keyof TlaFileState>(['userId', 'fileId', 'firstVisitAt', 'isFileOwner']),
 }
 
 export function isColumnMutable(tableName: keyof typeof immutableColumns, column: string) {


### PR DESCRIPTION
This stuff was a little bit of a mess. I made it synchronous again and hopefully caught an extra edge case or two.

- added a `isFileOwner` field to file_state, populated by triggers on both the file table and the file_state table.
- used `isFileOwner` to avoid checking ownership while dispatching events in the replicator
- simplified the event dispatching logic by moving it out into separate methods for each table, so it's easier to follow what's happening.
- fixed the 'file deleting isn't working in prod' bug, that was to do with r2 complaining about things it doesn't complain about in dev mode.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
