### PR TITLE
docs: Clarity on examples path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Learn more at [tldraw.dev](https://tldraw.dev).
 
 The local development server will run our examples app. The basic example will show any changes you've made to the codebase.
 
-To run the local development server, first clone this repo.
+To run the local development server, first clone this repo and navigate to the examples folder
+
+```bash
+cd apps/examples
+```
 
 Enable [corepack](https://nodejs.org/api/corepack.html) to make sure you have the right version of `yarn`:
 


### PR DESCRIPTION
Adds clarity that to run the local demo example app you need to be in the `apps/examples` folder.

Am unsure if this was just unclear to me due to unfamiliarity with Typescript project structures.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Adds example folder path to local demo instructions