### PR TITLE
Emit a before-event from Editor

### DIFF
--- a/packages/editor/api-report.md
+++ b/packages/editor/api-report.md
@@ -3340,6 +3340,8 @@ export type TLEventInfo = TLCancelEventInfo | TLClickEventInfo | TLCompleteEvent
 // @public (undocumented)
 export interface TLEventMap {
     // (undocumented)
+    'before-event': [TLEventInfo];
+    // (undocumented)
     'max-shapes': [{
         count: number;
         name: string;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9333,6 +9333,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	dispatch(info: TLEventInfo) {
+		this.emit('before-event', info)
 		this._pendingEventsForNextTick.push(info)
 		if (
 			!(

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9333,7 +9333,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	dispatch(info: TLEventInfo) {
-		this.emit('before-event', info)
 		this._pendingEventsForNextTick.push(info)
 		if (
 			!(
@@ -9369,6 +9368,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// prevent us from spamming similar event errors if we're crashed.
 		// todo: replace with new readonly mode?
 		if (this.getCrashingError()) return this
+
+		this.emit('before-event', info)
 
 		const { inputs } = this
 		const { type } = info

--- a/packages/editor/src/lib/editor/types/emit-types.ts
+++ b/packages/editor/src/lib/editor/types/emit-types.ts
@@ -12,6 +12,7 @@ export interface TLEventMap {
 	crash: [{ error: unknown }]
 	'stop-camera-animation': []
 	'stop-following': []
+	'before-event': [TLEventInfo]
 	event: [TLEventInfo]
 	tick: [number]
 	frame: [number]


### PR DESCRIPTION
This will emit an event from Editor when dispatch is called that can be used to handle events before they are handled by tldraw.

The specific thing we need this for is to update camera options on wheel and pointer events before tldraw handles them in order to have a different wheelBehavior based on if you are using a mouse or a touchpad (which is determined from a heuristic based on the wheel and pointer events).

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Emit a `before-event` from Editor for events before they are handled by tldraw.