### PR TITLE
Expand helpers available in actions / toasts overrides.

### DIFF
--- a/apps/examples/src/examples/action-overrides/ActionOverridesExample.tsx
+++ b/apps/examples/src/examples/action-overrides/ActionOverridesExample.tsx
@@ -1,4 +1,4 @@
-import { Tldraw } from 'tldraw'
+import { Tldraw, TLUiActionItem, TLUiActionsContextType } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function BasicExample() {
@@ -6,11 +6,29 @@ export default function BasicExample() {
 		<div className="tldraw__editor">
 			<Tldraw
 				overrides={{
-					actions: (_editor, actions, _helpers) => {
-						const newActions = {
-							...actions,
-							delete: { ...actions['delete'], kbd: 'x' },
+					actions: (_editor, actions, helpers) => {
+						const myCustomAction: TLUiActionItem = {
+							id: 'my-action',
+							label: 'My action',
+							icon: 'circle',
+							// [2]
+							kbd: '$u',
+							onSelect(source) {
+								// [3]
+								helpers.addToast({ title: `My action was selected from ${source}!` })
+							},
 						}
+
+						// [4]
+						const newActions: TLUiActionsContextType = {
+							...actions,
+							'my-action': myCustomAction,
+							delete: {
+								...actions['delete'],
+								kbd: '!x',
+							},
+						}
+
 						return newActions
 					},
 				}}
@@ -20,8 +38,18 @@ export default function BasicExample() {
 }
 
 /* 
-This example shows how you can override tldraw's actions object to change the keyboard shortcuts.
-In this case we're changing the delete action's shortcut to 'x'. To customize the actions menu
-please see the custom actions menu example. For more information on keyboard shortcuts see the
+Tldraw's actions can be fired via keyboard shortcuts, or from anywhere in the user interface via 
+the `useActions` hook. This example shows how you can override tldraw's actions object via the Tldraw
+component's `overrides` prop. To learn more about using this actions via a customized menu, see the 
+custom actions menu example.
+
+[2]
+For kbds, Shift = !, Alt = ?, Cmd = $, i.e. Cmd+Shift+U is $!u. For more information on keyboard shortcuts see the
 keyboard shortcuts example.
+
+[3]
+You can access UI helpers like addToast, removeToast, etc. from the helpers object.
+
+[4]
+Return a new object with the new actions added. You can also modify existing actions as shown here with the delete action.
 */

--- a/apps/examples/src/examples/action-overrides/README.md
+++ b/apps/examples/src/examples/action-overrides/README.md
@@ -6,7 +6,7 @@ priority: 2
 keywords: [keyboard, shortcut, copy, paste, group, align]
 ---
 
-Override tldraw's actions
+Override tldraw's actions.
 
 ---
 

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -2993,9 +2993,7 @@ export interface TLUiOverrides {
     // (undocumented)
     actions?(editor: Editor, actions: TLUiActionsContextType, helpers: TLUiOverrideHelpers): TLUiActionsContextType;
     // (undocumented)
-    tools?(editor: Editor, tools: TLUiToolsContextType, helpers: {
-        insertMedia(): void;
-    } & TLUiOverrideHelpers): TLUiToolsContextType;
+    tools?(editor: Editor, tools: TLUiToolsContextType, helpers: TLUiOverrideHelpers): TLUiToolsContextType;
     // (undocumented)
     translations?: TLUiTranslationProviderProps['overrides'];
 }

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -122,7 +122,7 @@ export interface ActionsProviderProps {
     // (undocumented)
     children: React_2.ReactNode;
     // (undocumented)
-    overrides?(editor: Editor, actions: TLUiActionsContextType, helpers: undefined): TLUiActionsContextType;
+    overrides?(editor: Editor, actions: TLUiActionsContextType, helpers: TLUiOverrideHelpers): TLUiActionsContextType;
 }
 
 // @public (undocumented)
@@ -3755,8 +3755,16 @@ export function useDefaultHelpers(): {
     }) => string;
     clearDialogs: () => void;
     clearToasts: () => void;
+    copy: (source: TLUiEventSource) => Promise<void>;
+    copyAs: (ids: TLShapeId[], format?: TLCopyType) => void;
+    cut: (source: TLUiEventSource) => Promise<void>;
+    exportAs: (ids: TLShapeId[], format: TLExportType | undefined, name: string | undefined) => void;
+    getEmbedDefinition: (url: string) => TLEmbedResult;
+    insertMedia: () => void;
     isMobile: boolean;
     msg: (id?: string | undefined) => string;
+    paste: (data: ClipboardItem[] | DataTransfer, source: TLUiEventSource, point?: VecLike | undefined) => Promise<void>;
+    printSelectionOrPages: () => Promise<void>;
     removeDialog: (id: string) => string;
     removeToast: (id: string) => string;
 };

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -24,20 +24,12 @@ import { kickoutOccludedShapes } from '../../tools/SelectTool/selectHelpers'
 import { fitFrameToContent, removeFrame } from '../../utils/frames/frames'
 import { EditLinkDialog } from '../components/EditLinkDialog'
 import { EmbedDialog } from '../components/EmbedDialog'
-import { useMenuClipboardEvents } from '../hooks/useClipboardEvents'
-import { useCopyAs } from '../hooks/useCopyAs'
-import { useExportAs } from '../hooks/useExportAs'
 import { flattenShapesToImages } from '../hooks/useFlatten'
-import { useGetEmbedDefinition } from '../hooks/useGetEmbedDefinition'
-import { useInsertMedia } from '../hooks/useInsertMedia'
 import { useShowCollaborationUi } from '../hooks/useIsMultiplayer'
-import { usePrint } from '../hooks/usePrint'
 import { TLUiTranslationKey } from '../hooks/useTranslation/TLUiTranslationKey'
-import { useTranslation } from '../hooks/useTranslation/useTranslation'
 import { TLUiIconType } from '../icon-types'
-import { useDialogs } from './dialogs'
+import { TLUiOverrideHelpers, useDefaultHelpers } from '../overrides'
 import { TLUiEventSource, useUiEvents } from './events'
-import { useToasts } from './toasts'
 
 /** @public */
 export interface TLUiActionItem<
@@ -64,7 +56,7 @@ export interface ActionsProviderProps {
 	overrides?(
 		editor: Editor,
 		actions: TLUiActionsContextType,
-		helpers: undefined
+		helpers: TLUiOverrideHelpers
 	): TLUiActionsContextType
 	children: React.ReactNode
 }
@@ -86,21 +78,10 @@ function getExportName(editor: Editor, defaultName: string) {
 export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 	const editor = useEditor()
 	const showCollaborationUi = useShowCollaborationUi()
-
-	const { addDialog, clearDialogs } = useDialogs()
-	const { clearToasts, addToast } = useToasts()
-	const msg = useTranslation()
-
-	const insertMedia = useInsertMedia()
-	const printSelectionOrPages = usePrint()
-	const { cut, copy, paste } = useMenuClipboardEvents()
-	const copyAs = useCopyAs()
-	const exportAs = useExportAs()
-	const defaultDocumentName = msg('document.default-name')
-
-	const getEmbedDefinition = useGetEmbedDefinition()
-
+	const helpers = useDefaultHelpers()
 	const trackEvent = useUiEvents()
+
+	const defaultDocumentName = helpers.msg('document.default-name')
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {
@@ -130,7 +111,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					trackEvent('edit-link', { source })
 					editor.markHistoryStoppingPoint('edit-link')
-					addDialog({ component: EditLinkDialog })
+					helpers.addDialog({ component: EditLinkDialog })
 				},
 			},
 			{
@@ -139,7 +120,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$i',
 				onSelect(source) {
 					trackEvent('insert-embed', { source })
-					addDialog({ component: EmbedDialog })
+					helpers.addDialog({ component: EmbedDialog })
 				},
 			},
 			{
@@ -148,7 +129,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$u',
 				onSelect(source) {
 					trackEvent('insert-media', { source })
-					insertMedia()
+					helpers.insertMedia()
 				},
 			},
 			{
@@ -184,7 +165,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-as', { format: 'svg', source })
-					exportAs(ids, 'svg', getExportName(editor, defaultDocumentName))
+					helpers.exportAs(ids, 'svg', getExportName(editor, defaultDocumentName))
 				},
 			},
 			{
@@ -200,7 +181,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-as', { format: 'png', source })
-					exportAs(ids, 'png', getExportName(editor, defaultDocumentName))
+					helpers.exportAs(ids, 'png', getExportName(editor, defaultDocumentName))
 				},
 			},
 			{
@@ -216,7 +197,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-as', { format: 'json', source })
-					exportAs(ids, 'json', getExportName(editor, defaultDocumentName))
+					helpers.exportAs(ids, 'json', getExportName(editor, defaultDocumentName))
 				},
 			},
 			{
@@ -232,7 +213,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-all-as', { format: 'svg', source })
-					exportAs(
+					helpers.exportAs(
 						Array.from(editor.getCurrentPageShapeIds()),
 						'svg',
 						getExportName(editor, defaultDocumentName)
@@ -251,7 +232,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-all-as', { format: 'png', source })
-					exportAs(ids, 'png', getExportName(editor, defaultDocumentName))
+					helpers.exportAs(ids, 'png', getExportName(editor, defaultDocumentName))
 				},
 			},
 			{
@@ -266,7 +247,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('export-all-as', { format: 'json', source })
-					exportAs(ids, 'json', getExportName(editor, defaultDocumentName))
+					helpers.exportAs(ids, 'json', getExportName(editor, defaultDocumentName))
 				},
 			},
 			{
@@ -283,7 +264,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('copy-as', { format: 'svg', source })
-					copyAs(ids, 'svg')
+					helpers.copyAs(ids, 'svg')
 				},
 			},
 			{
@@ -299,7 +280,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('copy-as', { format: 'png', source })
-					copyAs(ids, 'png')
+					helpers.copyAs(ids, 'png')
 				},
 			},
 			{
@@ -315,7 +296,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())
 					if (ids.length === 0) return
 					trackEvent('copy-as', { format: 'json', source })
