### PR TITLE
Don't allow setting file name to null. Fix drag and drop import.

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -332,6 +332,9 @@ export class TldrawApp {
 		}
 		if (typeof fileOrId === 'object') {
 			Object.assign(file, fileOrId)
+			if (!file.name) {
+				Object.assign(file, { name: this.getFallbackFileName(file.createdAt) })
+			}
 		}
 
 		this.z.mutate.file.create(file)

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -430,7 +430,7 @@ export class TldrawApp {
 				const documentEntry = entries.find(([_, value]) => isDocument(value)) as
 					| [string, TLDocument]
 					| undefined
-				const name = documentEntry?.[1]?.name || undefined
+				const name = documentEntry?.[1]?.name || ''
 
 				const result = this.createFile({ id: slug, name })
 				if (!result.ok) {

--- a/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
+++ b/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
@@ -1,4 +1,5 @@
 import { useAuth } from '@clerk/clerk-react'
+import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { DragEvent, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Editor, TLStoreSnapshot, parseTldrawJsonFile, tlmenus, useToasts } from 'tldraw'
@@ -70,7 +71,9 @@ export function useTldrFileDrop() {
 					keepOpen: true,
 				})
 				if (results.slugs.length > 0) {
-					navigate(routes.tlaFile(results.slugs[0]))
+					navigate(routes.tlaFile(results.slugs[0]), {
+						state: { mode: 'create' } as TlaFileOpenState,
+					})
 				}
 			}
 		},


### PR DESCRIPTION
This looks like the only place where the `null` file name error might have occurred. Hopefully this fixes it, will keep an eye out.

Also found out that importing files by dragging them to the sidebar didn't work. This should fix it.

### Change type

- [x] `bugfix`

### Release notes

- Fix an error with creating file's with null names. 
- Fix an error with dragging and dropping files to the sidebar.