### PR TITLE
Docs improvements, add FAQ to repo. (#5514)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,78 @@
+# Frequently Asked Questions
+
+This document is meant to be provide answers to frequently asked questions about the [tldraw developer SDK](https://tldraw.dev). For questions related to **[tldraw.com](https://tldraw.com)**, please see our [tldraw.com guides](https://tldraw.notion.site/tldraw-com-1283e4c324c08086b585d438f088580f).
+
+**Need more help?** See the [docs](https://tldraw.dev/docs) for our [guides](https://tldraw.dev/quick-start), [API reference](https://tldraw.dev/reference), and [examples](https://tldraw.dev/examples). You can also [join our Discord](https://discord.tldraw.com/?utm_source=github&utm_medium=social&utm_campaign=sociallink) to chat with the team and other developers.
+
+**Want to help out?** That's great! See the **Contributing** section at the very bottom of this document.
+
+---
+
+### How do I get started?
+
+If you're new to tldraw, your first visit should be our [quick start guide](https://tldraw.dev/quick-start).
+
+### How do I submit a bug?
+
+[Create an issue](https://github.com/tldraw/tldraw/issues) on our GitHub using the Bug template.
+
+### How do I submit a feature request?
+
+[Create an issue](https://github.com/tldraw/tldraw/issues) on our GitHub using the Feature Request template.
+
+### Can I use the tldraw SDK with Vue, Angular, or another framework?
+
+Yes. The SDK's main export (`<Tldraw>`) is a regular React component. To render it in a different framework, you would use your framework's regular method of rendering React components. For example, in Vue you would use a [Vue connector](https://dev.to/amirkian007/how-to-render-react-components-in-vue-1e0f). In Angular, you would use an [Angular wrapper component](https://web-world.medium.com/how-to-use-react-web-components-in-angular-b3ac7e39fd17).
+
+### How do I run code when the editor first mounts?
+
+Use the `Tldraw` component's `onMount` callback. See [this example](https://tldraw.dev/examples/editor-api/api) for more about using the editor API.
+
+```tsx
+<Tldraw
+	onMount={(editor) => {
+		editor.selectAll()
+	}}
+/>
+```
+
+### How do I turn on / off dark mode?
+
+Color theme preferences are stored in the user object. To change the theme at runtime, update the user preferences:
+
+```ts
+editor.user.updateUserPreferences({ colorScheme: 'dark' })
+editor.user.updateUserPreferences({ colorScheme: 'light' })
+editor.user.updateUserPreferences({ colorScheme: 'system' })
+```
+
+### How do I turn on / off readonly mode?
+
+You can use the `Editor` API.
+
+### How can I lock or unlock a shape?
+
+### How do I prevent the camera from moving?
+
+---
+
+## Contributing
+
+Want to help with this document? Great! We welcome contributions that add new questions or improve existing answers. You can quickly edit the page [here](https://github.com/tldraw/tldraw/edit/main/FAQ.md)—or you can clone the repository, edit this file, and submit a Pull Reqeust.
+
+Some tips:
+
+- keep answers simple (English is a second language to many readers)
+- include short code examples if you can
+- provide links to relevant docs, examples, or files
+
+You can use the example format below:
+
+### Example question?
+
+Example answer. [Link](https://tldraw.dev/quick-start).
+
+```ts
+// Code example
+editor.showCodeExample()
+```

--- a/apps/docs/app/(marketing)/page.tsx
+++ b/apps/docs/app/(marketing)/page.tsx
@@ -15,9 +15,10 @@ export default function Page() {
 		<>
 			<HeroSection />
 			<LogoSection />
+			<PricingSection />
+			<InstallationSection />
 			<FeaturesSection />
 			<DetailsSection />
-			<InstallationSection />
 			{/* <CustomizationSection /> */}
 			{/* <CaseStudiesSection /> */}
 			<WatermarkSection />

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -14,11 +14,11 @@ import './globals.css'
 export const metadata: Metadata = {
 	metadataBase: new URL('https://tldraw.dev'),
 	title: {
-		default: 'The infinite canvas SDK • tldraw',
+		default: 'tldraw: Build whiteboards in React with the tldraw SDK',
 		template: `%s • tldraw`,
 	},
 	description:
-		'Infinite canvas SDK from tldraw. Build whiteboards, design tools, and canvas experiences for the web.',
+		'The tldraw SDK provides tools, services, and APIs to build beautiful whiteboards and infinite canvas applications with real-time collaboration and a powerful React-based canvas.',
 	twitter: {
 		creator: '@tldraw',
 	},

--- a/apps/docs/app/not-found.tsx
+++ b/apps/docs/app/not-found.tsx
@@ -5,6 +5,7 @@ import { DiscordIcon } from '@/components/common/icon/discord'
 import { DocsSearchBar } from '@/components/docs/docs-search-bar'
 import { NavigationLink } from '@/components/navigation/link'
 import Handwritten404 from '@/public/images/404.svg'
+import { RocketLaunchIcon } from '@heroicons/react/16/solid'
 import { AcademicCapIcon, BookOpenIcon, NewspaperIcon, PlayIcon } from '@heroicons/react/20/solid'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -12,8 +13,13 @@ import Link from 'next/link'
 const links = [
 	{
 		caption: 'Quick Start',
-		icon: AcademicCapIcon,
+		icon: RocketLaunchIcon,
 		href: '/quick-start',
+	},
+	{
+		caption: 'Guides',
+		icon: AcademicCapIcon,
+		href: '/editor',
 	},
 	{
 		caption: 'Reference',

--- a/apps/docs/components/common/talk-to-me.tsx
+++ b/apps/docs/components/common/talk-to-me.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useLocalStorageState } from '@/utils/storage'
-import { ArrowRightCircleIcon, XMarkIcon } from '@heroicons/react/24/solid'
+import { XMarkIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 
 export function TalkToMe() {
@@ -25,16 +25,11 @@ export function TalkToMe() {
 				>
 					<div className="hidden md:flex flex-row gap-2 items-center">
 						Take our developer survey
-						<ArrowRightCircleIcon className="w-4 h-4 flex-shrink-0" />
 					</div>
 					<div className="hidden sm:flex md:hidden flex-row gap-2 items-center">
 						Take our survey
-						<ArrowRightCircleIcon className="w-4 h-4 flex-shrink-0" />
 					</div>
-					<div className="flex sm:hidden flex-row gap-2 items-center">
-						hi
-						<ArrowRightCircleIcon className="w-4 h-4 flex-shrink-0" />
-					</div>
+					<div className="flex sm:hidden flex-row gap-2 items-center">hey</div>
 				</Link>
 			</div>
 		</div>

--- a/apps/docs/components/docs/docs-category-menu.tsx
+++ b/apps/docs/components/docs/docs-category-menu.tsx
@@ -1,18 +1,23 @@
 'use client'
 
 import { NavigationLink } from '@/components/navigation/link'
+import { RocketLaunchIcon } from '@heroicons/react/16/solid'
 import { AcademicCapIcon, CommandLineIcon, PlayIcon } from '@heroicons/react/20/solid'
 import { usePathname } from 'next/navigation'
 
 const categoryLinks = [
 	{
 		caption: 'Quick Start',
-		icon: AcademicCapIcon,
+		icon: RocketLaunchIcon,
 		href: '/quick-start',
 		active: (pathname: string) =>
-			['/quick-start', '/installation', '/releases', '/docs', '/community'].some((e) =>
-				pathname.startsWith(e)
-			),
+			['/quick-start', '/installation', '/releases'].some((e) => pathname.startsWith(e)),
+	},
+	{
+		caption: 'Guides',
+		icon: AcademicCapIcon,
+		href: '/editor',
+		active: (pathname: string) => ['/docs', '/community'].some((e) => pathname.startsWith(e)),
 	},
 	{
 		caption: 'Reference',

--- a/apps/docs/components/marketing/hero-section.tsx
+++ b/apps/docs/components/marketing/hero-section.tsx
@@ -5,17 +5,14 @@ import Link from 'next/link'
 
 export function HeroSection() {
 	return (
-		<section className="w-full max-w-screen-xl mx-auto md:px-5 flex flex-col items-center py-8 sm:py-16">
-			<div className="relative">
-				<h1 className="hidden sm:block relative font-black text-black dark:text-white text-center leading-tight text-4xl md:text-5xl md:leading-tight w-full px-[8px] pt-12 pb-6">
-					The <u>perfect</u>
-					<br />
-					whiteboard SDK
+		<section className="max-w-screen-xl w-full mx-auto md:px-5 flex flex-col items-center py-8 sm:py-16">
+			<div className="relative max-w-[100%] lg:max-w-[80%]">
+				<h1 className="hidden sm:block relative text-center font-black text-black dark:text-white text-balance leading-tight text-4xl md:text-5xl md:leading-tight px-[8px] pt-12 pb-6">
+					Build whiteboards in React with the tldraw <span className="whitespace-nowrap">SDK</span>
 				</h1>
-				<h1 className="block text-balance sm:hidden relative font-black text-black dark:text-white text-center text-4xl leading-tight w-full px-[8px] pt-12 pb-6">
-					The <u>perfect</u>
-					<br />
-					whiteboard SDK
+				<h1 className="block text-center text-balance sm:hidden relative font-black text-black dark:text-white text-center text-4xl leading-tight px-[8px] pt-12 pb-6">
+					Build whiteboards in React with the <br />
+					<span className="whitespace-nowrap">tldraw SDK</span>
 				</h1>
 				{/* <Underline
 					className={cn(
@@ -47,11 +44,11 @@ export function HeroSection() {
                     developers and users.
                 </div>
             </div> */}
-			<p className="mt-5 sm:mt-8 px-5 text-center text-zinc-800 dark:text-zinc-200 sm:text-lg max-w-lg md:max-w-xl text-balance">
-				An instant collaborative whiteboard for your product, complete with the components,
-				services, and APIs you need to build further.
+			<p className="mt-0 sm:mt-5 px-5 text-center text-zinc-800 dark:text-zinc-200 sm:text-lg w-full text-balance w-[90%]">
+				Have an idea for an infinite canvas? The tldraw SDK has everything you need to build instant
+				real-time collaborative whiteboards and more.
 			</p>
-			<div className="flex flex-row items-center sm:items-start sm:flex-row gap-x-4 gap-y-2 mt-6 sm:mt-9 flex-wrap justify-center sm:max-width-xl pb-8 sm:pb-16">
+			<div className="pt-5 flex flex-row items-center sm:items-start sm:flex-row gap-x-4 gap-y-2 mt-6 sm:mt-9 flex-wrap justify-center sm:max-width-xl pb-8 sm:pb-16">
 				<Button
 					id="hero-quick-start"
 					href="/quick-start"

--- a/apps/docs/components/marketing/pricing-section.tsx
+++ b/apps/docs/components/marketing/pricing-section.tsx
@@ -8,9 +8,8 @@ export function PricingSection() {
 	return (
 		<Section id="pricing">
 			<SectionHeading
-				subheading="Pricing"
-				heading="Purchase a License"
-				description="Remove the watermark and access additional support."
+				heading="Pricing"
+				description="Use the SDK free with our watermark or purchase a license."
 			/>
 			<div className="mt-20 flow-root">
 				<div className="isolate mx-auto px-8 md:px-5 -mt-16 grid max-w-sm grid-cols-1 gap-y-16 divide-y divide-gray-100 sm:mx-auto lg:-mx-8 lg:mt-0 lg:max-w-none lg:grid-cols-3 lg:divide-x lg:divide-y-0 xl:-mx-4">

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -271,7 +271,7 @@ The [Editor#getInstanceState](?) method returns settings that relate to each ind
 
 ## User preferences
 
-The editor's user preferences are shared between all instances. See the [TLUserPreferences](?) docs for more about the user preferences.
+The editor's user preferences are shared between all instances. See the the [UserPreferencesManager](?) for more about the user preferences.
 
 # Camera and coordinates
 
@@ -654,18 +654,18 @@ editor.setCameraOptions({ isLocked: true })
 
 ### Turn on dark mode
 
-You can turn on or off dark mode via the [setUserPreferences](?) method. Note that this effects all editor instances that share the same user—even instances in other tabs.
+You can turn on or off dark mode via the [UserPreferencesManager](?). Note that this effects all editor instances that share the same user—even instances in other tabs.
 
 ```ts
-setUserPreferences({ colorScheme: 'dark' })
+editor.user.updateUserPreferences({ colorScheme: 'dark' })
 ```
 
 ### Using the system color scheme
 
-You can also use the system color scheme via the [setUserPreferences](?) method.
+You can also use the system color scheme via the [UserPreferencesManager](?).
 
 ```ts
-setUserPreferences({ colorScheme: 'system' })
+editor.user.updateUserPreferences({ colorScheme: 'system' })
 ```
 
 ### Make changes without effecting the history

--- a/apps/examples/src/examples.tsx
+++ b/apps/examples/src/examples.tsx
@@ -32,17 +32,17 @@ const getExamplesForCategory = (category: Category) =>
 			return a.priority - b.priority
 		})
 
-const categories: Record<Category, string> = {
-	basic: 'Getting started',
-	collaboration: 'Sync',
-	ui: 'UI & theming',
-	'shapes/tools': 'Shapes & tools',
-	'data/assets': 'Data & assets',
-	'editor-api': 'Editor API',
-	'use-cases': 'Use cases',
-}
+const categories = [
+	['basic', 'Getting started'],
+	['collaboration', 'Sync'],
+	['ui', 'UI & theming'],
+	['shapes/tools', 'Shapes & tools'],
+	['editor-api', 'Editor API'],
+	['data/assets', 'Data & assets'],
+	['use-cases', 'Use cases'],
+]
 
-export const examples = Object.entries(categories).map(([category, title]) => ({
+export const examples = categories.map(([category, title]) => ({
 	id: title,
 	value: getExamplesForCategory(category as Category),
 }))

--- a/apps/examples/src/examples/camera-options/README.md
+++ b/apps/examples/src/examples/camera-options/README.md
@@ -2,6 +2,7 @@
 title: Camera options
 component: ./CameraOptionsExample.tsx
 category: editor-api
+priority: 3
 keywords: [api, fixed, constraints, camera bounds, pan speed, zoom speed]
 ---
 

--- a/apps/examples/src/examples/lock-camera-zoom/README.md
+++ b/apps/examples/src/examples/lock-camera-zoom/README.md
@@ -2,7 +2,6 @@
 title: Lock camera zoom
 component: ./LockCameraZoomExample.tsx
 category: editor-api
-priority: 1
 keywords: [camera, lock, zoom]
 ---
 

--- a/apps/examples/src/examples/snapshots/README.md
+++ b/apps/examples/src/examples/snapshots/README.md
@@ -2,7 +2,7 @@
 title: Snapshots
 component: ./SnapshotExample.tsx
 category: editor-api
-priority: 1
+priority: 2
 keywords: []
 ---
 

--- a/apps/examples/src/examples/ui-events/README.md
+++ b/apps/examples/src/examples/ui-events/README.md
@@ -2,7 +2,6 @@
 title: UI events
 component: ./UiEventsExample.tsx
 category: editor-api
-priority: 0
 keywords: [ui, events, api, x-ray]
 ---
 


### PR DESCRIPTION
This PR makes some minor improvements to the landing page / docs.

- split quick start and guides categories
- improve ordering of examples
- update landing page copy

It also adds an FAQ to the repo root. We can use this for the developer FAQ (and possibly slurp it into the docs site).

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`