### PR TITLE
Fix safari tooltip arrow appears late

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
@@ -7,7 +7,7 @@
 	color: var(--color-text-shadow);
 	animation-name: fade-in;
 	animation-duration: 0.1s;
-	z-index: 200;
+	z-index: 500;
 }
 
 .tooltipArrow {

--- a/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaTooltip/tooltip.module.css
@@ -12,6 +12,7 @@
 
 .tooltipArrow {
 	fill: var(--tla-color-tooltip);
+	will-change: opacity;
 }
 
 @keyframes fade-in {


### PR DESCRIPTION
🤷‍♂️ 

Before

https://github.com/user-attachments/assets/4a91853f-7657-48ec-911c-c50c9eccaefe

After

https://github.com/user-attachments/assets/251b5bd3-d48d-4534-96cd-5e9c3c71dfea



### Change type

- [x] `bugfix`
