### PR TITLE
Make updates less frequent 

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -145,7 +145,6 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				updateSessionState.flush()
 				abortController.abort()
 				cleanup()
-				updateSessionState.cancel()
 			}
 		},
 		[addDialog, app, fileId, remountImageShapes, setIsReady]
@@ -249,7 +248,6 @@ function SneakyFileUpdateHandler({ fileId }: { fileId: string }) {
 		return () => {
 			onChange.flush()
 			unsub()
-			onChange.cancel()
 		}
 	}, [app, fileId, editor])
 

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -118,7 +118,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			const sessionState$ = createSessionStateSnapshotSignal(editor.store)
 			const updateSessionState = throttle((state: TLSessionStateSnapshot) => {
 				app.onFileSessionStateUpdate(fileId, state)
-			}, 1000)
+			}, 5000)
 			// don't want to update if they only open the file and didn't look around
 			let firstTime = true
 			const cleanup = react('update session state', () => {
@@ -142,6 +142,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			}).then(setIsReady)
 
 			return () => {
+				updateSessionState.flush()
 				abortController.abort()
 				cleanup()
 				updateSessionState.cancel()
@@ -240,12 +241,13 @@ function SneakyFileUpdateHandler({ fileId }: { fileId: string }) {
 				app.onFileEdit(fileId)
 			},
 			// This is used to update the lastEditAt time in the database, and to let the local
-			// room know that an edit ahs been made.
+			// room know that an edit has been made.
 			// It doesn't need to be super fast or accurate so we can throttle it a lot
-			5000
+			10_000
 		)
 		const unsub = editor.store.listen(onChange, { scope: 'document', source: 'user' })
 		return () => {
+			onChange.flush()
 			unsub()
 			onChange.cancel()
 		}


### PR DESCRIPTION
Updates to `fileState` `sessionState` and `file` `updatedAt` fields are by far the most frequent queries in our DB. Make them a bit less frequent and also make sure we do flush any pending updates if we navigate to a different file.
 
### Change type

- [x] `improvement`

### Release notes

- Make updates to file and file state a bit less frequent. Make sure we flush and pending updates before navigating though.