### PR TITLE
Add eslint rule for "whilst"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -148,6 +148,7 @@ export default [
 			'local/tagged-components': 'error',
 			'local/prefer-class-methods': 'error',
 			'local/tsdoc-param-matching': 'error',
+			'local/no-whilst': 'error',
 			'no-only-tests/no-only-tests': 'error',
 			'formatjs/enforce-default-message': ['error', 'literal'],
 

--- a/internal/scripts/lib/eslint-plugin.ts
+++ b/internal/scripts/lib/eslint-plugin.ts
@@ -13,6 +13,61 @@ const { ESLintUtils } = utils
 import TSESTree = utils.TSESTree
 
 exports.rules = {
+	// Rule to enforce using "while" instead of "whilst"
+	'no-whilst': ESLintUtils.RuleCreator.withoutDocs({
+		create(context) {
+			// If we're in the ESLint plugin file, don't apply the rule to avoid
+			// self-reference issues
+			if (context.filename.includes('eslint-plugin.ts')) {
+				return {}
+			}
+
+			return {
+				Literal(node) {
+					if (typeof node.value === 'string' && node.value.includes('whilst')) {
+						context.report({
+							messageId: 'noWhilst',
+							node,
+							fix: (fixer) => {
+								return fixer.replaceText(node, node.raw.replace(/whilst/g, 'while'))
+							},
+						})
+					}
+				},
+				JSXText(node) {
+					if (node.value.includes('whilst')) {
+						context.report({
+							messageId: 'noWhilst',
+							node,
+							fix: (fixer) => {
+								return fixer.replaceText(node, node.value.replace(/whilst/g, 'while'))
+							},
+						})
+					}
+				},
+				TemplateElement(node) {
+					if (node.value.raw.includes('whilst')) {
+						context.report({
+							messageId: 'noWhilst',
+							node,
+							fix: (fixer) => {
+								return fixer.replaceText(node, node.value.raw.replace(/whilst/g, 'while'))
+							},
+						})
+					}
+				},
+			}
+		},
+		meta: {
+			messages: {
+				noWhilst: 'Use "while" instead of "whilst" to maintain American English style, sorry.',
+			},
+			type: 'problem',
+			schema: [],
+			fixable: 'code',
+		},
+		defaultOptions: [],
+	}),
 	'no-export-star': ESLintUtils.RuleCreator.withoutDocs({
 		create(context) {
 			return {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4003,7 +4003,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * Create a page.
+	 * Create a page whilst ensuring that the page name is unique.
 	 *
 	 * @example
 	 * ```ts

--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -21,7 +21,7 @@ export class ExportDelay {
 			)
 		}
 		this.promisesToWaitFor.push(
-			promise.catch((err) => console.error('Error whilst waiting for export:', err))
+			promise.catch((err) => console.error('Error while waiting for export:', err))
 		)
 	}
 


### PR DESCRIPTION
Every now and then the word "whilst" will appear in our codebase. This PR enforces an eslint rule that prevents it from appearing and suggests "while" as a fix.

We use American english and spelling in our codebase and communications. While whilst is common here in the UK (where our development team is) in the US the word sounds intentionally affected, like thou or thee or m'lady. It is absolutely critical that we avoid any perception of whimsy.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Use 'whilst' in a comment
2. Linting should fail
