### PR TITLE
Fix max image dimension prop not getting applied.

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -235,7 +235,6 @@ export function registerDefaultExternalContentHandlers(
 				: editor.getViewportPageBounds().center)
 
 		const pagePoint = new Vec(position.x, position.y)
-		const assets: TLAsset[] = []
 		const assetsToUpdate: {
 			asset: TLAsset
 			file: File
@@ -288,11 +287,10 @@ export function registerDefaultExternalContentHandlers(
 			if (isImageType) {
 				temporaryAssetPreview = editor.createTemporaryAssetPreview(assetId, file)
 			}
-			assets.push(assetInfo)
 			assetsToUpdate.push({ asset: assetInfo, file, temporaryAssetPreview })
 		}
 
-		const updatedAssets: TLAsset[] = []
+		const assets: TLAsset[] = []
 		await Promise.allSettled(
 			assetsToUpdate.map(async (assetAndFile) => {
 				try {
@@ -306,7 +304,7 @@ export function registerDefaultExternalContentHandlers(
 					}
 
 					const updated = { ...newAsset, id: assetAndFile.asset.id }
-					updatedAssets.push(updated)
+					assets.push(updated)
 					// Save the new asset under the old asset's id
 					editor.updateAssets([updated])
 				} catch (error) {
@@ -320,7 +318,7 @@ export function registerDefaultExternalContentHandlers(
 			})
 		)
 
-		createShapesForAssets(editor, updatedAssets, pagePoint)
+		createShapesForAssets(editor, assets, pagePoint)
 	})
 
 	// text

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -292,7 +292,8 @@ export function registerDefaultExternalContentHandlers(
 			assetsToUpdate.push({ asset: assetInfo, file, temporaryAssetPreview })
 		}
 
-		Promise.allSettled(
+		const updatedAssets: TLAsset[] = []
+		await Promise.allSettled(
 			assetsToUpdate.map(async (assetAndFile) => {
 				try {
 					const newAsset = await editor.getAssetForExternalContent({
@@ -304,8 +305,10 @@ export function registerDefaultExternalContentHandlers(
 						throw Error('Could not create an asset')
 					}
 
+					const updated = { ...newAsset, id: assetAndFile.asset.id }
+					updatedAssets.push(updated)
 					// Save the new asset under the old asset's id
-					editor.updateAssets([{ ...newAsset, id: assetAndFile.asset.id }])
+					editor.updateAssets([updated])
 				} catch (error) {
 					toasts.addToast({
 						title: msg('assets.files.upload-failed'),
@@ -317,7 +320,7 @@ export function registerDefaultExternalContentHandlers(
 			})
 		)
 
-		createShapesForAssets(editor, assets, pagePoint)
+		createShapesForAssets(editor, updatedAssets, pagePoint)
 	})
 
 	// text


### PR DESCRIPTION
The problem was twofold:
- we weren't awaiting the updating of the assets
- we used old asset values when creating the shapes.

fixes https://github.com/tldraw/tldraw/issues/5173 / TLD-2910

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. In `develop.tsx` set `maxImageDimension` to some value.
2. Paste an image.
3. The image should be within the max dimension.

### Release notes

- Fix a bug with `maxImageDimension` not getting applied to pasted images.