### PR TITLE
Fix invite button on people menu

### DIFF
--- a/apps/dotcom/client/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/client/src/components/MultiplayerEditor.tsx
@@ -24,7 +24,6 @@ import {
 	TldrawUiButtonLabel,
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
-	tlmenus,
 	useActions,
 	useEditor,
 	useTranslation,
@@ -91,6 +90,7 @@ const components: TLComponents = {
 		return <DocumentTopZone isOffline={isOffline} />
 	},
 	SharePanel: () => {
+		const editor = useEditor()
 		const msg = useTranslation()
 		return (
 			<div className="tlui-share-zone" draggable={false}>
@@ -99,7 +99,7 @@ const components: TLComponents = {
 						<TldrawUiButton
 							type="menu"
 							data-testid="people-menu.invite"
-							onClick={() => tlmenus.addOpenMenu('share menu')}
+							onClick={() => editor.menus.addOpenMenu('share menu')}
 						>
 							<TldrawUiButtonLabel>{msg('people-menu.invite')}</TldrawUiButtonLabel>
 							<TldrawUiButtonIcon icon="plus" />


### PR DESCRIPTION
This PR fixes the invite button on the people menu.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open the people menu
2. Click the invite button
3. The share menu should open

### Release notes

- Fixed a bug causing the invite button on the collaborators menu not to open the share panel