### PR TITLE
Fix an issue with legacy assets not getting their urls changed when they get slurped.

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -614,7 +614,10 @@ export class TLDrawDurableObject extends DurableObject {
 				})
 				asset.props.src = asset.props.src.replace(objectName, newObjectName)
 				if (asset.props.src.includes(this.env.ASSET_UPLOAD_ORIGIN)) {
-					asset.props.src.replace(this.env.ASSET_UPLOAD_ORIGIN, this.env.MULTIPLAYER_SERVER)
+					asset.props.src.replace(
+						this.env.ASSET_UPLOAD_ORIGIN,
+						`${this.env.MULTIPLAYER_SERVER}/api/app`
+					)
 				}
 
 				asset.meta.fileId = slug

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -613,6 +613,10 @@ export class TLDrawDurableObject extends DurableObject {
 					httpMetadata: currentAsset.httpMetadata,
 				})
 				asset.props.src = asset.props.src.replace(objectName, newObjectName)
+				if (asset.props.src.includes(this.env.ASSET_UPLOAD_ORIGIN)) {
+					asset.props.src.replace(this.env.ASSET_UPLOAD_ORIGIN, this.env.MULTIPLAYER_SERVER)
+				}
+
 				asset.meta.fileId = slug
 				store.put(asset)
 				assetsToUpdate.push({ objectName: newObjectName, fileId: slug })

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -54,6 +54,7 @@ export interface Environment {
 	IS_LOCAL: string | undefined
 	WORKER_NAME: string | undefined
 	ASSET_UPLOAD_ORIGIN: string | undefined
+	MULTIPLAYER_SERVER: string | undefined
 
 	RATE_LIMITER: RateLimit
 }

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -239,6 +239,7 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 			CLERK_PUBLISHABLE_KEY: env.VITE_CLERK_PUBLISHABLE_KEY,
 			BOTCOM_POSTGRES_CONNECTION_STRING,
 			BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
+			MULTIPLAYER_SERVER: env.MULTIPLAYER_SERVER,
 		},
 		sentry: {
 			project: 'tldraw-sync',


### PR DESCRIPTION
Looks like this change was lost (might have forgot to push it).

### Change type

- [x] `bugfix`
