### PR TITLE
Do hard deletes reactively

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -776,12 +776,15 @@ export class TLDrawDurableObject extends DurableObject {
 		}
 	}
 
-	async appFileRecordDidDelete() {
-		// force isOrWasCreateMode to be false so next open will check the database
+	async appFileRecordDidDelete({
+		id,
+		publishedSlug,
+	}: Pick<TlaFile, 'id' | 'ownerId' | 'publishedSlug'>) {
 		if (this._documentInfo?.deleted) return
 
 		this._fileRecordCache = null
 
+		// prevent new connections while we clean everything up
 		this.setDocumentInfo({
 			version: CURRENT_DOCUMENT_INFO_VERSION,
 			slug: this.documentInfo.slug,
@@ -790,14 +793,43 @@ export class TLDrawDurableObject extends DurableObject {
 		})
 
 		await this.executionQueue.push(async () => {
-			const room = await this.getRoom()
-			for (const session of room.getSessions()) {
-				room.closeSession(session.sessionId, TLSyncErrorCloseEventReason.NOT_FOUND)
+			if (this._room) {
+				const room = await this.getRoom()
+				for (const session of room.getSessions()) {
+					room.closeSession(session.sessionId, TLSyncErrorCloseEventReason.NOT_FOUND)
+				}
+				room.close()
 			}
-			room.close()
 			// setting _room to null will prevent any further persists from going through
 			this._room = null
 			// delete should be handled by the delete endpoint now
+
+			// Delete published slug mapping
+			await this.env.SNAPSHOT_SLUG_TO_PARENT_SLUG.delete(publishedSlug)
+
+			// remove published files
+			const publishedPrefixKey = getR2KeyForRoom({
+				slug: `${id}/${publishedSlug}`,
+				isApp: true,
+			})
+
+			const publishedHistory = await listAllObjectKeys(this.env.ROOM_SNAPSHOTS, publishedPrefixKey)
+			if (publishedHistory.length > 0) {
+				await this.env.ROOM_SNAPSHOTS.delete(publishedHistory)
+			}
+
+			// remove edit history
+			const r2Key = getR2KeyForRoom({ slug: id, isApp: true })
+			const editHistory = await listAllObjectKeys(this.env.ROOMS_HISTORY_EPHEMERAL, r2Key)
+			if (editHistory.length > 0) {
+				await this.env.ROOMS_HISTORY_EPHEMERAL.delete(editHistory)
+			}
+
+			// remove main file
+			await this.env.ROOMS.delete(r2Key)
+
+			// finally clear storage so we don't keep the data around
+			this.ctx.storage.deleteAll()
 		})
 	}
 
@@ -808,4 +840,17 @@ export class TLDrawDurableObject extends DurableObject {
 		if (!this._documentInfo) return
 		await this.persistToDatabase()
 	}
+}
+
+async function listAllObjectKeys(bucket: R2Bucket, prefix: string): Promise<string[]> {
+	const keys: string[] = []
+	let cursor: string | undefined
+
+	do {
+		const result = await bucket.list({ prefix, cursor })
+		keys.push(...result.objects.map((o) => o.key))
+		cursor = result.truncated ? result.cursor : undefined
+	} while (cursor)
+
+	return keys
 }

--- a/apps/dotcom/zero-cache/migrations/014_add_publishedSlug_to_file_key.sql
+++ b/apps/dotcom/zero-cache/migrations/014_add_publishedSlug_to_file_key.sql
@@ -1,0 +1,5 @@
+-- In order to correctly clean up resources for deleted files, we need to know the publishSlug of the file.
+
+ALTER TABLE "file"
+DROP CONSTRAINT "file_pkey",
+ADD PRIMARY KEY ("id", "ownerId", "publishedSlug");


### PR DESCRIPTION
Before this PR the only path we had available for hard deletes was via client-side mutations. If we deleted the row manually in the db (e.g. because a user asked us to wipe their data) it would not result in the R2/KV artefacts being cleaned up.

Before this PR we also needed to get the publsihedSlug from the row before deleting it so we could clean up the publishing artefacts.

Now I added the publishedSlug to the file table primary key so we get it in delete events. Then when we handle those delete events in the file durable object, it does the cleanup there.

We'd end up doing this during the switch to zero anyway I think.

(note this wasn't totally safe to do before because file deletes may have happened while the replicator didn't have an open subscription to Postgres. But now we use a persistent replication slot this should always work)

### Change type

- [x] `other`
