### PR TITLE
Show quick actions panel above toolbar when not logged in.

### DIFF
--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -13,6 +13,7 @@ import {
 	PreferencesGroup,
 	TLComponents,
 	Tldraw,
+	TldrawOptions,
 	TldrawUiButton,
 	TldrawUiButtonLabel,
 	TldrawUiDialogBody,
@@ -91,12 +92,14 @@ export function LocalEditor({
 	children,
 	persistenceKey,
 	'data-testid': dataTestId,
+	options,
 }: {
 	componentsOverride?: TLComponents
 	onMount?(editor: Editor): void
 	children?: ReactNode
 	persistenceKey?: string
 	'data-testid'?: string
+	options?: Partial<TldrawOptions>
 }) {
 	const handleUiEvent = useHandleUiEvents()
 	const sharingUiOverrides = useSharing()
@@ -119,6 +122,7 @@ export function LocalEditor({
 				overrides={[sharingUiOverrides, fileSystemUiOverrides]}
 				onUiEvent={handleUiEvent}
 				components={componentsOverride ?? components}
+				options={options}
 			>
 				<SneakyOnDropOverride isMultiplayer={false} />
 				<ThemeUpdater />

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -75,6 +75,7 @@ function LocalTldraw() {
 						}
 					})
 				}}
+				options={{ actionShortcutsLocation: 'toolbar' }}
 			>
 				<SneakyDarkModeSync />
 			</LocalEditor>


### PR DESCRIPTION
We didn't show the quick actions panel above the toolbar when logged out. This fixes it.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
