### PR TITLE
Secret local file index

### DIFF
--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -15,6 +15,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/f/[^/]*/?$",
   },
   {
+    "reactRouterPattern": "/lf",
+    "vercelRouterPattern": "^/lf/?$",
+  },
+  {
     "reactRouterPattern": "/lf/:fileSlug",
     "vercelRouterPattern": "^/lf/[^/]*/?$",
   },

--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
 	tlaRoot: `/`,
 	tlaNew: `/new`,
 	tlaFile: `/f/:fileSlug`,
+	tlaLocalFileIndex: `/lf`,
 	tlaLocalFile: `/lf/:fileSlug`,
 	tlaPublish: `/p/:fileSlug`,
 	// Legacy routes

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -74,6 +74,10 @@ export const router = createRoutesFromElements(
 				<Route path={ROUTES.tlaNew} lazy={() => import('./pages/tla-new')} />
 				<Route path={ROUTES.tlaOptIn} loader={() => redirect(routes.tlaRoot())} />
 				<Route path={ROUTES.tlaLocalFile} lazy={() => import('./tla/pages/local-file')} />
+				<Route
+					path={ROUTES.tlaLocalFileIndex}
+					lazy={() => import('./tla/pages/local-file-index')}
+				/>
 				{/* File view */}
 				<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
 				<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />

--- a/apps/dotcom/client/src/tla/pages/local-file-index.tsx
+++ b/apps/dotcom/client/src/tla/pages/local-file-index.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/jsx-no-literals */
+import { deleteDB } from 'idb'
+import { Link, useNavigate } from 'react-router-dom'
+import { compact } from 'tldraw'
+import { routes } from '../../routeDefs'
+import { defineLoader } from '../../utils/defineLoader'
+
+const STORE_PREFIX = 'TLDRAW_DOCUMENT_v2'
+
+async function getAllPersistenceKeys() {
+	return compact(await indexedDB.databases().then((d) => d.map(({ name }) => name)))
+		.filter((name) => name.startsWith(STORE_PREFIX))
+		.map((name) => name.slice(STORE_PREFIX.length))
+		.sort()
+}
+
+const { loader, useData } = defineLoader(getAllPersistenceKeys)
+export { loader }
+
+export function Component() {
+	const data = useData()
+	const navigate = useNavigate()
+	const onDelete = async (persistenceKey: string) => {
+		if (confirm('Are you 100% sure you want to delete this file? This action cannot be undone.')) {
+			await deleteDB(STORE_PREFIX + persistenceKey)
+			// reload data
+			navigate('.', { replace: true })
+		}
+	}
+
+	return (
+		<div style={{ padding: 20 }}>
+			<h1>Secret local tldraw files 🕵️‍♂️</h1>
+			<p>Don&rsquo;t rely on this page existing, we might get rid of it.</p>
+			<p>You have {data.length} local file(s) stored on your machine:</p>
+			<ul>
+				{data.map((persistenceKey) => (
+					<li key={persistenceKey}>
+						<Link
+							style={{ color: 'var(--tla-color-primary)' }}
+							to={routes.tlaLocalFile(persistenceKey)}
+						>
+							{routes.tlaLocalFile(persistenceKey)}
+						</Link>
+						-{' '}
+						<button onClick={() => onDelete(persistenceKey)} style={{ padding: 0 }}>
+							delete
+						</button>
+					</li>
+				))}
+			</ul>
+			<p>
+				You can make a new local file by changing the url to be e.g. `
+				<span style={{ userSelect: 'all' }}>
+					{location.origin}
+					{routes.tlaLocalFile('my-secret-file')}
+				</span>
+				`. Replace &apos;my-secret-file&apos; with whatever you want.
+			</p>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/tla/pages/local-file.tsx
+++ b/apps/dotcom/client/src/tla/pages/local-file.tsx
@@ -1,14 +1,26 @@
 import { useParams } from 'react-router-dom'
-import { TLComponents } from 'tldraw'
+import {
+	DefaultMainMenu,
+	DefaultMainMenuContent,
+	TLComponents,
+	TldrawUiMenuActionItem,
+	TldrawUiMenuGroup,
+} from 'tldraw'
 import { LocalEditor } from '../../components/LocalEditor'
-import { TlaEditorTopLeftPanel } from '../components/TlaEditor/TlaEditorTopLeftPanel'
 
 const components: TLComponents = {
 	ErrorFallback: ({ error }) => {
 		throw error
 	},
-	MenuPanel: () => <TlaEditorTopLeftPanel isAnonUser />,
 	SharePanel: null,
+	MainMenu: () => (
+		<DefaultMainMenu>
+			<TldrawUiMenuGroup id="download">
+				<TldrawUiMenuActionItem actionId={'save-file-copy'} />
+			</TldrawUiMenuGroup>
+			<DefaultMainMenuContent />
+		</DefaultMainMenu>
+	),
 }
 
 export function Component() {


### PR DESCRIPTION
So on tldraw.com if you're logged out your content will be saved only in indexeddb. Then if you added at least one shape, when you log in we slurp it into an app file. We then _don't_ delete the indexeddb entry in case something went wrong with the slurping. This did indeed appear to happen one time with one of our users. Luckily their data was under the default persistenceKey and we were able to link them to `https://tldraw.com/lf/tldraw_document_v3` or whatever it was. 

This `/lf/:persistenceKey` route is a local-only route that loads a tldraw document from indexeddb, and it will create a document if one doesn't already exist for the given :persistenceKey.

This PR adds an index page under the `/lf` route, so that you can see a list of all the tldraw documents in your indexeddb. This will be useful to us in case we ever get someone who complains that something they drew while logged out disappeared after they logged in, but it wasn't under the default persistenceKey of `tldraw_document_v3` (we generate a new persistenceKey every time we slurp a local file into the app). We can just point them to `https://tldraw.com/lf` and let them do any recovery they need.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
