### PR TITLE
Add option to disable numbered shortcuts on the toolbar

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -714,6 +714,7 @@ export const defaultTldrawOptions: {
     readonly edgeScrollDistance: 8;
     readonly edgeScrollEaseDuration: 200;
     readonly edgeScrollSpeed: 25;
+    readonly enableToolbarKeyboardShortcuts: true;
     readonly exportProvider: ExoticComponent<    {
     children?: ReactNode;
     }>;
@@ -3142,6 +3143,7 @@ export interface TldrawOptions {
     readonly edgeScrollEaseDuration: number;
     // (undocumented)
     readonly edgeScrollSpeed: number;
+    readonly enableToolbarKeyboardShortcuts: boolean;
     readonly exportProvider: ComponentType<{
         children: React.ReactNode;
     }>;

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -71,6 +71,10 @@ export interface TldrawOptions {
 	 * but you can set it to be user-resizable using scale.
 	 */
 	readonly noteShapeResizeMode: 'none' | 'scale'
+	/**
+	 * By default, the toolbar items are accessible via number shortcuts according to their order. To disable this, set this option to false.
+	 */
+	readonly enableToolbarKeyboardShortcuts: boolean
 }
 
 /** @public */
@@ -117,4 +121,5 @@ export const defaultTldrawOptions = {
 	createTextOnCanvasDoubleClick: true,
 	exportProvider: Fragment,
 	noteShapeResizeMode: 'none',
+	enableToolbarKeyboardShortcuts: true,
 } as const satisfies TldrawOptions

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -126,6 +126,8 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 
 		function handleKeyDown(event: KeyboardEvent) {
 			if (areShortcutsDisabled(editor)) return
+			// no accelerator keys
+			if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
 			for (const [key, index] of KEYS) {
 				preventDefault(event)
 				if (event.key === key) {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -95,6 +95,8 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 	}, [onDomUpdate])
 
 	useEffect(() => {
+		if (!editor.options.enableToolbarKeyboardShortcuts) return
+
 		const keys = [
 			['1', 0],
 			['2', 1],

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -17,18 +17,18 @@ import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuCon
 
 export const IsInOverflowContext = createContext(false)
 
-const KEYS = [
-	['1', 0],
-	['2', 1],
-	['3', 2],
-	['4', 3],
-	['5', 4],
-	['6', 5],
-	['7', 6],
-	['8', 7],
-	['9', 8],
-	['0', 9],
-] as const
+const NUMBERED_SHORTCUT_KEYS: Record<string, number> = {
+	'1': 0,
+	'2': 1,
+	'3': 2,
+	'4': 3,
+	'5': 4,
+	'6': 5,
+	'7': 6,
+	'8': 7,
+	'9': 8,
+	'0': 9,
+}
 
 /** @public */
 export interface OverflowingToolbarProps {
@@ -128,12 +128,10 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 			if (areShortcutsDisabled(editor)) return
 			// no accelerator keys
 			if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
-			for (const [key, index] of KEYS) {
+			const index = NUMBERED_SHORTCUT_KEYS[event.key]
+			if (index) {
 				preventDefault(event)
-				if (event.key === key) {
-					rButtons.current[index]?.click()
-					return
-				}
+				rButtons.current[index]?.click()
 			}
 		}
 


### PR DESCRIPTION
This PR:

- adds an editor option to disable the numbered keyboard shortcuts for the default toolbar.
- improves the UX of keyboard shortcuts for the toolbar (allowing simultaneous keys, for fast changing)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Use the keyboard shortcuts
2. When the option is off, keyboard shortcuts should be ignored

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- SDK: Added editor option to disable 0-9 keyboard shortcuts for the toolbar
- Improved keyboard shortcuts for the toolbar