### PR TITLE
Don't pass through mousewheel events on scrollable elements

### DIFF
--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -11,6 +11,13 @@ export function usePassThroughWheelEvents(ref: RefObject<HTMLElement>) {
 	useEffect(() => {
 		function onWheel(e: WheelEvent) {
 			if ((e as any).isSpecialRedispatchedEvent) return
+
+			// if the element is scrollable, don't redispatch the event
+			const elm = ref.current
+			if (elm && elm.scrollHeight > elm.clientHeight) {
+				return
+			}
+
 			preventDefault(e)
 			const cvs = container.querySelector('.tl-canvas')
 			if (!cvs) return


### PR DESCRIPTION
Extracted from https://github.com/tldraw/tldraw/pull/5332.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed a bug with scrollable UI elements not being scrollable.