### PR TITLE
Fix typo and missing word

### DIFF
--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -15,7 +15,7 @@ keywords:
 
 In tldraw, persistence means storing information about the editor's state to a database and then restoring it later.
 
-The simplest implementation is the browser's local storage. But this also provides the hooks for a sync engine, which can send realtime incremenal updates the canvas to your backend server, allowing multiple people to collaborate on the canvas.
+The simplest implementation is the browser's local storage. But this also provides the hooks for a sync engine, which can send realtime incremental updates of the canvas to your backend server, allowing multiple people to collaborate on the canvas.
 
 ## The `"persistenceKey"` prop
 


### PR DESCRIPTION
Fixes typos in the persistence docs.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
