### PR TITLE
Make sure that pinned files don't take precedence.

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -268,13 +268,6 @@ export class TldrawApp {
 		// sort by date with most recent first
 		nextRecentFileOrdering.sort((a, b) => b.date - a.date)
 
-		// move pinned files to the top, stable sort
-		nextRecentFileOrdering.sort((a, b) => {
-			if (a.isPinned && !b.isPinned) return -1
-			if (!a.isPinned && b.isPinned) return 1
-			return 0
-		})
-
 		// stash the ordering for next time
 		this.lastRecentFileOrdering = nextRecentFileOrdering
 


### PR DESCRIPTION
Pinned files always took precedence in the recent user's files. This meant that after returning to the app you'd always land on a pinned file.

### Change type

- [x] `bugfix`

### Test plan

1. Pin a file
2. Switch to a different file and make some edits to it (seems like our recent files takes last edit time as the preferred way of determining the order).
3. Go to the root route.
4. You should land on the correct file.

### Release notes

- Fix an issue with pinned files always taking precedence when returning to the app.