-					copyAs(ids, 'json')
+					helpers.copyAs(ids, 'json')
 				},
 			},
 			{
@@ -452,7 +433,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 							const { url } = shape.props
 
-							const embedInfo = getEmbedDefinition(url)
+							const embedInfo = helpers.getEmbedDefinition(url)
 
 							if (!embedInfo) continue
 							if (!embedInfo.definition) continue
@@ -928,7 +909,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					editor.markHistoryStoppingPoint('cut')
-					cut(source)
+					helpers.cut(source)
 				},
 			},
 			{
@@ -940,7 +921,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (!canApplySelectionAction()) return
 					if (mustGoBackToSelectToolFirst()) return
 
-					copy(source)
+					helpers.copy(source)
 				},
 			},
 			{
@@ -951,16 +932,16 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					navigator.clipboard
 						?.read()
 						.then((clipboardItems) => {
-							paste(
+							helpers.paste(
 								clipboardItems,
 								source,
 								source === 'context-menu' ? editor.inputs.currentPagePoint : undefined
 							)
 						})
 						.catch(() => {
-							addToast({
-								title: msg('action.paste-error-title'),
-								description: msg('action.paste-error-description'),
+							helpers.addToast({
+								title: helpers.msg('action.paste-error-title'),
+								description: helpers.msg('action.paste-error-description'),
 								severity: 'error',
 							})
 						})
@@ -1267,8 +1248,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					editor.timers.requestAnimationFrame(() => {
 						editor.run(() => {
 							trackEvent('toggle-focus-mode', { source })
-							clearDialogs()
-							clearToasts()
+							helpers.clearDialogs()
+							helpers.clearToasts()
 							editor.updateInstanceState({ isFocusMode: !editor.getInstanceState().isFocusMode })
 						})
 					})
@@ -1310,7 +1291,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				readonlyOk: true,
 				onSelect(source) {
 					trackEvent('print', { source })
-					printSelectionOrPages()
+					helpers.printSelectionOrPages()
 				},
 			},
 			{
@@ -1366,7 +1347,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const ids = editor.getSelectedShapeIds()
 					editor.run(() => {
 						editor.markHistoryStoppingPoint('move_shapes_to_page')
-						editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
+						editor.createPage({
+							name: helpers.msg('page-menu.new-page-initial-name'),
+							id: newPageId,
+						})
 						editor.moveShapesToPage(ids, newPageId)
 					})
 					trackEvent('move-to-new-page', { source })
@@ -1453,30 +1437,11 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 		const actions = makeActions(actionItems)
 
 		if (overrides) {
-			return overrides(editor, actions, undefined)
+			return overrides(editor, actions, helpers)
 		}
 
 		return actions
-	}, [
-		editor,
-		trackEvent,
-		overrides,
-		addDialog,
-		addToast,
-		insertMedia,
-		exportAs,
-		copyAs,
-		cut,
-		copy,
-		paste,
-		clearDialogs,
-		clearToasts,
-		printSelectionOrPages,
-		msg,
-		defaultDocumentName,
-		showCollaborationUi,
-		getEmbedDefinition,
-	])
+	}, [helpers, editor, trackEvent, overrides, defaultDocumentName, showCollaborationUi])
 
 	return <ActionsContext.Provider value={asActions(actions)}>{children}</ActionsContext.Provider>
 }

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -140,6 +140,11 @@ export function useKeyboardShortcuts() {
 	}, [actions, tools, isReadonlyMode, editor, isFocused])
 }
 
