### PR TITLE
Move account menu side to end

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
@@ -38,6 +38,7 @@ export function TlaAccountMenu({
 				<TldrawUiDropdownMenuContent
 					className="tla-account-menu"
 					side="bottom"
+					align="end"
 					alignOffset={0}
 					sideOffset={4}
 				>


### PR DESCRIPTION
I'm ok with the menu being a full width trigger, though the menu itself should be end-aligned.

<img width="617" alt="Screenshot 2025-01-26 at 4 36 56 PM" src="https://github.com/user-attachments/assets/78a40826-1e00-4441-9548-9c980b07bbee" />

Eventually we should have a profile page link with full settings etc, rather than just this menu. In that case, I'd like to restore the previous placement of the menu at right.

<img width="660" alt="Screenshot 2025-01-26 at 4 38 08 PM" src="https://github.com/user-attachments/assets/7cf4de8d-ad03-45f6-84c4-c3d27a0f9eb6" />

But in the absence of that, I agree that having the full width trigger makes more sense.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
