### PR TITLE
error logging for i18n-upload-strings

### DIFF
--- a/internal/scripts/i18n-upload-strings.ts
+++ b/internal/scripts/i18n-upload-strings.ts
@@ -80,4 +80,7 @@ async function i18nUploadStrings() {
 	console.log('Finished placing order for new strings.')
 }
 
-i18nUploadStrings()
+i18nUploadStrings().catch((e) => {
+	console.error(e)
+	process.exit(1)
+})


### PR DESCRIPTION
this seems to have been failing sometimes but it doesn't really say why because the underlying error seems to be eaten up by the 'unhandled promise rejection' reporter.

### Change type

- [x] `other`
