### PR TITLE
Close connections

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -309,6 +309,7 @@ export class TLDrawDurableObject extends DurableObject {
 			const fileRecord =
 				await postgres`SELECT * FROM PUBLIC.FILE WHERE ID = ${this.documentInfo.slug}`
 			this._fileRecordCache = fileRecord[0] as TlaFile
+			postgres.end()
 			return this._fileRecordCache
 		} catch (_e) {
 			return null

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -31,7 +31,6 @@ import { getR2KeyForRoom } from './r2'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
 import { createSupabaseClient } from './utils/createSupabaseClient'
-import { getReplicator } from './utils/durableObjects'
 import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
@@ -305,9 +304,11 @@ export class TLDrawDurableObject extends DurableObject {
 		if (this._fileRecordCache) {
 			return this._fileRecordCache
 		}
-		const stub = getReplicator(this.env)
 		try {
-			this._fileRecordCache = await stub.getFileRecord(this.documentInfo.slug)
+			const postgres = getPostgres(this.env, { pooled: true })
+			const fileRecord =
+				await postgres`SELECT * FROM PUBLIC.FILE WHERE ID = ${this.documentInfo.slug}`
+			this._fileRecordCache = fileRecord[0] as TlaFile
 			return this._fileRecordCache
 		} catch (_e) {
 			return null
@@ -588,6 +589,7 @@ export class TLDrawDurableObject extends DurableObject {
 				if (this.documentInfo.isApp) {
 					const pg = getPostgres(this.env, { pooled: true })
 					await pg`UPDATE public.file SET "updatedAt" = ${new Date().getTime()} WHERE id = ${this.documentInfo.slug}`
+					await pg.end()
 				}
 			})
 		} catch (e) {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -307,7 +307,7 @@ export class TLDrawDurableObject extends DurableObject {
 		try {
 			const postgres = getPostgres(this.env, { pooled: true })
 			const fileRecord =
-				await postgres`SELECT * FROM PUBLIC.FILE WHERE ID = ${this.documentInfo.slug}`
+				await postgres`SELECT * FROM public.file WHERE ID = ${this.documentInfo.slug}`
 			this._fileRecordCache = fileRecord[0] as TlaFile
 			postgres.end()
 			return this._fileRecordCache


### PR DESCRIPTION
This makes sure we close connections when we run migrations and also from the `TLDrawDurableObject`. It also gets the file record data straight from pg instead of going through the replicator.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
