### PR TITLE
pass custom migrations to useLocalStore

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -297,6 +297,7 @@ function TldrawEditorWithOwnStore(
 		sessionId,
 		user,
 		assets,
+		migrations,
 	} = props
 
 	const syncedStore = useLocalStore({
@@ -308,6 +309,7 @@ function TldrawEditorWithOwnStore(
 		defaultName,
 		snapshot,
 		assets,
+		migrations,
 	})
 
 	return <TldrawEditorWithLoadingStore {...props} store={syncedStore} user={user} />


### PR DESCRIPTION
Fixes https://discord.com/channels/859816885297741824/859816885801713728/1318729897958707312

Fixed a bug with locally synced stores where custom migrations were not being passed to the store constructor

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with locally synced stores where custom migrations were not being passed to the store constructor.