### PR TITLE
Add "select geo tool" shortcut

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1363,6 +1363,15 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					}
 				},
 			},
+			{
+				id: 'select-geo-tool',
+				kbd: 'g',
+				onSelect: async (source) => {
+					// will select whatever the most recent geo tool was
+					trackEvent('select-tool', { source, id: `geo-previous` })
+					editor.setCurrentTool('geo')
+				},
+			},
 		]
 
 		if (showCollaborationUi) {


### PR DESCRIPTION
Not every geo tool has a keyboard shortcut. When using the geo tool with shapes that have no shortcuts, we don't have an easy way of saying "select whatever geo tool I was just using". This PR adds a generic "geo tool" shortcut (g) that will do this.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Use a cloud shape
2. Use an arrow tool
3. Press G to select the cloud shape again

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added `g` shortcut to select the most recent geometric tool.