### PR TITLE
[botcom] Use clerk cookie to control routing

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/HomePage.ts
+++ b/apps/dotcom/client/e2e/fixtures/HomePage.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { Editor } from './Editor'
 import { step } from './tla-test'
 
-const rootUrl = 'http://localhost:3000/q'
+const rootUrl = 'http://localhost:3000/'
 
 export class HomePage {
 	public readonly signInButton: Locator

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -7,10 +7,6 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^//?$",
   },
   {
-    "reactRouterPattern": "/beta",
-    "vercelRouterPattern": "^/beta/?$",
-  },
-  {
     "reactRouterPattern": "/f/:fileSlug",
     "vercelRouterPattern": "^/f/[^/]*/?$",
   },
@@ -25,6 +21,10 @@ exports[`the_routes 1`] = `
   {
     "reactRouterPattern": "/p/:fileSlug",
     "vercelRouterPattern": "^/p/[^/]*/?$",
+  },
+  {
+    "reactRouterPattern": "/preview",
+    "vercelRouterPattern": "^/preview/?$",
   },
   {
     "reactRouterPattern": "/q",

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -7,48 +7,16 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^//?$",
   },
   {
+    "reactRouterPattern": "/beta",
+    "vercelRouterPattern": "^/beta/?$",
+  },
+  {
     "reactRouterPattern": "/new",
     "vercelRouterPattern": "^/new/?$",
   },
   {
     "reactRouterPattern": "/q",
     "vercelRouterPattern": "^/q/?$",
-  },
-  {
-    "reactRouterPattern": "/q/f/:fileSlug",
-    "vercelRouterPattern": "^/q/f/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/lf/:fileSlug",
-    "vercelRouterPattern": "^/q/lf/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/p/:fileSlug",
-    "vercelRouterPattern": "^/q/p/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/r/:boardId/history",
-    "vercelRouterPattern": "^/q/r/[^/]*/history/?$",
-  },
-  {
-    "reactRouterPattern": "/q/r/:boardId/history/:timestamp",
-    "vercelRouterPattern": "^/q/r/[^/]*/history/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/r/:roomId",
-    "vercelRouterPattern": "^/q/r/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/ro/:roomId",
-    "vercelRouterPattern": "^/q/ro/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/s/:roomId",
-    "vercelRouterPattern": "^/q/s/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/q/v/:roomId",
-    "vercelRouterPattern": "^/q/v/[^/]*/?$",
   },
   {
     "reactRouterPattern": "/r",
@@ -81,6 +49,18 @@ exports[`the_routes 1`] = `
   {
     "reactRouterPattern": "/v/:roomId",
     "vercelRouterPattern": "^/v/[^/]*/?$",
+  },
+  {
+    "reactRouterPattern": "/f/:fileSlug",
+    "vercelRouterPattern": "^/f/[^/]*/?$",
+  },
+  {
+    "reactRouterPattern": "/lf/:fileSlug",
+    "vercelRouterPattern": "^/lf/[^/]*/?$",
+  },
+  {
+    "reactRouterPattern": "/p/:fileSlug",
+    "vercelRouterPattern": "^/p/[^/]*/?$",
   },
 ]
 `;

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -11,8 +11,20 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/beta/?$",
   },
   {
+    "reactRouterPattern": "/f/:fileSlug",
+    "vercelRouterPattern": "^/f/[^/]*/?$",
+  },
+  {
+    "reactRouterPattern": "/lf/:fileSlug",
+    "vercelRouterPattern": "^/lf/[^/]*/?$",
+  },
+  {
     "reactRouterPattern": "/new",
     "vercelRouterPattern": "^/new/?$",
+  },
+  {
+    "reactRouterPattern": "/p/:fileSlug",
+    "vercelRouterPattern": "^/p/[^/]*/?$",
   },
   {
     "reactRouterPattern": "/q",
@@ -49,18 +61,6 @@ exports[`the_routes 1`] = `
   {
     "reactRouterPattern": "/v/:roomId",
     "vercelRouterPattern": "^/v/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/f/:fileSlug",
-    "vercelRouterPattern": "^/f/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/lf/:fileSlug",
-    "vercelRouterPattern": "^/lf/[^/]*/?$",
-  },
-  {
-    "reactRouterPattern": "/p/:fileSlug",
-    "vercelRouterPattern": "^/p/[^/]*/?$",
   },
 ]
 `;

--- a/apps/dotcom/client/src/pages/tla-opt-in.tsx
+++ b/apps/dotcom/client/src/pages/tla-opt-in.tsx
@@ -1,0 +1,47 @@
+import { SignInButton, useAuth } from '@clerk/clerk-react'
+import { TlaButton } from '../tla/components/TlaButton/TlaButton'
+import { F } from '../tla/utils/i18n'
+export function Component() {
+	const { isSignedIn, isLoaded } = useAuth()
+	if (isSignedIn) {
+		// redirect to home page once the user is signed in
+		window.location.href = location.origin
+		return null
+	}
+	if (!isLoaded) return null
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '1rem',
+				justifyContent: 'center',
+				alignItems: 'center',
+				flex: 1,
+				padding: 20,
+			}}
+		>
+			<h2>
+				<F defaultMessage="Try the new tldraw (beta)" />
+			</h2>
+			<p style={{ maxWidth: 400, textAlign: 'center' }}>
+				<F defaultMessage="Sign in to access the beta version of tldraw.com, which adds new file management and collaboration options." />
+			</p>
+			<div style={{ display: 'flex', gap: 10 }}>
+				<TlaButton
+					variant="secondary"
+					onClick={() => {
+						window.location.href = '/'
+					}}
+				>
+					<F defaultMessage="No thanks" />
+				</TlaButton>
+				<SignInButton mode="modal">
+					<TlaButton data-testid="tla-opt-in">
+						<F defaultMessage="Sign in" />
+					</TlaButton>
+				</SignInButton>
+			</div>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/pages/tla-opt-in.tsx
+++ b/apps/dotcom/client/src/pages/tla-opt-in.tsx
@@ -1,11 +1,12 @@
 import { SignInButton, useAuth } from '@clerk/clerk-react'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { F } from '../tla/utils/i18n'
+
 export function Component() {
 	const { isSignedIn, isLoaded } = useAuth()
 	if (isSignedIn) {
 		// redirect to home page once the user is signed in
-		window.location.href = location.origin
+		window.location.href = window.location.origin
 		return null
 	}
 	if (!isLoaded) return null
@@ -19,13 +20,14 @@ export function Component() {
 				alignItems: 'center',
 				flex: 1,
 				padding: 20,
+				textAlign: 'center',
 			}}
 		>
 			<h2>
 				<F defaultMessage="Try the new tldraw (beta)" />
 			</h2>
-			<p style={{ maxWidth: 400, textAlign: 'center' }}>
-				<F defaultMessage="Sign in to access the beta version of tldraw.com, which adds new file management and collaboration options." />
+			<p style={{ maxWidth: 400 }}>
+				<F defaultMessage="Sign in to access the beta version of tldraw.com, which adds file management and collaboration features." />
 			</p>
 			<div style={{ display: 'flex', gap: 10 }}>
 				<TlaButton

--- a/apps/dotcom/client/src/pages/tla-opt-in.tsx
+++ b/apps/dotcom/client/src/pages/tla-opt-in.tsx
@@ -24,10 +24,10 @@ export function Component() {
 			}}
 		>
 			<h2>
-				<F defaultMessage="Try the new tldraw (beta)" />
+				<F defaultMessage="Try the new tldraw (preview)" />
 			</h2>
 			<p style={{ maxWidth: 400 }}>
-				<F defaultMessage="Sign in to access the beta version of tldraw.com, which adds file management and collaboration features." />
+				<F defaultMessage="Sign in to access the preview version of tldraw.com, which adds file management and collaboration features." />
 			</p>
 			<div style={{ display: 'flex', gap: 10 }}>
 				<TlaButton

--- a/apps/dotcom/client/src/pages/tla-override.tsx
+++ b/apps/dotcom/client/src/pages/tla-override.tsx
@@ -1,0 +1,59 @@
+import { useLocation } from 'react-router-dom'
+import { deleteFromLocalStorage, setInLocalStorage } from 'tldraw'
+import { tlaOverrideFlagName } from '../routes'
+import { TlaButton } from '../tla/components/TlaButton/TlaButton'
+
+export function Component() {
+	const location = useLocation()
+	if (!location.pathname.startsWith('/q')) return null
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '1rem',
+				justifyContent: 'center',
+				alignItems: 'center',
+				flex: 1,
+				padding: 20,
+				textAlign: 'center',
+			}}
+		>
+			<div
+				style={{
+					marginTop: 20,
+					border: '1px dashed #888',
+					padding: 20,
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '1rem',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<p>Sneaky stuff for testing new logged-out UI</p>
+				<div style={{ display: 'flex', gap: 10 }}>
+					<TlaButton
+						variant="primary"
+						onClick={() => {
+							setInLocalStorage(tlaOverrideFlagName, 'true')
+							window.location.href = '/'
+						}}
+					>
+						Enable override
+					</TlaButton>
+					<TlaButton
+						variant="secondary"
+						onClick={() => {
+							deleteFromLocalStorage(tlaOverrideFlagName)
+							window.location.href = '/'
+						}}
+					>
+						Disable override
+					</TlaButton>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/pages/tla-override.tsx
+++ b/apps/dotcom/client/src/pages/tla-override.tsx
@@ -1,12 +1,8 @@
-import { useLocation } from 'react-router-dom'
 import { deleteFromLocalStorage, setInLocalStorage } from 'tldraw'
 import { tlaOverrideFlagName } from '../routes'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 
 export function Component() {
-	const location = useLocation()
-	if (!location.pathname.startsWith('/q')) return null
-
 	return (
 		<div
 			style={{

--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -12,7 +12,7 @@ export const ROUTES = {
 	legacyReadonly: '/ro/:roomId',
 	legacyReadonlyOld: '/v/:roomId',
 
-	tlaOptIn: '/beta',
+	tlaOptIn: '/preview',
 	tlaOverride: '/q',
 
 	tlaRoot: `/`,

--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -12,8 +12,8 @@ export const ROUTES = {
 	legacyReadonly: '/ro/:roomId',
 	legacyReadonlyOld: '/v/:roomId',
 
-	tlaOptIn: '/q',
-	tlaOptIn2: '/beta',
+	tlaOptIn: '/beta',
+	tlaOverride: '/q',
 
 	tlaRoot: `/`,
 	tlaFile: `/f/:fileSlug`,

--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -12,19 +12,22 @@ export const ROUTES = {
 	legacyReadonly: '/ro/:roomId',
 	legacyReadonlyOld: '/v/:roomId',
 
-	tlaRoot: `/q`,
-	tlaFile: `/q/f/:fileSlug`,
-	tlaLocalFile: `/q/lf/:fileSlug`,
-	tlaPlayground: `/q/playground`,
-	tlaPublish: `/q/p/:fileSlug`,
+	tlaOptIn: '/q',
+	tlaOptIn2: '/beta',
+
+	tlaRoot: `/`,
+	tlaFile: `/f/:fileSlug`,
+	tlaLocalFile: `/lf/:fileSlug`,
+	tlaPlayground: `/playground`,
+	tlaPublish: `/p/:fileSlug`,
 	// Legacy routes
-	tlaTouchScreenSidePanel: '/q/ts-side',
-	tlaLegacyRoom: '/q/r/:roomId',
-	tlaLegacyRoomHistory: '/q/r/:boardId/history',
-	tlaLegacyRoomHistorySnapshot: '/q/r/:boardId/history/:timestamp',
-	tlaLegacySnapshot: '/q/s/:roomId',
-	tlaLegacyReadonly: '/q/ro/:roomId',
-	tlaLegacyReadonlyOld: '/q/v/:roomId',
+	tlaTouchScreenSidePanel: '/ts-side',
+	tlaLegacyRoom: '/r/:roomId',
+	tlaLegacyRoomHistory: '/r/:boardId/history',
+	tlaLegacyRoomHistorySnapshot: '/r/:boardId/history/:timestamp',
+	tlaLegacySnapshot: '/s/:roomId',
+	tlaLegacyReadonly: '/ro/:roomId',
+	tlaLegacyReadonlyOld: '/v/:roomId',
 } as const
 
 export const routes: {

--- a/apps/dotcom/client/src/routes.test.tsx
+++ b/apps/dotcom/client/src/routes.test.tsx
@@ -92,6 +92,7 @@ function extract(...routes: ReactElement[]) {
 }
 
 const spaRoutes = uniq(extract(legacyRoutes).concat(extract(tlaRoutes)))
+	.sort()
 	// ignore the root catch-all route
 	.filter((path) => path !== '/*' && path !== '*')
 	.map((path) => ({

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -58,34 +58,46 @@ export const legacyRoutes = (
 )
 
 export const tlaRoutes = (
-	<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
-		<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />
-		<Route element={<NoIndex />}>
-			<Route path={ROUTES.tlaLocalFile} lazy={() => import('./tla/pages/local-file')} />
-			{/* <Route path={ROUTES.tlaPlayground} lazy={() => import('./tla/pages/playground')} /> */}
-			{/* File view */}
-			<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
-			<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
-			{/* Legacy room */}
-			<Route path={ROUTES.tlaLegacyRoom} lazy={() => import('./tla/pages/legacy-room')} />
-			{/* Legacy readonly */}
-			<Route path={ROUTES.tlaLegacyReadonly} lazy={() => import('./tla/pages/legacy-readonly')} />
+	<Route>
+		<Route element={<ShimIntlProvider />}>
+			<Route path={ROUTES.legacyNewPage} lazy={() => import('./pages/new')} />
 			<Route
-				path={ROUTES.tlaLegacyReadonlyOld}
-				lazy={() => import('./tla/pages/legacy-readonly-old')}
+				path={ROUTES.touchscreenSidePanel}
+				lazy={() => import('./pages/public-touchscreen-side-panel')}
 			/>
-			{/* Legacy snapshot */}
-			<Route path={ROUTES.tlaLegacySnapshot} lazy={() => import('./tla/pages/legacy-snapshot')} />
-			{/* Legacy history */}
-			<Route path={ROUTES.tlaLegacyRoomHistory} lazy={() => import('./tla/pages/legacy-history')} />
-			{/* Legacy history snapshot */}
-			<Route
-				path={ROUTES.tlaLegacyRoomHistorySnapshot}
-				lazy={() => import('./tla/pages/legacy-history-snapshot')}
-			/>
-			{/* Views that require login */}
-			<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>
-			<Route path={ROUTES.tlaOverride} lazy={() => import('./pages/tla-override')} />
+		</Route>
+		<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
+			<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />
+			<Route element={<NoIndex />}>
+				<Route path={ROUTES.tlaLocalFile} lazy={() => import('./tla/pages/local-file')} />
+				{/* <Route path={ROUTES.tlaPlayground} lazy={() => import('./tla/pages/playground')} /> */}
+				{/* File view */}
+				<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
+				<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
+				{/* Legacy room */}
+				<Route path={ROUTES.tlaLegacyRoom} lazy={() => import('./tla/pages/legacy-room')} />
+				{/* Legacy readonly */}
+				<Route path={ROUTES.tlaLegacyReadonly} lazy={() => import('./tla/pages/legacy-readonly')} />
+				<Route
+					path={ROUTES.tlaLegacyReadonlyOld}
+					lazy={() => import('./tla/pages/legacy-readonly-old')}
+				/>
+				{/* Legacy snapshot */}
+				<Route path={ROUTES.tlaLegacySnapshot} lazy={() => import('./tla/pages/legacy-snapshot')} />
+				{/* Legacy history */}
+				<Route
+					path={ROUTES.tlaLegacyRoomHistory}
+					lazy={() => import('./tla/pages/legacy-history')}
+				/>
+				{/* Legacy history snapshot */}
+				<Route
+					path={ROUTES.tlaLegacyRoomHistorySnapshot}
+					lazy={() => import('./tla/pages/legacy-history-snapshot')}
+				/>
+				{/* Views that require login */}
+				<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>
+				<Route path={ROUTES.tlaOverride} lazy={() => import('./pages/tla-override')} />
+			</Route>
 		</Route>
 	</Route>
 )

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -21,12 +21,14 @@ const isClerkCookieSet = document.cookie
 export const legacyRoutes = (
 	<Route errorElement={<DefaultErrorFallback />}>
 		<Route path={ROUTES.legacyRoot} lazy={() => import('./pages/root')} />
-		<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
-			<Route path={ROUTES.tlaOptIn} lazy={() => import('./pages/tla-opt-in')} />
-			<Route path={ROUTES.tlaOptIn2} lazy={() => import('./pages/tla-opt-in')} />
-		</Route>
 		{/* We don't want to index multiplayer rooms */}
 		<Route element={<NoIndex />}>
+			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
+				<Route path={ROUTES.tlaOptIn} lazy={() => import('./pages/tla-opt-in')} />
+				<Route path={ROUTES.tlaOptIn2} lazy={() => import('./pages/tla-opt-in')} />
+				<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
+				<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
+			</Route>
 			<Route element={<ShimIntlProvider />}>
 				<Route path={ROUTES.legacyNewPage} lazy={() => import('./pages/new')} />
 				<Route path={ROUTES.legacyNewPage2} lazy={() => import('./pages/new')} />

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -20,7 +20,7 @@ const isClerkCookieSet = document.cookie
 	.split(';')
 	.some((item) => item.trim().startsWith(clerkCookieName))
 
-const isOverrideFlagSet = !!getFromLocalStorage(tlaOverrideFlagName)
+const isOverrideFlagSet = !!getFromLocalStorage(tlaOverrideFlagName) || navigator.webdriver
 
 export const legacyRoutes = (
 	<Route errorElement={<DefaultErrorFallback />}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -12,6 +12,77 @@ import { TlaNotFoundError } from './tla/utils/notFoundError'
 
 const LoginRedirectPage = lazy(() => import('./components/LoginRedirectPage/LoginRedirectPage'))
 
+const clerkCookieName = '__session'
+
+const isClerkCookieSet = document.cookie
+	.split(';')
+	.some((item) => item.trim().startsWith(clerkCookieName))
+
+export const legacyRoutes = (
+	<Route errorElement={<DefaultErrorFallback />}>
+		<Route path={ROUTES.legacyRoot} lazy={() => import('./pages/root')} />
+		<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
+			<Route path={ROUTES.tlaOptIn} lazy={() => import('./pages/tla-opt-in')} />
+			<Route path={ROUTES.tlaOptIn2} lazy={() => import('./pages/tla-opt-in')} />
+		</Route>
+		{/* We don't want to index multiplayer rooms */}
+		<Route element={<NoIndex />}>
+			<Route element={<ShimIntlProvider />}>
+				<Route path={ROUTES.legacyNewPage} lazy={() => import('./pages/new')} />
+				<Route path={ROUTES.legacyNewPage2} lazy={() => import('./pages/new')} />
+				<Route
+					path={ROUTES.touchscreenSidePanel}
+					lazy={() => import('./pages/public-touchscreen-side-panel')}
+				/>
+				<Route path={ROUTES.legacyRoom} lazy={() => import('./pages/public-multiplayer')} />
+				<Route path={ROUTES.legacyRoomHistory} lazy={() => import('./pages/history')} />
+				<Route
+					path={ROUTES.legacyRoomHistorySnapshot}
+					lazy={() => import('./pages/history-snapshot')}
+				/>
+				<Route path={ROUTES.legacySnapshot} lazy={() => import('./pages/public-snapshot')} />
+				<Route
+					path={ROUTES.legacyReadonlyOld}
+					lazy={() => import('./pages/public-readonly-legacy')}
+				/>
+				<Route path={ROUTES.legacyReadonly} lazy={() => import('./pages/public-readonly')} />
+			</Route>
+		</Route>
+	</Route>
+)
+
+export const tlaRoutes = (
+	<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
+		<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />
+		<Route element={<NoIndex />}>
+			<Route path={ROUTES.tlaLocalFile} lazy={() => import('./tla/pages/local-file')} />
+			{/* <Route path={ROUTES.tlaPlayground} lazy={() => import('./tla/pages/playground')} /> */}
+			{/* File view */}
+			<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
+			<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
+			{/* Legacy room */}
+			<Route path={ROUTES.tlaLegacyRoom} lazy={() => import('./tla/pages/legacy-room')} />
+			{/* Legacy readonly */}
+			<Route path={ROUTES.tlaLegacyReadonly} lazy={() => import('./tla/pages/legacy-readonly')} />
+			<Route
+				path={ROUTES.tlaLegacyReadonlyOld}
+				lazy={() => import('./tla/pages/legacy-readonly-old')}
+			/>
+			{/* Legacy snapshot */}
+			<Route path={ROUTES.tlaLegacySnapshot} lazy={() => import('./tla/pages/legacy-snapshot')} />
+			{/* Legacy history */}
+			<Route path={ROUTES.tlaLegacyRoomHistory} lazy={() => import('./tla/pages/legacy-history')} />
+			{/* Legacy history snapshot */}
+			<Route
+				path={ROUTES.tlaLegacyRoomHistorySnapshot}
+				lazy={() => import('./tla/pages/legacy-history-snapshot')}
+			/>
+			{/* Views that require login */}
+			<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>
+		</Route>
+	</Route>
+)
+
 export const router = createRoutesFromElements(
 	<Route
 		ErrorBoundary={() => {
@@ -64,66 +135,7 @@ export const router = createRoutesFromElements(
 			)
 		}}
 	>
-		<Route errorElement={<DefaultErrorFallback />}>
-			<Route path={ROUTES.legacyRoot} lazy={() => import('./pages/root')} />
-			{/* We don't want to index multiplayer rooms */}
-			<Route element={<NoIndex />}>
-				<Route element={<ShimIntlProvider />}>
-					<Route path={ROUTES.legacyNewPage} lazy={() => import('./pages/new')} />
-					<Route path={ROUTES.legacyNewPage2} lazy={() => import('./pages/new')} />
-					<Route
-						path={ROUTES.touchscreenSidePanel}
-						lazy={() => import('./pages/public-touchscreen-side-panel')}
-					/>
-					<Route path={ROUTES.legacyRoom} lazy={() => import('./pages/public-multiplayer')} />
-					<Route path={ROUTES.legacyRoomHistory} lazy={() => import('./pages/history')} />
-					<Route
-						path={ROUTES.legacyRoomHistorySnapshot}
-						lazy={() => import('./pages/history-snapshot')}
-					/>
-					<Route path={ROUTES.legacySnapshot} lazy={() => import('./pages/public-snapshot')} />
-					<Route
-						path={ROUTES.legacyReadonlyOld}
-						lazy={() => import('./pages/public-readonly-legacy')}
-					/>
-					<Route path={ROUTES.legacyReadonly} lazy={() => import('./pages/public-readonly')} />
-				</Route>
-			</Route>
-		</Route>
-		{/* begin tla */}
-		<Route element={<NoIndex />}>
-			<Route path={ROUTES.tlaLocalFile} lazy={() => import('./tla/pages/local-file')} />
-			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
-				<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />
-				{/* <Route path={ROUTES.tlaPlayground} lazy={() => import('./tla/pages/playground')} /> */}
-				{/* File view */}
-				<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
-				<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
-				{/* Legacy room */}
-				<Route path={ROUTES.tlaLegacyRoom} lazy={() => import('./tla/pages/legacy-room')} />
-				{/* Legacy readonly */}
-				<Route path={ROUTES.tlaLegacyReadonly} lazy={() => import('./tla/pages/legacy-readonly')} />
-				<Route
-					path={ROUTES.tlaLegacyReadonlyOld}
-					lazy={() => import('./tla/pages/legacy-readonly-old')}
-				/>
-				{/* Legacy snapshot */}
-				<Route path={ROUTES.tlaLegacySnapshot} lazy={() => import('./tla/pages/legacy-snapshot')} />
-				{/* Legacy history */}
-				<Route
-					path={ROUTES.tlaLegacyRoomHistory}
-					lazy={() => import('./tla/pages/legacy-history')}
-				/>
-				{/* Legacy history snapshot */}
-				<Route
-					path={ROUTES.tlaLegacyRoomHistorySnapshot}
-					lazy={() => import('./tla/pages/legacy-history-snapshot')}
-				/>
-				{/* Views that require login */}
-				<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>
-			</Route>
-		</Route>
-		{/* end tla */}
+		{!isClerkCookieSet ? legacyRoutes : tlaRoutes}
 		<Route path="*" lazy={() => import('./pages/not-found')} />
 	</Route>
 )


### PR DESCRIPTION
This PR remove the `q` prefix for tla routes, but if you go to `/q` or `/beta` you will be met with a very basic sign-in page. when you sign in, you get the tla routes instead of the legacy routes. We can share this link on twitter or whatever when we want to let people in. (need to update the clerk settings to allow non-tldraw.com emails first)

### Change type

- [x] `other`
