### PR TITLE
docs: fix dismissable content logic

### DIFF
--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react'
 type CookieConsent = undefined | 'unknown' | 'opted-in' | 'opted-out'
 
 export default function Analytics() {
-	const [hasConsent, setHasConsent] = useState<CookieConsent>('unknown')
+	const [hasConsent, setHasConsent] = useState<CookieConsent>()
 
 	const onConsentChanged = (hasConsent: boolean) => {
 		Cookies.set('allowTracking', hasConsent ? 'true' : 'false')

--- a/apps/docs/components/common/newsletter-signup.tsx
+++ b/apps/docs/components/common/newsletter-signup.tsx
@@ -11,7 +11,7 @@ import { FormEventHandler, useCallback, useState } from 'react'
 // when debugging is true, the form will always show (even if the user has submitted)
 const DEBUGGING = false
 
-type NewsletterSignupStatus = 'not-initialized' | 'not-subscribed' | 'subscribed'
+type NewsletterSignupStatus = 'not-subscribed' | 'subscribed'
 
 export function NewsletterSignup({
 	bg = true,
@@ -23,7 +23,7 @@ export function NewsletterSignup({
 	hideAfterSubmit?: boolean
 }) {
 	// If the user has submitted their email, we don't show the form anymore
-	const [newsletterSignupStatus, setNewsletterSignupStatus] =
+	const [newsletterSignupStatus, setNewsletterSignupStatus, isLoaded] =
 		useLocalStorageState<NewsletterSignupStatus>('dev_did_submit_newsletter', 'not-subscribed')
 
 	// Todo: replace with react query or something to handle the async work
@@ -58,7 +58,7 @@ export function NewsletterSignup({
 		[setNewsletterSignupStatus, formState]
 	)
 
-	if (newsletterSignupStatus === undefined) return null
+	if (!isLoaded) return null
 
 	// If the user has already submitted the form, we don't show it anymore,
 	// unless we're both in development mode AND the debug flag is enabled.

--- a/apps/docs/utils/storage.ts
+++ b/apps/docs/utils/storage.ts
@@ -12,7 +12,8 @@ import { useCallback, useLayoutEffect, useState } from 'react'
  * @public
  */
 export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
-	const [state, setState] = useState<T | undefined>(undefined)
+	const [isLoaded, setIsLoaded] = useState(false)
+	const [state, setState] = useState<T>(defaultValue)
 
 	useLayoutEffect(() => {
 		const value = getFromLocalStorage(key)
@@ -22,11 +23,9 @@ export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
 			} catch {
 				console.error(`Could not restore value ${key} from local storage.`)
 			}
-		} else {
-			setInLocalStorage(key, JSON.stringify(defaultValue))
-			setState(defaultValue)
 		}
-	}, [key, defaultValue])
+		setIsLoaded(true)
+	}, [key])
 
 	const updateValue = useCallback(
 		(setter: T | ((value: T) => T)) => {
@@ -39,5 +38,5 @@ export function useLocalStorageState<T = any>(key: string, defaultValue: T) {
 		[key]
 	)
 
-	return [state, updateValue] as const
+	return [state, updateValue, isLoaded] as const
 }


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/5570
wasn't working on the homepage / make the logic simpler anyway

### Change type

- [x] `other`

### Test plan

1. Verify newsletter signup can be dismissed on the homepage.
2. Verify dismissal state persists across page reloads.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where dismissable content was not working correctly on the homepage.