### PR TITLE
retry slurping document records if need be

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -3,6 +3,7 @@ import { captureException } from '@sentry/react'
 import {
 	CreateFilesResponseBody,
 	CreateSnapshotRequestBody,
+	LOCAL_FILE_PREFIX,
 	MAX_NUMBER_OF_FILES,
 	TlaFile,
 	TlaFilePartial,
@@ -389,7 +390,7 @@ export class TldrawApp {
 
 	slurpFile() {
 		return this.createFile({
-			createSource: `lf/${getScratchPersistenceKey()}`,
+			createSource: `${LOCAL_FILE_PREFIX}/${getScratchPersistenceKey()}`,
 		})
 	}
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -35,6 +35,7 @@ import {
 } from 'tldraw'
 import { MULTIPLAYER_SERVER } from '../../utils/config'
 import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
+import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
 import { TLAppUiContextType } from '../utils/app-ui-events'
 import { getDateFormat } from '../utils/dates'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
@@ -386,13 +387,10 @@ export class TldrawApp {
 		return
 	}
 
-	_slurpFileId: string | null = null
 	slurpFile() {
-		const res = this.createFile()
-		if (res.ok) {
-			this._slurpFileId = res.value.file.id
-		}
-		return res
+		return this.createFile({
+			createSource: `lf/${getScratchPersistenceKey()}`,
+		})
 	}
 
 	toggleFileShared(fileId: string) {

--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -73,8 +73,9 @@ export async function maybeSlurp(opts: SlurperOpts) {
 	if (opts.abortSignal.aborted) return
 	if (!opts.app.isFileOwner(opts.fileId)) return
 	const file = opts.app.getFile(opts.fileId)
-	if (!file?.createSource?.startsWith('lf/')) return
-	const persistenceKey = file.createSource.slice('lf/'.length)
+	const persistenceKey =
+		(opts.editor.getDocumentSettings().meta.slurpPersistenceKey as string | undefined) ||
+		file?.createSource?.match(/lf\/(.+)/)?.[1]
 	if (!persistenceKey) return
 	if (opts.editor.getDocumentSettings().meta.slurpFinished) return
 	return new Slurper({ ...opts, slurpPersistenceKey: persistenceKey }).slurp()

--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -75,9 +75,9 @@ export async function maybeSlurp(opts: SlurperOpts) {
 	const file = opts.app.getFile(opts.fileId)
 	if (!file?.createSource?.startsWith('lf/')) return
 	const persistenceKey = file.createSource.slice('lf/'.length)
-	if (persistenceKey) {
-		return new Slurper({ ...opts, slurpPersistenceKey: persistenceKey }).slurp()
-	}
+	if (!persistenceKey) return
+	if (opts.editor.getDocumentSettings().meta.slurpFinished) return
+	return new Slurper({ ...opts, slurpPersistenceKey: persistenceKey }).slurp()
 }
 
 export class Slurper {
@@ -225,8 +225,12 @@ export class Slurper {
 			// all uploads succeeded, clear the local db
 			// (temporarily do not delete the db in case something goes wrong and people lose their stuffs)
 			// deleteDB('TLDRAW_DOCUMENT_v2' + this.opts.slurpPersistenceKey)
-			const { slurpPersistenceKey: _, ...meta } = this.opts.editor.getDocumentSettings().meta
-			this.opts.editor.updateDocumentSettings({ meta })
+			this.opts.editor.updateDocumentSettings({
+				meta: {
+					...this.opts.editor.getDocumentSettings().meta,
+					slurpFinished: true,
+				},
+			})
 			return
 		}
 

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -6,6 +6,7 @@ import {
 	APP_ASSET_UPLOAD_ENDPOINT,
 	DB,
 	FILE_PREFIX,
+	LOCAL_FILE_PREFIX,
 	PUBLISH_PREFIX,
 	READ_ONLY_LEGACY_PREFIX,
 	READ_ONLY_PREFIX,
@@ -525,6 +526,10 @@ export class TLDrawDurableObject extends DurableObject {
 			case PUBLISH_PREFIX:
 				data = await getPublishedRoomSnapshot(this.env, id)
 				break
+			case LOCAL_FILE_PREFIX:
+				// create empty room, the client will populate it
+				data = new TLSyncRoom({ schema: createTLSchema() }).getSnapshot()
+				break
 		}
 
 		if (!data) {
@@ -546,16 +551,12 @@ export class TLDrawDurableObject extends DurableObject {
 				return { type: 'room_found', snapshot: await roomFromBucket.json() }
 			}
 			if (this._fileRecordCache?.createSource) {
-				const roomData = await this.handleFileCreateFromSource()
-				// Room found and created, so we can clean the create source field
-				if (roomData.type === 'room_found') {
-					await this.db
-						.updateTable('file')
-						.set({ createSource: null })
-						.where('id', '=', this._fileRecordCache.id)
-						.execute()
+				const res = await this.handleFileCreateFromSource()
+				if (res.type === 'room_found') {
+					// save it to the bucket so we don't try to create from source again
+					await this.r2.rooms.put(key, JSON.stringify(res.snapshot))
 				}
-				return roomData
+				return res
 			}
 
 			if (this.documentInfo.isApp) {

--- a/packages/dotcom-shared/src/routes.ts
+++ b/packages/dotcom-shared/src/routes.ts
@@ -18,6 +18,8 @@ export const SNAPSHOT_PREFIX = 's'
 export const FILE_PREFIX = 'f'
 /** @public */
 export const PUBLISH_PREFIX = 'p'
+/** @public */
+export const LOCAL_FILE_PREFIX = 'lf'
 
 /** @public */
 export const RoomOpenModeToPath: Record<RoomOpenMode, string> = {


### PR DESCRIPTION
There was a hole in the local file slurping logic where it would retry slurping assets but not the document records themselves. So if the user switched away from the slurped file before tlsync had a chance to finsih doing its thing, the data would seem to disappear.

This patches that hole by using the `createSource` column to signify that an app file should be initialized by slurping from a local file, rather than an ephemeral property on the TldrawApp instance. That way when we open such a file we can check whether the document.meta.slurpPersistenceKey has been added, and if so it means the records slurp happened successfully.

### Change type

- [x] `bugfix`
