### PR TITLE
Move to kysely

### DIFF
--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -15,7 +15,7 @@
 		"test-ci": "lazy inherit",
 		"test": "yarn run -T jest",
 		"test-coverage": "lazy inherit",
-		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 500000",
+		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 800000",
 		"reset-db": "./reset-db.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"
 	},

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -32,12 +32,15 @@
 		"@tldraw/worker-shared": "workspace:*",
 		"itty-router": "^5.0.17",
 		"jose": "^5.9.6",
+		"kysely": "^0.27.5",
+		"pg": "^8.13.1",
 		"postgres": "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20241022.0",
+		"@types/pg": "^8.11.10",
 		"esbuild": "^0.21.5",
 		"lazyrepo": "0.0.0-alpha.27",
 		"typescript": "~5.4.2",

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -3,6 +3,7 @@
 
 import { SupabaseClient } from '@supabase/supabase-js'
 import {
+	DB,
 	READ_ONLY_LEGACY_PREFIX,
 	READ_ONLY_PREFIX,
 	ROOM_OPEN_MODE,
@@ -24,9 +25,10 @@ import { ExecutionQueue, assert, assertExists, exhaustiveSwitchError } from '@tl
 import { createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
+import { Kysely } from 'kysely'
 import { AlarmScheduler } from './AlarmScheduler'
 import { PERSIST_INTERVAL_MS } from './config'
-import { getPooledPostgres } from './getPostgres'
+import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
@@ -156,6 +158,8 @@ export class TLDrawDurableObject extends DurableObject {
 
 	_documentInfo: DocumentInfo | null = null
 
+	db: Kysely<DB>
+
 	constructor(
 		private state: DurableObjectState,
 		override env: Environment
@@ -181,6 +185,7 @@ export class TLDrawDurableObject extends DurableObject {
 				this._documentInfo = existingDocumentInfo
 			}
 		})
+		this.db = createPostgresConnectionPool(env, 'TLDrawDurableObject')
 	}
 
 	readonly router = Router()
@@ -305,13 +310,11 @@ export class TLDrawDurableObject extends DurableObject {
 			return this._fileRecordCache
 		}
 		try {
-			const pg = getPooledPostgres(this.env, { name: 'TLDrawDurableObject' })
-			const fileRecord = await pg
+			const fileRecord = await this.db
 				.selectFrom('file')
 				.where('id', '=', this.documentInfo.slug)
 				.selectAll()
 				.executeTakeFirstOrThrow()
-			pg.destroy()
 			this._fileRecordCache = fileRecord
 			return this._fileRecordCache
 		} catch (_e) {
@@ -591,12 +594,11 @@ export class TLDrawDurableObject extends DurableObject {
 
 				// Update the updatedAt timestamp in the database
 				if (this.documentInfo.isApp) {
-					const pg = getPooledPostgres(this.env, { name: 'TLDrawDurableObject' })
-					pg.updateTable('file')
+					await this.db
+						.updateTable('file')
 						.set({ updatedAt: new Date().getTime() })
 						.where('id', '=', this.documentInfo.slug)
 						.execute()
-					pg.destroy()
 				}
 			})
 		} catch (e) {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -310,12 +310,11 @@ export class TLDrawDurableObject extends DurableObject {
 			return this._fileRecordCache
 		}
 		try {
-			const fileRecord = await this.db
+			this._fileRecordCache = await this.db
 				.selectFrom('file')
 				.where('id', '=', this.documentInfo.slug)
 				.selectAll()
 				.executeTakeFirstOrThrow()
-			this._fileRecordCache = fileRecord
 			return this._fileRecordCache
 		} catch (_e) {
 			return null

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -306,7 +306,11 @@ export class TLDrawDurableObject extends DurableObject {
 		}
 		try {
 			const pg = getPooledPostgres(this.env, { name: 'TLDrawDurableObject' })
-			const fileRecord = await pg.selectFrom('file').selectAll().executeTakeFirstOrThrow()
+			const fileRecord = await pg
+				.selectFrom('file')
+				.where('id', '=', this.documentInfo.slug)
+				.selectAll()
+				.executeTakeFirstOrThrow()
 			pg.destroy()
 			this._fileRecordCache = fileRecord
 			return this._fileRecordCache

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -13,7 +13,7 @@ import postgres from 'postgres'
 import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
 import type { TLDrawDurableObject } from './TLDrawDurableObject'
 import { ZReplicationEventWithoutSequenceInfo } from './UserDataSyncer'
-import { getPostgres } from './getPostgres'
+import { createPostgresConnection } from './postgres'
 import { Analytics, Environment, TLPostgresReplicatorEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
 import { getUserDurableObject } from './utils/durableObjects'
@@ -228,7 +228,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			// preserve the promise so any awaiters do eventually get resolved
 			// TODO: set a timeout on the promise?
 			promise,
-			db: getPostgres(this.env, { name: 'TLPostgresReplicator' }),
+			db: createPostgresConnection(this.env, { name: 'TLPostgresReplicator' }),
 			sequenceId: uniqueId(),
 		}
 		const subscription = await this.state.db.subscribe(

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -228,7 +228,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			// preserve the promise so any awaiters do eventually get resolved
 			// TODO: set a timeout on the promise?
 			promise,
-			db: getPostgres(this.env, { pooled: false, name: 'TLPostgresReplicator' }),
+			db: getPostgres(this.env, { name: 'TLPostgresReplicator' }),
 			sequenceId: uniqueId(),
 		}
 		const subscription = await this.state.db.subscribe(

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -1,4 +1,5 @@
 import {
+	DB,
 	isColumnMutable,
 	ROOM_PREFIX,
 	TlaFile,
@@ -15,9 +16,9 @@ import { assert } from '@tldraw/utils'
 import { createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
-import postgres from 'postgres'
+import { Kysely, sql } from 'kysely'
 import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
-import { getPostgres } from './getPostgres'
+import { getPooledPostgres } from './getPostgres'
 import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
 import { Analytics, Environment, TLUserDurableObjectEvent } from './types'
@@ -29,7 +30,7 @@ import { retryOnConnectionFailure } from './utils/retryOnConnectionFailure'
 import { getCurrentSerializedRoomSnapshot } from './utils/tla/getCurrentSerializedRoomSnapshot'
 
 export class TLUserDurableObject extends DurableObject<Environment> {
-	private readonly db: ReturnType<typeof postgres>
+	private readonly db: Kysely<DB>
 	private readonly replicator: TLPostgresReplicator
 	private measure: Analytics | undefined
 
@@ -50,7 +51,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.sentry = createSentry(ctx, env)
 		this.replicator = getReplicator(env)
 
-		this.db = getPostgres(env, { pooled: true, name: 'TLUserDurableObject' })
+		this.db = getPooledPostgres(env, { name: 'TLUserDurableObject' })
 		this.debug('created')
 		this.measure = env.MEASURE
 	}
@@ -286,22 +287,32 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private async _doMutate(msg: ZClientSentMessage) {
 		this.assertCache()
-		await this.db.begin(async (sql) => {
+		await this.db.transaction().execute(async (tx) => {
 			for (const update of msg.updates) {
 				await this.assertValidMutation(update)
 				switch (update.event) {
 					case 'insert': {
 						if (update.table === 'file_state') {
 							const { fileId: _fileId, userId: _userId, ...rest } = update.row as any
-							if (Object.keys(rest).length === 0) {
-								await sql`insert into ${sql('public.' + update.table)} ${sql(update.row)} ON CONFLICT ("fileId", "userId") DO NOTHING`
-							} else {
-								await sql`insert into ${sql('public.' + update.table)} ${sql(update.row)} ON CONFLICT ("fileId", "userId") DO UPDATE SET ${sql(rest)}`
-							}
+							await tx
+								.insertInto(update.table)
+								.values(update.row as TlaFileState)
+								.onConflict((oc) => {
+									if (Object.keys(oc).length === 0) {
+										return oc.columns(['fileId', 'userId']).doNothing()
+									} else {
+										return oc.columns(['fileId', 'userId']).doUpdateSet(rest)
+									}
+								})
+								.execute()
 							break
 						} else {
 							const { id: _id, ...rest } = update.row as any
-							await sql`insert into ${sql('public.' + update.table)} ${sql(update.row)} ON CONFLICT ("id") DO UPDATE SET ${sql(rest)}`
+							await tx
+								.insertInto(update.table)
+								.values(update.row as any)
+								.onConflict((oc) => oc.column('id').doUpdateSet(rest))
+								.execute()
 							break
 						}
 					}
@@ -315,11 +326,16 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 						)
 						if (update.table === 'file_state') {
 							const { fileId, userId } = update.row as any
-							await sql`update public.file_state set ${sql(updates)} where "fileId" = ${fileId} and "userId" = ${userId}`
+							await tx
+								.updateTable('file_state')
+								.set(updates)
+								.where('fileId', '=', fileId)
+								.where('userId', '=', userId)
+								.execute()
 						} else {
 							const { id, ...rest } = update.row as any
 
-							await sql`update ${sql('public.' + update.table)} set ${sql(updates)} where id = ${id}`
+							await tx.updateTable(update.table).set(updates).where('id', '=', id).execute()
 							if (update.table === 'file') {
 								const currentFile = this.cache.store.getFullData()?.files.find((f) => f.id === id)
 								if (currentFile && currentFile.published !== rest.published) {
@@ -342,10 +358,14 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 					case 'delete':
 						if (update.table === 'file_state') {
 							const { fileId, userId } = update.row as any
-							await sql`delete from public.file_state where "fileId" = ${fileId} and "userId" = ${userId}`
+							await tx
+								.deleteFrom('file_state')
+								.where('fileId', '=', fileId)
+								.where('userId', '=', userId)
+								.execute()
 						} else {
 							const { id } = update.row as any
-							await sql`delete from ${sql('public.' + update.table)} where id = ${id}`
+							await tx.deleteFrom(update.table).where('id', '=', id).execute()
 						}
 						if (update.table === 'file') {
 							const { id } = update.row as TlaFile
@@ -372,11 +392,23 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			// TODO: We should probably handle a case where the above operation succeeds but the one below fails
 			this.debug('mutation success', this.userId)
 			await this.db
-				.begin(async (sql) => {
-					const result =
-						await sql`insert into public.user_mutation_number ("userId", "mutationNumber") values (${this.userId}, 1) on conflict ("userId") do update set "mutationNumber" = user_mutation_number."mutationNumber" + 1 returning "mutationNumber"`
+				.transaction()
+				.execute(async (tx) => {
+					const result = await tx
+						.insertInto('user_mutation_number')
+						.values({
+							userId: this.userId!,
+							mutationNumber: 1,
+						})
+						.onConflict((oc) =>
+							oc.column('userId').doUpdateSet({
+								mutationNumber: sql`user_mutation_number."mutationNumber" + 1`,
+							})
+						)
+						.returning('mutationNumber')
+						.executeTakeFirstOrThrow()
 					this.debug('mutation number success', this.userId)
-					const mutationNumber = Number(result[0].mutationNumber)
+					const mutationNumber = Number(result.mutationNumber)
 					const currentMutationNumber = this.cache.mutations.at(-1)?.mutationNumber ?? 0
 					assert(
 						mutationNumber > currentMutationNumber,

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -18,7 +18,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, sql } from 'kysely'
 import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
-import { getPooledPostgres } from './getPostgres'
+import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
 import { Analytics, Environment, TLUserDurableObjectEvent } from './types'
@@ -51,7 +51,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.sentry = createSentry(ctx, env)
 		this.replicator = getReplicator(env)
 
-		this.db = getPooledPostgres(env, { name: 'TLUserDurableObject' })
+		this.db = createPostgresConnectionPool(env, 'TLUserDurableObject')
 		this.debug('created')
 		this.measure = env.MEASURE
 	}

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -298,7 +298,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								.insertInto(update.table)
 								.values(update.row as TlaFileState)
 								.onConflict((oc) => {
-									if (Object.keys(oc).length === 0) {
+									if (Object.keys(rest).length === 0) {
 										return oc.columns(['fileId', 'userId']).doNothing()
 									} else {
 										return oc.columns(['fileId', 'userId']).doUpdateSet(rest)

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -1,4 +1,5 @@
 import {
+	DB,
 	OptimisticAppStore,
 	TlaRow,
 	ZEvent,
@@ -8,7 +9,7 @@ import {
 } from '@tldraw/dotcom-shared'
 import { ExecutionQueue, assert, promiseWithResolve, sleep, uniqueId } from '@tldraw/utils'
 import { createSentry } from '@tldraw/worker-shared'
-import postgres from 'postgres'
+import { Kysely } from 'kysely'
 import type { EventHint } from 'toucan-js/node_modules/@sentry/types'
 import { TLPostgresReplicator } from './TLPostgresReplicator'
 import {
@@ -116,7 +117,7 @@ export class UserDataSyncer {
 	constructor(
 		ctx: DurableObjectState,
 		env: Environment,
-		private db: postgres.Sql,
+		private db: Kysely<DB>,
 		private userId: string,
 		private broadcast: (message: ZServerSentMessage) => void,
 		private logEvent: (event: TLUserDurableObjectEvent) => void
@@ -231,7 +232,7 @@ export class UserDataSyncer {
 
 		const promise = this.state.promise
 
-		const sql = getFetchUserDataSql(this.userId, bootId)
+		const userSql = getFetchUserDataSql(this.userId, bootId)
 		const initialData: ZStoreData = {
 			user: null as any,
 			files: [],
@@ -246,31 +247,26 @@ export class UserDataSyncer {
 				initialData.files = []
 				initialData.fileStates = []
 
-				await this.db.begin(async (db) => {
-					return db
-						.unsafe(sql, [], { prepare: false })
-						.simple()
-						.forEach((row: any) => {
-							assert(this.state.type === 'connecting', 'state should be connecting in boot')
-							switch (row.table) {
-								case 'user':
-									initialData.user = parseResultRow(userKeys, row)
-									break
-								case 'file':
-									initialData.files.push(parseResultRow(fileKeys, row))
-									break
-								case 'file_state':
-									initialData.fileStates.push(parseResultRow(fileStateKeys, row))
-									break
-								case 'user_mutation_number':
-									assert(
-										typeof row.mutationNumber === 'number',
-										'mutationNumber should be a number'
-									)
-									this.state.mutationNumber = row.mutationNumber
-									break
-							}
-						})
+				await this.db.transaction().execute(async (tx) => {
+					const result = await userSql.execute(tx)
+					return result.rows.forEach((row: any) => {
+						assert(this.state.type === 'connecting', 'state should be connecting in boot')
+						switch (row.table) {
+							case 'user':
+								initialData.user = parseResultRow(userKeys, row)
+								break
+							case 'file':
+								initialData.files.push(parseResultRow(fileKeys, row))
+								break
+							case 'file_state':
+								initialData.fileStates.push(parseResultRow(fileStateKeys, row))
+								break
+							case 'user_mutation_number':
+								assert(typeof row.mutationNumber === 'number', 'mutationNumber should be a number')
+								this.state.mutationNumber = row.mutationNumber
+								break
+						}
+					})
 				})
 			},
 			() => {

--- a/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
+++ b/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
@@ -1,4 +1,5 @@
 import { ZColumn, tlaFileSchema, tlaFileStateSchema, tlaUserSchema } from '@tldraw/dotcom-shared'
+import { sql } from 'kysely'
 interface ColumnStuff {
 	name: string
 	type: 'string' | 'number' | 'boolean'
@@ -41,15 +42,19 @@ const fileColumns = fileKeys.map((c) => `${c.reference} as "${c.alias}"`)
 const fileStateColumns = fileStateKeys.map((c) => `${c.reference} as "${c.alias}"`)
 
 export function getFetchUserDataSql(userId: string, bootId: string) {
-	return `
-INSERT INTO public.user_boot_id ("userId", "bootId") VALUES ('${userId}', '${bootId}') ON CONFLICT ("userId") DO UPDATE SET "bootId" = '${bootId}';
-SELECT 'user' AS "table", null::bigint as "mutationNumber", ${userColumns.concat(fileNulls).concat(fileStateNulls)} FROM public.user WHERE "id" = '${userId}'
+	return sql`
+WITH upsert AS (
+  INSERT INTO public.user_boot_id ("userId", "bootId")
+  VALUES (${userId}, ${bootId})
+  ON CONFLICT ("userId") DO UPDATE SET "bootId" = ${bootId}
+)
+SELECT 'user' AS "table", null::bigint as "mutationNumber", ${sql.raw(userColumns + ',' + fileNulls + ',' + fileStateNulls)} FROM public.user WHERE "id" = '${sql.raw(userId)}'
 UNION
-SELECT 'file' AS "table", null::bigint as "mutationNumber", ${userNulls.concat(fileColumns).concat(fileStateNulls)} FROM public.file WHERE "ownerId" = '${userId}' OR "shared" = true AND EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${userId}' AND public.file_state."fileId" = public.file.id) 
+SELECT 'file' AS "table", null::bigint as "mutationNumber", ${sql.raw(userNulls + ',' + fileColumns + ',' + fileStateNulls)} FROM public.file WHERE "ownerId" = '${sql.raw(userId)}' OR "shared" = true AND EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${sql.raw(userId)}' AND public.file_state."fileId" = public.file.id)
 UNION
-SELECT 'file_state' AS "table", null::bigint as "mutationNumber", ${userNulls.concat(fileNulls).concat(fileStateColumns)} FROM public.file_state WHERE "userId" = '${userId}'
+SELECT 'file_state' AS "table", null::bigint as "mutationNumber", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateColumns)} FROM public.file_state WHERE "userId" = '${sql.raw(userId)}'
 UNION
-SELECT 'user_mutation_number' as "table", "mutationNumber"::bigint, ${userNulls.concat(fileNulls).concat(fileStateNulls)} FROM public.user_mutation_number WHERE "userId" = '${userId}';
+SELECT 'user_mutation_number' as "table", "mutationNumber"::bigint, ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateNulls)} FROM public.user_mutation_number WHERE "userId" = '${sql.raw(userId)}';
 `
 }
 

--- a/apps/dotcom/sync-worker/src/getPostgres.ts
+++ b/apps/dotcom/sync-worker/src/getPostgres.ts
@@ -9,25 +9,22 @@ import { Environment } from './types'
  */
 export function getPostgres(
 	env: Environment,
-	{ pooled, name, idleTimeout = 30 }: { pooled: boolean; name: string; idleTimeout?: number }
+	{ name, idleTimeout = 30 }: { name: string; idleTimeout?: number }
 ) {
-	return postgres(
-		pooled ? env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING : env.BOTCOM_POSTGRES_CONNECTION_STRING,
-		{
-			types: {
-				bigint: {
-					from: [20], // PostgreSQL OID for BIGINT
-					parse: (value: string) => Number(value), // Convert string to number
-					to: 20,
-					serialize: (value: number) => String(value), // Convert number to string
-				},
+	return postgres(env.BOTCOM_POSTGRES_CONNECTION_STRING, {
+		types: {
+			bigint: {
+				from: [20], // PostgreSQL OID for BIGINT
+				parse: (value: string) => Number(value), // Convert string to number
+				to: 20,
+				serialize: (value: number) => String(value), // Convert number to string
 			},
-			idle_timeout: idleTimeout,
-			connection: {
-				application_name: name,
-			},
-		}
-	)
+		},
+		idle_timeout: idleTimeout,
+		connection: {
+			application_name: name,
+		},
+	})
 }
 
 const int8TypeId = 20
@@ -42,14 +39,11 @@ export function getPooledPostgres(env: Environment, { name }: { name: string }) 
 			application_name: name,
 			idleTimeoutMillis: 10_000,
 			max: 450,
-			// log: (msg) => console.log(msg),
 		}),
 	})
 
 	const db = new Kysely<DB>({
 		dialect,
-		// plugins: [new CamelCasePlugin()],
-		// log: ['query', 'error'],
 		log: ['error'],
 	})
 	return db

--- a/apps/dotcom/sync-worker/src/getPostgres.ts
+++ b/apps/dotcom/sync-worker/src/getPostgres.ts
@@ -1,3 +1,6 @@
+import { DB } from '@tldraw/dotcom-shared'
+import { Kysely, PostgresDialect } from 'kysely'
+import * as pg from 'pg'
 import postgres from 'postgres'
 import { Environment } from './types'
 
@@ -25,4 +28,29 @@ export function getPostgres(
 			},
 		}
 	)
+}
+
+const int8TypeId = 20
+pg.types.setTypeParser(int8TypeId, (val) => {
+	return parseInt(val, 10)
+})
+
+export function getPooledPostgres(env: Environment, { name }: { name: string }) {
+	const dialect = new PostgresDialect({
+		pool: new pg.Pool({
+			connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
+			application_name: name,
+			idleTimeoutMillis: 10_000,
+			max: 450,
+			// log: (msg) => console.log(msg),
+		}),
+	})
+
+	const db = new Kysely<DB>({
+		dialect,
+		// plugins: [new CamelCasePlugin()],
+		// log: ['query', 'error'],
+		log: ['error'],
+	})
+	return db
 }

--- a/apps/dotcom/sync-worker/src/getPostgres.ts
+++ b/apps/dotcom/sync-worker/src/getPostgres.ts
@@ -5,7 +5,8 @@ import postgres from 'postgres'
 import { Environment } from './types'
 
 /**
- * `pooled` should be almost always be true.
+ * In most cases you want to use a pooled connection, which is what `getPooledPostgres` does.
+ * Use this one only for cases like subscriptions where you need to listen for notifications / WAL.
  */
 export function getPostgres(
 	env: Environment,

--- a/apps/dotcom/sync-worker/src/postgres.ts
+++ b/apps/dotcom/sync-worker/src/postgres.ts
@@ -5,10 +5,10 @@ import postgres from 'postgres'
 import { Environment } from './types'
 
 /**
- * In most cases you want to use a pooled connection, which is what `getPooledPostgres` does.
+ * In most cases you want to use a pooled connection, which is what `createPostgresConnectionPool` does.
  * Use this one only for cases like subscriptions where you need to listen for notifications / WAL.
  */
-export function getPostgres(
+export function createPostgresConnection(
 	env: Environment,
 	{ name, idleTimeout = 30 }: { name: string; idleTimeout?: number }
 ) {
@@ -33,7 +33,7 @@ pg.types.setTypeParser(int8TypeId, (val) => {
 	return parseInt(val, 10)
 })
 
-export function getPooledPostgres(env: Environment, { name }: { name: string }) {
+export function createPostgresConnectionPool(env: Environment, name: string) {
 	const dialect = new PostgresDialect({
 		pool: new pg.Pool({
 			connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,

--- a/internal/scripts/check-worker-bundle.ts
+++ b/internal/scripts/check-worker-bundle.ts
@@ -38,6 +38,8 @@ const EXTERNAL_DEPS = [
 	'fs',
 	'os',
 	'perf_hooks',
+	'path',
+	'dns',
 ]
 
 async function checkBundleSize() {

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -127,6 +127,8 @@ class SizeReporter {
 			'--external:fs',
 			'--external:perf_hooks',
 			'--external:tls',
+			'--external:path',
+			'--external:dns',
 			'--target=esnext',
 			'--format=esm',
 		])

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -147,6 +147,10 @@ export type TlaUserPartial = Partial<TlaUser> & {
 }
 
 export type TlaRow = TlaFile | TlaFileState | TlaUser
+export interface TlaUserMutationNumber {
+	userId: string
+	mutationNumber: number
+}
 
 const immutableColumns: Record<string, Set<string>> = {
 	user: new Set<keyof TlaUser>(['id', 'email', 'createdAt', 'avatar']),
@@ -156,4 +160,11 @@ const immutableColumns: Record<string, Set<string>> = {
 
 export function isColumnMutable(tableName: keyof typeof immutableColumns, column: string) {
 	return !immutableColumns[tableName].has(column)
+}
+
+export interface DB {
+	file: TlaFile
+	file_state: TlaFileState
+	user: TlaUser
+	user_mutation_number: TlaUserMutationNumber
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,10 +7159,13 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     "@tldraw/validate": "workspace:*"
     "@tldraw/worker-shared": "workspace:*"
+    "@types/pg": "npm:^8.11.10"
     esbuild: "npm:^0.21.5"
     itty-router: "npm:^5.0.17"
     jose: "npm:^5.9.6"
+    kysely: "npm:^0.27.5"
     lazyrepo: "npm:0.0.0-alpha.27"
+    pg: "npm:^8.13.1"
     postgres: "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -8081,6 +8084,17 @@ __metadata:
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
   checksum: 5bf62eec37c332ad10059252fc0dab7e7da730764869c980b0714777ad3d065e490627be9f40fc52f238ffa3ac4199b19de4127196910576c2fe34dd47c7a470
+  languageName: node
+  linkType: hard
+
+"@types/pg@npm:^8.11.10":
+  version: 8.11.10
+  resolution: "@types/pg@npm:8.11.10"
+  dependencies:
+    "@types/node": "npm:*"
+    pg-protocol: "npm:*"
+    pg-types: "npm:^4.0.1"
+  checksum: 65b7d7ca9c90b7cb94aa94ad94bb1883356845e1f64688bc824ecd499da25f63a2400f0a58500554637048a7cc8b91055bbfe14301c082ce9669afd0c18e414c
   languageName: node
   linkType: hard
 
@@ -16844,6 +16858,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kysely@npm:^0.27.5":
+  version: 0.27.5
+  resolution: "kysely@npm:0.27.5"
+  checksum: f93057319d387bb03baabd6eddeb7e435816b8531ba4bb7a65264122004f789954e1dc683209472201a7459b2ed4728d6dc9c5c5a2f219286d7d5c258e7dc3fb
+  languageName: node
+  linkType: hard
+
 "language-subtag-registry@npm:^0.3.20":
   version: 0.3.22
   resolution: "language-subtag-registry@npm:0.3.22"
@@ -19282,6 +19303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obuf@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "obuf@npm:1.1.2"
+  checksum: 53ff4ab3a13cc33ba6c856cf281f2965c0aec9720967af450e8fd06cfd50aceeefc791986a16bcefa14e7898b3ca9acdfcf15b9d9a1b9c7e1366581a8ad6e65e
+  languageName: node
+  linkType: hard
+
 "octokit@npm:^3.1.1":
   version: 3.1.2
   resolution: "octokit@npm:3.1.2"
@@ -19961,6 +19989,109 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-cloudflare@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pg-cloudflare@npm:1.1.1"
+  checksum: 45ca0c7926967ec9e66a9efc73ca57e3e933671b541bc774631a02ce683e7f658d0a4e881119b3f61486f38e344ae1b008d3a20eb5e21701c5fa8ff8382c5538
+  languageName: node
+  linkType: hard
+
+"pg-connection-string@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "pg-connection-string@npm:2.7.0"
+  checksum: 68015a8874b7ca5dad456445e4114af3d2602bac2fdb8069315ecad0ff9660ec93259b9af7186606529ac4f6f72a06831e6f20897a689b16cc7fda7ca0e247fd
+  languageName: node
+  linkType: hard
+
+"pg-int8@npm:1.0.1":
+  version: 1.0.1
+  resolution: "pg-int8@npm:1.0.1"
+  checksum: a1e3a05a69005ddb73e5f324b6b4e689868a447c5fa280b44cd4d04e6916a344ac289e0b8d2695d66e8e89a7fba023affb9e0e94778770ada5df43f003d664c9
+  languageName: node
+  linkType: hard
+
+"pg-numeric@npm:1.0.2":
+  version: 1.0.2
+  resolution: "pg-numeric@npm:1.0.2"
+  checksum: 8899f8200caa1744439a8778a9eb3ceefb599d893e40a09eef84ee0d4c151319fd416634a6c0fc7b7db4ac268710042da5be700b80ef0de716fe089b8652c84f
+  languageName: node
+  linkType: hard
+
+"pg-pool@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "pg-pool@npm:3.7.0"
+  peerDependencies:
+    pg: ">=8.0"
+  checksum: a07a4f9e26eec9d7ac3597dc7b3469c62983edff9a321dbb7acbe1bbc7f5e9b2d33438e277d4cf8145071f3d63c7ebdc287a539fd69dfb8cdddb15b33eefe1a2
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:*, pg-protocol@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "pg-protocol@npm:1.7.0"
+  checksum: ffffdf74426c9357b57050f1c191e84447c0e8b2a701b3ab302ac7dd0eb27b862d92e5e3b2d38876a1051de83547eb9165d6a58b3a8e90bb050dae97f9993d54
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "pg-types@npm:2.2.0"
+  dependencies:
+    pg-int8: "npm:1.0.1"
+    postgres-array: "npm:~2.0.0"
+    postgres-bytea: "npm:~1.0.0"
+    postgres-date: "npm:~1.0.4"
+    postgres-interval: "npm:^1.1.0"
+  checksum: 87a84d4baa91378d3a3da6076c69685eb905d1087bf73525ae1ba84b291b9dd8738c6716b333d8eac6cec91bf087237adc3e9281727365e9cbab0d9d072778b1
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "pg-types@npm:4.0.2"
+  dependencies:
+    pg-int8: "npm:1.0.1"
+    pg-numeric: "npm:1.0.2"
+    postgres-array: "npm:~3.0.1"
+    postgres-bytea: "npm:~3.0.0"
+    postgres-date: "npm:~2.1.0"
+    postgres-interval: "npm:^3.0.0"
+    postgres-range: "npm:^1.1.1"
+  checksum: f4d529da864d4169afab300eb8629a84a6a06aa70c471160a7e46c34b6d4dd0e61cbd57d10d98c3a36e98f474e2ff85d41e4b1c953a321146b4bae09372c58d3
+  languageName: node
+  linkType: hard
+
+"pg@npm:^8.13.1":
+  version: 8.13.1
+  resolution: "pg@npm:8.13.1"
+  dependencies:
+    pg-cloudflare: "npm:^1.1.1"
+    pg-connection-string: "npm:^2.7.0"
+    pg-pool: "npm:^3.7.0"
+    pg-protocol: "npm:^1.7.0"
+    pg-types: "npm:^2.1.0"
+    pgpass: "npm:1.x"
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 542aa49fcb37657cf5f779b4a31fe6eb336e683445ecca38e267eeb0ca85d873ffe51f04794f9f9e184187e9f74bf7895e932a0fa9507132ac0dfc76c7c73451
+  languageName: node
+  linkType: hard
+
+"pgpass@npm:1.x":
+  version: 1.0.5
+  resolution: "pgpass@npm:1.0.5"
+  dependencies:
+    split2: "npm:^4.1.0"
+  checksum: 0a6f3bf76e36bdb3c20a7e8033140c732767bba7e81f845f7489fc3123a2bd6e3b8e704f08cba86b117435414b5d2422e20ba9d5f2efb6f0c75c9efca73e8e87
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -20182,6 +20313,73 @@ __metadata:
     picocolors: "npm:^1.1.0"
     source-map-js: "npm:^1.2.1"
   checksum: f2b50ba9b6fcb795232b6bb20de7cdc538c0025989a8ed9c4438d1960196ba3b7eaff41fdb1a5c701b3504651ea87aeb685577707f0ae4d6ce6f3eae5df79a81
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "postgres-array@npm:2.0.0"
+  checksum: aff99e79714d1271fe942fec4ffa2007b755e7e7dc3d2feecae3f1ceecb86fd3637c8138037fc3d9e7ec369231eeb136843c0b25927bf1ce295245a40ef849b4
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~3.0.1":
+  version: 3.0.2
+  resolution: "postgres-array@npm:3.0.2"
+  checksum: 0159517e4e5f263bf9e324f0c4d3c10244a294021f2b5980abc8c23afdb965370a7fc0c82012fce4d28e83186ad089b6476b05fcef6c88f8e43e37a3a2fa0ad5
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "postgres-bytea@npm:1.0.0"
+  checksum: d844ae4ca7a941b70e45cac1261a73ee8ed39d72d3d74ab1d645248185a1b7f0ac91a3c63d6159441020f4e1f7fe64689ac56536a307b31cef361e5187335090
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "postgres-bytea@npm:3.0.0"
+  dependencies:
+    obuf: "npm:~1.1.2"
+  checksum: f5c01758fd2fa807afbd34e1ba2146f683818ebc2d23f4a62f0fd627c0b1126fc543cab1b63925f97ce6c7d8f5f316043218619c447445210ea82f10411efb1b
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~1.0.4":
+  version: 1.0.7
+  resolution: "postgres-date@npm:1.0.7"
+  checksum: 571ef45bec4551bb5d608c31b79987d7a895141f7d6c7b82e936a52d23d97474c770c6143e5cf8936c1cdc8b0dfd95e79f8136bf56a90164182a60f242c19f2b
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "postgres-date@npm:2.1.0"
+  checksum: faa1c70dfad0e35bd4aa7cb6088fcd4e4f039aa25dc42150129178fc2a0baa7e37eca0bf18e4142a40dea18d1955459b08783f78ec487ef27b4b93ab5e854597
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "postgres-interval@npm:1.2.0"
+  dependencies:
+    xtend: "npm:^4.0.0"
+  checksum: 746b71f93805ae33b03528e429dc624706d1f9b20ee81bf743263efb6a0cd79ae02a642a8a480dbc0f09547b4315ab7df6ce5ec0be77ed700bac42730f5c76b2
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postgres-interval@npm:3.0.0"
+  checksum: c7a1cf006de97de663b6b8c4d2b167aa9909a238c4866a94b15d303762f5ac884ff4796cd6e2111b7f0a91302b83c570453aa8506fd005b5a5d5dfa87441bebc
+  languageName: node
+  linkType: hard
+
+"postgres-range@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "postgres-range@npm:1.1.4"
+  checksum: 035759f17b44bf9ba7e71a30402ed2ca1e2b7fabb3ad794b08169a5b453d38d06905a6dfb51fe41a3f6d9fac4e183dac9e769b95053053db933be16785edce1f
   languageName: node
   linkType: hard
 
@@ -22252,6 +22450,13 @@ __metadata:
   bin:
     wordwrap: cli.js
   checksum: 944a2defff4eccf193216177b284bd8d3da0d83391827d89efa4250d4c0a0729e63fecfc0cf56fa2c50acba2b8017753b332b13d0aebdb9fb5c1c2164a943ce5
+  languageName: node
+  linkType: hard
+
+"split2@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "split2@npm:4.2.0"
+  checksum: 09bbefc11bcf03f044584c9764cd31a252d8e52cea29130950b26161287c11f519807c5e54bd9e5804c713b79c02cefe6a98f4688630993386be353e03f534ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Switches from using postgres js to kysely. We still use postgres js for subscription to the db.

During stress tests we noticed that postgres js was not good at managing the connection pool. Kysely performed much better.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
