### PR TITLE
Tooltip tweaks

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -1,7 +1,7 @@
 import { TlaFile, TlaFileOpenState } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
-import { KeyboardEvent, useEffect, useRef, useState } from 'react'
-import { Link, useLocation, useParams } from 'react-router-dom'
+import { KeyboardEvent, MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { preventDefault, useContainer, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
@@ -160,36 +160,45 @@ export function TlaSidebarFileLinkInner({
 				>
 					{fileName}
 				</div>
-				{!isOwnFile && <GuestBadge file={file} />}
+				{!isOwnFile && <GuestBadge file={file} href={href} />}
 			</div>
 			<TlaSidebarFileLinkMenu fileId={fileId} onRenameAction={handleRenameAction} />
 		</div>
 	)
 }
 
-function GuestBadge({ file }: { file: TlaFile }) {
+function GuestBadge({ file, href }: { file: TlaFile; href: string }) {
 	const container = useContainer()
 	const ownerName = file.ownerName.trim()
+	const navigate = useNavigate()
+
+	const handleToolTipClick = useCallback(
+		(e: MouseEvent) => {
+			e.preventDefault()
+			// the tool tip needs pointer events in order to accept the click...
+			// but that means it also blocks the link to the file. Here we bend
+			// the world to our will, ruling by desire: clicking the tooltip will
+			// navigate to the file
+			navigate(href)
+		},
+		[navigate, href]
+	)
+
 	return (
 		<div className={styles.guestBadge}>
-			<TlaTooltipRoot>
+			<TlaTooltipRoot disableHoverableContent>
 				<TlaTooltipTrigger
 					dir="ltr"
 					// this is needed to prevent the tooltip from closing when clicking the badge
-					onClick={(e) => {
-						e.preventDefault()
-					}}
+					onClick={handleToolTipClick}
 					className={styles.guestBadgeTrigger}
 				>
 					<TlaIcon icon="group" />
 				</TlaTooltipTrigger>
 				<TlaTooltipPortal container={container}>
 					<TlaTooltipContent
-						style={{ zIndex: 200 }}
 						// this is also needed to prevent the tooltip from closing when clicking the badge
-						onPointerDownOutside={(event) => {
-							event.preventDefault()
-						}}
+						onPointerDownOutside={preventDefault}
 					>
 						{ownerName ? (
 							<F defaultMessage={`Shared by {ownerName}`} values={{ ownerName }} />

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -458,7 +458,7 @@
 
 .guestBadge {
 	display: inline-flex;
-	pointer-events: all;
+	pointer-events: none;
 	flex: 0 0 auto;
 }
 
@@ -476,6 +476,8 @@
 	z-index: 3;
 	padding: 0;
 	background: none;
+	pointer-events: all;
+	cursor: pointer;
 	color: var(--tla-color-text-1);
 }
 

--- a/apps/dotcom/client/src/tla/components/TlaTooltip/TlaTooltip.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaTooltip/TlaTooltip.tsx
@@ -8,14 +8,18 @@ import style from './tooltip.module.css'
 export const TlaTooltipRoot: typeof Tooltip.Root = (props) => (
 	<Tooltip.Root delayDuration={150} {...props} />
 )
+
 export const TlaTooltipTrigger = Tooltip.Trigger
+
 export const TlaTooltipArrow: typeof Tooltip.Arrow = React.forwardRef((props, ref) => (
 	<Tooltip.Arrow {...props} className={classNames(style.tooltipArrow, props.className)} ref={ref} />
 ))
+
 export const TlaTooltipContent: typeof Tooltip.Content = React.forwardRef((props, ref) => (
 	<Tooltip.Content
 		avoidCollisions
 		collisionPadding={8}
+		sideOffset={4}
 		dir="ltr"
 		{...props}
 		className={classNames('tlui-menu', style.tooltip)}

--- a/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
@@ -1,17 +1,19 @@
 .tooltip {
 	font-size: 12px;
-	padding: 6px 12px;
-	border-radius: 8px;
+	padding: 2px 8px;
+	border-radius: 4px;
 	background-color: var(--tla-color-tooltip);
 	box-shadow: none;
 	color: var(--color-text-shadow);
 	animation-name: fade-in;
 	animation-duration: 0.1s;
+	z-index: 200;
 }
 
 .tooltipArrow {
 	fill: var(--tla-color-tooltip);
 }
+
 @keyframes fade-in {
 	from {
 		opacity: 0;

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -31,7 +31,7 @@
 
 .tla-theme__light {
 	--tla-color-sidebar: hsl(0, 0%, 99%);
-	--tla-color-tooltip: hsla(200, 14%, 4%, 0.838);
+	--tla-color-tooltip: hsla(200, 14%, 4%, 1);
 	--tla-color-canvas: hsl(210, 20%, 98%);
 	--tla-color-panel: hsl(0, 0%, 100%);
 	--tla-color-text-1: hsl(204, 8%, 5%);


### PR DESCRIPTION
This PR makes a few minor tweaks to the botcom tooltip:
- tightens up spacing
- sets background opacity to 100%
- allows the user to click the tooltip to view the file (previously clicking the tooltip had no effect0

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
