### PR TITLE
fix pasting text/plain with keyboard shortcut

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -291,7 +291,7 @@ const handlePasteFromClipboardApi = async ({
 		}
 	}
 
-	if (fallbackFiles && things.length === 1 && things[0].type === 'text') {
+	if (fallbackFiles?.length && things.length === 1 && things[0].type === 'text') {
 		things.pop()
 		things.push(
 			...fallbackFiles.map((f): ClipboardThing => ({ type: 'file', source: Promise.resolve(f) }))


### PR DESCRIPTION
Seems like this was broken a couple of weeks ago.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug with handling native paste events for plain text