### PR TITLE
Migrate newsletter form to hubspot

### DIFF
--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -33,12 +33,12 @@ export function NewsletterSignup({
 			setFormState('loading')
 			try {
 				const _email = new FormData(e.currentTarget)?.get('email') as string
-				const cookie = document.cookie
+				const hubspotCookie = document.cookie
 					.split('; ')
 					.find((row) => row.startsWith('hubspotutk='))
 					?.split('=')[1]
 				const url = window.location.href
-				const { error } = await submitNewsletterSignup(_email, cookie, url)
+				const { error } = await submitNewsletterSignup(_email, hubspotCookie, url)
 				if (error) throw error
 				setFormState('success')
 				// After a pause, we locally save that the user has submitted the form

--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -33,7 +33,11 @@ export function NewsletterSignup({
 			setFormState('loading')
 			try {
 				const _email = new FormData(e.currentTarget)?.get('email') as string
-				const { error } = await submitNewsletterSignup(_email)
+				const cookie = document.cookie
+					.split('; ')
+					.find((row) => row.startsWith('hubspotutk='))
+					?.split('=')[1]
+				const { error } = await submitNewsletterSignup(_email, cookie)
 				if (error) throw error
 				setFormState('success')
 				// After a pause, we locally save that the user has submitted the form

--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -37,7 +37,8 @@ export function NewsletterSignup({
 					.split('; ')
 					.find((row) => row.startsWith('hubspotutk='))
 					?.split('=')[1]
-				const { error } = await submitNewsletterSignup(_email, cookie)
+				const url = window.location.href
+				const { error } = await submitNewsletterSignup(_email, cookie, url)
 				if (error) throw error
 				setFormState('success')
 				// After a pause, we locally save that the user has submitted the form

--- a/apps/docs/scripts/submit-newsletter-signup.ts
+++ b/apps/docs/scripts/submit-newsletter-signup.ts
@@ -1,10 +1,6 @@
 'use server'
 
-export async function submitNewsletterSignup(
-	email: string,
-	cookie: string | undefined,
-	url: string
-) {
+export async function submitNewsletterSignup(email: string, hutk: string | undefined, url: string) {
 	const res = await fetch(
 		'https://api.hsforms.com/submissions/v3/integration/secure/submit/145620695/ff47937e-8c83-4f26-b00a-1ea4ae11a7c4',
 		{
@@ -22,7 +18,7 @@ export async function submitNewsletterSignup(
 					},
 				],
 				context: {
-					hutk: cookie,
+					hutk,
 					pageUri: url,
 					pageName: 'tldraw dev',
 				},

--- a/apps/docs/scripts/submit-newsletter-signup.ts
+++ b/apps/docs/scripts/submit-newsletter-signup.ts
@@ -1,21 +1,32 @@
 'use server'
 
-export async function submitNewsletterSignup(email: string) {
-	const res = await fetch('https://api.sendgrid.com/v3/marketing/contacts', {
-		method: 'PUT',
-		headers: {
-			Authorization: `Bearer ${process.env.SENDGRID_API_KEY}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({
-			list_ids: [process.env.SENDGRID_LIST_ID],
-			contacts: [
-				{
-					email,
+export async function submitNewsletterSignup(email: string, cookie: string | undefined) {
+	const res = await fetch(
+		'https://api.hsforms.com/submissions/v3/integration/secure/submit/145620695/ff47937e-8c83-4f26-b00a-1ea4ae11a7c4',
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${process.env.HUBSPOT_API_KEY}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				submittedAt: Date.now(),
+				fields: [
+					{
+						name: 'email',
+						value: email,
+					},
+				],
+				context: {
+					hutk: cookie,
+					pageUri: 'https://tldraw.dev/',
+					pageName: 'tldraw dev',
 				},
-			],
-		}),
-	})
-	if (res.status !== 202) return { error: true }
+			}),
+		}
+	)
+	if (res.status !== 200) {
+		return { error: true }
+	}
 	return { error: false }
 }

--- a/apps/docs/scripts/submit-newsletter-signup.ts
+++ b/apps/docs/scripts/submit-newsletter-signup.ts
@@ -1,6 +1,10 @@
 'use server'
 
-export async function submitNewsletterSignup(email: string, cookie: string | undefined) {
+export async function submitNewsletterSignup(
+	email: string,
+	cookie: string | undefined,
+	url: string
+) {
 	const res = await fetch(
 		'https://api.hsforms.com/submissions/v3/integration/secure/submit/145620695/ff47937e-8c83-4f26-b00a-1ea4ae11a7c4',
 		{
@@ -19,7 +23,7 @@ export async function submitNewsletterSignup(email: string, cookie: string | und
 				],
 				context: {
 					hutk: cookie,
-					pageUri: 'https://tldraw.dev/',
+					pageUri: url,
 					pageName: 'tldraw dev',
 				},
 			}),


### PR DESCRIPTION
Submit newsletter subscribers to hubspot instead of sendgrid.

The reason why we don't use a straight api call to add a contact is that you [can't set the contact to be a marketing contact](https://community.hubspot.com/t5/APIs-Integrations/How-do-I-set-a-contact-as-a-marketing-contact-using-Hubspot-s/m-p/895454) via an API. So I created a form in hubspot and we then [submit to that form](https://community.hubspot.com/t5/APIs-Integrations/Cannot-set-a-contact-s-marketing-status-via-API/m-p/800944/highlight/true#M64478). 

An alternative approach would be to use hubspot's form directly, but since this form is used in a couple of different places with different styling options it would make it a bit annoying to correctly style.

### Change type

- [x] `improvement`
