### PR TITLE
Fix typo in TldrawEditor example

### DIFF
--- a/apps/examples/src/examples/only-editor/README.md
+++ b/apps/examples/src/examples/only-editor/README.md
@@ -10,4 +10,4 @@ Use the `<TldrawEditor/>` component to render a bare-bones editor with minimal b
 
 ---
 
-This example show show the `<TldrawEditor/>` component can be used to render a bare-bones editor. It uses minimal built-in shapes and tools.
+This example shows how the `<TldrawEditor/>` component can be used to render a bare-bones editor. It uses minimal built-in shapes and tools.


### PR DESCRIPTION
Fixes the description of the TldrawEditor example by changing the double show to shows how

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

### Release notes

- Fixed a typo in the TldrawEditor example