+// Shift is !
+// Alt is ?
+// Cmd / control is $
+// so cmd+shift+u would be $!u
+
 function getHotkeysStringFromKbd(kbd: string) {
 	return getKeys(kbd)
 		.map((kbd) => {

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -1,10 +1,9 @@
 import { Editor, GeoShapeGeoStyle, useEditor } from '@tldraw/editor'
 import * as React from 'react'
 import { EmbedDialog } from '../components/EmbedDialog'
-import { useDialogs } from '../context/dialogs'
 import { TLUiEventSource, useUiEvents } from '../context/events'
 import { TLUiIconType } from '../icon-types'
-import { useInsertMedia } from './useInsertMedia'
+import { useDefaultHelpers } from '../overrides'
 import { TLUiTranslationKey } from './useTranslation/TLUiTranslationKey'
 
 /** @public */
@@ -45,8 +44,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()
 
-	const { addDialog } = useDialogs()
-	const insertMedia = useInsertMedia()
+	const helpers = useDefaultHelpers()
 
 	const tools = React.useMemo<TLUiToolsContextType>(() => {
 		const toolsArray: TLUiToolItem<TLUiTranslationKey, TLUiIconType>[] = [
@@ -165,7 +163,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				icon: 'tool-media',
 				kbd: '$u',
 				onSelect(source) {
-					insertMedia()
+					helpers.insertMedia()
 					trackEvent('select-tool', { source, id: 'media' })
 				},
 			},
@@ -195,7 +193,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 				label: 'tool.embed',
 				icon: 'dot',
 				onSelect(source) {
-					addDialog({ component: EmbedDialog })
+					helpers.addDialog({ component: EmbedDialog })
 					trackEvent('select-tool', { source, id: 'embed' })
 				},
 			},
@@ -217,11 +215,11 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 		const tools = Object.fromEntries(toolsArray.map((t) => [t.id, t]))
 
 		if (overrides) {
-			return overrides(editor, tools, { insertMedia })
+			return overrides(editor, tools, helpers)
 		}
 
 		return tools
-	}, [overrides, editor, trackEvent, insertMedia, addDialog])
+	}, [overrides, editor, trackEvent, helpers])
 
 	return <ToolsContext.Provider value={tools}>{children}</ToolsContext.Provider>
 }

