### PR TITLE
icons: followup to add crossorigin

### DIFF
--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -80,7 +80,13 @@
 		/>
 
 		<!-- $PRELOADED_ICONS -->
-		<link rel="preload" href="/tla/0_merged_tla.svg" as="image" type="image/svg+xml" crossorigin="anonymous" />
+		<link
+			rel="preload"
+			href="/tla/0_merged_tla.svg"
+			as="image"
+			type="image/svg+xml"
+			crossorigin="anonymous"
+		/>
 
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:url" content="https://www.tldraw.com/" />

--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -80,7 +80,7 @@
 		/>
 
 		<!-- $PRELOADED_ICONS -->
-		<link rel="preload" href="/tla/0_merged_tla.svg" as="image" type="image/svg+xml" />
+		<link rel="preload" href="/tla/0_merged_tla.svg" as="image" type="image/svg+xml" crossorigin="anonymous" />
 
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:url" content="https://www.tldraw.com/" />


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/5483

fix this:
<img width="1459" alt="Screenshot 2025-02-25 at 16 23 21" src="https://github.com/user-attachments/assets/023d4dbf-4563-4bd8-b1fd-b28af84e60e9" />



### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
