### PR TITLE
Remove logging

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/createSupabaseClient.ts
+++ b/apps/dotcom/sync-worker/src/utils/createSupabaseClient.ts
@@ -4,8 +4,7 @@ import { Environment } from '../types'
 export function createSupabaseClient(env: Environment) {
 	return env.SUPABASE_URL && env.SUPABASE_KEY
 		? createClient(env.SUPABASE_URL, env.SUPABASE_KEY)
-		: // eslint-disable-next-line no-console
-			console.log('No supabase credentials, loading from supabase disabled')
+		: undefined
 }
 
 export function noSupabaseSorry() {


### PR DESCRIPTION
We removed supabase as our primary db for storing room data a while ago.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Remove logging when supabase credentials are not present.