### PR TITLE
Add Frame colors

### DIFF
--- a/apps/examples/src/examples/frame-colors/FrameColorsExample.tsx
+++ b/apps/examples/src/examples/frame-colors/FrameColorsExample.tsx
@@ -1,0 +1,12 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+export default function FrameColorsExample() {
+	return (
+		<>
+			<div className="tldraw__editor">
+				<Tldraw persistenceKey="example" options={{ showFrameColors: true }}></Tldraw>
+			</div>
+		</>
+	)
+}

--- a/apps/examples/src/examples/frame-colors/README.md
+++ b/apps/examples/src/examples/frame-colors/README.md
@@ -1,0 +1,14 @@
+---
+title: Frame colors
+component: ./FrameColorsExample.tsx
+category: editor-api
+keywords:
+  - frame
+  - color
+---
+
+Create a frame (keyboard shortcut **F**) and see how it looks with the `showFrameColors` option enabled.
+
+---
+
+Use the `editor.showFrameColors" editor option to display colored fills and headings on frame shapes.

--- a/apps/examples/src/examples/ui-events/README.md
+++ b/apps/examples/src/examples/ui-events/README.md
@@ -2,7 +2,6 @@
 title: UI events
 component: ./UiEventsExample.tsx
 category: editor-api
-priority: 0
 keywords: [ui, events, api, x-ray]
 ---
 

--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -746,6 +746,7 @@ export const defaultTldrawOptions: {
     readonly maxPointsPerDrawShape: 500;
     readonly maxShapesPerPage: 4000;
     readonly multiClickDurationMs: 200;
+    readonly showFrameColors: false;
     readonly temporaryAssetPreviewLifetimeMs: 180000;
     readonly textShadowLod: 0.35;
 };
@@ -3133,6 +3134,7 @@ export interface TldrawOptions {
     readonly maxShapesPerPage: number;
     // (undocumented)
     readonly multiClickDurationMs: number;
+    readonly showFrameColors: boolean;
     readonly temporaryAssetPreviewLifetimeMs: number;
     // (undocumented)
     readonly textShadowLod: number;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1292,13 +1292,18 @@ input,
 }
 
 .tl-frame-heading {
+	--fpx: 6px;
+	--fh: 24px;
+	--fmw: 32px;
+	--fho: -8px;
+	--fow: 16px;
 	display: flex;
 	align-items: center;
 	position: absolute;
 	transform-origin: 0% 100%;
 	overflow: hidden;
 	max-width: 100%;
-	min-width: 32px;
+	min-width: var(--fmw);
 	height: auto;
 	font-size: 12px;
 	padding-bottom: 4px;
@@ -1310,18 +1315,17 @@ input,
 	/* scale from bottom left corner so we can pin it to the top left corner of the frame */
 	transform-origin: 0% 100%;
 	display: flex;
-	height: 100%;
+	height: var(--fh);
 	width: 100%;
 	align-items: center;
 	border-radius: var(--radius-1);
-	background-color: var(--color-background);
 }
 
 .tl-frame-label {
 	pointer-events: all;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	padding: var(--space-3) var(--space-3);
+	padding: 0px var(--fpx);
 	position: relative;
 	font-size: inherit;
 	white-space: pre;
@@ -1332,6 +1336,8 @@ input,
 	color: transparent;
 	white-space: pre;
 	width: auto;
+	min-width: var(--fmw);
+	height: 100%;
 	overflow: visible;
 	background-color: var(--color-panel);
 	border-radius: var(--radius-1);
@@ -1343,7 +1349,7 @@ input,
 	border: none;
 	background: none;
 	outline: none;
-	padding: var(--space-3) var(--space-3);
+	padding: 0px var(--fpx);
 	inset: 0px;
 	height: 100%;
 	width: 100%;

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -66,6 +66,10 @@ export interface TldrawOptions {
 	 * external context providers. By default, this is `React.Fragment`.
 	 */
 	readonly exportProvider: ComponentType<{ children: React.ReactNode }>
+	/**
+	 * When frame colors are enabled, frames will be drawn with a colored border and fill.
+	 */
+	readonly showFrameColors: boolean
 }
 
 /** @public */
@@ -111,4 +115,5 @@ export const defaultTldrawOptions = {
 	actionShortcutsLocation: 'swap',
 	createTextOnCanvasDoubleClick: true,
 	exportProvider: Fragment,
+	showFrameColors: false,
 } as const satisfies TldrawOptions

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -51,7 +51,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	override getDefaultProps(): TLFrameShape['props'] {
-		return { w: 160 * 2, h: 90 * 2, name: '' }
+		return { w: 160 * 2, h: 90 * 2, name: '', color: 'black' }
 	}
 
 	override getGeometry(shape: TLFrameShape): Geometry2d {
@@ -127,6 +127,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const theme = useDefaultColorTheme()
 
+		const color = theme[shape.props.color]
+
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const isCreating = useValue(
 			'is creating this shape',
@@ -142,6 +144,12 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 			[shape.id]
 		)
 
+		const showFrameColors = this.editor.options.showFrameColors
+		const frameFill = showFrameColors ? color.frame.fill : theme.white.solid
+		const frameStroke = showFrameColors ? color.frame.stroke : theme.text
+		const frameHeadingFill = showFrameColors ? color.fill : theme.background
+		const frameHeadingText = showFrameColors ? color.frame.text : theme.text
+
 		return (
 			<>
 				<SVGContainer>
@@ -149,8 +157,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 						className={classNames('tl-frame__body', { 'tl-frame__creating': isCreating })}
 						width={bounds.width}
 						height={bounds.height}
-						fill={theme.solid}
-						stroke={theme.text}
+						fill={frameFill}
+						stroke={frameStroke}
 					/>
 				</SVGContainer>
 				{isCreating ? null : (
@@ -159,6 +167,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 						name={shape.props.name}
 						width={bounds.width}
 						height={bounds.height}
+						fill={frameHeadingFill}
+						color={frameHeadingText}
 					/>
 				)}
 			</>

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -8,11 +8,15 @@ export function FrameHeading({
 	name,
 	width,
 	height,
+	fill,
+	color,
 }: {
 	id: TLShapeId
 	name: string
 	width: number
 	height: number
+	fill: string
+	color: string
 }) {
 	const editor = useEditor()
 	const { side, translation } = useValue(
@@ -54,12 +58,12 @@ export function FrameHeading({
 				overflow: isEditing ? 'visible' : 'hidden',
 				maxWidth: `calc(var(--tl-zoom) * ${
 					side === 0 || side === 2 ? Math.ceil(width) : Math.ceil(height)
-				}px + var(--space-5))`,
+				}px + var(--fow))`,
 				bottom: '100%',
