### PR TITLE
[botcom] Nav spacing/typography/alignment fixes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -8,7 +8,7 @@
 	display: none;
 	flex-direction: column;
 	flex: 0 0 auto;
-	padding: 2px 12px 2px 12px;
+	padding: 3px 12px 2px 12px;
 	background: var(--tla-color-sidebar);
 	border-right: 1px solid transparent;
 }
@@ -180,7 +180,7 @@
 	border: none;
 	cursor: pointer;
 	position: absolute;
-	top: 3px;
+	top: 3.5px;
 	right: 0px;
 	height: 40px;
 	width: 40px;
@@ -230,7 +230,6 @@
 	height: 40px;
 	flex-grow: 2;
 	display: flex;
-	gap: 8px;
 	align-items: center;
 	white-space: nowrap;
 	overflow: hidden;
@@ -241,6 +240,7 @@
 .user {
 	padding: 0px 8px;
 	cursor: pointer;
+	gap: 8px;
 }
 
 .userName {

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -103,7 +103,10 @@
 .tla-text_ui__title {
 	font-size: 14px;
 	line-height: 1.3;
-	font-weight: 600;
+	font-weight: 700;
+	letter-spacing: 0.2px;
+	position: relative;
+	top: 1px;
 	font-family: var(--tla-font-ui);
 	color: var(--tla-color-text-1);
 	text-rendering: optimizeLegibility;


### PR DESCRIPTION
- made brand name slightly heavier, added a tiny amount of letter spacing, to make it look brand-y instead of label-y
- align buttons with each other
- align buttons with neighboring text
- fix spacing and alignment between mark and brand name

Before
<img width="624" alt="image" src="https://github.com/user-attachments/assets/28e7b3ce-710b-455a-9f27-43628002b71e">

After
<img width="515" alt="image" src="https://github.com/user-attachments/assets/246a8402-24b6-4c37-b030-6cb5d8519093">




### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
