### PR TITLE
Fix an issue with drag and dropping the files

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -30,12 +30,11 @@ export function TlaDeleteFileDialog({ fileId, onClose }: { fileId: string; onClo
 		await app.deleteOrForgetFile(fileId)
 		const recentFiles = app.getUserRecentFiles()
 		if (recentFiles.length === 0) {
-			app.createFile().then((res) => {
-				if (res.ok) {
-					navigate(getFilePath(res.value.file.id), { state: { mode: 'create' } })
-					trackEvent('delete-file', { source: 'file-menu' })
-				}
-			})
+			const result = app.createFile()
+			if (result.ok) {
+				navigate(getFilePath(result.value.file.id), { state: { mode: 'create' } })
+				trackEvent('delete-file', { source: 'file-menu' })
+			}
 		} else {
 			navigate(getFilePath(recentFiles[0].fileId))
 		}

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -17,11 +17,10 @@ export function Component() {
 		if (!app) return
 		if (app.getUserRecentFiles().length === 0) {
 			creatingFile.current = true
-			app.createFile().then((res) => {
-				if (res.ok) {
-					navigate(getFilePath(res.value.file.id), { state: { mode: 'create' } })
-				}
-			})
+			const result = app.createFile()
+			if (result.ok) {
+				navigate(getFilePath(result.value.file.id), { state: { mode: 'create' } })
+			}
 		}
 	}, [app, navigate])
 

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -351,6 +351,9 @@ export function isBinding(record?: UnknownRecord): record is TLBinding;
 export function isBindingId(id?: string): id is TLBindingId;
 
 // @public (undocumented)
+export function isDocument(record?: UnknownRecord): record is TLDocument;
+
+// @public (undocumented)
 export function isPageId(id: string): id is TLPageId;
 
 // @public (undocumented)

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -71,7 +71,12 @@ export {
 	type TLUnknownBinding,
 } from './records/TLBinding'
 export { CameraRecordType, type TLCamera, type TLCameraId } from './records/TLCamera'
-export { DocumentRecordType, TLDOCUMENT_ID, type TLDocument } from './records/TLDocument'
+export {
+	DocumentRecordType,
+	TLDOCUMENT_ID,
+	isDocument,
+	type TLDocument,
+} from './records/TLDocument'
 export {
 	TLINSTANCE_ID,
 	pluckPreservingValues,

--- a/packages/tlschema/src/records/TLDocument.ts
+++ b/packages/tlschema/src/records/TLDocument.ts
@@ -4,6 +4,7 @@ import {
 	createRecordMigrationSequence,
 	createRecordType,
 	RecordId,
+	UnknownRecord,
 } from '@tldraw/store'
 import { JsonObject } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
@@ -30,6 +31,12 @@ export const documentValidator: T.Validator<TLDocument> = T.model(
 		meta: T.jsonValue as T.ObjectValidator<JsonObject>,
 	})
 )
+
+/** @public */
+export function isDocument(record?: UnknownRecord): record is TLDocument {
+	if (!record) return false
+	return record.typeName === 'document'
+}
 
 /** @public */
 export const documentVersions = createMigrationIds('com.tldraw.document', {


### PR DESCRIPTION
We got an error saying there was a bad request when drag and dropping files. This is because we wanted to create a file state as the file owner, but the file did not exist yet (which is not allowed, we only allow that for guest files). So we now also create a file together with the file state.

![image](https://github.com/user-attachments/assets/2bde9622-e511-4f84-ad08-b1d6dd54e3cc)

I also noticed that the `createFile` function does not need to be async and also extracted document names from the files if we have them.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Drag some files to the sidebar.
2. They should correctly appear (with the correct names if they have time) and you should not see any rejected mutation toasts (like the one above).
