### PR TITLE
Track embedded examples on docs site

### DIFF
--- a/apps/docs/components/content/example.tsx
+++ b/apps/docs/components/content/example.tsx
@@ -13,7 +13,7 @@ export function Example({ article }: { article: Article }) {
 	return (
 		<div className="w-full mt-12">
 			{/* Disable auto focus using the preserveFocus search param */}
-			<Embed src={`${server}/${article.id}/full?preserveFocus=true`} />
+			<Embed src={`${server}/${article.id}/full?preserveFocus=true&utm_source=docs-embed`} />
 			<CodeFiles files={files} />
 		</div>
 	)


### PR DESCRIPTION
This PR adds a URL query so that we can track which views on the examples site come from being embedded within our docs

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
