### PR TITLE
Use tick for asset debounce

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -5,13 +5,12 @@ import {
 	TLImageAsset,
 	TLShapeId,
 	TLVideoAsset,
-	debounce,
 	react,
 	useDelaySvgExport,
 	useEditor,
 	useSvgExportContext,
 } from '@tldraw/editor'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /**
  * Options for {@link useImageOrVideoAsset}.
@@ -47,8 +46,6 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 	const editor = useEditor()
 	const exportInfo = useSvgExportContext()
 	const exportIsReady = useDelaySvgExport()
-
-	const resolveAssetUrlDebounced = useMemo(() => debounce(resolveAssetUrl, 500), [])
 
 	// We use a state to store the result of the asset resolution, and we're going to avoid updating this whenever we can
 	const [result, setResult] = useState<{
@@ -108,10 +105,20 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 
 			// If we already resolved the URL, debounce fetching potentially multiple image variations.
 			if (didAlreadyResolve.current) {
-				resolveAssetUrlDebounced(editor, assetId, screenScale, exportInfo, (url) =>
-					resolve(asset, url)
-				)
-				cancelDebounceFn = resolveAssetUrlDebounced.cancel // cancel the debounce when the hook unmounts
+				let tick = 0
+
+				const resolveAssetAfterAWhile = () => {
+					tick++
+					if (tick > 500 / 16) {
+						// debounce for 500ms
+						resolveAssetUrl(editor, assetId, screenScale, exportInfo, (url) => resolve(asset, url))
+						cancelDebounceFn?.()
+					}
+				}
+
+				cancelDebounceFn?.()
+				editor.on('tick', resolveAssetAfterAWhile)
+				cancelDebounceFn = () => editor.off('tick', resolveAssetAfterAWhile)
 			} else {
 				resolveAssetUrl(editor, assetId, screenScale, exportInfo, (url) => resolve(asset, url))
 			}
@@ -122,7 +129,7 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 			cancelDebounceFn?.()
 			isCancelled = true
 		}
-	}, [editor, assetId, exportInfo, exportIsReady, shapeId, resolveAssetUrlDebounced, width])
+	}, [editor, assetId, exportInfo, exportIsReady, shapeId, width])
 
 	return result
 }


### PR DESCRIPTION
When a user zooms in, all of the image or video shapes will run a debounced function that attempts to resolve a new URL for the asset. This is part of the LOD work done in #3684 / https://github.com/tldraw/tldraw/pull/3827. One interesting issue is that the debounce function itself is relatively expensive. With many _n_ shapes on the canvas, the browser is adding and removing at least _n_ global timers on each frame.

For example, here's me zooming in and out on a bunch of images. The 

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/0548318a-52fd-44a9-8cee-a5b7dd323d51" />

<img width="458" alt="image" src="https://github.com/user-attachments/assets/cd82014b-e48d-4f82-92bd-54f9280ba797" />

To avoid this work, this PR hooks into the editor's tick event, which fires every 16ms. Rather than debouncing for 500ms, we count the ticks and add / remove listeners from the editor.

We make a request when the screen size of an image changes. This can happen when a user resizes a change or when a user changes the zoom. We could further improve the latter case by firing a "zoom ended" or "camera settled" event from the editor and only making those requests then; but we'd still need to "debounce" the resizing story.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Make lots of images of any size.
2. Zoom in and out.
3. Check performance tab for smooth sailing.

### Release notes

- Improve zoom performance when many shapes are in a document.