### PR TITLE
Fix text padding, add context to shape geometry

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3464,7 +3464,6 @@ export interface TLFilesExternalContent extends TLBaseExternalContent {
 
 // @public
 export interface TLGeometryOpts {
-    // (undocumented)
     context?: string;
 }
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1292,7 +1292,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         renderingOnly?: boolean | undefined;
     }): TLShape | undefined;
     getShapeClipPath(shape: TLShape | TLShapeId): string | undefined;
-    getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId): T;
+    getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, context?: string): T;
     getShapeHandles<T extends TLShape>(shape: T | T['id']): TLHandle[] | undefined;
     getShapeLocalTransform(shape: TLShape | TLShapeId): Mat;
     getShapeMask(shape: TLShape | TLShapeId): undefined | VecLike[];
@@ -2527,7 +2527,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     getBoundsSnapGeometry(_shape: Shape): BoundsSnapGeometry;
     getCanvasSvgDefs(): TLShapeUtilCanvasSvgDef[];
     abstract getDefaultProps(): Shape['props'];
-    abstract getGeometry(shape: Shape): Geometry2d;
+    abstract getGeometry(shape: Shape, context?: string): Geometry2d;
     getHandles?(shape: Shape): TLHandle[];
     getHandleSnapGeometry(_shape: Shape): HandleSnapGeometry;
     getInterpolatedProps?(startShape: Shape, endShape: Shape, progress: number): Shape['props'];

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1292,7 +1292,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         renderingOnly?: boolean | undefined;
     }): TLShape | undefined;
     getShapeClipPath(shape: TLShape | TLShapeId): string | undefined;
-    getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, context?: string): T;
+    getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, opts?: TLGeometryOpts): T;
     getShapeHandles<T extends TLShape>(shape: T | T['id']): TLHandle[] | undefined;
     getShapeLocalTransform(shape: TLShape | TLShapeId): Mat;
     getShapeMask(shape: TLShape | TLShapeId): undefined | VecLike[];
@@ -2527,7 +2527,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     getBoundsSnapGeometry(_shape: Shape): BoundsSnapGeometry;
     getCanvasSvgDefs(): TLShapeUtilCanvasSvgDef[];
     abstract getDefaultProps(): Shape['props'];
-    abstract getGeometry(shape: Shape, context?: string): Geometry2d;
+    abstract getGeometry(shape: Shape, opts?: TLGeometryOpts): Geometry2d;
     getHandles?(shape: Shape): TLHandle[];
     getHandleSnapGeometry(_shape: Shape): HandleSnapGeometry;
     getInterpolatedProps?(startShape: Shape, endShape: Shape, progress: number): Shape['props'];
