### PR TITLE
Always override session state on initial load

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -114,7 +114,10 @@ function TlaEditorInner({ fileSlug, fileOpenState, deepLinks }: TlaEditorProps) 
 
 			const fileState = app.getFileState(fileId)
 			if (fileState?.lastSessionState) {
-				editor.loadSnapshot({ session: JSON.parse(fileState.lastSessionState.trim() || 'null') })
+				editor.loadSnapshot(
+					{ session: JSON.parse(fileState.lastSessionState.trim() || 'null') },
+					{ forceOverwriteSessionState: true }
+				)
 			}
 			const sessionState$ = createSessionStateSnapshotSignal(editor.store)
 			const updateSessionState = throttle((state: TLSessionStateSnapshot) => {

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -128,7 +128,7 @@ export function createTLStore({
 
 	if (rest.snapshot) {
 		if (initialData) throw new Error('Cannot provide both initialData and snapshot')
-		loadSnapshot(store, rest.snapshot)
+		loadSnapshot(store, rest.snapshot, { forceOverwriteSessionState: true })
 	}
 
 	return store

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -196,7 +196,9 @@ export class TLLocalSyncClient {
 				}
 
 				if (sessionStateSnapshot) {
-					loadSessionStateSnapshotIntoStore(this.store, sessionStateSnapshot)
+					loadSessionStateSnapshotIntoStore(this.store, sessionStateSnapshot, {
+						forceOverwrite: true,
+					})
 				}
 			}
 


### PR DESCRIPTION
closes #4391 too

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug where grid mode and other settings would not persist across page reloads.