### PR TITLE
Allow expandSelectionOutlinePx to return a Box

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -2247,7 +2247,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     // (undocumented)
     editor: Editor;
     // @internal (undocumented)
-    expandSelectionOutlinePx(shape: Shape): number;
+    expandSelectionOutlinePx(shape: Shape): Box | number;
     getBoundsSnapGeometry(_shape: Shape): BoundsSnapGeometry;
     getCanvasSvgDefs(): TLShapeUtilCanvasSvgDef[];
     abstract getDefaultProps(): Shape['props'];

--- a/packages/editor/src/lib/components/default-components/DefaultSelectionForeground.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSelectionForeground.tsx
@@ -29,7 +29,10 @@ export function DefaultSelectionForeground({ bounds, rotation }: TLSelectionFore
 		y: -expandOutlineBy,
 	})
 
-	bounds = bounds.clone().expandBy(expandOutlineBy).zeroFix()
+	bounds =
+		expandOutlineBy instanceof Box
+			? bounds.clone().expand(expandOutlineBy).zeroFix()
+			: bounds.clone().expandBy(expandOutlineBy).zeroFix()
 
 	return (
 		<svg

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -342,7 +342,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	): ReactElement | null | Promise<ReactElement | null>
 
 	/** @internal */
-	expandSelectionOutlinePx(shape: Shape): number {
+	expandSelectionOutlinePx(shape: Shape): number | Box {
 		return 0
 	}
 

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -1,4 +1,5 @@
 import {
+	Box,
 	RotateCorner,
 	TLEmbedShape,
 	TLSelectionForegroundProps,
@@ -47,14 +48,17 @@ export const TldrawSelectionForeground = track(function TldrawSelectionForegroun
 		: 0
 
 	useTransform(rSvg, bounds?.x, bounds?.y, 1, editor.getSelectionRotation(), {
-		x: -expandOutlineBy,
-		y: -expandOutlineBy,
+		x: expandOutlineBy instanceof Box ? expandOutlineBy.x - bounds.x : -expandOutlineBy,
+		y: expandOutlineBy instanceof Box ? expandOutlineBy.y - bounds.y : -expandOutlineBy,
 	})
 
 	if (onlyShape && editor.isShapeHidden(onlyShape)) return null
 
 	if (!bounds) return null
-	bounds = bounds.clone().expandBy(expandOutlineBy).zeroFix()
+	bounds =
+		expandOutlineBy instanceof Box
+			? bounds.clone().expand(expandOutlineBy).zeroFix()
+			: bounds.clone().expandBy(expandOutlineBy).zeroFix()
 
 	const zoom = editor.getZoomLevel()
 	const isChangingStyle = editor.getInstanceState().isChangingStyle

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -54,7 +54,6 @@ export const TldrawSelectionForeground = track(function TldrawSelectionForegroun
 
 	if (onlyShape && editor.isShapeHidden(onlyShape)) return null
 
-	if (!bounds) return null
 	bounds =
 		expandOutlineBy instanceof Box
 			? bounds.clone().expand(expandOutlineBy).zeroFix()

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -47,23 +47,23 @@ export const TldrawSelectionForeground = track(function TldrawSelectionForegroun
 		? editor.getShapeUtil(onlyShape).expandSelectionOutlinePx(onlyShape)
 		: 0
 
-	useTransform(rSvg, bounds?.x, bounds?.y, 1, editor.getSelectionRotation(), {
-		x: expandOutlineBy instanceof Box ? expandOutlineBy.x - bounds.x : -expandOutlineBy,
-		y: expandOutlineBy instanceof Box ? expandOutlineBy.y - bounds.y : -expandOutlineBy,
-	})
-
-	if (onlyShape && editor.isShapeHidden(onlyShape)) return null
-
-	bounds =
+	const expandedBounds =
 		expandOutlineBy instanceof Box
 			? bounds.clone().expand(expandOutlineBy).zeroFix()
 			: bounds.clone().expandBy(expandOutlineBy).zeroFix()
 
+	useTransform(rSvg, bounds?.x, bounds?.y, 1, editor.getSelectionRotation(), {
+		x: expandedBounds.x - bounds.x,
+		y: expandedBounds.y - bounds.y,
+	})
+
+	if (onlyShape && editor.isShapeHidden(onlyShape)) return null
+
 	const zoom = editor.getZoomLevel()
 	const isChangingStyle = editor.getInstanceState().isChangingStyle
 
-	const width = bounds.width
-	const height = bounds.height
+	const width = expandedBounds.width
+	const height = expandedBounds.height
 
 	const size = 8 / zoom
 	const isTinyX = width < size * 2


### PR DESCRIPTION
This allows the selection outline to be expanded by different amounts on each side by supporting returning a `Box` from `expandSelectionOutlinePx`. Currently it only supports returning a number which will expand the selection that amount on each side.

Together with #5137 this allows us to implement an alternative cropping behavior where the shape size remains fixed while cropping, while the uncropped image size is what you change instead. This is useful in scenarios where you want to first lay out shapes in a certain layout, and afterwards crop them so they display the portion of the image you want.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Add a `expandSelectionOutlinePx` function to a shape that returns a Box.
2. Verify that the selection outline is expanded according to this Box.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Support expanding the selection outline by different amounts on each side by returning a `Box` from `expandSelectionOutlinePx`.