### PR TITLE
Delete the link to the discussion page from README.md that is now closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/C
 
 ## Community
 
-Have questions, comments or feedback? [Join our discord](https://discord.gg/rhsyWMUJxd) or [start a discussion](https://github.com/tldraw/tldraw/discussions/new). For the latest news and release notes, visit [tldraw.dev](https://tldraw.dev).
+Have questions, comments or feedback? [Join our discord](https://discord.gg/rhsyWMUJxd). For the latest news and release notes, visit [tldraw.dev](https://tldraw.dev).
 
 ## Contributors
 


### PR DESCRIPTION
nit: Looks like the GH discussion tab is now closed, so just deleted the link from README.md not to make the readers confused.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other` (docs)

### Test plan

n/a

### Release notes

- Delete the link to the discussion page from README.md that is now closed.