### PR TITLE
Fix issue with duplicating bound arrows.

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9978,7 +9978,7 @@ function withIsolatedShapes<T>(
 				}
 			})
 
-			editor.store.applyDiff(reverseRecordsDiff(changes))
+			editor.store.applyDiff(reverseRecordsDiff(changes), { runCallbacks: false })
 		},
 		{ history: 'ignore' }
 	)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5788,7 +5788,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const { shapesToCreateWithOriginals, bindingsToCreate } = withIsolatedShapes(
 				this,
 				shapeIdSet,
-				false,
 				(bindingIdsToMaintain) => {
 					const bindingsToCreate: TLBinding[] = []
 					for (const originalId of bindingIdsToMaintain) {
@@ -8167,7 +8166,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const shapeIds = this.getShapeAndDescendantIds(ids)
 
-		return withIsolatedShapes(this, shapeIds, true, (bindingIdsToKeep) => {
+		return withIsolatedShapes(this, shapeIds, (bindingIdsToKeep) => {
 			const bindings: TLBinding[] = []
 			for (const id of bindingIdsToKeep) {
 				const binding = this.getBinding(id)
@@ -9943,7 +9942,6 @@ function pushShapeWithDescendants(editor: Editor, id: TLShapeId, result: TLShape
 function withIsolatedShapes<T>(
 	editor: Editor,
 	shapeIds: Set<TLShapeId>,
-	runCallbacks: boolean,
 	callback: (bindingsWithBoth: Set<TLBindingId>) => T
 ): T {
 	let result!: Result<T, unknown>
@@ -9980,7 +9978,7 @@ function withIsolatedShapes<T>(
 				}
 			})
 
-			editor.store.applyDiff(reverseRecordsDiff(changes), { runCallbacks })
+			editor.store.applyDiff(reverseRecordsDiff(changes), { runCallbacks: false })
 		},
 		{ history: 'ignore' }
 	)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5788,6 +5788,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const { shapesToCreateWithOriginals, bindingsToCreate } = withIsolatedShapes(
 				this,
 				shapeIdSet,
+				false,
 				(bindingIdsToMaintain) => {
 					const bindingsToCreate: TLBinding[] = []
 					for (const originalId of bindingIdsToMaintain) {
@@ -8166,7 +8167,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const shapeIds = this.getShapeAndDescendantIds(ids)
 
-		return withIsolatedShapes(this, shapeIds, (bindingIdsToKeep) => {
+		return withIsolatedShapes(this, shapeIds, true, (bindingIdsToKeep) => {
 			const bindings: TLBinding[] = []
 			for (const id of bindingIdsToKeep) {
 				const binding = this.getBinding(id)
@@ -9942,6 +9943,7 @@ function pushShapeWithDescendants(editor: Editor, id: TLShapeId, result: TLShape
 function withIsolatedShapes<T>(
 	editor: Editor,
 	shapeIds: Set<TLShapeId>,
+	runCallbacks: boolean,
 	callback: (bindingsWithBoth: Set<TLBindingId>) => T
 ): T {
 	let result!: Result<T, unknown>
@@ -9978,7 +9980,7 @@ function withIsolatedShapes<T>(
 				}
 			})
 
-			editor.store.applyDiff(reverseRecordsDiff(changes), { runCallbacks: false })
+			editor.store.applyDiff(reverseRecordsDiff(changes), { runCallbacks })
 		},
 		{ history: 'ignore' }
 	)

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -246,9 +246,6 @@ test('copying the from shape on its own does trigger isolation operations', () =
 		  "onBeforeDelete",
 		  "onAfterDelete",
 		  "onOperationComplete",
-		  "onBeforeCreate",
-		  "onAfterCreate",
-		  "onOperationComplete",
 		]
 	`)
 })
@@ -264,9 +261,6 @@ test('copying the to shape on its own does trigger the unbind operation', () => 
 		  "onBeforeIsolateToShape",
 		  "onBeforeDelete",
 		  "onAfterDelete",
-		  "onOperationComplete",
-		  "onBeforeCreate",
-		  "onAfterCreate",
 		  "onOperationComplete",
 		]
 	`)


### PR DESCRIPTION
[Reversing the diff](https://github.com/tldraw/tldraw/blob/d799df28e99e17bb71d1ab198f7c910fc3987a88/packages/editor/src/lib/editor/Editor.ts#L9981) caused some Arrow side effects to trigger, which updated the indexes of the arrows. This then caused the [siblings array](https://github.com/tldraw/tldraw/blob/d799df28e99e17bb71d1ab198f7c910fc3987a88/packages/editor/src/lib/editor/Editor.ts#L5845) in `duplicateShapes` to get out of order which resulted in  errors like`Error: aU4P6 >= aTnD8` since we passed incorrect lower and upper values to `getIndexBetween`.

### Change type

- [x] `bugfix`

### Release notes

- Fix a bug with duplicating bound arrows.