### PR TITLE
Provided an ability to select multiple arrow labels using ctrl/cmd key

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -57,6 +57,15 @@ export class PointingArrowLabel extends StateNode {
 		this._labelDragOffset = Vec.Sub(labelGeometry.center, pointInShapeSpace)
 
 		this.markId = this.editor.markHistoryStoppingPoint('label-drag start')
+
+    const additiveSelectionKey = info.shiftKey || info.accelKey
+		if (additiveSelectionKey) {
+			const selectedShapeIds = this.editor.getSelectedShapeIds()
+			this.editor.setSelectedShapes([...selectedShapeIds, this.shapeId])
+
+			return
+		}
+
 		this.editor.setSelectedShapes([this.shapeId])
 	}
 


### PR DESCRIPTION
This PR solves the issue #5065. It makes it possible to select multiple arrow descriptions using the cmd key, which was impossible before.

https://github.com/user-attachments/assets/193ee887-1011-481d-b2d3-16dfa753c0fc

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Provided an ability to select multiple arrow labels using ctrl/cmd key