### PR TITLE
Fix an issue with rejections not getting sent.

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -170,7 +170,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private async handleSocketMessage(message: string) {
 		const rateLimited = await isRateLimited(this.env, this.userId!)
-
 		this.assertCache()
 		await this.cache.waitUntilConnected()
 

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -170,6 +170,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private async handleSocketMessage(message: string) {
 		const rateLimited = await isRateLimited(this.env, this.userId!)
+
 		this.assertCache()
 		await this.cache.waitUntilConnected()
 
@@ -177,7 +178,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		switch (msg.type) {
 			case 'mutate':
 				if (rateLimited) {
-					this.rejectMutation(msg.mutationId, ZErrorCode.rate_limit_exceeded)
+					await this.rejectMutation(msg.mutationId, ZErrorCode.rate_limit_exceeded)
 				} else {
 					await this.handleMutate(msg)
 				}
@@ -191,15 +192,11 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.assertCache()
 		await this.cache.waitUntilConnected()
 		this.cache.store.rejectMutation(mutationId)
-		for (const socket of this.ctx.getWebSockets()) {
-			socket.send(
-				JSON.stringify({
-					type: 'reject',
-					mutationId,
-					errorCode,
-				} satisfies ZServerSentMessage)
-			)
-		}
+		this.broadcast({
+			type: 'reject',
+			mutationId,
+			errorCode,
+		} satisfies ZServerSentMessage)
 	}
 
 	private async assertValidMutation(update: ZRowUpdate) {
@@ -352,7 +349,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			this.captureException(e, {
 				data: { errorCode: code, reason: 'mutation failed' },
 			})
-			this.rejectMutation(msg.mutationId, code)
+			await this.rejectMutation(msg.mutationId, code)
 		}
 	}
 


### PR DESCRIPTION
Looks like we were using incorrect sockets. Also noticed we weren't awaiting some async method calls.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix an issue with mutation rejections not being sent.