### PR TITLE
Add dev env variable (makes the asset association work locally)

### DIFF
--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -46,6 +46,7 @@ name = "dev-tldraw-multiplayer"
 BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
 BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
 TLDRAW_ENV = "development"
+MULTIPLAYER_SERVER = "http://localhost:3000"
 
 # we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.
 


### PR DESCRIPTION
We use this for associating assets to a file. Looks like we weren't setting the variable at all.

This only works for files uploaded to the app. Existing legacy rooms used assets uploader worker, which stores files into a separate folder in dev mode, so those still won't work.

### Change type

- [x] `improvement`

### Release notes

- Add env variable for local development.