### PR TITLE
[botcom] Set document title from file name

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -290,7 +290,9 @@ export class TldrawApp {
 		return Result.ok({ file })
 	}
 
-	getFileName(file: TlaFile | string | null) {
+	getFileName(file: TlaFile | string | null, useDateFallback: false): string | undefined
+	getFileName(file: TlaFile | string | null, useDateFallback?: true): string
+	getFileName(file: TlaFile | string | null, useDateFallback = true) {
 		if (typeof file === 'string') {
 			file = this.getFile(file)
 		}
@@ -305,9 +307,13 @@ export class TldrawApp {
 			return name
 		}
 
-		const createdAt = new Date(file.createdAt)
-		const format = getDateFormat(createdAt)
-		return this.intl.formatDate(createdAt, format)
+		if (useDateFallback) {
+			const createdAt = new Date(file.createdAt)
+			const format = getDateFormat(createdAt)
+			return this.intl.formatDate(createdAt, format)
+		}
+
+		return
 	}
 
 	claimTemporaryFile(fileId: string) {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -306,7 +306,11 @@ function SetDocumentTitle() {
 	const editor = useValue('editor', () => globalEditor.get(), [])
 	const title = useValue(
 		'title',
-		() => (fileSlug ? app?.getFileName(fileSlug) : null) ?? editor?.getDocumentSettings().name,
+		() =>
+			((fileSlug ? app?.getFileName(fileSlug, false) : null) ??
+				editor?.getDocumentSettings().name) ||
+			// rather than displaying the date for the project here, display Untitled project
+			'Untitled project',
 		[app, editor, fileSlug]
 	)
 	if (!title) return null

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@clerk/clerk-react'
 import { TlaFileOpenMode } from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
 import { useCallback, useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { useParams } from 'react-router-dom'
 import {
 	DefaultKeyboardShortcutsDialog,
@@ -21,6 +22,7 @@ import {
 	useActions,
 	useCollaborationStatus,
 	useEditor,
+	useValue,
 } from 'tldraw'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
 import { assetUrls } from '../../../utils/assetUrls'
@@ -96,9 +98,12 @@ export function TlaEditor(props: TlaEditorProps) {
 	}
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
-		<ReadyWrapper key={props.fileSlug}>
-			<TlaEditorInner {...props} key={props.fileSlug} />
-		</ReadyWrapper>
+		<>
+			<SetDocumentTitle />
+			<ReadyWrapper key={props.fileSlug}>
+				<TlaEditorInner {...props} key={props.fileSlug} />
+			</ReadyWrapper>
+		</>
 	)
 }
 
@@ -293,4 +298,17 @@ function SneakyFileUpdateHandler({
 	}, [app, onDocumentChange, fileId, editor])
 
 	return null
+}
+
+function SetDocumentTitle() {
+	const { fileSlug } = useParams<{ fileSlug: string }>()
+	const app = useMaybeApp()
+	const editor = useValue('editor', () => globalEditor.get(), [])
+	const title = useValue(
+		'title',
+		() => (fileSlug ? app?.getFileName(fileSlug) : null) ?? editor?.getDocumentSettings().name,
+		[app, editor, fileSlug]
+	)
+	if (!title) return null
+	return <Helmet title={title} />
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -139,8 +139,13 @@ export function TlaEditorTopLeftPanelSignedIn() {
 		// We should figure out a way to have a single source of truth for the file name.
 		// And to allow guests to 'subscribe' to file metadata updates somehow.
 		() => {
-			// we need that backup file name for empty file names
-			return app.getFileName(fileId).trim() || editor.getDocumentSettings().name
+			// we need that backup file name for empty file names (the initial value for the name is empty)
+			return (
+				app.getFileName(fileId, false)?.trim() ||
+				editor.getDocumentSettings().name ||
+				// rather than displaying the date for the project here, display Untitled project
+				'Untitled project'
+			)
 		},
 		[app, editor, fileId]
 	)
@@ -148,9 +153,12 @@ export function TlaEditorTopLeftPanelSignedIn() {
 		(name: string) => {
 			if (isOwner) {
 				setIsRenaming(false)
-				// don't allow guests to update the file name
-				app.updateFile({ id: fileId, name })
-				editor.updateDocumentSettings({ name })
+				// only actually update the name if name is a value, otherwise keep the previous name
+				if (name) {
+					// don't allow guests to update the file name
+					app.updateFile({ id: fileId, name })
+					editor.updateDocumentSettings({ name })
+				}
 			}
 		},
 		[app, editor, fileId, isOwner]


### PR DESCRIPTION
This PR copies Chat GPT's behavior of replacing the `document.title` with the name of the current file.

### Change type

- [x] `other`
