### PR TITLE
Fix long press bug (#5032)

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9498,9 +9498,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (!this.inputs.isPanning) {
 							// Start a long press timeout
 							this._longPressTimeout = this.timers.setTimeout(() => {
+								const vsb = this.getViewportScreenBounds()
 								this.dispatch({
 									...info,
-									point: this.inputs.currentScreenPoint,
+									// important! non-obvious!! the screenpoint was adjusted using the
+									// viewport bounds, and will be again when this event is handled...
+									// so we need to counter-adjust from the stored value so that the
+									// new value is set correctly.
+									point: this.inputs.originScreenPoint.clone().addXY(vsb.x, vsb.y),
 									name: 'long_press',
 								})
 							}, this.options.longPressDurationMs)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1,4 +1,4 @@
-import { TLFrameShape, TLGeoShape, createShapeId, tlenv } from '@tldraw/editor'
+import { Box, TLFrameShape, TLGeoShape, createShapeId, tlenv } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -2170,5 +2170,21 @@ describe('control pointing', () => {
 		editor.pointerDown()
 		editor.pointerUp()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+	})
+})
+
+describe('long press', () => {
+	it('works correctly with screenbounds offset', () => {
+		editor.updateViewportScreenBounds(new Box(100, 100, 800, 600))
+		editor.pointerDown(201, 202)
+		expect(editor.inputs.currentScreenPoint).toMatchObject({ x: 101, y: 102 })
+	})
+
+	it('works correctly with screenbounds offset', () => {
+		editor.updateViewportScreenBounds(new Box(100, 100, 800, 600))
+		editor.pointerDown(201, 202)
+		jest.advanceTimersByTime(1000)
+		// without the fix added in this PR, it would have been 1, 2
+		expect(editor.inputs.currentScreenPoint).toMatchObject({ x: 101, y: 102 })
 	})
 })


### PR DESCRIPTION
This PR fixes a bug with long presses where the point would be wrong.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Long press on a shape
2. The shape should not move under your pointer

- [x] Unit tests

### Release notes

- Fixed a bug with long press on inset canvases.