### PR TITLE
Disable rename dialog on file create on mobile

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
@@ -6,7 +6,9 @@ import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
 import { useFileSidebarFocusContext } from '../../../providers/FileInputFocusProvider'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
+import { getIsCoarsePointer } from '../../../utils/getIsCoarsePointer'
 import { useMsg } from '../../../utils/i18n'
+import { toggleMobileSidebar } from '../../../utils/local-session-state'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import styles from '../sidebar.module.css'
 import { messages } from './sidebar-shared'
@@ -25,12 +27,18 @@ export function TlaSidebarCreateFileButton() {
 		if (!rCanCreate.current) return
 		const res = app.createFile()
 		if (res.ok) {
-			focusCtx.shouldRenameNextNewFile = true
+			const isMobile = getIsCoarsePointer()
+			if (!isMobile) {
+				focusCtx.shouldRenameNextNewFile = true
+			}
 			const { file } = res.value
 			navigate(routes.tlaFile(file.id), { state: { mode: 'create' } satisfies TlaFileOpenState })
 			trackEvent('create-file', { source: 'sidebar' })
 			rCanCreate.current = false
 			tltime.setTimeout('can create again', () => (rCanCreate.current = true), 1000)
+			if (isMobile) {
+				toggleMobileSidebar(false)
+			}
 		}
 	}, [app, focusCtx, navigate, trackEvent])
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -104,9 +104,7 @@ export function TlaSidebarFileLinkInner({
 			focusCtx.shouldRenameNextNewFile
 		) {
 			focusCtx.shouldRenameNextNewFile = false
-			if (getIsCoarsePointer()) {
-				handleRenameAction()
-			}
+			handleRenameAction()
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -104,7 +104,9 @@ export function TlaSidebarFileLinkInner({
 			focusCtx.shouldRenameNextNewFile
 		) {
 			focusCtx.shouldRenameNextNewFile = false
-			handleRenameAction()
+			if (getIsCoarsePointer()) {
+				handleRenameAction()
+			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])

--- a/apps/dotcom/client/src/tla/utils/local-session-state.ts
+++ b/apps/dotcom/client/src/tla/utils/local-session-state.ts
@@ -118,6 +118,12 @@ export function toggleSidebar(open: boolean = !getIsSidebarOpen()) {
 	})
 }
 
+export function toggleMobileSidebar(open: boolean = !getIsSidebarOpenMobile()) {
+	updateLocalSessionState(() => {
+		return { isSidebarOpenMobile: open }
+	})
+}
+
 export function setLocalSessionState(state: TldrawAppSessionState) {
 	localSessionState.set(state)
 	setInLocalStorage(STORAGE_KEY, JSON.stringify(localSessionState.get()))


### PR DESCRIPTION
This was feeling super rough. On android it was downright abysmal. Better to just immediately open the new file and let them rename it as and when.

### Change type

- [x] `other`
