### PR TITLE
Create a utility type for making undefined properties optional

### DIFF
--- a/packages/validate/api-report.md
+++ b/packages/validate/api-report.md
@@ -80,6 +80,13 @@ function literal<T extends boolean | number | string>(expectedValue: T): Validat
 // @public (undocumented)
 function literalEnum<const Values extends readonly unknown[]>(...values: Values): Validator<Values[number]>;
 
+// @public (undocumented)
+export type MakeUndefinedOptional<T extends object> = Expand<{
+    [P in ExtractRequiredKeys<T>]: T[P];
+} & {
+    [P in ExtractOptionalKeys<T>]?: T[P];
+}>;
+
 // @public
 function model<T extends {
     readonly id: string;
@@ -103,11 +110,7 @@ function numberUnion<Key extends string, Config extends UnionValidatorConfig<Key
 // @public
 function object<Shape extends object>(config: {
     readonly [K in keyof Shape]: Validatable<Shape[K]>;
-}): ObjectValidator<Expand<{
-    [P in ExtractRequiredKeys<Shape>]: Shape[P];
-} & {
-    [P in ExtractOptionalKeys<Shape>]?: Shape[P];
-}>>;
+}): ObjectValidator<MakeUndefinedOptional<Shape>>;
 
 // @public (undocumented)
 export class ObjectValidator<Shape extends object> extends Validator<Shape> {
@@ -187,6 +190,7 @@ declare namespace T {
         unknownObject,
         ExtractRequiredKeys,
         ExtractOptionalKeys,
+        MakeUndefinedOptional,
         jsonValue,
         linkUrl,
         srcUrl,

--- a/packages/validate/src/index.ts
+++ b/packages/validate/src/index.ts
@@ -9,6 +9,7 @@ export {
 	Validator,
 	type ExtractOptionalKeys,
 	type ExtractRequiredKeys,
+	type MakeUndefinedOptional,
 	type UnionValidatorConfig,
 } from './lib/validation'
 export { T }

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -689,6 +689,15 @@ export type ExtractOptionalKeys<T extends object> = {
 	[K in keyof T]: undefined extends T[K] ? K : never
 }[keyof T]
 
+/** @public */
+export type MakeUndefinedOptional<T extends object> = Expand<
+	{
+		[P in ExtractRequiredKeys<T>]: T[P]
+	} & {
+		[P in ExtractOptionalKeys<T>]?: T[P]
+	}
+>
+
 /**
  * Validate an object has a particular shape.
  *
@@ -696,13 +705,7 @@ export type ExtractOptionalKeys<T extends object> = {
  */
 export function object<Shape extends object>(config: {
 	readonly [K in keyof Shape]: Validatable<Shape[K]>
-}): ObjectValidator<
-	Expand<
-		{ [P in ExtractRequiredKeys<Shape>]: Shape[P] } & {
-			[P in ExtractOptionalKeys<Shape>]?: Shape[P]
-		}
-	>
-> {
+}): ObjectValidator<MakeUndefinedOptional<Shape>> {
 	return new ObjectValidator(config) as any
 }
 


### PR DESCRIPTION
This extracts a type used in the object validation for making all properties of an object that accepts undefined optional. This is useful when you have an object of validators (e.g. props for a shape) and want to create the typescript type for an object that will be accepted by it. With this, any of the properties that has a validator with `.optional()` will be optional in that object.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Expose a utility type for making undefined properties optional