### PR TITLE
fix: consider font style in text measuring

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -230,6 +230,7 @@ export class TextManager {
 		elm.style.setProperty('font-weight', opts.fontWeight)
 		elm.style.setProperty('line-height', `${opts.lineHeight * opts.fontSize}px`)
 		elm.style.setProperty('text-align', textAlignmentsForLtr[opts.textAlign])
+		elm.style.setProperty('font-style', opts.fontStyle)
 
 		const shouldTruncateToFirstLine =
 			opts.overflow === 'truncate-ellipsis' || opts.overflow === 'truncate-clip'


### PR DESCRIPTION
Fixed bug where texts that used non default font style where getting wrong svg conversion. The SVG text calculated didn't take into account the real text dimensions, resulting in weird line breaks and wrong positioning in certain cases

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed a bug with…