### PR TITLE
[hotfixme] Fix copy as SVG

### DIFF
--- a/packages/tldraw/src/lib/utils/export/copyAs.ts
+++ b/packages/tldraw/src/lib/utils/export/copyAs.ts
@@ -73,10 +73,9 @@ export function copyAs(
 		}
 
 		if (opts?.format === 'svg') {
-			const blobPromise = editor
+			types['text/plain'] = editor
 				.getSvgString(ids, opts)
 				.then((result) => new Blob([result?.svg ?? ''], { type: 'text/plain' }))
-			types['text/plain'] = blobPromise
 		}
 
 		return clipboardWrite(types)

--- a/packages/tldraw/src/lib/utils/export/copyAs.ts
+++ b/packages/tldraw/src/lib/utils/export/copyAs.ts
@@ -72,6 +72,13 @@ export function copyAs(
 			)
 		}
 
+		if (opts?.format === 'svg') {
+			const blobPromise = editor
+				.getSvgString(ids, opts)
+				.then((result) => new Blob([result?.svg ?? ''], { type: 'text/plain' }))
+			types['text/plain'] = blobPromise
+		}
+
 		return clipboardWrite(types)
 	}
 

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -73,7 +73,7 @@ const mimeTypeByFormat = {
 	jpeg: 'image/jpeg',
 	png: 'image/png',
 	webp: 'image/webp',
-	svg: 'text/plain',
+	svg: 'image/svg+xml',
 }
 
 export function exportToImagePromise(


### PR DESCRIPTION
This PR fixes a bug where Copy as SVG would throw an error.

Previously, copying as an SVG would copy the image as plain text. In #5114 we started writing the image blob to the clipboard for SVGs, though the mimeType we were using was still plain text. This would cause an error: `NotAllowedError: Failed to execute 'write' on 'Clipboard': Type text/plain does not match the blob's type image/svg+xml`.

In this PR, we now correctly write the image to the clipboard. We _also_ write the SVG string as plain text.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Select some shapes
2. Copy as SVG
3. Paste into a text editor (should paste the string)
4. Paste into a raster graphics program (should paste the SVG)
5. Paste into Figma (should paste as individual shapes)

### Release notes

- Fixed a bug with Copy as SVG