### PR TITLE
Fix an issue when navigating back to a forgoten file did not restore it.

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -180,13 +180,13 @@ export class TldrawApp {
 
 		for (const fileId of myFileIds) {
 			const file = myFiles[fileId]
-			if (!file) continue
+			const state = myStates[fileId]
+			if (!file || !state) continue
 			const existing = this.lastRecentFileOrdering?.find((f) => f.fileId === fileId)
 			if (existing) {
 				nextRecentFileOrdering.push(existing)
 				continue
 			}
-			const state = myStates[fileId]
 
 			nextRecentFileOrdering.push({
 				fileId,


### PR DESCRIPTION
The issue was that recent files was still returning the forgotten file, which meant that we did not navigate to a new file. So when you then went back in the browser you landed on the same route which didn't rerun the logic to enter a file.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open a shared file.
2. Forget the file.
3. Navigate back in the browser.
4. The forgotten file should reappear.

### Release notes

- Fixes an issue when navigating back to a forgotten file did not restore it.