### PR TITLE
fix(ui): use useMaybeEditor in ui context to prevent remounts

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacytSetDocumentTitle.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacytSetDocumentTitle.tsx
@@ -1,11 +1,11 @@
 import { Helmet } from 'react-helmet-async'
 import { useValue } from 'tldraw'
-import { globalEditor } from '../../../../utils/globalEditor'
+import { useGlobalEditor } from '../../../../utils/globalEditor'
 import { useMsg } from '../../../utils/i18n'
 import { editorMessages as messages } from '../editor-messages'
 
 export function SneakyLegacySetDocumentTitle() {
-	const editor = useValue('editor', () => globalEditor.get(), [])
+	const editor = useGlobalEditor()
 	const untitledProject = useMsg(messages.untitledProject)
 	const title = useValue('title', () => editor?.getDocumentSettings().name || untitledProject, [
 		editor,

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakySetDocumentTitle.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakySetDocumentTitle.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from 'react-helmet-async'
 import { useParams } from 'react-router-dom'
 import { useValue } from 'tldraw'
-import { globalEditor } from '../../../../utils/globalEditor'
+import { useGlobalEditor } from '../../../../utils/globalEditor'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { useMsg } from '../../../utils/i18n'
 import { editorMessages as messages } from '../editor-messages'
@@ -9,7 +9,7 @@ import { editorMessages as messages } from '../editor-messages'
 export function SneakySetDocumentTitle() {
 	const { fileSlug } = useParams<{ fileSlug: string }>()
 	const app = useMaybeApp()
-	const editor = useValue('editor', () => globalEditor.get(), [])
+	const editor = useGlobalEditor()
 	const untitledProject = useMsg(messages.untitledProject)
 	const title = useValue(
 		'title',

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggle.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggle.tsx
@@ -1,5 +1,5 @@
 import { useValue } from 'tldraw'
-import { globalEditor } from '../../../../utils/globalEditor'
+import { useGlobalEditor } from '../../../../utils/globalEditor'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { useMsg } from '../../../utils/i18n'
 import { getIsSidebarOpen, toggleSidebar } from '../../../utils/local-session-state'
@@ -10,7 +10,7 @@ import { messages } from './sidebar-shared'
 export function TlaSidebarToggle() {
 	const trackEvent = useTldrawAppUiEvents()
 	const toggleLbl = useMsg(messages.toggleSidebar)
-	const editor = globalEditor.get()
+	const editor = useGlobalEditor()
 
 	const hideSidebarToggle = useValue(
 		'hideSidebarToggle',

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
@@ -1,5 +1,5 @@
 import { useValue } from 'tldraw'
-import { globalEditor } from '../../../../utils/globalEditor'
+import { useGlobalEditor } from '../../../../utils/globalEditor'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { useMsg } from '../../../utils/i18n'
 import { getLocalSessionState, updateLocalSessionState } from '../../../utils/local-session-state'
@@ -10,7 +10,7 @@ import { messages } from './sidebar-shared'
 export function TlaSidebarToggleMobile() {
 	const trackEvent = useTldrawAppUiEvents()
 	const toggleSidebarLbl = useMsg(messages.toggleSidebar)
-	const editor = globalEditor.get()
+	const editor = useGlobalEditor()
 
 	const hideSidebarToggle = useValue(
 		'hideSidebarToggle',

--- a/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
+++ b/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx
@@ -77,12 +77,7 @@ export const TldrawUiContextProvider = track(function TldrawUiContextProvider({
 							<TldrawUiDialogsProvider context={'tla'}>
 								<BreakPointProvider forceMobile={forceMobile}>
 									<TldrawUiComponentsProvider overrides={components}>
-										{editor ? (
-											// the internal providers are only valid when an editor is present
-											<InternalProviders overrides={overrides}>{children}</InternalProviders>
-										) : (
-											children
-										)}
+										<InternalProviders overrides={overrides}>{children}</InternalProviders>
 									</TldrawUiComponentsProvider>
 								</BreakPointProvider>
 							</TldrawUiDialogsProvider>

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -17,7 +17,7 @@ import {
 	compact,
 	createShapeId,
 	openWindow,
-	useEditor,
+	useMaybeEditor,
 } from '@tldraw/editor'
 import * as React from 'react'
 import { kickoutOccludedShapes } from '../../tools/SelectTool/selectHelpers'
@@ -76,7 +76,7 @@ function getExportName(editor: Editor, defaultName: string) {
 
 /** @internal */
 export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
-	const editor = useEditor()
+	const _editor = useMaybeEditor()
 	const showCollaborationUi = useShowCollaborationUi()
 	const helpers = useDefaultHelpers()
 	const trackEvent = useUiEvents()
@@ -85,6 +85,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {
+		const editor = _editor as Editor
+		if (!editor) return {}
 		function mustGoBackToSelectToolFirst() {
 			if (!editor.isIn('select')) {
 				editor.complete()
@@ -1439,7 +1441,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 		}
 
 		return actions
-	}, [helpers, editor, trackEvent, overrides, defaultDocumentName, showCollaborationUi])
+	}, [helpers, _editor, trackEvent, overrides, defaultDocumentName, showCollaborationUi])
 
 	return <ActionsContext.Provider value={asActions(actions)}>{children}</ActionsContext.Provider>
 }

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -4,12 +4,14 @@ import {
 	TLExternalContentSource,
 	Vec,
 	VecLike,
+	assert,
 	compact,
 	isDefined,
 	preventDefault,
 	stopEventPropagation,
 	uniq,
 	useEditor,
+	useMaybeEditor,
 	useValue,
 } from '@tldraw/editor'
 import lz from 'lz-string'
@@ -600,11 +602,12 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 
 /** @public */
 export function useMenuClipboardEvents() {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
 	const trackEvent = useUiEvents()
 
 	const copy = useCallback(
 		async function onCopy(source: TLUiEventSource) {
+			assert(editor, 'editor is required for copy')
 			if (editor.getSelectedShapeIds().length === 0) return
 
 			await handleNativeOrMenuCopy(editor)
@@ -615,6 +618,7 @@ export function useMenuClipboardEvents() {
 
 	const cut = useCallback(
 		async function onCut(source: TLUiEventSource) {
+			if (!editor) return
 			if (editor.getSelectedShapeIds().length === 0) return
 
 			await handleNativeOrMenuCopy(editor)
@@ -630,6 +634,7 @@ export function useMenuClipboardEvents() {
 			source: TLUiEventSource,
 			point?: VecLike
 		) {
+			if (!editor) return
 			// If we're editing a shape, or we are focusing an editable input, then
 			// we would want the user's paste interaction to go to that element or
 			// input instead; e.g. when pasting text into a text shape's content

--- a/packages/tldraw/src/lib/ui/hooks/useCopyAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useCopyAs.ts
@@ -1,4 +1,4 @@
-import { TLShapeId, useEditor } from '@tldraw/editor'
+import { TLShapeId, assert, useMaybeEditor } from '@tldraw/editor'
 import { useCallback } from 'react'
 import { TLCopyType, copyAs } from '../../utils/export/copyAs'
 import { useToasts } from '../context/toasts'
@@ -6,12 +6,13 @@ import { useTranslation } from './useTranslation/useTranslation'
 
 /** @public */
 export function useCopyAs() {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
 	const { addToast } = useToasts()
 	const msg = useTranslation()
 
 	return useCallback(
 		(ids: TLShapeId[], format: TLCopyType = 'svg') => {
+			assert(editor, 'useCopyAs: editor is required')
 			copyAs(editor, ids, { format }).catch(() => {
 				addToast({
 					id: 'copy-fail',

--- a/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useExportAs.ts
@@ -1,4 +1,4 @@
-import { TLExportType, TLShapeId, useEditor } from '@tldraw/editor'
+import { TLExportType, TLShapeId, assert, useMaybeEditor } from '@tldraw/editor'
 import { useCallback } from 'react'
 import { exportAs } from '../../utils/export/exportAs'
 import { useToasts } from '../context/toasts'
@@ -6,12 +6,13 @@ import { useTranslation } from './useTranslation/useTranslation'
 
 /** @public */
 export function useExportAs() {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
 	const { addToast } = useToasts()
 	const msg = useTranslation()
 
 	return useCallback(
 		(ids: TLShapeId[], format: TLExportType = 'png', name: string | undefined) => {
+			assert(editor, 'useExportAs: editor is required')
 			exportAs(editor, ids, {
 				format,
 				name,

--- a/packages/tldraw/src/lib/ui/hooks/useGetEmbedDefinition.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useGetEmbedDefinition.ts
@@ -1,9 +1,10 @@
-import { useEditor } from '@tldraw/editor'
+import { useMaybeEditor } from '@tldraw/editor'
 import { EmbedShapeUtil } from '../../shapes/embed/EmbedShapeUtil'
 
 /** @internal */
 export function useGetEmbedShapeUtil() {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
+	if (!editor) return undefined
 	if (editor.hasShapeUtil('embed')) {
 		return editor.getShapeUtil('embed') as EmbedShapeUtil
 	}

--- a/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useInsertMedia.ts
@@ -1,6 +1,7 @@
 import {
 	DEFAULT_SUPPORTED_MEDIA_TYPE_LIST,
-	useEditor,
+	Editor,
+	useMaybeEditor,
 	useShallowArrayIdentity,
 } from '@tldraw/editor'
 import React, { useCallback, useEffect, useRef } from 'react'
@@ -8,11 +9,14 @@ import React, { useCallback, useEffect, useRef } from 'react'
 export const MimeTypeContext = React.createContext<string[] | undefined>([])
 
 export function useInsertMedia() {
-	const editor = useEditor()
+	const _editor = useMaybeEditor()
 	const inputRef = useRef<HTMLInputElement>()
 	const mimeTypes = useShallowArrayIdentity(React.useContext(MimeTypeContext))
 
 	useEffect(() => {
+		const editor = _editor as Editor
+		if (!editor) return
+
 		const input = window.document.createElement('input')
 		input.type = 'file'
 		input.accept = mimeTypes?.join(',') ?? DEFAULT_SUPPORTED_MEDIA_TYPE_LIST
@@ -35,7 +39,7 @@ export function useInsertMedia() {
 			inputRef.current = undefined
 			input.removeEventListener('change', onchange)
 		}
-	}, [editor, mimeTypes])
+	}, [_editor, mimeTypes])
 
 	return useCallback(() => {
 		inputRef.current?.click()

--- a/packages/tldraw/src/lib/ui/hooks/usePrint.ts
+++ b/packages/tldraw/src/lib/ui/hooks/usePrint.ts
@@ -1,14 +1,15 @@
-import { tlenv, uniqueId, useEditor } from '@tldraw/editor'
+import { assert, tlenv, uniqueId, useMaybeEditor } from '@tldraw/editor'
 import { useCallback, useRef } from 'react'
 
 /** @internal */
 export function usePrint() {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
 	const prevPrintEl = useRef<HTMLDivElement | null>(null)
 	const prevStyleEl = useRef<HTMLStyleElement | null>(null)
 
 	return useCallback(
 		async function printSelectionOrPages() {
+			assert(editor, 'usePrint: editor is required')
 			const el = document.createElement('div')
 			const style = document.createElement('style')
 

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -1,4 +1,4 @@
-import { Editor, GeoShapeGeoStyle, useEditor } from '@tldraw/editor'
+import { Editor, GeoShapeGeoStyle, useMaybeEditor } from '@tldraw/editor'
 import * as React from 'react'
 import { EmbedDialog } from '../components/EmbedDialog'
 import { TLUiEventSource, useUiEvents } from '../context/events'
@@ -41,12 +41,13 @@ export interface TLUiToolsProviderProps {
 
 /** @internal */
 export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
-	const editor = useEditor()
+	const editor = useMaybeEditor()
 	const trackEvent = useUiEvents()
 
 	const helpers = useDefaultHelpers()
 
 	const tools = React.useMemo<TLUiToolsContextType>(() => {
+		if (!editor) return {}
 		const toolsArray: TLUiToolItem<TLUiTranslationKey, TLUiIconType>[] = [
 			{
 				id: 'select',


### PR DESCRIPTION
So we were facing a weird problem in dotcom where the editor would remount immediately after mounting for the first time, causing the room data to be fetched twice (once before initial editor mount, and once again on remount).

We tracked it down to this [UI context provider](https://github.com/tldraw/tldraw/blob/c661dfedf191a5d9b9fd168a881a99ab7e719f6b/packages/tldraw/src/lib/ui/context/TldrawUiContextProvider.tsx#L79-L86), and specifically the fact that reparenting this react-subtree inside a new context provider after the editor becomes available causes the whole thing to be remounted and the editor reinstantiates.

A quick and dirty way to fix this is to make the provider tree static and make sure that all components within it use `useMaybeEditor` so the app doesn't crash if there isn't an editor available.

The slow and clean way around this is to refactor to not have this UIContextProvider be so coupled to the Editor, but this is a bad perf issue that needs fixing asap, it's very noticeable for larger files.

### Change type

- [x] `bugfix` 

### Test plan

1. Open a large file in dotcom
2. Verify that the editor does not remount and room data is only fetched once

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a performance issue where the editor would remount on initial load.