### PR TITLE
Add page navigation kbds

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2988,7 +2988,9 @@ export interface TLUiEventMap {
         locale: string;
     };
     // (undocumented)
-    'change-page': null;
+    'change-page': {
+        direction?: 'next' | 'prev';
+    };
     // (undocumented)
     'change-user-name': null;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1410,6 +1410,52 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					editor.setCurrentTool('geo')
 				},
 			},
+			{
+				id: 'change-page-prev',
+				kbd: '?←',
+				onSelect: async (source) => {
+					// will select whatever the most recent geo tool was
+					trackEvent('change-page', { source, direction: 'prev' })
+					const pages = editor.getPages()
+					const currentPageIndex = pages.findIndex((page) => page.id === editor.getCurrentPageId())
+					if (currentPageIndex < 1) return
+					const prevPageIndex = currentPageIndex - 1
+					editor.setCurrentPage(pages[prevPageIndex].id)
+				},
+			},
+			{
+				id: 'change-page-next',
+				kbd: '?→',
+				onSelect: async (source) => {
+					// will select whatever the most recent geo tool was
+					const pages = editor.getPages()
+					const currentPageIndex = pages.findIndex((page) => page.id === editor.getCurrentPageId())
+
+					// If we're on the last page...
+					if (currentPageIndex === -1 || currentPageIndex >= pages.length - 1) {
+						// if the current page is blank or if we're in readonly mode, do nothing
+						if (editor.getCurrentPageShapes().length <= 0 || editor.getIsReadonly()) {
+							return
+						}
+						// Otherwise, create a new page
+						trackEvent('new-page', { source })
+						editor.run(() => {
+							editor.markHistoryStoppingPoint('creating page')
+							const newPageId = PageRecordType.createId()
+							editor.createPage({
+								name: helpers.msg('page-menu.new-page-initial-name'),
+								id: newPageId,
+							})
+							editor.setCurrentPage(newPageId)
+						})
+						return
+					}
+
+					const nextPageIndex = currentPageIndex + 1
+					editor.setCurrentPage(pages[nextPageIndex].id)
+					trackEvent('change-page', { source, direction: 'next' })
+				},
+			},
 		]
 
 		if (showCollaborationUi) {

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -30,7 +30,7 @@ export interface TLUiEventMap {
 	undo: null
 	redo: null
 	'change-language': { locale: string }
-	'change-page': null
+	'change-page': { direction?: 'prev' | 'next' }
 	'delete-page': null
 	'duplicate-page': null
 	'move-page': null

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -140,38 +140,56 @@ export function useKeyboardShortcuts() {
 	}, [actions, tools, isReadonlyMode, editor, isFocused])
 }
 
-// Shift is !
-// Alt is ?
-// Cmd / control is $
-// so cmd+shift+u would be $!u
+// convenience mapping since all real keys need to be single characters, sorry
+const MAPPED_KEYS: Record<string, string> = {
+	'→': 'right',
+	'←': 'left',
+}
+function getMappedKey(kbd: string) {
+	if (MAPPED_KEYS[kbd]) return MAPPED_KEYS[kbd]
+	return kbd
+}
 
 function getHotkeysStringFromKbd(kbd: string) {
 	return getKeys(kbd)
 		.map((kbd) => {
 			let str = ''
-			const chars = kbd.split('')
-			if (chars.length === 1) {
-				str = chars[0]
-			} else {
-				if (chars[0] === '!') {
-					str = `shift+${chars[1]}`
-				} else if (chars[0] === '?') {
-					if (chars.length === 3 && chars[1] === '!') {
-						str = `alt+shift+${chars[2]}`
-					} else {
-						str = `alt+${chars[1]}`
-					}
-				} else if (chars[0] === '$') {
-					if (chars[1] === '!') {
-						str = `cmd+shift+${chars[2]},ctrl+shift+${chars[2]}`
-					} else if (chars[1] === '?') {
-						str = `cmd+⌥+${chars[2]},ctrl+alt+${chars[2]}`
-					} else {
-						str = `cmd+${chars[1]},ctrl+${chars[1]}`
-					}
-				} else {
-					str = kbd
+			// The actual key being pressed (the others will be modifiers)
+			let k = ''
+
+			// Shift is !
+			// Alt is ?
+			// Cmd / control is $
+
+			// so cmd+shift+u would be $!u
+
+			const [a, b, c] = kbd.split('')
+
+			if (c) {
+				// This is a 3 key combo, the third key (c) is the real key
+				k = getMappedKey(c)
+				const m = a + b // the modifiers...
+				if (m === '!?' || m === '?!') {
+					str = `shift+alt+${k}`
+				} else if (m === '!$' || m === '$!') {
+					str = `cmd+shift+${k},ctrl+shift+${k}`
+				} else if (m === '?$' || m === '$?') {
+					str = `cmd+alt+${k},ctrl+alt+${k}`
 				}
+			} else if (b) {
+				// This is a 2 key combo, the second key (b) is the real key
+				k = getMappedKey(b)
+				if (a === '!') {
+					str = `shift+${k}`
+				} else if (a === '?') {
+					str = `alt+${k}`
+				} else if (a === '$') {
+					str = `cmd+${k},ctrl+${k}`
+				}
+			} else {
+				// This is a single key combo, the only key (a) is the real key
+				k = getMappedKey(a)
+				str = k
 			}
 			return str
 		})


### PR DESCRIPTION
This PR adds shortcuts for moving between pages. Option + ArrowLeft will go to the prev page (eg from Page 2 to Page 1), Option + ArrowRight will go to the next page (from Page 1 to Page 2).

If the current page is NOT blank, then going to the next page from the last page will create a new page.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create some pages
2. Use the keyboard to navigate between pages
3. On a last page with shapes, create a new page by going "up" from the last page
3. On a last page without shapes, fail to create a new page by going "up" from the last page

### Release notes

- Added keyboard shortcuts (option + arrows) for navigating between pages.