### PR TITLE
Localize `Untitled project`

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/sl.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/sl.json
@@ -1,0 +1,3 @@
+{
+  "bbc5a713da": "Neimenovan projekt"
+}

--- a/apps/dotcom/client/public/tla/locales/sl.json
+++ b/apps/dotcom/client/public/tla/locales/sl.json
@@ -1,0 +1,6 @@
+{
+   "bbc5a713da": {
+      "translation": "Neimenovan projekt"
+   }
+}  
+

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -27,7 +27,7 @@ import { useApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
 import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
-import { defineMessages, useMsg } from '../../utils/i18n'
+import { defineMessages, useIntl, useMsg } from '../../utils/i18n'
 import { TlaAppMenuGroupLazyFlipped } from '../TlaAppMenuGroup/TlaAppMenuGroup'
 import { TlaFileMenu } from '../TlaFileMenu/TlaFileMenu'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
@@ -39,6 +39,7 @@ const messages = defineMessages({
 	signIn: { defaultMessage: 'Sign in' },
 	pageMenu: { defaultMessage: 'Page menu' },
 	brand: { defaultMessage: 'tldraw' },
+	untitledProject: { defaultMessage: 'Untitled project' },
 })
 
 // There are some styles in tla.css that adjust the regular tlui top panels
@@ -127,6 +128,7 @@ export function TlaEditorTopLeftPanelAnonymous() {
 
 export function TlaEditorTopLeftPanelSignedIn() {
 	const editor = useEditor()
+	const intl = useIntl()
 	const [isRenaming, setIsRenaming] = useState(false)
 	const pageMenuLbl = useMsg(messages.pageMenu)
 
@@ -147,10 +149,10 @@ export function TlaEditorTopLeftPanelSignedIn() {
 				app.getFileName(fileId, false)?.trim() ||
 				editor.getDocumentSettings().name ||
 				// rather than displaying the date for the project here, display Untitled project
-				'Untitled project'
+				intl.formatMessage(messages.untitledProject)
 			)
 		},
-		[app, editor, fileId]
+		[app, editor, fileId, intl]
 	)
 	const handleFileNameChange = useCallback(
 		(name: string) => {

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -21,7 +21,7 @@ const config = {
 	scripts: {
 		build: {
 			baseCommand: 'exit 0',
-			runsAfter: { prebuild: {}, 'refresh-assets': {} },
+			runsAfter: { prebuild: {}, 'refresh-assets': {}, 'build-i18n': {} },
 			workspaceOverrides: {
 				'apps/vscode/*': { runsAfter: { 'refresh-assets': {} } },
 				'packages/*': {
@@ -49,7 +49,7 @@ const config = {
 		},
 		dev: {
 			execution: 'independent',
-			runsAfter: { predev: {}, 'refresh-assets': {} },
+			runsAfter: { predev: {}, 'refresh-assets': {}, 'build-i18n': {} },
 			cache: 'none',
 			workspaceOverrides: {
 				'apps/vscode/*': { runsAfter: { build: { in: 'self-only' } } },
@@ -127,6 +127,13 @@ const config = {
 					// local .tsbuild files
 					usesOutput: false,
 				},
+			},
+		},
+		'build-i18n': {
+			execution: 'independent',
+			cache: {
+				inputs: ['<rootDir>/apps/dotcom/client/public/tla/locales/*.json'],
+				outputs: ['<rootDir>/apps/dotcom/client/public/tla/locales-compiled/*.json'],
 			},
 		},
 		'api-check': {


### PR DESCRIPTION
Also added building of i18n as a `runsAfter` for `dev` and `build`.

Discovered another issue with i18n, created a ticket [here](https://linear.app/tldraw/issue/INT-588/localization-of-file-names-date-formatting-is-not-working).

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
