### PR TITLE
close sockets on 'close' event

### DIFF
--- a/packages/sync-core/src/lib/RoomSession.ts
+++ b/packages/sync-core/src/lib/RoomSession.ts
@@ -13,7 +13,7 @@ export const RoomSessionState = {
 export type RoomSessionState = (typeof RoomSessionState)[keyof typeof RoomSessionState]
 
 export const SESSION_START_WAIT_TIME = 10000
-export const SESSION_REMOVAL_WAIT_TIME = 10000
+export const SESSION_REMOVAL_WAIT_TIME = 5000
 export const SESSION_IDLE_TIMEOUT = 20000
 
 /** @internal */

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -494,15 +494,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		const presence = this.getDocument(session.presenceId ?? '')
 
 		try {
-			if (session.socket.isOpen) {
-				if (fatalReason) {
-					session.socket.close(TLSyncErrorCloseEventCode, fatalReason)
-				} else {
-					session.socket.close()
-				}
+			if (fatalReason) {
+				session.socket.close(TLSyncErrorCloseEventCode, fatalReason)
+			} else {
+				session.socket.close()
 			}
 		} catch {
-			// noop
+			// noop, calling .close() multiple times is fine
 		}
 
 		if (presence) {
@@ -545,6 +543,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			isReadonly: session.isReadonly,
 			requiresLegacyRejection: session.requiresLegacyRejection,
 		})
+
+		try {
+			session.socket.close()
+		} catch {
+			// noop, calling .close() multiple times is fine
+		}
 	}
 
 	/**


### PR DESCRIPTION
apparently it is necessary to call .close on the server socket to make the tcp connection close cleanly, even after the client has called .close() ?

before

![Kapture 2025-01-14 at 11 27 52](https://github.com/user-attachments/assets/a13c5061-48d8-401e-84c4-151fd864c4c9)


after

![Kapture 2025-01-14 at 11 26 22](https://github.com/user-attachments/assets/6133080e-e7da-410b-a6ef-283a00d8e898)


### Change type

- [x] `improvement`

### Release notes

- sync: close the server sockets on disconnect to proactively clean up socket connections.