### PR TITLE
Add is_signed_in property to posthog events

### DIFF
--- a/apps/dotcom/client/src/utils/posthog.tsx
+++ b/apps/dotcom/client/src/utils/posthog.tsx
@@ -36,6 +36,11 @@ function configurePosthog(options: AnalyticsOptions) {
 		api_host: '/api/ph',
 		capture_pageview: false,
 		persistence: options.optedIn ? 'localStorage+cookie' : 'memory',
+		before_send: (payload) => {
+			if (!payload) return null
+			payload.properties.is_signed_in = !!options.user
+			return payload
+		},
 	}
 	if (!currentOptions) {
 		posthog.init(POSTHOG_KEY, config)


### PR DESCRIPTION
Adds an is_signed_in property to posthog events that we can use to differentiate pageviews.

### Change type

- [x] `other`
