### PR TITLE
Gist embed: restrict the url to a more strict format

### DIFF
--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -343,9 +343,17 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		// Security warning:
+		// Gists allow adding .json extensions to the URL which return JSONP.
+		// Furthermore, the JSONP can include callbacks that execute arbitrary JavaScript.
+		// It _is_ sandboxed by the iframe but we still want to disable it nonetheless.
+		// We restrict the id to only allow hexdecimal characters to prevent this.
+		// Read more:
+		//   https://github.com/bhaveshk90/Content-Security-Policy-CSP-Bypass-Techniques
+		//   https://github.com/renniepak/CSPBypass
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
-			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([^/]+)/)) {
+			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([0-9a-f]+)$/)) {
 				if (!url.split('/').pop()) return
 				return url
 			}
@@ -353,7 +361,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		},
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
-			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([^/]+)/)) {
+			if (urlObj && urlObj.pathname.match(/\/([^/]+)\/([0-9a-f]+)$/)) {
 				if (!url.split('/').pop()) return
 				return url
 			}

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -230,7 +230,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 function Gist({
 	id,
-	file,
 	isInteractive,
 	width,
 	height,
@@ -238,13 +237,22 @@ function Gist({
 	pageRotation,
 }: {
 	id: string
-	file?: string
 	isInteractive: boolean
 	width: number
 	height: number
 	pageRotation: number
 	style?: React.CSSProperties
 }) {
+	// Security warning:
+	// Gists allow adding .json extensions to the URL which return JSONP.
+	// Furthermore, the JSONP can include callbacks that execute arbitrary JavaScript.
+	// It _is_ sandboxed by the iframe but we still want to disable it nonetheless.
+	// We restrict the id to only allow hexdecimal characters to prevent this.
+	// Read more:
+	//   https://github.com/bhaveshk90/Content-Security-Policy-CSP-Bypass-Techniques
+	//   https://github.com/renniepak/CSPBypass
+	if (!id.match(/^[0-9a-f]+$/)) throw Error('No gist id!')
+
 	return (
 		<iframe
 			className="tl-embed"
@@ -253,7 +261,6 @@ function Gist({
 			height={toDomPrecision(height)}
 			frameBorder="0"
 			scrolling="no"
-			seamless
 			referrerPolicy="no-referrer-when-downgrade"
 			style={{
 				...style,
@@ -268,7 +275,7 @@ function Gist({
 					<base target="_blank">
 				</head>
 				<body>
-					<script src=${`https://gist.github.com/${id}.js${file ? `?file=${file}` : ''}`}></script>
+					<script src=${`https://gist.github.com/${id}.js`}></script>
 					<style type="text/css">
 						* { margin: 0px; }
 						table { height: 100%; background-color: red; }

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -194,6 +194,10 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		url: 'https://gist.github.com/discover',
 		match: false,
 	},
+	{
+		url: 'https://gist.github.com/x/ixSly&sol;98210ba6e8683bd772e857128cd3cdca.json&quest;callback=prompt&amp;x=ixSly',
+		match: false,
+	},
 	// replit
 	{
 		url: 'https://replit.com/@omar/Blob-Generator',
@@ -479,6 +483,11 @@ const MATCH_EMBED_TEST_URLS: (MatchEmbedTestMatchDef | MatchEmbedTestNoMatchDef)
 	},
 	{
 		embedUrl: 'https://gist.github.com/discover',
+		match: false,
+	},
+	{
+		embedUrl:
+			'https://gist.github.com/x/ixSly&sol;98210ba6e8683bd772e857128cd3cdca.json&quest;callback=prompt&amp;x=ixSly',
 		match: false,
 	},
 	// replit


### PR DESCRIPTION
A user reported that there was a slight risk in allowing Github Gist's as they were currently being added to the canvas — basically, the JSONP option on Github can be used to pass in arbitrary Javascript which can look quite dodgy. But, in the end the Gist is iframed and thus, sandboxed.

Nonetheless @MitjaBezensek and I worked to come up with a more restrictive URL filter which should mitigate the issue.

Further reading:
- https://github.com/bhaveshk90/Content-Security-Policy-CSP-Bypass-Techniques
- https://github.com/renniepak/CSPBypass

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Restrict Github Gists to a more strict URL format.