### PR TITLE
Revert "Fix for resizing snapshot bug (#5211)"

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -56,14 +56,7 @@ export class Resizing extends StateNode {
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		this.creationCursorOffset = creationCursorOffset
 
-		try {
-			// On rare and mysterious occasions, the user can enter the resizing state with no shapes selected
-			this.snapshot = this._createSnapshot()
-		} catch (e) {
-			console.error(e)
-			this.cancel()
-			return
-		}
+		this.snapshot = this._createSnapshot()
 
 		this.markId = ''
 
@@ -449,8 +442,6 @@ export class Resizing extends StateNode {
 		} = this.editor
 
 		const selectionBounds = this.editor.getSelectionRotatedPageBounds()!
-
-		if (!selectionBounds) throw Error('Resizing but nothing is selected')
 
 		const dragHandlePoint = Vec.RotWith(
 			selectionBounds.getHandlePoint(this.info.handle!),


### PR DESCRIPTION
This reverts commit 4e8dbf183d7ccf788c36de38abc982dec0870a6a.

@steveruizok you mighta missed my comment on your PR:
> I was gonna approve but actually, before you land, I'd like to leave this PR open so that I can better test this Sentry improvements: https://github.com/tldraw/tldraw/pull/5221
> I was looking at the events, and I think it's when people are "fighting" over a shape but it's a guess that I'd like to confirm with more context.

So, before we suppress this error, I want to see if I can find out more with the extra context/tooling that was recently added.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
