### PR TITLE
Fix API links for state packages

### DIFF
--- a/packages/state-react/src/lib/useAtom.ts
+++ b/packages/state-react/src/lib/useAtom.ts
@@ -4,7 +4,7 @@ import { useState } from 'react'
 /**
  * Creates a new atom and returns it. The atom will be created only once.
  *
- * See [[atom]]
+ * See {@link state#atom}
  *
  * @example
  * ```ts

--- a/packages/state-react/src/lib/useComputed.ts
+++ b/packages/state-react/src/lib/useComputed.ts
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 /**
  * Creates a new computed signal and returns it. The computed signal will be created only once.
  *
- * See [[computed]]
+ * See {@link state#computed}
  *
  * @example
  * ```ts

--- a/packages/state-react/src/lib/useValue.ts
+++ b/packages/state-react/src/lib/useValue.ts
@@ -5,7 +5,7 @@ import { useMemo, useRef, useSyncExternalStore } from 'react'
 /**
  * Extracts the value from a signal and subscribes to it.
  *
- * Note that you do not need to use this hook if you are wrapping the component with [[track]]
+ * Note that you do not need to use this hook if you are wrapping the component with {@link track}
  *
  * @example
  * ```ts
@@ -17,7 +17,7 @@ import { useMemo, useRef, useSyncExternalStore } from 'react'
  * }
  * ```
  *
- * You can also pass a function to compute the value and it will be memoized as in [[useComputed]]:
+ * You can also pass a function to compute the value and it will be memoized as in {@link state#useComputed}:
  *
  * @example
  * ```ts

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -6,14 +6,14 @@ import { advanceGlobalEpoch, atomDidChange, getGlobalEpoch } from './transaction
 import { Child, ComputeDiff, RESET_VALUE, Signal } from './types'
 
 /**
- * The options to configure an atom, passed into the [[atom]] function.
+ * The options to configure an atom, passed into the {@link atom} function.
  * @public
  */
 export interface AtomOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via [[Atom.set]], you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -22,7 +22,7 @@ export interface AtomOptions<Value, Diff> {
 	 */
 	historyLength?: number
 	/**
-	 * A method used to compute a diff between the atom's old and new values. If provided, it will not be used unless you also specify [[AtomOptions.historyLength]].
+	 * A method used to compute a diff between the atom's old and new values. If provided, it will not be used unless you also specify {@link AtomOptions.historyLength}.
 	 */
 	computeDiff?: ComputeDiff<Value, Diff>
 	/**
@@ -36,9 +36,9 @@ export interface AtomOptions<Value, Diff> {
 }
 
 /**
- * An Atom is a signal that can be updated directly by calling [[Atom.set]] or [[Atom.update]].
+ * An Atom is a signal that can be updated directly by calling {@link Atom.set} or {@link Atom.update}.
  *
- * Atoms are created using the [[atom]] function.
+ * Atoms are created using the {@link atom} function.
  *
  * @example
  * ```ts
@@ -54,7 +54,7 @@ export interface Atom<Value, Diff = unknown> extends Signal<Value, Diff> {
 	 * Sets the value of this atom to the given value. If the value is the same as the current value, this is a no-op.
 	 *
 	 * @param value - The new value to set.
-	 * @param diff - The diff to use for the update. If not provided, the diff will be computed using [[AtomOptions.computeDiff]].
+	 * @param diff - The diff to use for the update. If not provided, the diff will be computed using {@link AtomOptions.computeDiff}.
 	 */
 	set(value: Value, diff?: Diff): Value
 	/**
@@ -156,9 +156,9 @@ export const _Atom = singleton('Atom', () => __Atom__)
 export type _Atom = InstanceType<typeof _Atom>
 
 /**
- * Creates a new [[Atom]].
+ * Creates a new {@link Atom}.
  *
- * An Atom is a signal that can be updated directly by calling [[Atom.set]] or [[Atom.update]].
+ * An Atom is a signal that can be updated directly by calling {@link Atom.set} or {@link Atom.update}.
  *
  * @example
  * ```ts
@@ -183,7 +183,7 @@ export function atom<Value, Diff = unknown>(
 	 */
 	initialValue: Value,
 	/**
-	 * The options to configure the atom. See [[AtomOptions]].
+	 * The options to configure the atom. See {@link AtomOptions}.
 	 */
 	options?: AtomOptions<Value, Diff>
 ): Atom<Value, Diff> {
@@ -191,7 +191,7 @@ export function atom<Value, Diff = unknown>(
 }
 
 /**
- * Returns true if the given value is an [[Atom]].
+ * Returns true if the given value is an {@link Atom}.
  * @public
  */
 export function isAtom(value: unknown): value is Atom<unknown> {

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -16,7 +16,7 @@ export const UNINITIALIZED = Symbol.for('com.tldraw.state/UNINITIALIZED')
 /**
  * The type of the first value passed to a computed signal function as the 'prevValue' parameter.
  *
- * @see [[isUninitialized]].
+ * @see {@link isUninitialized}.
  * @public
  */
 export type UNINITIALIZED = typeof UNINITIALIZED
@@ -65,7 +65,7 @@ export interface WithDiff<Value, Diff> {
 /**
  * When writing incrementally-computed signals it is convenient (and usually more performant) to incrementally compute the diff too.
  *
- * You can use this function to wrap the return value of a computed signal function to indicate that the diff should be used instead of calculating a new one with [[AtomOptions.computeDiff]].
+ * You can use this function to wrap the return value of a computed signal function to indicate that the diff should be used instead of calculating a new one with {@link AtomOptions.computeDiff}.
  *
  * @example
  * ```ts
@@ -89,14 +89,14 @@ export function withDiff<Value, Diff>(value: Value, diff: Diff): WithDiff<Value,
 }
 
 /**
- * Options for creating computed signals. Used when calling [[computed]].
+ * Options for creating computed signals. Used when calling {@link state#computed}.
  * @public
  */
 export interface ComputedOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via [[Atom.set]], you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -105,7 +105,7 @@ export interface ComputedOptions<Value, Diff> {
 	 */
 	historyLength?: number
 	/**
-	 * A method used to compute a diff between the atom's old and new values. If provided, it will not be used unless you also specify [[AtomOptions.historyLength]].
+	 * A method used to compute a diff between the atom's old and new values. If provided, it will not be used unless you also specify {@link AtomOptions.historyLength}.
 	 */
 	computeDiff?: ComputeDiff<Value, Diff>
 	/**
@@ -119,7 +119,7 @@ export interface ComputedOptions<Value, Diff> {
 }
 
 /**
- * A computed signal created via [[computed]].
+ * A computed signal created via {@link state#computed}.
  *
  * @public
  */
@@ -391,7 +391,7 @@ function computedDecorator(
 const isComputedMethodKey = '@@__isComputedMethod__@@'
 
 /**
- * Retrieves the underlying computed instance for a given property created with the [[computed]]
+ * Retrieves the underlying computed instance for a given property created with the {@link state#computed}
  * decorator.
  *
  * @example
@@ -458,7 +458,7 @@ export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
  * }
  * ```
  *
- * You may optionally pass in a [[ComputedOptions]] when used as a decorator:
+ * You may optionally pass in a {@link ComputedOptions} when used as a decorator:
  *
  * @example
  * ```ts

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -119,7 +119,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	/**
 	 * Makes this scheduler become 'actively listening' to its parents.
 	 * If it has been executed before it will immediately become eligible to receive 'maybeScheduleEffect' calls.
-	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling [[EffectScheduler.execute]].
+	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling {@link state#EffectScheduler.execute}.
 	 * @public
 	 */
 	attach() {
@@ -131,7 +131,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 
 	/**
 	 * Makes this scheduler stop 'actively listening' to its parents.
-	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until [[EffectScheduler.attach]] is called again.
+	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until {@link state#EffectScheduler.attach} is called again.
 	 */
 	detach() {
 		this._isActivelyListening = false
@@ -165,7 +165,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
  *
  * You probably don't need to use this directly unless you're integrating this library with a framework of some kind.
  *
- * Instead, use the [[react]] and [[reactor]] functions.
+ * Instead, use the {@link react} and {@link reactor} functions.
  *
  * @example
  * ```ts
@@ -225,14 +225,14 @@ export interface EffectScheduler<Result> {
 	/**
 	 * Makes this scheduler become 'actively listening' to its parents.
 	 * If it has been executed before it will immediately become eligible to receive 'maybeScheduleEffect' calls.
-	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling [[EffectScheduler.execute]].
+	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling {@link state#EffectScheduler.execute}.
 	 * @public
 	 */
 	attach(): void
 
 	/**
 	 * Makes this scheduler stop 'actively listening' to its parents.
-	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until [[EffectScheduler.attach]] is called again.
+	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until {@link state#EffectScheduler.attach} is called again.
 	 */
 	detach(): void
 
@@ -287,13 +287,13 @@ export function react(
 }
 
 /**
- * The reactor is a user-friendly interface for starting and stopping an [[EffectScheduler]].
+ * The reactor is a user-friendly interface for starting and stopping an {@link state#EffectScheduler}.
  *
  * Calling .start() will attach the scheduler and execute the effect immediately the first time it is called.
  *
  * If the reactor is stopped, calling `.start()` will re-attach the scheduler but will only execute the effect if any of its parents have changed since it was stopped.
  *
- * You can create a reactor with [[reactor]].
+ * You can create a reactor with {@link reactor}.
  * @public
  */
 export interface Reactor<T = unknown> {
@@ -319,7 +319,7 @@ export interface Reactor<T = unknown> {
 }
 
 /**
- * Creates a [[Reactor]], which is a thin wrapper around an [[EffectScheduler]].
+ * Creates a {@link Reactor}, which is a thin wrapper around an {@link state#EffectScheduler}.
  *
  * @public
  */

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -11,8 +11,8 @@ export type RESET_VALUE = typeof RESET_VALUE
  *
  * There are two types of signal:
  *
- * - Atomic signals, created using [[atom]]. These are mutable references to values that can be changed using [[Atom.set]].
- * - Computed signals, created using [[computed]]. These are values that are computed from other signals. They are recomputed lazily if their dependencies change.
+ * - Atomic signals, created using {@link atom}. These are mutable references to values that can be changed using {@link Atom.set}.
+ * - Computed signals, created using {@link state#computed}. These are values that are computed from other signals. They are recomputed lazily if their dependencies change.
  *
  * @public
  */
@@ -35,7 +35,7 @@ export interface Signal<Value, Diff = unknown> {
 	lastChangedEpoch: number
 	/**
 	 * Returns the sequence of diffs between the the value at the given epoch and the current value.
-	 * Returns the [[RESET_VALUE]] constant if there is not enough information to compute the diff sequence.
+	 * Returns the {@link state#RESET_VALUE} constant if there is not enough information to compute the diff sequence.
 	 * @param epoch - The epoch to get diffs since.
 	 */
 	getDiffSince(epoch: number): RESET_VALUE | Diff[]
@@ -60,7 +60,7 @@ export interface Child {
 /**
  * Computes the diff between the previous and current value.
  *
- * If the diff cannot be computed for whatever reason, it should return [[RESET_VALUE]].
+ * If the diff cannot be computed for whatever reason, it should return {@link state#RESET_VALUE}.
  *
  * @public
  */


### PR DESCRIPTION
This PR fixes the links in our state package references.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
