### PR TITLE
post release backend error handling

### DIFF
--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -381,6 +381,7 @@ export class UserDataSyncer {
 		// if any mutations have been not been committed for 5 seconds, let's reboot the cache
 		for (const mutation of this.mutations) {
 			if (Date.now() - mutation.timestamp > 5000) {
+				this.log.debug("Mutations haven't been committed for 5 seconds, rebooting")
 				this.reboot()
 				break
 			}

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -123,6 +123,7 @@ export type TLUserDurableObjectEvent =
 				| 'reject_mutation'
 				| 'replication_event'
 				| 'connect_retry'
+				| 'user_do_abort'
 			id: string
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }


### PR DESCRIPTION
we were getting a lot of these errors in sentry https://tldraw.sentry.io/issues/6152025342/?environment=production&environment=production-tldraw-multiplayer&project=4503966963662848&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1
which seemed to mostly the registerUser failing ?

But I couldn't figure out why, so I fixed the error reporting for that method, and added a bunch of debugs to add breadcrumb context on sentry.
 
At the same time, I added a bunch of extra fail-safes to restart things if the user durable objects are failing to connect to the replicator. hopefully that will mitigate whatever is going on. this was causing the durable object's in-memory cache to get stale and make it look like the db writes were failing when in fact they were not.

### Change type

- [x] `other`
