### PR TITLE
Allow renaming files when pressing enter

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
@@ -19,7 +19,7 @@ export function TlaSidebarCreateFileButton() {
 
 	const handleSidebarCreate = useCallback(async () => {
 		if (!rCanCreate.current) return
-		const res = await app.createFile()
+		const res = app.createFile()
 		if (res.ok) {
 			const { file } = res.value
 			navigate(getFilePath(file.id), { state: { mode: 'create' } })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -79,6 +79,7 @@ export function TlaSidebarFileLinkInner({
 	const handleRenameAction = () => setIsRenaming(true)
 	const handleRenameClose = () => setIsRenaming(false)
 	const handleKeyDown = (e: KeyboardEvent) => {
+		if (!isActive) return
 		if (e.key === 'Enter') {
 			handleRenameAction()
 		}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -87,7 +87,7 @@ export function TlaSidebarFileLinkInner({
 
 	useEffect(() => {
 		if (!isActive || !linkRef.current) return
-		linkRef.current?.focus()
+		linkRef.current.focus()
 	}, [isActive, linkRef])
 
 	const file = useValue('file', () => app.getFile(fileId), [fileId, app])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -1,6 +1,6 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
-import { useEffect, useState } from 'react'
+import { KeyboardEvent, useEffect, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useContainer, useValue } from 'tldraw'
 import { useApp } from '../../../hooks/useAppState'
@@ -72,11 +72,22 @@ export function TlaSidebarFileLinkInner({
 	debugIsRenaming?: boolean
 }) {
 	const trackEvent = useTldrawAppUiEvents()
+	const linkRef = useRef<HTMLAnchorElement | null>(null)
+	const app = useApp()
 
 	const [isRenaming, setIsRenaming] = useState(debugIsRenaming)
 	const handleRenameAction = () => setIsRenaming(true)
 	const handleRenameClose = () => setIsRenaming(false)
-	const app = useApp()
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			handleRenameAction()
+		}
+	}
+
+	useEffect(() => {
+		if (!isActive || !linkRef.current) return
+		linkRef.current?.focus()
+	}, [isActive, linkRef])
 
 	const file = useValue('file', () => app.getFile(fileId), [fileId, app])
 	if (!file) return null
@@ -105,6 +116,8 @@ export function TlaSidebarFileLinkInner({
 				</div>
 			</div>
 			<Link
+				ref={linkRef}
+				onKeyDown={handleKeyDown}
 				onClick={() => trackEvent('click-file-link', { source: 'sidebar' })}
 				to={href}
 				className={styles.linkButton}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRenameInline.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRenameInline.tsx
@@ -59,6 +59,7 @@ export function TlaSidebarRenameInline({
 				defaultValue={app.getFileName(fileId)}
 				onComplete={handleSave}
 				onCancel={onClose}
+				onBlur={onClose}
 				autoSelect
 				autoFocus
 			/>


### PR DESCRIPTION
This allows renaming active files when the sidebar has focus and when you press enter. When the file link becomes active it focuses itself and when focused it enters rename mode if we press enter.

This also prevents creating a new file if we first click the create file button and then press enter immediately. The focus changes to the new file and we will start renaming it.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Click create file button.
2. Press enter. You should not see another file getting created. Instead, you should be in the rename mode for the newly added file.
