### PR TITLE
[fix] Flipped shape walking

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6696,7 +6696,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const initialShape = opts.initialShape ?? this.getShape(id)
 		if (!initialShape) return this
 
-		const scaleOrigin = opts.scaleOrigin ?? this.getShapePageBounds(id)?.center
+		const scaleOrigin = opts.scaleOrigin ?? this.getShapesRotatedPageBounds([id])?.center
 		if (!scaleOrigin) return this
 
 		const pageTransform = opts.initialPageTransform
@@ -6710,7 +6710,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const scaleAxisRotation = opts.scaleAxisRotation ?? pageRotation
 
-		const initialBounds = opts.initialBounds ?? this.getShapeGeometry(id).bounds
+		const initialBounds =
+			opts.initialBounds ?? Box.FromPoints(this.getShapeGeometry(id).getVertices())
 
 		if (!initialBounds) return this
 
@@ -6921,9 +6922,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		)
 
 		// now calculate how far away the shape is from where it needs to be
-		const pageBounds = this.getShapePageBounds(id)!
+		const pageBounds = Box.FromPoints(this.getShapeGeometry(id).getVertices())
 		const pageTransform = this.getShapePageTransform(id)!
-		const currentPageCenter = pageBounds.center
+
+		const currentPageCenter = Mat.applyToPoint(pageTransform, pageBounds.center)
+
 		const shapePageTransformOrigin = pageTransform.point()
 		if (!currentPageCenter || !shapePageTransformOrigin) return this
 		const pageDelta = Vec.Sub(postScaleShapePageCenter, currentPageCenter)


### PR DESCRIPTION
This PR attempts to improve (but does not entirely fix) a bug where rotated shapes were not being offset correctly. Generally: we were using page transform centers rather than rotated page transform centers.

![Kapture 2024-12-09 at 16 34 06](https://github.com/user-attachments/assets/502bac71-7d51-46d3-9663-2d11bdccd938)


This part of our codebase is really rough to work with because it relies on making updates and then rmeasuring the changes. Some of the information will be stale until these first changes are applied. IIRC I simplified this once in a branch that was never merged, I'll see if I can dig that up.

Fixes issue https://github.com/tldraw/tldraw/issues/5091

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Rotate a triangle shape.
2. Use the flip horizontal / flip vertical shortcuts.
3. Select multiple shapes that include a rotated shape
4. Flip h / v

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with rotating individual shapes.