### PR TITLE
[botcom] Clear local session state on sign out

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
@@ -15,6 +15,7 @@ import { getSnapshotsFromDroppedTldrawFiles } from '../../hooks/useTldrFileDrop'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getCurrentEditor } from '../../utils/getCurrentEditor'
 import { defineMessages, useMsg } from '../../utils/i18n'
+import { clearLocalSessionState } from '../../utils/local-session-state'
 import { TlaAppMenuGroup } from '../TlaAppMenuGroup/TlaAppMenuGroup'
 
 const messages = defineMessages({
@@ -57,7 +58,7 @@ function SignOutMenuItem({ source }: { source: TLAppUiEventSource }) {
 	const label = useMsg(messages.signOut)
 
 	const handleSignout = useCallback(() => {
-		auth.signOut()
+		auth.signOut().then(clearLocalSessionState)
 		trackEvent('sign-out-clicked', { source })
 	}, [auth, trackEvent, source])
 

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -22,7 +22,11 @@ import { AppStateProvider, useMaybeApp } from '../hooks/useAppState'
 import { UserProvider } from '../hooks/useUser'
 import '../styles/tla.css'
 import { IntlProvider, setupCreateIntl } from '../utils/i18n'
-import { getLocalSessionState, updateLocalSessionState } from '../utils/local-session-state'
+import {
+	clearLocalSessionState,
+	getLocalSessionState,
+	updateLocalSessionState,
+} from '../utils/local-session-state'
 
 const assetUrls = getAssetUrlsByImport()
 
@@ -154,9 +158,7 @@ function SignedInProvider({
 				auth: { userId: auth.userId },
 			}))
 		} else {
-			updateLocalSessionState(() => ({
-				auth: undefined,
-			}))
+			clearLocalSessionState()
 		}
 	}, [auth.userId, auth.isSignedIn])
 

--- a/apps/dotcom/client/src/tla/utils/local-session-state.ts
+++ b/apps/dotcom/client/src/tla/utils/local-session-state.ts
@@ -1,5 +1,11 @@
 import { TlaUser } from '@tldraw/dotcom-shared'
-import { atom, getFromLocalStorage, setInLocalStorage, useValue } from 'tldraw'
+import {
+	atom,
+	deleteFromLocalStorage,
+	getFromLocalStorage,
+	setInLocalStorage,
+	useValue,
+} from 'tldraw'
 
 const STORAGE_KEY = 'tldrawapp_session_3'
 
@@ -65,6 +71,9 @@ try {
 
 const localSessionState = atom<TldrawAppSessionState>('session', prev)
 
+export function clearLocalSessionState() {
+	return deleteFromLocalStorage(STORAGE_KEY)
+}
 export function getLocalSessionStateUnsafe() {
 	return localSessionState.__unsafe__getWithoutCapture()
 }


### PR DESCRIPTION
before this only the auth part would be wiped, and only after a page load. Now it's nuked entirely, immediately after clicking the sign out button.

### Change type

- [x] `other`
