### PR TITLE
Fix relative CSS import rules failing to be fetched

### DIFF
--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -94,7 +94,8 @@ async function getCurrentDocumentFontFaces() {
 				if (rule instanceof CSSFontFaceRule) {
 					fontFaces.push(parseCssFontFaces(rule.cssText, styleSheet.href ?? document.baseURI))
 				} else if (rule instanceof CSSImportRule) {
-					fontFaces.push(fetchCssFontFaces(rule.href))
+					const absoluteUrl = new URL(rule.href, rule.parentStyleSheet?.href ?? document.baseURI)
+					fontFaces.push(fetchCssFontFaces(absoluteUrl.href))
 				}
 			}
 		} else if (styleSheet.href) {


### PR DESCRIPTION
When getting fonts for an export, all stylesheets on the page are traversed. If any CSS import rules are found, they are downloaded. However this just directly used the href of the import rule, which makes it relative to the document. Import rule URLs should however be relative to the style sheet they are included in. We therefore have to construct an absolute URL by using the style sheet as the base. If the import rule doesn't have a parent style sheet it means it's an inline style sheet and we should fall back to using the baseURI as the base.

Fixes #4939

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Include a relative `@import` rule on your page.
2. Trigger an export or print.
3. Observe that the rule is resolved correctly after this change.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix relative CSS import rules failing to be fetched when exporting or printing.