### PR TITLE
Fix the border around the guest icon in Safari

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -194,7 +194,7 @@ function GuestBadge({ file, href }: { file: TlaFile; href: string }) {
 					onClick={handleToolTipClick}
 					className={styles.guestBadgeTrigger}
 				>
-					<TlaIcon icon="group" />
+					<TlaIcon icon="group" className="tlui-guest-icon" />
 				</TlaTooltipTrigger>
 				<TlaTooltipPortal container={container}>
 					<TlaTooltipContent

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -447,3 +447,8 @@ a {
 	min-width: 36px;
 	height: 36px;
 }
+
+.tlui-guest-icon {
+	/* https://stackoverflow.com/a/23735769/1810018 */
+	-webkit-transform: translateZ(0);
+}


### PR DESCRIPTION
🤷‍♂️ 

### Change type

- [x] `bugfix`

### Release notes

- Removes the border around the guest badge for Safari.