### PR TITLE
Hotfix: Track Enter key to accept search query (#5625)

### DIFF
--- a/apps/docs/components/search/SearchAutocomplete.tsx
+++ b/apps/docs/components/search/SearchAutocomplete.tsx
@@ -116,6 +116,11 @@ function Results({ items, sendEvent }: { items: Hit<SearchEntry>[]; sendEvent: S
 						'[&_.ais-Highlight-nonHighlighted]:data-[active-item=true]:text-white'
 					)}
 					value={href}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') {
+							sendEvent('click', hit, 'Hit clicked via keyboard')
+						}
+					}}
 				>
 					<Link href={href} onClick={() => sendEvent('click', hit, 'Hit clicked')}>
 						<Highlight attribute="title" hit={hit} />


### PR DESCRIPTION
This is a manual hotfix as it cherrypicks a PR that landed *before* the new hotfix infra arrived.

---

This PR makes us also track enter key presses in search queries too. This will help us evaluate how helpful our search is to developers.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
