### PR TITLE
[botcom] move sidebar toggles in to sidebar layout so they're always visible

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -31,8 +31,6 @@ import { defineMessages, useIntl, useMsg } from '../../utils/i18n'
 import { TlaAppMenuGroupLazyFlipped } from '../TlaAppMenuGroup/TlaAppMenuGroup'
 import { TlaFileMenu } from '../TlaFileMenu/TlaFileMenu'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
-import { TlaSidebarToggle } from '../TlaSidebar/components/TlaSidebarToggle'
-import { TlaSidebarToggleMobile } from '../TlaSidebar/components/TlaSidebarToggleMobile'
 import styles from './top.module.css'
 
 const messages = defineMessages({
@@ -175,8 +173,8 @@ export function TlaEditorTopLeftPanelSignedIn() {
 	const separator = '/'
 	return (
 		<>
-			<TlaSidebarToggle />
-			<TlaSidebarToggleMobile />
+			{/* spacer for the sidebar toggle button */}
+			<div style={{ width: 40 }} />
 			<TlaFileNameEditor
 				source="file-header"
 				isRenaming={isRenaming}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
@@ -23,7 +23,7 @@ export function TlaSidebarToggleMobile() {
 				})
 			}}
 		>
-			<TlaIcon icon="sidebar" />
+			<TlaIcon icon="sidebar-strong" />
 		</button>
 	)
 }

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode, useCallback, useRef } from 'react'
 import { clamp, tltime, useQuickReactor, useValue } from 'tldraw'
 import { TlaSidebar } from '../../components/TlaSidebar/TlaSidebar'
+import { TlaSidebarToggle } from '../../components/TlaSidebar/components/TlaSidebarToggle'
+import { TlaSidebarToggleMobile } from '../../components/TlaSidebar/components/TlaSidebarToggleMobile'
 import { useApp } from '../../hooks/useAppState'
 import { usePreventAccidentalDrops } from '../../hooks/usePreventAccidentalDrops'
 import {
@@ -163,6 +165,10 @@ export function TlaSidebarLayout({ children }: { children: ReactNode; collapsibl
 		>
 			<TlaSidebar />
 			{children}
+			<div className={styles.toggleContainer}>
+				<TlaSidebarToggle />
+				<TlaSidebarToggleMobile />
+			</div>
 			{isSidebarOpen && (
 				<div
 					className={styles.resizeHandle}

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useRef } from 'react'
+import React, { ReactNode, useCallback, useLayoutEffect, useRef } from 'react'
 import { clamp, tltime, useQuickReactor, useValue } from 'tldraw'
 import { TlaSidebar } from '../../components/TlaSidebar/TlaSidebar'
 import { TlaSidebarToggle } from '../../components/TlaSidebar/components/TlaSidebarToggle'
@@ -31,15 +31,17 @@ export function TlaSidebarLayout({ children }: { children: ReactNode; collapsibl
 
 	const rLayoutContainer = useRef<HTMLDivElement>(null)
 
+	const updateSidebarWidth = useCallback(() => {
+		if (!rLayoutContainer.current) return
+		const width = getLocalSessionState().sidebarWidth
+		if (typeof width !== 'number') return
+		rLayoutContainer.current.style.setProperty('--tla-sidebar-width', `${width}px`)
+	}, [])
+
 	// When the local session state sidebar width changes, update the sidebar element's width
-	useQuickReactor('update sidebar width', () => {
-		if (rLayoutContainer.current) {
-			const width = getLocalSessionState().sidebarWidth
-			if (typeof width === 'number') {
-				rLayoutContainer.current.style.setProperty('--tla-sidebar-width', `${width}px`)
-			}
-		}
-	})
+	useQuickReactor('update sidebar width', updateSidebarWidth)
+	// also update before initial paint to avoid flicker when the width is not default
+	useLayoutEffect(updateSidebarWidth, [updateSidebarWidth])
 
 	const rResizeState = useRef<
 		| { name: 'idle' }

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
@@ -70,5 +70,5 @@
 	position: absolute;
 	top: 4px;
 	margin-left: 2px;
-	z-index: 240;
+	z-index: 1;
 }

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
@@ -65,3 +65,10 @@
 	transition: opacity 150ms 80ms;
 	opacity: 1;
 }
+
+.toggleContainer {
+	position: absolute;
+	top: 4px;
+	margin-left: 2px;
+	z-index: 240;
+}


### PR DESCRIPTION
Previously the sidebar toggle button would disappear when you see an error page because it was only rendered as a child of the editor's MenuPanel.

This was mitigated on desktop because we forced the sidebar open on error pages, but that doesn't work on mobile because the sidebar is a modal drawer.

So here I've just moved the toggle button to be rendered by the sidebar layout component, and added a spacer div where it would be in the MenuPanel.

this should be a pixel perfect match for what was there before, but it obviously makes the menu panel code a tiny bit more fragile. but since we see it all the time it's unlikely we'll introduce style regressions by accident.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
