### PR TITLE
fix pasting files in safari

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -294,6 +294,13 @@ const handlePasteFromClipboardApi = async ({
 		things.push(
 			...fallbackFiles.map((f): ClipboardThing => ({ type: 'file', source: Promise.resolve(f) }))
 		)
+	} else if (fallbackFiles?.length && things.length === 0) {
+		// Files pasted in Safari from your computer don't have types, so we need to use the fallback files directly
+		// if they're available. This only works if pasted keyboard shortcuts. Pasting from the menu in Safari seems to never
+		// let you access files that are copied from your computer.
+		things.push(
+			...fallbackFiles.map((f): ClipboardThing => ({ type: 'file', source: Promise.resolve(f) }))
+		)
 	}
 
 	return await handleClipboardThings(editor, things, point)


### PR DESCRIPTION
This PR fixes a small bug with pasting files from your computer into Safari.
It only addresses pasting with Cmd+V, I don't know if there is any hope for the Menu paste in Safari.

It uses the existing "fallbackFiles" which appear to be designed to handle this but were only handling text files?

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On `main` copy a supported file from your local computer, such as a PNG.
2. In the editor, in Safari, press Cmd/Ctrl + V.
3. Note that nothing happens.
4. Repeat the process on this branch and the file[s] should be loaded into the editor as expected.

### Release notes

- Fixed a bug with pasting files from your computer in Safari