### PR TITLE
[botcom] stress test fixes

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -12,26 +12,44 @@ import { DurableObject } from 'cloudflare:workers'
 import postgres from 'postgres'
 import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
 import type { TLDrawDurableObject } from './TLDrawDurableObject'
-import { ZReplicationEvent } from './UserDataSyncer'
+import { ZReplicationEventWithoutSequenceInfo } from './UserDataSyncer'
 import { getPostgres } from './getPostgres'
 import { Analytics, Environment, TLPostgresReplicatorEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
 import { getUserDurableObject } from './utils/durableObjects'
 
-const seed = `
--- we keep the active_user data between reboots to 
--- make sure users don't miss updates.
-CREATE TABLE IF NOT EXISTS active_user (
-	id TEXT PRIMARY KEY
-);
-DROP TABLE IF EXISTS user_file_subscriptions;
-CREATE TABLE user_file_subscriptions (
-	userId TEXT,
-	fileId TEXT,
-	PRIMARY KEY (userId, fileId),
-	FOREIGN KEY (userId) REFERENCES active_user(id) ON DELETE CASCADE
-);
-`
+interface Migration {
+	id: string
+	code: string
+}
+
+const migrations: Migration[] = [
+	{
+		id: '000_seed',
+		code: `
+			CREATE TABLE IF NOT EXISTS active_user (
+				id TEXT PRIMARY KEY
+			);
+			CREATE TABLE IF NOT EXISTS user_file_subscriptions (
+				userId TEXT,
+				fileId TEXT,
+				PRIMARY KEY (userId, fileId),
+				FOREIGN KEY (userId) REFERENCES active_user(id) ON DELETE CASCADE
+			);
+			CREATE TABLE migrations (
+				id TEXT PRIMARY KEY,
+				code TEXT NOT NULL
+			);
+		`,
+	},
+	{
+		id: '001_add_sequence_number',
+		code: `
+			ALTER TABLE active_user ADD COLUMN sequenceNumber INTEGER NOT NULL DEFAULT 0;
+			ALTER TABLE active_user ADD COLUMN sequenceIdSuffix TEXT NOT NULL DEFAULT '';
+		`,
+	},
+]
 
 const ONE_MINUTE = 60 * 1000
 
@@ -57,15 +75,20 @@ type BootState =
 	  }
 
 export class TLPostgresReplicator extends DurableObject<Environment> {
-	sql: SqlStorage
-	state: BootState = {
+	private sql: SqlStorage
+	private state: BootState = {
 		type: 'init',
 		promise: promiseWithResolve(),
 		sequenceId: uniqueId(),
 	}
-	measure: Analytics | undefined
-	postgresUpdates = 0
-	lastRpmLogTime = Date.now()
+	private measure: Analytics | undefined
+	private postgresUpdates = 0
+	private lastRpmLogTime = Date.now()
+
+	// we need to guarantee in-order delivery of messages to users
+	// but DO RPC calls are not guaranteed to happen in order, so we need to
+	// use a queue per user
+	private userDispatchQueues: Map<string, ExecutionQueue> = new Map()
 
 	sentry
 	// eslint-disable-next-line local/prefer-class-methods
@@ -81,10 +104,49 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		super(ctx, env)
 		this.sentry = createSentry(ctx, env)
 		this.sql = this.ctx.storage.sql
-		this.sql.exec(seed)
+
+		this.ctx
+			.blockConcurrencyWhile(async () => this._migrate())
+			.catch((e) => {
+				console.error('Migration error', e)
+			})
 		this.reboot(false)
 		this.alarm()
 		this.measure = env.MEASURE
+	}
+
+	private _applyMigration(index: number) {
+		this.sql.exec(migrations[index].code)
+		this.sql.exec(
+			'insert into migrations (id, code) values (?, ?)',
+			migrations[index].id,
+			migrations[index].code
+		)
+	}
+
+	private _migrate() {
+		let appliedMigrations: Migration[]
+		try {
+			appliedMigrations = this.sql
+				.exec('select code, id from migrations order by id asc')
+				.toArray() as any
+		} catch (_e) {
+			// no migrations table, run initial migration
+			this._applyMigration(0)
+			appliedMigrations = [migrations[0]]
+		}
+
+		for (let i = 0; i < appliedMigrations.length; i++) {
+			if (appliedMigrations[i].id !== migrations[i].id) {
+				throw new Error(
+					'TLPostgresReplicator migrations have changed!! this is an append-only array!!'
+				)
+			}
+		}
+
+		for (let i = appliedMigrations.length; i < migrations.length; i++) {
+			this._applyMigration(i)
+		}
 	}
 
 	__test__forceReboot() {
@@ -200,7 +262,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			if (users.length === 0) return
 			const batch = users.splice(0, BATCH_SIZE)
 			for (const user of batch) {
-				this.messageUser(user.id as string, { type: 'force_reboot', sequenceId })
+				this.messageUser(user.id as string, { type: 'force_reboot' })
 			}
 			setTimeout(tick, 10)
 		}
@@ -244,7 +306,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			type: 'boot_complete',
 			userId: row.userId,
 			bootId: row.bootId,
-			sequenceId: this.state.sequenceId,
 		})
 	}
 
