### PR TITLE
Track user do cold start time on server side replicator

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -580,7 +580,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				)
 			}
 			this.log.debug('inserted guest files', guestFiles.length)
-
 			return {
 				sequenceId: this.state.sequenceId + ':' + sequenceIdSuffix,
 				sequenceNumber: 0,

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -64,6 +64,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	private userId: string | null = null
+	private coldStartStartTime: number | null = null
 
 	readonly router = Router()
 		.all('/app/:userId/*', async (req) => {
@@ -77,6 +78,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				throw new Error('Rate limited')
 			}
 			if (!this.cache) {
+				this.coldStartStartTime = Date.now()
 				this.log.debug('creating cache', this.userId)
 				this.cache = new UserDataSyncer(
 					this.ctx,
@@ -119,8 +121,16 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	private readonly sockets = new Set<WebSocket>()
 
+	maybeReportColdStartTime(type: ZServerSentMessage['type']) {
+		if (type !== 'initial_data' || !this.coldStartStartTime) return
+		const time = Date.now() - this.coldStartStartTime
+		this.coldStartStartTime = null
+		this.logEvent({ type: 'cold_start_time', id: this.userId!, duration: time })
+	}
+
 	broadcast(message: ZServerSentMessage) {
 		this.logEvent({ type: 'broadcast_message', id: this.userId! })
+		this.maybeReportColdStartTime(message.type)
 		const msg = JSON.stringify(message)
 		for (const socket of this.sockets) {
 			if (socket.readyState === WebSocket.OPEN) {
@@ -554,6 +564,12 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	logEvent(event: TLUserDurableObjectEvent) {
 		switch (event.type) {
 			case 'reboot_duration':
+				this.writeEvent({
+					blobs: [event.type, event.id],
+					doubles: [event.duration],
+				})
+				break
+			case 'cold_start_time':
 				this.writeEvent({
 					blobs: [event.type, event.id],
 					doubles: [event.duration],

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -131,3 +131,4 @@ export type TLUserDurableObjectEvent =
 			id: string
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }
+	| { type: 'cold_start_time'; id: string; duration: number }

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -114,6 +114,7 @@ export type TLPostgresReplicatorEvent =
 	| { type: 'reboot' | 'reboot_error' | 'register_user' | 'unregister_user' | 'get_file_record' }
 	| { type: 'reboot_duration'; duration: number }
 	| { type: 'rpm'; rpm: number }
+	| { type: 'active_users'; count: number }
 
 export type TLUserDurableObjectEvent =
 	| {


### PR DESCRIPTION
Add some additional tracking (active users in replicator and cold start time for user DO). Added some additional panes to grafana, here's [the view](https://tldraw.grafana.net/d/adgumkhou3chsd/events?orgId=1&from=now-12h&to=now&timezone=browser&var-environment=pr-5380) for this pr.

### Change type

- [x] `improvement`

### Release notes

- Add some additional tracking (active users in replicator and cold start time to used do).