### PR TITLE
Add more postgres history, reduce ping overhead

### DIFF
--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -138,6 +138,8 @@ export type TLUserDurableObjectEvent =
 			type:
 				| 'reboot'
 				| 'full_data_fetch'
+				| 'full_data_fetch_hard'
+				| 'found_snapshot'
 				| 'reboot_error'
 				| 'rate_limited'
 				| 'broadcast_message'
@@ -146,6 +148,7 @@ export type TLUserDurableObjectEvent =
 				| 'replication_event'
 				| 'connect_retry'
 				| 'user_do_abort'
+				| 'not_enough_history_for_fast_reboot'
 			id: string
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -127,6 +127,7 @@ export type TLPostgresReplicatorRebootSource =
 
 export type TLPostgresReplicatorEvent =
 	| { type: 'reboot'; source: TLPostgresReplicatorRebootSource }
+	| { type: 'request_lsn_update' }
 	| { type: 'reboot_error' | 'register_user' | 'unregister_user' | 'get_file_record' }
 	| { type: 'reboot_duration'; duration: number }
 	| { type: 'rpm'; rpm: number }


### PR DESCRIPTION
Last time we did a dotcom release during working hours there were way more User DO full postgres refetches than anticipated, which led to a couple of minutes of slowness.

Investigating this, I couldn't find a link in the chain that had failed, so it seems likely that the history pruning was too aggressive and the length of time between 'noop' mutations was too long. So in this PR I tweak both of those variables, and make 'noop' mutations more efficient by bypassing postgres and just asking the replicator for an lsn update directly.

If this doesn't work there is definitely something I'm missing about the production env that makes this stuff fail. In this PR I also added a bunch of extra analytics to maybe help narrow it down after the next release.

### Change type

- [x] `other`
