### PR TITLE
chore(dotcom): temporarily disable idb deletion after successful slurp

### DIFF
--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -1,4 +1,4 @@
-import { deleteDB } from 'idb'
+// import { deleteDB } from 'idb'
 import {
 	Editor,
 	ExecutionQueue,
@@ -233,7 +233,8 @@ export class Slurper {
 			// were no assets to upload!
 
 			// all uploads succeeded, clear the local db
-			deleteDB('TLDRAW_DOCUMENT_v2' + this.opts.slurpPersistenceKey)
+			// (temporarily do not delete the db in case something goes wrong and people lose their stuffs)
+			// deleteDB('TLDRAW_DOCUMENT_v2' + this.opts.slurpPersistenceKey)
 			const { slurpPersistenceKey: _, ...meta } = this.opts.editor.getDocumentSettings().meta
 			this.opts.editor.updateDocumentSettings({ meta })
 			return


### PR DESCRIPTION
Temporarily disable IndexedDB deletion after a successful slurp of a local file as per request.

### Change type

- [x] `other`

### Test plan

1. Perform a local file slurp and verify that the IndexedDB data is not deleted.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Internal: Temporarily disabled IDB deletion after slurp.