### PR TITLE
Use the uncropped width when requesting an image shape asset

### DIFF
--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -1280,7 +1280,7 @@ export function getOccludedChildren(editor: Editor, parent: TLShape): TLShapeId[
 export function getUncroppedSize(shapeSize: {
     h: number;
     w: number;
-}, crop: TLShapeCrop): {
+}, crop: null | TLShapeCrop): {
     h: number;
     w: number;
 };

--- a/packages/tldraw/api-report.md
+++ b/packages/tldraw/api-report.md
@@ -106,6 +106,7 @@ import { TLScribbleProps } from '@tldraw/editor';
 import { TLSelectionBackgroundProps } from '@tldraw/editor';
 import { TLSelectionForegroundProps } from '@tldraw/editor';
 import { TLShape } from '@tldraw/editor';
+import { TLShapeCrop } from '@tldraw/editor';
 import { TLShapeId } from '@tldraw/editor';
 import { TLShapePartial } from '@tldraw/editor';
 import { TLShapeUtilCanBindOpts } from '@tldraw/editor';
@@ -1274,6 +1275,15 @@ export function getEmbedInfo(definitions: readonly TLEmbedDefinition[], inputUrl
 
 // @public (undocumented)
 export function getOccludedChildren(editor: Editor, parent: TLShape): TLShapeId[];
+
+// @public
+export function getUncroppedSize(shapeSize: {
+    h: number;
+    w: number;
+}, crop: TLShapeCrop): {
+    h: number;
+    w: number;
+};
 
 // @public (undocumented)
 export function GroupMenuItem(): JSX_2.Element | null;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -75,7 +75,12 @@ export { LineShapeUtil } from './lib/shapes/line/LineShapeUtil'
 export { NoteShapeTool } from './lib/shapes/note/NoteShapeTool'
 export { NoteShapeUtil } from './lib/shapes/note/NoteShapeUtil'
 export { TextLabel, type TextLabelProps } from './lib/shapes/shared/TextLabel'
-export { getCropBox, getDefaultCrop, type CropBoxOptions } from './lib/shapes/shared/crop'
+export {
+	getCropBox,
+	getDefaultCrop,
+	getUncroppedSize,
+	type CropBoxOptions,
+} from './lib/shapes/shared/crop'
 export {
 	ARROW_LABEL_FONT_SIZES,
 	FONT_FAMILIES,

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -120,7 +120,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 		if (!asset) return null
 
-		let src = await ctx.resolveAssetUrl(shape.props.assetId, shape.props.w)
+		const { w } = getUncroppedSize(shape.props, shape.props.crop)
+		let src = await ctx.resolveAssetUrl(shape.props.assetId, w)
 		if (!src) return null
 		if (
 			src.startsWith('blob:') ||
@@ -204,10 +205,11 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) {
 	const editor = useEditor()
 
+	const { w } = getUncroppedSize(shape.props, shape.props.crop)
 	const { asset, url } = useImageOrVideoAsset({
 		shapeId: shape.id,
 		assetId: shape.props.assetId,
-		width: shape.props.w,
+		width: w,
 	})
 
 	const prefersReducedMotion = usePrefersReducedMotion()

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -27,6 +27,7 @@ import { memo, useEffect, useState } from 'react'
 
 import { BrokenAssetIcon } from '../shared/BrokenAssetIcon'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
+import { getUncroppedSize } from '../shared/crop'
 import { useImageOrVideoAsset } from '../shared/useImageOrVideoAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
@@ -148,8 +149,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		}
 
 		// The true asset dimensions
-		const w = (1 / (crop.bottomRight.x - crop.topLeft.x)) * shape.props.w
-		const h = (1 / (crop.bottomRight.y - crop.topLeft.y)) * shape.props.h
+		const { w, h } = getUncroppedSize(shape.props, crop)
 
 		const pointDelta = new Vec(crop.topLeft.x * w, crop.topLeft.y * h).rot(shape.rotation)
 
@@ -375,9 +375,7 @@ function getCroppedContainerStyle(shape: TLImageShape) {
 		}
 	}
 
-	const w = (1 / (crop.bottomRight.x - crop.topLeft.x)) * shape.props.w
-	const h = (1 / (crop.bottomRight.y - crop.topLeft.y)) * shape.props.h
-
+	const { w, h } = getUncroppedSize(shape.props, crop)
 	const offsetX = -topLeft.x * w
 	const offsetY = -topLeft.y * h
 	return {

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -31,8 +31,9 @@ export function getDefaultCrop() {
  */
 export function getUncroppedSize(
 	shapeSize: { w: number; h: number },
-	crop: TLShapeCrop
+	crop: TLShapeCrop | null
 ): { w: number; h: number } {
+	if (!crop) return { w: shapeSize.w, h: shapeSize.h }
 	const w = shapeSize.w / (crop.bottomRight.x - crop.topLeft.x)
 	const h = shapeSize.h / (crop.bottomRight.y - crop.topLeft.y)
 	return { w, h }

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -1,4 +1,11 @@
-import { ShapeWithCrop, TLCropInfo, TLShapeId, Vec, structuredClone } from '@tldraw/editor'
+import {
+	ShapeWithCrop,
+	TLCropInfo,
+	TLShapeCrop,
+	TLShapeId,
+	Vec,
+	structuredClone,
+} from '@tldraw/editor'
 
 /** @internal */
 export const MIN_CROP_SIZE = 8
@@ -15,6 +22,20 @@ export function getDefaultCrop() {
 		topLeft: { x: 0, y: 0 },
 		bottomRight: { x: 1, y: 1 },
 	}
+}
+
+/**
+ * Original (uncropped) width and height of shape.
+ *
+ * @public
+ */
+export function getUncroppedSize(
+	shapeSize: { w: number; h: number },
+	crop: TLShapeCrop
+): { w: number; h: number } {
+	const w = shapeSize.w / (crop.bottomRight.x - crop.topLeft.x)
+	const h = shapeSize.h / (crop.bottomRight.y - crop.topLeft.y)
+	return { w, h }
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
@@ -1,4 +1,5 @@
 import { Editor, ShapeWithCrop, TLShapePartial, Vec, structuredClone } from '@tldraw/editor'
+import { getUncroppedSize } from '../../../../../shapes/shared/crop'
 
 export function getTranslateCroppedImageChange(editor: Editor, shape: ShapeWithCrop, delta: Vec) {
 	if (!shape) {
@@ -25,10 +26,7 @@ export function getTranslateCroppedImageChange(editor: Editor, shape: ShapeWithC
 
 	delta.rot(-shape.rotation)
 
-	// original (uncropped) width and height of shape
-	const w = (1 / (oldCrop.bottomRight.x - oldCrop.topLeft.x)) * shape.props.w
-	const h = (1 / (oldCrop.bottomRight.y - oldCrop.topLeft.y)) * shape.props.h
-
+	const { w, h } = getUncroppedSize(shape.props, oldCrop)
 	const yCrop = oldCrop.bottomRight.y - oldCrop.topLeft.y
 	const xCrop = oldCrop.bottomRight.x - oldCrop.topLeft.x
 	const newCrop = structuredClone(oldCrop)


### PR DESCRIPTION
This fixes an issue where the more you cropped an image, the lower scale
the image would be resolved to. However, when cropping the image is
still rendered at the same size, it just shows only a part of the image.
Therefore use the uncropped size when resolving the asset instead, so it
keeps the correct scale.

Fixes #5299

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Have an asset store that scales assets
2. Create an image shape
3. Crop the image
4. Observe that the more you crop the image, the lower scale it gets

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where a cropped image would use lower scaled assets the more it was cropped.