### PR TITLE
fix reparentshapes preserve order

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5342,7 +5342,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const invertedParentTransform = parentTransform.clone().invert()
 
-		const shapesToReparent = compact(ids.map((id) => this.getShape(id)))
+		const shapesToReparent = compact(ids.map((id) => this.getShape(id))).sort(sortByIndex)
 
 		// Ignore locked shapes so that we can reparent locked shapes, for example
 		// when a locked shape's parent is deleted.

--- a/packages/tldraw/src/test/commands/reparentShapesById.test.ts
+++ b/packages/tldraw/src/test/commands/reparentShapesById.test.ts
@@ -149,14 +149,14 @@ it('adds children at a given index', () => {
 	// - box1 a1
 	// - box2 a1V
 	//   - ellipse1 a1
-	// - box3 a2
-	// - box5 a3
+	// - box5 a2
+	// - box3 a3
 	// - box4 a4
 
 	expect(editor.getShape(ids.box1)!.index).toBe('a1')
 	expect(editor.getShape(ids.box2)!.index).toBe('a1V')
-	expect(editor.getShape(ids.box3)!.index).toBe('a2')
+	expect(editor.getShape(ids.box3)!.index).toBe('a3')
 	expect(editor.getShape(ids.box4)!.index).toBe('a4')
-	expect(editor.getShape(ids.box5)!.index).toBe('a3')
+	expect(editor.getShape(ids.box5)!.index).toBe('a2')
 	expect(editor.getShape(ids.ellipse1)!.index).toBe('a1')
 })


### PR DESCRIPTION
When multiple shapes are selected and dragged over or out of a frame shape, they get reparented. However, during this process, the order of the selected shapes changes.

The issue arises because, inside reparentShapes(), the indices from indices are simply assigned to shapesToReparent in a loop. To preserve the original order, shapesToReparent should be sorted by their index before the loop runs. This ensures that new indices are assigned in the correct order.

I am attaching a video demonstrating the issue.

[without sorting]
https://github.com/user-attachments/assets/81130860-1578-476c-ba69-fe078ad44406

[with sorting]
https://github.com/user-attachments/assets/abb5f6a2-ddbb-4d80-9efd-2f416a1d6cb2

To fix the issue, modifying the reparentShapes() function as follows should work:

Change this line:
const shapesToReparent = compact(ids.map((id) => this.getShape(id)));
To:
const shapesToReparent = compact(ids.map((id) => this.getShape(id))).sort(sortByIndex);

This ensures that the shapes are sorted by their index before being processed, preserving their original selection order during reparenting.

[build result]
![2025-03-06_16-57](https://github.com/user-attachments/assets/2e23d549-83f5-4ef3-a09b-df0bf0bbfc7e)

[test result]
![2025-03-06_17-10](https://github.com/user-attachments/assets/864583a3-ad7c-42db-b0ef-f420c4fd8891)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Add a frame shape along with multiple other shapes.
2. Select multiple shapes one by one while holding the Shift key to enter multi-select mode.
3. Drag the multi-selected shapes over the frame shape.

- [v] Unit tests
- [v] End to end tests

### Release notes

- Modify the reparentShapes() function to ensure that the original order of the shapes is preserved when reparenting.