@@ -258,7 +319,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			type: 'mutation_commit',
 			mutationNumber: row.mutationNumber,
 			userId: row.userId,
-			sequenceId: this.state.sequenceId,
 		})
 	}
 
@@ -296,7 +356,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 						row: file as any,
 						table: 'file',
 						event: 'insert',
-						sequenceId: this.state.sequenceId,
 						userId: row.userId,
 					})
 				})
@@ -329,7 +388,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 					row: { id: row.fileId } as any,
 					table: 'file',
 					event: 'delete',
-					sequenceId: this.state.sequenceId,
 					userId: row.userId,
 				})
 			}
@@ -339,7 +397,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			row: row as any,
 			table: event.relation.table as ZTable,
 			event: event.command,
-			sequenceId: this.state.sequenceId,
 			userId: row.userId,
 		})
 	}
@@ -369,7 +426,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				row: row as any,
 				table: event.relation.table as ZTable,
 				event: event.command,
-				sequenceId: this.state.sequenceId,
 				userId,
 			})
 		}
@@ -377,12 +433,12 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private handleUserEvent(row: postgres.Row | null, event: postgres.ReplicationEvent) {
 		assert(row?.id, 'user id is required')
+		this.debug('USER EVENT', event.command, row.id)
 		this.messageUser(row.id, {
 			type: 'row_update',
 			row: row as any,
 			table: event.relation.table as ZTable,
 			event: event.command,
-			sequenceId: this.state.sequenceId,
 			userId: row.id,
 		})
 	}
@@ -415,12 +471,38 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		}
 	}
 
-	private async messageUser(userId: string, event: ZReplicationEvent) {
-		const user = getUserDurableObject(this.env, userId)
-		const res = await user.handleReplicationEvent(event)
-		if (res === 'unregister') {
-			this.debug('unregistering user', userId, event)
-			this.unregisterUser(userId)
+	private async messageUser(userId: string, event: ZReplicationEventWithoutSequenceInfo) {
+		try {
+			let q = this.userDispatchQueues.get(userId)
+			if (!q) {
+				q = new ExecutionQueue()
+				this.userDispatchQueues.set(userId, q)
+			}
+			await q.push(async () => {
+				const { sequenceNumber, sequenceIdSuffix } = this.sql
+					.exec(
+						'UPDATE active_user SET sequenceNumber = sequenceNumber + 1 WHERE id = ? RETURNING sequenceNumber, sequenceIdSuffix',
+						userId
+					)
+					.one()
+
+				const user = getUserDurableObject(this.env, userId)
+
+				assert(typeof sequenceNumber === 'number', 'sequenceNumber should be a number')
+				assert(typeof sequenceIdSuffix === 'string', 'sequenceIdSuffix should be a string')
+
+				const res = await user.handleReplicationEvent({
+					...event,
+					sequenceNumber,
+					sequenceId: this.state.sequenceId + ':' + sequenceIdSuffix,
+				})
+				if (res === 'unregister') {
+					this.debug('unregistering user', userId, event)
+					this.unregisterUser(userId)
+				}
+			})
+		} catch (e) {
+			console.error('Error in messageUser', e)
 		}
 	}
 
@@ -437,9 +519,15 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		const guestFiles = await this.state
 			.db`SELECT "fileId" as id FROM file_state where "userId" = ${userId}`
 
+		const sequenceIdSuffix = uniqueId()
+
 		// clear user and subscriptions
 		this.sql.exec(`DELETE FROM active_user WHERE id = ?`, userId)
-		this.sql.exec(`INSERT INTO active_user (id) VALUES (?)`, userId)
+		this.sql.exec(
+			`INSERT INTO active_user (id, sequenceNumber, sequenceIdSuffix) VALUES (?, 0, ?)`,
+			userId,
+			sequenceIdSuffix
+		)
 		for (const file of guestFiles) {
 			this.sql.exec(
 				`INSERT INTO user_file_subscriptions (userId, fileId) VALUES (?, ?) ON CONFLICT (userId, fileId) DO NOTHING`,
@@ -447,12 +535,20 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				file.id
 			)
 		}
-		return this.state.sequenceId
+		return {
+			sequenceId: this.state.sequenceId + ':' + sequenceIdSuffix,
+			sequenceNumber: 0,
+		}
 	}
 
 	async unregisterUser(userId: string) {
 		this.logEvent({ type: 'unregister_user' })
 		this.sql.exec(`DELETE FROM active_user WHERE id = ?`, userId)
+		const queue = this.userDispatchQueues.get(userId)
+		if (queue) {
+			queue.close()
+			this.userDispatchQueues.delete(userId)
+		}
 	}
 
 	private writeEvent(eventData: EventData) {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -370,15 +370,25 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				}
 			)
 			// TODO: We should probably handle a case where the above operation succeeds but the one below fails
