### PR TITLE
Use localStorage instead of cookie to detect logged in state

### DIFF
--- a/apps/dotcom/client/src/pages/tla-opt-in.tsx
+++ b/apps/dotcom/client/src/pages/tla-opt-in.tsx
@@ -38,7 +38,11 @@ export function Component() {
 				>
 					<F defaultMessage="No thanks" />
 				</TlaButton>
-				<SignInButton mode="modal">
+				<SignInButton
+					mode="modal"
+					forceRedirectUrl={location.pathname}
+					signUpForceRedirectUrl={location.pathname}
+				>
 					<TlaButton data-testid="tla-opt-in">
 						<F defaultMessage="Sign in" />
 					</TlaButton>

--- a/apps/dotcom/client/src/pages/tla-override.tsx
+++ b/apps/dotcom/client/src/pages/tla-override.tsx
@@ -1,5 +1,5 @@
 import { deleteFromLocalStorage, setInLocalStorage } from 'tldraw'
-import { tlaOverrideFlagName } from '../routes'
+import { tlaOverrideFlag } from '../routes'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 
 export function Component() {
@@ -33,7 +33,7 @@ export function Component() {
 					<TlaButton
 						variant="primary"
 						onClick={() => {
-							setInLocalStorage(tlaOverrideFlagName, 'true')
+							setInLocalStorage(tlaOverrideFlag, 'true')
 							window.location.href = '/'
 						}}
 					>
@@ -42,7 +42,7 @@ export function Component() {
 					<TlaButton
 						variant="secondary"
 						onClick={() => {
-							deleteFromLocalStorage(tlaOverrideFlagName)
+							deleteFromLocalStorage(tlaOverrideFlag)
 							window.location.href = '/'
 						}}
 					>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -13,14 +13,11 @@ import { TlaNotFoundError } from './tla/utils/notFoundError'
 
 const LoginRedirectPage = lazy(() => import('./components/LoginRedirectPage/LoginRedirectPage'))
 
-const clerkCookieName = '__session'
-export const tlaOverrideFlagName = 'tla-override-flag'
+export const tlaOverrideFlag = 'tla-override-flag'
+export const tlaProbablyLoggedInFlag = 'tla-probably-logged-in-flag'
 
-const isClerkCookieSet = document.cookie
-	.split(';')
-	.some((item) => item.trim().startsWith(clerkCookieName))
-
-const isOverrideFlagSet = !!getFromLocalStorage(tlaOverrideFlagName) || navigator.webdriver
+const isOverrideFlagSet = !!getFromLocalStorage(tlaOverrideFlag) || navigator.webdriver
+const isProbablyLoggedIn = !!getFromLocalStorage(tlaProbablyLoggedInFlag)
 
 export const legacyRoutes = (
 	<Route errorElement={<DefaultErrorFallback />}>
@@ -154,7 +151,7 @@ export const router = createRoutesFromElements(
 			)
 		}}
 	>
-		{isClerkCookieSet || isOverrideFlagSet ? tlaRoutes : legacyRoutes}
+		{isProbablyLoggedIn || isOverrideFlagSet ? tlaRoutes : legacyRoutes}
 		<Route path="/__debug-tail" lazy={() => import('./tla/pages/worker-debug-tail')} />
 		<Route path="*" lazy={() => import('./pages/not-found')} />
 	</Route>

--- a/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
@@ -9,7 +9,9 @@ import {
 	TldrawUiMenuContextProvider,
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
+	deleteFromLocalStorage,
 } from 'tldraw'
+import { tlaProbablyLoggedInFlag } from '../../../routes'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { getSnapshotsFromDroppedTldrawFiles } from '../../hooks/useTldrFileDrop'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
@@ -58,6 +60,7 @@ function SignOutMenuItem({ source }: { source: TLAppUiEventSource }) {
 	const label = useMsg(messages.signOut)
 
 	const handleSignout = useCallback(() => {
+		deleteFromLocalStorage(tlaProbablyLoggedInFlag)
 		auth.signOut().then(clearLocalSessionState)
 		trackEvent('sign-out-clicked', { source })
 	}, [auth, trackEvent, source])

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -10,11 +10,14 @@ import {
 	TldrawUiContextProvider,
 	TldrawUiDialogs,
 	TldrawUiToasts,
+	deleteFromLocalStorage,
 	fetch,
+	setInLocalStorage,
 	useToasts,
 	useValue,
 } from 'tldraw'
 import { routes } from '../../routeDefs'
+import { tlaProbablyLoggedInFlag } from '../../routes'
 import { globalEditor } from '../../utils/globalEditor'
 import { SignedInPosthog, SignedOutPosthog } from '../../utils/posthog'
 import { MaybeForceUserRefresh } from '../components/MaybeForceUserRefresh/MaybeForceUserRefresh'
@@ -146,6 +149,15 @@ function SignedInProvider({
 		() => globalEditor.get()?.user.getUserPreferences().locale ?? 'en',
 		[]
 	)
+
+	useEffect(() => {
+		if (!auth.isLoaded) return
+		if (auth.isSignedIn) {
+			setInLocalStorage(tlaProbablyLoggedInFlag, 'true')
+		} else {
+			deleteFromLocalStorage(tlaProbablyLoggedInFlag)
+		}
+	}, [auth.isSignedIn, auth.isLoaded])
 
 	useEffect(() => {
 		if (locale === currentLocale) return


### PR DESCRIPTION
I was finding the _session cookie was not a reliable way to detect signed-in state, so have switched to localStorage. It's not perfect either, but should be a lot more accurate.

### Change type

- [x] `other`
