### PR TITLE
David/int 677 guests see slurp failure modal

### DIFF
--- a/apps/dotcom/client/src/components/LoginRedirectPage/LoginRedirectPage.tsx
+++ b/apps/dotcom/client/src/components/LoginRedirectPage/LoginRedirectPage.tsx
@@ -1,21 +1,6 @@
-import { ClerkProvider, useClerk } from '@clerk/clerk-react'
+import { useClerk } from '@clerk/clerk-react'
 
 export default function LoginRedirectPage() {
-	// @ts-ignore this is fine
-	const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
-
-	if (!PUBLISHABLE_KEY) {
-		throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY in .env.local')
-	}
-
-	return (
-		<ClerkProvider publishableKey={PUBLISHABLE_KEY}>
-			<LoginRedirectPageInner />
-		</ClerkProvider>
-	)
-}
-
-function LoginRedirectPageInner() {
 	const clerk = useClerk()
 
 	const signInUrl = clerk.buildSignInUrl({

--- a/apps/dotcom/client/src/main.tsx
+++ b/apps/dotcom/client/src/main.tsx
@@ -1,3 +1,4 @@
+import { ClerkProvider } from '@clerk/clerk-react'
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react'
 import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
@@ -5,16 +6,28 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import '../sentry.client.config'
 import '../styles/globals.css'
 import { Head } from './components/Head/Head'
-import { router } from './routes'
+import { routes } from './routeDefs'
+import { SetPreviewFlag, router } from './routes'
 
 const browserRouter = createBrowserRouter(router)
 
+// @ts-ignore this is fine
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+if (!PUBLISHABLE_KEY) {
+	throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY in .env.local')
+}
+
 createRoot(document.getElementById('root')!).render(
-	<HelmetProvider>
-		<Head />
-		<RouterProvider router={browserRouter} />
-		<VercelAnalytics debug={false} />
-	</HelmetProvider>
+	<ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl={routes.tlaRoot()}>
+		<SetPreviewFlag>
+			<HelmetProvider>
+				<Head />
+				<RouterProvider router={browserRouter} />
+				<VercelAnalytics debug={false} />
+			</HelmetProvider>
+		</SetPreviewFlag>
+	</ClerkProvider>
 )
 
 try {

--- a/apps/dotcom/client/src/pages/tla-opt-in.tsx
+++ b/apps/dotcom/client/src/pages/tla-opt-in.tsx
@@ -1,18 +1,8 @@
-import { SignUpButton, useAuth } from '@clerk/clerk-react'
-import { useLocation } from 'react-router-dom'
+import { SignUpButton } from '@clerk/clerk-react'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { F } from '../tla/utils/i18n'
 
 export function Component() {
-	const { isSignedIn, isLoaded } = useAuth()
-	const location = useLocation()
-	if (isSignedIn) {
-		// redirect to home page once the user is signed in
-		window.location.href = window.location.origin
-		return null
-	}
-	if (!isLoaded) return null
-	const url = `${window.location.origin}${location.pathname}`
 	return (
 		<div
 			style={{
@@ -41,13 +31,7 @@ export function Component() {
 				>
 					<F defaultMessage="No thanks" />
 				</TlaButton>
-				<SignUpButton
-					mode="modal"
-					fallbackRedirectUrl={url}
-					forceRedirectUrl={url}
-					signInForceRedirectUrl={url}
-					signInFallbackRedirectUrl={url}
-				>
+				<SignUpButton mode="modal" forceRedirectUrl="/" signInForceRedirectUrl="/">
 					<TlaButton data-testid="tla-opt-in">
 						<F defaultMessage="Sign up" />
 					</TlaButton>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo } from 'react'
+import { createContext, useCallback, useContext, useEffect } from 'react'
 import {
 	LocalIndexedDb,
 	TAB_ID,
@@ -42,19 +42,14 @@ function WelcomeDialog() {
 		dialogs.removeDialog(dialogId)
 	}, [dialogs])
 
-	const abortController = useMemo(() => new AbortController(), [])
 	const remountImageShapes = useContext(RemountImagesContext)
 
-	useEffect(
-		() => () => {
-			abortController.abort()
-		},
-		[abortController]
-	)
 	const app = useApp()
 	const fileId = useCurrentFileId()!
 
 	const onSlurp = useCallback(async () => {
+		const abortController = new AbortController()
+		editor.disposables.add(() => abortController.abort())
 		await new Slurper({
 			abortSignal: abortController.signal,
 			addDialog: dialogs.addDialog,
@@ -65,15 +60,7 @@ function WelcomeDialog() {
 			slurpPersistenceKey: getScratchPersistenceKey(),
 		}).slurp()
 		onDismiss()
-	}, [
-		abortController.signal,
-		app,
-		dialogs.addDialog,
-		editor,
-		fileId,
-		onDismiss,
-		remountImageShapes,
-	])
+	}, [app, dialogs.addDialog, editor, fileId, onDismiss, remountImageShapes])
 
 	if (data.loading) return null
 	const file = app.getFile(fileId)

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -1,4 +1,4 @@
-import { ClerkProvider, useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
+import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip'
 import { getAssetUrlsByImport } from '@tldraw/assets/imports.vite'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
@@ -10,14 +10,10 @@ import {
 	EditorContext,
 	TLUiEventHandler,
 	TldrawUiContextProvider,
-	deleteFromLocalStorage,
 	fetch,
-	setInLocalStorage,
 	useToasts,
 	useValue,
 } from 'tldraw'
-import { routes } from '../../routeDefs'
-import { tlaProbablyLoggedInFlag } from '../../routes'
 import { globalEditor } from '../../utils/globalEditor'
 import { SignedInPosthog, SignedOutPosthog } from '../../utils/posthog'
 import { MaybeForceUserRefresh } from '../components/MaybeForceUserRefresh/MaybeForceUserRefresh'
@@ -57,17 +53,15 @@ export function Component() {
 		>
 			<IntlWrapper locale={locale}>
 				<MaybeForceUserRefresh>
-					<ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl={routes.tlaRoot()}>
-						<SignedInProvider onThemeChange={handleThemeChange} onLocaleChange={handleLocaleChange}>
-							{container && (
-								<ContainerProvider container={container}>
-									<InsideOfContainerContext>
-										<Outlet />
-									</InsideOfContainerContext>
-								</ContainerProvider>
-							)}
-						</SignedInProvider>
-					</ClerkProvider>
+					<SignedInProvider onThemeChange={handleThemeChange} onLocaleChange={handleLocaleChange}>
+						{container && (
+							<ContainerProvider container={container}>
+								<InsideOfContainerContext>
+									<Outlet />
+								</InsideOfContainerContext>
+							</ContainerProvider>
+						)}
+					</SignedInProvider>
 				</MaybeForceUserRefresh>
 			</IntlWrapper>
 		</div>
@@ -150,15 +144,6 @@ function SignedInProvider({
 		() => globalEditor.get()?.user.getUserPreferences().locale ?? 'en',
 		[]
 	)
-
-	useEffect(() => {
-		if (!auth.isLoaded) return
-		if (auth.isSignedIn) {
-			setInLocalStorage(tlaProbablyLoggedInFlag, 'true')
-		} else {
-			deleteFromLocalStorage(tlaProbablyLoggedInFlag)
-		}
-	}, [auth.isSignedIn, auth.isLoaded])
 
 	useEffect(() => {
 		if (locale === currentLocale) return

--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -74,6 +74,7 @@ interface SlurperOpts {
 
 export async function maybeSlurp(opts: SlurperOpts) {
 	if (opts.abortSignal.aborted) return
+	if (!opts.app.isFileOwner(opts.fileId)) return
 	let persistenceKey = null as string | null
 	if (opts.app._slurpFileId === opts.fileId) {
 		// we just landed on this file after signing in on the root page


### PR DESCRIPTION
- fix slurping images from /preview sign in. (it used an abortController bound to the lifecycle of the dialog, but it should have been bound to the lifecycle of the editor)
- prevent guest users trying to slurp files they don't own
- (unrelated) i made the route switching more robust. I saw a few times in staging that it would get out of sync with my logged in status somehow. so now we just force a refresh if the auth status changes and it doesn't match the preview flag.

### Change type

- [x] `other`
