### PR TITLE
[botcom] scroll whenever active file changes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -23,7 +23,6 @@ import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { copyTextToClipboard } from '../../utils/copy'
 import { getFilePath, getShareableFileUrl } from '../../utils/urls'
-import { scrollActiveFileLinkIntoView } from '../TlaSidebar/TlaSidebar'
 import { TlaDeleteFileDialog } from '../dialogs/TlaDeleteFileDialog'
 
 const messages = defineMessages({
@@ -82,7 +81,6 @@ export function TlaFileMenu({
 		const file = app.getFile(fileId)
 		if (!file) return
 		app.createFile({ id: newFileId, name: getDuplicateName(file, app) })
-		scrollActiveFileLinkIntoView()
 		navigate(getFilePath(newFileId), { state: { mode: 'duplicate', duplicateId: fileId } })
 	}, [app, fileId, navigate])
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -116,7 +116,6 @@ function TlaSidebarCreateFileButton() {
 		if (res.ok) {
 			const { file } = res.value
 			navigate(getFilePath(file.id), { state: { mode: 'create' } })
-			scrollActiveFileLinkIntoView()
 			trackEvent('create-file', { source: 'sidebar' })
 		}
 	}, [app, navigate, trackEvent])
@@ -250,6 +249,11 @@ function TlaSidebarFileLink({ item, index }: { item: RecentFile; index: number }
 	const isOwnFile = useIsFileOwner(fileId)
 	const { fileSlug } = useParams<{ fileSlug: string }>()
 	const isActive = fileSlug === fileId
+	useEffect(() => {
+		if (isActive) {
+			scrollActiveFileLinkIntoView()
+		}
+	}, [isActive])
 	const [isRenaming, setIsRenaming] = useState(false)
 	const trackEvent = useTldrawAppUiEvents()
 

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -15,7 +15,6 @@ import { useApp } from '../../hooks/useAppState'
 import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getFilePath } from '../../utils/urls'
-import { scrollActiveFileLinkIntoView } from '../TlaSidebar/TlaSidebar'
 
 export function TlaDeleteFileDialog({ fileId, onClose }: { fileId: string; onClose(): void }) {
 	const app = useApp()
@@ -40,7 +39,6 @@ export function TlaDeleteFileDialog({ fileId, onClose }: { fileId: string; onClo
 		} else {
 			navigate(getFilePath(recentFiles[0].fileId))
 		}
-		scrollActiveFileLinkIntoView()
 		onClose()
 	}, [auth, app, fileId, onClose, navigate, trackEvent])
 


### PR DESCRIPTION
Slight tweak to #4974, to enable the scrolling on any route change, not just when creating/deleting/duplicating. The main use case here would be navigating back/forward through browser history.

### Change type

- [x] `other`
