### PR TITLE
fix copy as svg mime type

### DIFF
--- a/packages/tldraw/src/lib/utils/clipboard.ts
+++ b/packages/tldraw/src/lib/utils/clipboard.ts
@@ -1,4 +1,5 @@
 import { getOwnProperty, objectMapFromEntries } from '@tldraw/editor'
+import { TLCopyType } from './export/copyAs'
 
 // Browsers sanitize image formats to prevent security issues when pasting between applications. For
 // paste within an application though, some browsers (only chromium-based browsers as of Nov 2024)
@@ -11,14 +12,15 @@ import { getOwnProperty, objectMapFromEntries } from '@tldraw/editor'
 export const TLDRAW_CUSTOM_PNG_MIME_TYPE = 'web image/vnd.tldraw+png' as const
 
 const additionalClipboardWriteTypes = {
-	'image/png': TLDRAW_CUSTOM_PNG_MIME_TYPE,
+	png: TLDRAW_CUSTOM_PNG_MIME_TYPE,
+	svg: 'image/svg+xml',
 } as const
 const canonicalClipboardReadTypes = {
 	[TLDRAW_CUSTOM_PNG_MIME_TYPE]: 'image/png',
 }
 
-export function getAdditionalClipboardWriteType(mimeType: string): string | null {
-	return getOwnProperty(additionalClipboardWriteTypes, mimeType) ?? null
+export function getAdditionalClipboardWriteType(format: TLCopyType): string | null {
+	return getOwnProperty(additionalClipboardWriteTypes, format) ?? null
 }
 export function getCanonicalClipboardReadType(mimeType: string): string {
 	return getOwnProperty(canonicalClipboardReadTypes, mimeType) ?? mimeType

--- a/packages/tldraw/src/lib/utils/export/copyAs.ts
+++ b/packages/tldraw/src/lib/utils/export/copyAs.ts
@@ -10,7 +10,7 @@ import {
 	doesClipboardSupportType,
 	getAdditionalClipboardWriteType,
 } from '../clipboard'
-import { exportToImagePromise } from './export'
+import { exportToImagePromiseForClipboard } from './export'
 
 /** @public */
 export type TLCopyType = 'svg' | 'png'
@@ -62,10 +62,10 @@ export function copyAs(
 
 	if (!navigator.clipboard) return Promise.reject(new Error('Copy not supported'))
 	if (navigator.clipboard.write as any) {
-		const { blobPromise, mimeType } = exportToImagePromise(editor, ids, opts)
+		const { blobPromise, mimeType } = exportToImagePromiseForClipboard(editor, ids, opts)
 
 		const types: Record<string, Promise<Blob>> = { [mimeType]: blobPromise }
-		const additionalMimeType = getAdditionalClipboardWriteType(mimeType)
+		const additionalMimeType = getAdditionalClipboardWriteType(opts.format)
 		if (additionalMimeType && doesClipboardSupportType(additionalMimeType)) {
 			types[additionalMimeType] = blobPromise.then((blob) =>
 				FileHelpers.rewriteMimeType(blob, additionalMimeType)

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -77,7 +77,7 @@ const clipboardMimeTypesByFormat = {
 	svg: 'text/plain',
 }
 
-export function exportToImagePromise(
+export function exportToImagePromiseForClipboard(
 	editor: Editor,
 	ids: TLShapeId[],
 	opts: TLImageExportOptions = {}

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -1,5 +1,6 @@
 import {
 	Editor,
+	FileHelpers,
 	TLExportType,
 	TLImageExportOptions,
 	TLShapeId,
@@ -69,7 +70,7 @@ export async function exportToBlob({
 	}
 }
 
-const mimeTypeByFormat = {
+const clipboardMimeTypesByFormat = {
 	jpeg: 'image/jpeg',
 	png: 'image/png',
 	webp: 'image/webp',
@@ -84,7 +85,11 @@ export function exportToImagePromise(
 	const idsToUse = ids?.length ? ids : [...editor.getCurrentPageShapeIds()]
 	const format = opts.format ?? 'png'
 	return {
-		blobPromise: editor.toImage(idsToUse, opts).then((result) => result.blob),
-		mimeType: mimeTypeByFormat[format],
+		blobPromise: editor
+			.toImage(idsToUse, opts)
+			.then((result) =>
+				FileHelpers.rewriteMimeType(result.blob, clipboardMimeTypesByFormat[format])
+			),
+		mimeType: clipboardMimeTypesByFormat[format],
 	}
 }


### PR DESCRIPTION
The type here doesn't match the mimetype. They're different because browsers don't support writing `image/svg+xml` to the clipboard, so we write `text/plain` instead. But the blob was coming through with the `text/plain` format.

### Change type

- [x] `bugfix`

### Release notes

- Fix copy as svg