### PR TITLE
Fix custom embed first render

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -891,6 +891,8 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
     component(shape: TLEmbedShape): JSX_2.Element | null;
     // (undocumented)
+    static embedDefinitions: readonly EmbedDefinition[];
+    // (undocumented)
     getDefaultProps(): TLEmbedShape['props'];
     // (undocumented)
     getEmbedDefinition(url: string): TLEmbedResult;
@@ -912,8 +914,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     onResize(shape: TLEmbedShape, info: TLResizeInfo<TLEmbedShape>): TLEmbedShape;
     // (undocumented)
     static props: RecordProps<TLEmbedShape>;
-    // (undocumented)
-    setEmbedDefinitions(definitions: TLEmbedDefinition[]): void;
     // (undocumented)
     static type: "embed";
 }

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -891,8 +891,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
     component(shape: TLEmbedShape): JSX_2.Element | null;
     // (undocumented)
-    static embedDefinitions: readonly EmbedDefinition[];
-    // (undocumented)
     getDefaultProps(): TLEmbedShape['props'];
     // (undocumented)
     getEmbedDefinition(url: string): TLEmbedResult;
@@ -914,6 +912,8 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     onResize(shape: TLEmbedShape, info: TLResizeInfo<TLEmbedShape>): TLEmbedShape;
     // (undocumented)
     static props: RecordProps<TLEmbedShape>;
+    // (undocumented)
+    static setEmbedDefinitions(embedDefinitions: readonly TLEmbedDefinition[]): void;
     // (undocumented)
     static type: "embed";
 }

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -149,7 +149,7 @@ export function Tldraw(props: TldrawProps) {
 
 	const embedShapeUtil = shapeUtilsWithDefaults.find((util) => util.type === 'embed')
 	if (embedShapeUtil && embeds) {
-		EmbedShapeUtil.embedDefinitions = embeds
+		EmbedShapeUtil.setEmbedDefinitions(embeds)
 	}
 
 	return (

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -147,6 +147,11 @@ export function Tldraw(props: TldrawProps) {
 		)
 	}
 
+	const embedShapeUtil = shapeUtilsWithDefaults.find((util) => util.type === 'embed')
+	if (embedShapeUtil && embeds) {
+		EmbedShapeUtil.embedDefinitions = embeds
+	}
+
 	return (
 		<TldrawEditor
 			initialState="select"
@@ -163,7 +168,6 @@ export function Tldraw(props: TldrawProps) {
 					acceptedImageMimeTypes={_imageMimeTypes}
 					acceptedVideoMimeTypes={_videoMimeTypes}
 					onMount={onMount}
-					embeds={embeds}
 				/>
 				{children}
 			</TldrawUi>
@@ -178,20 +182,14 @@ function InsideOfEditorAndUiContext({
 	acceptedImageMimeTypes = DEFAULT_SUPPORTED_IMAGE_TYPES,
 	acceptedVideoMimeTypes = DEFAULT_SUPPORT_VIDEO_TYPES,
 	onMount,
-	embeds,
 }: TLExternalContentProps & {
 	onMount?: TLOnMountHandler
-	embeds?: TLEmbedDefinition[]
 }) {
 	const editor = useEditor()
 	const toasts = useToasts()
 	const msg = useTranslation()
 
 	useOnMount(() => {
-		const embedUtil = editor.getShapeUtil('embed') as EmbedShapeUtil | undefined
-		if (embedUtil && embeds) {
-			embedUtil.setEmbedDefinitions(embeds)
-		}
 		const unsubs: (void | (() => void) | undefined)[] = []
 
 		unsubs.push(registerDefaultSideEffects(editor))

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -38,7 +38,11 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	static override type = 'embed' as const
 	static override props = embedShapeProps
 	static override migrations = embedShapeMigrations
-	static embedDefinitions: readonly EmbedDefinition[] = DEFAULT_EMBED_DEFINITIONS
+	private static embedDefinitions: readonly EmbedDefinition[] = DEFAULT_EMBED_DEFINITIONS
+
+	static setEmbedDefinitions(embedDefinitions: readonly TLEmbedDefinition[]) {
+		EmbedShapeUtil.embedDefinitions = embedDefinitions
+	}
 
 	getEmbedDefinitions(): readonly TLEmbedDefinition[] {
 		return EmbedShapeUtil.embedDefinitions

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -38,18 +38,14 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	static override type = 'embed' as const
 	static override props = embedShapeProps
 	static override migrations = embedShapeMigrations
-	private embedDefinitions: readonly EmbedDefinition[] = DEFAULT_EMBED_DEFINITIONS
-
-	setEmbedDefinitions(definitions: TLEmbedDefinition[]) {
-		this.embedDefinitions = definitions
-	}
+	static embedDefinitions: readonly EmbedDefinition[] = DEFAULT_EMBED_DEFINITIONS
 
 	getEmbedDefinitions(): readonly TLEmbedDefinition[] {
-		return this.embedDefinitions
+		return EmbedShapeUtil.embedDefinitions
 	}
 
 	getEmbedDefinition(url: string): TLEmbedResult {
-		return getEmbedInfo(this.embedDefinitions, url)
+		return getEmbedInfo(EmbedShapeUtil.embedDefinitions, url)
 	}
 
 	override getText(shape: TLEmbedShape) {


### PR DESCRIPTION
The custom embed definitions were set too late, the editor already did the initial render before we managed to update the embed definitions with the custom ones. This sets the definitions before the editor is instantiated so it should fix that.

Solves https://github.com/tldraw/tldraw/issues/5003

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix an issue with custom embeds not rendering correctly on the first render.