### PR TITLE
add snowstorm example, remove snowstorm from app

### DIFF
--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -15,49 +15,51 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
-## Current release: [v3.4.0](/releases/v3.4.0)
+## Current release: [v3.6.0](/releases/v3.6.0)
 
-Welcome to the 3.4.0 release of the tldraw SDK. This issue fixes a few bugs in our user interface, improves performance around images and videos, and even improves our very secret ability to accept pasted content from [Excalidraw](https://excalidraw.com/). See below for the full list of changes.
+Welcome to the 3.6.0 release of tldraw. This month's SDK release expands DX around helpers (e.g. toasts), and addresses various issues.
 
-#### Breaking changes
+## What's new
 
-- The `id` attribute that was present on some shapes in the dom has been removed. There's now a data-shape-id attribute on every shape wrapper that can be used instead. ([#4694](https://github.com/tldraw/tldraw/pull/4694))
+#### Expand helpers available in actions / toasts overrides. ([#5041](https://github.com/tldraw/tldraw/pull/5041))
+
+Makes new helper available via actions and tools overrides, things like clipboard interactions, toasts, exports, printing, and a couple more.
 
 #### Improvements
 
-- Clearer tooltip wording in the style panel. ([#4750](https://github.com/tldraw/tldraw/pull/4750))
-- Arrow labels no longer have their indictors showing behind them. ([#4749](https://github.com/tldraw/tldraw/pull/4749))
-- Limit the page name length in the move to page menu. ([#4747](https://github.com/tldraw/tldraw/pull/4747))
-- Improve performance of image/video rendering. ([#4659](https://github.com/tldraw/tldraw/pull/4659))
+- Create a utility type for making undefined properties optional [#5055](https://github.com/tldraw/tldraw/pull/5055)
+- Make sure notes snap to grid after position is updated [#5010](https://github.com/tldraw/tldraw/pull/5010)
+- Add incremental derivation example [#5038](https://github.com/tldraw/tldraw/pull/5038)
 
 #### API changes
 
-- Add `labelColor` to note shapes. ([#4724](https://github.com/tldraw/tldraw/pull/4724))
-- There are a new set of APIs for working with unique DOM IDs in tldraw components: [`useUniqueSafeId`](https://staging.tldraw.dev/reference/editor/useUniqueSafeId) & [`useSharedSafeId`](https://staging.tldraw.dev/reference/editor/useSharedSafeId). ([#4694](https://github.com/tldraw/tldraw/pull/4694))
+- Expand helpers available in actions / toasts overrides. [#5041](https://github.com/tldraw/tldraw/pull/5041) ([@steveruizok](https://github.com/steveruizok))
+- `setEmbedDefinitions` used to be an instance method on the `EmbedShapeUtil` class, but has been converted into a static method on that class. [#5027](https://github.com/tldraw/tldraw/pull/5027)
+- Remove `ExtractOptionalKeys` and `ExtractRequiredKeys` types. https://github.com/tldraw/tldraw/pull/5055
 
-#### Bug fixes
+#### Bug fix
 
-- Writing `options` inline in the Tldraw component will no longer cause re-render loops. ([#4762](https://github.com/tldraw/tldraw/pull/4762))
-- Make sure toolbar button outlines match the border-radius of the button. ([#4759](https://github.com/tldraw/tldraw/pull/4759))
-- Make sure content pasted from Excalidraw keeps the correct color. ([#4752](https://github.com/tldraw/tldraw/pull/4752))
-- Don't highlight menu triggers that dont have their submenus open. ([#4710](https://github.com/tldraw/tldraw/pull/4710))
-- Pass through the correct event type for drag events. ([#4739](https://github.com/tldraw/tldraw/pull/4739))
-- Prevent multiple images accidentally being created when you drop one onto the canvas. ([#4704](https://github.com/tldraw/tldraw/pull/4704))
-- Make sure the link indicator is visible on sticky notes. ([#4708](https://github.com/tldraw/tldraw/pull/4708))
-- The insert embed dialog now parses URLs correctly. ([#4709](https://github.com/tldraw/tldraw/pull/4709))
-- Exports and other tldraw instances no longer can affect how each other are rendered. ([#4694](https://github.com/tldraw/tldraw/pull/4694))
-- Show the correct set of menu options in read-only mode. ([#4696](https://github.com/tldraw/tldraw/pull/4696))
+- Fix up resolving assets when copy/pasting multiple items; also, fix up copy/pasting videos [#5061](https://github.com/tldraw/tldraw/pull/5061)
+- Fix properly clipping scaled text in frames when exporting [#5022](https://github.com/tldraw/tldraw/pull/5022)
+- Fix multiple concurrent exports from interfering with each-others fonts [#5022](https://github.com/tldraw/tldraw/pull/5022)
+- Fix issue with long press where the point would be incorrect [#5032](https://github.com/tldraw/tldraw/pull/5032)
+- Fix file name when exporting a single unnamed frame [#4918](https://github.com/tldraw/tldraw/pull/4918)
+- Fix first render of custom embeds [#5027](https://github.com/tldraw/tldraw/pull/5027)
 
-#### Authors
+#### Authors: 7
 
-- [@nayounsang](https://github.com/nayounsang)
 - alex ([@SomeHats](https://github.com/SomeHats))
 - David Sheldrick ([@ds300](https://github.com/ds300))
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
+- Trygve Aaberge ([@trygve-aaberge-adsk](https://github.com/trygve-aaberge-adsk))
 
 ## Previous releases
+
+- [v3.5.0](/releases/v3.5.0)
+
+- [v3.4.0](/releases/v3.4.0)
 
 - [v3.3.0](/releases/v3.3.0)
 

--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -39,7 +39,6 @@ import { LocalFileMenu } from './FileMenu'
 import { Links } from './Links'
 import { ShareMenu } from './ShareMenu'
 import { SneakyOnDropOverride } from './SneakyOnDropOverride'
-import { SnowStorm } from './SnowStorm'
 import { ThemeUpdater } from './ThemeUpdater/ThemeUpdater'
 
 const components: TLComponents = {
@@ -83,9 +82,6 @@ const components: TLComponents = {
 				<ShareMenu />
 			</div>
 		)
-	},
-	InFrontOfTheCanvas: () => {
-		return <SnowStorm />
 	},
 }
 

--- a/apps/dotcom/client/src/components/MultiplayerEditor.tsx
+++ b/apps/dotcom/client/src/components/MultiplayerEditor.tsx
@@ -44,7 +44,6 @@ import { MultiplayerFileMenu } from './FileMenu'
 import { Links } from './Links'
 import { ShareMenu } from './ShareMenu'
 import { SneakyOnDropOverride } from './SneakyOnDropOverride'
-import { SnowStorm } from './SnowStorm'
 import { StoreErrorScreen } from './StoreErrorScreen'
 import { ThemeUpdater } from './ThemeUpdater/ThemeUpdater'
 
@@ -113,9 +112,6 @@ const components: TLComponents = {
 				<ShareMenu />
 			</div>
 		)
-	},
-	InFrontOfTheCanvas: () => {
-		return <SnowStorm />
 	},
 }
 

--- a/apps/dotcom/client/src/components/SnapshotsEditor.tsx
+++ b/apps/dotcom/client/src/components/SnapshotsEditor.tsx
@@ -19,7 +19,6 @@ import { SAVE_FILE_COPY_ACTION, useFileSystem } from '../utils/useFileSystem'
 import { useHandleUiEvents } from '../utils/useHandleUiEvent'
 import { ExportMenu } from './ExportMenu'
 import { MultiplayerFileMenu } from './FileMenu'
-import { SnowStorm } from './SnowStorm'
 
 const components: TLComponents = {
 	ErrorFallback: ({ error }) => {
@@ -47,9 +46,6 @@ const components: TLComponents = {
 				<ExportMenu />
 			</div>
 		)
-	},
-	InFrontOfTheCanvas: () => {
-		return <SnowStorm />
 	},
 }
 

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -447,19 +447,3 @@ a {
 	min-width: 36px;
 	height: 36px;
 }
-
-/* -------------------- Snowstorm ------------------- */
-
-.tl-snowflake {
-	position: absolute;
-	background-color: #ccc;
-	border-radius: 100%;
-	pointer-events: none;
-}
-
-.tl-snowstorm {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	pointer-events: none;
-}

--- a/apps/examples/src/examples/snowstorm/README.md
+++ b/apps/examples/src/examples/snowstorm/README.md
@@ -1,0 +1,10 @@
+---
+title: Snow Storm
+component: ./SnowStormExample.tsx
+category: use-cases
+keywords: [snowstorm, front]
+---
+
+---
+
+This example shows how you can display a snowstorm in front of the canvas.

--- a/apps/examples/src/examples/snowstorm/SnowStorm.tsx
+++ b/apps/examples/src/examples/snowstorm/SnowStorm.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useRef } from 'react'
 import { Vec, useEditor, usePrefersReducedMotion } from 'tldraw'
 
-/* eslint-disable local/prefer-class-methods */
+const MAX_GUST_SPEED = 2
+const GUST_ROTATION_DURATION = 30_000
+
+const MAX_PIXELS_SCROLL_EFFECT = 18
+const MAX_SCROLL_SPEED = 2
+
+const MIN_POINTER_DISTANCE_SQUARED = 10_000
+const SNOWFLAKE_VELOCITY_DECAY = 0.82
+
 interface Snowflake {
 	element: HTMLElement
 	x: number
@@ -32,11 +40,11 @@ class Snowstorm {
 	// Configuration options
 	private readonly config = {
 		flakesMax: 128,
-		flakesMaxActive: 64,
-		animationInterval: 30,
 		flakeSizeMin: 2,
 		flakeSizeMax: 5,
-		windMax: 2,
+		flakeSpeedMinY: 1,
+		flakeSpeedMaxY: 3,
+		flakeSpeedX: 2,
 	}
 
 	constructor(container: HTMLElement = document.body) {
@@ -46,58 +54,75 @@ class Snowstorm {
 	}
 
 	private createSnowflake(): Snowflake {
-		const size = rnd(this.config.flakeSizeMin, this.config.flakeSizeMax)
-		const opacity = rnd(0.5, 1)
-
 		const element = document.createElement('div')
-		element.style.width = `${size}px`
-		element.style.height = `${size}px`
-		element.classList.add('tl-snowflake')
-		element.style.opacity = opacity.toString()
-
+		element.classList.add('snowflake')
 		this.container.appendChild(element)
 
 		return {
 			element,
-			x: rnd(0, this.width),
-			y: rnd(-this.height, 0),
-			vx: rnd(-this.config.windMax, this.config.windMax),
-			vy: rnd(1, 3),
+			x: 0,
+			y: 0,
+			vx: 0,
+			vy: 0,
 			pvx: 0,
 			pvy: 0,
-			size,
+			size: 1,
 		}
 	}
 
+	configureSnowflake(flake: Snowflake) {
+		const size = rnd(this.config.flakeSizeMin, this.config.flakeSizeMax)
+		flake.x = rnd(0, this.width)
+		flake.y = rnd(-this.height, 0)
+		flake.vx = rnd(-this.config.flakeSpeedX, this.config.flakeSpeedX)
+		flake.vy = rnd(this.config.flakeSpeedMinY, this.config.flakeSpeedMaxY)
+		flake.element.style.width = `${size}px`
+		flake.element.style.height = `${size}px`
+		flake.element.style.opacity = rnd(0.5, 1).toString()
+	}
+
 	// Main render loop
-	render = (screenPoint: Vec, pointerVelocity: Vec) => {
+	render(screenPoint: Vec, pointerVelocity: Vec, time: number) {
 		if (!this.active) return
+
+		const q = Math.sin(time / GUST_ROTATION_DURATION)
+
+		// make wind gradually cycle between 0 and 10, maybe a bit randomly, like gusts of wind
+		this.baseWindX = q * MAX_GUST_SPEED
 
 		const pointerLen = pointerVelocity.len2()
 
 		for (const flake of this.flakes) {
 			const dist2 = Vec.Dist2(screenPoint, new Vec(flake.x, flake.y))
-			// if the snowflake is close to the pointer, give it a little boost based on the pointer velocity
 
-			if (dist2 < 10000 && pointerLen > 1) {
-				flake.pvx = pointerVelocity.x
-				flake.pvy = pointerVelocity.y
+			// if the pointer is moving quickly, give nearby snowflakes a little boost based on the pointer velocity
+			if (dist2 < MIN_POINTER_DISTANCE_SQUARED) {
+				if (pointerLen > 1) {
+					flake.pvx = pointerVelocity.x
+					flake.pvy = pointerVelocity.y < 0 ? pointerVelocity.y / 2 : pointerVelocity.y // don't push up as easily
+				}
 			} else {
+				// otherwise, declay down other snowflakes that have been boosted
 				if (flake.pvx !== 0) {
-					flake.pvx *= 0.9
+					flake.pvx *= SNOWFLAKE_VELOCITY_DECAY
 					if (Math.abs(flake.pvx) < 0.01) {
 						flake.pvx = 0
 					}
-					flake.pvy *= 0.9
-					if (Math.abs(flake.pvy) < 0.01) {
-						flake.pvy = 0
+
+					if (flake.pvy !== 0) {
+						flake.pvy *= SNOWFLAKE_VELOCITY_DECAY
+						if (Math.abs(flake.pvy) < 0.01) {
+							flake.pvy = 0
+						}
 					}
 				}
 			}
 
+			// Move the flake based on the wind, the base wind, the pointer velocity, and some random wobble
 			flake.x += flake.vx + this.windX + this.baseWindX + flake.pvx
 			flake.y += flake.vy + this.windY + flake.pvy
 
+			// Wrap the snowflakes around the screen horizontally
 			if (flake.x < 0) {
 				flake.x += this.width
 				flake.pvx = 0
@@ -106,19 +131,20 @@ class Snowstorm {
 				flake.pvx = 0
 			}
 
+			// Wrap the snowflakes around the screen vertically
 			if (flake.y < 0) {
 				flake.y += this.height
-				flake.pvx = 0
+				flake.pvy = 0
 			} else if (flake.y > this.height) {
 				flake.y -= this.height
-				flake.pvx = 0
+				flake.pvy = 0
 			}
 
 			flake.element.style.transform = `translate(${flake.x}px, ${flake.y}px)`
 		}
 	}
 
-	resize = () => {
+	resize() {
 		this.width = this.container.clientWidth
 		this.height = this.container.clientHeight
 	}
@@ -126,7 +152,9 @@ class Snowstorm {
 	start() {
 		this.active = true
 		while (this.flakes.length < this.config.flakesMax) {
-			this.flakes.push(this.createSnowflake())
+			const flake = this.createSnowflake()
+			this.configureSnowflake(flake)
+			this.flakes.push(flake)
 		}
 		window.addEventListener('resize', this.resize)
 	}
@@ -162,20 +190,21 @@ export function SnowStorm() {
 		function updateOnTick() {
 			const time = Date.now() - start
 
-			// make wind gradually cycle between 0 and 10, maybe a bit randomly, like gusts of wind
-			snowstorm.baseWindX = Math.sin(time / 30_000) * 2
-
 			const newCamera = editor.getCamera()
 
+			// Apply camera movement effect only when zoom isn't changing
 			if (newCamera.z === camera.z) {
 				const dx = (newCamera.x - camera.x) * camera.z
 				const dy = (newCamera.y - camera.y) * camera.z
 
 				// add the camera movement to the velocity
-				velocity.addXY(dx / 18, dy / 18)
+				velocity.addXY(
+					Math.min(dx / MAX_PIXELS_SCROLL_EFFECT, MAX_SCROLL_SPEED),
+					Math.min(dy / MAX_PIXELS_SCROLL_EFFECT, MAX_SCROLL_SPEED)
+				)
 
 				// decay velocity
-				velocity.mul(0.82)
+				velocity.mul(SNOWFLAKE_VELOCITY_DECAY)
 
 				// stop the snowflakes from moving if the camera is not moving
 				if (velocity.len2() < 1) {
@@ -188,19 +217,17 @@ export function SnowStorm() {
 			}
 
 			camera.setTo(newCamera)
-			snowstorm.render(editor.inputs.currentScreenPoint, editor.inputs.pointerVelocity)
+			snowstorm.render(editor.inputs.currentScreenPoint, editor.inputs.pointerVelocity, time)
 		}
 
 		snowstorm.start()
 		editor.on('tick', updateOnTick)
 
-		// eslint-disable-next-line no-console
-		console.log('happy holidays from tldraw')
 		return () => {
 			editor.off('tick', updateOnTick)
 			snowstorm.dispose()
 		}
 	}, [editor, prefersReducedMotion])
 
-	return <div ref={rElm} className="tl-snowstorm" />
+	return <div ref={rElm} className="snowstorm" />
 }

--- a/apps/examples/src/examples/snowstorm/SnowStormExample.tsx
+++ b/apps/examples/src/examples/snowstorm/SnowStormExample.tsx
@@ -1,0 +1,14 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+import { SnowStorm } from './SnowStorm'
+import './snowstorm.css'
+
+export default function BasicExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="example">
+				<SnowStorm />
+			</Tldraw>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/snowstorm/snowstorm.css
+++ b/apps/examples/src/examples/snowstorm/snowstorm.css
@@ -1,0 +1,13 @@
+.snowflake {
+	position: absolute;
+	background-color: #ccc;
+	border-radius: 100%;
+	pointer-events: none;
+}
+
+.snowstorm {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+}


### PR DESCRIPTION
This removes the snowstorm effect from dotcom and adds it as an example.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`