### PR TITLE
a11y: focus ring

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -172,6 +172,7 @@
 		inset 0px 0px 0px 1px var(--color-panel-contrast);
 	--shadow-4: 0px 0px 3px hsl(0, 0%, 0%, 19%), 0px 5px 4px hsl(0, 0%, 0%, 16%),
 		0px 2px 16px hsl(0, 0%, 0%, 6%), inset 0px 0px 0px 1px var(--color-panel-contrast);
+	--shadow-focus-ring: inset 0 0 0 3px hsl(213, 100%, 68%);
 }
 
 .tl-theme__dark {

--- a/packages/editor/src/lib/editor/managers/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager.ts
@@ -30,6 +30,10 @@ export class FocusManager {
 			editor.updateInstanceState({ isFocused: !!autoFocus })
 		}
 		this.updateContainerClass()
+
+		const container = this.editor.getContainer()
+		container.addEventListener('keydown', this.handleKeyDown.bind(this))
+		container.addEventListener('mouseover', this.handleMouseOver.bind(this))
 	}
 
 	/**
@@ -52,6 +56,18 @@ export class FocusManager {
 		}
 	}
 
+	private handleKeyDown(keyEvent: KeyboardEvent) {
+		const container = this.editor.getContainer()
+		if (keyEvent.key === 'Tab') {
+			container.classList.remove('tl-container__no-focus-ring')
+		}
+	}
+
+	private handleMouseOver() {
+		const container = this.editor.getContainer()
+		container.classList.add('tl-container__no-focus-ring')
+	}
+
 	focus() {
 		this.editor.getContainer().focus()
 	}
@@ -62,6 +78,8 @@ export class FocusManager {
 	}
 
 	dispose() {
+		this.editor.getContainer().removeEventListener('keydown', this.handleKeyDown.bind(this))
+		this.editor.getContainer().removeEventListener('mouseover', this.handleMouseOver.bind(this))
 		this.disposeSideEffectListener?.()
 	}
 }

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -61,12 +61,13 @@
 	text-align: left;
 }
 
-.tlui-button:focus-visible:not(:hover) {
+.tl-container__focused:not(.tl-container__no-focus-ring) .tlui-button:focus-visible:not(:hover) {
 	/* todo: fix the indicator errors in radix dropdown menus before restoring */
 	/* outline: 1px solid var(--color-selected); */
-	outline: none;
-	outline-offset: -4px;
+	/* outline: none;
+	outline-offset: -4px; */
 	border-radius: var(--radius-3);
+	box-shadow: var(--shadow-focus-ring);
 }
 
 .tlui-button::after {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -65,6 +65,9 @@ export function OverflowingToolbar({ children }: OverflowingToolbarProps) {
 			#${id}_more > *:nth-child(-n + ${overflowIndex}) {
 				display: none;
 			}
+			#${id}_more > *:nth-child(-n + ${overflowIndex + 4}) {
+				margin-top: 0;
+			}
         `
 	}, [lastActiveOverflowItem, id, overflowIndex])
 


### PR DESCRIPTION
mini-side quest: bring a focus ring, when not mousing around, only when using the Tab key

https://github.com/user-attachments/assets/5280f40b-8460-476e-b2bc-7080809b31aa

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- a11y: enable focus ring.