### PR TITLE
Allow slurping of legacy multiplayer routes.

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -142,18 +142,13 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 				remountImageShapes,
 			}).then(setIsReady)
 
-			if (mode === 'slurp-legacy-file') {
-				assert(fileOpenState?.snapshot, 'snapshot is required when mode is slurp-legacy-file')
-				editor.loadSnapshot(fileOpenState.snapshot)
-			}
-
 			return () => {
 				abortController.abort()
 				cleanup()
 				updateSessionState.cancel()
 			}
 		},
-		[addDialog, app, fileId, fileOpenState, mode, remountImageShapes, setIsReady]
+		[addDialog, app, fileId, remountImageShapes, setIsReady]
 	)
 
 	const user = useTldrawUser()
@@ -166,7 +161,7 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 			}
 			if (mode) {
 				url.searchParams.set('mode', mode)
-				if (mode === 'duplicate') {
+				if (mode === 'duplicate' || mode === 'slurp-legacy-file') {
 					const duplicateId = fileOpenState.duplicateId
 					assert(duplicateId, 'duplicateId is required when mode is duplicate')
 					url.searchParams.set('duplicateId', duplicateId)

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -56,7 +56,7 @@ interface TlaEditorProps {
 
 export function TlaEditor(props: TlaEditorProps) {
 	if (props.fileOpenState?.mode === 'duplicate') {
-		assert(props.fileOpenState?.duplicateId, 'duplicateId is required when mode is duplicate')
+		assert(props.fileOpenState.duplicateId, 'duplicateId is required when mode is duplicate')
 	}
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -55,8 +55,14 @@ interface TlaEditorProps {
 }
 
 export function TlaEditor(props: TlaEditorProps) {
-	if (props.fileOpenState?.mode === 'duplicate') {
-		assert(props.fileOpenState.duplicateId, 'duplicateId is required when mode is duplicate')
+	if (
+		props.fileOpenState?.mode === 'duplicate' ||
+		props.fileOpenState?.mode === 'slurp-legacy-file'
+	) {
+		assert(
+			props.fileOpenState.duplicateId,
+			'duplicateId is required when mode is duplicate or slurp-legacy-file'
+		)
 	}
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
@@ -163,7 +169,7 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 				url.searchParams.set('mode', mode)
 				if (mode === 'duplicate' || mode === 'slurp-legacy-file') {
 					const duplicateId = fileOpenState.duplicateId
-					assert(duplicateId, 'duplicateId is required when mode is duplicate')
+					assert(duplicateId, 'duplicateId is required when mode is duplicate or slurp-legacy-file')
 					url.searchParams.set('duplicateId', duplicateId)
 				}
 			}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -1,4 +1,4 @@
-import { TlaFileOpenMode } from '@tldraw/dotcom-shared'
+import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
 import { useCallback, useEffect } from 'react'
 import {
@@ -50,16 +50,13 @@ export const components: TLComponents = {
 
 interface TlaEditorProps {
 	fileSlug: string
-	mode?: TlaFileOpenMode
-	duplicateId?: string
+	fileOpenState?: TlaFileOpenState
 	deepLinks?: boolean
 }
 
 export function TlaEditor(props: TlaEditorProps) {
-	if (props.mode === 'duplicate') {
-		assert(props.duplicateId, 'duplicateId is required when mode is duplicate')
-	} else {
-		assert(!props.duplicateId, 'duplicateId is not allowed when mode is not duplicate')
+	if (props.fileOpenState?.mode === 'duplicate') {
+		assert(props.fileOpenState?.duplicateId, 'duplicateId is required when mode is duplicate')
 	}
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
@@ -72,9 +69,10 @@ export function TlaEditor(props: TlaEditorProps) {
 	)
 }
 
-function TlaEditorInner({ fileSlug, mode, deepLinks, duplicateId }: TlaEditorProps) {
+function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) {
 	const handleUiEvent = useHandleUiEvents()
 	const app = useMaybeApp()
+	const mode = fileOpenState?.mode
 
 	const fileId = fileSlug
 
@@ -144,13 +142,18 @@ function TlaEditorInner({ fileSlug, mode, deepLinks, duplicateId }: TlaEditorPro
 				remountImageShapes,
 			}).then(setIsReady)
 
+			if (mode === 'slurp-legacy-file') {
+				assert(fileOpenState?.snapshot, 'snapshot is required when mode is slurp-legacy-file')
+				editor.loadSnapshot(fileOpenState.snapshot)
+			}
+
 			return () => {
 				abortController.abort()
 				cleanup()
 				updateSessionState.cancel()
 			}
 		},
-		[addDialog, app, fileId, remountImageShapes, setIsReady]
+		[addDialog, app, fileId, fileOpenState, mode, remountImageShapes, setIsReady]
 	)
 
 	const user = useTldrawUser()
@@ -164,12 +167,13 @@ function TlaEditorInner({ fileSlug, mode, deepLinks, duplicateId }: TlaEditorPro
 			if (mode) {
 				url.searchParams.set('mode', mode)
 				if (mode === 'duplicate') {
+					const duplicateId = fileOpenState.duplicateId
 					assert(duplicateId, 'duplicateId is required when mode is duplicate')
 					url.searchParams.set('duplicateId', duplicateId)
 				}
 			}
 			return url.toString()
-		}, [fileSlug, user, mode, duplicateId]),
+		}, [fileSlug, user, mode, fileOpenState]),
 		assets: multiplayerAssetStore,
 		userInfo: app?.tlUser.userPreferences,
 	})

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -55,14 +55,8 @@ interface TlaEditorProps {
 }
 
 export function TlaEditor(props: TlaEditorProps) {
-	if (
-		props.fileOpenState?.mode === 'duplicate' ||
-		props.fileOpenState?.mode === 'slurp-legacy-file'
-	) {
-		assert(
-			props.fileOpenState.duplicateId,
-			'duplicateId is required when mode is duplicate or slurp-legacy-file'
-		)
+	if (props.fileOpenState?.mode === 'duplicate') {
+		assert(props.fileOpenState.duplicateId, 'duplicateId is required when mode is duplicate')
 	}
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
@@ -148,13 +142,18 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 				remountImageShapes,
 			}).then(setIsReady)
 
+			if (mode === 'slurp-legacy-file') {
+				assert(fileOpenState?.snapshot, 'snapshot is required when mode is slurp-legacy-file')
+				editor.loadSnapshot(fileOpenState.snapshot)
+			}
+
 			return () => {
 				abortController.abort()
 				cleanup()
 				updateSessionState.cancel()
 			}
 		},
-		[addDialog, app, fileId, remountImageShapes, setIsReady]
+		[addDialog, app, fileId, fileOpenState, mode, remountImageShapes, setIsReady]
 	)
 
 	const user = useTldrawUser()
