### PR TITLE
setup pgbouncer for local dev (fix flaky e2e tests?)

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -9,10 +9,10 @@ import { getStorageStateFileName } from './helpers'
 const db = new Kysely<DB>({
 	dialect: new PostgresDialect({
 		pool: new pg.Pool({
-			connectionString: 'postgresql://user:password@127.0.0.1:6543/postgres',
+			connectionString: 'postgresql://user:password@127.0.0.1:6432/postgres',
 			application_name: 'migrate',
 			idleTimeoutMillis: 10_000,
-			max: 1,
+			max: 10,
 		}),
 	}),
 	log: ['error'],

--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from '@playwright/test'
+import { TldrawApp } from '../../src/tla/app/TldrawApp'
 import { expect, step } from './tla-test'
 
 export class Sidebar {
@@ -49,6 +50,8 @@ export class Sidebar {
 		await this.page.keyboard.press('Enter')
 		const newNumDocuments = await this.getNumberOfFiles()
 		expect(newNumDocuments).toBe(numDocuments + 1)
+		// give the websocket a chance to catch up
+		await this.mutationResolution()
 	}
 
 	async getNumberOfFiles() {
@@ -65,10 +68,13 @@ export class Sidebar {
 		await this.openAccountMenu()
 		await this.themeButton.hover()
 		await this.darkModeButton.click()
+		await this.mutationResolution()
 	}
 
 	@step
 	async openLanguageMenu(languageButtonText: string) {
+		// need the editor to be mounted for the menu to be available
+		await expect(this.page.getByTestId('canvas')).toBeVisible()
 		await this.openAccountMenu()
 		await this.page.getByText(languageButtonText).hover()
 	}
@@ -89,6 +95,7 @@ export class Sidebar {
 		await this.openLanguageMenu(languageButtonText)
 		await this.page.getByRole('menuitemcheckbox', { name: language }).click()
 		await this.page.keyboard.press('Escape')
+		await this.mutationResolution()
 	}
 
 	@step
@@ -143,6 +150,7 @@ export class Sidebar {
 	@step
 	private async deleteFromFileMenu() {
 		await this.page.getByRole('menuitem', { name: 'Delete' }).click()
+		await this.mutationResolution()
 	}
 
 	@step
@@ -150,6 +158,13 @@ export class Sidebar {
 		const fileLink = this.getFileLink('today', index)
 		await this.openFileMenu(fileLink)
 		await this.renameFromFileMenu(newName)
+		await this.mutationResolution()
+	}
+
+	async mutationResolution() {
+		await this.page.evaluate(() =>
+			((window as any).app as TldrawApp).z.__e2e__waitForMutationResolution()
+		)
 	}
 
 	@step
@@ -158,6 +173,7 @@ export class Sidebar {
 		const input = this.page.getByRole('textbox')
 		await input.fill(name)
 		await this.page.keyboard.press('Enter')
+		await this.mutationResolution()
 	}
 
 	@step
@@ -170,6 +186,7 @@ export class Sidebar {
 			await input.fill(name)
 		}
 		await this.page.keyboard.press('Enter')
+		await this.mutationResolution()
 	}
 
 	@step
@@ -177,6 +194,7 @@ export class Sidebar {
 		const fileLink = this.getFileLink('today', index)
 		await this.openFileMenu(fileLink)
 		await this.page.getByRole('menuitem', { name: 'Pin' }).click()
+		await this.mutationResolution()
 	}
 
 	@step
@@ -184,6 +202,7 @@ export class Sidebar {
 		const fileLink = this.getFileLink('pinned', index)
 		await this.openFileMenu(fileLink)
 		await this.page.getByRole('menuitem', { name: 'Unpin' }).click()
+		await this.mutationResolution()
 	}
 
 	@step
@@ -191,6 +210,7 @@ export class Sidebar {
 		const fileLink = this.getFileLink('today', index)
 		await this.openFileMenu(fileLink)
 		await this.duplicateFromFileMenu(name)
+		await this.mutationResolution()
 	}
 
 	@step

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
 		reuseExistingServer: !process.env.CI,
 		cwd: path.join(__dirname, '../../../'),
 		// remove comment if you wish to see the output of the server
-		// stdout: 'pipe',
+		stdout: 'pipe',
+		stderr: 'pipe',
 	},
 })

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
 		reuseExistingServer: !process.env.CI,
 		cwd: path.join(__dirname, '../../../'),
 		// remove comment if you wish to see the output of the server
-		stdout: 'pipe',
-		stderr: 'pipe',
+		// stdout: 'pipe',
+		// stderr: 'pipe',
 	},
 })

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -12,7 +12,7 @@ import {
 	ZServerSentMessage,
 } from '@tldraw/dotcom-shared'
 import { ClientWebSocketAdapter, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
-import { Signal, computed, react, transact, uniqueId } from 'tldraw'
+import { Signal, computed, react, sleep, transact, uniqueId } from 'tldraw'
 import { TLAppUiContextType } from '../utils/app-ui-events'
 
 export class Zero {
@@ -79,6 +79,14 @@ export class Zero {
 				}
 			}
 		})
