### PR TITLE
improvement(editor): pass userId to collaboration components

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2896,6 +2896,8 @@ export interface TLBrushProps {
     color?: string;
     // (undocumented)
     opacity?: number;
+    // (undocumented)
+    userId?: string;
 }
 
 // @public (undocumented)
@@ -2979,6 +2981,8 @@ export interface TLCollaboratorHintProps {
     // (undocumented)
     point: VecModel;
     // (undocumented)
+    userId: string;
+    // (undocumented)
     viewport: Box;
     // (undocumented)
     zoom: number;
@@ -3038,6 +3042,8 @@ export interface TLCursorProps {
     name: null | string;
     // (undocumented)
     point: null | VecModel;
+    // (undocumented)
+    userId: string;
     // (undocumented)
     zoom: number;
 }
@@ -3753,6 +3759,8 @@ export interface TLScribbleProps {
     // (undocumented)
     scribble: TLScribble;
     // (undocumented)
+    userId?: string;
+    // (undocumented)
     zoom: number;
 }
 
@@ -3826,6 +3834,8 @@ export interface TLShapeIndicatorProps {
     opacity?: number;
     // (undocumented)
     shapeId: TLShapeId;
+    // (undocumented)
+    userId?: string;
 }
 
 // @public

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -92,6 +92,7 @@ const Collaborator = track(function Collaborator({
 				<CollaboratorBrush
 					className="tl-collaborator__brush"
 					key={userId + '_brush'}
+					userId={userId}
 					brush={brush}
 					color={color}
 					opacity={0.1}
@@ -101,6 +102,7 @@ const Collaborator = track(function Collaborator({
 				<CollaboratorCursor
 					className="tl-collaborator__cursor"
 					key={userId + '_cursor'}
+					userId={userId}
 					point={cursor}
 					color={color}
 					zoom={zoomLevel}
@@ -111,6 +113,7 @@ const Collaborator = track(function Collaborator({
 				<CollaboratorHint
 					className="tl-collaborator__cursor-hint"
 					key={userId + '_cursor_hint'}
+					userId={userId}
 					point={cursor}
 					color={color}
 					zoom={zoomLevel}
@@ -123,6 +126,7 @@ const Collaborator = track(function Collaborator({
 						<CollaboratorScribble
 							key={userId + '_scribble_' + scribble.id}
 							className="tl-collaborator__scribble"
+							userId={userId}
 							scribble={scribble}
 							color={color}
 							zoom={zoomLevel}
@@ -138,6 +142,7 @@ const Collaborator = track(function Collaborator({
 						<CollaboratorShapeIndicator
 							className="tl-collaborator__shape-indicator"
 							key={userId + '_' + shapeId}
+							userId={userId}
 							shapeId={shapeId}
 							color={color}
 							opacity={0.5}

--- a/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
@@ -5,6 +5,7 @@ import { toDomPrecision } from '../../primitives/utils'
 
 /** @public */
 export interface TLBrushProps {
+	userId?: string
 	brush: BoxModel
 	color?: string
 	opacity?: number

--- a/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
@@ -9,6 +9,7 @@ import { clamp } from '../../primitives/utils'
 
 /** @public */
 export interface TLCollaboratorHintProps {
+	userId: string
 	className?: string
 	point: VecModel
 	viewport: Box

--- a/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
@@ -6,6 +6,7 @@ import { useTransform } from '../../hooks/useTransform'
 
 /** @public */
 export interface TLCursorProps {
+	userId: string
 	className?: string
 	point: VecModel | null
 	zoom: number

--- a/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
@@ -4,6 +4,7 @@ import { getSvgPathFromPoints } from '../../utils/getSvgPathFromPoints'
 
 /** @public */
 export interface TLScribbleProps {
+	userId?: string
 	scribble: TLScribble
 	zoom: number
 	color?: string

--- a/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
@@ -38,6 +38,7 @@ const InnerIndicator = ({ editor, id }: { editor: Editor; id: TLShapeId }) => {
 
 /** @public */
 export interface TLShapeIndicatorProps {
+	userId?: string
 	shapeId: TLShapeId
 	color?: string | undefined
 	opacity?: number


### PR DESCRIPTION
Pass userId to collaboration components and updated types to match as discussed on Discord (https://discord.com/channels/859816885297741824/1344355258129846364/1344355258129846364)

### Change type

- [x] `improvement` 

### Test plan

1. Create a custom collaboration component (such as `CollaboratorCursor` or `CollaboratorHint`) and use the `userId` passed in props to identify which user it belongs to either with `usePresence` (not public yet?) or `editor.getCollaborators().find((c) => c.userId === userId)`

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Pass `userId` to collaboration components in `LiveCollaborators`