### PR TITLE
assets: fix up regression with temporaryAssetPreview

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -716,7 +716,7 @@ export function defaultHandleExternalFileAsset(editor: Editor, { file, assetId }
 export function defaultHandleExternalFileContent(editor: Editor, { point, files }: {
     files: File[];
     point?: VecLike;
-}, { maxAssetSize, acceptedImageMimeTypes, acceptedVideoMimeTypes, toasts, msg, }: TLDefaultExternalContentHandlerOpts): Promise<void>;
+}, { maxAssetSize, maxImageDimension, acceptedImageMimeTypes, acceptedVideoMimeTypes, toasts, msg, }: TLDefaultExternalContentHandlerOpts): Promise<void>;
 
 // @public (undocumented)
 export function defaultHandleExternalSvgTextContent(editor: Editor, { point, text }: {
@@ -1343,7 +1343,7 @@ export function getDefaultCrop(): {
 export function getEmbedInfo(definitions: readonly TLEmbedDefinition[], inputUrl: string): TLEmbedResult;
 
 // @public (undocumented)
-export function getMediaAssetInfoPartial(file: File, assetId: TLAssetId, isImageType: boolean, isVideoType: boolean): Promise<TLImageAsset | TLVideoAsset>;
+export function getMediaAssetInfoPartial(file: File, assetId: TLAssetId, isImageType: boolean, isVideoType: boolean, maxImageDimension?: number): Promise<TLImageAsset | TLVideoAsset>;
 
 // @public (undocumented)
 export function getOccludedChildren(editor: Editor, parent: TLShape): TLShapeId[];

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -163,16 +163,13 @@ export async function defaultHandleExternalFileAsset(
 
 	const hash = getHashForBuffer(await file.arrayBuffer())
 	assetId = assetId ?? AssetRecordType.createId(hash)
-	const assetInfo = await getMediaAssetInfoPartial(file, assetId, isImageType, isVideoType)
-
-	if (isFinite(maxImageDimension)) {
-		const size = { w: assetInfo.props.w, h: assetInfo.props.h }
-		const resizedSize = containBoxSize(size, { w: maxImageDimension, h: maxImageDimension })
-		if (size !== resizedSize && MediaHelpers.isStaticImageType(file.type)) {
-			assetInfo.props.w = resizedSize.w
-			assetInfo.props.h = resizedSize.h
-		}
-	}
+	const assetInfo = await getMediaAssetInfoPartial(
+		file,
+		assetId,
+		isImageType,
+		isVideoType,
+		maxImageDimension
+	)
 
 	const result = await editor.uploadAsset(assetInfo, file)
 	assetInfo.props.src = result.src
@@ -311,6 +308,7 @@ export async function defaultHandleExternalFileContent(
 	{ point, files }: { point?: VecLike; files: File[] },
 	{
 		maxAssetSize = DEFAULT_MAX_ASSET_SIZE,
+		maxImageDimension = DEFAULT_MAX_IMAGE_DIMENSION,
 		acceptedImageMimeTypes = DEFAULT_SUPPORTED_IMAGE_TYPES,
 		acceptedVideoMimeTypes = DEFAULT_SUPPORT_VIDEO_TYPES,
 		toasts,
@@ -329,6 +327,7 @@ export async function defaultHandleExternalFileContent(
 			: editor.getViewportPageBounds().center)
 
 	const pagePoint = new Vec(position.x, position.y)
+	const assetPartials: TLAsset[] = []
 	const assetsToUpdate: {
 		asset: TLAsset
 		file: File
@@ -377,16 +376,22 @@ export async function defaultHandleExternalFileContent(
 		const isVideoType = acceptedVideoMimeTypes.includes(file.type)
 		const hash = getHashForBuffer(await file.arrayBuffer())
 		const assetId: TLAssetId = AssetRecordType.createId(hash)
-		const assetInfo = await getMediaAssetInfoPartial(file, assetId, isImageType, isVideoType)
+		const assetInfo = await getMediaAssetInfoPartial(
+			file,
+			assetId,
+			isImageType,
+			isVideoType,
+			maxImageDimension
+		)
 		let temporaryAssetPreview
 		if (isImageType) {
 			temporaryAssetPreview = editor.createTemporaryAssetPreview(assetId, file)
 		}
+		assetPartials.push(assetInfo)
 		assetsToUpdate.push({ asset: assetInfo, file, temporaryAssetPreview })
 	}
 
-	const assets: TLAsset[] = []
-	await Promise.allSettled(
+	Promise.allSettled(
 		assetsToUpdate.map(async (assetAndFile) => {
 			try {
 				const newAsset = await editor.getAssetForExternalContent({
@@ -398,10 +403,8 @@ export async function defaultHandleExternalFileContent(
 					throw Error('Could not create an asset')
 				}
 
-				const updated = { ...newAsset, id: assetAndFile.asset.id }
-				assets.push(updated)
 				// Save the new asset under the old asset's id
-				editor.updateAssets([updated])
+				editor.updateAssets([{ ...newAsset, id: assetAndFile.asset.id }])
 			} catch (error) {
 				toasts.addToast({
 					title: msg('assets.files.upload-failed'),
@@ -413,7 +416,7 @@ export async function defaultHandleExternalFileContent(
 		})
 	)
 
-	createShapesForAssets(editor, assets, pagePoint)
+	createShapesForAssets(editor, assetPartials, pagePoint)
 }
 
 /** @public */
@@ -618,7 +621,8 @@ export async function getMediaAssetInfoPartial(
 	file: File,
 	assetId: TLAssetId,
 	isImageType: boolean,
-	isVideoType: boolean
+	isVideoType: boolean,
+	maxImageDimension?: number
 ) {
 	let fileType = file.type
 
@@ -647,9 +651,18 @@ export async function getMediaAssetInfoPartial(
 			isAnimated,
 		},
 		meta: {},
-	} as TLAsset
+	} as TLImageAsset | TLVideoAsset
 
-	return assetInfo as TLImageAsset | TLVideoAsset
+	if (maxImageDimension && isFinite(maxImageDimension)) {
+		const size = { w: assetInfo.props.w, h: assetInfo.props.h }
+		const resizedSize = containBoxSize(size, { w: maxImageDimension, h: maxImageDimension })
+		if (size !== resizedSize && MediaHelpers.isStaticImageType(file.type)) {
+			assetInfo.props.w = resizedSize.w
+			assetInfo.props.h = resizedSize.h
+		}
+	}
+
+	return assetInfo
 }
 
 /**


### PR DESCRIPTION
Fixes up a regression from https://github.com/tldraw/tldraw/pull/5176
I missed this during the review that making it synchronous would block the temp image view.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix a regression with temporary image previews while images are uploading.