### PR TITLE
Fix the blue text color on mobile

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -291,6 +291,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	color: var(--tla-color-text-1);
 }
 
 .main-link {


### PR DESCRIPTION
Looks like it was applying some device specific styles in this case.

![CleanShot 2025-01-22 at 16 25 43@2x](https://github.com/user-attachments/assets/754d12d6-555d-44b3-809c-5d9f1b03ab8d)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