--- a/packages/tldraw/src/lib/ui/overrides.ts
+++ b/packages/tldraw/src/lib/ui/overrides.ts
@@ -84,7 +84,7 @@ export interface TLUiOverrides {
 	tools?(
 		editor: Editor,
 		tools: TLUiToolsContextType,
-		helpers: { insertMedia(): void } & TLUiOverrideHelpers
+		helpers: TLUiOverrideHelpers
 	): TLUiToolsContextType
 	translations?: TLUiTranslationProviderProps['overrides']
 }

--- a/packages/tldraw/src/lib/ui/overrides.ts
+++ b/packages/tldraw/src/lib/ui/overrides.ts
@@ -5,6 +5,12 @@ import { ActionsProviderProps, TLUiActionsContextType } from './context/actions'
 import { useBreakpoint } from './context/breakpoints'
 import { useDialogs } from './context/dialogs'
 import { useToasts } from './context/toasts'
+import { useMenuClipboardEvents } from './hooks/useClipboardEvents'
+import { useCopyAs } from './hooks/useCopyAs'
+import { useExportAs } from './hooks/useExportAs'
+import { useGetEmbedDefinition } from './hooks/useGetEmbedDefinition'
+import { useInsertMedia } from './hooks/useInsertMedia'
+import { usePrint } from './hooks/usePrint'
 import { TLUiToolsContextType, TLUiToolsProviderProps } from './hooks/useTools'
 import { TLUiTranslationProviderProps, useTranslation } from './hooks/useTranslation/useTranslation'
 
