### PR TITLE
Disable creating new multiplayer rooms and snapshots (the old logic)

### DIFF
--- a/apps/dotcom/client/src/components/FileMenu.tsx
+++ b/apps/dotcom/client/src/components/FileMenu.tsx
@@ -1,3 +1,4 @@
+import { OLD_FILE_CREATION_DISABLED } from '@tldraw/dotcom-shared'
 import { TldrawUiMenuActionItem, TldrawUiMenuGroup, TldrawUiMenuSubmenu } from 'tldraw'
 import {
 	FORK_PROJECT_ACTION,
@@ -16,13 +17,17 @@ export function LocalFileMenu() {
 		<TldrawUiMenuSubmenu id="file" label="menu.file">
 			<TldrawUiMenuGroup id="file-actions">
 				<TldrawUiMenuActionItem actionId={NEW_PROJECT_ACTION} />
-				<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
+				{!OLD_FILE_CREATION_DISABLED && (
+					<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
+				)}
 				<TldrawUiMenuActionItem actionId={OPEN_FILE_ACTION} />
 				<TldrawUiMenuActionItem actionId={SAVE_FILE_COPY_ACTION} />
 			</TldrawUiMenuGroup>
-			<TldrawUiMenuGroup id="share">
-				<TldrawUiMenuActionItem actionId={SHARE_PROJECT_ACTION} />
-			</TldrawUiMenuGroup>
+			{!OLD_FILE_CREATION_DISABLED && (
+				<TldrawUiMenuGroup id="share">
+					<TldrawUiMenuActionItem actionId={SHARE_PROJECT_ACTION} />
+				</TldrawUiMenuGroup>
+			)}
 		</TldrawUiMenuSubmenu>
 	)
 }
