### PR TITLE
Move to server side slurping.

### DIFF
--- a/apps/dotcom/client/src/pages/tla-new.tsx
+++ b/apps/dotcom/client/src/pages/tla-new.tsx
@@ -1,4 +1,3 @@
-import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { routes } from '../routeDefs'
@@ -13,7 +12,7 @@ export function Component() {
 		const res = app.createFile()
 		if (res.ok) {
 			const { file } = res.value
-			navigate(routes.tlaFile(file.id), { state: { mode: 'create' } satisfies TlaFileOpenState })
+			navigate(routes.tlaFile(file.id))
 			trackEvent('create-file', { source: 'new-page' })
 		} else {
 			navigate(routes.tlaRoot())

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -322,6 +322,7 @@ export class TldrawApp {
 			thumbnail: '',
 			updatedAt: Date.now(),
 			isDeleted: false,
+			createSource: null,
 		}
 		if (typeof fileOrId === 'object') {
 			Object.assign(file, fileOrId)

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -86,7 +86,7 @@ function useGetFileName() {
 	return ''
 }
 
-function useGetPrefix() {
+function usePrefix() {
 	const location = useLocation()
 	const roomPrefix = location.pathname.split('/')[1]
 	switch (roomPrefix) {
@@ -99,9 +99,9 @@ function useGetPrefix() {
 	return null
 }
 
-function useGetRoomInfo() {
+function useRoomInfo() {
 	const id = useParams()['roomId'] as string
-	const prefix = useGetPrefix()
+	const prefix = usePrefix()
 	if (!id || !prefix) return null
 	return { prefix, id }
 }
@@ -112,7 +112,7 @@ function LegacyImportButton() {
 	const editor = useEditor()
 	const navigate = useNavigate()
 	const name = useGetFileName()
-	const roomInfo = useGetRoomInfo()
+	const roomInfo = useRoomInfo()
 
 	const handleClick = useCallback(() => {
 		if (!app || !editor || !roomInfo) return

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { useCallback, useRef } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { PeopleMenu, useEditor, usePassThroughWheelEvents, useTranslation } from 'tldraw'
 import { routes } from '../../../routeDefs'
 import { useMaybeApp } from '../../hooks/useAppState'
@@ -86,7 +86,8 @@ function useGetFileName() {
 	return ''
 }
 
-function getPrefix() {
+function useGetPrefix() {
+	const location = useLocation()
 	const roomPrefix = location.pathname.split('/')[1]
 	switch (roomPrefix) {
 		case ROOM_PREFIX:
@@ -100,7 +101,7 @@ function getPrefix() {
 
 function useGetRoomInfo() {
 	const id = useParams()['roomId'] as string
-	const prefix = getPrefix()
+	const prefix = useGetPrefix()
 	if (!id || !prefix) return null
 	return { prefix, id }
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -1,6 +1,6 @@
 /* ---------------------- Menu ---------------------- */
 
-import { TlaFile, TlaFileOpenState } from '@tldraw/dotcom-shared'
+import { FILE_PREFIX, TlaFile } from '@tldraw/dotcom-shared'
 import { Fragment, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -116,7 +116,11 @@ function FileItems({
 		const newFileId = uniqueId()
 		const file = app.getFile(fileId)
 		if (!file) return
-		const res = app.createFile({ id: newFileId, name: getDuplicateName(file, app) })
+		const res = app.createFile({
+			id: newFileId,
+			name: getDuplicateName(file, app),
+			createSource: `${FILE_PREFIX}/${fileId}`,
+		})
 		// copy the state too
 		const prevState = app.getFileState(fileId)
 		app.getOrCreateFileState(newFileId)
@@ -125,9 +129,7 @@ function FileItems({
 		})
 		if (res.ok) {
 			focusCtx.shouldRenameNextNewFile = true
-			navigate(routes.tlaFile(newFileId), {
-				state: { mode: 'duplicate', duplicateId: fileId } satisfies TlaFileOpenState,
-			})
+			navigate(routes.tlaFile(newFileId))
 		}
 	}, [app, fileId, focusCtx, navigate])
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
@@ -1,4 +1,3 @@
-import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { tltime } from 'tldraw'
@@ -32,7 +31,7 @@ export function TlaSidebarCreateFileButton() {
 				focusCtx.shouldRenameNextNewFile = true
 			}
 			const { file } = res.value
-			navigate(routes.tlaFile(file.id), { state: { mode: 'create' } satisfies TlaFileOpenState })
+			navigate(routes.tlaFile(file.id))
 			trackEvent('create-file', { source: 'sidebar' })
 			rCanCreate.current = false
 			tltime.setTimeout('can create again', () => (rCanCreate.current = true), 1000)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -1,7 +1,7 @@
-import { TlaFile, TlaFileOpenState } from '@tldraw/dotcom-shared'
+import { TlaFile } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { KeyboardEvent, MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { preventDefault, useContainer, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
@@ -81,7 +81,6 @@ export function TlaSidebarFileLinkInner({
 	const linkRef = useRef<HTMLAnchorElement | null>(null)
 	const app = useApp()
 	const intl = useIntl()
-	const state = useLocation().state as TlaFileOpenState | undefined
 	const focusCtx = useFileSidebarFocusContext()
 
 	const [isRenaming, setIsRenaming] = useState(debugIsRenaming)
@@ -98,11 +97,7 @@ export function TlaSidebarFileLinkInner({
 
 	useEffect(() => {
 		// on mount, trigger rename action if this is a new file.
-		if (
-			(state?.mode === 'create' || state?.mode === 'duplicate') &&
-			isActive &&
-			focusCtx.shouldRenameNextNewFile
-		) {
+		if (isActive && focusCtx.shouldRenameNextNewFile) {
 			focusCtx.shouldRenameNextNewFile = false
 			handleRenameAction()
 		}

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from '@clerk/clerk-react'
-import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -33,9 +32,7 @@ export function TlaDeleteFileDialog({ fileId, onClose }: { fileId: string; onClo
 		if (recentFiles.length === 0) {
 			const result = app.createFile()
 			if (result.ok) {
-				navigate(routes.tlaFile(result.value.file.id), {
-					state: { mode: 'create' } satisfies TlaFileOpenState,
-				})
+				navigate(routes.tlaFile(result.value.file.id))
 				trackEvent('delete-file', { source: 'file-menu' })
 			}
 		} else {

--- a/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
+++ b/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
@@ -1,5 +1,4 @@
 import { useAuth } from '@clerk/clerk-react'
-import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { DragEvent, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Editor, TLStoreSnapshot, parseTldrawJsonFile, tlmenus, useToasts } from 'tldraw'
@@ -71,9 +70,7 @@ export function useTldrFileDrop() {
 					keepOpen: true,
 				})
 				if (results.slugs.length > 0) {
-					navigate(routes.tlaFile(results.slugs[0]), {
-						state: { mode: 'create' } as TlaFileOpenState,
-					})
+					navigate(routes.tlaFile(results.slugs[0]))
 				}
 			}
 		},

--- a/apps/dotcom/client/src/tla/pages/file.tsx
+++ b/apps/dotcom/client/src/tla/pages/file.tsx
@@ -1,6 +1,6 @@
 import { captureException } from '@sentry/react'
 import { useEffect } from 'react'
-import { useLocation, useParams, useRouteError } from 'react-router-dom'
+import { useParams, useRouteError } from 'react-router-dom'
 import { TlaEditor } from '../components/TlaEditor/TlaEditor'
 import { TlaFileError } from '../components/TlaFileError/TlaFileError'
 import { useMaybeApp } from '../hooks/useAppState'
@@ -21,7 +21,6 @@ export function Component({ error }: { error?: unknown }) {
 	const { fileSlug } = useParams<{ fileSlug: string }>()
 	if (!fileSlug) throw Error('File id not found')
 	const userId = useMaybeApp()?.userId
-	const routeState = useLocation().state
 
 	const errorElem = error ? <TlaFileError error={error} /> : null
 
@@ -48,7 +47,7 @@ export function Component({ error }: { error?: unknown }) {
 
 	return (
 		<TlaSidebarLayout collapsible>
-			{errorElem ?? <TlaEditor fileSlug={fileSlug} fileOpenState={routeState} deepLinks />}
+			{errorElem ?? <TlaEditor fileSlug={fileSlug} deepLinks />}
 		</TlaSidebarLayout>
 	)
 }

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -1,4 +1,3 @@
-import { TlaFileOpenState } from '@tldraw/dotcom-shared'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { assert, react } from 'tldraw'
@@ -23,7 +22,6 @@ export function Component() {
 			if (res.ok) {
 				clearShouldSlurpFile()
 				navigate(routes.tlaFile(res.value.file.id), {
-					state: { mode: 'create' } satisfies TlaFileOpenState,
 					replace: true,
 				})
 			} else {
@@ -42,7 +40,6 @@ export function Component() {
 			// we don't need to handle that case here since they have no files
 			if (result.ok) {
 				navigate(routes.tlaFile(result.value.file.id), {
-					state: { mode: 'create' } satisfies TlaFileOpenState,
 					replace: true,
 				})
 			}

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -245,8 +245,7 @@ export class TLDrawDurableObject extends DurableObject {
 			await getSlug(this.env, req.params.roomId, roomOpenMode),
 			'roomId must be present'
 		)
-		const url = new URL(req.url)
-		const isApp = url.pathname.startsWith('/app/')
+		const isApp = new URL(req.url).pathname.startsWith('/app/')
 
 		if (this._documentInfo) {
 			assert(this._documentInfo.slug === slug, 'slug must match')
@@ -403,14 +402,6 @@ export class TLDrawDurableObject extends DurableObject {
 					}
 				}
 			}
-			// else if (!this.documentInfo.appMode) {
-			// 	// If there is no owner that means it's a temporary room, but if they didn't add the create
-			// 	// flag don't let them in.
-			// 	// This prevents people from just creating rooms by typing extra chars in the URL because we only
-			// 	// add that flag in temporary rooms.
-			// 	return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
-			// }
-			// otherwise, it's a temporary room and we let them in
 		}
 
 		try {

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -325,8 +325,8 @@ export class TLDrawDurableObject extends DurableObject {
 					return this._fileRecordCache
 				},
 				{
-					attempts: 5,
-					waitDuration: 200,
+					attempts: 10,
+					waitDuration: 100,
 				}
 			)
 		} catch (_e) {
@@ -706,6 +706,7 @@ export class TLDrawDurableObject extends DurableObject {
 	}
 
 	async appFileRecordCreated(file: TlaFile) {
+		if (this._fileRecordCache) return
 		this._fileRecordCache = file
 
 		this.setDocumentInfo({

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -4,12 +4,13 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import {
 	DB,
+	FILE_PREFIX,
 	READ_ONLY_LEGACY_PREFIX,
 	READ_ONLY_PREFIX,
 	ROOM_OPEN_MODE,
 	ROOM_PREFIX,
+	SNAPSHOT_PREFIX,
 	TlaFile,
-	TlaFileOpenMode,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
 import {
@@ -26,6 +27,7 @@ import {
 	assert,
 	assertExists,
 	exhaustiveSwitchError,
+	retry,
 	uniqueId,
 } from '@tldraw/utils'
 import { createSentry } from '@tldraw/worker-shared'
@@ -44,6 +46,7 @@ import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
 import { getAuthFromSearchParams } from './utils/tla/getAuth'
+import { getLegacyRoomData } from './utils/tla/getLegacyRoomData'
 
 const MAX_CONNECTIONS = 50
 
@@ -53,11 +56,6 @@ interface DocumentInfo {
 	version: number
 	slug: string
 	isApp: boolean
-	// Create mode is used by the app to bypass the 'room not found' check.
-	// i.e. if this is a new file it creates the file, even if it wasn't
-	// added to the user's app database yet.
-	appMode: TlaFileOpenMode
-	duplicateId: string | null
 	deleted: boolean
 }
 
@@ -247,12 +245,8 @@ export class TLDrawDurableObject extends DurableObject {
 			await getSlug(this.env, req.params.roomId, roomOpenMode),
 			'roomId must be present'
 		)
-		const isApp = new URL(req.url).pathname.startsWith('/app/')
-		const appMode = isApp
-			? ((new URL(req.url).searchParams.get('mode') as TlaFileOpenMode) ?? null)
-			: null
-
-		const duplicateId = isApp ? new URL(req.url).searchParams.get('duplicateId') : null
+		const url = new URL(req.url)
+		const isApp = url.pathname.startsWith('/app/')
 
 		if (this._documentInfo) {
 			assert(this._documentInfo.slug === slug, 'slug must match')
@@ -261,8 +255,6 @@ export class TLDrawDurableObject extends DurableObject {
 				version: CURRENT_DOCUMENT_INFO_VERSION,
 				slug,
 				isApp,
-				appMode,
-				duplicateId,
 				deleted: false,
 			})
 		}
@@ -316,16 +308,28 @@ export class TLDrawDurableObject extends DurableObject {
 	// this might return null if the file doesn't exist yet in the backend, or if it was deleted
 	_fileRecordCache: TlaFile | null = null
 	async getAppFileRecord(): Promise<TlaFile | null> {
-		if (this._fileRecordCache) {
-			return this._fileRecordCache
-		}
 		try {
-			this._fileRecordCache = await this.db
-				.selectFrom('file')
-				.where('id', '=', this.documentInfo.slug)
-				.selectAll()
-				.executeTakeFirstOrThrow()
-			return this._fileRecordCache
+			return await retry(
+				async () => {
+					if (this._fileRecordCache) {
+						return this._fileRecordCache
+					}
+					const result = await this.db
+						.selectFrom('file')
+						.where('id', '=', this.documentInfo.slug)
+						.selectAll()
+						.executeTakeFirst()
+					if (!result) {
+						throw new Error('File not found')
+					}
+					this._fileRecordCache = result
+					return this._fileRecordCache
+				},
+				{
+					attempts: 5,
+					waitDuration: 200,
+				}
+			)
 		} catch (_e) {
 			return null
 		}
@@ -398,13 +402,14 @@ export class TLDrawDurableObject extends DurableObject {
 						openMode = ROOM_OPEN_MODE.READ_ONLY
 					}
 				}
-			} else if (!this.documentInfo.appMode) {
-				// If there is no owner that means it's a temporary room, but if they didn't add the create
-				// flag don't let them in.
-				// This prevents people from just creating rooms by typing extra chars in the URL because we only
-				// add that flag in temporary rooms.
-				return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
 			}
+			// else if (!this.documentInfo.appMode) {
+			// 	// If there is no owner that means it's a temporary room, but if they didn't add the create
+			// 	// flag don't let them in.
+			// 	// This prevents people from just creating rooms by typing extra chars in the URL because we only
+			// 	// add that flag in temporary rooms.
+			// 	return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
+			// }
 			// otherwise, it's a temporary room and we let them in
 		}
 
@@ -494,6 +499,44 @@ export class TLDrawDurableObject extends DurableObject {
 		}
 	}
 
+	async handleFileCreateFromSource() {
+		assert(this._fileRecordCache, 'we need to have a file record to create a file from source')
+		const split = this._fileRecordCache.createSource?.split('/')
+		if (!split || split?.length !== 2) {
+			return { type: 'room_not_found' as const }
+		}
+
+		let data: string | null | undefined = undefined
+		const [prefix, id] = split
+		switch (prefix) {
+			case FILE_PREFIX: {
+				await getRoomDurableObject(this.env, id).awaitPersist()
+				data = await this.r2.rooms
+					.get(getR2KeyForRoom({ slug: id, isApp: true }))
+					.then((r) => r?.text())
+				break
+			}
+			case ROOM_PREFIX:
+				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
+				break
+			case READ_ONLY_PREFIX:
+				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
+				break
+			case READ_ONLY_LEGACY_PREFIX:
+				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
+				break
+			case SNAPSHOT_PREFIX:
+				data = await getLegacyRoomData(this.env, id, 'snapshot')
+				break
+		}
+
+		if (!data) {
+			return { type: 'room_not_found' as const }
+		}
+		await this.r2.rooms.put(this._fileRecordCache.id, data)
+		return { type: 'room_found' as const, snapshot: JSON.parse(data) }
+	}
+
 	// Load the room's drawing data. First we check the R2 bucket, then we fallback to supabase (legacy).
 	async loadFromDatabase(slug: string): Promise<DBLoadResult> {
 		try {
@@ -503,33 +546,17 @@ export class TLDrawDurableObject extends DurableObject {
 			if (roomFromBucket) {
 				return { type: 'room_found', snapshot: await roomFromBucket.json() }
 			}
-
-			if (
-				this.documentInfo.appMode === 'create' ||
-				this.documentInfo.appMode === 'slurp-legacy-file'
-			) {
-				return {
-					type: 'room_found',
-					snapshot: new TLSyncRoom({
-						schema: createTLSchema(),
-					}).getSnapshot(),
+			if (this._fileRecordCache?.createSource) {
+				const roomData = await this.handleFileCreateFromSource()
+				// Room found and created, so we can clean the create source field
+				if (roomData.type === 'room_found') {
+					await this.db
+						.updateTable('file')
+						.set({ createSource: null })
+						.where('id', '=', this._fileRecordCache.id)
+						.execute()
 				}
-			}
-
-			if (this.documentInfo.appMode === 'duplicate') {
-				assert(this.documentInfo.duplicateId, 'duplicateId must be present')
-				// load the duplicate id
-				await getRoomDurableObject(this.env, this.documentInfo.duplicateId).awaitPersist()
-				const data = await this.r2.rooms
-					.get(getR2KeyForRoom({ slug: this.documentInfo.duplicateId, isApp: true }))
-					.then((r) => r?.text())
-
-				if (!data) {
-					return { type: 'room_not_found' }
-				}
-				// otherwise copy the snapshot
-				await this.r2.rooms.put(key, data)
-				return { type: 'room_found', snapshot: JSON.parse(data) }
+				return roomData
 			}
 
 			if (this.documentInfo.isApp) {
@@ -687,6 +714,18 @@ export class TLDrawDurableObject extends DurableObject {
 		await this.scheduler.onAlarm()
 	}
 
+	async appFileRecordCreated(file: TlaFile) {
+		this._fileRecordCache = file
+
+		this.setDocumentInfo({
+			version: CURRENT_DOCUMENT_INFO_VERSION,
+			slug: file.id,
+			isApp: true,
+			deleted: false,
+		})
+		await this.getRoom()
+	}
+
 	async appFileRecordDidUpdate(file: TlaFile) {
 		if (!file) {
 			console.error('file record updated but no file found')
@@ -698,8 +737,6 @@ export class TLDrawDurableObject extends DurableObject {
 				version: CURRENT_DOCUMENT_INFO_VERSION,
 				slug: file.id,
 				isApp: true,
-				appMode: null,
-				duplicateId: null,
 				deleted: false,
 			})
 		}
@@ -748,8 +785,6 @@ export class TLDrawDurableObject extends DurableObject {
 			version: CURRENT_DOCUMENT_INFO_VERSION,
 			slug: this.documentInfo.slug,
 			isApp: true,
-			appMode: null,
-			duplicateId: null,
 			deleted: true,
 		})
 

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -1,4 +1,4 @@
-import { DB, ROOM_PREFIX, TlaFile, ZTable } from '@tldraw/dotcom-shared'
+import { DB, TlaFile, ZTable } from '@tldraw/dotcom-shared'
 import {
 	ExecutionQueue,
 	assert,
@@ -12,12 +12,11 @@ import { DurableObject } from 'cloudflare:workers'
 import { Kysely, sql } from 'kysely'
 import postgres from 'postgres'
 import { Logger } from './Logger'
-import type { TLDrawDurableObject } from './TLDrawDurableObject'
 import { ZReplicationEventWithoutSequenceInfo } from './UserDataSyncer'
 import { createPostgresConnection, createPostgresConnectionPool } from './postgres'
 import { Analytics, Environment, TLPostgresReplicatorEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
-import { getUserDurableObject } from './utils/durableObjects'
+import { getRoomDurableObject, getUserDurableObject } from './utils/durableObjects'
 
 interface Migration {
 	id: string
@@ -441,17 +440,17 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			.map((x) => x.userId as string)
 		// if the file state was deleted before the file, we might not have any impacted users
 		if (event.command === 'delete') {
-			this.getStubForFile(row.id).appFileRecordDidDelete()
+			getRoomDurableObject(this.env, row.id).appFileRecordDidDelete()
 			this.sql.exec(`DELETE FROM user_file_subscriptions WHERE fileId = ?`, row.id)
 		} else if (event.command === 'update') {
 			assert(row.ownerId, 'ownerId is required when updating file')
-			this.getStubForFile(row.id).appFileRecordDidUpdate(row as TlaFile)
+			getRoomDurableObject(this.env, row.id).appFileRecordDidUpdate(row as TlaFile)
 		} else if (event.command === 'insert') {
 			assert(row.ownerId, 'ownerId is required when inserting file')
 			if (!impactedUserIds.includes(row.ownerId)) {
 				impactedUserIds.push(row.ownerId)
 			}
-			this.getStubForFile(row.id).appFileRecordCreated(row as TlaFile)
+			getRoomDurableObject(this.env, row.id).appFileRecordCreated(row as TlaFile)
 		}
 		for (const userId of impactedUserIds) {
 			this.messageUser(userId, {
@@ -537,11 +536,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		} catch (e) {
 			console.error('Error in messageUser', e)
 		}
-	}
-
-	private getStubForFile(fileId: string) {
-		const id = this.env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${fileId}`)
-		return this.env.TLDR_DOC.get(id) as any as TLDrawDurableObject
 	}
 
 	async registerUser(userId: string) {

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -451,6 +451,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			if (!impactedUserIds.includes(row.ownerId)) {
 				impactedUserIds.push(row.ownerId)
 			}
+			this.getStubForFile(row.id).appFileRecordCreated(row as TlaFile)
 		}
 		for (const userId of impactedUserIds) {
 			this.messageUser(userId, {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -319,12 +319,16 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								.execute()
 							break
 						} else {
-							const { id: _id, ...rest } = update.row as any
-							await tx
+							const { id, ...rest } = update.row as any
+							const result = await tx
 								.insertInto(update.table)
 								.values(update.row as any)
 								.onConflict((oc) => oc.column('id').doUpdateSet(rest))
+								.returningAll()
 								.execute()
+							if (update.table === 'file' && result.length > 0) {
+								getRoomDurableObject(this.env, id).appFileRecordCreated(result[0] as any as TlaFile)
+							}
 							break
 						}
 					}

--- a/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
@@ -3,6 +3,7 @@ import { RoomSnapshot } from '@tldraw/sync-core'
 import { getR2KeyForRoom, getR2KeyForSnapshot } from '../../r2'
 import { R2Snapshot } from '../../routes/createRoomSnapshot'
 import { Environment } from '../../types'
+import { getRoomDurableObject } from '../durableObjects'
 import { getSlug } from '../roomOpenMode'
 
 export async function getLegacyRoomData(
@@ -26,5 +27,6 @@ export async function getLegacyRoomData(
 
 	const slug = await getSlug(env, id, type)
 	if (!slug) return null
+	await getRoomDurableObject(env, id).awaitPersist()
 	return await env.ROOMS.get(getR2KeyForRoom({ slug, isApp: false })).then((r) => r?.text())
 }

--- a/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
@@ -1,0 +1,30 @@
+import { RoomOpenMode } from '@tldraw/dotcom-shared'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { getR2KeyForRoom, getR2KeyForSnapshot } from '../../r2'
+import { R2Snapshot } from '../../routes/createRoomSnapshot'
+import { Environment } from '../../types'
+import { getSlug } from '../roomOpenMode'
+
+export async function getLegacyRoomData(
+	env: Environment,
+	id: string,
+	type: RoomOpenMode | 'snapshot'
+) {
+	if (type === 'snapshot') {
+		const parentSlug = await env.SNAPSHOT_SLUG_TO_PARENT_SLUG.get(id)
+		if (!parentSlug) return null
+
+		const snapshot = await env.ROOM_SNAPSHOTS.get(
+			getR2KeyForSnapshot({ parentSlug, snapshotSlug: id, isApp: false })
+		)
+		if (snapshot) {
+			const result = ((await snapshot.json()) as R2Snapshot)?.drawing as RoomSnapshot
+			if (result) return JSON.stringify(result)
+		}
+		return null
+	}
+
+	const slug = await getSlug(env, id, type)
+	if (!slug) return null
+	return await env.ROOMS.get(getR2KeyForRoom({ slug, isApp: false })).then((r) => r?.text())
+}

--- a/apps/dotcom/zero-cache/migrations/011_file_creation_column.sql
+++ b/apps/dotcom/zero-cache/migrations/011_file_creation_column.sql
@@ -1,0 +1,5 @@
+-- Used for tracking the creation source of a file. Can be a duplication of an existing file, 
+-- or slurping of a legacy file (multiplayer, readonly, snapshot).
+-- This is only used immediately after creation and should then be set to null.
+ALTER TABLE "file"
+ADD COLUMN "createSource" VARCHAR;

--- a/packages/dotcom-shared/src/index.ts
+++ b/packages/dotcom-shared/src/index.ts
@@ -2,6 +2,7 @@
 export * from './OptimisticAppStore'
 export { default as getLicenseKey } from './license'
 export {
+	FILE_PREFIX,
 	READ_ONLY_LEGACY_PREFIX,
 	READ_ONLY_PREFIX,
 	ROOM_OPEN_MODE,

--- a/packages/dotcom-shared/src/routes.ts
+++ b/packages/dotcom-shared/src/routes.ts
@@ -14,6 +14,8 @@ export const READ_ONLY_LEGACY_PREFIX = 'v'
 export const ROOM_PREFIX = 'r'
 /** @public */
 export const SNAPSHOT_PREFIX = 's'
+/** @public */
+export const FILE_PREFIX = 'f'
 
 /** @public */
 export const RoomOpenModeToPath: Record<RoomOpenMode, string> = {

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -61,6 +61,7 @@ export const tlaFileSchema = {
 		updatedAt: { type: 'number' },
 		isEmpty: { type: 'boolean' },
 		isDeleted: { type: 'boolean' },
+		createSource: { type: 'string', optional: true },
 	},
 	primaryKey: ['id'],
 	relationships: {

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,5 +1,5 @@
 import { stringEnum } from '@tldraw/utils'
-import type { SerializedSchema, SerializedStore, TLEditorSnapshot, TLRecord } from 'tldraw'
+import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaFile,
 	TlaFilePartial,
@@ -138,18 +138,6 @@ export interface ZClientSentMessage {
 	mutationId: string
 	updates: ZRowUpdate[]
 }
-
-export type TlaFileOpenState =
-	| { mode: 'create' }
-	| { mode: 'duplicate'; duplicateId: string }
-	| {
-			mode: 'slurp-legacy-file'
-			snapshot: TLEditorSnapshot
-	  }
-	| null
-	| undefined
-
-export type TlaFileOpenMode = NonNullable<TlaFileOpenState>['mode'] | null
 
 export const UserPreferencesKeys = [
 	'locale',


### PR DESCRIPTION
This moves duplication and legacy room slurping to the backend:
* It removes the the file open mode logic (no more setting it when navigating, no more sending search params to the backend).
* We now insert a file into the db with an additional column called `createSource` which is in the form of `f/kZTr6Zdx6TClE6I4qExV4`. In this case this means duplication of an existing app file. For legacy files we'd similarly use `/r|ro|v|s/kZTr6Zdx6TClE6I4qExV4` to use that existing legacy file as a starting point.
* Room DO then sees this column and reads the data from the appropriate source and initializes the room.
* We now retry getting the file record from the db, because otherwise we could still end up with a "Not found" issue since the navigation might happen before the replicator tells the room DO about the file creation.
* Assets will get re-uploaded with our existing `maybeAssociateFileAssets` logic, that makes sure all the assets are associated with the file.

We had to do this because in some cases the file got created in the db, then an file update was dispatched to the replicator (due to the trigger we have on the file table), which incorrectly the set room DO (its document info was set to a non app file without the creation params). If this happened before the user navigation hit the worker it would mean that duplication as well as slurping legacy files end up in a "Not found" error, even though the file was correctly inserted into the db.

### Change type
- [x] `improvement`

### Release notes

- Move duplicating and legacy file slurping to the server.