### PR TITLE
worker debug logging

### DIFF
--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -155,6 +155,7 @@ export const router = createRoutesFromElements(
 		}}
 	>
 		{isClerkCookieSet || isOverrideFlagSet ? tlaRoutes : legacyRoutes}
+		<Route path="/__debug-tail" lazy={() => import('./tla/pages/worker-debug-tail')} />
 		<Route path="*" lazy={() => import('./pages/not-found')} />
 	</Route>
 )

--- a/apps/dotcom/client/src/tla/pages/worker-debug-tail.tsx
+++ b/apps/dotcom/client/src/tla/pages/worker-debug-tail.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+import { MULTIPLAYER_SERVER } from '../../utils/config'
+
+export function Component() {
+	const ref = useRef<HTMLDivElement>(null)
+	const isAutoScroll = useRef(true)
+	useEffect(() => {
+		const elem = ref.current
+		if (!elem) return
+		const socket = new WebSocket(MULTIPLAYER_SERVER + '/app/__debug-tail')
+		socket.onmessage = (msg) => {
+			const div = document.createElement('pre')
+			div.textContent = msg.data
+			elem.appendChild(div)
+			if (isAutoScroll.current) {
+				elem.scrollTo({ top: elem.scrollHeight })
+			}
+		}
+		socket.onerror = (err) => {
+			console.error(err)
+		}
+		socket.onclose = () => {
+			setTimeout(() => {
+				window.location.reload()
+			}, 500)
+		}
+
+		const onScroll = () => {
+			isAutoScroll.current = elem.scrollTop + elem.clientHeight > elem.scrollHeight - 100
+		}
+		elem.addEventListener('scroll', onScroll)
+		return () => {
+			socket.close()
+			elem.removeEventListener('scroll', onScroll)
+		}
+	}, [])
+	return (
+		<div ref={ref} style={{ fontFamily: 'monospace', overflow: 'scroll', height: '100vh' }}></div>
+	)
+}

--- a/apps/dotcom/sync-worker/src/Logger.ts
+++ b/apps/dotcom/sync-worker/src/Logger.ts
@@ -1,0 +1,44 @@
+import { createSentry } from '@tldraw/worker-shared'
+import { Environment, isDebugLogging } from './types'
+import { getLogger } from './utils/durableObjects'
+
+export class Logger {
+	readonly logger
+	constructor(
+		env: Environment,
+		private prefix: string,
+		private sentry?: ReturnType<typeof createSentry>
+	) {
+		if (isDebugLogging(env)) {
+			this.logger = getLogger(env)
+		}
+	}
+	private outgoing: string[] = []
+
+	private isRunning = false
+
+	debug(...args: any[]) {
+		if (!this.logger && !this.sentry) return
+		const msg = `${this.prefix}: ${args.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' ')}`
+		this.outgoing.push(msg)
+		this.processQueue()
+	}
+
+	private async processQueue() {
+		if (this.isRunning) return
+		this.isRunning = true
+		try {
+			while (this.outgoing.length) {
+				const batch = this.outgoing
+				this.outgoing = []
+				await this.logger?.debug(batch)
+				for (const message of batch) {
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
+					this.sentry?.addBreadcrumb({ message })
+				}
+			}
+		} finally {
+			this.isRunning = false
+		}
+	}
+}

