### PR TITLE
Filter out deleted files when doing the max file check on the BE

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -355,7 +355,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 						} else {
 							const { id: _id, ...rest } = update.row as any
 							if (update.table === 'file') {
-								const count = this.cache.store.getFullData()?.files.length ?? 0
+								const count =
+									this.cache.store.getFullData()?.files.filter((f) => !f.isDeleted).length ?? 0
 								if (count >= MAX_NUMBER_OF_FILES) {
 									throw new ZMutationError(
 										ZErrorCode.max_files_reached,


### PR DESCRIPTION
Noticed this [sentry issue](https://tldraw.sentry.io/issues/6349570543/?environment=production-tldraw-multiplayer&project=4503966963662848&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=6).

### Change type

- [x] `bugfix`
