### PR TITLE
Fix keyboard shortcut `1` not working for selecting the first tool

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -129,7 +129,7 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 			// no accelerator keys
 			if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
 			const index = NUMBERED_SHORTCUT_KEYS[event.key]
-			if (index) {
+			if (typeof index === 'number') {
 				preventDefault(event)
 				rButtons.current[index]?.click()
 			}


### PR DESCRIPTION
Keyboards shortcut 1 didn't work since we got index of 0 which is falsy.

### Change type

- [x] `bugfix`

### Release notes

- Fix a bug when 1 didn't work as a keyboard shortcut to select the first tool.