+	}
+
+	async __e2e__waitForMutationResolution() {
+		let safety = 0
+		while (this.store.getOptimisticUpdates().length && safety++ < 100) {
+			await sleep(50)
+		}
+		// console.log('Mutation resolved', JSON.stringify(this.store.getOptimisticUpdates()))
 	}
 
 	dispose() {

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -52,7 +52,7 @@ name = "dev-tldraw-multiplayer"
 
 [env.dev.vars]
 BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
-BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
+BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6432/postgres"
 TLDRAW_ENV = "development"
 MULTIPLAYER_SERVER = "http://localhost:3000"
 

--- a/apps/dotcom/zero-cache/.env
+++ b/apps/dotcom/zero-cache/.env
@@ -1,3 +1,0 @@
-ZSTART_DB_PORT=6543
-ZSTART_DB="postgresql://user:password@127.0.0.1:6543/postgres"
-ZSTART_REPLICA_DB_FILE="/tmp/zstart_replica.db"

--- a/apps/dotcom/zero-cache/clean.sh
+++ b/apps/dotcom/zero-cache/clean.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-source .env
-docker volume rm -f docker_tlapp_pgdata && rm -rf "${ZSTART_REPLICA_DB_FILE}"*
+docker volume rm -f docker_tlapp_pgdata

--- a/apps/dotcom/zero-cache/docker/docker-compose.yml
+++ b/apps/dotcom/zero-cache/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - ${ZSTART_DB_PORT}:5432
+      - 6543:5432
     environment:
       POSTGRES_USER: user
       POSTGRES_DB: postgres
@@ -20,6 +20,7 @@ services:
       -c wal_level=logical
       -c max_wal_senders=10 
       -c max_replication_slots=5 
+      -c max_connections=300
       -c hot_standby=on 
       -c hot_standby_feedback=on
 #       Uncomment the following line to enable query logging
@@ -28,6 +29,20 @@ services:
       - tlapp_pgdata:/var/lib/postgresql/data
       - ./:/docker-entrypoint-initdb.d
       - ./postgres-logging.conf:/etc/postgresql/postgresql.conf
+
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: always
+    ports:
+      - "6432:6432"
+    environment:
+      DATABASE_URL: postgres://user:password@zstart_postgres:5432/postgres
+    volumes:
+      - ./pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini
+      - ./userlist.txt:/etc/pgbouncer/userlist.txt
+# Don't show pg bouncer logs
+    command: >
+       sh -c "pgbouncer /etc/pgbouncer/pgbouncer.ini > /dev/null 2>&1"
 
 volumes:
   tlapp_pgdata:

--- a/apps/dotcom/zero-cache/docker/pgbouncer.ini
+++ b/apps/dotcom/zero-cache/docker/pgbouncer.ini
@@ -1,0 +1,21 @@
+[databases]
+postgres = host=zstart_postgres port=5432 dbname=postgres user=user password=password
+
+; neon config, doesn't seem to work due to pool_mode transaction
+; https://neon.tech/docs/connect/connection-pooling#neon-pgbouncer-configuration-settings
+; [pgbouncer]
+; pool_mode=transaction
+; max_client_conn=10000
+; default_pool_size=64
+; max_prepared_statements=0
+; query_wait_timeout=120
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = plain
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = transaction
+max_client_conn = 450
+default_pool_size = 100
+max_prepared_statements=10

--- a/apps/dotcom/zero-cache/docker/userlist.txt
+++ b/apps/dotcom/zero-cache/docker/userlist.txt
@@ -1,0 +1,1 @@
+"user" "password"

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -12,8 +12,8 @@
 	],
 	"scripts": {
 		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success'",
-		"docker-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
-		"docker-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
+		"docker-up": "docker compose -f ./docker/docker-compose.yml up",
+		"docker-down": "docker compose -f ./docker/docker-compose.yml down",
 		"migrate": "yarn tsx ./migrate.ts",
 		"clean": "yarn docker-down && ./clean.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"


### PR DESCRIPTION

1. Running tests in parallel seems to be prone to slowness due to limits on db connections. For me adding pgbouncer improves things quite a bit.
1. If the page reloads before a mutation has been sent over the socket, the 'before and after reload' assertion helper we have can fail. So I've tentatively added a thing for the Sidebar operations where after making a mutation it waits for the optimistic updates log in the client to clear before continuing.
2. cleaned up some defunct infra code

### Change type

- [x] `bugfix`
