### PR TITLE
[botcom] use editor bg as page bg to make loading states less funky

### DIFF
--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
@@ -5,6 +5,7 @@
 	width: 100%;
 	height: 100%;
 	transition: padding-left 0.16s ease-in-out;
+	background-color: var(--color-background);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
before
![Kapture 2024-12-06 at 17 31 53](https://github.com/user-attachments/assets/5be0cf43-de00-4539-a7b5-489a68cd0cfc)

after
![Kapture 2024-12-06 at 17 29 44](https://github.com/user-attachments/assets/52a85f4e-314b-4bab-bc1a-1b82de0f837b)

it's hard to see on gifs, and it's more noticeable in a deployed build since there's an extra 100ms or so of loading time.

### Change type

- [x] `other`