### PR TITLE
Fix the file name flashing with an old value

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -71,11 +71,11 @@ export class TldrawApp {
 	}
 
 	toasts: TLUiToastsContextType | null = null
-	intl: IntlShape | null = null
 
 	private constructor(
 		public readonly userId: string,
-		getToken: () => Promise<string | null>
+		getToken: () => Promise<string | null>,
+		private intl: IntlShape
 	) {
 		const sessionId = uniqueId()
 		this.z = new Zero({
@@ -297,12 +297,8 @@ export class TldrawApp {
 		}
 
 		const createdAt = new Date(file.createdAt)
-		if (this.intl) {
-			const format = getDateFormat(createdAt)
-			return this.intl.formatDate(createdAt, format)
-		}
-		const locale = this.user$.get()?.locale
-		return new Date(createdAt).toLocaleString(locale ?? 'en-gb')
+		const format = getDateFormat(createdAt)
+		return this.intl.formatDate(createdAt, format)
 	}
 
 	claimTemporaryFile(fileId: string) {
@@ -557,13 +553,14 @@ export class TldrawApp {
 		email: string
 		avatar: string
 		getToken(): Promise<string | null>
+		intl: IntlShape
 	}) {
 		// This is an issue: we may have a user record but not in the store.
 		// Could be just old accounts since before the server had a version
 		// of the store... but we should probably identify that better.
 
 		const { id: _id, name: _name, color, ...restOfPreferences } = getUserPreferences()
-		const app = new TldrawApp(opts.userId, opts.getToken)
+		const app = new TldrawApp(opts.userId, opts.getToken, opts.intl)
 		// @ts-expect-error
 		window.app = app
 		await app.preload({

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -2,12 +2,14 @@ import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
 import { assertExists, deleteFromLocalStorage, getFromLocalStorage } from 'tldraw'
 import { TldrawApp } from '../app/TldrawApp'
+import { useIntl } from '../utils/i18n'
 import { TEMPORARY_FILE_KEY } from '../utils/temporary-files'
 
 const appContext = createContext<TldrawApp | null>(null)
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
 	const [app, setApp] = useState(null as TldrawApp | null)
+	const intl = useIntl()
 	const auth = useAuth()
 	const { user, isLoaded } = useClerkUser()
 
@@ -34,6 +36,7 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 				email: user.emailAddresses[0]?.emailAddress || '',
 				avatar: user.imageUrl || '',
 				getToken: async () => await auth.getToken(),
+				intl,
 			}).then(({ app }) => {
 				if (didCancel) {
 					app.dispose()

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -19,7 +19,7 @@ import { components } from '../components/TlaEditor/TlaEditor'
 import { AppStateProvider, useMaybeApp } from '../hooks/useAppState'
 import { UserProvider } from '../hooks/useUser'
 import '../styles/tla.css'
-import { IntlProvider, setupCreateIntl, useIntl } from '../utils/i18n'
+import { IntlProvider, setupCreateIntl } from '../utils/i18n'
 import { getLocalSessionState, updateLocalSessionState } from '../utils/local-session-state'
 import { getRootPath } from '../utils/urls'
 
@@ -107,7 +107,6 @@ function InsideOfContainerContext({ children }: { children: ReactNode }) {
 				<TldrawUiDialogs />
 				<TldrawUiToasts />
 				<PutToastsInApp />
-				<PutIntlInApp />
 			</TldrawUiContextProvider>
 		</EditorContext.Provider>
 	)
@@ -117,13 +116,6 @@ function PutToastsInApp() {
 	const toasts = useToasts()
 	const app = useMaybeApp()
 	if (app) app.toasts = toasts
-	return null
-}
-
-function PutIntlInApp() {
-	const intl = useIntl()
-	const app = useMaybeApp()
-	if (app) app.intl = intl
 	return null
 }
 


### PR DESCRIPTION
App provider is inside the intl provider, so we can just get the intl and pass it along.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
