### PR TITLE
Stabilize useSync invocation

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -148,6 +148,10 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	)
 
 	const user = useTldrawUser()
+	const getUserToken = useEvent(async () => {
+		return (await user?.getToken()) ?? 'not-logged-in'
+	})
+	const hasUser = !!user
 	const assets = useMemo(() => {
 		return multiplayerAssetStore(() => fileId)
 	}, [fileId])
@@ -155,11 +159,11 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const store = useSync({
 		uri: useCallback(async () => {
 			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
-			if (user) {
-				url.searchParams.set('accessToken', await user.getToken())
+			if (hasUser) {
+				url.searchParams.set('accessToken', await getUserToken())
 			}
 			return url.toString()
-		}, [fileSlug, user]),
+		}, [fileSlug, hasUser, getUserToken]),
 		assets,
 		userInfo: app?.tlUser.userPreferences,
 	})


### PR DESCRIPTION
Phil reported an issue 

> Created new page in the "sales" project called Sales Funnel v3

> Noticed it was called "untitled"...and when I clicked on the pages view the site refreshed and the page had gone.

I reckon this was the same kind of thing that started happening randomly a couple of months ago where clerk, upon token refresh or something, would return a new object from the useAuth hook which in turn would invalidate our useTldrawUser hook, which in turn would invalidate our useSync invocation and cause the entire editor to remount.

So here I've stabilized the useSync invocation so that it only invalidates when the file slug changes or the auth status (isSignedIn vs not) changes, and then we use a useEvent to handle fetching the token.

### Change type

- [x] `other`
