### PR TITLE
assets: fix up resolving when copy/pasting multiple items; also, videos

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8183,6 +8183,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				if (
 					(asset.type === 'image' || asset.type === 'video') &&
 					!asset.props.src?.startsWith('data:image') &&
+					!asset.props.src?.startsWith('data:video') &&
 					!asset.props.src?.startsWith('http')
 				) {
 					const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
@@ -8420,8 +8421,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			if (
-				(asset.type === 'image' || asset.type === 'video') &&
-				asset.props.src?.startsWith('data:image')
+				(asset.type === 'image' && asset.props.src?.startsWith('data:image')) ||
+				(asset.type === 'video' && asset.props.src?.startsWith('data:video'))
 			) {
 				// it's src is a base64 image or video; we need to create a new asset without the src,
 				// then create a new asset from the original src. So we save a copy of the original asset,

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -37,7 +37,6 @@ export function useLocalStore(
 		const assets: TLAssetStore = {
 			upload: async (asset, file) => {
 				await client.db.storeAsset(asset.id, file)
-
 				return asset.id
 			},
 			resolve: async (asset) => {

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -37,6 +37,7 @@ export function useLocalStore(
 		const assets: TLAssetStore = {
 			upload: async (asset, file) => {
 				await client.db.storeAsset(asset.id, file)
+
 				return asset.id
 			},
 			resolve: async (asset) => {

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -136,14 +136,14 @@ function resolveAssetUrl(
 		})
 }
 
-const debouncedFunctions = new Map<TLAssetId, typeof resolveAssetUrl>()
+const debouncedFunctions = new Map<TLAssetId, typeof resolveAssetUrl & { cancel(): void }>()
 
 function getResolveAssetUrlDebounced(assetId: TLAssetId) {
 	if (!debouncedFunctions.has(assetId)) {
 		const debouncedFn = debounce(resolveAssetUrl, 500)
 		debouncedFunctions.set(assetId, debouncedFn)
 	}
-	return debouncedFunctions.get(assetId) as typeof resolveAssetUrl & { cancel(): void }
+	return debouncedFunctions.get(assetId)!
 }
 
 /**

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import {
 	BaseBoxShapeUtil,
 	Editor,
 	HTMLContainer,
 	MediaHelpers,
-	TLAsset,
 	TLVideoShape,
 	toDomPrecision,
+	useEditor,
 	useEditorComponents,
 	useIsEditing,
 	videoShapeMigrations,
@@ -44,12 +43,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	}
 
 	component(shape: TLVideoShape) {
-		const { asset, url } = useImageOrVideoAsset({
-			shapeId: shape.id,
-			assetId: shape.props.assetId,
-		})
-
-		return <VideoShape editor={this.editor} shape={shape} asset={asset} url={url} />
+		return <VideoShape shape={shape} />
 	}
 
 	indicator(shape: TLVideoShape) {
@@ -63,21 +57,17 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	}
 }
 
-const VideoShape = memo(function VideoShape({
-	editor,
-	shape,
-	asset,
-	url,
-}: {
-	editor: Editor
-	shape: TLVideoShape
-	asset?: TLAsset | null
-	url: string | null
-}) {
+const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) {
+	const editor = useEditor()
 	const showControls = editor.getShapeGeometry(shape).bounds.w * editor.getZoomLevel() >= 110
 	const isEditing = useIsEditing(shape.id)
 	const prefersReducedMotion = usePrefersReducedMotion()
 	const { Spinner } = useEditorComponents()
+
+	const { asset, url } = useImageOrVideoAsset({
+		shapeId: shape.id,
+		assetId: shape.props.assetId,
+	})
 
 	const rVideo = useRef<HTMLVideoElement>(null!)
 


### PR DESCRIPTION
Fixes issue https://github.com/tldraw/tldraw/issues/5052

This is a regression from https://github.com/tldraw/tldraw/pull/4682 (which was rolled up into https://github.com/tldraw/tldraw/pull/4659 )

Couple things were problematic here:
- main issue was that `debounce`'d urls all rolled up into one single debounce call that was _shared_ for all assets. this needed to be split to be per asset, which is now the case. (see `getResolveAssetUrlDebounced`)
- As long as I was looking at this it turns out videos weren't working at all. We weren't accounting for `data:video` as well as `data:image` - that's now been corrected. Not sure how long that's been broken for...
- Noticed also that `isReady()` was not called appropriately in the non-preview case - that's now fixed as well.
- finally, made `VideoShapeUtil`'s calling of `useImageOrVideoAsset` consistent with `ImageShapeUtil`

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed bugs with copy/pasting multilple assets from one board to another.
- Fixed bug with copy/pasting videos from one board to another.