### PR TITLE
Rename files in window.prompt on mobile

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -57,6 +57,7 @@
   "7daeced9ff": "Publish changes",
   "7fcdcc6455": "Forget file",
   "85a082de1b": "Please refresh the page to get the latest version of tldraw.",
+  "86c66437fd": "Rename file",
   "8eb2c00e96": "Shared with you",
   "8f7f4c1ce7": "About",
   "8ff3d0a705": "Rate limited",

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -173,6 +173,9 @@
   "85a082de1b": {
     "translation": "Please refresh the page to get the latest version of tldraw."
   },
+  "86c66437fd": {
+    "translation": "Rename file"
+  },
   "8eb2c00e96": {
     "translation": "Shared with you"
   },

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -27,10 +27,12 @@ import { useApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
 import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
+import { getIsCoarsePointer } from '../../utils/getIsCoarsePointer'
 import { defineMessages, useIntl, useMsg } from '../../utils/i18n'
 import { TlaAppMenuGroupLazyFlipped } from '../TlaAppMenuGroup/TlaAppMenuGroup'
 import { TlaFileMenu } from '../TlaFileMenu/TlaFileMenu'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
+import { sidebarMessages } from '../TlaSidebar/components/TlaSidebarFileLink'
 import styles from './top.module.css'
 
 const messages = defineMessages({
@@ -168,7 +170,16 @@ export function TlaEditorTopLeftPanelSignedIn() {
 		[app, editor, fileId, isOwner]
 	)
 
-	const handleRenameAction = () => setIsRenaming(true)
+	const handleRenameAction = () => {
+		if (getIsCoarsePointer()) {
+			const newName = prompt(intl.formatMessage(sidebarMessages.renameFile), fileName)?.trim()
+			if (newName) {
+				app.updateFile({ id: fileId, name: newName })
+			}
+		} else {
+			setIsRenaming(true)
+		}
+	}
 	const handleRenameEnd = () => setIsRenaming(false)
 
 	const separator = '/'
@@ -224,10 +235,19 @@ function TlaFileNameEditor({
 }) {
 	const [isEditing, setIsEditing] = useState(false)
 	const trackEvent = useTldrawAppUiEvents()
+
+	const intl = useIntl()
 	const handleEditingStart = useCallback(() => {
 		if (!onChange) return
-		setIsEditing(true)
-	}, [onChange])
+		if (getIsCoarsePointer()) {
+			const newName = prompt(intl.formatMessage(sidebarMessages.renameFile), fileName)?.trim()
+			if (newName) {
+				onChange(newName)
+			}
+		} else {
+			setIsEditing(true)
+		}
+	}, [fileName, intl, onChange])
 
 	const handleEditingEnd = useCallback(() => {
 		if (!onChange) return

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -7,7 +7,8 @@ import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
 import { useIsFileOwner } from '../../../hooks/useIsFileOwner'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
-import { F } from '../../../utils/i18n'
+import { getIsCoarsePointer } from '../../../utils/getIsCoarsePointer'
+import { F, defineMessages, useIntl } from '../../../utils/i18n'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import {
 	TlaTooltipArrow,
@@ -53,6 +54,10 @@ export function TlaSidebarFileLink({ item, testId }: { item: RecentFile; testId:
 	)
 }
 
+export const sidebarMessages = defineMessages({
+	renameFile: { defaultMessage: 'Rename file' },
+})
+
 export function TlaSidebarFileLinkInner({
 	testId,
 	fileId,
@@ -74,9 +79,19 @@ export function TlaSidebarFileLinkInner({
 	const trackEvent = useTldrawAppUiEvents()
 	const linkRef = useRef<HTMLAnchorElement | null>(null)
 	const app = useApp()
+	const intl = useIntl()
 
 	const [isRenaming, setIsRenaming] = useState(debugIsRenaming)
-	const handleRenameAction = () => setIsRenaming(true)
+	const handleRenameAction = () => {
+		if (getIsCoarsePointer()) {
+			const newName = prompt(intl.formatMessage(sidebarMessages.renameFile), fileName)?.trim()
+			if (newName) {
+				app.updateFile({ id: fileId, name: newName })
+			}
+		} else {
+			setIsRenaming(true)
+		}
+	}
 	const handleRenameClose = () => setIsRenaming(false)
 	const params = useParams()
 	const { fileSlug } = params

--- a/apps/dotcom/client/src/tla/utils/getIsCoarsePointer.tsx
+++ b/apps/dotcom/client/src/tla/utils/getIsCoarsePointer.tsx
@@ -1,0 +1,17 @@
+import { tlenv } from 'tldraw'
+
+const mql =
+	(typeof window !== 'undefined' &&
+		window.matchMedia &&
+		window.matchMedia('(any-pointer: coarse)')) ||
+	undefined
+
+// This is a workaround for a Firefox bug where we don't correctly
+// detect coarse VS fine pointer. For now, let's assume that you have a fine
+// pointer if you're on Firefox on desktop.
+const isForcedFinePointer = tlenv.isFirefox && !tlenv.isAndroid && !tlenv.isIos
+
+export function getIsCoarsePointer() {
+	// default to true if matchMedia is not supported, which is extremely unlikely
+	return isForcedFinePointer ? false : mql?.matches ?? true
+}


### PR DESCRIPTION
these text inputs have weird behavior on iOS and anyway it's better to show a native prompt.

### Change type

- [x] `other`
