### PR TITLE
[botcom] allow creating rooms quickly

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -498,6 +498,18 @@ export class TLDrawDurableObject extends DurableObject {
 				return { type: 'room_found', snapshot: JSON.parse(data) }
 			}
 
+			if (this.documentInfo.isApp) {
+				// finally check whether the file exists in the DB but not in R2 yet
+				const file = await this.getAppFileRecord()
+				if (!file) {
+					return { type: 'room_not_found' }
+				}
+				return {
+					type: 'room_found',
+					snapshot: new TLSyncRoom({ schema: createTLSchema() }).getSnapshot(),
+				}
+			}
+
 			// if we don't have a room in the bucket, try to load from supabase
 			if (!this.supabaseClient) return { type: 'room_not_found' }
 			const { data, error } = await this.supabaseClient


### PR DESCRIPTION
Before this PR, if you clicked the new room button a bunch of times quickly, it would trigger a race condition where the room would end up never actually being created and added to R2, which would result in `404`s being returned from the server when you went to look at the rooms you created later. This PR fixes that by having a fallback to check that a file has been added to the DB but not R2 yet.

### Change type

- [x] `other`

