### PR TITLE
rich text: fix links getting in the way of some tools and android selection

### DIFF
--- a/apps/examples/e2e/tests/test-rich-text.spec.ts
+++ b/apps/examples/e2e/tests/test-rich-text.spec.ts
@@ -12,6 +12,7 @@ test.describe('more rich text', () => {
 	}) => {
 		await toolbar.tools.select.click()
 		await page.mouse.dblclick(150, 150)
+		await sleep(500) // racey here
 		await page.keyboard.type('id like to go to india')
 		expect(page.getByTestId('rich-text-area')).toHaveText('id like to go to india')
 	})
@@ -19,6 +20,7 @@ test.describe('more rich text', () => {
 	test('Click with text tool to create and edit text on the canvas', async ({ page, toolbar }) => {
 		await toolbar.tools.text.click()
 		await page.mouse.click(150, 150)
+		await sleep(500) // racey here
 		await page.keyboard.type('Live in a big white house in the forest')
 		expect(page.getByTestId('rich-text-area')).toHaveText('Live in a big white house in the forest')
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -970,6 +970,10 @@ input,
 	text-decoration: underline;
 }
 
+.tl-rich-text[data-is-select-tool-active='false'] a {
+	cursor: inherit;
+}
+
 .tl-rich-text code {
 	font-family: var(--tl-font-mono);
 }

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -189,7 +189,8 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 			// However, that caused selecting over list items to break.
 			// The handleDOMEvents in TipTap don't seem to support the pointerDownCapture event.
 			onPointerDownCapture={stopEventPropagation}
-			// onTouchEnd={stopEventPropagation} // moving this to the PointerStateExtension
+			// This onTouchEnd is important for Android to be able to change selection on text.
+			onTouchEnd={stopEventPropagation}
 			// On FF, there's a behavior where dragging a selection will grab that selection into
 			// the drag event. However, once the drag is over, and you select away from the textarea,
 			// starting a drag over the textarea will restart a selection drag instead of a shape drag.

--- a/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
@@ -62,6 +62,10 @@ export function LinkEditor({ textEditor, value: initialValue, onComplete }: Link
 		}
 	}, [value])
 
+	useEffect(() => {
+		setValue(initialValue)
+	}, [initialValue])
+
 	return (
 		<>
 			<TldrawUiInput


### PR DESCRIPTION
- fix links getting in the way of tools, like Hand
- fix LinkEditor not being reset when switching between links
- fix fine-grained selection on Android

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix issue with rich text links taking precedence over tools. Also, fix fine-grained selection on Android.