@@ -167,9 +166,9 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 			}
 			if (mode) {
 				url.searchParams.set('mode', mode)
-				if (mode === 'duplicate' || mode === 'slurp-legacy-file') {
+				if (mode === 'duplicate') {
 					const duplicateId = fileOpenState.duplicateId
-					assert(duplicateId, 'duplicateId is required when mode is duplicate or slurp-legacy-file')
+					assert(duplicateId, 'duplicateId is required when mode is duplicate')
 					url.searchParams.set('duplicateId', duplicateId)
 				}
 			}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -2,7 +2,7 @@ import { SignInButton } from '@clerk/clerk-react'
 import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { useCallback, useRef } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { PeopleMenu, useEditor, usePassThroughWheelEvents, useTranslation } from 'tldraw'
 import { routes } from '../../../routeDefs'
 import { useMaybeApp } from '../../hooks/useAppState'
@@ -84,23 +84,23 @@ function useGetFileName() {
 function LegacyImportButton() {
 	const trackEvent = useTldrawAppUiEvents()
 	const app = useMaybeApp()
+	const editor = useEditor()
 	const navigate = useNavigate()
-	const params = useParams()
-	const roomId = params.roomId
 	const name = useGetFileName()
 
 	const handleClick = useCallback(() => {
-		if (!app || !roomId) return
+		if (!app || !editor) return
 
 		const res = app.createFile({ name })
 		if (res.ok) {
 			const { file } = res.value
+			const snapshot = editor.getSnapshot()
 			navigate(routes.tlaFile(file.id), {
-				state: { mode: 'slurp-legacy-file', duplicateId: roomId } satisfies TlaFileOpenState,
+				state: { mode: 'slurp-legacy-file', snapshot } satisfies TlaFileOpenState,
 			})
 			trackEvent('create-file', { source: 'legacy-import-button' })
 		}
-	}, [app, name, navigate, roomId, trackEvent])
+	}, [app, editor, name, navigate, trackEvent])
 
 	return (
 		<TlaCtaButton data-testid="tla-import-button" onClick={handleClick}>

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -1,6 +1,6 @@
 /* ---------------------- Menu ---------------------- */
 
-import { TlaFile } from '@tldraw/dotcom-shared'
+import { TlaFile, TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { Fragment, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -115,7 +115,7 @@ function FileItems({
 		if (!file) return
 		app.createFile({ id: newFileId, name: getDuplicateName(file, app) })
 		navigate(routes.tlaFile(newFileId), {
-			state: { mode: 'duplicate', duplicateId: fileId },
+			state: { mode: 'duplicate', duplicateId: fileId } satisfies TlaFileOpenState,
 		})
 	}, [app, fileId, navigate])
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
@@ -1,3 +1,4 @@
+import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { tltime } from 'tldraw'
@@ -22,7 +23,7 @@ export function TlaSidebarCreateFileButton() {
 		const res = app.createFile()
 		if (res.ok) {
 			const { file } = res.value
-			navigate(routes.tlaFile(file.id), { state: { mode: 'create' } })
+			navigate(routes.tlaFile(file.id), { state: { mode: 'create' } satisfies TlaFileOpenState })
 			trackEvent('create-file', { source: 'sidebar' })
 			rCanCreate.current = false
 			tltime.setTimeout('can create again', () => (rCanCreate.current = true), 1000)

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@clerk/clerk-react'
+import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -32,7 +33,9 @@ export function TlaDeleteFileDialog({ fileId, onClose }: { fileId: string; onClo
 		if (recentFiles.length === 0) {
 			const result = app.createFile()
 			if (result.ok) {
-				navigate(routes.tlaFile(result.value.file.id), { state: { mode: 'create' } })
+				navigate(routes.tlaFile(result.value.file.id), {
+					state: { mode: 'create' } satisfies TlaFileOpenState,
+				})
 				trackEvent('delete-file', { source: 'file-menu' })
 			}
 		} else {

--- a/apps/dotcom/client/src/tla/pages/file.tsx
+++ b/apps/dotcom/client/src/tla/pages/file.tsx
@@ -48,14 +48,7 @@ export function Component({ error }: { error?: unknown }) {
 
 	return (
 		<TlaSidebarLayout collapsible>
-			{errorElem ?? (
-				<TlaEditor
-					fileSlug={fileSlug}
-					mode={routeState?.mode}
-					duplicateId={routeState?.duplicateId}
-					deepLinks
-				/>
-			)}
+			{errorElem ?? <TlaEditor fileSlug={fileSlug} fileOpenState={routeState} deepLinks />}
 		</TlaSidebarLayout>
 	)
 }

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -1,3 +1,4 @@
+import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { assert, react } from 'tldraw'
@@ -22,7 +23,7 @@ export function Component() {
 			if (res.ok) {
 				clearShouldSlurpFile()
 				navigate(routes.tlaFile(res.value.file.id), {
-					state: { mode: 'create' },
+					state: { mode: 'create' } satisfies TlaFileOpenState,
 					replace: true,
 				})
 			} else {
@@ -41,7 +42,7 @@ export function Component() {
 			// we don't need to handle that case here since they have no files
 			if (result.ok) {
 				navigate(routes.tlaFile(result.value.file.id), {
-					state: { mode: 'create' },
+					state: { mode: 'create' } satisfies TlaFileOpenState,
 					replace: true,
 				})
 			}

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -14,6 +14,7 @@ export type TLAppUiEventSource =
 	| 'anon-top-bar'
 	| 'account-menu'
 	| 'top-bar'
+	| 'legacy-import-button'
 
 /** @public */
 export interface TLAppUiEventMap {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -494,7 +494,10 @@ export class TLDrawDurableObject extends DurableObject {
 				return { type: 'room_found', snapshot: await roomFromBucket.json() }
 			}
 
-			if (this.documentInfo.appMode === 'create') {
+			if (
+				this.documentInfo.appMode === 'create' ||
+				this.documentInfo.appMode === 'slurp-legacy-file'
+			) {
 				return {
 					type: 'room_found',
 					snapshot: new TLSyncRoom({
@@ -503,10 +506,7 @@ export class TLDrawDurableObject extends DurableObject {
 				}
 			}
 
-			if (
-				this.documentInfo.appMode === 'duplicate' ||
-				this.documentInfo.appMode === 'slurp-legacy-file'
-			) {
+			if (this.documentInfo.appMode === 'duplicate') {
 				assert(this.documentInfo.duplicateId, 'duplicateId must be present')
 				// load the duplicate id
 				let data: string | undefined = undefined
@@ -516,12 +516,9 @@ export class TLDrawDurableObject extends DurableObject {
 					) as any as TLDrawDurableObject
 					data = await otherRoom.getCurrentSerializedSnapshot()
 				} catch (_e) {
-					// We only want to load from existing app file when duplicating, slurping should only look at legacy multiplayer rooms
-					if (this.documentInfo.appMode === 'duplicate') {
-						data = await this.r2.rooms
-							.get(getR2KeyForRoom({ slug: this.documentInfo.duplicateId, isApp: true }))
-							.then((r) => r?.text())
-					}
+					data = await this.r2.rooms
+						.get(getR2KeyForRoom({ slug: this.documentInfo.duplicateId, isApp: true }))
+						.then((r) => r?.text())
 				}
 
 				if (!data) {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -516,7 +516,7 @@ export class TLDrawDurableObject extends DurableObject {
 					) as any as TLDrawDurableObject
 					data = await otherRoom.getCurrentSerializedSnapshot()
 				} catch (_e) {
-					// We only want to load from existing app file when duplicating, slurping should only look at existing multiplayer rooms
+					// We only want to load from existing app file when duplicating, slurping should only look at legacy multiplayer rooms
 					if (this.documentInfo.appMode === 'duplicate') {
 						data = await this.r2.rooms
 							.get(getR2KeyForRoom({ slug: this.documentInfo.duplicateId, isApp: true }))

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -494,7 +494,10 @@ export class TLDrawDurableObject extends DurableObject {
 				return { type: 'room_found', snapshot: await roomFromBucket.json() }
 			}
 
-			if (this.documentInfo.appMode === 'create') {
+			if (
+				this.documentInfo.appMode === 'create' ||
+				this.documentInfo.appMode === 'slurp-legacy-file'
+			) {
 				return {
 					type: 'room_found',
 					snapshot: new TLSyncRoom({

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,5 +1,5 @@
 import { stringEnum } from '@tldraw/utils'
-import { SerializedSchema, SerializedStore, TLEditorSnapshot, TLRecord } from 'tldraw'
+import { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaFile,
 	TlaFilePartial,
@@ -144,7 +144,7 @@ export type TlaFileOpenState =
 	| { mode: 'duplicate'; duplicateId: string }
 	| {
 			mode: 'slurp-legacy-file'
-			snapshot: TLEditorSnapshot
+			duplicateId: string
 	  }
 	| null
 	| undefined

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,5 +1,5 @@
 import { stringEnum } from '@tldraw/utils'
-import { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
+import { SerializedSchema, SerializedStore, TLEditorSnapshot, TLRecord } from 'tldraw'
 import {
 	TlaFile,
 	TlaFilePartial,
@@ -139,7 +139,17 @@ export interface ZClientSentMessage {
 	updates: ZRowUpdate[]
 }
 
-export type TlaFileOpenMode = 'create' | 'duplicate' | null | undefined
+export type TlaFileOpenState =
+	| { mode: 'create' }
+	| { mode: 'duplicate'; duplicateId: string }
+	| {
+			mode: 'slurp-legacy-file'
+			snapshot: TLEditorSnapshot
+	  }
+	| null
+	| undefined
+
+export type TlaFileOpenMode = NonNullable<TlaFileOpenState>['mode'] | null
 
 export const UserPreferencesKeys = [
 	'locale',

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,5 +1,5 @@
 import { stringEnum } from '@tldraw/utils'
-import { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
+import { SerializedSchema, SerializedStore, TLEditorSnapshot, TLRecord } from 'tldraw'
 import {
 	TlaFile,
 	TlaFilePartial,
@@ -144,7 +144,7 @@ export type TlaFileOpenState =
 	| { mode: 'duplicate'; duplicateId: string }
 	| {
 			mode: 'slurp-legacy-file'
-			duplicateId: string
+			snapshot: TLEditorSnapshot
 	  }
 	| null
 	| undefined


### PR DESCRIPTION
When a logged in user visits a legacy multiplayer room (`/q/r/roomId`) they can now click the `Copy to my files` button to slurp the multiplayer room to a file that gets created.

This currently reuses all the existing assets - the files don't get re-uploaded. We will need to re-upload them so that we will be able to associate them with the user. Decided to skip this step for now and come back to it once we have the assets/user/file associations ready.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a legacy multiplayer room.
2. Login to the app and use the multiplayer room link, but prefix it with `/q` (so something like `/q/r/roomId`
3. Click the `Copy to my files` button.
4. You should now see the same contents in the newly created file.