### PR TITLE
embed: youtube perf improvement; support time and loop

### DIFF
--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -64,6 +64,7 @@
 		"classnames": "^2.5.1",
 		"hotkeys-js": "^3.13.9",
 		"idb": "^7.1.1",
+		"lite-youtube-embed": "^0.3.3",
 		"lodash.isequal": "^4.5.0",
 		"lz-string": "^1.5.0"
 	},

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -230,13 +230,16 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			const hostname = urlObj.hostname.replace(/^www./, '')
 			if (hostname === 'youtu.be') {
 				const videoId = urlObj.pathname.split('/').filter(Boolean)[0]
-				return `https://www.youtube.com/embed/${videoId}`
+				return `https://www.youtube.com/embed/${videoId}${urlObj.search}`
 			} else if (
 				(hostname === 'youtube.com' || hostname === 'm.youtube.com') &&
 				urlObj.pathname.match(/^\/watch/)
 			) {
 				const videoId = urlObj.searchParams.get('v')
-				return `https://www.youtube.com/embed/${videoId}`
+				const searchParams = new URLSearchParams(urlObj.search)
+				searchParams.delete('v')
+				const search = searchParams.toString() ? '?' + searchParams.toString() : ''
+				return `https://www.youtube.com/embed/${videoId}${search}`
 			}
 			return
 		},
@@ -248,7 +251,9 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			if (hostname === 'youtube.com') {
 				const matches = urlObj.pathname.match(/^\/embed\/([^/]+)\/?/)
 				if (matches) {
-					return `https://www.youtube.com/watch?v=${matches[1]}`
+					const params = new URLSearchParams(urlObj.search)
+					params.set('v', matches?.[1] ?? '')
+					return `https://www.youtube.com/watch?${params.toString()}`
 				}
 			}
 			return

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -116,6 +116,14 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		},
 	},
 	{
+		url: 'https://youtu.be/u1016UnJIgA?feature=shared&t=16',
+		match: true,
+		output: {
+			type: 'youtube',
+			embedUrl: 'https://www.youtube.com/embed/u1016UnJIgA?feature=shared&t=16',
+		},
+	},
+	{
 		url: 'https://www.youtube.com/feed/subscriptions',
 		match: false,
 	},
@@ -427,6 +435,22 @@ const MATCH_EMBED_TEST_URLS: (MatchEmbedTestMatchDef | MatchEmbedTestNoMatchDef)
 		output: {
 			type: 'youtube',
 			url: 'https://www.youtube.com/watch?v=ZMklf0vUl18',
+		},
+	},
+	{
+		embedUrl: 'https://www.youtube.com/embed/q8KyQovatd0?loop=1&playlist=q8KyQovatd0',
+		match: true,
+		output: {
+			type: 'youtube',
+			url: 'https://www.youtube.com/watch?loop=1&playlist=q8KyQovatd0&v=q8KyQovatd0',
+		},
+	},
+	{
+		embedUrl: 'https://www.youtube.com/embed/u1016UnJIgA?start=16',
+		match: true,
+		output: {
+			type: 'youtube',
+			url: 'https://www.youtube.com/watch?start=16&v=u1016UnJIgA',
 		},
 	},
 	{

--- a/yarn.lock
+++ b/yarn.lock
@@ -17288,6 +17288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lite-youtube-embed@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "lite-youtube-embed@npm:0.3.3"
+  checksum: 575ff8e600464881db366120d5d7628f8902008a5bc2a7e207f3d3d6e82ae7bc2d5e9acb9caa4e15932824afbc38a53bc6477f37435651a012f8acbbd78be0a3
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:^4.0.0":
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
@@ -23937,6 +23944,7 @@ __metadata:
     jest-canvas-mock: "npm:^2.5.2"
     jest-environment-jsdom: "npm:^29.7.0"
     lazyrepo: "npm:0.0.0-alpha.27"
+    lite-youtube-embed: "npm:^0.3.3"
     lodash.isequal: "npm:^4.5.0"
     lz-string: "npm:^1.5.0"
     resize-observer-polyfill: "npm:^1.5.1"


### PR DESCRIPTION
- doesn't load the iframe for youtube videos for a lighter page
- adds support for passing params to the embed, like `t`/`start`/`loop` which can be useful for folks

If you think it's worth maybe pulling in Paul Irish's `lite-youtube-embed` dep lemme know and we can do something more custom @SomeHats 

related issues:
- https://github.com/tldraw/tldraw/issues/5202
- https://github.com/tldraw/tldraw/issues/5151

<img width="1186" alt="Screenshot 2025-03-04 at 12 02 41" src="https://github.com/user-attachments/assets/8a575761-baea-46c3-9277-57da7e55b13e" />


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improve YouTube embed performance; add support for `t`/`start`/`loop` params.