### PR TITLE
pull writing image/svg to clipboard

### DIFF
--- a/packages/tldraw/src/lib/utils/clipboard.ts
+++ b/packages/tldraw/src/lib/utils/clipboard.ts
@@ -1,4 +1,4 @@
-import { getOwnProperty, objectMapFromEntries, tlenv } from '@tldraw/editor'
+import { getOwnProperty, objectMapFromEntries } from '@tldraw/editor'
 import { TLCopyType } from './export/copyAs'
 
 // Browsers sanitize image formats to prevent security issues when pasting between applications. For
@@ -11,18 +11,15 @@ import { TLCopyType } from './export/copyAs'
 // if it's there, use that instead of the normal png.
 export const TLDRAW_CUSTOM_PNG_MIME_TYPE = 'web image/vnd.tldraw+png' as const
 
-const browserCanExportSvgFaithfully = tlenv.isSafari || tlenv.isFirefox
-
 const additionalClipboardWriteTypes = {
 	png: TLDRAW_CUSTOM_PNG_MIME_TYPE,
-	svg: browserCanExportSvgFaithfully ? 'image/svg+xml' : null,
 } as const
 const canonicalClipboardReadTypes = {
 	[TLDRAW_CUSTOM_PNG_MIME_TYPE]: 'image/png',
 }
 
 export function getAdditionalClipboardWriteType(format: TLCopyType): string | null {
-	return getOwnProperty(additionalClipboardWriteTypes, format) ?? null
+	return getOwnProperty<TLCopyType, string>(additionalClipboardWriteTypes, format) ?? null
 }
 export function getCanonicalClipboardReadType(mimeType: string): string {
 	return getOwnProperty(canonicalClipboardReadTypes, mimeType) ?? mimeType


### PR DESCRIPTION
It doesn't work in non chrome browsers, and we disabled it for chrome in #5524 

### Change type

- [x] `bugfix`
