### PR TITLE
Wait for the guest file to be loaded before showing an entry in the sidebar

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -184,6 +184,7 @@ export class TldrawApp {
 				continue
 			}
 			const file = myFiles[fileId]
+			if (!file) continue
 			const state = myStates[fileId]
 
 			nextRecentFileOrdering.push({


### PR DESCRIPTION
### Before

https://github.com/user-attachments/assets/24e5bdaf-483f-4f39-a73f-fbd709293ef0

### After

https://github.com/user-attachments/assets/46aa6e15-06c6-4f83-8c92-200af64da5c7

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- We only show the guest file in the sidebar when the file record is loaded. Otherwise we get this file name flickering since we don't have the file name when we just visit the shared link.