### PR TITLE
Fix vscode publishing.

### DIFF
--- a/apps/vscode/extension/package.json
+++ b/apps/vscode/extension/package.json
@@ -36,7 +36,7 @@
 		"Visualization"
 	],
 	"engines": {
-		"vscode": "^1.75.1"
+		"vscode": "^1.96.0"
 	},
 	"activationEvents": [],
 	"browser": "./dist/web/extension.js",


### PR DESCRIPTION
I guess we had to upgrade the `@types/vscode` to`^1.96.0` to get it working with react 19?

Updated the engine as well. This means that users will only get the update if they are using vs code with that engine or higher. I guess people update their editors so they should be using close to the latest one.

### Change type

- [x] `bugfix`

### Release notes

- Fix packaging of the vs code extension.