### PR TITLE
Show errors when loading legacy multiplayer rooms and when logged in

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -98,6 +98,7 @@ function TlaEditorInner({
 	)
 
 	if (storeWithStatus.error) {
+		setIsReady()
 		return <StoreErrorScreen error={storeWithStatus.error} />
 	}
 


### PR DESCRIPTION
Is ready wrapper continued to show the spinner even after we errored out.

### Change type

- [x] `bugfix`

### Test plan

1. Log in (logged out experience wasn't broken).
2. Got to a non existing legacy room.
3. You should see a `Room not found` error page.

### Release notes

- Show error pages instead of getting stuck on the spinner when logged in and visiting a legacy route.