### PR TITLE
5% minimum zoom / zoom-towards-cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2317,7 +2317,7 @@ Adds the ability to customize the embeds that are supported. You can now customi
 
 - Fix a bug with fractional indexing validation with the new jitter library.
 
-#### images: show ghost preview image whilst uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
+#### images: show ghost preview image while uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
 
 - Media: add image and video upload indicators.
 
@@ -2615,7 +2615,7 @@ This was done because calling `editor.mark(id)` is a potential footgun unless yo
 - `@tldraw/editor`, `tldraw`, `@tldraw/tlschema`
   - [api] Widen snapshots pit of success [#4392](https://github.com/tldraw/tldraw/pull/4392) ([@ds300](https://github.com/ds300))
 - `@tldraw/editor`, `@tldraw/sync`, `tldraw`
-  - images: show ghost preview image whilst uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+  - images: show ghost preview image while uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 
 #### 🎉 New Features
 

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -164,12 +164,12 @@ test.describe('camera', () => {
 		// now zoom in
 		await multiTouchGesture({
 			start: [
-				{ x: 149, y: 149 },
-				{ x: 151, y: 151 },
+				{ x: 200, y: 200 },
+				{ x: 200, y: 200 },
 			],
 			end: [
 				{ x: 0, y: 0 },
-				{ x: 300, y: 300 },
+				{ x: 400, y: 400 },
 			],
 			steps: 50,
 		})

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -159,7 +159,7 @@ test.describe('camera', () => {
 			],
 			steps: 50,
 		})
-		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0.1)
+		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(0.05)
 
 		// now zoom in
 		await multiTouchGesture({

--- a/apps/examples/src/examples/lock-camera-zoom/LockCameraZoomExample.tsx
+++ b/apps/examples/src/examples/lock-camera-zoom/LockCameraZoomExample.tsx
@@ -1,7 +1,7 @@
 import { Tldraw, TLUiOverrides } from 'tldraw'
 import 'tldraw/tldraw.css'
 
-const DEFAULT_CAMERA_STEPS = [0.1, 0.25, 0.5, 1, 2, 4, 8]
+const DEFAULT_CAMERA_STEPS = [0.05, 0.1, 0.25, 0.5, 1, 2, 4, 8]
 
 const overrides: TLUiOverrides = {
 	actions(editor, actions) {

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -781,7 +781,7 @@ Adds the ability to customize the embeds that are supported. You can now customi
 
 - Add licensing docs.
 
-#### images: show ghost preview image whilst uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
+#### images: show ghost preview image while uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
 
 - Media: add image and video upload indicators.
 
@@ -887,7 +887,7 @@ This was done because calling `editor.mark(id)` is a potential footgun unless yo
 - Preserve focus search param [#4344](https://github.com/tldraw/tldraw/pull/4344) ([@steveruizok](https://github.com/steveruizok))
 - why did we have this dpr constrained width/height stuff again? [#4297](https://github.com/tldraw/tldraw/pull/4297) ([@ds300](https://github.com/ds300))
 - license: allow wildcard to make apex domains also work [#4334](https://github.com/tldraw/tldraw/pull/4334) ([@mimecuvalo](https://github.com/mimecuvalo))
-- images: show ghost preview image whilst uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+- images: show ghost preview image while uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 - Add option for max pasted / dropped files [#4294](https://github.com/tldraw/tldraw/pull/4294) ([@steveruizok](https://github.com/steveruizok))
 - support custom delay for laser pointer [#4300](https://github.com/tldraw/tldraw/pull/4300) ([@raviteja83](https://github.com/raviteja83))
 - Allow non default z value for scribble points. [#4260](https://github.com/tldraw/tldraw/pull/4260) ([@MitjaBezensek](https://github.com/MitjaBezensek))

--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_CAMERA_OPTIONS: TLCameraOptions = {
 	wheelBehavior: 'pan',
 	panSpeed: 1,
 	zoomSpeed: 1,
-	zoomSteps: [0.1, 0.25, 0.5, 1, 2, 4, 8],
+	zoomSteps: [0.05, 0.1, 0.25, 0.5, 1, 2, 4, 8],
 }
 
 /** @internal */

--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -21,7 +21,7 @@ export class ExportDelay {
 			)
 		}
 		this.promisesToWaitFor.push(
-			promise.catch((err) => console.error('Error whilst waiting for export:', err))
+			promise.catch((err) => console.error('Error while waiting for export:', err))
 		)
 	}
 

--- a/packages/editor/src/lib/exports/exportToSvg.tsx
+++ b/packages/editor/src/lib/exports/exportToSvg.tsx
@@ -62,7 +62,7 @@ export async function exportToSvg(
 		const svg = renderTarget.firstElementChild
 		assert(svg instanceof SVGSVGElement, 'Expected an SVG element')
 
-		// And apply any changes to <foreignObject> elements that we need to make. Whilst we're in
+		// And apply any changes to <foreignObject> elements that we need to make. while we're in
 		// the document, these elements work exactly as we'd expect from other dom elements - they
 		// can load external resources, and any stylesheets in the document apply to them as we
 		// would expect them to. But when we pull the SVG into its own file or draw it to a canvas

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -185,7 +185,7 @@
 
 - Renames `StoreOptions.multiplayerStatus` to `StoreOptions.collaboration.status`.
 
-#### images: show ghost preview image whilst uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
+#### images: show ghost preview image while uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
 
 - Media: add image and video upload indicators.
 
@@ -212,7 +212,7 @@
 #### 💄 Product Improvements
 
 - inline nanoid [#4410](https://github.com/tldraw/tldraw/pull/4410) ([@SomeHats](https://github.com/SomeHats))
-- images: show ghost preview image whilst uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+- images: show ghost preview image while uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 
 #### 🛠️ API Changes
 

--- a/packages/tldraw/CHANGELOG.md
+++ b/packages/tldraw/CHANGELOG.md
@@ -1016,7 +1016,7 @@ Adds the ability to customize the embeds that are supported. You can now customi
 
 - bookmark: dont show broken favicon and cleanup HTML entities in title
 
-#### images: show ghost preview image whilst uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
+#### images: show ghost preview image while uploading ([#3988](https://github.com/tldraw/tldraw/pull/3988))
 
 - Media: add image and video upload indicators.
 
@@ -1150,7 +1150,7 @@ This was done because calling `editor.mark(id)` is a potential footgun unless yo
 - Deep Links [#4333](https://github.com/tldraw/tldraw/pull/4333) ([@ds300](https://github.com/ds300))
 - Gracefully handle deleted tools & actions (remix) [#4345](https://github.com/tldraw/tldraw/pull/4345) ([@steveruizok](https://github.com/steveruizok))
 - Interpolation: draw/highlight points, discrete props [#4241](https://github.com/tldraw/tldraw/pull/4241) ([@Taha-Hassan-Git](https://github.com/Taha-Hassan-Git) [@steveruizok](https://github.com/steveruizok))
-- images: show ghost preview image whilst uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
+- images: show ghost preview image while uploading [#3988](https://github.com/tldraw/tldraw/pull/3988) ([@mimecuvalo](https://github.com/mimecuvalo) [@SomeHats](https://github.com/SomeHats) [@steveruizok](https://github.com/steveruizok))
 - text shape: dont make a fixed width unless more intentional drag [#4293](https://github.com/tldraw/tldraw/pull/4293) ([@mimecuvalo](https://github.com/mimecuvalo) [@steveruizok](https://github.com/steveruizok))
 - Add option for max pasted / dropped files [#4294](https://github.com/tldraw/tldraw/pull/4294) ([@steveruizok](https://github.com/steveruizok))
 - support custom delay for laser pointer [#4300](https://github.com/tldraw/tldraw/pull/4300) ([@raviteja83](https://github.com/raviteja83))

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3153,11 +3153,15 @@ export interface TLUiEventMap {
     // (undocumented)
     'unlock-all': null;
     // (undocumented)
-    'zoom-in': null;
+    'zoom-in': {
+        towardsCursor: boolean;
+    };
     // (undocumented)
     'zoom-into-view': null;
     // (undocumented)
-    'zoom-out': null;
+    'zoom-out': {
+        towardsCursor: boolean;
+    };
     // (undocumented)
     'zoom-to-content': null;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -21,7 +21,7 @@ export interface UseImageOrVideoAssetOptions {
 	/** The asset ID you want a URL for. */
 	assetId: TLAssetId | null
 	/**
-	 * The shape the asset is being used for. We won't update the resolved URL whilst the shape is
+	 * The shape the asset is being used for. We won't update the resolved URL while the shape is
 	 * off-screen.
 	 */
 	shapeId?: TLShapeId

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1021,7 +1021,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$=,=',
 				readonlyOk: true,
 				onSelect(source) {
-					trackEvent('zoom-in', { source })
+					trackEvent('zoom-in', { source, towardsCursor: false })
 					editor.zoomIn(undefined, {
 						animation: { duration: editor.options.animationMediumMs },
 					})
@@ -1033,7 +1033,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!$=,!=',
 				readonlyOk: true,
 				onSelect(source) {
-					trackEvent('zoom-in', { source })
+					trackEvent('zoom-in', { source, towardsCursor: true })
 					editor.zoomIn(editor.inputs.currentScreenPoint, {
 						animation: { duration: editor.options.animationMediumMs },
 					})
@@ -1045,7 +1045,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '$-,-',
 				readonlyOk: true,
 				onSelect(source) {
-					trackEvent('zoom-out', { source })
+					trackEvent('zoom-out', { source, towardsCursor: false })
 					editor.zoomOut(undefined, {
 						animation: { duration: editor.options.animationMediumMs },
 					})
@@ -1057,7 +1057,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: '!$-,!-',
 				readonlyOk: true,
 				onSelect(source) {
-					trackEvent('zoom-out', { source })
+					trackEvent('zoom-out', { source, towardsCursor: true })
 					editor.zoomOut(editor.inputs.currentScreenPoint, {
 						animation: { duration: editor.options.animationMediumMs },
 					})

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1028,6 +1028,18 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				},
 			},
 			{
+				id: 'zoom-in-on-curson',
+				label: 'action.zoom-in',
+				kbd: '!$=,!=',
+				readonlyOk: true,
+				onSelect(source) {
+					trackEvent('zoom-in', { source })
+					editor.zoomIn(editor.inputs.currentScreenPoint, {
+						animation: { duration: editor.options.animationMediumMs },
+					})
+				},
+			},
+			{
 				id: 'zoom-out',
 				label: 'action.zoom-out',
 				kbd: '$-,-',
@@ -1035,6 +1047,18 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect(source) {
 					trackEvent('zoom-out', { source })
 					editor.zoomOut(undefined, {
+						animation: { duration: editor.options.animationMediumMs },
+					})
+				},
+			},
+			{
+				id: 'zoom-out-on-cursor',
+				label: 'action.zoom-out',
+				kbd: '!$-,!-',
+				readonlyOk: true,
+				onSelect(source) {
+					trackEvent('zoom-out', { source })
+					editor.zoomOut(editor.inputs.currentScreenPoint, {
 						animation: { duration: editor.options.animationMediumMs },
 					})
 				},

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1028,7 +1028,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				},
 			},
 			{
-				id: 'zoom-in-on-curson',
+				id: 'zoom-in-on-cursor',
 				label: 'action.zoom-in',
 				kbd: '!$=,!=',
 				readonlyOk: true,

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -70,8 +70,8 @@ export interface TLUiEventMap {
 	'select-none-shapes': null
 	'rotate-ccw': null
 	'rotate-cw': null
-	'zoom-in': null
-	'zoom-out': null
+	'zoom-in': { towardsCursor: boolean }
+	'zoom-out': { towardsCursor: boolean }
 	'zoom-to-fit': null
 	'zoom-to-selection': null
 	'reset-zoom': null

--- a/packages/tldraw/src/test/commands/zoomIn.test.ts
+++ b/packages/tldraw/src/test/commands/zoomIn.test.ts
@@ -11,16 +11,16 @@ it('zooms by increments', () => {
 	const cameraOptions = DEFAULT_CAMERA_OPTIONS
 
 	// Starts at 1
-	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3])
-	editor.zoomIn()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4])
 	editor.zoomIn()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[5])
 	editor.zoomIn()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[6])
+	editor.zoomIn()
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[7])
 	// does not zoom out past min
 	editor.zoomIn()
-	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[6])
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[7])
 })
 
 it('is ignored by undo/redo', () => {
@@ -29,7 +29,7 @@ it('is ignored by undo/redo', () => {
 	editor.markHistoryStoppingPoint()
 	editor.zoomIn()
 	editor.undo()
-	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4])
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[5])
 })
 
 it('preserves the screen center', () => {

--- a/packages/tldraw/src/test/commands/zoomOut.test.ts
+++ b/packages/tldraw/src/test/commands/zoomOut.test.ts
@@ -10,6 +10,8 @@ it('zooms out and in by increments', () => {
 	const cameraOptions = editor.getCameraOptions()
 
 	// Starts at 1
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4])
+	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3])
 	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2])
@@ -28,7 +30,7 @@ it('is ignored by undo/redo', () => {
 	editor.markHistoryStoppingPoint()
 	editor.zoomOut()
 	editor.undo()
-	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2])
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3])
 })
 
 it('does not zoom out when camera is frozen', () => {
@@ -53,6 +55,8 @@ it('zooms out and in by increments when the camera options have constraints but 
 		},
 	})
 	// Starts at 1
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4])
+	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3])
 	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2])
@@ -84,6 +88,8 @@ it('zooms out and in by increments when the camera options have constraints and 
 
 	expect(editor.getInitialZoom()).toBe(0.5) // fitting the x axis
 	// Starts at 1
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4] * 0.5)
+	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3] * 0.5)
 	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2] * 0.5)
