### PR TITLE
Make sure we only allow asset uploads.

### DIFF
--- a/apps/dotcom/client/src/utils/config.ts
+++ b/apps/dotcom/client/src/utils/config.ts
@@ -1,7 +1,6 @@
 import { isProductionEnv, isStagingEnv } from './env'
 
 export const BOOKMARK_ENDPOINT = '/api/unfurl'
-export const APP_ASSET_UPLOAD_ENDPOINT = '/api/app/uploads'
 
 // some boilerplate to get the URL of the server to upload/fetch assets
 

--- a/apps/dotcom/client/src/utils/multiplayerAssetStore.ts
+++ b/apps/dotcom/client/src/utils/multiplayerAssetStore.ts
@@ -1,6 +1,7 @@
+import { APP_ASSET_UPLOAD_ENDPOINT } from '@tldraw/dotcom-shared'
 import { MediaHelpers, TLAssetStore, clamp, fetch, uniqueId } from 'tldraw'
 import { loadLocalFile } from '../tla/utils/slurping'
-import { APP_ASSET_UPLOAD_ENDPOINT, ASSET_UPLOADER_URL, IMAGE_WORKER } from './config'
+import { ASSET_UPLOADER_URL, IMAGE_WORKER } from './config'
 import { isDevelopmentEnv } from './env'
 
 async function getUrl(file: File, fileId: string | undefined) {
@@ -8,7 +9,7 @@ async function getUrl(file: File, fileId: string | undefined) {
 
 	const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
 	if (fileId) {
-		const url = `${window.location.origin}${APP_ASSET_UPLOAD_ENDPOINT}/${objectName}`
+		const url = `${window.location.origin}${APP_ASSET_UPLOAD_ENDPOINT}${objectName}`
 		return {
 			fetchUrl: `${url}?${new URLSearchParams({ fileId }).toString()}`,
 			src: url,

--- a/apps/dotcom/image-resize-worker/package.json
+++ b/apps/dotcom/image-resize-worker/package.json
@@ -19,7 +19,9 @@
 		"@tldraw/dotcom-shared": "workspace:*",
 		"@tldraw/validate": "workspace:*",
 		"@tldraw/worker-shared": "workspace:*",
-		"itty-router": "^5.0.18"
+		"itty-router": "^5.0.18",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250124.3",

--- a/apps/dotcom/image-resize-worker/package.json
+++ b/apps/dotcom/image-resize-worker/package.json
@@ -16,6 +16,7 @@
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"
 	},
 	"dependencies": {
+		"@tldraw/dotcom-shared": "workspace:*",
 		"@tldraw/validate": "workspace:*",
 		"@tldraw/worker-shared": "workspace:*",
 		"itty-router": "^5.0.18"

--- a/apps/dotcom/image-resize-worker/src/worker.ts
+++ b/apps/dotcom/image-resize-worker/src/worker.ts
@@ -1,3 +1,4 @@
+import { APP_ASSET_UPLOAD_ENDPOINT } from '@tldraw/dotcom-shared'
 import { T } from '@tldraw/validate'
 import { createRouter, handleApiRequest, notFound, parseRequestQuery } from '@tldraw/worker-shared'
 import { WorkerEntrypoint } from 'cloudflare:workers'
@@ -75,6 +76,10 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 
 			let actualResponse: Response
 			if (useServiceBinding(this.env, origin)) {
+				const route = `/${path}`
+				if (!route.startsWith(APP_ASSET_UPLOAD_ENDPOINT)) {
+					return notFound()
+				}
 				const req = new Request(passthroughUrl.href, { cf: { image: imageOptions } })
 				actualResponse = await this.env.SYNC_WORKER.fetch(req)
 			} else {

--- a/apps/dotcom/image-resize-worker/tsconfig.json
+++ b/apps/dotcom/image-resize-worker/tsconfig.json
@@ -8,6 +8,9 @@
 	},
 	"references": [
 		{
+			"path": "../../../packages/dotcom-shared"
+		},
+		{
 			"path": "../../../packages/validate"
 		},
 		{

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -3,6 +3,7 @@
 
 import { SupabaseClient } from '@supabase/supabase-js'
 import {
+	APP_ASSET_UPLOAD_ENDPOINT,
 	DB,
 	FILE_PREFIX,
 	PUBLISH_PREFIX,
@@ -633,7 +634,7 @@ export class TLDrawDurableObject extends DurableObject {
 				})
 				asset.props.src = asset.props.src.replace(objectName, newObjectName)
 				assert(this.env.MULTIPLAYER_SERVER, 'MULTIPLAYER_SERVER must be present')
-				asset.props.src = `${this.env.MULTIPLAYER_SERVER.replace(/^ws/, 'http')}/api/app/uploads/${newObjectName}`
+				asset.props.src = `${this.env.MULTIPLAYER_SERVER.replace(/^ws/, 'http')}${APP_ASSET_UPLOAD_ENDPOINT}${newObjectName}`
 
 				asset.meta.fileId = slug
 				store.put(asset)

--- a/packages/dotcom-shared/src/routes.ts
+++ b/packages/dotcom-shared/src/routes.ts
@@ -25,3 +25,6 @@ export const RoomOpenModeToPath: Record<RoomOpenMode, string> = {
 	[ROOM_OPEN_MODE.READ_ONLY_LEGACY]: READ_ONLY_LEGACY_PREFIX,
 	[ROOM_OPEN_MODE.READ_WRITE]: ROOM_PREFIX,
 }
+
+/** @public */
+export const APP_ASSET_UPLOAD_ENDPOINT = '/api/app/uploads/'

--- a/yarn.lock
+++ b/yarn.lock
@@ -14884,6 +14884,7 @@ __metadata:
   resolution: "images.tldraw.com@workspace:apps/dotcom/image-resize-worker"
   dependencies:
     "@cloudflare/workers-types": "npm:^4.20250124.3"
+    "@tldraw/dotcom-shared": "workspace:*"
     "@tldraw/validate": "workspace:*"
     "@tldraw/worker-shared": "workspace:*"
     itty-router: "npm:^5.0.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14889,6 +14889,8 @@ __metadata:
     "@tldraw/worker-shared": "workspace:*"
     itty-router: "npm:^5.0.18"
     lazyrepo: "npm:0.0.0-alpha.27"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
     wrangler: "npm:^3.105.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Limit the types of urls we allow to be passed through.

### Change type

- [x] `improvement`

### Release notes

- Lock down our image resize worker to only allow asset upload urls to pass through.