### PR TITLE
Improve frame heading perf

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -27,9 +27,9 @@ import {
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 import { FrameHeading } from './components/FrameHeading'
 import {
-	getFrameHeadingInfo,
 	getFrameHeadingOpts,
 	getFrameHeadingSide,
+	getFrameHeadingSize,
 	getFrameHeadingTranslation,
 } from './frameHelpers'
 
@@ -58,13 +58,13 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		const { editor } = this
 		const z = editor.getZoomLevel()
 		const opts = getFrameHeadingOpts(shape, 'black')
-		const headingInfo = getFrameHeadingInfo(editor, shape, opts)
+		const box = getFrameHeadingSize(editor, shape, opts)
 		const labelSide = getFrameHeadingSide(editor, shape)
 
 		// wow this fucking sucks!!!
 		let x: number, y: number, w: number, h: number
 
-		const { w: hw, h: hh } = headingInfo.box
+		const { w: hw, h: hh } = box
 		const scaledW = Math.min(hw, shape.props.w * z)
 		const scaledH = Math.min(hh, shape.props.h * z)
 
@@ -175,7 +175,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		// Truncate with ellipsis
 		const opts: TLCreateTextJsxFromSpansOpts = getFrameHeadingOpts(shape, theme.text)
 
-		const { box: labelBounds, spans } = getFrameHeadingInfo(this.editor, shape, opts)
+		const frameTitle = defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203)
+		const labelBounds = getFrameHeadingSize(this.editor, shape, opts)
+		const spans = this.editor.textMeasure.measureTextSpans(frameTitle, opts)
 		const text = createTextJsxFromSpans(this.editor, spans, opts)
 
 		return (

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -18,7 +18,9 @@ export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 
 
 /**
  * We use a weak map here to prevent re-measuring the text width of frames that haven't changed their names.
- * It's only really important for performance reasons while zooming in and out.
+ * It's only really important for performance reasons while zooming in and out. The measured text size is
+ * independent of the zoom level, so we can cache the expensive part (measurement) and apply those changes
+ * using the zoom level.
  */
 const measurementWeakmap = new WeakMap()
 

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -17,6 +17,12 @@ export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 
 }
 
 /**
+ * We use a weak map here to prevent re-measuring the text width of frames that haven't changed their names.
+ * It's only really important for performance reasons while zooming in and out.
+ */
+const measurementWeakmap = new WeakMap()
+
+/**
  * Get the frame heading info (size and text) for a frame shape.
  *
  * @param editor The editor instance.
@@ -25,32 +31,28 @@ export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 
  *
  * @returns The frame heading's size (as a Box) and JSX text spans.
  */
-export function getFrameHeadingInfo(
+export function getFrameHeadingSize(
 	editor: Editor,
 	shape: TLFrameShape,
 	opts: TLCreateTextJsxFromSpansOpts
 ) {
 	if (process.env.NODE_ENV === 'test') {
 		// can't really measure text in tests
-		return {
-			box: new Box(0, -opts.height, shape.props.w, opts.height),
-			spans: [],
-		}
+		return new Box(0, -opts.height, shape.props.w, opts.height)
 	}
 
-	const spans = editor.textMeasure.measureTextSpans(
-		defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203),
-		opts
-	)
+	const frameTitle = defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203)
 
-	const firstSpan = spans[0]
-	const lastSpan = last(spans)!
-	const labelTextWidth = lastSpan.box.w + lastSpan.box.x - firstSpan.box.x
-
-	return {
-		box: new Box(0, -opts.height, labelTextWidth, opts.height),
-		spans,
+	let width = measurementWeakmap.get(shape.props)
+	if (!width) {
+		const spans = editor.textMeasure.measureTextSpans(frameTitle, opts)
+		const firstSpan = spans[0]
+		const lastSpan = last(spans)!
+		width = lastSpan.box.w + lastSpan.box.x - firstSpan.box.x
+		measurementWeakmap.set(shape.props, width)
 	}
+
+	return new Box(0, -opts.height, width, opts.height)
 }
 
 export function getFrameHeadingOpts(


### PR DESCRIPTION
This PR prevents rapid re-measurement of frame headings while zooming.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a lot of frame shapes
2. Zoom in and out

### Release notes

- Fix bug effecting performance when many frames are on the screen.