### PR TITLE
embeds: fix Gist; fix Val Town; add support for <iframe>

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -31,10 +31,18 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'https://*.clerk.accounts.dev',
 		'https://clerk.tldraw.com',
 		'https://clerk.staging.tldraw.com',
+		// embeds that have scripts
+		'https://gist.github.com',
 	],
 	'worker-src': [`'self'`, `blob:`],
 	'style-src': [`'self'`, `'unsafe-inline'`, `https://fonts.googleapis.com`],
-	'style-src-elem': [`'self'`, `'unsafe-inline'`, `https://fonts.googleapis.com`],
+	'style-src-elem': [
+		`'self'`,
+		`'unsafe-inline'`,
+		`https://fonts.googleapis.com`,
+		// embeds that have styles
+		'https://github.githubassets.com',
+	],
 	'report-uri': [process.env.SENTRY_CSP_REPORT_URI ?? ``],
 }
 

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -73,13 +73,15 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			'allow-presentation': true,
 		},
 		toEmbedUrl: (url) => {
-			if (url.includes('/maps/')) {
+			if (url.includes('/maps/embed?')) {
+				return url
+			} else if (url.includes('/maps/')) {
 				const match = url.match(/@(.*),(.*),(.*)z/)
 				let result: string
 				if (match) {
 					const [, lat, lng, z] = match
 					const host = new URL(url).host.replace('www.', '')
-					result = `https://${host}/maps/embed/v1/view?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=${lat},${lng}&zoom=${z}`
+					result = `https://${host}/maps/embed/v1/view?key=AIzaSyD2M5rZTN_CWNWl1egdKaQBSZk-uxhIl5Q&center=${lat},${lng}&zoom=${z}`
 				} else {
 					result = ''
 				}

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -76,7 +76,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			if (url.includes('/maps/embed?')) {
 				return url
 			} else if (url.includes('/maps/')) {
-				const match = url.match(/@(.*),(.*),(.*)z/)
+				const match = url.match(/@(.*?),(.*?),(.*?)z/)
 				let result: string
 				if (match) {
 					const [, lat, lng, z] = match

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -81,7 +81,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 				if (match) {
 					const [, lat, lng, z] = match
 					const host = new URL(url).host.replace('www.', '')
-					result = `https://${host}/maps/embed/v1/view?key=AIzaSyD2M5rZTN_CWNWl1egdKaQBSZk-uxhIl5Q&center=${lat},${lng}&zoom=${z}`
+					result = `https://${host}/maps/embed/v1/view?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=${lat},${lng}&zoom=${z}`
 				} else {
 					result = ''
 				}

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -16,6 +16,7 @@ import {
 	useValue,
 } from '@tldraw/editor'
 
+import { SyntheticEvent } from 'react'
 import {
 	DEFAULT_EMBED_DEFINITIONS,
 	EmbedDefinition,
@@ -177,6 +178,16 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			...(embedInfo?.definition.overridePermissions ?? {}),
 		})
 
+		const onLoad = (e: SyntheticEvent<HTMLIFrameElement>) => {
+			// XXX There's a bug with Val Town where when loading the iframe sometimes it doesn't
+			// fully load the content until it's touched a bit.
+			// This "shakes" it awake.
+			if (embedInfo?.definition.type === 'val_town') {
+				e.currentTarget.style.height = `${parseInt(e.currentTarget.height) - 1}px`
+				e.currentTarget.style.height = `${parseInt(e.currentTarget.height) + 1}px`
+			}
+		}
+
 		return (
 			<HTMLContainer className="tl-embed-container" id={shape.id}>
 				{embedInfo?.definition ? (
@@ -189,6 +200,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 						draggable={false}
 						frameBorder="0"
 						referrerPolicy="no-referrer-when-downgrade"
+						onLoad={onLoad}
 						style={{
 							border: 0,
 							pointerEvents: isInteractive ? 'auto' : 'none',

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -16,7 +16,6 @@ import {
 	useValue,
 } from '@tldraw/editor'
 
-import { SyntheticEvent } from 'react'
 import {
 	DEFAULT_EMBED_DEFINITIONS,
 	EmbedDefinition,
@@ -178,16 +177,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			...(embedInfo?.definition.overridePermissions ?? {}),
 		})
 
-		const onLoad = (e: SyntheticEvent<HTMLIFrameElement>) => {
-			// XXX There's a bug with Val Town where when loading the iframe sometimes it doesn't
-			// fully load the content until it's touched a bit.
-			// This "shakes" it awake.
-			if (embedInfo?.definition.type === 'val_town') {
-				e.currentTarget.style.height = `${parseInt(e.currentTarget.height) - 1}px`
-				e.currentTarget.style.height = `${parseInt(e.currentTarget.height) + 1}px`
-			}
-		}
-
 		return (
 			<HTMLContainer className="tl-embed-container" id={shape.id}>
 				{embedInfo?.definition ? (
@@ -200,7 +189,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 						draggable={false}
 						frameBorder="0"
 						referrerPolicy="no-referrer-when-downgrade"
-						onLoad={onLoad}
 						style={{
 							border: 0,
 							pointerEvents: isInteractive ? 'auto' : 'none',

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -461,6 +461,27 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 				return
 			}
 		}
+
+		// Allow you to paste YouTube or Google Maps embeds, for example.
+		if (result.type === 'text' && result.subtype === 'text' && result.data.startsWith('<iframe ')) {
+			// try to find an iframe
+			const rootNode = new DOMParser().parseFromString(result.data, 'text/html')
+			const bodyNode = rootNode.querySelector('body')
+
+			const isSingleIframe =
+				bodyNode &&
+				Array.from(bodyNode.children).filter((el) => el.nodeType === 1).length === 1 &&
+				bodyNode.firstElementChild &&
+				bodyNode.firstElementChild.tagName === 'IFRAME' &&
+				bodyNode.firstElementChild.hasAttribute('src') &&
+				bodyNode.firstElementChild.getAttribute('src') !== ''
+
+			if (isSingleIframe) {
+				const src = bodyNode.firstElementChild.getAttribute('src')!
+				handleText(editor, src, point, results)
+				return
+			}
+		}
 	}
 
 	// Try to paste a link

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -440,7 +440,11 @@ const MATCH_EMBED_TEST_URLS: (MatchEmbedTestMatchDef | MatchEmbedTestNoMatchDef)
 	{
 		embedUrl:
 			'https://google.com/maps/embed?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=52.2449313,0.0813192&zoom=14',
-		match: false,
+		match: true,
+		output: {
+			type: 'google_maps',
+			url: 'https://google.com/maps/embed?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=52.2449313,0.0813192&zoom=14',
+		},
 	},
 	// google_calendar
 	{

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -152,6 +152,22 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		},
 	},
 	{
+		url: `https://www.google.com/maps/place/Shepherd's+Bush,+London/@51.5041626,-0.2468738,14z/data=!4m15!1m8!3m7!1s0x48760e1ce753774f:0x4420ec29705422c7!2sActon,+London!3b1!8m2!3d51.508372!4d-0.27444!16zL20vMG44cm0!3m5!1s0x48760fd28997cb07:0x6c79a6e5e0483766!8m2!3d51.5051913!4d-0.22469!16zL20vMDFqMTJo?entry=ttu&g_ep=EgoyMDI0MTIxMS4wIKXMDSoASAFQAw%3D%3D`,
+		match: true,
+		output: {
+			type: 'google_maps',
+			embedUrl: `https://google.com/maps/embed/v1/view?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=51.5041626,-0.2468738&zoom=14`,
+		},
+	},
+	{
+		url: `https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2480.1159099846072!2d-0.11034668719177695!3d51.566108606294414!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b96b188bb1b%3A0x9d8d2ab7a55d095e!2stldraw!5e0!3m2!1sen!2suk!4v1734706216129!5m2!1sen!2suk`,
+		match: true,
+		output: {
+			type: 'google_maps',
+			embedUrl: `https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2480.1159099846072!2d-0.11034668719177695!3d51.566108606294414!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b96b188bb1b%3A0x9d8d2ab7a55d095e!2stldraw!5e0!3m2!1sen!2suk!4v1734706216129!5m2!1sen!2suk`,
+		},
+	},
+	{
 		url: 'https://www.google.com/maps/timeline',
 		match: false,
 	},
@@ -440,11 +456,7 @@ const MATCH_EMBED_TEST_URLS: (MatchEmbedTestMatchDef | MatchEmbedTestNoMatchDef)
 	{
 		embedUrl:
 			'https://google.com/maps/embed?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=52.2449313,0.0813192&zoom=14',
-		match: true,
-		output: {
-			type: 'google_maps',
-			url: 'https://google.com/maps/embed?key=${process.env.NEXT_PUBLIC_GC_API_KEY}&center=52.2449313,0.0813192&zoom=14',
-		},
+		match: false,
 	},
 	// google_calendar
 	{


### PR DESCRIPTION
Initial report was a problem with Github Gist's not working on dotcom but then as long as I was here I noticed we had some other embed issues.

Fixes:
- [x] Gists not working on dotcom
- [ ] Val Town being flaky to load (prbly we should report to them separately)
- [x] Adds support for pasting in YouTube/Google Maps embeds 

### Change type

- [x] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixes bugs with Github Gist and Val Town; adds support for pasting `<iframe src="...">` embeds