### PR TITLE
export: fix style embedding for foreignObjects in Firefox

### DIFF
--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -242,7 +242,7 @@ function styleFromComputedStyle(
 	{ defaultStyles, parentStyles }: ReadStyleOpts
 ) {
 	const styles: Record<string, string> = {}
-	for (const [property, _] of Object.entries(style)) {
+	for (const property in style) {
 		if (!shouldIncludeCssProperty(property)) continue
 
 		const value = style.getPropertyValue(property)

--- a/packages/tldraw/src/test/commands/__snapshots__/getSvgString.test.ts.snap
+++ b/packages/tldraw/src/test/commands/__snapshots__/getSvgString.test.ts.snap
@@ -83,7 +83,7 @@ exports[`Matches a snapshot: Basic SVG 1`] = `
         y="0"
       >
         <div
-          style="display: flex; height: 100%; justify-content: center; align-items: center; padding: 16px;"
+          style="display: flex; height: 100%; justify-content: center; align-items: center; padding: 16px 16px 16px 16px; visibility: visible;"
           xmlns="http://www.w3.org/1999/xhtml"
         >
           <div
@@ -215,7 +215,7 @@ exports[`Returns all shapes when no ids are provided: All shapes 1`] = `
         y="0"
       >
         <div
-          style="display: flex; height: 100%; justify-content: center; align-items: center; padding: 16px;"
+          style="display: flex; height: 100%; justify-content: center; align-items: center; padding: 16px 16px 16px 16px; visibility: visible;"
           xmlns="http://www.w3.org/1999/xhtml"
         >
           <div


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/5592

A user noticed that text rendering was off in Firefox. (it was manifesting as a line-height issue). However the issue ran further — the computed style map in Firefox needed to be iterated over differently. We hadn't noticed, oops :)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix exports / style embedding for foreignObjects in Firefox