### PR TITLE
Fix for resizing snapshot bug

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -56,7 +56,14 @@ export class Resizing extends StateNode {
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		this.creationCursorOffset = creationCursorOffset
 
-		this.snapshot = this._createSnapshot()
+		try {
+			// On rare and mysterious occasions, the user can enter the resizing state with no shapes selected
+			this.snapshot = this._createSnapshot()
+		} catch (e) {
+			console.error(e)
+			this.cancel()
+			return
+		}
 
 		this.markId = ''
 
@@ -442,6 +449,8 @@ export class Resizing extends StateNode {
 		} = this.editor
 
 		const selectionBounds = this.editor.getSelectionRotatedPageBounds()!
+
+		if (!selectionBounds) throw Error('Resizing but nothing is selected')
 
 		const dragHandlePoint = Vec.RotWith(
 			selectionBounds.getHandlePoint(this.info.handle!),


### PR DESCRIPTION
Fixes issue described here: https://tldraw.sentry.io/issues/5687288900/?project=4504203639193600

Interesting that the event just before the bug was a resize on mobile followed by clicking the delete button. I wonder if there are cases where the resizing state doesn't correctly enter or exit?

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug that could occur when resizing on mobile