@@ -34,8 +39,12 @@ export function MultiplayerFileMenu() {
 				<TldrawUiMenuActionItem actionId={SAVE_FILE_COPY_ACTION} />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="share">
-				<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
-				<TldrawUiMenuActionItem actionId={FORK_PROJECT_ACTION} />
+				{!OLD_FILE_CREATION_DISABLED && (
+					<>
+						<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
+						<TldrawUiMenuActionItem actionId={FORK_PROJECT_ACTION} />
+					</>
+				)}
 				<TldrawUiMenuActionItem actionId={LEAVE_SHARED_PROJECT_ACTION} />
 			</TldrawUiMenuGroup>
 		</TldrawUiMenuSubmenu>

--- a/apps/dotcom/client/src/components/FileMenu.tsx
+++ b/apps/dotcom/client/src/components/FileMenu.tsx
@@ -12,18 +12,18 @@ import {
 	SAVE_FILE_COPY_ACTION,
 } from '../utils/useFileSystem'
 
+const allowSharing = !OLD_FILE_CREATION_DISABLED
+
 export function LocalFileMenu() {
 	return (
 		<TldrawUiMenuSubmenu id="file" label="menu.file">
 			<TldrawUiMenuGroup id="file-actions">
 				<TldrawUiMenuActionItem actionId={NEW_PROJECT_ACTION} />
-				{!OLD_FILE_CREATION_DISABLED && (
-					<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
-				)}
+				{allowSharing && <TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />}
 				<TldrawUiMenuActionItem actionId={OPEN_FILE_ACTION} />
 				<TldrawUiMenuActionItem actionId={SAVE_FILE_COPY_ACTION} />
 			</TldrawUiMenuGroup>
-			{!OLD_FILE_CREATION_DISABLED && (
+			{allowSharing && (
 				<TldrawUiMenuGroup id="share">
 					<TldrawUiMenuActionItem actionId={SHARE_PROJECT_ACTION} />
 				</TldrawUiMenuGroup>
@@ -39,7 +39,7 @@ export function MultiplayerFileMenu() {
 				<TldrawUiMenuActionItem actionId={SAVE_FILE_COPY_ACTION} />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="share">
-				{!OLD_FILE_CREATION_DISABLED && (
+				{allowSharing && (
 					<>
 						<TldrawUiMenuActionItem actionId={NEW_SHARED_PROJECT_ACTION} />
 						<TldrawUiMenuActionItem actionId={FORK_PROJECT_ACTION} />

--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -1,4 +1,4 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { getLicenseKey, OLD_FILE_CREATION_DISABLED } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect } from 'react'
 import {
 	DefaultDebugMenu,
@@ -6,11 +6,13 @@ import {
 	DefaultKeyboardShortcutsDialog,
 	DefaultKeyboardShortcutsDialogContent,
 	DefaultMainMenu,
-	EditSubmenu,
 	Editor,
+	EditSubmenu,
 	ExportFileContentSubMenu,
 	ExtrasGroup,
+	getFromLocalStorage,
 	PreferencesGroup,
+	setInLocalStorage,
 	TLComponents,
 	Tldraw,
 	TldrawUiButton,
@@ -22,11 +24,9 @@ import {
 	TldrawUiDialogTitle,
 	TldrawUiMenuActionItem,
 	TldrawUiMenuGroup,
-	ViewSubmenu,
-	getFromLocalStorage,
-	setInLocalStorage,
 	useDialogs,
 	useEditor,
+	ViewSubmenu,
 } from 'tldraw'
 import { assetUrls } from '../utils/assetUrls'
 import { createAssetFromUrl } from '../utils/createAssetFromUrl'
@@ -74,6 +74,7 @@ const components: TLComponents = {
 		)
 	},
 	SharePanel: () => {
+		if (OLD_FILE_CREATION_DISABLED) return null
 		return (
 			<div className="tlui-share-zone" draggable={false}>
 				<ShareMenu />

--- a/apps/dotcom/client/src/components/SnapshotLinkCopy.tsx
+++ b/apps/dotcom/client/src/components/SnapshotLinkCopy.tsx
@@ -1,4 +1,4 @@
-import { SNAPSHOT_PREFIX } from '@tldraw/dotcom-shared'
+import { OLD_FILE_CREATION_DISABLED, SNAPSHOT_PREFIX } from '@tldraw/dotcom-shared'
 import React, { useCallback, useState } from 'react'
 import {
 	TldrawUiMenuGroup,
@@ -31,6 +31,7 @@ export const SnapshotLinkCopy = React.memo(function SnapshotLinkCopy() {
 		setDidCopySnapshotLink(true)
 		setTimeout(() => setDidCopySnapshotLink(false), 1000)
 	}, [shareSnapshot])
+	if (OLD_FILE_CREATION_DISABLED) return null
 
 	return (
 		<TldrawUiMenuGroup id="snapshot">

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -1,5 +1,6 @@
 import { captureException } from '@sentry/react'
 import {
+	OLD_FILE_CREATION_DISABLED,
 	READ_ONLY_LEGACY_PREFIX,
 	READ_ONLY_PREFIX,
 	ROOM_PREFIX,
@@ -75,8 +76,12 @@ export const router = createRoutesFromElements(
 			{/* We don't want to index multiplayer rooms */}
 			<Route element={<NoIndex />}>
 				<Route element={<ShimIntlProvider />}>
-					<Route path={`/${ROOM_PREFIX}`} lazy={() => import('./pages/new')} />
-					<Route path="/new" lazy={() => import('./pages/new')} />
+					{!OLD_FILE_CREATION_DISABLED && (
+						<>
+							<Route path={`/${ROOM_PREFIX}`} lazy={() => import('./pages/new')} />
+							<Route path="/new" lazy={() => import('./pages/new')} />
+						</>
+					)}
 					<Route path={`/ts-side`} lazy={() => import('./pages/public-touchscreen-side-panel')} />
 					<Route
 						path={`/${ROOM_PREFIX}/:roomId`}

--- a/apps/dotcom/sync-worker/src/routes/createRoom.ts
+++ b/apps/dotcom/sync-worker/src/routes/createRoom.ts
@@ -1,4 +1,4 @@
-import { CreateRoomRequestBody } from '@tldraw/dotcom-shared'
+import { CreateRoomRequestBody, OLD_FILE_CREATION_DISABLED } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
 import { createTLSchema } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
@@ -9,6 +9,11 @@ import { validateSnapshot } from '../utils/validateSnapshot'
 
 // Sets up a new room based on a provided snapshot, e.g. when a user clicks the "Share" buttons or the "Fork project" buttons.
 export async function createRoom(request: IRequest, env: Environment): Promise<Response> {
+	if (OLD_FILE_CREATION_DISABLED) {
+		return new Response(JSON.stringify({ error: true, message: 'File creation is disabled' }), {
+			status: 400,
+		})
+	}
 	// The data sent from the client will include the data for the new room
 	const data = (await request.json()) as CreateRoomRequestBody
 

--- a/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
@@ -1,4 +1,4 @@
-import { CreateSnapshotRequestBody } from '@tldraw/dotcom-shared'
+import { CreateSnapshotRequestBody, OLD_FILE_CREATION_DISABLED } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
 import { uniqueId } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
@@ -12,6 +12,10 @@ export interface R2Snapshot {
 }
 
 export async function createRoomSnapshot(request: IRequest, env: Environment): Promise<Response> {
+	if (OLD_FILE_CREATION_DISABLED)
+		return new Response(JSON.stringify({ error: true, message: 'File creation is disabled' }), {
+			status: 400,
+		})
 	const data = (await request.json()) as CreateSnapshotRequestBody
 
 	const snapshotResult = validateSnapshot(data)

--- a/packages/dotcom-shared/src/featureFlag.ts
+++ b/packages/dotcom-shared/src/featureFlag.ts
@@ -1,0 +1,1 @@
+export const OLD_FILE_CREATION_DISABLED = true

--- a/packages/dotcom-shared/src/featureFlag.ts
+++ b/packages/dotcom-shared/src/featureFlag.ts
@@ -1,1 +1,1 @@
-export const OLD_FILE_CREATION_DISABLED = true
+export const OLD_FILE_CREATION_DISABLED = false

--- a/packages/dotcom-shared/src/index.ts
+++ b/packages/dotcom-shared/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable local/no-export-star */
 export * from './OptimisticAppStore'
+export * from './featureFlag'
 export { default as getLicenseKey } from './license'
 export {
 	READ_ONLY_LEGACY_PREFIX,


### PR DESCRIPTION
We don't have a feature flag system that would cover both FE and BE so at least for now I added a simple flag to `dotcom-shared`.

When we decide to go live we can turn `OLD_FILE_CREATION_DISABLED` to `true`. Then after a while we can remove all the logic that is gated behind it.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Set `OLD_FILE_CREATION_DISABLED` to `true`
2. You should not see any UI that lets you create a new shared room or snapshot.
