### PR TITLE
[Hotfix] dismissibles

### DIFF
--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -8,7 +8,7 @@ import Cookies from 'js-cookie'
 import Script from 'next/script'
 import { useEffect, useState } from 'react'
 
-type CookieConsent = 'unknown' | 'opted-in' | 'opted-out'
+type CookieConsent = undefined | 'unknown' | 'opted-in' | 'opted-out'
 
 export default function Analytics() {
 	const [hasConsent, setHasConsent] = useState<CookieConsent>('unknown')
@@ -63,7 +63,9 @@ function CookieConsent({
 		}
 	}
 
-	if (hasConsent !== 'unknown') return null
+	if (hasConsent === undefined || hasConsent !== 'unknown') {
+		return null
+	}
 
 	return (
 		<>

--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -11,6 +11,8 @@ import { FormEventHandler, useCallback, useState } from 'react'
 // when debugging is true, the form will always show (even if the user has submitted)
 const DEBUGGING = false
 
+type NewsletterSignupStatus = 'not-initialized' | 'not-subscribed' | 'subscribed'
+
 export function NewsletterSignup({
 	bg = true,
 	size = 'large',
@@ -21,7 +23,8 @@ export function NewsletterSignup({
 	hideAfterSubmit?: boolean
 }) {
 	// If the user has submitted their email, we don't show the form anymore
-	const [didSubmit, setDidSubmit] = useLocalStorageState('dev_did_submit_newsletter', false)
+	const [newsletterSignupStatus, setNewsletterSignupStatus] =
+		useLocalStorageState<NewsletterSignupStatus>('dev_did_submit_newsletter', 'not-subscribed')
 
 	// Todo: replace with react query or something to handle the async work
 	const [formState, setFormState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
@@ -43,7 +46,7 @@ export function NewsletterSignup({
 				setFormState('success')
 				// After a pause, we locally save that the user has submitted the form
 				setTimeout(() => {
-					setDidSubmit(true)
+					setNewsletterSignupStatus('subscribed')
 					setTimeout(() => setFormState('idle'), 3000)
 				}, 3000)
 			} catch {
@@ -52,12 +55,18 @@ export function NewsletterSignup({
 				setTimeout(() => setFormState('idle'), 3000)
 			}
 		},
-		[setDidSubmit, formState]
+		[setNewsletterSignupStatus, formState]
 	)
+
+	if (newsletterSignupStatus === undefined) return null
 
 	// If the user has already submitted the form, we don't show it anymore,
 	// unless we're both in development mode AND the debug flag is enabled.
-	if (hideAfterSubmit && didSubmit && !(DEBUGGING && process.env.NODE_ENV === 'development')) {
+	if (
+		hideAfterSubmit &&
+		newsletterSignupStatus === 'subscribed' &&
+		!(DEBUGGING && process.env.NODE_ENV === 'development')
+	) {
 		return null
 	}
 

--- a/apps/docs/components/docs/docs-feedback-widget.tsx
+++ b/apps/docs/components/docs/docs-feedback-widget.tsx
@@ -65,6 +65,7 @@ export function DocsFeedbackWidget({ className }: { className?: string }) {
 		async (e) => {
 			e.preventDefault()
 			if (state === 'loading') return
+			if (!sessionId) return
 
 			try {
 				const form = e.currentTarget

--- a/apps/docs/utils/storage.ts
+++ b/apps/docs/utils/storage.ts
@@ -1,9 +1,18 @@
 import { getFromLocalStorage, setInLocalStorage } from '@tldraw/utils'
 import { useCallback, useLayoutEffect, useState } from 'react'
 
-/** @public */
+/**
+ * Helper for dealing with values stored in local storage
+ *
+ * @param key - The key of the state we are interested in.
+ * @param defaultValue - The default value to use if there is no value in local storage.
+ * @param initialValue - The initial value to use before reading from local storage. `undefined` is not supported.
+ * @returns A tuple containing the current state and a function to update the state.
+ *
+ * @public
+ */
 export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
-	const [state, setState] = useState(defaultValue)
+	const [state, setState] = useState<T | undefined>(undefined)
 
 	useLayoutEffect(() => {
 		const value = getFromLocalStorage(key)
@@ -13,8 +22,11 @@ export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
 			} catch {
 				console.error(`Could not restore value ${key} from local storage.`)
 			}
+		} else {
+			setInLocalStorage(key, JSON.stringify(defaultValue))
+			setState(defaultValue)
 		}
-	}, [key])
+	}, [key, defaultValue])
 
 	const updateValue = useCallback(
 		(setter: T | ((value: T) => T)) => {

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
-	"packages": [
-		"packages/*"
-	],
+	"packages": ["packages/*"],
 	"version": "3.10.2"
 }


### PR DESCRIPTION
…570)

We used to default to "user didn't dismiss" this yet. Which meant that we always showed a dismissible element first, then we read the actual value, and we then might have dismissed the elements (if that's what the stored state dictated). We now have a "not initialized" state during which we don't show the elements.

Side effect of this change is that some users that have already dismissed these elements might see them again. I guess we could add some sort of migration of the state, but meh, doesn't seem worth the hassle?

- [x] `improvement`
