### PR TITLE
Fix file dropdown crashing the app on slow connections

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
@@ -14,6 +14,12 @@ import { useMaybeApp } from '../../hooks/useAppState'
 import { useIntl, useMsg } from '../../utils/i18n'
 import { editorMessages as messages } from './editor-messages'
 
+export async function download(editor: Editor, name: string) {
+	const blobToSave = await serializeTldrawJsonBlob(editor)
+	const file = new File([blobToSave], name, { type: 'application/json' })
+	downloadFile(file)
+}
+
 export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 	const app = useMaybeApp()
 	const untitledProject = useMsg(messages.untitledProject)
@@ -55,10 +61,7 @@ export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 					async onSelect() {
 						trackEvent('download-file', { source: '' })
 						const defaultName = getFileName(editor) + TLDRAW_FILE_EXTENSION
-
-						const blobToSave = await serializeTldrawJsonBlob(editor)
-						const file = new File([blobToSave], defaultName, { type: 'application/json' })
-						downloadFile(file)
+						await download(editor, defaultName)
 					},
 				}
 

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -192,7 +192,6 @@ export function FileItems({
 					readonlyOk
 					onSelect={handleDownloadClick}
 				/>
-				{/* <TldrawUiMenuItem label={intl.formatMessage(messages.pin)} id="pin" readonlyOk onSelect={handlePinClick} /> */}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="file-delete">
 				<TldrawUiMenuItem

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -144,7 +144,7 @@ export function FileItems({
 	}, [fileId, addDialog])
 
 	const untitledProject = useMsg(editorMessages.untitledProject)
-	const handleDowloadClick = useCallback(async () => {
+	const handleDownloadClick = useCallback(async () => {
 		if (!editor) return
 		const defaultName =
 			app.getFileName(fileId, false) ?? editor.getDocumentSettings().name ?? untitledProject
@@ -191,7 +191,7 @@ export function FileItems({
 						label={downloadFile}
 						id="download-file"
 						readonlyOk
-						onSelect={handleDowloadClick}
+						onSelect={handleDownloadClick}
 					/>
 				)}
 				{/* <TldrawUiMenuItem label={intl.formatMessage(messages.pin)} id="pin" readonlyOk onSelect={handlePinClick} /> */}

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -7,7 +7,6 @@ import {
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
-	TldrawUiMenuActionItem,
 	TldrawUiMenuContextProvider,
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
@@ -174,7 +173,6 @@ export function FileItems({
 					onSelect={handlePinUnpinClick}
 				/>
 				{/* <TldrawUiMenuItem label={intl.formatMessage(messages.pin)} id="pin" readonlyOk onSelect={handlePinClick} /> */}
-				<TldrawUiMenuActionItem actionId={'save-file-copy'} />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="file-delete">
 				<TldrawUiMenuItem

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -186,14 +186,12 @@ export function FileItems({
 					readonlyOk
 					onSelect={handlePinUnpinClick}
 				/>
-				{editor && (
-					<TldrawUiMenuItem
-						label={downloadFile}
-						id="download-file"
-						readonlyOk
-						onSelect={handleDownloadClick}
-					/>
-				)}
+				<TldrawUiMenuItem
+					label={downloadFile}
+					id="download-file"
+					readonlyOk
+					onSelect={handleDownloadClick}
+				/>
 				{/* <TldrawUiMenuItem label={intl.formatMessage(messages.pin)} id="pin" readonlyOk onSelect={handlePinClick} /> */}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="file-delete">

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -26,6 +26,7 @@ export interface TLAppUiEventMap {
 	'delete-file': null
 	'rename-file': { name: string }
 	'duplicate-file': null
+	'download-file': null
 	'drop-tldr-file': null
 	'import-tldr-file': null
 	'change-user-name': null


### PR DESCRIPTION
Fixes an error that would occur on slow connections. 

The issue was that on a slow connection the editor might take a while to load, which meant that we didn't have the actions provider set yet [due to this logic](https://github.com/tldraw/tldraw/blob/165f4f0749222457f70284e779e7eaf9c5616acd/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx#L80-L85). 

 I also discovered that we didn't actually show the file dropdown item that caused the issue in the first place. The reason was that we didn't set the `fileOverrides` for `TldrawUiContextProvider` [here](https://github.com/tldraw/tldraw/blob/1a89d9688c44affc84ed01495be37a082a83cc22/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx#L116-L125). This meant that the `save-file-copy` action was not available anyway. We could not make this work with `TldrawUiMenuActionItem` since there's no way for us to pass in the file slug to the action, so I reworked this to use regular handlers that don't go through actions.

(Looks like using the actions approach was meant for the main menu, there we always download the current file and can use the file slug. But sidebar has many files, so that approach didn't work)

### Change type

- [x] `bugfix`

### Test plan

1. Use slow 4g network setting.
2. Reload the page.
3. Open the file dropdown as soon as you can.
4. It should not crash the app.
