### PR TITLE
use correct domain for app socket connection

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -32,6 +32,7 @@ import {
 	parseTldrawJsonFile,
 	react,
 } from 'tldraw'
+import { MULTIPLAYER_SERVER } from '../../utils/config'
 import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
 import { TLAppUiContextType } from '../utils/app-ui-events'
 import { getDateFormat } from '../utils/dates'
@@ -95,7 +96,7 @@ export class TldrawApp {
 				})
 				const token = await getToken()
 				params.set('accessToken', token || 'no-token-found')
-				return `${process.env.MULTIPLAYER_SERVER}/api/app/${userId}/connect?${params}`
+				return `${MULTIPLAYER_SERVER}/api/app/${userId}/connect?${params}`
 			},
 			// schema,
 			// This is often easier to develop with if you're frequently changing

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -96,7 +96,7 @@ export class TldrawApp {
 				})
 				const token = await getToken()
 				params.set('accessToken', token || 'no-token-found')
-				return `${MULTIPLAYER_SERVER}/api/app/${userId}/connect?${params}`
+				return `${MULTIPLAYER_SERVER}/app/${userId}/connect?${params}`
 			},
 			// schema,
 			// This is often easier to develop with if you're frequently changing


### PR DESCRIPTION
this was using the raw process.env.MULTIPLAYER_SERVER when it should have been using the MULTIPLAYER_SERVER const defined in our config file, which uses the local origin in staging and prod.

### Change type

- [x] `other`
