### PR TITLE
debug: move hard reset option to avoid fat finger

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -39,6 +39,7 @@ export function DefaultDebugMenuContent() {
 	return (
 		<>
 			<TldrawUiMenuGroup id="items">
+				<TldrawUiMenuItem id="hard-reset" onSelect={hardResetEditor} label={'Hard reset'} />
 				<TldrawUiMenuItem
 					id="add-toast"
 					onSelect={() => {
@@ -166,7 +167,6 @@ export function DefaultDebugMenuContent() {
 					return null
 				})()}
 				<TldrawUiMenuItem id="throw-error" onSelect={() => setError(true)} label={'Throw error'} />
-				<TldrawUiMenuItem id="hard-reset" onSelect={hardResetEditor} label={'Hard reset'} />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="flags">
 				<DebugFlags />


### PR DESCRIPTION
little nit that i would run into occassionally, it's so close to the debug flags, and has no `confirm`.
i could have added a dialog to confirm but meh ¯\\_(ツ)_/¯ 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