-			const result = await this
-				.db`insert into public.user_mutation_number ("userId", "mutationNumber") values (${this.userId}, 1) on conflict ("userId") do update set "mutationNumber" = user_mutation_number."mutationNumber" + 1 returning "mutationNumber"`
-			const mutationNumber = Number(result[0].mutationNumber)
-			const currentMutationNumber = this.cache.mutations.at(-1)?.mutationNumber ?? 0
-			assert(
-				mutationNumber > currentMutationNumber,
-				`mutation number did not increment mutationNumber: ${mutationNumber} current: ${currentMutationNumber}`
-			)
-			this.cache.mutations.push({ mutationNumber, mutationId: msg.mutationId })
+			this.debug('mutation success', this.userId)
+			await this.db
+				.begin(async (sql) => {
+					const result =
+						await sql`insert into public.user_mutation_number ("userId", "mutationNumber") values (${this.userId}, 1) on conflict ("userId") do update set "mutationNumber" = user_mutation_number."mutationNumber" + 1 returning "mutationNumber"`
+					this.debug('mutation number success', this.userId)
+					const mutationNumber = Number(result[0].mutationNumber)
+					const currentMutationNumber = this.cache.mutations.at(-1)?.mutationNumber ?? 0
+					assert(
+						mutationNumber > currentMutationNumber,
+						`mutation number did not increment mutationNumber: ${mutationNumber} current: ${currentMutationNumber}`
+					)
+					this.debug('pushing mutation to cache', this.userId, mutationNumber)
+					this.cache.mutations.push({ mutationNumber, mutationId: msg.mutationId })
+				})
+				.catch((e) => {
+					this.cache.mutations = this.cache.mutations.filter((m) => m.mutationId !== msg.mutationId)
+					throw e
+				})
 		} catch (e) {
 			const code = e instanceof ZMutationError ? e.errorCode : ZErrorCode.unknown_error
 			this.captureException(e, {

--- a/apps/dotcom/sync-worker/src/testRoutes.ts
+++ b/apps/dotcom/sync-worker/src/testRoutes.ts
@@ -19,13 +19,7 @@ export const testRoutes = createRouter<Environment>()
 		getUserDurableObject(env, req.params.userId).handleReplicationEvent({
 			type: 'force_reboot',
 			sequenceId: 'test',
-		})
-		return new Response('ok')
-	})
-	.get('/app/__test__/user/:userId/panic', (req, env) => {
-		getUserDurableObject(env, req.params.userId).handleReplicationEvent({
-			type: 'force_reboot',
-			sequenceId: 'test',
+			sequenceNumber: 0,
 		})
 		return new Response('ok')
 	})

--- a/packages/utils/api-report.md
+++ b/packages/utils/api-report.md
@@ -81,6 +81,8 @@ export interface ErrorResult<E> {
 export class ExecutionQueue {
     constructor(timeout?: number | undefined);
     // (undocumented)
+    close(): void;
+    // (undocumented)
     push<T>(task: () => T): Promise<Awaited<T>>;
 }
 

--- a/packages/utils/src/lib/ExecutionQueue.ts
+++ b/packages/utils/src/lib/ExecutionQueue.ts
@@ -31,4 +31,8 @@ export class ExecutionQueue {
 			this.run()
 		})
 	}
+
+	close() {
+		this.queue = []
+	}
 }


### PR DESCRIPTION
This PR fixes two consistency issues we ran into while stress testing

1. Send the messages to the user DOs in guaranteed order, using one ExecutionQueue per user.
2. Update the mutation number in a transaction, to make sure the mutated data is synced before the mutation number gets back.

this involved doing a few extra bits

- set up migrations for sqlite in the replicator
- add a per-user sequence id and sequence number, so that user DOs can reboot if there's any weird issues that prevent things from arriving in order despite the execution queues.


### Change type

- [x] `other`
