### PR TITLE
[botcom] handle existing google users going through the sign-up flow

### DIFF
--- a/apps/dotcom/client/src/components/LoginRedirectPage/LoginRedirectPage.tsx
+++ b/apps/dotcom/client/src/components/LoginRedirectPage/LoginRedirectPage.tsx
@@ -1,21 +1,6 @@
-import { ClerkProvider, useClerk } from '@clerk/clerk-react'
+import { useClerk } from '@clerk/clerk-react'
 
 export default function LoginRedirectPage() {
-	// @ts-ignore this is fine
-	const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
-
-	if (!PUBLISHABLE_KEY) {
-		throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY in .env.local')
-	}
-
-	return (
-		<ClerkProvider publishableKey={PUBLISHABLE_KEY}>
-			<LoginRedirectPageInner />
-		</ClerkProvider>
-	)
-}
-
-function LoginRedirectPageInner() {
 	const clerk = useClerk()
 
 	const signInUrl = clerk.buildSignInUrl({

--- a/apps/dotcom/client/src/main.tsx
+++ b/apps/dotcom/client/src/main.tsx
@@ -1,3 +1,4 @@
+import { ClerkProvider } from '@clerk/clerk-react'
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react'
 import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
@@ -5,16 +6,26 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import '../sentry.client.config'
 import '../styles/globals.css'
 import { Head } from './components/Head/Head'
+import { routes } from './routeDefs'
 import { router } from './routes'
 
 const browserRouter = createBrowserRouter(router)
 
+// @ts-ignore this is fine
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+if (!PUBLISHABLE_KEY) {
+	throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY in .env.local')
+}
+
 createRoot(document.getElementById('root')!).render(
-	<HelmetProvider>
-		<Head />
-		<RouterProvider router={browserRouter} />
-		<VercelAnalytics debug={false} />
-	</HelmetProvider>
+	<ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl={routes.tlaRoot()}>
+		<HelmetProvider>
+			<Head />
+			<RouterProvider router={browserRouter} />
+			<VercelAnalytics debug={false} />
+		</HelmetProvider>
+	</ClerkProvider>
 )
 
 try {

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -1,4 +1,4 @@
-import { ClerkProvider, useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
+import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip'
 import { getAssetUrlsByImport } from '@tldraw/assets/imports.vite'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
@@ -16,7 +16,6 @@ import {
 	useToasts,
 	useValue,
 } from 'tldraw'
-import { routes } from '../../routeDefs'
 import { tlaProbablyLoggedInFlag } from '../../routes'
 import { globalEditor } from '../../utils/globalEditor'
 import { SignedInPosthog, SignedOutPosthog } from '../../utils/posthog'
@@ -57,17 +56,15 @@ export function Component() {
 		>
 			<IntlWrapper locale={locale}>
 				<MaybeForceUserRefresh>
-					<ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl={routes.tlaRoot()}>
-						<SignedInProvider onThemeChange={handleThemeChange} onLocaleChange={handleLocaleChange}>
-							{container && (
-								<ContainerProvider container={container}>
-									<InsideOfContainerContext>
-										<Outlet />
-									</InsideOfContainerContext>
-								</ContainerProvider>
-							)}
-						</SignedInProvider>
-					</ClerkProvider>
+					<SignedInProvider onThemeChange={handleThemeChange} onLocaleChange={handleLocaleChange}>
+						{container && (
+							<ContainerProvider container={container}>
+								<InsideOfContainerContext>
+									<Outlet />
+								</InsideOfContainerContext>
+							</ContainerProvider>
+						)}
+					</SignedInProvider>
 				</MaybeForceUserRefresh>
 			</IntlWrapper>
 		</div>


### PR DESCRIPTION
So it turns out that sign-up with google would fail if the user was already signed up. they would be redirected to e.g. https://staging.tldraw.com/#/sso-callback?sign_up_force_redirect_url=https%3A%2F%2Fstaging.tldraw.com%2Fpreview&sign_in_force_redirect_url=https%3A%2F%2Fstaging.tldraw.com%2Fpreview and it wouldn't complete the session initialisation. 

I'm not sure why this happens but I asked clerk about it. In the meantime I've added some edge case logic for this situation and now users should be signed in as expected.

### Change type

- [x] `other`
