### PR TITLE
Fix an issue with `firstVisitAt` not getting set

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -484,39 +484,33 @@ export class TldrawApp {
 		return this.getUserFileStates().find((f) => f.fileId === fileId)
 	}
 
-	updateFileState(fileId: string, cb: (fileState: TlaFileState) => Partial<TlaFileState>) {
+	updateFileState(fileId: string, partial: Partial<TlaFileState>) {
 		const fileState = this.getFileState(fileId)
 		if (!fileState) return
 		// remove relationship because zero complains
-		const { file: _, ...rest } = fileState
-		this.z.mutate.file_state.update({ ...cb(rest), fileId, userId: fileState.userId })
+		this.z.mutate.file_state.update({ ...partial, fileId, userId: fileState.userId })
 	}
 
 	async onFileEnter(fileId: string) {
 		await this.getOrCreateFileState(fileId)
-		this.updateFileState(fileId, (fileState) => ({
-			firstVisitAt: fileState.firstVisitAt ?? Date.now(),
+		this.updateFileState(fileId, {
 			lastVisitAt: Date.now(),
-		}))
+		})
 	}
 
 	onFileEdit(fileId: string) {
-		this.updateFileState(fileId, () => ({
-			lastEditAt: Date.now(),
-		}))
+		this.updateFileState(fileId, { lastEditAt: Date.now() })
 	}
 
 	onFileSessionStateUpdate(fileId: string, sessionState: TLSessionStateSnapshot) {
-		this.updateFileState(fileId, () => ({
+		this.updateFileState(fileId, {
 			lastSessionState: JSON.stringify(sessionState),
 			lastVisitAt: Date.now(),
-		}))
+		})
 	}
 
 	onFileExit(fileId: string) {
-		this.updateFileState(fileId, () => ({
-			lastVisitAt: Date.now(),
-		}))
+		this.updateFileState(fileId, { lastVisitAt: Date.now() })
 	}
 
 	static async create(opts: {

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -487,7 +487,6 @@ export class TldrawApp {
 	updateFileState(fileId: string, partial: Partial<TlaFileState>) {
 		const fileState = this.getFileState(fileId)
 		if (!fileState) return
-		// remove relationship because zero complains
 		this.z.mutate.file_state.update({ ...partial, fileId, userId: fileState.userId })
 	}
 

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -153,7 +153,7 @@ export class Zero {
 					{
 						table: 'file_state',
 						event: 'insert',
-						row: { fileId: data.id, userId: store.user.id } as any,
+						row: { fileId: data.id, userId: store.user.id, firstVisitAt: Date.now() } as any,
 					},
 				])
 			},


### PR DESCRIPTION
I noticed an issue with `firstVisitAt` not getting getting set when I was reviewing #4998. The problem was that we didn't set the `firstVisitAt` when we created a new file. We then didn't allow updating the `firstVisitAt` field, which meant that it never got populated.

Since we don't allow changing `firstVisitAt` I could also simplify some other parts of mutating file state.

File state gets created in two cases:
- when we create a file we immediately also create the file state (this one now correctly sets `firstVisitAt`).
- for guest files we call `onFileEnter` which in turn calls `getOrCreateFileState` which already correctly set the `firstVisitAt` in the insert mutation.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
