### PR TITLE
fix: Updating shape props to undefined when using editor.updateShape

### DIFF
--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -1,14 +1,58 @@
-import { Box, createShapeId, createTLStore } from '../..'
+import {
+	Box,
+	Geometry2d,
+	RecordProps,
+	Rectangle2d,
+	ShapeUtil,
+	T,
+	TLBaseShape,
+	createShapeId,
+	createTLStore,
+} from '../..'
 import { Editor } from './Editor'
+
+type ICustomShape = TLBaseShape<
+	'my-custom-shape',
+	{
+		w: number
+		h: number
+		text: string | undefined
+	}
+>
+
+class CustomShape extends ShapeUtil<ICustomShape> {
+	static override type = 'my-custom-shape' as const
+	static override props: RecordProps<ICustomShape> = {
+		w: T.number,
+		h: T.number,
+		text: T.string.optional(),
+	}
+	getDefaultProps(): ICustomShape['props'] {
+		return {
+			w: 200,
+			h: 200,
+			text: '',
+		}
+	}
+	getGeometry(shape: ICustomShape): Geometry2d {
+		return new Rectangle2d({
+			width: shape.props.w,
+			height: shape.props.h,
+			isFilled: true,
+		})
+	}
+	indicator() {}
+	component() {}
+}
 
 let editor: Editor
 
 beforeEach(() => {
 	editor = new Editor({
-		shapeUtils: [],
+		shapeUtils: [CustomShape],
 		bindingUtils: [],
 		tools: [],
-		store: createTLStore({ shapeUtils: [] }),
+		store: createTLStore({ shapeUtils: [CustomShape] }),
 		getContainer: () => document.body,
 	})
 	editor.setCameraOptions({ isLocked: true })
@@ -25,6 +69,23 @@ describe('centerOnPoint', () => {
 	it('sets camera when isLocked is set and force flag is set', () => {
 		editor.centerOnPoint({ x: 0, y: 0 }, { force: true })
 		expect(editor.setCamera).toHaveBeenCalled()
+	})
+})
+
+describe('updateShape', () => {
+	it('updates shape props to undefined', () => {
+		const id = createShapeId('sample')
+		editor.createShape({
+			id,
+			type: 'my-custom-shape',
+			props: { w: 100, h: 100, text: 'Hello' },
+		})
+		const shape = editor.getShape(id) as ICustomShape
+		expect(shape.props).toEqual({ w: 100, h: 100, text: 'Hello' })
+
+		editor.updateShape({ ...shape, props: { ...shape.props, text: undefined } })
+		const updatedShape = editor.getShape(id) as ICustomShape
+		expect(updatedShape.props).toEqual({ w: 100, h: 100, text: undefined })
 	})
 })
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9800,9 +9800,7 @@ function applyPartialToRecordWithProps<
 		if (k === 'props' || k === 'meta') {
 			next[k] = { ...prev[k] } as JsonObject
 			for (const [nextKey, nextValue] of Object.entries(v as object)) {
-				if (nextValue !== undefined) {
-					;(next[k] as JsonObject)[nextKey] = nextValue
-				}
+				;(next[k] as JsonObject)[nextKey] = nextValue
 			}
 			continue
 		}


### PR DESCRIPTION
When using `editor.store.put`, any property within the props of a shape can be updated to undefined. However, when using `editor.updateShape`, updates to undefined are ignored.

To address this, I have modified `editor.updateShape` to allow updating any property within props to undefined as well.

related: #4953
### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Updating shape props to undefined  when using editor.updateShape