### PR TITLE
fix file extension for downloads

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -4,6 +4,7 @@ import { FILE_PREFIX, TlaFile } from '@tldraw/dotcom-shared'
 import { Fragment, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
+	TLDRAW_FILE_EXTENSION,
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
@@ -149,7 +150,7 @@ export function FileItems({
 		const defaultName =
 			app.getFileName(fileId, false) ?? editor.getDocumentSettings().name ?? untitledProject
 		trackEvent('download-file', { source })
-		await download(editor, defaultName)
+		await download(editor, defaultName + TLDRAW_FILE_EXTENSION)
 	}, [app, editor, fileId, source, trackEvent, untitledProject])
 
 	const copyLinkMsg = useMsg(messages.copyLink)


### PR DESCRIPTION
before this, the 'Download file' option would return with a .json extension.

### Change type

- [x] `other`