@@ -111,6 +117,8 @@ it('zooms out and in by increments when the camera options have constraints and 
 
 	expect(editor.getInitialZoom()).toBe(0.25) // fitting the y axis
 	// Starts at 1
+	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[4] * 0.25)
+	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[3] * 0.25)
 	editor.zoomOut()
 	expect(editor.getZoomLevel()).toBe(cameraOptions.zoomSteps[2] * 0.25)

--- a/packages/tldraw/src/test/commands/zoomToBounds.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToBounds.test.ts
@@ -38,7 +38,7 @@ it('does not zoom past max', () => {
 
 it('does not zoom past min', () => {
 	editor.zoomToBounds(new Box(0, 0, 1000000, 100000))
-	expect(editor.getZoomLevel()).toBe(0.1)
+	expect(editor.getZoomLevel()).toBe(0.05)
 })
 
 it('does not zoom to bounds when camera is frozen', () => {

--- a/packages/tldraw/src/test/commands/zoomToSelection.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToSelection.test.ts
@@ -30,7 +30,7 @@ it('does not zoom past min', () => {
 	editor.updateShapes([{ id: ids.box1, type: 'geo', props: { w: 100000, h: 100000 } }])
 	editor.select(ids.box1)
 	editor.zoomToSelection()
-	expect(editor.getZoomLevel()).toBe(0.1)
+	expect(editor.getZoomLevel()).toBe(0.05)
 })
 
 it('does not zoom to selection when camera is frozen', () => {


### PR DESCRIPTION
This PR makes two changes to the zoom defaults:

- Adds a new 5% zoom step as the smallest zoom step (down from 10%)
- Adds Shift + / Shift - for zoom towards cursor.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Zoom out
2. Zoom in

### Release notes

- Added a new minimum zoom step at 5%
- Added new keyboard shortcuts for zoom in or out towards your cursor (Shift +, Shift -)