### PR TITLE
hard code context id for dialogs

### DIFF
--- a/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
+++ b/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
@@ -74,7 +74,7 @@ export const TldrawUiContextProvider = track(function TldrawUiContextProvider({
 				>
 					<TldrawUiEventsProvider onEvent={onUiEvent}>
 						<TldrawUiToastsProvider>
-							<TldrawUiDialogsProvider context={editor?.contextId}>
+							<TldrawUiDialogsProvider context={'tla'}>
 								<BreakPointProvider forceMobile={forceMobile}>
 									<TldrawUiComponentsProvider overrides={components}>
 										{editor ? (


### PR DESCRIPTION
Quick fix for the pointer capture issue. I can't see the downside to hard-coding the context id here.

Ultimately I feel this contextId stuff should be refactored away, it has been a repeated source of subtle bugs. 

global state im comin for u 🗡️ 

### Change type

- [x] `other`
