### PR TITLE
Cmd+click on active file opens in new tab

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -145,7 +145,8 @@ export function TlaSidebarFileLinkInner({
 				onKeyDown={handleKeyDown}
 				onClick={(event) => {
 					// Don't navigate if we are already on the file page
-					if (isActive) {
+					// unless the user is holding ctrl or cmd to open in a new tab
+					if (isActive && !(event.ctrlKey || event.metaKey)) {
 						preventDefault(event)
 					}
 					trackEvent('click-file-link', { source: 'sidebar' })


### PR DESCRIPTION
We were blocking this with a preventDefault

### Change type

- [x] `other`