### PR TITLE
[Fix] Use adjacent shape margin option in stackShapes, packShapes

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1521,7 +1521,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): this;
     readonly snaps: SnapManager;
     squashToMark(markId: string): this;
-    stackShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical', gap: number): this;
+    stackShapes(shapes: TLShape[] | TLShapeId[], operation: 'horizontal' | 'vertical', gap?: number): this;
     startFollowingUser(userId: string): this;
     stopCameraAnimation(): this;
     stopFollowingUser(): this;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1438,7 +1438,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     nudgeShapes(shapes: TLShape[] | TLShapeId[], offset: VecLike): this;
     // (undocumented)
     readonly options: TldrawOptions;
-    packShapes(shapes: TLShape[] | TLShapeId[], gap: number): this;
+    packShapes(shapes: TLShape[] | TLShapeId[], _gap?: number): this;
     pageToScreen(point: VecLike): Vec;
     pageToViewport(point: VecLike): Vec;
     popFocusedGroupId(): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6501,13 +6501,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @example
 	 * ```ts
-	 * editor.packShapes([box1, box2], 32)
+	 * editor.packShapes([box1, box2])
 	 * editor.packShapes(editor.getSelectedShapeIds(), 32)
 	 * ```
 	 *
 	 *
 	 * @param shapes - The shapes (or shape ids) to pack.