-				transform: `${translation} scale(var(--tl-scale)) translateX(calc(-1 * var(--space-3))`,
+				transform: `${translation} scale(var(--tl-scale)) translateX(var(--fho))`,
 			}}
 		>
-			<div className="tl-frame-heading-hit-area">
+			<div className="tl-frame-heading-hit-area" style={{ color, backgroundColor: fill }}>
 				<FrameLabelInput ref={rInput} id={id} name={name} isEditing={isEditing} />
 			</div>
 		</div>

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
@@ -72,6 +72,8 @@ export const FrameLabelInput = forwardRef<
 				onKeyDown={handleKeyDown}
 				onBlur={handleBlur}
 				onChange={handleChange}
+				onPointerDown={isEditing ? stopEventPropagation : undefined}
+				draggable={false}
 			/>
 			{defaultEmptyAs(name, 'Frame') + String.fromCharCode(8203)}
 		</div>

--- a/packages/tlschema/api-report.md
+++ b/packages/tlschema/api-report.md
@@ -879,6 +879,12 @@ export interface TLDefaultColorThemeColor {
     // (undocumented)
     fill: string;
     // (undocumented)
+    frame: {
+        fill: string;
+        stroke: string;
+        text: string;
+    };
+    // (undocumented)
     highlight: {
         p3: string;
         srgb: string;
@@ -984,6 +990,8 @@ export type TLFrameShape = TLBaseShape<'frame', TLFrameShapeProps>;
 
 // @public (undocumented)
 export interface TLFrameShapeProps {
+    // (undocumented)
+    color: TLDefaultColorStyle;
     // (undocumented)
     h: number;
     // (undocumented)

--- a/packages/tlschema/src/migrations.test.ts
+++ b/packages/tlschema/src/migrations.test.ts
@@ -16,6 +16,7 @@ import { arrowShapeVersions } from './shapes/TLArrowShape'
 import { bookmarkShapeVersions } from './shapes/TLBookmarkShape'
 import { drawShapeVersions } from './shapes/TLDrawShape'
 import { embedShapeVersions } from './shapes/TLEmbedShape'
+import { frameShapeVersions } from './shapes/TLFrameShape'
 import { geoShapeVersions } from './shapes/TLGeoShape'
 import { highlightShapeVersions } from './shapes/TLHighlightShape'
 import { imageShapeVersions } from './shapes/TLImageShape'
@@ -2091,6 +2092,18 @@ describe('TLPresence NullableCameraCursor', () => {
 			chatMessage: '',
 			meta: {},
 		})
+	})
+})
+
+describe('Adding color to frame shapes', () => {
+	const { up, down } = getTestMigration(frameShapeVersions.AddColorProp)
+
+	test('up works as expected', () => {
+		expect(up({ props: {} })).toEqual({ props: { color: 'black' } })
+	})
+
+	test('down works as expected', () => {
+		expect(down({ props: { color: 'black' } })).toEqual({ props: {} })
 	})
 })
 

