### PR TITLE
fix: fix broken bluesky link with old handle name

### DIFF
--- a/apps/docs/components/navigation/footer.tsx
+++ b/apps/docs/components/navigation/footer.tsx
@@ -29,7 +29,7 @@ const menus = [
 			{ caption: 'X/Twitter', href: 'https://x.com/tldraw/' },
 			{ caption: 'Discord', href: 'https://discord.com/invite/SBBEVCA4PG' },
 			{ caption: 'GitHub', href: 'https://github.com/tldraw/tldraw' },
-			{ caption: 'Bluesky', href: 'https://bsky.app/profile/tldraw.bsky.social' },
+			{ caption: 'Bluesky', href: 'https://bsky.app/profile/tldraw.com' },
 			{ caption: 'Mastodon', href: 'https://mas.to/@tldraw' },
 		],
 	},


### PR DESCRIPTION
Hi, this PR fixes the broken link to Bluesky account. This is due to that change of handle name: from `@tldraw.bsky.social` to `@tldraw.com`.

![screenshot of footer section including "Bluesky" link](https://github.com/user-attachments/assets/7ee52079-af31-4541-b8e1-e9d0ca555472)

---

Also, I'd recommend adding Bluesky (or +Mastodon) icons on the website's header as well to show support for an open platforms. I think X's disrespectful actions toward developers and the open web is not aligned with tldraw's open nature.

![screenshot of website header including only X, Discord, and GitHub](https://github.com/user-attachments/assets/3ede735b-8804-4214-8194-1622063148a0)


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
N/A

### Release notes

- Fixed a broken Bluesky link with an old handle name