### PR TITLE
[proof-of-concept] contextual toolbar: mobile variant

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2051,6 +2051,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	setEditingShape(shape: TLShapeId | TLShape | null): this {
 		const id = typeof shape === 'string' ? shape : (shape?.id ?? null)
+		this.setEditingShapeTipTapTextEditor(null)
 		if (id !== this.getEditingShapeId()) {
 			if (id) {
 				const shape = this.getShape(id)

--- a/packages/editor/src/lib/hooks/useViewportHeight.ts
+++ b/packages/editor/src/lib/hooks/useViewportHeight.ts
@@ -26,9 +26,11 @@ export function useViewportHeight(): number {
 		}
 
 		window.visualViewport?.addEventListener('resize', handleResize)
+		window.visualViewport?.addEventListener('scroll', handleResize)
 
 		return () => {
 			window.visualViewport?.removeEventListener('resize', handleResize)
+			window.visualViewport?.removeEventListener('scroll', handleResize)
 		}
 	}, [])
 	return height

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -8,7 +8,6 @@ import {
 	stopEventPropagation,
 	useEditor,
 	useUniqueSafeId,
-	useValue,
 } from '@tldraw/editor'
 import React, { useEffect, useState } from 'react'
 
@@ -61,11 +60,6 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 	const [initialPositionOnCreate, setInitialPositionOnCreate] = useState(
 		null as { x: number; y: number } | null
 	)
-	const isCoarsePointer = useValue(
-		'isCoarsePointer',
-		() => editor.getInstanceState().isCoarsePointer,
-		[editor]
-	)
 
 	const handleCreate = (props: EditorEvents['create']) => {
 		if (editor.getEditingShapeId() !== shapeId) return
@@ -74,7 +68,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 		editor.setEditingShapeTipTapTextEditor(textEditor)
 
 		// Either we select-all the text upon creation if desired.
-		if (shouldSelectAllOnCreate || isCoarsePointer) {
+		if (shouldSelectAllOnCreate) {
 			textEditor.chain().focus().selectAll().run()
 		} else if (initialPositionOnCreate) {
 			// Or, we place the caret at the intended clicked position, if

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -8,6 +8,7 @@ import {
 	stopEventPropagation,
 	useEditor,
 	useUniqueSafeId,
+	useValue,
 } from '@tldraw/editor'
 import React, { useEffect, useState } from 'react'
 
@@ -60,6 +61,11 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 	const [initialPositionOnCreate, setInitialPositionOnCreate] = useState(
 		null as { x: number; y: number } | null
 	)
+	const isCoarsePointer = useValue(
+		'isCoarsePointer',
+		() => editor.getInstanceState().isCoarsePointer,
+		[editor]
+	)
 
 	const handleCreate = (props: EditorEvents['create']) => {
 		if (editor.getEditingShapeId() !== shapeId) return
@@ -68,7 +74,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 		editor.setEditingShapeTipTapTextEditor(textEditor)
 
 		// Either we select-all the text upon creation if desired.
-		if (shouldSelectAllOnCreate) {
+		if (shouldSelectAllOnCreate || isCoarsePointer) {
 			textEditor.chain().focus().selectAll().run()
 		} else if (initialPositionOnCreate) {
 			// Or, we place the caret at the intended clicked position, if

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -970,6 +970,12 @@
 	.tl-contextual-toolbar .tl-contextual-toolbar__indicator {
 		display: none;
 	}
+
+	.tl-contextual-toolbar .tlui-toolbar__tools {
+		width: 100vw;
+		justify-content: space-between;
+		border-radius: 0;
+	}
 }
 
 .tl-rich-text__toolbar-link-input {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
@@ -1,4 +1,4 @@
-import { preventDefault, TiptapEditor, tlenv } from '@tldraw/editor'
+import { preventDefault, TiptapEditor, useEditor } from '@tldraw/editor'
 import { useEffect, useRef, useState } from 'react'
 import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -15,6 +15,7 @@ export interface LinkEditorProps {
 
 /** @public @react */
 export function LinkEditor({ textEditor, value: initialValue, onComplete }: LinkEditorProps) {
+	const editor = useEditor()
 	const [value, setValue] = useState(initialValue)
 	const msg = useTranslation()
 	const ref = useRef<HTMLInputElement>(null)
@@ -31,9 +32,9 @@ export function LinkEditor({ textEditor, value: initialValue, onComplete }: Link
 		}
 
 		textEditor.commands.setLink({ href: link })
-		// N.B. We shouldn't focus() on iOS because it causes the
+		// N.B. We shouldn't focus() on mobile because it causes the
 		// Return key to replace the link with a newline :facepalm:
-		if (tlenv.isIos) {
+		if (editor.getInstanceState().isCoarsePointer) {
 			textEditor.commands.blur()
 		} else {
 			textEditor.commands.focus()

--- a/packages/tldraw/src/lib/ui/hooks/useContextualToolbarPosition.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useContextualToolbarPosition.ts
@@ -62,8 +62,8 @@ export function useContextualToolbarPosition({
 
 	if (isMobile || isNaN(selectionBounds.x) || isNaN(selectionBounds.y) || isSelectionOffscreen) {
 		return {
-			x: container.clientWidth / 2 - menuWidth / 2,
-			y: viewportHeight - menuHeight - 16,
+			x: isMobile ? 0 : container.clientWidth / 2 - menuWidth / 2,
+			y: viewportHeight - menuHeight,
 			indicatorOffset: 0,
 			visible: true,
 		}


### PR DESCRIPTION
variant where the toolbar goes across the virtual keyboard to make it feel more integrated with the keyboard (h/t to Alex for the suggestion)

![Screenshot_20250206-085426](https://github.com/user-attachments/assets/b041bf89-4dd8-44cb-a0e1-45105d3404c4)


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
