### PR TITLE
perf: improve being able to pan around in larger rooms

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -1,5 +1,5 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
-import { updateHoveredShapeId } from '../../../tools/selection-logic/updateHoveredShapeId'
+import { updateHoveredShapeIdThrottled } from '../../../tools/selection-logic/updateHoveredShapeId'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -8,7 +8,7 @@ export class Idle extends StateNode {
 		switch (info.target) {
 			case 'shape':
 			case 'canvas': {
-				updateHoveredShapeId(this.editor)
+				updateHoveredShapeIdThrottled(this.editor)
 			}
 		}
 	}
@@ -22,7 +22,7 @@ export class Idle extends StateNode {
 	}
 
 	override onExit() {
-		updateHoveredShapeId.cancel()
+		updateHoveredShapeIdThrottled.cancel()
 	}
 
 	override onKeyDown(info: TLKeyboardEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -11,7 +11,7 @@ import {
 import { getTextLabels } from '../../../utils/shapes/shapes'
 import { renderPlaintextFromRichText } from '../../../utils/text/richText'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
-import { updateHoveredShapeId } from '../../selection-logic/updateHoveredShapeId'
+import { updateHoveredShapeIdThrottled } from '../../selection-logic/updateHoveredShapeId'
 
 interface EditingShapeInfo {
 	isCreatingTextWhileToolLocked?: boolean
@@ -34,7 +34,7 @@ export class EditingShape extends StateNode {
 			this.parent.setCurrentToolIdMask('text')
 		}
 
-		updateHoveredShapeId(this.editor)
+		updateHoveredShapeIdThrottled(this.editor)
 		this.editor.select(editingShape)
 	}
 
@@ -45,7 +45,7 @@ export class EditingShape extends StateNode {
 		// Clear the editing shape
 		this.editor.setEditingShape(null)
 
-		updateHoveredShapeId.cancel()
+		updateHoveredShapeIdThrottled.cancel()
 
 		const shape = this.editor.getShape(editingShapeId)!
 		const util = this.editor.getShapeUtil(shape)
@@ -74,7 +74,7 @@ export class EditingShape extends StateNode {
 		switch (info.target) {
 			case 'shape':
 			case 'canvas': {
-				updateHoveredShapeId(this.editor)
+				updateHoveredShapeIdThrottled(this.editor)
 				return
 			}
 		}
@@ -192,7 +192,7 @@ export class EditingShape extends StateNode {
 		} else if (isMobile && isEditToEditAction) {
 			this.editor.emit('select-all-text', { shapeId: hitShape.id })
 		}
-		updateHoveredShapeId(this.editor)
+		updateHoveredShapeIdThrottled(this.editor)
 	}
 
 	override onComplete(info: TLCompleteEventInfo) {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -1,4 +1,4 @@
-import { Editor, TLShape, throttle } from '@tldraw/editor'
+import { Editor, TLShape, debounce, throttle } from '@tldraw/editor'
 
 function _updateHoveredShapeId(editor: Editor) {
 	// todo: consider replacing `get hoveredShapeId` with this; it would mean keeping hoveredShapeId in memory rather than in the store and possibly re-computing it more often than necessary
@@ -32,7 +32,13 @@ function _updateHoveredShapeId(editor: Editor) {
 }
 
 /** @internal */
-export const updateHoveredShapeId = throttle(
+export const updateHoveredShapeIdThrottled = throttle(
+	_updateHoveredShapeId,
+	process.env.NODE_ENV === 'test' ? 0 : 32
+)
+
+/** @internal */
+export const updateHoveredShapeIdDebounced = debounce(
 	_updateHoveredShapeId,
 	process.env.NODE_ENV === 'test' ? 0 : 32
 )


### PR DESCRIPTION
When I was looking at coalesced events, that had me slowdown my CPU more than usual. It made me notice that panning when there was a lot of shapes was chunky. Digging into the flamegraph, I noted that `updateHoveredShapeId` was a pretty big culprit. This splits off that function into a throttled or debounced version depending on context of what's happening on the canvas. 

Before (note FPS in corner):

https://github.com/user-attachments/assets/6f07c761-c16c-47e3-8dff-2ba1016203e0

After (note FPS in corner):

https://github.com/user-attachments/assets/8a1c3731-a327-40a3-8954-7b4916a64956



(Mitja, I tagged you since you've done perf stuff a lot but don't review while you're off!)

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve performance when panning in a large room with a lot of shapes.