### PR TITLE
edit menu: don't disable if not in select tool

### DIFF
--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
@@ -1,4 +1,3 @@
-import { useEditor, useValue } from '@tldraw/editor'
 import { useCanRedo, useCanUndo } from '../../hooks/menu-hooks'
 import { ColorSchemeMenu } from '../ColorSchemeMenu'
 import { KeyboardShortcutsMenuItem } from '../HelpMenu/DefaultHelpMenuContent'
@@ -69,16 +68,8 @@ export function ExportFileContentSubMenu() {
 
 /** @public @react */
 export function EditSubmenu() {
-	const editor = useEditor()
-
-	const selectToolActive = useValue(
-		'isSelectToolActive',
-		() => editor.getCurrentToolId() === 'select',
-		[editor]
-	)
-
 	return (
-		<TldrawUiMenuSubmenu id="edit" label="menu.edit" disabled={!selectToolActive}>
+		<TldrawUiMenuSubmenu id="edit" label="menu.edit">
 			<UndoRedoGroup />
 			<ClipboardMenuGroup />
 			<ConversionsMenuGroup />


### PR DESCRIPTION
We noticed that the Edit menu is disabled when not in the Select tool. So, you can't undo, select all, unlock, etc. We should let this submenu still be accessible.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes

- Edit menu: fix accessing edit menu when not in the Select tool