--- a/packages/tlschema/src/shapes/TLFrameShape.ts
+++ b/packages/tlschema/src/shapes/TLFrameShape.ts
@@ -1,6 +1,7 @@
 import { T } from '@tldraw/validate'
-import { createShapePropsMigrationSequence } from '../records/TLShape'
+import { createShapePropsMigrationIds, createShapePropsMigrationSequence } from '../records/TLShape'
 import { RecordProps } from '../recordsWithProps'
+import { DefaultColorStyle, TLDefaultColorStyle } from '../styles/TLColorStyle'
 import { TLBaseShape } from './TLBaseShape'
 
 /** @public */
@@ -8,6 +9,7 @@ export interface TLFrameShapeProps {
 	w: number
 	h: number
 	name: string
+	color: TLDefaultColorStyle
 }
 
 /** @public */
@@ -18,9 +20,26 @@ export const frameShapeProps: RecordProps<TLFrameShape> = {
 	w: T.nonZeroNumber,
 	h: T.nonZeroNumber,
 	name: T.string,
+	color: DefaultColorStyle,
 }
+
+const Versions = createShapePropsMigrationIds('frame', {
+	AddColorProp: 1,
+})
+
+export { Versions as frameShapeVersions }
 
 /** @public */
 export const frameShapeMigrations = createShapePropsMigrationSequence({
-	sequence: [],
+	sequence: [
+		{
+			id: Versions.AddColorProp,
+			up: (props) => {
+				props.color = 'black'
+			},
+			down: (props) => {
+				delete props.color
+			},
+		},
+	],
 })