@@ -3460,6 +3460,12 @@ export interface TLFilesExternalContent extends TLBaseExternalContent {
     ignoreParent: boolean;
     // (undocumented)
     type: 'files';
+}
+
+// @public
+export interface TLGeometryOpts {
+    // (undocumented)
+    context?: string;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -184,6 +184,7 @@ export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseB
 export {
 	ShapeUtil,
 	type TLCropInfo,
+	type TLGeometryOpts,
 	type TLHandleDragInfo,
 	type TLResizeInfo,
 	type TLResizeMode,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -144,7 +144,7 @@ import { SnapManager } from './managers/SnapManager/SnapManager'
 import { TextManager } from './managers/TextManager'
 import { TickManager } from './managers/TickManager'
 import { UserPreferencesManager } from './managers/UserPreferencesManager'
-import { ShapeUtil, TLResizeMode } from './shapes/ShapeUtil'
+import { ShapeUtil, TLGeometryOpts, TLResizeMode } from './shapes/ShapeUtil'
 import { RootState } from './tools/RootState'
 import { StateNode, TLStateNodeConstructor } from './tools/StateNode'
 import { TLContent } from './types/clipboard-types'
@@ -4212,18 +4212,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```ts
 	 * editor.getShapeGeometry(myShape)
 	 * editor.getShapeGeometry(myShapeId)
+	 * editor.getShapeGeometry(myShapeId, { context: "arrow" })
 	 * ```
 	 *
 	 * @param shape - The shape (or shape id) to get the geometry for.
-	 * @param context - The context in which to get the geometry for, e.g. 'none' or 'arrow'
+	 * @param opts - The context in which to get the geometry for, e.g. 'none' or 'arrow'
 	 *
 	 * @public
 	 */
-	getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, context = 'none'): T {
+	getShapeGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, opts?: TLGeometryOpts): T {
+		const context = opts?.context ?? 'none'
 		if (!this._shapeGeometryCaches[context]) {
 			this._shapeGeometryCaches[context] = this.store.createComputedCache(
 				'bounds',
-				(shape) => this.getShapeUtil(shape).getGeometry(shape, context),
+				(shape) => this.getShapeUtil(shape).getGeometry(shape, opts),
 				(a, b) => a.props === b.props
 			)
 		}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4216,7 +4216,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```
 	 *
 	 * @param shape - The shape (or shape id) to get the geometry for.
-	 * @param opts - The context in which to get the geometry for, e.g. 'none' or 'arrow'
+	 * @param opts - Additional options about the request for geometry. Passed to {@link ShapeUtil.getGeometry}.
 	 *
 	 * @public
 	 */

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -46,11 +46,12 @@ export interface TLShapeUtilCanBindOpts<Shape extends TLUnknownShape = TLShape> 
 }
 
 /**
- * Options for the {@link ShapeUtil.getGeometry} method.
+ * Additional options for the {@link ShapeUtil.getGeometry} method.
  *
  * @public
  */
 export interface TLGeometryOpts {
+	/** The context in which the geometry is being requested. */
 	context?: string
 }
 

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -45,6 +45,15 @@ export interface TLShapeUtilCanBindOpts<Shape extends TLUnknownShape = TLShape> 
 	bindingType: string
 }
 
+/**
+ * Options for the {@link ShapeUtil.getGeometry} method.
+ *
+ * @public
+ */
+export interface TLGeometryOpts {
+	context?: string
+}
+
 /** @public */
 export interface TLShapeUtilCanvasSvgDef {
 	key: string
@@ -128,10 +137,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * Get the shape's geometry.
 	 *
 	 * @param shape - The shape.
-	 * @param context - The context in which to get the geometry for.
+	 * @param opts - Additional options for the request.
 	 * @public
 	 */
-	abstract getGeometry(shape: Shape, context?: string): Geometry2d
+	abstract getGeometry(shape: Shape, opts?: TLGeometryOpts): Geometry2d
 
 	/**
 	 * Get a JSX element for the shape (as an HTML element).

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -128,9 +128,10 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * Get the shape's geometry.
 	 *
 	 * @param shape - The shape.
+	 * @param context - The context in which to get the geometry for.
 	 * @public
 	 */
-	abstract getGeometry(shape: Shape): Geometry2d
+	abstract getGeometry(shape: Shape, context?: string): Geometry2d
 
 	/**
 	 * Get a JSX element for the shape (as an HTML element).

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1990,6 +1990,11 @@ export interface TextLabelProps {
 }
 
 // @public (undocumented)
+export interface TextShapeOptions {
+    extraArrowHorizontalPadding: number;
+}
+
+// @public (undocumented)
 export class TextShapeTool extends StateNode {
     // (undocumented)
     static children(): TLStateNodeConstructor[];
@@ -2069,6 +2074,8 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
         x: number;
         y: number;
     };
+    // (undocumented)
+    options: TextShapeOptions;
     // (undocumented)
     static props: RecordProps<TLTextShape>;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2009,7 +2009,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     getDefaultProps(): TLTextShape['props'];
     // (undocumented)
-    getGeometry(shape: TLTextShape): Rectangle2d;
+    getGeometry(shape: TLTextShape, context: string): Rectangle2d;
     // (undocumented)
     getMinDimensions(shape: TLTextShape): {
         height: number;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -83,6 +83,7 @@ import { TLExportType } from '@tldraw/editor';
 import { TLFileExternalAsset } from '@tldraw/editor';
 import { TLFrameShape } from '@tldraw/editor';
 import { TLFrameShapeProps } from '@tldraw/editor';
+import { TLGeometryOpts } from '@tldraw/editor';
 import { TLGeoShape } from '@tldraw/editor';
 import { TLGeoShapeProps } from '@tldraw/editor';
 import { TLHandle } from '@tldraw/editor';
@@ -2009,7 +2010,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     getDefaultProps(): TLTextShape['props'];
     // (undocumented)
-    getGeometry(shape: TLTextShape, context: string): Rectangle2d;
+    getGeometry(shape: TLTextShape, opts: TLGeometryOpts): Rectangle2d;
     // (undocumented)
     getMinDimensions(shape: TLTextShape): {
         height: number;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -113,7 +113,7 @@ export {
 	type UseImageOrVideoAssetOptions,
 } from './lib/shapes/shared/useImageOrVideoAsset'
 export { TextShapeTool } from './lib/shapes/text/TextShapeTool'
-export { TextShapeUtil } from './lib/shapes/text/TextShapeUtil'
+export { TextShapeUtil, type TextShapeOptions } from './lib/shapes/text/TextShapeUtil'
 export { VideoShapeUtil } from './lib/shapes/video/VideoShapeUtil'
 export { type StyleValuesForUi } from './lib/styles'
 export { EraserTool } from './lib/tools/EraserTool/EraserTool'

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -41,7 +41,10 @@ export function getBoundShapeInfoForTerminal(
 	const boundShape = editor.getShape(binding.toId)!
 	if (!boundShape) return
 	const transform = editor.getShapePageTransform(boundShape)!
-	const geometry = editor.getShapeGeometry(boundShape, 'arrow')
+	const geometry = editor.getShapeGeometry(
+		boundShape,
+		terminalName === 'start' ? { context: '@tldraw/arrow-start' } : undefined
+	)
 
 	// This is hacky: we're only looking at the first child in the group. Really the arrow should
 	// consider all items in the group which are marked as snappable as separate polygons with which

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -41,7 +41,7 @@ export function getBoundShapeInfoForTerminal(
 	const boundShape = editor.getShape(binding.toId)!
 	if (!boundShape) return
 	const transform = editor.getShapePageTransform(boundShape)!
-	const geometry = editor.getShapeGeometry(boundShape)
+	const geometry = editor.getShapeGeometry(boundShape, 'arrow')
 
 	// This is hacky: we're only looking at the first child in the group. Really the arrow should
 	// consider all items in the group which are marked as snappable as separate polygons with which

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -51,11 +51,12 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return sizeCache.get(shape.props, (props) => getTextSize(this.editor, props))
 	}
 
-	getGeometry(shape: TLTextShape) {
+	getGeometry(shape: TLTextShape, context: string) {
 		const { scale } = shape.props
 		const { width, height } = this.getMinDimensions(shape)!
 		return new Rectangle2d({
-			width: width * scale,
+			x: context === 'arrow' ? -10 : 0,
+			width: width * scale + (context === 'arrow' ? 20 : 0),
 			height: height * scale,
 			isFilled: true,
 			isLabel: true,

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -5,6 +5,7 @@ import {
 	Rectangle2d,
 	ShapeUtil,
 	SvgExportContext,
+	TLGeometryOpts,
 	TLResizeInfo,
 	TLShapeId,
 	TLTextShape,
@@ -51,11 +52,12 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return sizeCache.get(shape.props, (props) => getTextSize(this.editor, props))
 	}
 
-	getGeometry(shape: TLTextShape, context: string) {
+	getGeometry(shape: TLTextShape, opts: TLGeometryOpts) {
 		const { scale } = shape.props
 		const { width, height } = this.getMinDimensions(shape)!
+		const context = opts?.context ?? 'none'
 		return new Rectangle2d({
-			x: context === 'arrow' ? -10 : 0,
+			x: context === '@tldraw/arrow-start' ? -10 : 0,
 			width: width * scale + (context === 'arrow' ? 20 : 0),
 			height: height * scale,
 			isFilled: true,

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -27,6 +27,12 @@ import { FONT_FAMILIES, FONT_SIZES, TEXT_PROPS } from '../shared/default-shape-c
 import { getFontDefForExport } from '../shared/defaultStyleDefs'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
 
+/** @public */
+export interface TextShapeOptions {
+	/** How much addition padding should be added to the horizontal geometry of the shape when binding to an arrow? */
+	extraArrowHorizontalPadding: number
+}
+
 const sizeCache = new WeakCache<TLTextShape['props'], { height: number; width: number }>()
 
 /** @public */
@@ -34,6 +40,10 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	static override type = 'text' as const
 	static override props = textShapeProps
 	static override migrations = textShapeMigrations
+
+	override options: TextShapeOptions = {
+		extraArrowHorizontalPadding: 10,
+	}
 
 	getDefaultProps(): TLTextShape['props'] {
 		return {
@@ -57,8 +67,12 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		const { width, height } = this.getMinDimensions(shape)!
 		const context = opts?.context ?? 'none'
 		return new Rectangle2d({
-			x: context === '@tldraw/arrow-start' ? -10 : 0,
-			width: width * scale + (context === 'arrow' ? 20 : 0),
+			x:
+				(context === '@tldraw/arrow-start' ? -this.options.extraArrowHorizontalPadding : 0) * scale,
+			width:
+				(width +
+					(context === '@tldraw/arrow-start' ? this.options.extraArrowHorizontalPadding * 2 : 0)) *
+				scale,
 			height: height * scale,
 			isFilled: true,
 			isLabel: true,


### PR DESCRIPTION
Long have we suffered from this:

<img width="630" alt="image" src="https://github.com/user-attachments/assets/6675d2be-09e4-4f08-8d1b-5c30ec8ff2c5" />

Text has no horizontal padding. We've tried adding horizontal padding before (see #1084, #2855) however we always ran into a circular problem.

- Adding horizontal text padding makes arrows look better
- ...but then it runs alignment / snapping / selection
- ...and it makes text move around

![image](https://github.com/user-attachments/assets/ab12d896-d5df-486b-aca8-19170cae781b)

What do we really want? **Contextual geometry**.

![Kapture 2025-02-24 at 15 42 22](https://github.com/user-attachments/assets/84e4c2b9-3688-410c-ae3f-e386d5fd8b6c)

If I'm creating arrow info, I might want a different geometry than if I'm snapping or aligning. 

**Pros:**

 - Additive API, no other changes
 - No migrations needed
 - Opens the door for other contextual geometries
 - Might be useful also for lines, highlighters, draw shapes, and other shapes
 
**Cons**

- More geometries cached (ie any shape that I've ever pointed an arrow to)

### Change type

- [x] `improvement`
- [x] `api`

### Test plan

1. Create a text shape
2. Make a horizontal arrow pointing from the text shape to something else

### Release notes

- Improved horizontal padding for arrows bound to text shapes