### PR TITLE
remove import from core-js

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -92,7 +92,6 @@ import {
 	structuredClone,
 	uniqueId,
 } from '@tldraw/utils'
-import { Number } from 'core-js'
 import EventEmitter from 'eventemitter3'
 import {
 	TLEditorSnapshot,


### PR DESCRIPTION
Removes the `import { Number } from 'core-js` line in Editor.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Build and run TLDraw and see if it still loads/works. If something isn't right it should blow in the build step.

### Release notes

- Fixed bug with loading TLDraw in an SSR environment by removing a core-js import  https://github.com/tldraw/tldraw/issues/5543