### PR TITLE
Numeric shortcuts were still getting triggered when used inside some inputs (like the file rename input)

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -97,6 +97,9 @@ import { useValue } from '@tldraw/state-react';
 import { VecModel } from '@tldraw/tlschema';
 import { whyAmIRunning } from '@tldraw/state';
 
+// @public (undocumented)
+export function activeElementShouldCaptureKeys(): boolean | null | string;
+
 // @public
 export function angleDistance(fromAngle: number, toAngle: number, direction: number): number;
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -98,7 +98,7 @@ import { VecModel } from '@tldraw/tlschema';
 import { whyAmIRunning } from '@tldraw/state';
 
 // @public (undocumented)
-export function activeElementShouldCaptureKeys(): boolean | null | string;
+export function activeElementShouldCaptureKeys(): boolean;
 
 // @public
 export function angleDistance(fromAngle: number, toAngle: number, direction: number): number;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -97,7 +97,7 @@ import { useValue } from '@tldraw/state-react';
 import { VecModel } from '@tldraw/tlschema';
 import { whyAmIRunning } from '@tldraw/state';
 
-// @public (undocumented)
+// @internal (undocumented)
 export function activeElementShouldCaptureKeys(): boolean;
 
 // @public

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -413,6 +413,7 @@ export {
 	type TLDeepLinkOptions,
 } from './lib/utils/deepLinks'
 export {
+	activeElementShouldCaptureKeys,
 	loopToHtmlElement,
 	preventDefault,
 	releasePointerCapture,

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -2,7 +2,7 @@ import { useValue } from '@tldraw/state-react'
 import { useEffect } from 'react'
 import { Editor } from '../editor/Editor'
 import { TLKeyboardEventInfo } from '../editor/types/event-types'
-import { preventDefault, stopEventPropagation } from '../utils/dom'
+import { activeElementShouldCaptureKeys, preventDefault, stopEventPropagation } from '../utils/dom'
 import { isAccelKey } from '../utils/keyboard'
 import { useContainer } from './useContainer'
 import { useEditor } from './useEditor'
@@ -274,15 +274,6 @@ export function useDocumentEvents() {
 	}, [editor, container, isAppFocused])
 }
 
-const INPUTS = ['input', 'select', 'button', 'textarea']
-
 function areShortcutsDisabled(editor: Editor) {
-	const { activeElement } = document
-
-	return (
-		editor.menus.hasOpenMenus() ||
-		(activeElement &&
-			(activeElement.getAttribute('contenteditable') ||
-				INPUTS.indexOf(activeElement.tagName.toLowerCase()) > -1))
-	)
+	return editor.menus.hasOpenMenus() || activeElementShouldCaptureKeys()
 }

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -90,3 +90,15 @@ export const setStyleProperty = (
 	if (!elm) return
 	elm.style.setProperty(property, value as string)
 }
+
+const INPUTS = ['input', 'select', 'button', 'textarea']
+
+/** @public */
+export function activeElementShouldCaptureKeys() {
+	const { activeElement } = document
+	return (
+		activeElement &&
+		(activeElement.getAttribute('contenteditable') ||
+			INPUTS.indexOf(activeElement.tagName.toLowerCase()) > -1)
+	)
+}

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -93,7 +93,7 @@ export const setStyleProperty = (
 
 const INPUTS = ['input', 'select', 'button', 'textarea']
 
-/** @public */
+/** @internal */
 export function activeElementShouldCaptureKeys() {
 	const { activeElement } = document
 	return !!(

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -96,7 +96,7 @@ const INPUTS = ['input', 'select', 'button', 'textarea']
 /** @public */
 export function activeElementShouldCaptureKeys() {
 	const { activeElement } = document
-	return (
+	return !!(
 		activeElement &&
 		(activeElement.getAttribute('contenteditable') ||
 			INPUTS.indexOf(activeElement.tagName.toLowerCase()) > -1)

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -1,4 +1,10 @@
-import { preventDefault, useEditor, useEvent, useUniqueSafeId } from '@tldraw/editor'
+import {
+	activeElementShouldCaptureKeys,
+	preventDefault,
+	useEditor,
+	useEvent,
+	useUniqueSafeId,
+} from '@tldraw/editor'
 import classNames from 'classnames'
 import { createContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
@@ -125,7 +131,7 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 		if (!editor.options.enableToolbarKeyboardShortcuts) return
 
 		function handleKeyDown(event: KeyboardEvent) {
-			if (areShortcutsDisabled(editor)) return
+			if (areShortcutsDisabled(editor) || activeElementShouldCaptureKeys()) return
 			// no accelerator keys
 			if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
 			const index = NUMBERED_SHORTCUT_KEYS[event.key]


### PR DESCRIPTION
We used `hotkeys` library [in the past t](https://github.com/tldraw/tldraw/pull/5340)o add the shortcuts for numeric tool shortcut keys. Looks like it handled the editable element filtering (not triggering keyboard shortcuts when the source was an editable element). Since we no longer use that we should prevent the shortcuts manually.

### Change type

- [x] `bugfix`

### Test plan

1. Edit the file name in the sidebar.
2. Pressing 1, 2, 3 should no longer change the tool and should add the pressed key to the name input.

### Release notes

- Fix an issue with numeric shortcuts working inside of editable elements.