### PR TITLE
Improve dragging files to the sidebar ux

### DIFF
--- a/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
+++ b/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
@@ -1,8 +1,10 @@
 import { useAuth } from '@clerk/clerk-react'
 import { DragEvent, useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Editor, TLStoreSnapshot, parseTldrawJsonFile, tlmenus, useToasts } from 'tldraw'
 import { globalEditor } from '../../utils/globalEditor'
 import { defineMessages, useIntl } from '../utils/i18n'
+import { getFilePath } from '../utils/urls'
 import { useApp } from './useAppState'
 
 const messages = defineMessages({
@@ -14,6 +16,7 @@ const messages = defineMessages({
 
 export function useTldrFileDrop() {
 	const app = useApp()
+	const navigate = useNavigate()
 
 	const [isDraggingOver, setIsDraggingOver] = useState(false)
 
@@ -54,7 +57,7 @@ export function useTldrFileDrop() {
 					title: uploadingTitle,
 				})
 
-				await app.createFilesFromTldrFiles(snapshots, token)
+				const results = await app.createFilesFromTldrFiles(snapshots, token)
 
 				removeToast(id)
 				addToast({
@@ -62,9 +65,12 @@ export function useTldrFileDrop() {
 					title: addedTitle,
 					keepOpen: true,
 				})
+				if (results.slugs.length > 0) {
+					navigate(getFilePath(results.slugs[0]), { state: { mode: 'create' } })
+				}
 			}
 		},
-		[app, addToast, removeToast, auth, intl]
+		[app, addToast, removeToast, auth, intl, navigate]
 	)
 
 	const onDragOver = useCallback((e: DragEvent) => {


### PR DESCRIPTION
Switch to the dragged in files instead of staying on the current file.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Drag some files to the sidebar.
2. It should switch to one of those dragged files.
