### PR TITLE
fix(dotcom): set measure before calling reboot in replicator

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -110,6 +110,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private readonly db: Kysely<DB>
 	constructor(ctx: DurableObjectState, env: Environment) {
 		super(ctx, env)
+		this.measure = env.MEASURE
 		this.sentry = createSentry(ctx, env)
 		this.sql = this.ctx.storage.sql
 
@@ -129,7 +130,6 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			this.captureException(e)
 			this.__test__panic()
 		})
-		this.measure = env.MEASURE
 	}
 
 	private _applyMigration(index: number) {


### PR DESCRIPTION
We need to set this first. Otherwise any events that come before it would not be tracked. We probably missed reboots because of this - we called `this.reboot` before setting the measure.

### Change type

- [x] `bugfix` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix replicator event tracking.