--- a/apps/dotcom/sync-worker/src/Logger.ts
+++ b/apps/dotcom/sync-worker/src/Logger.ts
@@ -19,7 +19,7 @@ export class Logger {
 
 	debug(...args: any[]) {
 		if (!this.logger && !this.sentry) return
-		const msg = `${this.prefix}: ${args.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' ')}`
+		const msg = `[${this.prefix} ${new Date().toISOString()}]: ${args.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' ')}`
 		this.outgoing.push(msg)
 		this.processQueue()
 	}

--- a/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
@@ -1,12 +1,12 @@
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest } from 'itty-router'
-import { Environment } from './types'
+import { Environment, isDebugLogging } from './types'
 
 export class TLLoggerDurableObject extends DurableObject<Environment> {
 	private readonly isDebugEnv
 	constructor(ctx: DurableObjectState, env: Environment) {
 		super(ctx, env)
-		this.isDebugEnv = env.TLDRAW_ENV === 'preview' || env.TLDRAW_ENV === 'development'
+		this.isDebugEnv = isDebugLogging(env)
 	}
 
 	private sockets = new Set<WebSocket>()
@@ -15,7 +15,6 @@ export class TLLoggerDurableObject extends DurableObject<Environment> {
 
 	async debug(messages: string[]) {
 		if (!this.isDebugEnv) return
-		messages = messages.map((msg) => `[${new Date().toISOString()}]: ${msg}`)
 		this.history.push(...messages)
 		while (this.history.length > 10000) {
 			this.history.shift()

--- a/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
@@ -1,0 +1,47 @@
+import { DurableObject } from 'cloudflare:workers'
+import { IRequest } from 'itty-router'
+import { Environment } from './types'
+
+export class TLLoggerDurableObject extends DurableObject<Environment> {
+	private readonly isDebugEnv
+	constructor(ctx: DurableObjectState, env: Environment) {
+		super(ctx, env)
+		this.isDebugEnv = env.TLDRAW_ENV === 'preview' || env.TLDRAW_ENV === 'development'
+	}
+
+	private sockets = new Set<WebSocket>()
+
+	private history: string[] = []
+
+	async debug(messages: string[]) {
+		if (this.sockets.size === 0) return
+		if (!this.isDebugEnv) return
+		const sockets = Array.from(this.sockets)
+		messages = messages.map((msg) => `[${new Date().toISOString()}]: ${msg}`)
+		this.history.push(...messages)
+		while (this.history.length > 10000) {
+			this.history.shift()
+		}
+		for (const message of messages) {
+			sockets.forEach((socket) => {
+				socket.send(message + '\n')
+			})
+		}
+	}
+
+	override async fetch(_req: IRequest) {
+		if (!this.isDebugEnv) return new Response('Not Found', { status: 404 })
+		const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair()
+		serverWebSocket.accept()
+
+		this.sockets.add(serverWebSocket)
+		const cleanup = () => {
+			this.sockets.delete(serverWebSocket)
+			serverWebSocket.close()
+		}
+		serverWebSocket.addEventListener('close', cleanup)
+		serverWebSocket.addEventListener('error', cleanup)
+		serverWebSocket.send('Connected to logger\n' + this.history.join('\n'))
+		return new Response(null, { status: 101, webSocket: clientWebSocket })
+	}
+}

--- a/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLLoggerDurableObject.ts
@@ -14,14 +14,14 @@ export class TLLoggerDurableObject extends DurableObject<Environment> {
 	private history: string[] = []
 
 	async debug(messages: string[]) {
-		if (this.sockets.size === 0) return
 		if (!this.isDebugEnv) return
-		const sockets = Array.from(this.sockets)
 		messages = messages.map((msg) => `[${new Date().toISOString()}]: ${msg}`)
 		this.history.push(...messages)
 		while (this.history.length > 10000) {
 			this.history.shift()
 		}
+		const sockets = Array.from(this.sockets)
+		if (this.sockets.size === 0) return
 		for (const message of messages) {
 			sockets.forEach((socket) => {
 				socket.send(message + '\n')

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -121,8 +121,11 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		// debug logging in preview envs by default
 		this.log = new Logger(env, 'TLPostgresReplicator', this.sentry)
 
-		this.reboot(false)
 		this.alarm()
+		this.reboot(false).catch((e) => {
+			this.captureException(e)
+			this.__test__panic()
+		})
 		this.measure = env.MEASURE
 	}
 

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -17,6 +17,7 @@ import { createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, sql } from 'kysely'
+import { Logger } from './Logger'
 import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { type TLPostgresReplicator } from './TLPostgresReplicator'
@@ -46,6 +47,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		}
 	}
 
+	private log
+
 	cache: UserDataSyncer | null = null
 
 	constructor(ctx: DurableObjectState, env: Environment) {
@@ -55,25 +58,31 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.replicator = getReplicator(env)
 
 		this.db = createPostgresConnectionPool(env, 'TLUserDurableObject')
-		this.debug('created')
 		this.measure = env.MEASURE
+
+		// debug logging in preview envs by default
+		this.log = new Logger(env, 'TLUserDurableObject', this.sentry)
 	}
 
 	private userId: string | null = null
 
 	readonly router = Router()
 		.all('/app/:userId/*', async (req) => {
+			this.log.debug('all')
 			if (!this.userId) {
 				this.userId = req.params.userId
 			}
 			const rateLimited = await isRateLimited(this.env, this.userId!)
 			if (rateLimited) {
+				this.log.debug('rate limited')
 				this.logEvent({ type: 'rate_limited', id: this.userId })
 				throw new Error('Rate limited')
 			}
-			if (this.cache === null) {
+			if (!this.cache) {
+				this.log.debug('initing', this.userId)
 				await this.init()
 			} else {
+				this.log.debug('waiting', this.cache, this.userId)
 				await this.cache.waitUntilConnected()
 			}
 		})
@@ -81,16 +90,17 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private async init() {
 		assert(this.userId, 'User ID not set')
-		this.debug('init')
+		this.log.debug('init')
 		this.cache = new UserDataSyncer(
 			this.ctx,
 			this.env,
 			this.db,
 			this.userId,
 			(message) => this.broadcast(message),
-			this.logEvent.bind(this)
+			this.logEvent.bind(this),
+			this.log
 		)
-		this.debug('cache', !!this.cache)
+		this.log.debug('cache', !!this.cache)
 		await this.cache.waitUntilConnected()
 	}
 
@@ -137,6 +147,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	async onRequest(req: IRequest) {
+		this.log.debug('yes')
 		assert(this.userId, 'User ID not set')
 		// handle legacy param names
 
@@ -181,17 +192,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.sockets.add(serverWebSocket)
 
 		return new Response(null, { status: 101, webSocket: clientWebSocket })
-	}
-
-	private debug(...args: any[]) {
-		// uncomment for dev time debugging
-		// console.log('[TLUserDurableObject]: ', ...args)
-		if (this.sentry) {
-			// eslint-disable-next-line @typescript-eslint/no-deprecated
-			this.sentry.addBreadcrumb({
-				message: `[TLUserDurableObject]: ${args.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' ')}`,
-			})
-		}
 	}
 
 	private async handleSocketMessage(message: string) {
@@ -393,7 +393,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				}
 			)
 			// TODO: We should probably handle a case where the above operation succeeds but the one below fails
-			this.debug('mutation success', this.userId)
+			this.log.debug('mutation success', this.userId)
 			await this.db
 				.transaction()
 				.execute(async (tx) => {
@@ -410,14 +410,14 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 						)
 						.returning('mutationNumber')
 						.executeTakeFirstOrThrow()
-					this.debug('mutation number success', this.userId)
+					this.log.debug('mutation number success', this.userId)
 					const mutationNumber = Number(result.mutationNumber)
 					const currentMutationNumber = this.cache.mutations.at(-1)?.mutationNumber ?? 0
 					assert(
 						mutationNumber > currentMutationNumber,
 						`mutation number did not increment mutationNumber: ${mutationNumber} current: ${currentMutationNumber}`
 					)
-					this.debug('pushing mutation to cache', this.userId, mutationNumber)
+					this.log.debug('pushing mutation to cache', this.userId, mutationNumber)
 					this.cache.mutations.push({ mutationNumber, mutationId: msg.mutationId })
 				})
 				.catch((e) => {
@@ -438,7 +438,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	async handleReplicationEvent(event: ZReplicationEvent) {
 		this.logEvent({ type: 'replication_event', id: this.userId ?? 'anon' })
-		this.debug('replication event', event, !!this.cache)
+		this.log.debug('replication event', event, !!this.cache)
 		if (!this.cache) {
 			return 'unregister'
 		}

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -68,7 +68,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	readonly router = Router()
 		.all('/app/:userId/*', async (req) => {
-			this.log.debug('all')
 			if (!this.userId) {
 				this.userId = req.params.userId
 			}
@@ -79,10 +78,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				throw new Error('Rate limited')
 			}
 			if (!this.cache) {
-				this.log.debug('initing', this.userId)
 				await this.init()
 			} else {
-				this.log.debug('waiting', this.cache, this.userId)
 				await this.cache.waitUntilConnected()
 			}
 		})
@@ -90,7 +87,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private async init() {
 		assert(this.userId, 'User ID not set')
-		this.log.debug('init')
+		this.log.debug('init', this.userId)
 		this.cache = new UserDataSyncer(
 			this.ctx,
 			this.env,
@@ -102,6 +99,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		)
 		this.log.debug('cache', !!this.cache)
 		await this.cache.waitUntilConnected()
+		this.log.debug('cache connected')
 	}
 
 	// Handle a request to the Durable Object.
@@ -147,7 +145,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	async onRequest(req: IRequest) {
-		this.log.debug('yes')
 		assert(this.userId, 'User ID not set')
 		// handle legacy param names
 

--- a/apps/dotcom/sync-worker/src/testRoutes.ts
+++ b/apps/dotcom/sync-worker/src/testRoutes.ts
@@ -1,10 +1,10 @@
 import { createRouter, notFound } from '@tldraw/worker-shared'
-import type { Environment } from './types'
+import { isDebugLogging, type Environment } from './types'
 import { getReplicator, getUserDurableObject } from './utils/durableObjects'
 
 export const testRoutes = createRouter<Environment>()
 	.all('/app/__test__/*', (_, env) => {
-		if (env.IS_LOCAL !== 'true') return notFound()
+		if (!isDebugLogging(env)) return notFound()
 		return undefined
 	})
 	.get('/app/__test__/replicator/reboot', (_, env) => {

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -1,10 +1,11 @@
 // https://developers.cloudflare.com/analytics/analytics-engine/
 
-import { RoomSnapshot } from '@tldraw/sync-core'
+import type { RoomSnapshot } from '@tldraw/sync-core'
 // import { TLAppDurableObject } from './TLAppDurableObject'
-import { TLDrawDurableObject } from './TLDrawDurableObject'
-import { TLPostgresReplicator } from './TLPostgresReplicator'
-import { TLUserDurableObject } from './TLUserDurableObject'
+import type { TLDrawDurableObject } from './TLDrawDurableObject'
+import type { TLLoggerDurableObject } from './TLLoggerDurableObject'
+import type { TLPostgresReplicator } from './TLPostgresReplicator'
+import type { TLUserDurableObject } from './TLUserDurableObject'
 
 // This type isn't available in @cloudflare/workers-types yet
 export interface Analytics {
@@ -21,6 +22,8 @@ export interface Environment {
 	// TLAPP_DO: DurableObjectNamespace<TLAppDurableObject>
 	TL_PG_REPLICATOR: DurableObjectNamespace<TLPostgresReplicator>
 	TL_USER: DurableObjectNamespace<TLUserDurableObject>
+	TL_LOGGER: DurableObjectNamespace<TLLoggerDurableObject>
+
 	BOTCOM_POSTGRES_CONNECTION_STRING: string
 	BOTCOM_POSTGRES_POOLED_CONNECTION_STRING: string
 	MEASURE: Analytics | undefined
@@ -52,6 +55,10 @@ export interface Environment {
 	ASSET_UPLOAD_ORIGIN: string | undefined
 
 	RATE_LIMITER: RateLimit
+}
+
+export function isDebugLogging(env: Environment) {
+	return env.TLDRAW_ENV === 'development' || env.TLDRAW_ENV === 'preview'
 }
 
 export type DBLoadResult =

--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -1,3 +1,4 @@
+import { TLLoggerDurableObject } from '../TLLoggerDurableObject'
 import type { TLPostgresReplicator } from '../TLPostgresReplicator'
 import type { TLUserDurableObject } from '../TLUserDurableObject'
 import { Environment } from '../types'
@@ -10,4 +11,8 @@ export function getReplicator(env: Environment) {
 
 export function getUserDurableObject(env: Environment, userId: string) {
 	return env.TL_USER.get(env.TL_USER.idFromName(userId)) as any as TLUserDurableObject
+}
+
+export function getLogger(env: Environment) {
+	return env.TL_LOGGER.get(env.TL_LOGGER.idFromName('logger')) as any as TLLoggerDurableObject
 }

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -65,7 +65,7 @@ const router = createRouter<Environment>()
 		const auth = await getAuth(req, env)
 		if (!auth) {
 			// eslint-disable-next-line no-console
-			console.log('auth not found', req.headers.get('Authorization'), req.url)
+			console.log('auth not found')
 			return notFound()
 		}
 		const stub = getUserDurableObject(env, auth.userId)

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -24,13 +24,15 @@ import { deleteFile } from './routes/tla/deleteFile'
 import { forwardRoomRequest } from './routes/tla/forwardRoomRequest'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
 import { testRoutes } from './testRoutes'
-import { Environment } from './types'
-import { getUserDurableObject } from './utils/durableObjects'
+import { Environment, isDebugLogging } from './types'
+import { getLogger, getUserDurableObject } from './utils/durableObjects'
 import { getAuth } from './utils/tla/getAuth'
 // export { TLAppDurableObject } from './TLAppDurableObject'
 export { TLDrawDurableObject } from './TLDrawDurableObject'
+export { TLLoggerDurableObject } from './TLLoggerDurableObject'
 export { TLPostgresReplicator } from './TLPostgresReplicator'
 export { TLUserDurableObject } from './TLUserDurableObject'
+
 export class TLAppDurableObject extends DurableObject {}
 
 const { preflight, corsify } = cors({
@@ -63,7 +65,7 @@ const router = createRouter<Environment>()
 		const auth = await getAuth(req, env)
 		if (!auth) {
 			// eslint-disable-next-line no-console
-			console.log('auth not found')
+			console.log('auth not found', req.headers.get('Authorization'), req.url)
 			return notFound()
 		}
 		const stub = getUserDurableObject(env, auth.userId)
@@ -82,6 +84,16 @@ const router = createRouter<Environment>()
 		)
 		proxied.headers.delete('cookie')
 		return fetch(proxied)
+	})
+	.get('/app/__debug-tail', (req, env) => {
+		if (isDebugLogging(env)) {
+			// upgrade to websocket
+			if (req.headers.get('upgrade') === 'websocket') {
+				return getLogger(env).fetch(req)
+			}
+		}
+
+		return new Response('Not Found', { status: 404 })
 	})
 	// end app
 	.all('*', notFound)

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -30,6 +30,10 @@ tag = "v5"
 new_sqlite_classes = ["TLPostgresReplicator"]
 new_classes = ["TLUserDurableObject"]
 
+[[migrations]]
+tag = "v6"
+new_sqlite_classes = ["TLLoggerDurableObject"]
+
 [[analytics_engine_datasets]]
 binding = "MEASURE"
 
@@ -41,6 +45,7 @@ name = "dev-tldraw-multiplayer"
 [env.dev.vars]
 BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
 BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
+TLDRAW_ENV = "development"
 
 # we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.
 
@@ -79,35 +84,40 @@ pattern = "sync.tldraw.xyz"
 bindings = [
 	{ name = "TLDR_DOC", class_name = "TLDrawDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
-	{ name = "TL_USER", class_name = "TLUserDurableObject" }
+	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 ]
 
 [durable_objects]
 bindings = [
 	{ name = "TLDR_DOC", class_name = "TLDrawDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
-	{ name = "TL_USER", class_name = "TLUserDurableObject" }
+	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 ]
 
 [env.preview.durable_objects]
 bindings = [
 	{ name = "TLDR_DOC", class_name = "TLDrawDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
-	{ name = "TL_USER", class_name = "TLUserDurableObject" }
+	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 ]
 
 [env.staging.durable_objects]
 bindings = [
 	{ name = "TLDR_DOC", class_name = "TLDrawDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
-	{ name = "TL_USER", class_name = "TLUserDurableObject" }
+	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 ]
 
 [env.production.durable_objects]
 bindings = [
 	{ name = "TLDR_DOC", class_name = "TLDrawDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
-	{ name = "TL_USER", class_name = "TLUserDurableObject" }
+	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 ]
 
 #################### Analytics engine ####################

--- a/packages/worker-shared/src/sentry.ts
+++ b/packages/worker-shared/src/sentry.ts
@@ -16,7 +16,7 @@ export interface SentryEnvironment {
 
 export function createSentry(ctx: Context, env: SentryEnvironment, request?: Request) {
 	// TLDRAW_ENV is undefined in dev
-	if (!env.SENTRY_DSN && !env.TLDRAW_ENV) {
+	if (!env.SENTRY_DSN && env.TLDRAW_ENV === 'development') {
 		return null
 	}
 


### PR DESCRIPTION
This PR begins to address some pains we've felt with regard to logging on cloudflare workers:

1. a console.log invocation is only flushed to the console (or cf dashboard) once a request completes. so if a request hangs for some reason you never see the log output.
2. logs are very eagerly sampled, which makes it hard to rely on them for debugging because you never know whether a log statement wasn't reached or whether it was just dropped.

so this PR

- adds a Logger durable object that you can connect to via a websocket to get an instant stream of every log statement, no waiting for requests to finish.
- wraps the Logger durable object with a Logger class to consolidate code.

The logger durable object is on in dev and preview envs, but is not available in staging or production yet because that would require auth and filtering user DO events by user.

You can try it on this PR by going to https://pr-5219-preview-deploy.tldraw.com/__debug-tail and then opening the app in another tab

also tackles https://linear.app/tldraw/issue/INT-648/investigate-flaky-preview-deploys somewhat

### Change type

- [x] `other`
