### PR TITLE
Fix line wobble issue

### DIFF
--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -80,8 +80,8 @@ export const Shape = memo(function Shape({
 			}
 
 			// Width / Height
-			const width = Math.max(Math.ceil(bounds.width), 1)
-			const height = Math.max(Math.ceil(bounds.height), 1)
+			const width = Math.max(bounds.width, 1)
+			const height = Math.max(bounds.height, 1)
 
 			if (width !== prev.width || height !== prev.height) {
 				setStyleProperty(containerRef.current, 'width', width + 'px')

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -80,8 +80,8 @@ export const Shape = memo(function Shape({
 			}
 
 			// Width / Height
-			const width = Math.max(bounds.width, 1)
-			const height = Math.max(bounds.height, 1)
+			const width = Math.max(Math.ceil(bounds.width), 1)
+			const height = Math.max(Math.ceil(bounds.height), 1)
 
 			if (width !== prev.width || height !== prev.height) {
 				setStyleProperty(containerRef.current, 'width', width + 'px')

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -163,7 +163,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 
 	component(shape: TLLineShape) {
 		return (
-			<SVGContainer>
+			<SVGContainer style={{ minWidth: 50, minHeight: 50 }}>
 				<LineShapeSvg shape={shape} />
 			</SVGContainer>
 		)


### PR DESCRIPTION
This fixes an issue where line shapes would wobble if you dragged points in a way that changes the shape's overall size after moving the first point away from the shape's origin point.

![2025-01-24 09 51 21](https://github.com/user-attachments/assets/1509bc85-3e8e-41ad-98c5-2d8e4391b865)

This re-introduces part of this fix from #1915 