### PR TITLE
add a captureException to catch file.name not being defined

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1,4 +1,5 @@
 // import { Query, QueryType, Smash, TableSchema, Zero } from '@rocicorp/zero'
+import { captureException } from '@sentry/react'
 import {
 	CreateFilesResponseBody,
 	CreateSnapshotRequestBody,
@@ -363,7 +364,11 @@ export class TldrawApp {
 		}
 		assert(typeof file !== 'string', 'ok')
 
-		const name = file.name.trim()
+		if (typeof file.name === 'undefined') {
+			captureException(new Error('file name is undefined somehow: ' + JSON.stringify(file)))
+		}
+		// need a ? here because we were seeing issues on sentry where file.name was undefined
+		const name = file.name?.trim()
 		if (name) {
 			return name
 		}


### PR DESCRIPTION
couldn't figure out why file.name might be undefined here. might be a bug in the optimistic store. need to check what these files look like.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
