### PR TITLE
Fix alignment, distribute

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2506,7 +2506,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     constructor(editor: Editor);
     // @internal
     backgroundComponent?(shape: Shape): any;
-    canBeLaidOut(_shape: Shape): boolean;
+    canBeLaidOut(_shape: Shape, _type?: 'align' | 'distribute' | 'flip' | 'pack' | 'stack'): boolean;
     canBind(_opts: TLShapeUtilCanBindOpts<Shape>): boolean;
     canCrop(_shape: Shape): boolean;
     canDropShapes(_shape: Shape, _shapes: TLShape[]): boolean;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6605,20 +6605,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let val: 'x' | 'y'
 		let min: 'minX' | 'minY'
 		let max: 'maxX' | 'maxY'
-		let mid: 'midX' | 'midY'
 		let dim: 'width' | 'height'
 
 		if (operation === 'horizontal') {
 			val = 'x'
 			min = 'minX'
 			max = 'maxX'
-			mid = 'midX'
 			dim = 'width'
 		} else {
 			val = 'y'
 			min = 'minY'
 			max = 'maxY'
-			mid = 'midY'
 			dim = 'height'
 		}
 		const changes: TLShapePartial[] = []
@@ -6649,17 +6646,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			})
 
 		const maxFirst = shapePageBounds[first.id][max]
-		const minLast = shapePageBounds[last.id][min]
-		// const step = (shapePageBounds[last.id][min] - maxFirst) / (len - 1)
-		const range = minLast - maxFirst
-		const rangeTakenUpByShapes = shapesToMove.reduce(
-			(acc, s) => acc + shapePageBounds[s.id][dim],
-			0
-		)
+		const range = shapePageBounds[last.id][min] - maxFirst
+		// The gap is the amount of space "left over" between the first and last shape. This can be a negative number if the shapes are overlapping.
+		const gap =
+			(range - shapesToMove.reduce((acc, s) => acc + shapePageBounds[s.id][dim], 0)) /
+			(shapesToMove.length + 1)
 
-		const step = (range - rangeTakenUpByShapes) / (shapesToMove.length + 1)
-
-		for (let v = maxFirst + step, i = 0; i < shapesToMove.length; i++) {
+		for (let v = maxFirst + gap, i = 0; i < shapesToMove.length; i++) {
 			const shape = shapesToMove[i]
 			const delta = new Vec()
 			const bounds = shapePageBounds[shape.id]
@@ -6676,7 +6669,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			delta.add(shape) // add the shape's x and y to the delta
 			changes.push(this.getChangesToTranslateShape(shape, delta))
 
-			v += bounds[dim] + step
+			v += bounds[dim] + gap
 		}
 
 		this.updateShapes(changes)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6631,9 +6631,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			(a, b) => shapePageBounds[b.id][max] - shapePageBounds[a.id][max]
 		)[0]
 
-		const midFirst = shapePageBounds[first.id][mid]
-		const step = (shapePageBounds[last.id][mid] - midFirst) / (len - 1)
-		const v = midFirst + step
+		const maxFirst = shapePageBounds[first.id][max]
+		const step = (shapePageBounds[last.id][min] - maxFirst) / (len - 1)
+		const v = maxFirst + step
 
 		shapesToDistribute
 			.filter((shape) => shape !== first && shape !== last)

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -151,6 +151,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	/**
 	 * Whether the shape can be snapped to by another shape.
 	 *
+	 * @param shape - The shape.
 	 * @public
 	 */
 	canSnap(_shape: Shape): boolean {
@@ -212,11 +213,15 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
-	 * Whether the shape participates in stacking, aligning, and distributing.
+	 * Whether the shape can participate in layout functions such as alignment or distribution.
+	 *
+	 * @param shape - The shape.
+	 * @param type - The type of layout being done.
+	 * @public
 	 *
 	 * @public
 	 */
-	canBeLaidOut(_shape: Shape): boolean {
+	canBeLaidOut(_shape: Shape, _type?: 'align' | 'distribute' | 'pack' | 'stack' | 'flip'): boolean {
 		return true
 	}
 


### PR DESCRIPTION
This PR fixes alignment and distribution. It:

## Alignment

Fixes a bug where arrows were being taken into account when aligning shapes.

![Kapture 2025-02-23 at 09 41 23](https://github.com/user-attachments/assets/de75ae58-17ab-430d-871f-cd8a0f3ad05e)

## Distribution

Adjusts the logic for distribution so that the result will space shapes out evenly between the first and last shapes, rather than distributing by centers.

Fixes a bug when distributing shapes if the same shape constituted the first and last shape.

![Kapture 2025-02-23 at 09 44 11](https://github.com/user-attachments/assets/9991a149-9eb1-43e7-bc7c-0dcc6f1a087b)

### Change type

- [x] `bugfix`

### Test plan

1. Align a shape to an edge where that edge in the shape bounds is defined by an arrow
2. Distribute overlapping or irregular shapes

- [ ] Unit tests: NEEDS DOING

### Release notes

- Fixed a bug when aligning shapes with arrows
- Fixed a bug with distribution with overlapping shapes