### PR TITLE
Prevent radix dialog warning

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
@@ -62,14 +62,15 @@ function WelcomeDialog() {
 		onDismiss()
 	}, [app, dialogs.addDialog, editor, fileId, onDismiss, remountImageShapes])
 
-	if (data.loading) return null
 	const file = app.getFile(fileId)
 	const isOwner = file && file.ownerId === app.getUser().id
 	const isEmpty = editor.store.allRecords().filter((r) => r.typeName === 'shape').length === 0
-	const offerSlurp = data.ok && data.value && isEmpty && isOwner
+	const offerSlurp = !data.loading && data.ok && data.value && isEmpty && isOwner
 
 	return (
-		<div>
+		// using `visibility: hidden` instead of `return null` when loading
+		// because radix dialog complains if we mount a dialog a title
+		<div style={{ visibility: data.loading ? 'hidden' : 'visible' }}>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle style={{ fontWeight: 700 }}>
 					<F defaultMessage="Welcome to the new tldraw.com!" />

--- a/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/PreviewWelcomeDialog.tsx
@@ -13,7 +13,6 @@ import {
 	useEditor,
 	useValue,
 } from 'tldraw'
-import { usePromise } from '../../../hooks/usePromise'
 import { getScratchPersistenceKey } from '../../../utils/scratch-persistence-key'
 import { useApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
@@ -33,8 +32,7 @@ async function userHasSlurpableDocument() {
 	return numShapes > 0
 }
 
-function WelcomeDialog() {
-	const data = usePromise(userHasSlurpableDocument)
+function WelcomeDialog({ hasSlurpableDocument }: { hasSlurpableDocument: boolean }) {
 	const dialogs = useDialogs()
 	const editor = useEditor()
 
@@ -64,13 +62,14 @@ function WelcomeDialog() {
 
 	const file = app.getFile(fileId)
 	const isOwner = file && file.ownerId === app.getUser().id
-	const isEmpty = editor.store.allRecords().filter((r) => r.typeName === 'shape').length === 0
-	const offerSlurp = !data.loading && data.ok && data.value && isEmpty && isOwner
+	const isCurrentFileEmpty =
+		editor.store.allRecords().filter((r) => r.typeName === 'shape').length === 0
+	const offerSlurp = hasSlurpableDocument && isCurrentFileEmpty && isOwner
 
 	return (
 		// using `visibility: hidden` instead of `return null` when loading
 		// because radix dialog complains if we mount a dialog a title
-		<div style={{ visibility: data.loading ? 'hidden' : 'visible' }}>
+		<div>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle style={{ fontWeight: 700 }}>
 					<F defaultMessage="Welcome to the new tldraw.com!" />
@@ -128,11 +127,13 @@ export function PreviewWelcomeDialog() {
 
 	useEffect(() => {
 		if (shouldShowWelcomeDialog) {
-			dialogs.addDialog({
-				id: dialogId,
-				component: WelcomeDialog,
-				onClose,
-				preventBackgroundClose: true,
+			userHasSlurpableDocument().then((hasSlurpableDocument) => {
+				dialogs.addDialog({
+					id: dialogId,
+					component: () => <WelcomeDialog hasSlurpableDocument={hasSlurpableDocument} />,
+					onClose,
+					preventBackgroundClose: true,
+				})
 			})
 		}
 	}, [dialogs, onClose, shouldShowWelcomeDialog])


### PR DESCRIPTION
Radix complains if we mount a dialog without a title, which we were doing by returning `null` while the data for this dialog loaded. Now we load the async part of the data before creating the dialog and pass it in.

### Change type

- [x] `other`
