### PR TITLE
[hotfixme] Option-cloning text shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
@@ -66,6 +66,8 @@ export const FrameLabelInput = forwardRef<
 			<input
 				className="tl-frame-name-input"
 				ref={ref}
+				disabled={!isEditing}
+				readOnly={!isEditing}
 				style={{ display: isEditing ? undefined : 'none' }}
 				value={name}
 				autoFocus

--- a/packages/tldraw/src/lib/shapes/text/TextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextArea.tsx
@@ -31,6 +31,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function 
 			className="tl-text tl-text-input"
 			name="text"
 			tabIndex={-1}
+			disabled={!isEditing}
 			readOnly={!isEditing}
 			autoComplete="off"
 			autoCapitalize="off"


### PR DESCRIPTION
This PR fixes a bug that could occur when pressing option to clone a selection after clicking on a text shape.

On tldraw.com, you can reproduce the bug by:

1. click a text shape
2. click the text shape again and drag it to a new position. Don't let go!
3. press alt / option

The way that drag-cloning works in tldraw, you would expect that the dragging shape would move back to its original position and a clone of that shape be placed under your cursor. If you released option, then the original shape would move back under your cursor and become the dragging shape again.

However that won't happen!

## Why not

When we use keyboard shortcuts, we make sure that the focused element isn't an element that would normally accept keyboard keys, such as text inputs, text areas, or content-editable elements. If the user has one of those focused, then we ignore the keyboard.

In the case of text, the browser would focus the text element on pointer down. Later, when you press Alt / Option, we would ignore that because hey, you're focused on a text element!

## The fix

The quick fix is to disable the text input / text element unless the user is actually editing that element. We can't guarantee much else (ie with custom shapes) so at least we can fix the bug on our shapes and make a recommendation to end user developers.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a text shape
2. Click on the text shape and drag it
3. Press Option to clone it
 
- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with cloning text shapes.