### PR TITLE
hotfix: Fix broken docs sidebar link (#5578)

### DIFF
--- a/apps/docs/components/docs/docs-category-menu.tsx
+++ b/apps/docs/components/docs/docs-category-menu.tsx
@@ -16,7 +16,7 @@ const categoryLinks = [
 	{
 		caption: 'Guides',
 		icon: AcademicCapIcon,
-		href: '/editor',
+		href: '/docs/editor',
 		active: (pathname: string) => ['/docs', '/community'].some((e) => pathname.startsWith(e)),
 	},
 	{


### PR DESCRIPTION
Fixes the "Guides" link in the docs sidebar

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other` docs
