### PR TITLE
Fix some video issues on the blog

### DIFF
--- a/apps/docs/components/content/video.tsx
+++ b/apps/docs/components/content/video.tsx
@@ -21,6 +21,8 @@ export function Video({
 					controls
 					preload={lazy ? 'metadata' : 'auto'}
 					autoPlay={autoplay}
+					muted={autoplay}
+					loop={autoplay}
 				/>
 			</span>
 			{caption && <span className="block text-xs text-zinc-500 mt-3 text-center">{caption}</span>}

--- a/apps/docs/content/blog/make-real-the-story-so-far.mdx
+++ b/apps/docs/content/blog/make-real-the-story-so-far.mdx
@@ -15,7 +15,7 @@ And here’s the story.
 <Video
 	lazy
 	autoplay
-	src="images/blog/F-5SomuWoAERTCa.mp4"
+	src="/images/blog/F-5SomuWoAERTCa.mp4"
 	thumbnail="/images/blog/b7a67dff-86f7-4516-8328-98ad1745efed/transcoded_00002.png"
 />
 

--- a/apps/docs/content/blog/make-real-the-story-so-far.mdx
+++ b/apps/docs/content/blog/make-real-the-story-so-far.mdx
@@ -125,7 +125,7 @@ It’s been an absolute joy to see.
 <Video
 	lazy
 	autoplay
-	src="images/blog/1725175294598750651_1.mp4"
+	src="/images/blog/1725175294598750651_1.mp4"
 	caption="From https://twitter.com/muvich3n/status/1725175294598750651"
 />
 

--- a/apps/docs/content/blog/release-notes-20240418.mdx
+++ b/apps/docs/content/blog/release-notes-20240418.mdx
@@ -42,7 +42,7 @@ We also now **dynamically adjust the font size** in notes to avoid broken words.
 
 This release also includes dozens of **performance improvements**. The canvas should now feel faster while panning, zooming, and working with large documents. Performance on iOS devices should be significantly faster, especially when working with text.
 
-![Video](blob:https://tldraw.substack.com/80230c44-df2b-4813-bc2c-d67c7d0c5e31)
+{/* <Video src="blob:https://tldraw.substack.com/80230c44-df2b-4813-bc2c-d67c7d0c5e31" autoplay lazy /> */}
 
 Best of all, we’ve sped up our canvas enough that we were able to remove the delayed rendering of off-screen shapes, meaning **no more grey boxes** when panning to a new part of the screen.
 


### PR DESCRIPTION
Found some issues with the blog while working on a blog post.

- Fixed missing videos in make real blog post.
- Fixed broken video on one of the release notes.
- Fixed videos not autoplaying.

This mostly affects the make real blog post.



### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. View the make real blog post
2. Make sure all of the videos load.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Blog: Fixed a broken video. 