### PR TITLE
Add locked camera example.

### DIFF
--- a/apps/examples/src/examples/lock-camera-zoom/LockCameraZoomExample.tsx
+++ b/apps/examples/src/examples/lock-camera-zoom/LockCameraZoomExample.tsx
@@ -1,0 +1,29 @@
+import { Tldraw, TLUiOverrides } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+const DEFAULT_CAMERA_STEPS = [0.1, 0.25, 0.5, 1, 2, 4, 8]
+
+const overrides: TLUiOverrides = {
+	actions(editor, actions) {
+		actions.lockCameraZoom = {
+			id: 'lock-camera-zoom',
+			kbd: '!k',
+			onSelect() {
+				const isCameraZoomLockedAlready = editor.getCameraOptions().zoomSteps.length === 1
+				editor.setCameraOptions({
+					zoomSteps: isCameraZoomLockedAlready ? DEFAULT_CAMERA_STEPS : [editor.getZoomLevel()],
+				})
+			},
+		}
+
+		return actions
+	},
+}
+
+export default function BasicExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="example" overrides={overrides} />
+		</div>
+	)
+}

--- a/apps/examples/src/examples/lock-camera-zoom/README.md
+++ b/apps/examples/src/examples/lock-camera-zoom/README.md
@@ -1,0 +1,13 @@
+---
+title: Lock camera zoom
+component: ./LockCameraZoomExample.tsx
+category: editor-api
+priority: 1
+keywords: [camera, lock, zoom]
+---
+
+Press Shift+K to lock the camera at its current zoom.
+
+---
+
+Need to lock the camera at its current zoom level? You can use the camera controls API to keep the zoom level from changing.


### PR DESCRIPTION
This PR adds an example demonstrating how to lock the current camera zoom using the camera controls API.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
