### PR TITLE
getImageSize: Fix inaccurate PNG image width height calculation by using exact pixels per meter value

### DIFF
--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -163,7 +163,12 @@ export class MediaHelpers {
 					if (physChunk) {
 						const physData = PngHelpers.parsePhys(view, physChunk.dataOffset)
 						if (physData.unit === 0 && physData.ppux === physData.ppuy) {
-							const pixelRatio = Math.max(physData.ppux / 2834.5, 1)
+							// Calculate pixels per meter:
+							// - 1 inch = 0.0254 meters
+							// - 72 DPI is 72 dots per inch
+							// - pixels per meter = 72 / 0.0254
+							const pixelsPerMeter = 72 / 0.0254
+							const pixelRatio = Math.max(physData.ppux / pixelsPerMeter, 1)
 							return {
 								w: Math.round(image.naturalWidth / pixelRatio),
 								h: Math.round(image.naturalHeight / pixelRatio),


### PR DESCRIPTION
Previously, if you try to upload a PNG image (1320 x 2868 | 72 dpi) into tldraw canvas, and then inspect its asset size, you will realize tldraw processes the image into (1320 x 2867) which is 1 pixel off in height.

This is caused by `getImageSize` function using an inaccurate pixels per meter value, after rounding off, we lose 1 pixel in the process.

The fix is to use the exact value of pixels per meter, which is calculated as so:

- 72 DPI is 72 dots per inch
- 1 inch is 0.0254 meter
- Therefore, pixels per meter for 72 DPI is 72 / 0.0254.

And so we just use 72 / 0.0254 as the pixels per inch value instead of rounding, which gives us the most accurate result.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Download an image with 1320 x 2868 (72dpi) 
2. Observe in file explorer that its size should be 1320 x 2868
![CleanShot 2025-02-26 at 23 35 48@2x](https://github.com/user-attachments/assets/4fa94203-de09-439b-ab65-b38168560e13)
3. Upload to tldraw canvas
4. Use inspector and issue this command `editor.getAsset(editor.getOnlySelectedShape().props.assetId)` and see that the image size is indeed 1320 x 2868


- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with `getImageSize` using inaccurate pixels per meter value which leads to discrepancies in calculating width and height in pixels for PNG images.