### PR TITLE
rich text: add `textOptions` to `<TldrawImage />`

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -127,6 +127,7 @@ import { TLShapeUtilCanvasSvgDef } from '@tldraw/editor';
 import { TLStateNodeConstructor } from '@tldraw/editor';
 import { TLStore } from '@tldraw/editor';
 import { TLStoreSnapshot } from '@tldraw/editor';
+import { TLTextOptions } from '@tldraw/editor';
 import { TLTextShape } from '@tldraw/editor';
 import { TLUrlExternalAsset } from '@tldraw/editor';
 import { TLVideoAsset } from '@tldraw/editor';
@@ -2398,6 +2399,7 @@ export interface TldrawImageProps extends TLImageExportOptions {
     pageId?: TLPageId;
     shapeUtils?: readonly TLAnyShapeUtilConstructor[];
     snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot;
+    textOptions?: TLTextOptions;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -6,6 +6,7 @@ import {
 	TLImageExportOptions,
 	TLPageId,
 	TLStoreSnapshot,
+	TLTextOptions,
 	useShallowArrayIdentity,
 	useTLStore,
 } from '@tldraw/editor'
@@ -13,6 +14,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { defaultBindingUtils } from './defaultBindingUtils'
 import { defaultShapeUtils } from './defaultShapeUtils'
 import { TLUiAssetUrlOverrides } from './ui/assetUrls'
+import { defaultAddFontsFromNode, tipTapDefaultExtensions } from './utils/text/richText'
 
 /** @public */
 export interface TldrawImageProps extends TLImageExportOptions {
@@ -47,6 +49,17 @@ export interface TldrawImageProps extends TLImageExportOptions {
 	 * Asset URL overrides.
 	 */
 	assetUrls?: TLUiAssetUrlOverrides
+	/**
+	 * Text options for the editor.
+	 */
+	textOptions?: TLTextOptions
+}
+
+const defaultTextOptions = {
+	tipTapConfig: {
+		extensions: tipTapDefaultExtensions,
+	},
+	addFontsFromNode: defaultAddFontsFromNode,
 }
 
 /**
@@ -92,6 +105,7 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 		format = 'svg',
 		licenseKey,
 		assetUrls,
+		textOptions = defaultTextOptions,
 	} = props
 
 	useLayoutEffect(() => {
@@ -112,6 +126,7 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 			getContainer: () => tempElm,
 			licenseKey,
 			fontAssetUrls: assetUrls?.fonts,
+			textOptions,
 		})
 
 		if (pageId) editor.setCurrentPage(pageId)
@@ -157,6 +172,7 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 		licenseKey,
 		pixelRatio,
 		assetUrls,
+		textOptions,
 	])
 
 	useEffect(() => {


### PR DESCRIPTION
whoops, we forgot to add `textOptions` to `TldrawImage`

fixes https://github.com/tldraw/tldraw/issues/5642

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix a bug where `textOptions` was missing on `<TldrawImage />`