@@ -12,9 +18,19 @@ import { TLUiTranslationProviderProps, useTranslation } from './hooks/useTransla
 export function useDefaultHelpers() {
 	const { addToast, removeToast, clearToasts } = useToasts()
 	const { addDialog, clearDialogs, removeDialog } = useDialogs()
+
+	const msg = useTranslation()
+	const insertMedia = useInsertMedia()
+	const printSelectionOrPages = usePrint()
+	const { cut, copy, paste } = useMenuClipboardEvents()
+	const copyAs = useCopyAs()
+	const exportAs = useExportAs()
+	const getEmbedDefinition = useGetEmbedDefinition()
+
+	// This is the only one that will change during runtime
 	const breakpoint = useBreakpoint()
 	const isMobile = breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM
-	const msg = useTranslation()
+
 	return useMemo(
 		() => ({
 			addToast,
@@ -25,8 +41,33 @@ export function useDefaultHelpers() {
 			clearDialogs,
 			msg,
 			isMobile,
+			insertMedia,
+			printSelectionOrPages,
+			cut,
+			copy,
+			paste,
+			copyAs,
+			exportAs,
+			getEmbedDefinition,
 		}),
-		[addDialog, addToast, clearDialogs, clearToasts, msg, removeDialog, removeToast, isMobile]
+		[
+			addToast,
+			removeToast,
+			clearToasts,
+			addDialog,
+			removeDialog,
+			clearDialogs,
+			msg,
+			isMobile,
+			insertMedia,
+			printSelectionOrPages,
+			cut,
+			copy,
+			paste,
+			copyAs,
+			exportAs,
+			getEmbedDefinition,
+		]
 	)
 }
 
@@ -71,10 +112,10 @@ export function mergeOverrides(
 		}
 	}
 	return {
-		actions: (editor, schema) => {
+		actions: (editor, schema, helpers) => {
 			for (const override of overrides) {
 				if (override.actions) {
-					schema = override.actions(editor, schema, defaultHelpers)
+					schema = override.actions(editor, schema, helpers)
 				}
 			}
 			return schema


### PR DESCRIPTION
Our actions and tools overrides have access to certain UI helpers, such as copy, print, or toasts. This PR adds additional items to those helpers which were previously only available internally.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Makes new helper available via actions and tools overrides.