### PR TITLE
Fix tooltips.

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
@@ -7,7 +7,7 @@
 	color: var(--color-text-shadow);
 	animation-name: fade-in;
 	animation-duration: 0.1s;
-	z-index: 200;
+	z-index: 500;
 }
 
 .tooltipArrow {


### PR DESCRIPTION
Looks like a regression from https://github.com/tldraw/tldraw/pull/5287

### Change type

- [x] `bugfix`

### Test plan
- Hover over the icons in the share menu.
- The tooltip should appear.
![CleanShot 2025-02-24 at 13 57 48](https://github.com/user-attachments/assets/bd87f913-e8b1-44d1-8ba6-08239831cfe8)

