### PR TITLE
Fix an error when embed util is not present.

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -1354,6 +1354,11 @@ export class Editor extends EventEmitter<TLEventMap> {
     hasAncestor(shape: TLShape | TLShapeId | undefined, ancestorId: TLShapeId): boolean;
     // (undocumented)
     hasExternalAssetHandler(type: TLExternalAssetContent['type']): boolean;
+    hasShapeUtil<S extends TLUnknownShape>(shape: S | TLShapePartial<S>): boolean;
+    // (undocumented)
+    hasShapeUtil<S extends TLUnknownShape>(type: S['type']): boolean;
+    // (undocumented)
+    hasShapeUtil<T extends ShapeUtil>(type: T extends ShapeUtil<infer R> ? R['type'] : string): boolean;
     protected readonly history: HistoryManager<TLRecord>;
     inputs: {
         buttons: Set<number>;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -929,6 +929,21 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return shapeUtil
 	}
 
+	/**
+	 * Returns true if the editor has a shape util for the given shape / shape type.
+	 *
+	 * @param shape - A shape, shape partial, or shape type.
+	 */
+	hasShapeUtil<S extends TLUnknownShape>(shape: S | TLShapePartial<S>): boolean
+	hasShapeUtil<S extends TLUnknownShape>(type: S['type']): boolean
+	hasShapeUtil<T extends ShapeUtil>(
+		type: T extends ShapeUtil<infer R> ? R['type'] : string
+	): boolean
+	hasShapeUtil(arg: string | { type: string }): boolean {
+		const type = typeof arg === 'string' ? arg : arg.type
+		return hasOwnProperty(this.shapeUtils, type)
+	}
+
 	/* ------------------- Binding Utils ------------------ */
 	/**
 	 * A map of shape utility classes (TLShapeUtils) by shape type.

--- a/packages/tldraw/src/lib/ui/hooks/useGetEmbedDefinition.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useGetEmbedDefinition.ts
@@ -4,7 +4,10 @@ import { EmbedShapeUtil } from '../../shapes/embed/EmbedShapeUtil'
 /** @internal */
 export function useGetEmbedShapeUtil() {
 	const editor = useEditor()
-	return editor.getShapeUtil('embed') as EmbedShapeUtil | undefined
+	if (editor.hasShapeUtil('embed')) {
+		return editor.getShapeUtil('embed') as EmbedShapeUtil
+	}
+	return undefined
 }
 
 /** @public */


### PR DESCRIPTION
Looks like we didn't gracefully handle the cases where the embed util is not present.

### Change type

- [x] `bugfix`

### Release notes

- Fix an issue with embeds logic not gracefully handling cases when we don't have an embed util.

### API changes
Adds `editor.hasShapeUtil` that returns  whether a shape util for a specific shape type is registered with the editor.