### PR TITLE
ShapeUtil.configure for shape options

### DIFF
--- a/apps/examples/src/examples/resize-note/ResizeNoteExample.tsx
+++ b/apps/examples/src/examples/resize-note/ResizeNoteExample.tsx
@@ -1,16 +1,15 @@
 import { NoteShapeUtil, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
-// The note shape util has a static `options` object.
-// Important! This example will effect other examples, too.
-// If you're running examples locally, reload after leaving this page!
-NoteShapeUtil.options.resizeMode = 'scale'
+// Configure the note shape util to allow scaling to resize
+const shapeUtils = [NoteShapeUtil.configure({ resizeMode: 'scale' })]
 
 export default function ResizeNoteExample() {
 	return (
 		<>
 			<div className="tldraw__editor">
-				<Tldraw persistenceKey="resize-note"></Tldraw>
+				{/* pass the configured shape utils to the editor */}
+				<Tldraw persistenceKey="resize-note" shapeUtils={shapeUtils}></Tldraw>
 			</div>
 		</>
 	)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2517,6 +2517,9 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canScroll(_shape: Shape): boolean;
     canSnap(_shape: Shape): boolean;
     abstract component(shape: Shape): any;
+    static configure<T extends TLShapeUtilConstructor<any, any>>(this: T, options: T extends new (...args: any[]) => {
+        options: infer Options;
+    } ? Partial<Options> : never): T;
     // (undocumented)
     editor: Editor;
     // @internal (undocumented)
@@ -2561,6 +2564,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onTranslateStart?(shape: Shape): TLShapePartial<Shape> | void;
+    options: {};
     static props?: RecordProps<TLUnknownShape>;
     // @internal
     providesBackgroundForChildren(_shape: Shape): boolean;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -53,7 +53,26 @@ export interface TLShapeUtilCanvasSvgDef {
 
 /** @public */
 export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
+	/** Configure this shape utils {@link ShapeUtil.options | `options`}. */
+	static configure<T extends TLShapeUtilConstructor<any, any>>(
+		this: T,
+		options: T extends new (...args: any[]) => { options: infer Options } ? Partial<Options> : never
+	): T {
+		// @ts-expect-error -- typescript has no idea what's going on here but it's fine
+		return class extends this {
+			// @ts-expect-error
+			options = { ...this.options, ...options }
+		}
+	}
+
 	constructor(public editor: Editor) {}
+
+	/**
+	 * Options for this shape util. If you're implementing a custom shape util, you can override
+	 * this to provide customization options for your shape. If using an existing shape util, you
+	 * can customizing this by calling {@link ShapeUtil.configure}.
+	 */
+	options = {}
 
 	/**
 	 * Props allow you to define the shape's properties in a way that the editor can understand.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -886,7 +886,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
         };
     };
     // (undocumented)
-    static options: DrawShapeOptions;
+    options: DrawShapeOptions;
     // (undocumented)
     static props: RecordProps<TLDrawShape>;
     // (undocumented)
@@ -1428,7 +1428,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
         };
     };
     // (undocumented)
-    static options: HighlightShapeOptions;
+    options: HighlightShapeOptions;
     // (undocumented)
     static props: RecordProps<TLHighlightShape>;
     // (undocumented)
@@ -1709,7 +1709,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         y: number;
     } | undefined;
     // (undocumented)
-    static options: NoteShapeOptions;
+    options: NoteShapeOptions;
     // (undocumented)
     static props: RecordProps<TLNoteShape>;
     // (undocumented)

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -73,6 +73,28 @@ export interface TldrawBaseProps
 /** @public */
 export type TldrawProps = TldrawBaseProps & TldrawEditorStoreProps
 
+function mergeWithAndReplaceDefaults<const Key extends string, T extends { [K in Key]: string }>(
+	key: Key,
+	customEntries: readonly T[],
+	defaults: readonly T[]
+) {
+	const overrideTypes = new Set(customEntries.map((entry) => entry[key]))
+
+	const result = []
+	for (const defaultEntry of defaults) {
+		if (overrideTypes.has(defaultEntry[key])) continue
+		result.push(defaultEntry)
+	}
+
+	for (const customEntry of customEntries) {
+		result.push(customEntry)
+	}
+
+	return result
+}
+
+const allDefaultTools = [...defaultTools, ...defaultShapeTools]
+
 /** @public @react */
 export function Tldraw(props: TldrawProps) {
 	const {
@@ -106,19 +128,19 @@ export function Tldraw(props: TldrawProps) {
 
 	const _shapeUtils = useShallowArrayIdentity(shapeUtils)
 	const shapeUtilsWithDefaults = useMemo(
-		() => [...defaultShapeUtils, ..._shapeUtils],
+		() => mergeWithAndReplaceDefaults('type', _shapeUtils, defaultShapeUtils),
 		[_shapeUtils]
 	)
 
 	const _bindingUtils = useShallowArrayIdentity(bindingUtils)
 	const bindingUtilsWithDefaults = useMemo(
-		() => [...defaultBindingUtils, ..._bindingUtils],
+		() => mergeWithAndReplaceDefaults('type', _bindingUtils, defaultBindingUtils),
 		[_bindingUtils]
 	)
 
 	const _tools = useShallowArrayIdentity(tools)
 	const toolsWithDefaults = useMemo(
-		() => [...defaultTools, ...defaultShapeTools, ..._tools],
+		() => mergeWithAndReplaceDefaults('id', allDefaultTools, _tools),
 		[_tools]
 	)
 

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -9,6 +9,7 @@ import {
 	TldrawEditor,
 	TldrawEditorBaseProps,
 	TldrawEditorStoreProps,
+	mergeArraysAndReplaceDefaults,
 	useEditor,
 	useEditorComponents,
 	useOnMount,
@@ -73,26 +74,6 @@ export interface TldrawBaseProps
 /** @public */
 export type TldrawProps = TldrawBaseProps & TldrawEditorStoreProps
 
-function mergeWithAndReplaceDefaults<const Key extends string, T extends { [K in Key]: string }>(
-	key: Key,
-	customEntries: readonly T[],
-	defaults: readonly T[]
-) {
-	const overrideTypes = new Set(customEntries.map((entry) => entry[key]))
-
-	const result = []
-	for (const defaultEntry of defaults) {
-		if (overrideTypes.has(defaultEntry[key])) continue
-		result.push(defaultEntry)
-	}
-
-	for (const customEntry of customEntries) {
-		result.push(customEntry)
-	}
-
-	return result
-}
-
 const allDefaultTools = [...defaultTools, ...defaultShapeTools]
 
 /** @public @react */
@@ -128,19 +109,19 @@ export function Tldraw(props: TldrawProps) {
 
 	const _shapeUtils = useShallowArrayIdentity(shapeUtils)
 	const shapeUtilsWithDefaults = useMemo(
-		() => mergeWithAndReplaceDefaults('type', _shapeUtils, defaultShapeUtils),
+		() => mergeArraysAndReplaceDefaults('type', _shapeUtils, defaultShapeUtils),
 		[_shapeUtils]
 	)
 
 	const _bindingUtils = useShallowArrayIdentity(bindingUtils)
 	const bindingUtilsWithDefaults = useMemo(
-		() => mergeWithAndReplaceDefaults('type', _bindingUtils, defaultBindingUtils),
+		() => mergeArraysAndReplaceDefaults('type', _bindingUtils, defaultBindingUtils),
 		[_bindingUtils]
 	)
 
 	const _tools = useShallowArrayIdentity(tools)
 	const toolsWithDefaults = useMemo(
-		() => mergeWithAndReplaceDefaults('id', allDefaultTools, _tools),
+		() => mergeArraysAndReplaceDefaults('id', allDefaultTools, _tools),
 		[_tools]
 	)
 

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -47,7 +47,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 	static override props = drawShapeProps
 	static override migrations = drawShapeMigrations
 
-	static options: DrawShapeOptions = {
+	override options: DrawShapeOptions = {
 		maxPointsPerShape: 600,
 	}
 

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -33,7 +33,6 @@ export class Drawing extends StateNode {
 	override shapeType = this.parent.id === 'highlight' ? ('highlight' as const) : ('draw' as const)
 
 	util = this.editor.getShapeUtil(this.shapeType) as DrawShapeUtil | HighlightShapeUtil
-	maxPoints = 500 // temporary
 
 	isPen = false
 	isPenOrStylus = false
@@ -57,10 +56,6 @@ export class Drawing extends StateNode {
 		this.info = info
 		this.lastRecordedPoint = this.editor.inputs.currentPagePoint.clone()
 		this.startShape()
-		this.maxPoints =
-			this.shapeType === 'draw'
-				? DrawShapeUtil.options.maxPointsPerShape
-				: HighlightShapeUtil.options.maxPointsPerShape
 	}
 
 	override onPointerMove() {
@@ -635,7 +630,7 @@ export class Drawing extends StateNode {
 				this.editor.updateShapes([shapePartial])
 
 				// Set a maximum length for the lines array; after 200 points, complete the line.
-				if (newPoints.length > this.maxPoints) {
+				if (newPoints.length > this.util.options.maxPointsPerShape) {
 					this.editor.updateShapes([{ id, type: this.shapeType, props: { isComplete: true } }])
 
 					const newShapeId = createShapeId()

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -45,7 +45,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	static override props = highlightShapeProps
 	static override migrations = highlightShapeMigrations
 
-	static options: HighlightShapeOptions = {
+	override options: HighlightShapeOptions = {
 		maxPointsPerShape: 600,
 		underlayOpacity: 0.82,
 		overlayOpacity: 0.35,
@@ -103,7 +103,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 					shape={shape}
 					forceSolid={forceSolid}
 					strokeWidth={strokeWidth}
-					opacity={HighlightShapeUtil.options.overlayOpacity}
+					opacity={this.options.overlayOpacity}
 				/>
 			</SVGContainer>
 		)
@@ -118,7 +118,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 					shape={shape}
 					forceSolid={forceSolid}
 					strokeWidth={strokeWidth}
-					opacity={HighlightShapeUtil.options.underlayOpacity}
+					opacity={this.options.underlayOpacity}
 				/>
 			</SVGContainer>
 		)
@@ -151,7 +151,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 					forceSolid={forceSolid}
 					strokeWidth={strokeWidth}
 					shape={shape}
-					opacity={HighlightShapeUtil.options.overlayOpacity}
+					opacity={this.options.overlayOpacity}
 				/>
 			</g>
 		)
@@ -167,7 +167,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 					forceSolid={forceSolid}
 					strokeWidth={strokeWidth}
 					shape={shape}
-					opacity={HighlightShapeUtil.options.underlayOpacity}
+					opacity={this.options.underlayOpacity}
 				/>
 			</g>
 		)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -65,7 +65,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	static override props = noteShapeProps
 	static override migrations = noteShapeMigrations
 
-	static options: NoteShapeOptions = {
+	override options: NoteShapeOptions = {
 		resizeMode: 'none',
 	}
 
@@ -73,7 +73,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		return true
 	}
 	override hideResizeHandles() {
-		const { resizeMode } = NoteShapeUtil.options
+		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
 				return true
@@ -88,7 +88,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	}
 
 	override isAspectRatioLocked() {
-		return NoteShapeUtil.options.resizeMode === 'scale'
+		return this.options.resizeMode === 'scale'
 	}
 
 	override hideSelectionBoundsFg() {
@@ -202,7 +202,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	}
 
 	override onResize(shape: any, info: TLResizeInfo<any>) {
-		const { resizeMode } = NoteShapeUtil.options
+		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
 				return undefined

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3544,9 +3544,11 @@ describe('resizing a selection of mixed rotations', () => {
 // })
 
 describe('editor.resizeNoteShape', () => {
-	it('can scale when that option is set to true', () => {
-		NoteShapeUtil.options.resizeMode = 'scale'
+	beforeEach(() => {
+		editor.getShapeUtil<NoteShapeUtil>('note').options.resizeMode = 'none'
+	})
 
+	it('can scale when that option is set to true', () => {
 		const noteBId = createShapeId('noteB')
 		editor.createShapes([box(ids.boxA, 0, 0, 200, 200), { id: noteBId, type: 'note', x: 0, y: 0 }])
 
@@ -3563,9 +3565,6 @@ describe('editor.resizeNoteShape', () => {
 		expect(editor.getShape(noteBId)).toMatchObject({ x: 0, y: 0, props: { scale: 2.1 } }) // but scaled!
 
 		expect(editor.getShapePageBounds(noteBId)).toMatchObject({ x: 0, y: 0, w: 420, h: 420 })
-
-		// for the sake of future tests, set it back to normal
-		NoteShapeUtil.options.resizeMode = 'none'
 	})
 })
 

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3545,7 +3545,7 @@ describe('resizing a selection of mixed rotations', () => {
 
 describe('editor.resizeNoteShape', () => {
 	beforeEach(() => {
-		editor.getShapeUtil<NoteShapeUtil>('note').options.resizeMode = 'none'
+		editor.getShapeUtil<NoteShapeUtil>('note').options.resizeMode = 'scale'
 	})
 
 	it('can scale when that option is set to true', () => {

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -287,6 +287,11 @@ export class MediaHelpers {
 }
 
 // @internal (undocumented)
+export function mergeArraysAndReplaceDefaults<const Key extends string, T extends {
+    [K in Key]: string;
+}>(key: Key, customEntries: readonly T[], defaults: readonly T[]): T[];
+
+// @internal (undocumented)
 export function minBy<T>(arr: readonly T[], fn: (item: T) => number): T | undefined;
 
 // @internal (undocumented)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export {
 	dedupe,
 	last,
 	maxBy,
+	mergeArraysAndReplaceDefaults,
 	minBy,
 	partition,
 	rotateArray,

--- a/packages/utils/src/lib/array.ts
+++ b/packages/utils/src/lib/array.ts
@@ -97,3 +97,23 @@ export function areArraysShallowEqual<T>(arr1: readonly T[], arr2: readonly T[])
 	}
 	return true
 }
+
+/** @internal */
+export function mergeArraysAndReplaceDefaults<
+	const Key extends string,
+	T extends { [K in Key]: string },
+>(key: Key, customEntries: readonly T[], defaults: readonly T[]) {
+	const overrideTypes = new Set(customEntries.map((entry) => entry[key]))
+
+	const result = []
+	for (const defaultEntry of defaults) {
+		if (overrideTypes.has(defaultEntry[key])) continue
+		result.push(defaultEntry)
+	}
+
+	for (const customEntry of customEntries) {
+		result.push(customEntry)
+	}
+
+	return result
+}


### PR DESCRIPTION
This diff tweaks the shape options API added in #5349 so that it's no longer global. Instead, shape utils have a `.configure()`  method, which accepts a partial of their options and returns a new shape util with those options applied.

We also tweak the behaviour of passing in custom shape utils to play nicer with this: previously, if you passed in a shape util with type "arrow", an error would be thrown complaining about duplicate shape utils because the default one was already specified. Now, we won't try to include the default arrow util because we can see you using a custom one. If you pass two utils with the type "arrow", you'll still get an error.

### Change type
- [x] `api`

### Release notes

- introduces shape options & `ShapeUtil.configure`, a utility for passing options to a shape util
- moves (unreleased) noteShapeResizeMode to NoteShapeOptions.resizeMode
- If you pass tldraw a shape util with the same type as a default, it'll now replace the default rather than crash
- **BREAKING** `options.maxDrawShapePoints` should now be specified with `DrawShapeUtil.configure({maxPoints})` and `HighlightShapeUtil.configure({maxPoints})`