### PR TITLE
Prevent renaming twice

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRenameInline.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRenameInline.tsx
@@ -16,9 +16,11 @@ export function TlaSidebarRenameInline({
 }) {
 	const app = useApp()
 	const ref = useRef<HTMLInputElement>(null)
+	const wasSaved = useRef(false)
 	const trackEvent = useTldrawAppUiEvents()
 
 	const handleSave = useCallback(() => {
+		if (wasSaved.current) return
 		// rename the file
 		const elm = ref.current
 		if (!elm) return
@@ -27,6 +29,7 @@ export function TlaSidebarRenameInline({
 		if (name) {
 			// Only update the name if there is a name there to update
 			app.updateFile({ id: fileId, name })
+			wasSaved.current = true
 		}
 		trackEvent('rename-file', { name, source })
 		onClose()


### PR DESCRIPTION
It actually wasn't the trigger that caused this (we used a before trigger). Looks like if you pressed enter to rename both `onBlur` as well as `onComplete` saved the new name, resulting in two mutations.

### Change type

- [x] `bugfix`

### Test plan

1. Rename a file, then press enter.
2. Only one mutation (and call to `updateFile`) should happen.

