### PR TITLE
Replace postgres.js pt 1

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -1,11 +1,12 @@
 import { Page } from '@playwright/test'
+import { DB } from '@tldraw/dotcom-shared'
 import fs from 'fs'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
 import { OTHER_USERS, USERS } from '../consts'
 import { getStorageStateFileName } from './helpers'
 
-const db = new Kysely({
+const db = new Kysely<DB>({
 	dialect: new PostgresDialect({
 		pool: new pg.Pool({
 			connectionString: 'postgresql://user:password@127.0.0.1:6543/postgres',
@@ -63,11 +64,7 @@ export class Database {
 		const id = await this.getUserId(isOther)
 		if (!id) return
 		try {
-			await sql`
-  UPDATE public.user
-  SET ${defaultUser}
-  WHERE id = ${id}
-`.execute(db)
+			await db.updateTable('user').set(defaultUser).where('id', '=', id).execute()
 
 			await sql`DELETE FROM public.file WHERE "ownerId" = ${id}`.execute(db)
 			// await fetch(`http://localhost:3000/api/app/__test__/user/${id}/reboot`)

--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -1,10 +1,21 @@
 import { Page } from '@playwright/test'
 import fs from 'fs'
-import postgres from 'postgres'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import pg from 'pg'
 import { OTHER_USERS, USERS } from '../consts'
 import { getStorageStateFileName } from './helpers'
 
-const sql = postgres('postgresql://user:password@127.0.0.1:6543/postgres')
+const db = new Kysely({
+	dialect: new PostgresDialect({
+		pool: new pg.Pool({
+			connectionString: 'postgresql://user:password@127.0.0.1:6543/postgres',
+			application_name: 'migrate',
+			idleTimeoutMillis: 10_000,
+			max: 1,
+		}),
+	}),
+	log: ['error'],
+})
 
 const defaultUser = {
 	color: 'salmon',
@@ -39,9 +50,11 @@ export class Database {
 
 	async getUserId(isOther: boolean = false) {
 		const email = isOther ? OTHER_USERS[this.parallelIndex] : USERS[this.parallelIndex]
-		const dbUser = await sql`SELECT id FROM public.user WHERE email = ${email ?? ''}`.execute()
-		if (!dbUser[0]) return
-		return dbUser[0].id
+		const dbUser = await sql<{
+			id: string
+		}>`SELECT id FROM public.user WHERE email = ${email ?? ''}`.execute(db)
+		if (!dbUser.rows[0]) return
+		return dbUser.rows[0].id
 	}
 
 	private async cleanUpUser(isOther: boolean) {
@@ -52,11 +65,11 @@ export class Database {
 		try {
 			await sql`
   UPDATE public.user
-  SET ${sql(defaultUser)}
+  SET ${defaultUser}
   WHERE id = ${id}
-`.execute()
+`.execute(db)
 
-			await sql`DELETE FROM public.file WHERE "ownerId" = ${id}`.execute()
+			await sql`DELETE FROM public.file WHERE "ownerId" = ${id}`.execute(db)
 			// await fetch(`http://localhost:3000/api/app/__test__/user/${id}/reboot`)
 		} catch (e) {
 			console.error('Error', e)

--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -74,8 +74,9 @@
 		"fast-glob": "^3.3.3",
 		"identity-obj-proxy": "^3.0.0",
 		"json5": "^2.2.3",
+		"kysely": "^0.27.5",
 		"lazyrepo": "0.0.0-alpha.27",
-		"postgres": "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch",
+		"pg": "^8.13.1",
 		"regexgen": "^1.3.0",
 		"vite": "^5.4.14",
 		"ws": "^8.18.0"

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -136,7 +136,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 		// debug logging in preview envs by default
 		this.log = new Logger(env, 'TLPostgresReplicator', this.sentry)
-		this.db = createPostgresConnectionPool(env, 'TLPostgresReplicator')
+		this.db = createPostgresConnectionPool(env, 'TLPostgresReplicator', 100)
 
 		this.alarm()
 		this.reboot('constructor', false).catch((e) => {

--- a/apps/dotcom/sync-worker/src/postgres.ts
+++ b/apps/dotcom/sync-worker/src/postgres.ts
@@ -1,32 +1,7 @@
 import { DB } from '@tldraw/dotcom-shared'
 import { Kysely, PostgresDialect } from 'kysely'
 import * as pg from 'pg'
-import postgres from 'postgres'
 import { Environment } from './types'
-
-/**
- * In most cases you want to use a pooled connection, which is what `createPostgresConnectionPool` does.
- * Use this one only for cases like subscriptions where you need to listen for notifications / WAL.
- */
-export function createPostgresConnection(
-	env: Environment,
-	{ name, idleTimeout = 30 }: { name: string; idleTimeout?: number }
-) {
-	return postgres(env.BOTCOM_POSTGRES_CONNECTION_STRING, {
-		types: {
-			bigint: {
-				from: [20], // PostgreSQL OID for BIGINT
-				parse: (value: string) => Number(value), // Convert string to number
-				to: 20,
-				serialize: (value: number) => String(value), // Convert number to string
-			},
-		},
-		idle_timeout: idleTimeout,
-		connection: {
-			application_name: name,
-		},
-	})
-}
 
 const int8TypeId = 20
 pg.types.setTypeParser(int8TypeId, (val) => {
@@ -39,7 +14,7 @@ export function createPostgresConnectionPool(env: Environment, name: string) {
 			connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
 			application_name: name,
 			idleTimeoutMillis: 10_000,
-			max: 450,
+			max: 1,
 		}),
 	})
 

--- a/apps/dotcom/sync-worker/src/postgres.ts
+++ b/apps/dotcom/sync-worker/src/postgres.ts
@@ -8,13 +8,13 @@ pg.types.setTypeParser(int8TypeId, (val) => {
 	return parseInt(val, 10)
 })
 
-export function createPostgresConnectionPool(env: Environment, name: string) {
+export function createPostgresConnectionPool(env: Environment, name: string, max: number = 1) {
 	const dialect = new PostgresDialect({
 		pool: new pg.Pool({
 			connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
 			application_name: name,
 			idleTimeoutMillis: 10_000,
-			max: 1,
+			max,
 		}),
 	})
 

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -20,12 +20,13 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"concurrently": "^9.1.2"
+		"concurrently": "^9.1.2",
+		"kysely": "^0.27.5",
+		"pg": "^8.13.1"
 	},
 	"devDependencies": {
 		"dotenv": "^16.4.7",
 		"lazyrepo": "0.0.0-alpha.27",
-		"postgres": "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch",
 		"tsx": "^4.19.2"
 	}
 }

--- a/internal/scripts/clean.sh
+++ b/internal/scripts/clean.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -eux
 
-# a function called 'goodbye' that takes a string as an argument
+yarn run lazy run clean || true
 
+# a function called 'goodbye' that takes a string as an argument
 function goodbye() {
   rm -rf $1
   rm -rf */$1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7222,8 +7222,9 @@ __metadata:
   dependencies:
     concurrently: "npm:^9.1.2"
     dotenv: "npm:^16.4.7"
+    kysely: "npm:^0.27.5"
     lazyrepo: "npm:0.0.0-alpha.27"
-    postgres: "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch"
+    pg: "npm:^8.13.1"
     tsx: "npm:^4.19.2"
   languageName: unknown
   linkType: soft
@@ -11555,11 +11556,12 @@ __metadata:
     identity-obj-proxy: "npm:^3.0.0"
     intl-messageformat: "npm:^10.7.14"
     json5: "npm:^2.2.3"
+    kysely: "npm:^0.27.5"
     lazyrepo: "npm:0.0.0-alpha.27"
     lodash.isequal: "npm:^4.5.0"
     lodash.pick: "npm:^4.4.0"
     md5: "npm:^2.3.0"
-    postgres: "patch:postgres@npm%3A3.4.5#~/.yarn/patches/postgres-npm-3.4.5-8a680ccbcd.patch"
+    pg: "npm:^8.13.1"
     posthog-js: "npm:^1.210.2"
     qrcode: "npm:^1.5.4"
     react: "npm:^18.3.1"


### PR DESCRIPTION
This replaces all the usages of postgres.js for normal (non-subscription) queries with Kysely. 

The next PR will be replacing the postgres.js subscription with [pg-logcial-replication](https://github.com/kibae/pg-logical-replication) and using a persistent replication slot to avoid the need to reboot user DOs whenever there is connection flake.

Then after that we can look at

- keeping a buffer of previous replication events so if a user DO misses a message or two it can request a catch-up rather than having to reboot.
- look at doing persistence in the user DOs and requesting catchups when starting up so during deploys we can avoid triggering a reboot on every active user DO.

And after that, new socket connections should be able to serve relatively up-to-date data immediately and we should have our immediate perf problems solved for a while.

### Change type

- [x] `other`