-	 * @param gap - The padding to apply to the packed shapes. Defaults to 16.
+	 * @param gap - The padding to apply to the packed shapes. Defaults to the editor's `adjacentShapeMargin` option.
 	 */
 	packShapes(shapes: TLShapeId[] | TLShape[], _gap?: number): this {
 		if (this.getIsReadonly()) return this

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6328,21 +6328,22 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @example
 	 * ```ts
-	 * editor.stackShapes([box1, box2], 'horizontal', 32)
-	 * editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 32)
+	 * editor.stackShapes([box1, box2], 'horizontal')
+	 * editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal')
 	 * ```
 	 *
 	 * @param shapes - The shapes (or shape ids) to stack.
 	 * @param operation - Whether to stack horizontally or vertically.
-	 * @param gap - The gap to leave between shapes.
+	 * @param gap - The gap to leave between shapes. By default, uses the editor's `adjacentShapeMargin` option.
 	 *
 	 * @public
 	 */
 	stackShapes(
 		shapes: TLShapeId[] | TLShape[],
 		operation: 'horizontal' | 'vertical',
-		gap: number
+		gap?: number
 	): this {
+		const _gap = gap ?? this.options.adjacentShapeMargin
 		const ids =
 			typeof shapes[0] === 'string'
 				? (shapes as TLShapeId[])
@@ -6400,7 +6401,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 
 		const len = shapeClustersToStack.length
-		if ((gap === 0 && len < 3) || len < 2) return this
+		if ((_gap === 0 && len < 3) || len < 2) return this
 
 		let val: 'x' | 'y'
 		let min: 'minX' | 'minY'
@@ -6421,7 +6422,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let shapeGap: number = 0
 
-		if (gap === 0) {
+		if (_gap === 0) {
 			// note: this is not used in the current tldraw.com; there we use a specified stack
 
 			const gaps: Record<number, number> = {}
@@ -6461,7 +6462,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 		} else {
 			// If a gap was provided, then use that instead.
-			shapeGap = gap
+			shapeGap = _gap
 		}
 
 		const changes: TLShapePartial[] = []

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6509,8 +6509,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @param shapes - The shapes (or shape ids) to pack.
 	 * @param gap - The padding to apply to the packed shapes. Defaults to 16.
 	 */
-	packShapes(shapes: TLShapeId[] | TLShape[], gap: number): this {
+	packShapes(shapes: TLShapeId[] | TLShape[], _gap?: number): this {
 		if (this.getIsReadonly()) return this
+
+		const gap = _gap ?? this.options.adjacentShapeMargin
 
 		const ids =
 			typeof shapes[0] === 'string'

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -285,6 +285,7 @@ const DebugFlagToggle = track(function DebugFlagToggle({
 let t = 0
 
 function createNShapes(editor: Editor, n: number) {
+	const gap = editor.options.adjacentShapeMargin
 	const shapesToCreate: TLShapePartial[] = Array(n)
 	const cols = Math.floor(Math.sqrt(n))
 
@@ -293,8 +294,8 @@ function createNShapes(editor: Editor, n: number) {
 		shapesToCreate[i] = {
 			id: createShapeId('box' + t),
 			type: 'geo',
-			x: (i % cols) * 132,
-			y: Math.floor(i / cols) * 132,
+			x: (i % cols) * (100 + gap),
+			y: Math.floor(i / cols) * (100 + gap),
 		}
 	}
 

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -806,7 +806,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					editor.markHistoryStoppingPoint('stack-vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
-						editor.stackShapes(selectedShapeIds, 'vertical', 16)
+						editor.stackShapes(selectedShapeIds, 'vertical', editor.options.adjacentShapeMargin)
 						kickoutOccludedShapes(editor, selectedShapeIds)
 					})
 				},
@@ -826,7 +826,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					editor.markHistoryStoppingPoint('stack-horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
-						editor.stackShapes(selectedShapeIds, 'horizontal', 16)
+						editor.stackShapes(selectedShapeIds, 'horizontal', editor.options.adjacentShapeMargin)
 						kickoutOccludedShapes(editor, selectedShapeIds)
 					})
 				},

--- a/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
+++ b/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
@@ -116,6 +116,122 @@ exports[`editor.packShapes packs rotated shapes: packed shapes 1`] = `
 ]
 `;
 
+exports[`editor.packShapes packs shapes using the adjacent shape margin option: packed shapes 1`] = `
+[
+  {
+    "id": "shape:boxA",
+    "index": "a1",
+    "isLocked": false,
+    "meta": {},
+    "opacity": 1,
+    "parentId": "wahtever",
+    "props": {
+      "align": "middle",
+      "color": "black",
+      "dash": "draw",
+      "fill": "none",
+      "font": "draw",
+      "geo": "rectangle",
+      "growY": 0,
+      "h": 100,
+      "labelColor": "black",
+      "richText": {
+        "content": [
+          {
+            "type": "paragraph",
+          },
+        ],
+        "type": "doc",
+      },
+      "scale": 1,
+      "size": "m",
+      "url": "",
+      "verticalAlign": "middle",
+      "w": 100,
+    },
+    "rotation": 0,
+    "type": "geo",
+    "typeName": "shape",
+    "x": 99,
+    "y": 200,
+  },
+  {
+    "id": "shape:boxB",
+    "index": "a2",
+    "isLocked": false,
+    "meta": {},
+    "opacity": 1,
+    "parentId": "wahtever",
+    "props": {
+      "align": "middle",
+      "color": "black",
+      "dash": "draw",
+      "fill": "none",
+      "font": "draw",
+      "geo": "rectangle",
+      "growY": 0,
+      "h": 100,
+      "labelColor": "black",
+      "richText": {
+        "content": [
+          {
+            "type": "paragraph",
+          },
+        ],
+        "type": "doc",
+      },
+      "scale": 1,
+      "size": "m",
+      "url": "",
+      "verticalAlign": "middle",
+      "w": 100,
+    },
+    "rotation": 0,
+    "type": "geo",
+    "typeName": "shape",
+    "x": 200,
+    "y": 200,
+  },
+  {
+    "id": "shape:boxC",
+    "index": "a3",
+    "isLocked": false,
+    "meta": {},
+    "opacity": 1,
+    "parentId": "wahtever",
+    "props": {
+      "align": "middle",
+      "color": "black",
+      "dash": "draw",
+      "fill": "none",
+      "font": "draw",
+      "geo": "rectangle",
+      "growY": 0,
+      "h": 100,
+      "labelColor": "black",
+      "richText": {
+        "content": [
+          {
+            "type": "paragraph",
+          },
+        ],
+        "type": "doc",
+      },
+      "scale": 1,
+      "size": "m",
+      "url": "",
+      "verticalAlign": "middle",
+      "w": 100,
+    },
+    "rotation": 0,
+    "type": "geo",
+    "typeName": "shape",
+    "x": 301,
+    "y": 200,
+  },
+]
+`;
+
 exports[`editor.packShapes packs shapes: packed shapes 1`] = `
 [
   {

--- a/packages/tldraw/src/test/commands/packShapes.test.ts
+++ b/packages/tldraw/src/test/commands/packShapes.test.ts
@@ -39,6 +39,20 @@ beforeEach(() => {
 })
 
 describe('editor.packShapes', () => {
+	it('packs shapes using the adjacent shape margin option', () => {
+		// @ts-expect-error - testing private api
+		editor.options.adjacentShapeMargin = 1
+		editor.selectAll()
+		const centerBefore = editor.getSelectionRotatedPageBounds()!.center.clone()
+		editor.packShapes(editor.getSelectedShapeIds())
+		jest.advanceTimersByTime(1000)
+		expect(
+			editor.getCurrentPageShapes().map((s) => ({ ...s, parentId: 'wahtever' }))
+		).toMatchSnapshot('packed shapes')
+		const centerAfter = editor.getSelectionRotatedPageBounds()!.center.clone()
+		expect(centerBefore).toMatchObject(centerAfter)
+	})
+
 	it('packs shapes', () => {
 		editor.selectAll()
 		const centerBefore = editor.getSelectionRotatedPageBounds()!.center.clone()

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -62,7 +62,7 @@ describe('distributeShapes command', () => {
 	describe('when stacking horizontally', () => {
 		it('stacks the shapes based on the editors adjacentShapeMargin', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
-			// @ts-ignore - private property
+			// @ts-expect-error
 			editor.options.adjacentShapeMargin = 1
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal')
 			jest.advanceTimersByTime(1000)

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -60,6 +60,33 @@ describe('distributeShapes command', () => {
 	})
 
 	describe('when stacking horizontally', () => {
+		it('stacks the shapes based on the editors adjacentShapeMargin', () => {
+			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
+			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal')
+			jest.advanceTimersByTime(1000)
+			// 200 distance gap between c and d
+			editor.expectShapeToMatch({
+				id: ids.boxA,
+				x: 0,
+				y: 0,
+			})
+			editor.expectShapeToMatch({
+				id: ids.boxB,
+				x: 110,
+				y: 100,
+			})
+			editor.expectShapeToMatch({
+				id: ids.boxC,
+				x: 220,
+				y: 400,
+			})
+			editor.expectShapeToMatch({
+				id: ids.boxD,
+				x: 330,
+				y: 700,
+			})
+		})
+
 		it('stacks the shapes based on a given value', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 10)

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -62,6 +62,8 @@ describe('distributeShapes command', () => {
 	describe('when stacking horizontally', () => {
 		it('stacks the shapes based on the editors adjacentShapeMargin', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
+			// @ts-ignore - private property
+			editor.options.adjacentShapeMargin = 1
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal')
 			jest.advanceTimersByTime(1000)
 			// 200 distance gap between c and d
@@ -72,17 +74,17 @@ describe('distributeShapes command', () => {
 			})
 			editor.expectShapeToMatch({
 				id: ids.boxB,
-				x: 110,
+				x: 101,
 				y: 100,
 			})
 			editor.expectShapeToMatch({
 				id: ids.boxC,
-				x: 220,
+				x: 202,
 				y: 400,
 			})
 			editor.expectShapeToMatch({
 				id: ids.boxD,
-				x: 330,
+				x: 303,
 				y: 700,
 			})
 		})


### PR DESCRIPTION
This PR makes `stackShapes` use the editor's `adjacentShapeMargin` option by default.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Stack shapes horizontally
2. The gap should be the same as when you duplicate shapes

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Adjusts distance for `stackShapes`.