### PR TITLE
assets: be able to remove assets that are unused

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2105,6 +2105,8 @@ export class LocalIndexedDb {
     // (undocumented)
     pruneSessions(): Promise<void>;
     // (undocumented)
+    removeAsset(assetId: string): Promise<void>;
+    // (undocumented)
     storeAsset(assetId: string, blob: File): Promise<void>;
     // (undocumented)
     storeChanges({ schema, changes, sessionId, sessionStateSnapshot, }: {

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -119,6 +119,7 @@ export function createTLStore({
 			assets: {
 				upload: assets.upload,
 				resolve: assets.resolve ?? defaultAssetResolve,
+				remove: assets.remove ?? (() => Promise.resolve()),
 			},
 			onMount: (editor) => {
 				assert(editor instanceof Editor)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4218,7 +4218,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 				: (assets as TLAsset[]).map((a) => a.id)
 		if (ids.length <= 0) return this
 
-		this.run(() => this.store.remove(ids), { history: 'ignore' })
+		this.run(
+			() => {
+				this.store.props.assets.remove?.(ids)
+				this.store.remove(ids)
+			},
+			{ history: 'ignore' }
+		)
 		return this
 	}
 

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -52,6 +52,11 @@ export function useLocalStore(
 
 				return asset.props.src
 			},
+			remove: async (assetIds) => {
+				for (const id of assetIds) {
+					await client.db.removeAsset(id)
+				}
+			},
 			...rest.assets,
 		}
 

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -303,6 +303,13 @@ export class LocalIndexedDb {
 			await assetsStore.put(blob, assetId)
 		})
 	}
+
+	async removeAsset(assetId: string) {
+		await this.tx('readwrite', [Table.Assets], async (tx) => {
+			const assetsStore = tx.objectStore(Table.Assets)
+			await assetsStore.delete(assetId)
+		})
+	}
 }
 
 /** @internal */

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -737,6 +737,7 @@ export type TLAssetShape = Extract<TLShape, {
 
 // @public
 export interface TLAssetStore {
+    remove?(assetIds: TLAssetId[]): Promise<void>;
     resolve?(asset: TLAsset, ctx: TLAssetContext): null | Promise<null | string> | string;
     upload(asset: TLAsset, file: File, abortSignal?: AbortSignal): Promise<{
         meta?: JsonObject;

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -7,7 +7,7 @@ import {
 	StoreValidationFailure,
 } from '@tldraw/store'
 import { IndexKey, JsonObject, annotateError, structuredClone } from '@tldraw/utils'
-import { TLAsset } from './records/TLAsset'
+import { TLAsset, TLAssetId } from './records/TLAsset'
 import { CameraRecordType, TLCameraId } from './records/TLCamera'
 import { DocumentRecordType, TLDOCUMENT_ID } from './records/TLDocument'
 import { TLINSTANCE_ID } from './records/TLInstance'
@@ -113,6 +113,13 @@ export interface TLAssetStore {
 	 * @returns The URL of the resolved asset, or `null` if the asset is not available
 	 */
 	resolve?(asset: TLAsset, ctx: TLAssetContext): Promise<string | null> | string | null
+	/**
+	 * Remove an asset from storage. This is called when the asset is no longer needed, e.g. when
+	 * the user deletes it from the editor.
+	 * @param asset - the asset being removed
+	 * @returns A promise that resolves when the asset has been removed
+	 */
+	remove?(assetIds: TLAssetId[]): Promise<void>
 }
 
 /** @public */


### PR DESCRIPTION
Be able to cleanup the assets when the assets are actually deleted. 
This came up in Discord here: https://discord.com/channels/859816885297741824/1349476132365537320/1349476132365537320

The IndexedDB can start getting crufty with old assets that are unused. This allows folks that proactively delete assets (not just the shapes) to be able to keep the local db clean.

fixes https://github.com/tldraw/tldraw/issues/5622

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Cleanup assets from the local indexedDB that are proactively deleted.