### PR TITLE
Unify the menus (logged in vs not logged in).

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaAppMenuGroup/TlaAppMenuGroup.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAppMenuGroup/TlaAppMenuGroup.tsx
@@ -33,16 +33,6 @@ export function TlaAppMenuGroup() {
 	)
 }
 
-export function TlaAppMenuGroupLazyFlipped() {
-	return (
-		<TldrawUiMenuGroup id="things-to-do">
-			<ColorThemeSubmenu />
-			<LanguageMenu />
-			<HelpSubMenu />
-		</TldrawUiMenuGroup>
-	)
-}
-
 function ColorThemeSubmenu() {
 	const editor = useMaybeEditor()
 	if (!editor) return null

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -29,7 +29,6 @@ import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getIsCoarsePointer } from '../../utils/getIsCoarsePointer'
 import { defineMessages, useIntl, useMsg } from '../../utils/i18n'
-import { TlaAppMenuGroupLazyFlipped } from '../TlaAppMenuGroup/TlaAppMenuGroup'
 import { TlaFileMenu } from '../TlaFileMenu/TlaFileMenu'
 import { TlaIcon, TlaIconWrapper } from '../TlaIcon/TlaIcon'
 import { sidebarMessages } from '../TlaSidebar/components/TlaSidebarFileLink'
@@ -116,7 +115,9 @@ export function TlaEditorTopLeftPanelAnonymous() {
 							<ExtrasGroup />
 							<TldrawUiMenuActionItem actionId={SAVE_FILE_COPY_ACTION} />
 						</TldrawUiMenuGroup>
-						<TlaAppMenuGroupLazyFlipped />
+						<TldrawUiMenuGroup id="preferences">
+							<PreferencesGroup />
+						</TldrawUiMenuGroup>
 						<TldrawUiMenuGroup id="signin">
 							<SignInMenuItem />
 						</TldrawUiMenuGroup>


### PR DESCRIPTION
The logged out menu was missing editor preferences (grid mode,...) so now we show the same options as for the logged in experience.

### Change type

- [x] `improvement`

### Release notes

- Show the same page menu for logged in and for logged out users.