### PR TITLE
Improve rerenedring of the page menu and quick actions

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3750,7 +3750,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed getPages(): TLPage[] {
-		return this._getAllPagesQuery().get().sort(sortByIndex)
+		return Array.from(this._getAllPagesQuery().get()).sort(sortByIndex)
 	}
 
 	/**

--- a/packages/store/src/lib/StoreQueries.ts
+++ b/packages/store/src/lib/StoreQueries.ts
@@ -7,7 +7,7 @@ import {
 	RESET_VALUE,
 	withDiff,
 } from '@tldraw/state'
-import { objectMapValues } from '@tldraw/utils'
+import { areArraysShallowEqual, objectMapValues } from '@tldraw/utils'
 import isEqual from 'lodash.isequal'
 import { IdOf, UnknownRecord } from './BaseRecord'
 import { executeQuery, objectMatchesQuery, QueryExpression } from './executeQuery'
@@ -333,15 +333,22 @@ export class StoreQueries<R extends UnknownRecord> {
 		type S = Extract<R, { typeName: TypeName }>
 		const ids = this.ids(typeName, queryCreator, 'ids:' + name)
 
-		return computed<S[]>(name, () => {
-			return [...ids.get()].map((id) => {
-				const atom = this.atoms.get()[id]
-				if (!atom) {
-					throw new Error('no atom found for record id: ' + id)
-				}
-				return atom.get() as S
-			})
-		})
+		return computed<S[]>(
+			name,
+			() => {
+				const atoms = this.atoms.get()
+				return [...ids.get()].map((id) => {
+					const atom = atoms[id]
+					if (!atom) {
+						throw new Error('no atom found for record id: ' + id)
+					}
+					return atom.get() as S
+				})
+			},
+			{
+				isEqual: areArraysShallowEqual,
+			}
+		)
 	}
 
 	/**

--- a/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
@@ -25,12 +25,12 @@ export function DefaultQuickActionsContent() {
 	return (
 		<>
 			<UndoRedoGroup />
-			<SelectDependentActionsGroup />
+			<DeleteDuplicateGroup />
 		</>
 	)
 }
 
-function SelectDependentActionsGroup() {
+function DeleteDuplicateGroup() {
 	const oneSelected = useUnlockedSelectedShapesCount(1)
 	const isInSelectState = useIsInSelectState()
 	const selectDependentActionsEnabled = oneSelected && isInSelectState

--- a/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
@@ -12,10 +12,6 @@ import { TldrawUiMenuActionItem } from '../primitives/menus/TldrawUiMenuActionIt
 export function DefaultQuickActionsContent() {
 	const editor = useEditor()
 
-	const canUndo = useCanUndo()
-	const canRedo = useCanRedo()
-	const oneSelected = useUnlockedSelectedShapesCount(1)
-
 	const isReadonlyMode = useReadonly()
 
 	const isInAcceptableReadonlyState = useValue(
@@ -23,17 +19,36 @@ export function DefaultQuickActionsContent() {
 		() => editor.isInAny('select', 'hand', 'zoom'),
 		[editor]
 	)
-	const isInSelectState = useIsInSelectState()
-	const selectDependentActionsEnabled = oneSelected && isInSelectState
 
 	if (isReadonlyMode && !isInAcceptableReadonlyState) return
 
 	return (
 		<>
-			<TldrawUiMenuActionItem actionId="undo" disabled={!canUndo} />
-			<TldrawUiMenuActionItem actionId="redo" disabled={!canRedo} />
+			<UndoRedoGroup />
+			<SelectDependentActionsGroup />
+		</>
+	)
+}
+
+function SelectDependentActionsGroup() {
+	const oneSelected = useUnlockedSelectedShapesCount(1)
+	const isInSelectState = useIsInSelectState()
+	const selectDependentActionsEnabled = oneSelected && isInSelectState
+	return (
+		<>
 			<TldrawUiMenuActionItem actionId="delete" disabled={!selectDependentActionsEnabled} />
 			<TldrawUiMenuActionItem actionId="duplicate" disabled={!selectDependentActionsEnabled} />
+		</>
+	)
+}
+
+function UndoRedoGroup() {
+	const canUndo = useCanUndo()
+	const canRedo = useCanRedo()
+	return (
+		<>
+			<TldrawUiMenuActionItem actionId="undo" disabled={!canUndo} />
+			<TldrawUiMenuActionItem actionId="redo" disabled={!canRedo} />
 		</>
 	)
 }


### PR DESCRIPTION
Page menu used to rerender when we created a new shape. Undo / redo buttons also often rerendered even though they enabled / disabled status did not change. This improves the number of times these items rerender.

### Before  

https://github.com/user-attachments/assets/0192ba66-4e87-4f7f-8686-8173d2da6241

### After

https://github.com/user-attachments/assets/11b5c697-bc54-4781-861e-b5abc1c95324


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improves rendering of the pages menu and quick actions.