### PR TITLE
Fix sync worker source maps.

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -236,6 +236,7 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 		sentry: {
 			project: 'tldraw-sync',
 			authToken: env.SENTRY_AUTH_TOKEN,
+			enviroment: workerId,
 		},
 	})
 }

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -236,7 +236,7 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 		sentry: {
 			project: 'tldraw-sync',
 			authToken: env.SENTRY_AUTH_TOKEN,
-			enviroment: workerId,
+			environment: workerId,
 		},
 	})
 }

--- a/internal/scripts/lib/deploy.ts
+++ b/internal/scripts/lib/deploy.ts
@@ -85,7 +85,7 @@ export async function wranglerDeploy({
 	sentry?: {
 		authToken: string
 		project: string
-		release?: string
+		enviroment?: string
 	}
 }) {
 	const varsArray = []
@@ -129,7 +129,7 @@ export async function wranglerDeploy({
 	}
 
 	if (sentry) {
-		const release = sentry.release ?? `${workerNameMatch[1]}.${versionMatch[1]}`
+		const release = `${sentry.enviroment ?? workerNameMatch[1]}.${versionMatch[1]}`
 
 		const sentryEnv = {
 			SENTRY_AUTH_TOKEN: sentry.authToken,

--- a/internal/scripts/lib/deploy.ts
+++ b/internal/scripts/lib/deploy.ts
@@ -85,7 +85,7 @@ export async function wranglerDeploy({
 	sentry?: {
 		authToken: string
 		project: string
-		enviroment?: string
+		environment?: string
 	}
 }) {
 	const varsArray = []
@@ -129,7 +129,7 @@ export async function wranglerDeploy({
 	}
 
 	if (sentry) {
-		const release = `${sentry.enviroment ?? workerNameMatch[1]}.${versionMatch[1]}`
+		const release = `${sentry.environment ?? workerNameMatch[1]}.${versionMatch[1]}`
 
 		const sentryEnv = {
 			SENTRY_AUTH_TOKEN: sentry.authToken,


### PR DESCRIPTION
Sync worker source maps are not working for the `production` and `staging` environments.

The issue was that our sync worker naming does not follow the `${env.TLDRAW_ENV}-tldraw-multiplayer` naming. Instead, our `staging` worker is `main-tldraw.multiplayer` and our production on is just `tldraw-multiplayer`. We then used these names to set up sentry releases. 

But when we are sending sentry issue reports we do use this naming since `WORKER_NAME` uses the mentioned naming:
https://tldraw.sentry.io/settings/projects/tldraw-sync/environments/
![image](https://github.com/user-attachments/assets/dd904a41-be84-4282-864e-7554be8f5fe9)

This means that we were linking sentry source maps to incorrect environments.

![CleanShot 2024-12-09 at 15 43 41](https://github.com/user-attachments/assets/eb1b92c1-8803-4066-bac1-3a10ceb590d1)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
