### PR TITLE
Increase the wait duration.

### DIFF
--- a/apps/dotcom/client/scripts/wait-for-docker.sh
+++ b/apps/dotcom/client/scripts/wait-for-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Waiting for postgres to become healthy..."
-for _ in {1..30}; do
+for _ in {1..120}; do
 
 	STATUS=$(docker inspect --format='{{json .State.Health.Status}}' docker-zstart_postgres-1 2>/dev/null)
 	if [ "$STATUS" = "\"healthy\"" ]; then


### PR DESCRIPTION
30s might not be enough for all cases (CI booting up from scratch).

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Increase how long we can wait for postgress to boot up.