--- a/packages/tlschema/src/styles/TLColorStyle.ts
+++ b/packages/tlschema/src/styles/TLColorStyle.ts
@@ -25,6 +25,11 @@ export interface TLDefaultColorThemeColor {
 	semi: string
 	pattern: string
 	fill: string // same as solid
+	frame: {
+		stroke: string
+		fill: string
+		text: string
+	}
 	note: {
 		fill: string
 		text: string
@@ -58,6 +63,11 @@ export const DefaultColorThemePalette: {
 		black: {
 			solid: '#1d1d1d',
 			fill: '#1d1d1d',
+			frame: {
+				stroke: '#1d1d1d',
+				fill: '#e8e8e8',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#FCE19C',
 				text: '#000000',
@@ -72,6 +82,11 @@ export const DefaultColorThemePalette: {
 		blue: {
 			solid: '#4465e9',
 			fill: '#4465e9',
+			frame: {
+				stroke: '#4465e9',
+				fill: '#dce1f8',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#8AA3FF',
 				text: '#000000',
@@ -86,6 +101,11 @@ export const DefaultColorThemePalette: {
 		green: {
 			solid: '#099268',
 			fill: '#099268',
+			frame: {
+				stroke: '#099268',
+				fill: '#6FC896',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#6FC896',
 				text: '#000000',
@@ -100,6 +120,11 @@ export const DefaultColorThemePalette: {
 		grey: {
 			solid: '#9fa8b2',
 			fill: '#9fa8b2',
+			frame: {
+				stroke: '#9fa8b2',
+				fill: '#eceef0',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#C0CAD3',
 				text: '#000000',
@@ -114,6 +139,11 @@ export const DefaultColorThemePalette: {
 		'light-blue': {
 			solid: '#4ba1f1',
 			fill: '#4ba1f1',
+			frame: {
+				stroke: '#4ba1f1',
+				fill: '#ddedfa',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#9BC4FD',
 				text: '#000000',
@@ -128,6 +158,11 @@ export const DefaultColorThemePalette: {
 		'light-green': {
 			solid: '#4cb05e',
 			fill: '#4cb05e',
+			frame: {
+				stroke: '#4cb05e',
+				fill: '#dbf0e0',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#98D08A',
 				text: '#000000',
@@ -142,6 +177,11 @@ export const DefaultColorThemePalette: {
 		'light-red': {
 			solid: '#f87777',
 			fill: '#f87777',
+			frame: {
+				stroke: '#f87777',
+				fill: '#f4dadb',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#F7A5A1',
 				text: '#000000',
@@ -156,6 +196,11 @@ export const DefaultColorThemePalette: {
 		'light-violet': {
 			solid: '#e085f4',
 			fill: '#e085f4',
+			frame: {
+				stroke: '#e085f4',
+				fill: '#f5eafa',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#DFB0F9',
 				text: '#000000',
@@ -170,6 +215,11 @@ export const DefaultColorThemePalette: {
 		orange: {
 			solid: '#e16919',
 			fill: '#e16919',
+			frame: {
+				stroke: '#e16919',
+				fill: '#f8e2d4',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#FAA475',
 				text: '#000000',
@@ -184,6 +234,11 @@ export const DefaultColorThemePalette: {
 		red: {
 			solid: '#e03131',
 			fill: '#e03131',
+			frame: {
+				stroke: '#e03131',
+				fill: '#f4dadb',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#FC8282',
 				text: '#000000',
@@ -198,6 +253,11 @@ export const DefaultColorThemePalette: {
 		violet: {
 			solid: '#ae3ec9',
 			fill: '#ae3ec9',
+			frame: {
+				stroke: '#ae3ec9',
+				fill: '#ecdcf2',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#DB91FD',
 				text: '#000000',
@@ -212,6 +272,11 @@ export const DefaultColorThemePalette: {
 		yellow: {
 			solid: '#f1ac4b',
 			fill: '#f1ac4b',
+			frame: {
+				stroke: '#f1ac4b',
+				fill: '#f9f0e6',
+				text: '#ffffff',
+			},
 			note: {
 				fill: '#FED49A',
 				text: '#000000',
@@ -228,6 +293,11 @@ export const DefaultColorThemePalette: {
 			fill: '#FFFFFF',
 			semi: '#f5f5f5',
 			pattern: '#f9f9f9',
+			frame: {
+				stroke: '#7d7d7d',
+				fill: '#ffffff',
+				text: '#000000',
+			},
 			note: {
 				fill: '#FFFFFF',
 				text: '#000000',
@@ -247,6 +317,11 @@ export const DefaultColorThemePalette: {
 		black: {
 			solid: '#f2f2f2',
 			fill: '#f2f2f2',
+			frame: {
+				stroke: '#f2f2f2',
+				fill: '#2c3036',
+				text: '#000000',
+			},
 			note: {
 				fill: '#2c2c2c',
 				text: '#f2f2f2',
@@ -261,6 +336,11 @@ export const DefaultColorThemePalette: {
 		blue: {
 			solid: '#4f72fc', // 3c60f0
 			fill: '#4f72fc',
+			frame: {
+				stroke: '#4f72fc',
+				fill: '#262d40',
+				text: '#000000',
+			},
 			note: {
 				fill: '#2A3F98',
 				text: '#f2f2f2',
@@ -275,6 +355,11 @@ export const DefaultColorThemePalette: {
 		green: {
 			solid: '#099268',
 			fill: '#099268',
+			frame: {
+				stroke: '#099268',
+				fill: '#253231',
+				text: '#000000',
+			},
 			note: {
 				fill: '#014429',
 				text: '#f2f2f2',
@@ -289,6 +374,11 @@ export const DefaultColorThemePalette: {
 		grey: {
 			solid: '#9398b0',
 			fill: '#9398b0',
+			frame: {
+				stroke: '#9398b0',
+				fill: '#33373c',
+				text: '#000000',
+			},
 			note: {
 				fill: '#56595F',
 				text: '#f2f2f2',
@@ -303,6 +393,11 @@ export const DefaultColorThemePalette: {
 		'light-blue': {
 			solid: '#4dabf7',
 			fill: '#4dabf7',
+			frame: {
+				stroke: '#4dabf7',
+				fill: '#2a3642',
+				text: '#000000',
+			},
 			note: {
 				fill: '#1F5495',
 				text: '#f2f2f2',
@@ -317,6 +412,11 @@ export const DefaultColorThemePalette: {
 		'light-green': {
 			solid: '#40c057',
 			fill: '#40c057',
+			frame: {
+				stroke: '#40c057',
+				fill: '#2a3830',
+				text: '#000000',
+			},
 			note: {
 				fill: '#21581D',
 				text: '#f2f2f2',
@@ -331,6 +431,11 @@ export const DefaultColorThemePalette: {
 		'light-red': {
 			solid: '#ff8787',
 			fill: '#ff8787',
+			frame: {
+				stroke: '#ff8787',
+				fill: '#3b3235',
+				text: '#000000',
+			},
 			note: {
 				fill: '#923632',
 				text: '#f2f2f2',
@@ -345,6 +450,11 @@ export const DefaultColorThemePalette: {
 		'light-violet': {
 			solid: '#e599f7',
 			fill: '#e599f7',
+			frame: {
+				stroke: '#e599f7',
+				fill: '#383442',
+				text: '#000000',
+			},
 			note: {
 				fill: '#762F8E',
 				text: '#f2f2f2',
@@ -359,6 +469,11 @@ export const DefaultColorThemePalette: {
 		orange: {
 			solid: '#f76707',
 			fill: '#f76707',
+			frame: {
+				stroke: '#f76707',
+				fill: '#3a2e2a',
+				text: '#000000',
+			},
 			note: {
 				fill: '#843906',
 				text: '#f2f2f2',
@@ -373,6 +488,11 @@ export const DefaultColorThemePalette: {
 		red: {
 			solid: '#e03131',
 			fill: '#e03131',
+			frame: {
+				stroke: '#e03131',
+				fill: '#36292b',
+				text: '#000000',
+			},
 			note: {
 				fill: '#89231A',
 				text: '#f2f2f2',
@@ -387,6 +507,11 @@ export const DefaultColorThemePalette: {
 		violet: {
 			solid: '#ae3ec9',
 			fill: '#ae3ec9',
+			frame: {
+				stroke: '#ae3ec9',
+				fill: '#31293c',
+				text: '#000000',
+			},
 			note: {
 				fill: '#681683',
 				text: '#f2f2f2',
@@ -401,6 +526,11 @@ export const DefaultColorThemePalette: {
 		yellow: {
 			solid: '#ffc034',
 			fill: '#ffc034',
+			frame: {
+				stroke: '#ffc034',
+				fill: '#3c3934',
+				text: '#000000',
+			},
 			note: {
 				fill: '#98571B',
 				text: '#f2f2f2',
@@ -417,6 +547,11 @@ export const DefaultColorThemePalette: {
 			fill: '#f3f3f3',
 			semi: '#f5f5f5',
 			pattern: '#f9f9f9',
+			frame: {
+				stroke: '#2c2c2c',
+				fill: '#030303',
+				text: '#000000',
+			},
 			note: {
 				fill: '#eaeaea',
 				text: '#1d1d1d',


### PR DESCRIPTION
This PR adds an editor option to enable frame colors.

When enabled:

<img width="1090" alt="Screenshot 2025-01-25 at 11 35 20" src="https://github.com/user-attachments/assets/227b5df3-85bf-45b9-ba75-3a68956c74fe" />
<img width="972" alt="image" src="https://github.com/user-attachments/assets/6ea56f62-6b15-4a3a-b560-c699c0c50290" />

This PR also:

- fixes a bug with the minimum size of frame headings
- tightens up the size of frame headings

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Visit the Frame colors example.
2. Create frames

### Release notes

- Added `editor.options.showFrameColors` option to display colors for frames.