### PR TITLE
Add a dot (test new docs deployment thing)

### DIFF
--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -108,7 +108,7 @@ const myOverrides: TLUiOverrides = {
 			label: 'tools.card',
 			kbd: 'c',
 			onSelect: () => {
-				// Whatever you want to happen when the tool is selected
+				// Whatever you want to happen when the tool is selected.
 				editor.setCurrentTool('card')
 			},
 		}


### PR DESCRIPTION

- [x] `other`
