### PR TITLE
Fix dancing icons.

### DIFF
--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -74,10 +74,8 @@ export function TlaSidebarLayout({ children }: { children: ReactNode; collapsibl
 		if (rResizeState.current.name === 'resizing') {
 			const { startX, startWidth } = rResizeState.current
 
-			const newWidth = clamp(
-				startWidth + (moveEvent.clientX - startX),
-				MIN_SIDEBAR_WIDTH,
-				MAX_SIDEBAR_WIDTH
+			const newWidth = Math.floor(
+				clamp(startWidth + (moveEvent.clientX - startX), MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH)
 			)
 
 			if (newWidth !== getLocalSessionStateUnsafe().sidebarWidth) {


### PR DESCRIPTION
Looks like this happened only on non-retina screens and was caused by subpixel rendering.

Resolves INT-720

### Before

https://github.com/user-attachments/assets/1018c07d-4f6e-4af1-ab2c-2b7ddd156e51


### After

https://github.com/user-attachments/assets/332316ec-b0b9-4b5f-afab-67658e2deb23



### Change type

- [x] `improvement`

### Release notes

- Fix the dancing icons when the sidebar width change.