### PR TITLE
Clear the dev db if we are missing any applied migrations

### DIFF
--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -1,4 +1,4 @@
-import { exec } from '../../../internal/scripts/lib/exec'
+import { execSync } from 'child_process'
 import { getPostgresAndMigrations, waitForPostgres } from './postgres'
 
 async function checkMigrations() {
@@ -8,7 +8,7 @@ async function checkMigrations() {
 	for (const appliedMigration of appliedMigrations) {
 		if (!migrations.includes(appliedMigration.filename)) {
 			console.error(`Migration ${appliedMigration.filename} is missing. Will clean the db.`)
-			await exec('yarn', ['clean'])
+			execSync('yarn clean')
 			break
 		}
 	}

--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -1,14 +1,9 @@
 import { readdirSync } from 'fs'
-import postgres from 'postgres'
 import { exec } from '../../../internal/scripts/lib/exec'
-import { postgresConnectionString, waitForPostgres } from './postgres'
+import { getPostgres, waitForPostgres } from './postgres'
 
 async function checkMigrations() {
-	const db = postgres(postgresConnectionString, {
-		connection: {
-			application_name: 'check-migrations',
-		},
-	})
+	const db = getPostgres('check-migrations')
 	const appliedMigrations = await db`SELECT filename FROM migrations.applied_migrations`.execute()
 	const migrations = readdirSync(`./migrations`).sort()
 	if (migrations.length === 0) {

--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { execSync } from 'child_process'
 import { getPostgresAndMigrations, waitForPostgres } from './postgres'
 

--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -6,7 +6,7 @@ import { postgresConnectionString, waitForPostgres } from './postgres'
 async function checkMigrations() {
 	const db = postgres(postgresConnectionString, {
 		connection: {
-			application_name: 'migrate',
+			application_name: 'check-migrations',
 		},
 	})
 	const appliedMigrations = await db`SELECT filename FROM migrations.applied_migrations`.execute()

--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -1,15 +1,8 @@
-import { readdirSync } from 'fs'
 import { exec } from '../../../internal/scripts/lib/exec'
-import { getPostgres, waitForPostgres } from './postgres'
+import { getPostgresAndMigrations, waitForPostgres } from './postgres'
 
 async function checkMigrations() {
-	const db = getPostgres('check-migrations')
-	const appliedMigrations = await db`SELECT filename FROM migrations.applied_migrations`.execute()
-	const migrations = readdirSync(`./migrations`).sort()
-	if (migrations.length === 0) {
-		throw new Error('No migrations found')
-	}
-
+	const { migrations, appliedMigrations } = await getPostgresAndMigrations('check-migrations')
 	console.log('Checking migrations')
 	// check that all applied migrations exist
 	for (const appliedMigration of appliedMigrations) {

--- a/apps/dotcom/zero-cache/check-migrations.ts
+++ b/apps/dotcom/zero-cache/check-migrations.ts
@@ -1,0 +1,41 @@
+import { readdirSync } from 'fs'
+import postgres from 'postgres'
+import { exec } from '../../../internal/scripts/lib/exec'
+import { postgresConnectionString, waitForPostgres } from './postgres'
+
+async function checkMigrations() {
+	const db = postgres(postgresConnectionString, {
+		connection: {
+			application_name: 'migrate',
+		},
+	})
+	const appliedMigrations = await db`SELECT filename FROM migrations.applied_migrations`.execute()
+	const migrations = readdirSync(`./migrations`).sort()
+	if (migrations.length === 0) {
+		throw new Error('No migrations found')
+	}
+
+	console.log('Checking migrations')
+	// check that all applied migrations exist
+	for (const appliedMigration of appliedMigrations) {
+		if (!migrations.includes(appliedMigration.filename)) {
+			console.error(`Migration ${appliedMigration.filename} is missing. Will clean the db.`)
+			await exec('yarn', ['clean'])
+			break
+		}
+	}
+	console.log('Migration check complete.')
+}
+
+async function run() {
+	try {
+		await waitForPostgres()
+		await checkMigrations()
+	} catch (e) {
+		console.error(e)
+		process.exit(1)
+	}
+	process.exit(0)
+}
+
+run()

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -4,6 +4,9 @@ import { createServer } from 'http'
 import postgres from 'postgres'
 import { migrationsPath, postgresConnectionString, waitForPostgres } from './postgres'
 
+if (!postgresConnectionString) {
+	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
+}
 console.log('Using connection string:', postgresConnectionString)
 
 const shouldSignalSuccess = process.argv.includes('--signal-success')

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -1,74 +1,15 @@
 /* eslint-disable no-console */
-import { existsSync, readFileSync, readdirSync } from 'fs'
+import { readFileSync, readdirSync } from 'fs'
 import { createServer } from 'http'
 import postgres from 'postgres'
+import { migrationsPath, postgresConnectionString, waitForPostgres } from './postgres'
 
-const postgresConnectionString: string =
-	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
-	'postgresql://user:password@127.0.0.1:6543/postgres'
-
-if (!postgresConnectionString) {
-	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
-}
 console.log('Using connection string:', postgresConnectionString)
-
-const migrationsPath = `./migrations`
-if (!existsSync(migrationsPath)) {
-	throw new Error(`Migrations path not found: ${migrationsPath}`)
-}
-
-const init = `
-CREATE SCHEMA IF NOT EXISTS migrations;
-
-CREATE TABLE IF NOT EXISTS migrations.applied_migrations (
-  filename VARCHAR PRIMARY KEY,
-  applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-`
-
-/**
-INSERT INTO migrations.applied_migrations (filename) VALUES 
-('000_seed.sql'),
-('001_replicator_boot.sql'),
-('002_add_user_id.sql'),
-('003_make_published_slug_unique.sql'),
-('004_guest_column_on_file_state.sql'),
-('005_update_file_trigger.sql'),
-('006_add_file_soft_delete.sql'),
-('007_update_file_owner_details.sql')
-ON CONFLICT DO NOTHING;
- */
 
 const shouldSignalSuccess = process.argv.includes('--signal-success')
 const dryRun = process.argv.includes('--dry-run')
 
 const DRY_RUN_ROLLBACK = new Error('dry-run-rollback')
-
-async function waitForPostgres() {
-	let attempts = 0
-	do {
-		try {
-			const sql = postgres(postgresConnectionString, {
-				connection: {
-					application_name: 'waitForPostgres',
-				},
-			})
-			await sql`SELECT 1`
-			await sql.end()
-			break
-		} catch (_e) {
-			if (attempts++ > 100) {
-				throw new Error('Failed to connect to postgres')
-			}
-			console.log('Waiting for postgres' + '.'.repeat(attempts))
-			await new Promise((resolve) => setTimeout(resolve, 500))
-		}
-		// eslint-disable-next-line no-constant-condition
-	} while (true)
-	const sql = postgres(postgresConnectionString)
-	await sql.unsafe(init).simple()
-	await sql.end()
-}
 
 async function migrate(summary: string[], dryRun: boolean) {
 	const db = postgres(postgresConnectionString, {
@@ -81,13 +22,6 @@ async function migrate(summary: string[], dryRun: boolean) {
 		const migrations = readdirSync(`./migrations`).sort()
 		if (migrations.length === 0) {
 			throw new Error('No migrations found')
-		}
-
-		// check that all applied migrations exist
-		for (const appliedMigration of appliedMigrations) {
-			if (!migrations.includes(appliedMigration.filename)) {
-				throw new Error(`Previously-applied migration ${appliedMigration.filename} not found`)
-			}
 		}
 
 		for (const migration of migrations) {

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -24,6 +24,13 @@ async function migrate(summary: string[], dryRun: boolean) {
 			throw new Error('No migrations found')
 		}
 
+		// check that all applied migrations exist
+		for (const appliedMigration of appliedMigrations) {
+			if (!migrations.includes(appliedMigration.filename)) {
+				throw new Error(`Previously-applied migration ${appliedMigration.filename} not found`)
+			}
+		}
+
 		for (const migration of migrations) {
 			if (appliedMigrations.some((m: any) => m.filename === migration)) {
 				summary.push(`🏃 ${migration} already applied`)

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -11,9 +11,11 @@
 		"defaults"
 	],
 	"scripts": {
-		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success'",
+		"dev": "yarn check-migrations && concurrently 'yarn docker-up' 'yarn migrate --signal-success'",
 		"docker-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
+		"docker-up-detached": "docker compose --env-file .env -f ./docker/docker-compose.yml up --detach",
 		"docker-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
+		"check-migrations": "yarn docker-up-detached && yarn tsx ./check-migrations.ts && yarn docker-down",
 		"migrate": "yarn tsx ./migrate.ts",
 		"clean": "yarn docker-down && ./clean.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"

--- a/apps/dotcom/zero-cache/postgres.ts
+++ b/apps/dotcom/zero-cache/postgres.ts
@@ -1,0 +1,50 @@
+import { existsSync } from 'fs'
+import postgres from 'postgres'
+
+const init = `
+CREATE SCHEMA IF NOT EXISTS migrations;
+
+CREATE TABLE IF NOT EXISTS migrations.applied_migrations (
+  filename VARCHAR PRIMARY KEY,
+  applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+export async function waitForPostgres() {
+	let attempts = 0
+	do {
+		try {
+			const sql = postgres(postgresConnectionString, {
+				connection: {
+					application_name: 'waitForPostgres',
+				},
+			})
+			await sql`SELECT 1`
+			await sql.end()
+			break
+		} catch (_e) {
+			if (attempts++ > 100) {
+				throw new Error('Failed to connect to postgres')
+			}
+			console.log('Waiting for postgres' + '.'.repeat(attempts))
+			await new Promise((resolve) => setTimeout(resolve, 500))
+		}
+		// eslint-disable-next-line no-constant-condition
+	} while (true)
+	const sql = postgres(postgresConnectionString)
+	await sql.unsafe(init).simple()
+	await sql.end()
+}
+
+export const postgresConnectionString: string =
+	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
+	'postgresql://user:password@127.0.0.1:6543/postgres'
+
+if (!postgresConnectionString) {
+	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
+}
+
+export const migrationsPath = `./migrations`
+if (!existsSync(migrationsPath)) {
+	throw new Error(`Migrations path not found: ${migrationsPath}`)
+}

--- a/apps/dotcom/zero-cache/postgres.ts
+++ b/apps/dotcom/zero-cache/postgres.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { existsSync, readdirSync } from 'fs'
 import postgres from 'postgres'
 

--- a/apps/dotcom/zero-cache/postgres.ts
+++ b/apps/dotcom/zero-cache/postgres.ts
@@ -14,10 +14,6 @@ export const postgresConnectionString: string =
 	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
 	'postgresql://user:password@127.0.0.1:6543/postgres'
 
-if (!postgresConnectionString) {
-	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
-}
-
 export const migrationsPath = `./migrations`
 if (!existsSync(migrationsPath)) {
 	throw new Error(`Migrations path not found: ${migrationsPath}`)
@@ -47,4 +43,15 @@ export async function waitForPostgres() {
 	const sql = postgres(postgresConnectionString)
 	await sql.unsafe(init).simple()
 	await sql.end()
+}
+
+export function getPostgres(applicationName: string) {
+	if (!postgresConnectionString) {
+		throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
+	}
+	return postgres(postgresConnectionString, {
+		connection: {
+			application_name: applicationName,
+		},
+	})
 }

--- a/apps/dotcom/zero-cache/postgres.ts
+++ b/apps/dotcom/zero-cache/postgres.ts
@@ -10,6 +10,19 @@ CREATE TABLE IF NOT EXISTS migrations.applied_migrations (
 );
 `
 
+export const postgresConnectionString: string =
+	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
+	'postgresql://user:password@127.0.0.1:6543/postgres'
+
+if (!postgresConnectionString) {
+	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
+}
+
+export const migrationsPath = `./migrations`
+if (!existsSync(migrationsPath)) {
+	throw new Error(`Migrations path not found: ${migrationsPath}`)
+}
+
 export async function waitForPostgres() {
 	let attempts = 0
 	do {
@@ -34,17 +47,4 @@ export async function waitForPostgres() {
 	const sql = postgres(postgresConnectionString)
 	await sql.unsafe(init).simple()
 	await sql.end()
-}
-
-export const postgresConnectionString: string =
-	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
-	'postgresql://user:password@127.0.0.1:6543/postgres'
-
-if (!postgresConnectionString) {
-	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
-}
-
-export const migrationsPath = `./migrations`
-if (!existsSync(migrationsPath)) {
-	throw new Error(`Migrations path not found: ${migrationsPath}`)
 }


### PR DESCRIPTION
This fixes an issue if you:
- were on a branch that has a new migration
- you then switch to a branch without that migration or a branch that has a different migration

Till now we would just error out in this case. After this change we will clear the db, then apply all the migrations from start.

### Change type

- [x] `improvement`

### Release notes

- Fix an issue with running the zero cache project when the db contains some migrations that the current branch doesn't know about.