### PR TITLE
Make better use of replicator history

### DIFF
--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -35,6 +35,7 @@
 		"itty-router": "^5.0.18",
 		"jose": "^5.9.6",
 		"kysely": "^0.27.5",
+		"lodash.throttle": "^4.1.1",
 		"pg": "^8.13.1",
 		"pg-logical-replication": "^2.0.7",
 		"react": "^18.3.1",

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -115,7 +115,7 @@ const migrations: Migration[] = [
 
 const ONE_MINUTE = 60 * 1000
 const PRUNE_INTERVAL = 10 * ONE_MINUTE
-const MAX_HISTORY_ROWS = 10_000
+const MAX_HISTORY_ROWS = 50_000
 
 type PromiseWithResolve = ReturnType<typeof promiseWithResolve>
 

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -387,14 +387,20 @@ export class UserDataSyncer {
 		}
 
 		transact(() => {
+			let maxMutationNumber = -1
 			for (const ev of event.changes) {
 				if (ev.type === 'mutation_commit') {
-					this.commitMutations(ev.mutationNumber)
+					if (ev.mutationNumber > maxMutationNumber) {
+						maxMutationNumber = ev.mutationNumber
+					}
 					continue
 				}
 
 				assert(ev.type === 'row_update', `event type should be row_update got ${event.type}`)
 				this.handleRowUpdateEvent(ev)
+			}
+			if (maxMutationNumber >= 0) {
+				this.commitMutations(maxMutationNumber)
 			}
 
 			this.store.commitLsn(event.lsn)

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -114,8 +114,6 @@ export class UserDataSyncer {
 		}
 	}
 
-	interval: NodeJS.Timeout | null = null
-
 	constructor(
 		private ctx: DurableObjectState,
 		private env: Environment,
@@ -127,19 +125,6 @@ export class UserDataSyncer {
 	) {
 		this.sentry = createSentry(ctx, env)
 		this.reboot({ delay: false })
-	}
-
-	maybeStartInterval() {
-		if (!this.interval) {
-			this.interval = setInterval(() => this.onInterval(), 1000)
-		}
-	}
-
-	stopInterval() {
-		if (this.interval) {
-			clearInterval(this.interval)
-			this.interval = null
-		}
 	}
 
 	private queue = new ExecutionQueue()
@@ -457,7 +442,7 @@ export class UserDataSyncer {
 		this.broadcast({ type: 'update', update })
 	}
 
-	private async onInterval() {
+	async onInterval() {
 		// if any mutations have been not been committed for 5 seconds, let's reboot the cache
 		if (this.store.epoch != this.lastStashEpoch && this.state.type === 'connected') {
 			const initialData = this.store.getCommittedData()

--- a/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
+++ b/apps/dotcom/sync-worker/src/getFetchEverythingSql.ts
@@ -43,13 +43,15 @@ const fileStateColumns = fileStateKeys.map((c) => `${c.reference} as "${c.alias}
 
 export function getFetchUserDataSql(userId: string) {
 	return sql`
-SELECT 'user' AS "table", null::text as "lsn", ${sql.raw(userColumns + ',' + fileNulls + ',' + fileStateNulls)} FROM public.user WHERE "id" = '${sql.raw(userId)}'
+SELECT 'user' AS "table", null::bigint as "mutationNumber", null::text as "lsn", ${sql.raw(userColumns + ',' + fileNulls + ',' + fileStateNulls)} FROM public.user WHERE "id" = '${sql.raw(userId)}'
 UNION
-SELECT 'file' AS "table", null::text as "lsn", ${sql.raw(userNulls + ',' + fileColumns + ',' + fileStateNulls)} FROM public.file WHERE ("ownerId" = '${sql.raw(userId)}' OR "shared" = true AND EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${sql.raw(userId)}' AND public.file_state."fileId" = public.file.id))
+SELECT 'file' AS "table", null::bigint as "mutationNumber", null::text as "lsn", ${sql.raw(userNulls + ',' + fileColumns + ',' + fileStateNulls)} FROM public.file WHERE ("ownerId" = '${sql.raw(userId)}' OR "shared" = true AND EXISTS(SELECT 1 FROM public.file_state WHERE "userId" = '${sql.raw(userId)}' AND public.file_state."fileId" = public.file.id))
 UNION
-SELECT 'file_state' AS "table", null::text as "lsn", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateColumns)} FROM public.file_state WHERE "userId" = '${sql.raw(userId)}'
+SELECT 'file_state' AS "table", null::bigint as "mutationNumber", null::text as "lsn", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateColumns)} FROM public.file_state WHERE "userId" = '${sql.raw(userId)}'
 UNION
-SELECT 'meta' as "table", pg_current_wal_lsn()::text as "lsn", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateNulls)};
+SELECT 'lsn' as "table", null::bigint as "mutationNumber", pg_current_wal_lsn()::text as "lsn", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateNulls)}
+UNION
+SELECT 'user_mutation_number' as "table", "mutationNumber"::bigint as "mutationNumber", null::text as "lsn", ${sql.raw(userNulls + ',' + fileNulls + ',' + fileStateNulls)} FROM public.user_mutation_number;
 `
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6903,6 +6903,7 @@ __metadata:
     jose: "npm:^5.9.6"
     kysely: "npm:^0.27.5"
     lazyrepo: "npm:0.0.0-alpha.27"
+    lodash.throttle: "npm:^4.1.1"
     pg: "npm:^8.13.1"
     pg-logical-replication: "npm:^2.0.7"
     react: "npm:^18.3.1"


### PR DESCRIPTION
After making a couple of deploys with the new backend this morning we noticed that a large portion of user DOs still ended up doing a full db reset and this seems to be for two reasons:

1. we only stored about 10 minutes worth of history
2. a lot of users in our active_users table are idle at any given time (maybe like 70-80% of them) so a lot of them will not have received updates for more than 10 minutes.

This PR makes it so that if a user hasn't done anything for 5 minutes but their socket is still open, we execute a noop mutation number bump so that they receive a new `lsn`.

I also cleaned up the mutation handling logic so that it no longer does two transactions per mutation. This was only required before because postgres.js would not dispatch events grouped by transaction, and the ordering was not maintained. wal2json guarantees changes to be grouped by transaction with formatVersion: 1 (the default that we use) so as long as we commit the mutations after handling any state updates it should avoid data races.

### Change type

- [x] `other`
