### PR TITLE
Make `type` optional for updateShapes

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -594,7 +594,6 @@ To update shapes, use the [Editor#updateShape](?) or [Editor#updateShapes](?) me
 editor.updateShapes([
 	{
 		id: shape.id, // required
-		type: shape.type, // required
 		x: 100,
 		y: 100,
 		props: {
@@ -604,7 +603,7 @@ editor.updateShapes([
 ])
 ```
 
-The update must be a partial of the full shape (a [TLShapePartial](?)). All props are optional except for the `type` of the shape and its `id`.
+The update must be a partial of the full shape (a [TLShapeUpdatePartial](?)). All props are optional except for the `id` of the shape.
 
 ### Delete shapes
 

--- a/apps/examples/src/examples/after-create-update-shape/AfterCreateUpdateShapeExample.tsx
+++ b/apps/examples/src/examples/after-create-update-shape/AfterCreateUpdateShapeExample.tsx
@@ -19,7 +19,6 @@ function ensureOnlyOneRedShape(editor: Editor, shapeId: TLShapeId) {
 	editor.updateShapes(
 		otherRedShapesOnPage.map((shape) => ({
 			id: shape.id,
-			type: shape.type,
 			props: {
 				color: 'black',
 			},

--- a/apps/examples/src/examples/api/APIExample.tsx
+++ b/apps/examples/src/examples/api/APIExample.tsx
@@ -7,6 +7,7 @@ import {
 	toRichText,
 	createShapeId,
 	useEditor,
+	TLShapeUpdatePartial,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { useEffect } from 'react'
@@ -40,9 +41,8 @@ export default function APIExample() {
 		// Get the created shape
 		const shape = editor.getShape<TLGeoShape>(id)!
 
-		const shapeUpdate: TLShapePartial<TLGeoShape> = {
+		const shapeUpdate: TLShapeUpdatePartial<TLGeoShape> = {
 			id,
-			type: 'geo',
 			props: {
 				h: shape.props.h * 3,
 				richText: toRichText('hello world!'),

--- a/apps/examples/src/examples/editable-shape/EditableShapeUtil.tsx
+++ b/apps/examples/src/examples/editable-shape/EditableShapeUtil.tsx
@@ -65,7 +65,6 @@ export class EditableShapeUtil extends BaseBoxShapeUtil<IMyEditableShape> {
 						onClick={() => {
 							this.editor.updateShape({
 								id: shape.id,
-								type: shape.type,
 								props: {
 									...shape.props,
 									animal: (shape.props.animal + 1) % ANIMAL_EMOJIS.length,

--- a/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/layout-bindings/LayoutExample.tsx
@@ -341,7 +341,6 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 			if (shape.x !== point.x || shape.y !== point.y) {
 				this.editor.updateShape({
 					id: binding.toId,
-					type: 'element',
 					x: point.x,
 					y: point.y,
 				})
@@ -358,7 +357,6 @@ class LayoutBindingUtil extends BindingUtil<LayoutBinding> {
 		if (width !== container.props.width || height !== container.props.height) {
 			this.editor.updateShape({
 				id: container.id,
-				type: 'container',
 				props: { width, height },
 			})
 		}

--- a/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
+++ b/apps/examples/src/examples/pdf-editor/PdfEditor.tsx
@@ -96,7 +96,6 @@ export function PdfEditor({ pdf }: { pdf: Pdf }) {
 					editor.updateShapes(
 						shapes.map((shape, i) => ({
 							id: shape.id,
-							type: shape.type,
 							isLocked: shape.isLocked,
 							index: indexes[i],
 						}))

--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -15,6 +15,7 @@ import {
 	TLEditorComponents,
 	TLPointerEventInfo,
 	TLShapeId,
+	TLShapeUpdatePartial,
 	TLShapeUtilCanBindOpts,
 	TLUiComponents,
 	TLUiOverrides,
@@ -240,7 +241,7 @@ class PinBindingUtil extends BindingUtil<PinBinding> {
 			}
 		}
 
-		const updates = []
+		const updates: TLShapeUpdatePartial[] = []
 		for (const [shapeId, position] of currentPositions) {
 			const delta = Vec.Sub(position, initialPositions.get(shapeId)!)
 			if (delta.len2() <= 0.01) continue
@@ -248,7 +249,6 @@ class PinBindingUtil extends BindingUtil<PinBinding> {
 			const newPosition = this.editor.getPointInParentSpace(shapeId, position)
 			updates.push({
 				id: shapeId,
-				type: this.editor.getShape(shapeId)!.type,
 				x: newPosition.x,
 				y: newPosition.y,
 			})

--- a/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/sticker-bindings/StickerExample.tsx
@@ -160,7 +160,6 @@ class StickerBindingUtil extends BindingUtil<StickerBinding> {
 
 		this.editor.updateShape({
 			id: sticker.id,
-			type: 'sticker',
 			x: stickerParentAnchor.x,
 			y: stickerParentAnchor.y,
 		})

--- a/apps/examples/src/examples/sync-custom-shape/CounterShape.tsx
+++ b/apps/examples/src/examples/sync-custom-shape/CounterShape.tsx
@@ -31,7 +31,6 @@ export class CounterShapeUtil extends BaseBoxShapeUtil<CounterShape> {
 			event.stopPropagation()
 			this.editor.updateShape({
 				id: shape.id,
-				type: 'counter',
 				props: { count: shape.props.count + change },
 			})
 		}

--- a/apps/examples/src/examples/ui-events/codeSnippets.ts
+++ b/apps/examples/src/examples/ui-events/codeSnippets.ts
@@ -67,7 +67,7 @@ export function getCodeSnippet(name: string, data: any) {
 		codeSnippet = 'editor.rotateShapesBy(editor.getSelectedShapeIds(), <number>)'
 	} else if (name === 'edit-link') {
 		codeSnippet =
-			'editor.updateShapes([{ id: editor.getOnlySelectedShape().id, type: editor.getOnlySelectedShape().type, props: { url: <url> }, }, ])'
+			'editor.updateShapes([{ id: editor.getOnlySelectedShape().id, props: { url: <url> }, }, ])'
 	} else if (name.startsWith('export-as')) {
 		codeSnippet = `exportAs(editor.getSelectedShapeIds(), '${data.format}')`
 	} else if (name.startsWith('copy-as')) {
@@ -111,10 +111,10 @@ editor.setCurrentTool('${data.id}')`
 	} else if (name === 'print') {
 		codeSnippet = 'printSelectionOrPages()'
 	} else if (name === 'unlock-all') {
-		codeSnippet = `\n  const updates = [] as TLShapePartial[]
+		codeSnippet = `\n  const updates = [] as TLShapeUpdatePartial[]
 for (const shape of editor.getCurrentPageShapes()) {
   if (shape.isLocked) {
-    updates.push({ id: shape.id, type: shape.type, isLocked: false })
+    updates.push({ id: shape.id, isLocked: false })
   }
 }
 if (updates.length > 0) {

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -81,6 +81,7 @@ import { TLShape } from '@tldraw/tlschema';
 import { TLShapeCrop } from '@tldraw/tlschema';
 import { TLShapeId } from '@tldraw/tlschema';
 import { TLShapePartial } from '@tldraw/tlschema';
+import { TLShapeUpdatePartial } from '@tldraw/tlschema';
 import { TLStore } from '@tldraw/tlschema';
 import { TLStoreProps } from '@tldraw/tlschema';
 import { TLStoreSchema } from '@tldraw/tlschema';
@@ -844,8 +845,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @deprecated (undocumented)
     addOpenMenu(id: string): this;
     alignShapes(shapes: TLShape[] | TLShapeId[], operation: 'bottom' | 'center-horizontal' | 'center-vertical' | 'left' | 'right' | 'top'): this;
-    animateShape(partial: null | TLShapePartial | undefined, opts?: TLCameraMoveOptions): this;
-    animateShapes(partials: (null | TLShapePartial | undefined)[], opts?: TLCameraMoveOptions): this;
+    animateShape(partial: null | TLShapeUpdatePartial | undefined, opts?: TLCameraMoveOptions): this;
+    animateShapes(partials: (null | TLShapeUpdatePartial | undefined)[], opts?: TLCameraMoveOptions): this;
     // @internal (undocumented)
     annotateError(error: unknown, { origin, willCrashApp, tags, extras, }: {
         extras?: Record<string, unknown>;
@@ -1565,10 +1566,10 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal (undocumented)
     _updateInstanceState(partial: Partial<Omit<TLInstance, 'currentPageId'>>, opts?: TLHistoryBatchOptions): void;
     updatePage(partial: RequiredKeys<Partial<TLPage>, 'id'>): this;
-    updateShape<T extends TLUnknownShape>(partial: null | TLShapePartial<T> | undefined): this;
-    updateShapes<T extends TLUnknownShape>(partials: (null | TLShapePartial<T> | undefined)[]): this;
+    updateShape<T extends TLUnknownShape>(partial: null | TLShapeUpdatePartial<T> | undefined): this;
+    updateShapes<T extends TLUnknownShape>(partials: (null | TLShapeUpdatePartial<T> | undefined)[]): this;
     // @internal (undocumented)
-    _updateShapes(_partials: (null | TLShapePartial | undefined)[]): void;
+    _updateShapes(_partials: (null | TLShapeUpdatePartial | undefined)[]): void;
     updateViewportScreenBounds(screenBounds: Box | HTMLElement, center?: boolean): this;
     uploadAsset(asset: TLAsset, file: File, abortSignal?: AbortSignal): Promise<{
         meta?: JsonObject;
@@ -2594,27 +2595,27 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onBeforeCreate?(next: Shape): Shape | void;
     onBeforeUpdate?(prev: Shape, next: Shape): Shape | void;
     // @internal
-    onBindingChange?(shape: Shape): TLShapePartial<Shape> | void;
-    onChildrenChange?(shape: Shape): TLShapePartial[] | void;
-    onClick?(shape: Shape): TLShapePartial<Shape> | void;
-    onCrop?(shape: Shape, info: TLCropInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
-    onDoubleClick?(shape: Shape): TLShapePartial<Shape> | void;
-    onDoubleClickEdge?(shape: Shape): TLShapePartial<Shape> | void;
-    onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapePartial<Shape> | void;
+    onBindingChange?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onChildrenChange?(shape: Shape): TLShapeUpdatePartial[] | void;
+    onClick?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onCrop?(shape: Shape, info: TLCropInfo<Shape>): Omit<TLShapeUpdatePartial<Shape>, 'id'> | undefined | void;
+    onDoubleClick?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onDoubleClickEdge?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapeUpdatePartial<Shape> | void;
     onDragShapesOut?(shape: Shape, shapes: TLShape[]): void;
     onDragShapesOver?(shape: Shape, shapes: TLShape[]): void;
     onDropShapesOver?(shape: Shape, shapes: TLShape[]): void;
     onEditEnd?(shape: Shape): void;
-    onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
-    onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
-    onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onResizeStart?(shape: Shape): TLShapePartial<Shape> | void;
-    onRotate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onRotateStart?(shape: Shape): TLShapePartial<Shape> | void;
-    onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onTranslateStart?(shape: Shape): TLShapePartial<Shape> | void;
+    onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapeUpdatePartial<Shape> | void;
+    onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapeUpdatePartial<Shape>, 'id'> | undefined | void;
+    onResizeEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void;
+    onResizeStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onRotate?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void;
+    onRotateEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void;
+    onRotateStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
+    onTranslate?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void;
+    onTranslateEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void;
+    onTranslateStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void;
     options: {};
     static props?: RecordProps<TLUnknownShape>;
     // @internal

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -7,7 +7,7 @@ import {
 	TLPropsMigrations,
 	TLShape,
 	TLShapeCrop,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	TLUnknownShape,
 } from '@tldraw/tlschema'
 import { ReactElement } from 'react'
@@ -490,7 +490,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	onCrop?(
 		shape: Shape,
 		info: TLCropInfo<Shape>
-	): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void
+	): Omit<TLShapeUpdatePartial<Shape>, 'id'> | undefined | void
 
 	/**
 	 * A callback called when some other shapes are dragged over this one.
@@ -534,7 +534,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onResizeStart?(shape: Shape): TLShapePartial<Shape> | void
+	onResizeStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape changes from a resize.
@@ -547,7 +547,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	onResize?(
 		shape: Shape,
 		info: TLResizeInfo<Shape>
-	): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void
+	): Omit<TLShapeUpdatePartial<Shape>, 'id'> | undefined | void
 
 	/**
 	 * A callback called when a shape finishes resizing.
@@ -557,7 +557,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+	onResizeEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape starts being translated.
@@ -566,7 +566,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onTranslateStart?(shape: Shape): TLShapePartial<Shape> | void
+	onTranslateStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape changes from a translation.
@@ -576,7 +576,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+	onTranslate?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape finishes translating.
@@ -586,7 +586,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+	onTranslateEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape's handle changes.
@@ -596,7 +596,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void
+	onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape starts being rotated.
@@ -605,7 +605,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onRotateStart?(shape: Shape): TLShapePartial<Shape> | void
+	onRotateStart?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape changes from a rotation.
@@ -615,7 +615,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onRotate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+	onRotate?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape finishes rotating.
@@ -625,14 +625,14 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+	onRotateEnd?(initial: Shape, current: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * Not currently used.
 	 *
 	 * @internal
 	 */
-	onBindingChange?(shape: Shape): TLShapePartial<Shape> | void
+	onBindingChange?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape's children change.
@@ -641,7 +641,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns An array of shape updates, or void.
 	 * @public
 	 */
-	onChildrenChange?(shape: Shape): TLShapePartial[] | void
+	onChildrenChange?(shape: Shape): TLShapeUpdatePartial[] | void
 
 	/**
 	 * A callback called when a shape's handle is double clicked.
@@ -651,7 +651,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapePartial<Shape> | void
+	onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape's edge is double clicked.
@@ -660,7 +660,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickEdge?(shape: Shape): TLShapePartial<Shape> | void
+	onDoubleClickEdge?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape is double clicked.
@@ -669,7 +669,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClick?(shape: Shape): TLShapePartial<Shape> | void
+	onDoubleClick?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape is clicked.
@@ -678,7 +678,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onClick?(shape: Shape): TLShapePartial<Shape> | void
+	onClick?(shape: Shape): TLShapeUpdatePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape finishes being editing.

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -1,4 +1,4 @@
-import { TLParentId, TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
+import { TLParentId, TLShape, TLShapeId, TLShapeUpdatePartial } from '@tldraw/tlschema'
 import { IndexKey, compact, getIndicesBetween, sortByIndex } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 import { Vec } from '../primitives/Vec'
@@ -28,7 +28,7 @@ export function getReorderingShapesChanges(
 		parents.get(parentId)!.moving.add(shape)
 	}
 
-	const changes: TLShapePartial[] = []
+	const changes: TLShapeUpdatePartial[] = []
 
 	switch (operation) {
 		case 'toBack': {
@@ -63,7 +63,7 @@ export function getReorderingShapesChanges(
  * @param children The parent's children
  * @param changes The changes array to push changes to
  */
-function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
+function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLShapeUpdatePartial[]) {
 	const len = children.length
 
 	// If all of the children are moving, there's nothing to do
@@ -112,7 +112,11 @@ function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLSha
  * @param children The parent's children
  * @param changes The changes array to push changes to
  */
-function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
+function reorderToFront(
+	moving: Set<TLShape>,
+	children: TLShape[],
+	changes: TLShapeUpdatePartial[]
+) {
 	const len = children.length
 
 	// If all of the children are moving, there's nothing to do
@@ -194,7 +198,7 @@ function reorderForward(
 	editor: Editor,
 	moving: Set<TLShape>,
 	children: TLShape[],
-	changes: TLShapePartial[],
+	changes: TLShapeUpdatePartial[],
 	opts?: { considerAllShapes?: boolean }
 ) {
 	const isOverlapping = getOverlapChecker(editor, moving)
@@ -253,7 +257,7 @@ function reorderBackward(
 	editor: Editor,
 	moving: Set<TLShape>,
 	children: TLShape[],
-	changes: TLShapePartial[],
+	changes: TLShapeUpdatePartial[],
 	opts?: { considerAllShapes?: boolean }
 ) {
 	const isOverlapping = getOverlapChecker(editor, moving)

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -1,4 +1,4 @@
-import { isShapeId, TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
+import { isShapeId, TLShape, TLShapeId, TLShapeUpdatePartial } from '@tldraw/tlschema'
 import { compact } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
 import { Mat } from '../primitives/Mat'
@@ -89,7 +89,6 @@ export function applyRotationToSnapshotShapes({
 
 			return {
 				id: shape.id,
-				type: shape.type,
 				x: newLocalPoint.x,
 				y: newLocalPoint.y,
 				rotation: newRotation,
@@ -99,7 +98,7 @@ export function applyRotationToSnapshotShapes({
 
 	// Handle change
 
-	const changes: TLShapePartial[] = []
+	const changes: TLShapeUpdatePartial[] = []
 
 	shapeSnapshots.forEach(({ shape }) => {
 		const current = editor.getShape(shape.id)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -120,7 +120,7 @@ import { TLSelectionForegroundProps } from '@tldraw/editor';
 import { TLShape } from '@tldraw/editor';
 import { TLShapeCrop } from '@tldraw/editor';
 import { TLShapeId } from '@tldraw/editor';
-import { TLShapePartial } from '@tldraw/editor';
+import { TLShapeUpdatePartial } from '@tldraw/editor';
 import { TLShapeUtilCanBeLaidOutOpts } from '@tldraw/editor';
 import { TLShapeUtilCanBindOpts } from '@tldraw/editor';
 import { TLShapeUtilCanvasSvgDef } from '@tldraw/editor';
@@ -245,7 +245,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     static migrations: MigrationSequence;
     // (undocumented)
-    onDoubleClickHandle(shape: TLArrowShape, handle: TLHandle): TLShapePartial<TLArrowShape> | void;
+    onDoubleClickHandle(shape: TLArrowShape, handle: TLHandle): TLShapeUpdatePartial<TLArrowShape> | void;
     // (undocumented)
     onEditEnd(shape: TLArrowShape): void;
     // (undocumented)
@@ -253,8 +253,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
         id: TLShapeId;
         meta?: Partial<JsonObject> | undefined;
         props?: Partial<TLArrowShapeProps> | undefined;
-        type: "arrow";
-    } & Partial<Omit<TLArrowShape, "id" | "meta" | "props" | "type">>;
+    } & Partial<Omit<TLArrowShape, "id" | "meta" | "props">>;
     // (undocumented)
     onResize(shape: TLArrowShape, info: TLResizeInfo<TLArrowShape>): {
         props: {

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -12,7 +12,7 @@ import {
 	TLParentId,
 	TLShape,
 	TLShapeId,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	Vec,
 	approximately,
 	arrowBindingMigrations,
@@ -215,12 +215,11 @@ export function updateArrowTerminal({
 
 	const update = {
 		id: arrow.id,
-		type: 'arrow',
 		props: {
 			[terminal]: { x: point.x, y: point.y },
 			bend: arrow.props.bend,
 		},
-	} satisfies TLShapePartial<TLArrowShape>
+	} satisfies TLShapeUpdatePartial<TLArrowShape>
 
 	// fix up the bend:
 	if (!info.isStraight) {

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -580,7 +580,6 @@ export async function defaultHandleExternalUrlContent(
 		editor.updateShapes([
 			{
 				id: shape.id,
-				type: shape.type,
 				props: {
 					assetId: asset.id,
 				},
@@ -777,7 +776,6 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 				const localDelta = Vec.Rot(offset, -localRotation)
 				return {
 					id: shape.id,
-					type: shape.type,
 					x: shape.x! - localDelta.x,
 					y: shape.y! - localDelta.y,
 				}
@@ -796,7 +794,6 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 				const newPoint = { x: shape.x! - delta.x, y: shape.y! - delta.y }
 				return {
 					id: shape.id,
-					type: shape.type,
 					x: newPoint.x,
 					y: newPoint.y,
 				}

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -105,7 +105,7 @@ describe('When translating a bound shape', () => {
 	})
 
 	it('updates the arrow when curved', () => {
-		editor.updateShapes([{ id: ids.arrow1, type: 'arrow', props: { bend: 20 } }])
+		editor.updateShapes([{ id: ids.arrow1, props: { bend: 20 } }])
 		editor.select(ids.box2)
 		editor.pointerDown(250, 250, { target: 'shape', shape: editor.getShape(ids.box2) })
 		editor.pointerMove(300, 300) // move box 2 by 50, 50
@@ -261,7 +261,7 @@ describe('Other cases when arrow are moved', () => {
 		})
 
 		// The arrow will not move because it is still bound to another shape
-		editor.updateShapes([{ id: ids.box4, type: 'geo', y: -600 }])
+		editor.updateShapes([{ id: ids.box4, y: -600 }])
 		editor.distributeShapes(editor.getSelectedShapeIds(), 'vertical')
 		jest.advanceTimersByTime(1000)
 
@@ -310,7 +310,7 @@ describe('When a shape is rotated', () => {
 			},
 		})
 
-		editor.updateShapes([{ id: ids.box2, type: 'geo', rotation: HALF_PI }])
+		editor.updateShapes([{ id: ids.box2, rotation: HALF_PI }])
 		editor.pointerMove(225, 350)
 
 		expect(bindings(arrowId)).toCloselyMatchObject({
@@ -430,7 +430,7 @@ describe('resizing', () => {
 		const arrow1 = editor.getCurrentPageShapes().at(-2)!
 		const arrow2 = editor.getCurrentPageShapes().at(-1)!
 
-		editor.updateShapes([{ id: arrow1.id, type: 'arrow', props: { bend: 50 } }])
+		editor.updateShapes([{ id: arrow1.id, props: { bend: 50 } }])
 
 		editor
 			.select(arrow1.id, arrow2.id)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -17,7 +17,7 @@ import {
 	TLHandle,
 	TLHandleDragInfo,
 	TLResizeInfo,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	TLShapeUtilCanBeLaidOutOpts,
 	TLShapeUtilCanBindOpts,
 	TLShapeUtilCanvasSvgDef,
@@ -231,7 +231,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		// Start or end, pointing the arrow...
 
-		const update: TLShapePartial<TLArrowShape> = { id: shape.id, type: 'arrow', props: {} }
+		const update: TLShapeUpdatePartial<TLArrowShape> = { id: shape.id, props: {} }
 
 		const currentBinding = bindings[handleId]
 
@@ -574,12 +574,11 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	override onDoubleClickHandle(
 		shape: TLArrowShape,
 		handle: TLHandle
-	): TLShapePartial<TLArrowShape> | void {
+	): TLShapeUpdatePartial<TLArrowShape> | void {
 		switch (handle.id) {
 			case ARROW_HANDLES.START: {
 				return {
 					id: shape.id,
-					type: shape.type,
 					props: {
 						...shape.props,
 						arrowheadStart: shape.props.arrowheadStart === 'none' ? 'arrow' : 'none',
@@ -589,7 +588,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			case ARROW_HANDLES.END: {
 				return {
 					id: shape.id,
-					type: shape.type,
 					props: {
 						...shape.props,
 						arrowheadEnd: shape.props.arrowheadEnd === 'none' ? 'arrow' : 'none',

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -7,7 +7,7 @@ import {
 	TLHighlightShape,
 	TLKeyboardEventInfo,
 	TLPointerEventInfo,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	Vec,
 	VecModel,
 	createShapeId,
@@ -222,16 +222,15 @@ export class Drawing extends StateNode {
 					this.currentLineLength = this.getLineLength(segments)
 				}
 
-				const shapePartial: TLShapePartial<DrawableShape> = {
+				const shapePartial: TLShapeUpdatePartial<DrawableShape> = {
 					id: shape.id,
-					type: this.shapeType,
 					props: {
 						segments,
 					},
 				}
 
 				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+					;(shapePartial as TLShapeUpdatePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
 						segments,
 						shape.props.size,
 						shape.props.scale
@@ -352,7 +351,7 @@ export class Drawing extends StateNode {
 						}
 					}
 
-					const shapePartial: TLShapePartial<DrawableShape> = {
+					const shapePartial: TLShapeUpdatePartial<DrawableShape> = {
 						id,
 						type: this.shapeType,
 						props: {
@@ -361,7 +360,7 @@ export class Drawing extends StateNode {
 					}
 
 					if (this.canClose()) {
-						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+						;(shapePartial as TLShapeUpdatePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
 							segments,
 							size,
 							scale
@@ -421,16 +420,15 @@ export class Drawing extends StateNode {
 						this.currentLineLength = this.getLineLength(finalSegments)
 					}
 
-					const shapePartial: TLShapePartial<DrawableShape> = {
+					const shapePartial: TLShapeUpdatePartial<DrawableShape> = {
 						id,
-						type: this.shapeType,
 						props: {
 							segments: finalSegments,
 						},
 					}
 
 					if (this.canClose()) {
-						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+						;(shapePartial as TLShapeUpdatePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
 							finalSegments,
 							size,
 							scale
@@ -563,16 +561,15 @@ export class Drawing extends StateNode {
 					points: [newSegment.points[0], newPoint],
 				}
 
-				const shapePartial: TLShapePartial<DrawableShape> = {
+				const shapePartial: TLShapeUpdatePartial<DrawableShape> = {
 					id,
-					type: this.shapeType,
 					props: {
 						segments: newSegments,
 					},
 				}
 
 				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+					;(shapePartial as TLShapeUpdatePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
 						segments,
 						size,
 						scale
@@ -611,7 +608,7 @@ export class Drawing extends StateNode {
 					this.currentLineLength = this.getLineLength(newSegments)
 				}
 
-				const shapePartial: TLShapePartial<DrawableShape> = {
+				const shapePartial: TLShapeUpdatePartial<DrawableShape> = {
 					id,
 					type: this.shapeType,
 					props: {
@@ -620,7 +617,7 @@ export class Drawing extends StateNode {
 				}
 
 				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+					;(shapePartial as TLShapeUpdatePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
 						newSegments,
 						size,
 						scale
@@ -631,7 +628,7 @@ export class Drawing extends StateNode {
 
 				// Set a maximum length for the lines array; after 200 points, complete the line.
 				if (newPoints.length > this.util.options.maxPointsPerShape) {
-					this.editor.updateShapes([{ id, type: this.shapeType, props: { isComplete: true } }])
+					this.editor.updateShapes([{ id, props: { isComplete: true } }])
 
 					const newShapeId = createShapeId()
 
@@ -707,9 +704,7 @@ export class Drawing extends StateNode {
 	complete() {
 		const { initialShape } = this
 		if (!initialShape) return
-		this.editor.updateShapes([
-			{ id: initialShape.id, type: initialShape.type, props: { isComplete: true } },
-		])
+		this.editor.updateShapes([{ id: initialShape.id, props: { isComplete: true } }])
 
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
@@ -30,13 +30,7 @@ export const FrameLabelInput = forwardRef<
 			const value = e.currentTarget.value.trim()
 			if (name === value) return
 
-			editor.updateShapes([
-				{
-					id,
-					type: 'frame',
-					props: { name: value },
-				},
-			])
+			editor.updateShapes([{ id, props: { name: value } }])
 		},
 		[id, editor]
 	)
@@ -50,13 +44,7 @@ export const FrameLabelInput = forwardRef<
 			const value = e.currentTarget.value
 			if (name === value) return
 
-			editor.updateShapes([
-				{
-					id,
-					type: 'frame',
-					props: { name: value },
-				},
-			])
+			editor.updateShapes([{ id, props: { name: value } }])
 		},
 		[id, editor]
 	)

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -11,7 +11,7 @@ import {
 	TLImageShape,
 	TLImageShapeProps,
 	TLResizeInfo,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	Vec,
 	WeakCache,
 	fetch,
@@ -171,9 +171,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 		const pointDelta = new Vec(crop.topLeft.x * w, crop.topLeft.y * h).rot(shape.rotation)
 
-		const partial: TLShapePartial<TLImageShape> = {
+		const partial: TLShapeUpdatePartial<TLImageShape> = {
 			id: shape.id,
-			type: shape.type,
 			x: shape.x - pointDelta.x,
 			y: shape.y - pointDelta.y,
 			props: {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
@@ -164,7 +164,6 @@ describe('Snapping', () => {
 	beforeEach(() => {
 		editor.updateShape({
 			id: id,
-			type: 'line',
 			props: {
 				points: {
 					a1: { id: 'a1', index: 'a1', x: 0, y: 0 },

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -76,7 +76,6 @@ export class Pointing extends StateNode {
 			this.editor.updateShapes([
 				{
 					id: this.shape.id,
-					type: this.shape.type,
 					props: {
 						points,
 					},

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -237,7 +237,6 @@ export function getNoteShapeForAdjacentPosition(
 
 		editor.updateShape({
 			id,
-			type: 'note',
 			x: topLeft.x,
 			y: topLeft.y,
 		})

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -135,7 +135,6 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 	editor.updateShapes([
 		{
 			id,
-			type: 'note',
 			x: newPoint.x,
 			y: newPoint.y,
 		},

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -86,7 +86,6 @@ export class Cropping extends StateNode {
 		this.editor.updateShapes([
 			{
 				id: shape.id,
-				type: shape.type,
 				...partial,
 			},
 		])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
@@ -1,4 +1,4 @@
-import { Editor, ShapeWithCrop, TLShapePartial, Vec, structuredClone } from '@tldraw/editor'
+import { Editor, ShapeWithCrop, TLShapeUpdatePartial, Vec, structuredClone } from '@tldraw/editor'
 import { getUncroppedSize } from '../../../../../shapes/shared/crop'
 
 export function getTranslateCroppedImageChange(editor: Editor, shape: ShapeWithCrop, delta: Vec) {
@@ -37,9 +37,8 @@ export function getTranslateCroppedImageChange(editor: Editor, shape: ShapeWithC
 	newCrop.bottomRight.x = newCrop.topLeft.x + xCrop
 	newCrop.bottomRight.y = newCrop.topLeft.y + yCrop
 
-	const partial: TLShapePartial<typeof shape> = {
+	const partial: TLShapeUpdatePartial<typeof shape> = {
 		id: shape.id,
-		type: shape.type,
 		props: {
 			crop: newCrop,
 		},

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -5,7 +5,7 @@ import {
 	TLLineShape,
 	TLPointerEventInfo,
 	TLShapeId,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	Vec,
 	snapAngle,
 	sortByIndex,
@@ -287,7 +287,7 @@ export class DraggingHandle extends StateNode {
 			initial: initial,
 		})
 
-		const next: TLShapePartial<any> = { id: shape.id, type: shape.type, ...changes }
+		const next: TLShapeUpdatePartial<any> = { id: shape.id, ...changes }
 
 		// Arrows
 		if (

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -10,7 +10,7 @@ import {
 	TLPointerEventInfo,
 	TLShape,
 	TLShapeId,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	TLTextShape,
 	TLTickEventInfo,
 	Vec,
@@ -150,7 +150,7 @@ export class Resizing extends StateNode {
 	private handleResizeStart() {
 		const { shapeSnapshots } = this.snapshot
 
-		const changes: TLShapePartial[] = []
+		const changes: TLShapeUpdatePartial[] = []
 
 		shapeSnapshots.forEach(({ shape }) => {
 			const util = this.editor.getShapeUtil(shape)
@@ -168,7 +168,7 @@ export class Resizing extends StateNode {
 	private handleResizeEnd() {
 		const { shapeSnapshots } = this.snapshot
 
-		const changes: TLShapePartial[] = []
+		const changes: TLShapeUpdatePartial[] = []
 
 		shapeSnapshots.forEach(({ shape }) => {
 			const current = this.editor.getShape(shape.id)!
@@ -372,7 +372,6 @@ export class Resizing extends StateNode {
 					for (const child of children) {
 						this.editor.updateShape({
 							id: child.id,
-							type: child.type,
 							x: child.x - delta.x,
 							y: child.y - delta.y,
 						})
@@ -387,7 +386,6 @@ export class Resizing extends StateNode {
 				for (const child of children) {
 					this.editor.updateShape({
 						id: child.id,
-						type: child.type,
 						x: child.x,
 						y: child.y,
 					})

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -8,7 +8,7 @@ import {
 	TLNoteShape,
 	TLPointerEventInfo,
 	TLShape,
-	TLShapePartial,
+	TLShapeUpdatePartial,
 	TLTickEventInfo,
 	Vec,
 	bind,
@@ -214,7 +214,7 @@ export class Translating extends StateNode {
 	protected handleStart() {
 		const { movingShapes } = this.snapshot
 
-		const changes: TLShapePartial[] = []
+		const changes: TLShapeUpdatePartial[] = []
 
 		movingShapes.forEach((shape) => {
 			const util = this.editor.getShapeUtil(shape)
@@ -249,7 +249,7 @@ export class Translating extends StateNode {
 			}
 		}
 
-		const changes: TLShapePartial[] = []
+		const changes: TLShapeUpdatePartial[] = []
 
 		movingShapes.forEach((shape) => {
 			const current = this.editor.getShape(shape.id)!
@@ -277,7 +277,7 @@ export class Translating extends StateNode {
 
 		const { movingShapes } = snapshot
 
-		const changes: TLShapePartial[] = []
+		const changes: TLShapeUpdatePartial[] = []
 
 		movingShapes.forEach((shape) => {
 			const current = this.editor.getShape(shape.id)!
@@ -510,7 +510,7 @@ export function moveShapesToPoint({
 
 	editor.updateShapes(
 		compact(
-			shapeSnapshots.map(({ shape, pagePoint, parentTransform }): TLShapePartial | null => {
+			shapeSnapshots.map(({ shape, pagePoint, parentTransform }): TLShapeUpdatePartial | null => {
 				const newPagePoint = Vec.Add(pagePoint, averageSnap)
 
 				const newLocalPoint = parentTransform
@@ -519,7 +519,6 @@ export function moveShapesToPoint({
 
 				return {
 					id: shape.id,
-					type: shape.type,
 					x: newLocalPoint.x,
 					y: newLocalPoint.y,
 				}

--- a/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/EditLinkDialog.tsx
@@ -98,9 +98,7 @@ export const EditLinkDialogInner = track(function EditLinkDialogInner({
 	const handleClear = useCallback(() => {
 		const onlySelectedShape = editor.getOnlySelectedShape()
 		if (!onlySelectedShape) return
-		editor.updateShapes([
-			{ id: onlySelectedShape.id, type: onlySelectedShape.type, props: { url: '' } },
-		])
+		editor.updateShapes([{ id: onlySelectedShape.id, props: { url: '' } }])
 		onClose()
 	}, [editor, onClose])
 
@@ -113,13 +111,7 @@ export const EditLinkDialogInner = track(function EditLinkDialogInner({
 		if (onlySelectedShape && 'url' in onlySelectedShape.props) {
 			// Here would be a good place to validate the next shape—would setting the empty
 			if (onlySelectedShape.props.url !== urlInputState.safe) {
-				editor.updateShapes([
-					{
-						id: onlySelectedShape.id,
-						type: onlySelectedShape.type,
-						props: { url: urlInputState.safe },
-					},
-				])
+				editor.updateShapes([{ id: onlySelectedShape.id, props: { url: urlInputState.safe } }])
 			}
 		}
 		onClose()

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -11,6 +11,7 @@ import {
 	TLGroupShape,
 	TLShapeId,
 	TLShapePartial,
+	TLShapeUpdatePartial,
 	TLTextShape,
 	Vec,
 	approximately,
@@ -274,7 +275,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							shapes.map((shape) => {
 								return {
 									id: shape.id,
-									type: shape.type,
 									props: {
 										...shape.props,
 										w: 8,
@@ -1237,10 +1237,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.unlock-all',
 				onSelect(source) {
 					trackEvent('unlock-all', { source })
-					const updates = [] as TLShapePartial[]
+					const updates = [] as TLShapeUpdatePartial[]
 					for (const shape of editor.getCurrentPageShapes()) {
 						if (shape.isLocked) {
-							updates.push({ id: shape.id, type: shape.type, isLocked: false })
+							updates.push({ id: shape.id, isLocked: false })
 						}
 					}
 					if (updates.length > 0) {

--- a/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
+++ b/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
@@ -354,7 +354,6 @@ export async function putExcalidrawContent(
 
 			return {
 				id: s.id,
-				type: s.type,
 				x: viewPortCenter.x + delta.x,
 				y: viewPortCenter.y + delta.y,
 			}

--- a/packages/tldraw/src/lib/utils/frames/frames.ts
+++ b/packages/tldraw/src/lib/utils/frames/frames.ts
@@ -1,4 +1,12 @@
-import { Box, Editor, TLFrameShape, TLShapeId, TLShapePartial, Vec, compact } from '@tldraw/editor'
+import {
+	Box,
+	Editor,
+	TLFrameShape,
+	TLShapeId,
+	TLShapeUpdatePartial,
+	Vec,
+	compact,
+} from '@tldraw/editor'
 
 /**
  * Remove a frame.
@@ -67,7 +75,7 @@ export function fitFrameToContent(editor: Editor, id: TLShapeId, opts = {} as { 
 
 	const diff = new Vec(dx, dy).rot(frame.rotation)
 	editor.run(() => {
-		const changes: TLShapePartial[] = childIds.map((child) => {
+		const changes: TLShapeUpdatePartial[] = childIds.map((child) => {
 			const shape = editor.getShape(child)!
 			return {
 				id: shape.id,

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -246,7 +246,6 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 								editor.updateShapes([
 									{
 										id: inCommon.id,
-										type: 'geo',
 										x: coerceNumber(shape.x) - (newW - w) / 2,
 										y: coerceNumber(shape.y) - (newH - h) / 2,
 										props: {
@@ -301,7 +300,6 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 								editor.updateShapes([
 									{
 										id: inCommon.id,
-										type: 'geo',
 										x: coerceNumber(shape.x) - (newW - w) / 2,
 										y: coerceNumber(shape.y) - (newH - h) / 2,
 										props: {
@@ -356,7 +354,6 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 								editor.updateShapes([
 									{
 										id: inCommon.id,
-										type: 'geo',
 										x: coerceNumber(shape.x) - (newW - w) / 2,
 										y: coerceNumber(shape.y) - (newH - h) / 2,
 										props: {

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -49,9 +49,9 @@ const moveShapesToPage2 = () => {
 	// directly maniuplate parentId like would happen in multiplayer situations
 
 	editor.updateShapes([
-		{ id: ids.box1, type: 'geo', parentId: ids.page2 },
-		{ id: ids.box2, type: 'geo', parentId: ids.page2 },
-		{ id: ids.group1, type: 'group', parentId: ids.page2 },
+		{ id: ids.box1, parentId: ids.page2 },
+		{ id: ids.box2, parentId: ids.page2 },
+		{ id: ids.group1, parentId: ids.page2 },
 	])
 }
 
@@ -753,22 +753,22 @@ describe('isShapeHidden', () => {
 
 	it('can be directly used via editor.isShapeHidden', () => {
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
 	})
 
 	it('excludes hidden shapes from the rendering shapes array', () => {
 		expect(editor.getRenderingShapes().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(editor.getRenderingShapes().length).toBe(2)
-		editor.updateShape({ id: ids.box2, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box2, meta: { hidden: true } })
 		expect(editor.getRenderingShapes().length).toBe(1)
 	})
 
 	it('excludes hidden shapes from hit testing', () => {
 		expect(editor.getShapeAtPoint({ x: 150, y: 150 })).toBeDefined()
 		expect(editor.getShapesAtPoint({ x: 150, y: 150 }).length).toBe(1)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(editor.getShapeAtPoint({ x: 150, y: 150 })).not.toBeDefined()
 		expect(editor.getShapesAtPoint({ x: 150, y: 150 }).length).toBe(0)
 	})
@@ -784,13 +784,13 @@ describe('isShapeHidden', () => {
 			renderingShapes = editor.getRenderingShapes()
 		})
 		expect(renderingShapes.length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(renderingShapes.length).toBe(2)
 		isFilteringEnabled.set(false)
 		expect(renderingShapes.length).toBe(3)
 		isFilteringEnabled.set(true)
 		expect(renderingShapes.length).toBe(2)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: false } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: false } })
 		expect(renderingShapes.length).toBe(3)
 	})
 
@@ -800,13 +800,13 @@ describe('isShapeHidden', () => {
 
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(false)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
-		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
+		editor.updateShape({ id: groupId, meta: { hidden: true } })
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
 	})
 
 	it('still allows hidden shapes to be selected', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		editor.select(ids.box1)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
@@ -814,13 +814,13 @@ describe('isShapeHidden', () => {
 
 	it('applies to getCurrentPageRenderingShapesSorted', () => {
 		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(2)
 	})
 
 	it('does not apply to getCurrentPageShapesSorted', () => {
 		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, meta: { hidden: true } })
 		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
 	})
 })

--- a/packages/tldraw/src/test/arrows-megabus.test.tsx
+++ b/packages/tldraw/src/test/arrows-megabus.test.tsx
@@ -234,8 +234,8 @@ describe('When shapes are overlapping', () => {
 
 	it('binds to the highest shape or to the first filled shape', () => {
 		editor.updateShapes([
-			{ id: ids.box1, type: 'geo', props: { fill: 'solid' } },
-			{ id: ids.box3, type: 'geo', props: { fill: 'solid' } },
+			{ id: ids.box1, props: { fill: 'solid' } },
+			{ id: ids.box3, props: { fill: 'solid' } },
 		])
 		editor.setCurrentTool('arrow')
 		editor.pointerDown(0, 50) // over nothing
@@ -480,7 +480,7 @@ describe('When starting an arrow inside of multiple shapes', () => {
 	it('starts a filled shape if it is above the hollow shape', () => {
 		// box2 - small, hollow
 		// box1 - big, filled
-		editor.updateShape({ id: ids.box1, type: 'geo', props: { fill: 'solid' } })
+		editor.updateShape({ id: ids.box1, props: { fill: 'solid' } })
 		editor.bringToFront([ids.box1])
 
 		expect(
@@ -526,7 +526,7 @@ describe('When starting an arrow inside of multiple shapes', () => {
 	it('starts a small hollow shape if it is above the bigger filled shape', () => {
 		// box1 - big, hollow
 		// box2 - small, filled
-		editor.updateShape({ id: ids.box2, type: 'geo', props: { fill: 'solid' } })
+		editor.updateShape({ id: ids.box2, props: { fill: 'solid' } })
 		editor.bringToFront([ids.box2])
 
 		editor.setCurrentTool('arrow')

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -418,13 +418,7 @@ test('onAfterChangeFromShape is called after the from shape is updated', () => {
 			foo: 'bar',
 		})
 	})
-	editor.updateShapes([
-		{
-			id: ids.box1,
-			type: 'geo',
-			meta: { foo: 'bar' },
-		},
-	])
+	editor.updateShapes([{ id: ids.box1, meta: { foo: 'bar' } }])
 	expect(editor.getShape(ids.box1)?.meta).toEqual({
 		foo: 'bar',
 	})
@@ -440,13 +434,7 @@ test('onAfterChangeToShape is called after the to shape is updated', () => {
 			foo: 'bar',
 		})
 	})
-	editor.updateShapes([
-		{
-			id: ids.box2,
-			type: 'geo',
-			meta: { foo: 'bar' },
-		},
-	])
+	editor.updateShapes([{ id: ids.box2, meta: { foo: 'bar' } }])
 	expect(editor.getShape(ids.box2)?.meta).toEqual({
 		foo: 'bar',
 	})

--- a/packages/tldraw/src/test/commands/alignShapes.test.tsx
+++ b/packages/tldraw/src/test/commands/alignShapes.test.tsx
@@ -111,21 +111,9 @@ describe('when multiple shapes are selected', () => {
 
 	it('aligns center, when shapes are rotated', () => {
 		editor.updateShapes([
-			{
-				id: ids.boxA,
-				type: 'geo',
-				rotation: PI,
-			},
-			{
-				id: ids.boxB,
-				type: 'geo',
-				rotation: PI,
-			},
-			{
-				id: ids.boxC,
-				type: 'geo',
-				rotation: PI,
-			},
+			{ id: ids.boxA, rotation: PI },
+			{ id: ids.boxB, rotation: PI },
+			{ id: ids.boxC, rotation: PI },
 		])
 
 		editor.alignShapes(editor.getSelectedShapeIds(), 'center-vertical')
@@ -150,21 +138,9 @@ describe('when multiple shapes are selected', () => {
 
 	it('aligns top-left, when shapes are rotated', () => {
 		editor.updateShapes([
-			{
-				id: ids.boxA,
-				type: 'geo',
-				rotation: 0.2,
-			},
-			{
-				id: ids.boxB,
-				type: 'geo',
-				rotation: 0.4,
-			},
-			{
-				id: ids.boxC,
-				type: 'geo',
-				rotation: 0.6,
-			},
+			{ id: ids.boxA, rotation: 0.2 },
+			{ id: ids.boxB, rotation: 0.4 },
+			{ id: ids.boxC, rotation: 0.6 },
 		])
 
 		editor.alignShapes(editor.getSelectedShapeIds(), 'top')
@@ -189,21 +165,9 @@ describe('when multiple shapes are selected', () => {
 
 	it('aligns bottom-right, when shapes are rotated', () => {
 		editor.updateShapes([
-			{
-				id: ids.boxA,
-				type: 'geo',
-				rotation: 0.2,
-			},
-			{
-				id: ids.boxB,
-				type: 'geo',
-				rotation: 0.4,
-			},
-			{
-				id: ids.boxC,
-				type: 'geo',
-				rotation: 0.6,
-			},
+			{ id: ids.boxA, rotation: 0.2 },
+			{ id: ids.boxB, rotation: 0.4 },
+			{ id: ids.boxC, rotation: 0.6 },
 		])
 
 		editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC])

--- a/packages/tldraw/src/test/commands/allShapesCommonBounds.test.ts
+++ b/packages/tldraw/src/test/commands/allShapesCommonBounds.test.ts
@@ -15,7 +15,6 @@ it('gets common bounds', () => {
 	editor.updateShapes([
 		{
 			id: defaultShapesIds.box1,
-			type: 'geo',
 			rotation: 0,
 			x: 0,
 			y: 0,
@@ -23,7 +22,6 @@ it('gets common bounds', () => {
 		},
 		{
 			id: defaultShapesIds.box2,
-			type: 'geo',
 			rotation: 0,
 			x: 300,
 			y: 300,
@@ -31,7 +29,6 @@ it('gets common bounds', () => {
 		},
 		{
 			id: defaultShapesIds.ellipse1,
-			type: 'geo',
 			rotation: 0,
 			x: 100,
 			y: 500,
@@ -75,7 +72,6 @@ it('gets common bounds', () => {
 	editor.updateShapes([
 		{
 			id: defaultShapesIds.box2,
-			type: 'geo',
 			rotation: 0,
 			x: 50,
 			y: 50,

--- a/packages/tldraw/src/test/commands/clipboard.test.ts
+++ b/packages/tldraw/src/test/commands/clipboard.test.ts
@@ -456,7 +456,6 @@ describe('When copying and pasting', () => {
 			.updateShapes([
 				{
 					id: editor.getCurrentPageShapes()[2].id,
-					type: 'group',
 					x: 400,
 					y: 400,
 				},

--- a/packages/tldraw/src/test/commands/distributeShapes.test.tsx
+++ b/packages/tldraw/src/test/commands/distributeShapes.test.tsx
@@ -67,7 +67,7 @@ describe('distributeShapes command', () => {
 		})
 
 		it('distributeShapes horizontally when shapes are clustered', () => {
-			editor.updateShapes([{ id: ids.boxC, type: 'geo', x: 25 }])
+			editor.updateShapes([{ id: ids.boxC, x: 25 }])
 			editor.selectAll()
 			editor.distributeShapes(editor.getSelectedShapeIds(), 'horizontal')
 			jest.advanceTimersByTime(1000)
@@ -90,7 +90,7 @@ describe('distributeShapes command', () => {
 		})
 
 		it('distributeShapes vertically when shapes are clustered', () => {
-			editor.updateShapes([{ id: ids.boxC, type: 'geo', y: 25 }])
+			editor.updateShapes([{ id: ids.boxC, y: 25 }])
 			editor.selectAll()
 			editor.distributeShapes(editor.getSelectedShapeIds(), 'vertical')
 			jest.advanceTimersByTime(1000)

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -99,7 +99,7 @@ describe('Locked shapes', () => {
 
 	it('Cannot be changed', () => {
 		const xBefore = editor.getShape(ids.lockedShapeA)!.x
-		editor.updateShapes([{ id: ids.lockedShapeA, type: 'geo', x: 100 }])
+		editor.updateShapes([{ id: ids.lockedShapeA, x: 100 }])
 		expect(editor.getShape(ids.lockedShapeA)!.x).toBe(xBefore)
 	})
 
@@ -188,7 +188,7 @@ describe('When forced', () => {
 	it('Can be changed', () => {
 		editor.run(
 			() => {
-				editor.updateShapes([{ id: ids.lockedShapeA, type: 'geo', x: 100 }])
+				editor.updateShapes([{ id: ids.lockedShapeA, x: 100 }])
 				expect(editor.getShape(ids.lockedShapeA)!.x).toBe(100)
 			},
 			{ ignoreShapeLock: true }

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -134,7 +134,7 @@ describe('When a shape is rotated...', () => {
 		// Rotate boxB by 90 degrees and move it to 0,0 for simplicity's sake
 		editor.select(ids.boxB)
 		editor.rotateShapesBy([ids.boxB], Math.PI / 2)
-		editor.updateShapes([{ id: ids.boxB, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+		editor.updateShapes([{ id: ids.boxB, x: 0, y: 0, props: { w: 100, h: 100 } }])
 		// Make box A a child of box B
 		editor.reparentShapes([ids.boxA], ids.boxB)
 		// editor.updateShapes([{ id: ids.boxB, type: 'geo', x: 10, y: 10 }])
@@ -241,12 +241,11 @@ describe('When undo redo is on...', () => {
 describe('When nudging a rotated shape...', () => {
 	it('Moves the page point correctly', () => {
 		editor.setSelectedShapes([ids.boxA])
-		const shapeA = editor.getShape(ids.boxA)!
 
-		editor.updateShapes([{ id: ids.boxA, type: shapeA.type, rotation: 90 }])
+		editor.updateShapes([{ id: ids.boxA, rotation: 90 }])
 		expect(nudgeAndGet([ids.boxA], 'ArrowRight', false)).toMatchObject([{ x: 11, y: 10 }])
 
-		editor.updateShapes([{ id: ids.boxA, type: shapeA.type, rotation: -90 }])
+		editor.updateShapes([{ id: ids.boxA, rotation: -90 }])
 		expect(nudgeAndGet([ids.boxA], 'ArrowDown', false)).toMatchObject([{ x: 11, y: 11 }])
 	})
 })
@@ -273,16 +272,8 @@ describe('When nudging multiple rotated shapes...', () => {
 		])
 
 		editor.updateShapes([
-			{
-				id: shapeA.id,
-				type: shapeA.type,
-				rotation: -90,
-			},
-			{
-				id: shapeB.id,
-				type: shapeB.type,
-				rotation: 90,
-			},
+			{ id: shapeA.id, rotation: -90 },
+			{ id: shapeB.id, rotation: 90 },
 		])
 		expect(nudgeAndGet([ids.boxA, ids.boxB], 'ArrowDown', false)).toMatchObject([
 			{ x: 11, y: 11 },

--- a/packages/tldraw/src/test/commands/packShapes.test.ts
+++ b/packages/tldraw/src/test/commands/packShapes.test.ts
@@ -66,7 +66,7 @@ describe('editor.packShapes', () => {
 	})
 
 	it('packs rotated shapes', () => {
-		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: Math.PI }])
+		editor.updateShapes([{ id: ids.boxA, rotation: Math.PI }])
 		editor.selectAll().packShapes(editor.getSelectedShapeIds(), 16)
 		jest.advanceTimersByTime(1000)
 		expect(

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -144,7 +144,7 @@ describe('distributeShapes command', () => {
 		})
 
 		it('stacks the shapes based on the average', () => {
-			editor.updateShapes([{ id: ids.boxD, type: 'geo', x: 540, y: 700 }])
+			editor.updateShapes([{ id: ids.boxD, x: 540, y: 700 }])
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 0)
 			jest.advanceTimersByTime(1000)
@@ -227,7 +227,7 @@ describe('distributeShapes command', () => {
 		})
 
 		it('stacks the shapes based on the average', () => {
-			editor.updateShapes([{ id: ids.boxD, type: 'geo', x: 700, y: 540 }])
+			editor.updateShapes([{ id: ids.boxD, x: 700, y: 540 }])
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'vertical', 0)
 			jest.advanceTimersByTime(1000)

--- a/packages/tldraw/src/test/commands/updateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/updateShapes.test.ts
@@ -16,13 +16,7 @@ beforeEach(() => {
 it('Uses typescript generics', () => {
 	expect(() => {
 		// No error here because no generic, the editor doesn't know what this guy is
-		editor.updateShapes([
-			{
-				id: ids.box1,
-				type: 'geo',
-				props: { w: 'OH NO' },
-			},
-		])
+		editor.updateShapes([{ id: ids.box1, props: { w: 'OH NO' } }])
 
 		// Yep error here because we are giving the wrong props to the shape
 		editor.updateShapes<TLGeoShape>([
@@ -82,14 +76,7 @@ it('Uses typescript generics', () => {
 
 it('updates shapes', () => {
 	editor.markHistoryStoppingPoint('update shapes')
-	editor.updateShapes([
-		{
-			id: ids.box1,
-			type: 'geo',
-			x: 200,
-			y: 200,
-		},
-	])
+	editor.updateShapes([{ id: ids.box1, x: 200, y: 200 }])
 
 	expect(editor.getShape(ids.box1)).toMatchObject({
 		x: 200,
@@ -149,9 +136,7 @@ it('updates shapes', () => {
 
 describe('When a shape has a different shape as a parent...', () => {
 	it("Prevents updateShapes from updating a shape's parentId", () => {
-		editor.updateShapes([
-			{ id: ids.ellipse1, type: 'geo', parentId: ids.box1, props: { geo: 'ellipse' } },
-		])
+		editor.updateShapes([{ id: ids.ellipse1, parentId: ids.box1, props: { geo: 'ellipse' } }])
 	})
 })
 
@@ -164,14 +149,14 @@ it('Throws out all shapes if any update is invalid', () => {
 	])
 
 	expect(() => {
-		editor.updateShapes([{ id: ids.box1, type: 'geo', x: 100, y: 0 }])
+		editor.updateShapes([{ id: ids.box1, x: 100, y: 0 }])
 	}).not.toThrow()
 
 	expect(() => {
 		editor.updateShapes([
-			{ id: ids.box1, type: 'geo', x: 200 },
+			{ id: ids.box1, x: 200 },
 			// @ts-expect-error
-			{ id: ids.ellipse1, type: 'geo', x: 'two hundred' }, // invalid x
+			{ id: ids.ellipse1, x: 'two hundred' }, // invalid x
 		])
 	}).toThrow()
 

--- a/packages/tldraw/src/test/commands/zoomToSelection.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToSelection.test.ts
@@ -20,14 +20,14 @@ it('zooms to selection bounds', () => {
 })
 
 it('does not zoom past max', () => {
-	editor.updateShapes([{ id: ids.box1, type: 'geo', props: { w: 1, h: 1 } }])
+	editor.updateShapes([{ id: ids.box1, props: { w: 1, h: 1 } }])
 	editor.select(ids.box1)
 	editor.zoomToSelection()
 	expect(editor.getZoomLevel()).toBe(1) // double check again when we're zooming in hard
 })
 
 it('does not zoom past min', () => {
-	editor.updateShapes([{ id: ids.box1, type: 'geo', props: { w: 100000, h: 100000 } }])
+	editor.updateShapes([{ id: ids.box1, props: { w: 100000, h: 100000 } }])
 	editor.select(ids.box1)
 	editor.zoomToSelection()
 	expect(editor.getZoomLevel()).toBe(0.05)

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -98,7 +98,6 @@ describe('When in the select.idle state', () => {
 
 		editor.updateShape({
 			id: ids.imageB,
-			type: 'image',
 			props: {
 				crop: { topLeft: { x: 0.1, y: 0.1 }, bottomRight: { x: 0.9, y: 0.9 } },
 			},

--- a/packages/tldraw/src/test/flipShapes.test.ts
+++ b/packages/tldraw/src/test/flipShapes.test.ts
@@ -106,7 +106,7 @@ describe('When flipping horizontally', () => {
 	})
 
 	it('Flips rotated shapes', () => {
-		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
+		editor.updateShapes([{ id: ids.boxA, rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
 		const a = editor.getSelectionPageBounds()
 		editor.markHistoryStoppingPoint('flipped')
@@ -131,7 +131,7 @@ describe('When flipping horizontally', () => {
 
 	it('Flips the children of rotated shapes', () => {
 		editor.reparentShapes([ids.boxB], ids.boxA)
-		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
+		editor.updateShapes([{ id: ids.boxA, rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
 		const a = editor.getSelectionPageBounds()
 		editor.markHistoryStoppingPoint('flipped')
@@ -186,7 +186,7 @@ describe('When flipping vertically', () => {
 	})
 
 	it('Flips rotated shapes', () => {
-		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
+		editor.updateShapes([{ id: ids.boxA, rotation: PI }])
 		editor.select(ids.boxA, ids.boxB)
 		const a = editor.getSelectionPageBounds()
 		editor.markHistoryStoppingPoint('flipped')
@@ -210,7 +210,7 @@ describe('When flipping vertically', () => {
 
 	it('Flips the children of rotated shapes', () => {
 		editor.reparentShapes([ids.boxB], ids.boxA)
-		editor.updateShapes([{ id: ids.boxA, type: 'geo', rotation: PI }])
+		editor.updateShapes([{ id: ids.boxA, rotation: PI }])
 		editor.select(ids.boxB, ids.boxC)
 		const a = editor.getSelectionPageBounds()
 		editor.markHistoryStoppingPoint('flipped')

--- a/packages/tldraw/src/test/getCulledShapes.test.tsx
+++ b/packages/tldraw/src/test/getCulledShapes.test.tsx
@@ -196,8 +196,8 @@ it('works for shapes that are outside of the viewport, but are then moved inside
 
 	// Move box1 and box2 inside the viewport
 	editor.updateShapes([
-		{ id: box1Id, type: 'geo', x: 100 },
-		{ id: box2Id, type: 'geo', x: 200 },
+		{ id: box1Id, x: 100 },
+		{ id: box2Id, x: 200 },
 	])
 	// Arrow should also not be culled
 	expect(editor.getCulledShapes()).toEqual(new Set())

--- a/packages/tldraw/src/test/groups.test.ts
+++ b/packages/tldraw/src/test/groups.test.ts
@@ -719,7 +719,7 @@ describe('the bounds of a rotated group', () => {
 		editor.select(ids.boxA, ids.boxB, ids.boxC)
 		editor.groupShapes(editor.getSelectedShapeIds())
 		const group = onlySelectedShape()
-		editor.updateShapes([{ id: group.id, type: 'group', rotation: Math.PI / 2, x: 10, y: 0 }])
+		editor.updateShapes([{ id: group.id, rotation: Math.PI / 2, x: 10, y: 0 }])
 
 		expect(editor.getShapePageBounds(group.id)!).toCloselyMatchObject({
 			x: 0,
@@ -759,7 +759,7 @@ describe('the bounds of a rotated group', () => {
 		editor.select(ids.boxA, ids.boxB, ids.boxC)
 		editor.groupShapes(editor.getSelectedShapeIds())
 		const group = onlySelectedShape()
-		editor.updateShapes([{ id: group.id, type: 'group', rotation: Math.PI / 2, x: 10, y: 0 }])
+		editor.updateShapes([{ id: group.id, rotation: Math.PI / 2, x: 10, y: 0 }])
 
 		expect(editor.getShapePageBounds(group.id)!).toCloselyMatchObject({
 			x: 0,
@@ -1974,7 +1974,7 @@ describe('Grouping / ungrouping locked shapes', () => {
 		editor.select(ids.boxA)
 
 		// Lock boxA
-		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+		editor.updateShape({ id: ids.boxA, isLocked: true })
 
 		// Select the group; when we ungroup, the children should be selected
 		editor.select(ids.groupA)

--- a/packages/tldraw/src/test/parentsToChildrenWithIndexes.test.ts
+++ b/packages/tldraw/src/test/parentsToChildrenWithIndexes.test.ts
@@ -30,12 +30,12 @@ describe('parentsToChildrenWithIndexes', () => {
 		expect(editor.getSortedChildIdsForParent(ids.box1)).toEqual([ids.box3])
 		expect(editor.getSortedChildIdsForParent(ids.box2)).toEqual([])
 
-		editor.updateShapes([{ id: ids.box3, type: 'geo', parentId: ids.box2 }])
+		editor.updateShapes([{ id: ids.box3, parentId: ids.box2 }])
 
 		expect(editor.getSortedChildIdsForParent(ids.box1)).toEqual([])
 		expect(editor.getSortedChildIdsForParent(ids.box2)).toEqual([ids.box3])
 
-		editor.updateShapes([{ id: ids.box1, type: 'geo', parentId: ids.box2 }])
+		editor.updateShapes([{ id: ids.box1, parentId: ids.box2 }])
 
 		expect(editor.getSortedChildIdsForParent(ids.box2)).toEqual([ids.box3, ids.box1])
 	})
@@ -70,7 +70,6 @@ describe('parentsToChildrenWithIndexes', () => {
 		editor.updateShapes([
 			{
 				id: ids.box1,
-				type: 'geo',
 				index: getIndexBetween(editor.getShape(ids.box2)!.index, editor.getShape(ids.box3)!.index),
 			},
 		])
@@ -80,9 +79,7 @@ describe('parentsToChildrenWithIndexes', () => {
 			ids.box3,
 		])
 
-		editor.updateShapes([
-			{ id: ids.box2, type: 'geo', index: getIndexAbove(editor.getShape(ids.box3)!.index) },
-		])
+		editor.updateShapes([{ id: ids.box2, index: getIndexAbove(editor.getShape(ids.box3)!.index) }])
 
 		expect(editor.getSortedChildIdsForParent(editor.getCurrentPageId())).toEqual([
 			ids.box1,
@@ -103,14 +100,7 @@ describe('parentsToChildrenWithIndexes', () => {
 		const box3Index = editor.getShape(ids.box3)!.index
 		const box4Index = getIndexBetween(box2Index, box3Index)
 
-		editor.updateShapes([
-			{
-				id: ids.box4,
-				type: 'geo',
-				parentId: ids.box1,
-				index: box4Index,
-			},
-		])
+		editor.updateShapes([{ id: ids.box4, parentId: ids.box1, index: box4Index }])
 
 		expect(editor.getSortedChildIdsForParent(ids.box1)).toEqual([ids.box2, ids.box4, ids.box3])
 	})

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -405,7 +405,6 @@ describe('When pasting into frames...', () => {
 			.updateShapes([
 				{
 					id: ids.frame2,
-					type: 'frame',
 					x: 50,
 					y: 50,
 					props: {

--- a/packages/tldraw/src/test/perf/perf.test.ts
+++ b/packages/tldraw/src/test/perf/perf.test.ts
@@ -1,4 +1,4 @@
-import { TLShapePartial, Vec, createShapeId } from '@tldraw/editor'
+import { TLShapePartial, TLShapeUpdatePartial, Vec, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 import { PerformanceMeasurer } from './PerformanceMeasurer'
 
@@ -81,7 +81,6 @@ describe.skip('Example perf tests', () => {
 			.add(() => {
 				for (let i = 0; i < 200; i++) {
 					editor.updateShape({
-						type: 'geo',
 						id: ids[i],
 						x: (i % 10) * 220 + 1,
 						props: {
@@ -111,11 +110,10 @@ describe.skip('Example perf tests', () => {
 				}
 			})
 			.add(() => {
-				const shapesToUpdate: TLShapePartial[] = []
+				const shapesToUpdate: TLShapeUpdatePartial[] = []
 				for (let i = 0; i < 200; i++) {
 					shapesToUpdate.push({
 						id: ids[i],
-						type: 'geo',
 						x: (i % 10) * 220 + 1,
 						props: {
 							w: 201,

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -300,7 +300,6 @@ describe('When resizing mulitple shapes...', () => {
 			editor.updateShapes([
 				{
 					id: ids.boxA,
-					type: 'geo',
 					x,
 					y,
 					rotation,
@@ -308,7 +307,6 @@ describe('When resizing mulitple shapes...', () => {
 				{
 					id: ids.boxB,
 					parentId: ids.boxA,
-					type: 'geo',
 					x: 100,
 					y: 100,
 					rotation: rotationB,
@@ -316,7 +314,6 @@ describe('When resizing mulitple shapes...', () => {
 				{
 					id: ids.boxC,
 					parentId: ids.boxA,
-					type: 'geo',
 					x: 200,
 					y: 200,
 					rotation: rotationB,
@@ -815,7 +812,6 @@ describe('When resizing a shape with children', () => {
 			.updateShapes([
 				{
 					id: ids.boxC,
-					type: 'geo',
 					parentId: ids.boxB,
 				},
 			])
@@ -850,7 +846,6 @@ describe('When resizing a shape with children', () => {
 			.updateShapes([
 				{
 					id: ids.boxA,
-					type: 'geo',
 					rotation: Math.PI,
 				},
 			])
@@ -880,14 +875,12 @@ describe('When resizing a shape with children', () => {
 			.updateShapes([
 				{
 					id: ids.boxA,
-					type: 'geo',
 					rotation: 0,
 					x: 10,
 					y: 10,
 				},
 				{
 					id: ids.boxB,
-					type: 'geo',
 					parentId: ids.boxA,
 					rotation: 0,
 					x: 0,
@@ -3452,16 +3445,14 @@ describe('resizing a selection of mixed rotations', () => {
 		expect(roundedPageBounds(ids.boxD)).toMatchObject({ x: 0, y: 20, w: 20, h: 5 })
 	})
 	it('does lock the aspect ratio if the rotations are not compatible', () => {
-		editor.updateShapes([{ id: ids.boxC, type: 'geo', rotation: Math.PI + Math.PI / 180 }])
+		editor.updateShapes([{ id: ids.boxC, rotation: Math.PI + Math.PI / 180 }])
 		editor.select(ids.boxA, ids.boxB, ids.boxC, ids.boxD)
 		editor.pointerDown(50, 50, { target: 'selection', handle: 'bottom_right' }).pointerMove(100, 25)
 		expect(roundedPageBounds(ids.boxA, 0.5)).toMatchObject({ x: 0, y: 0, w: 20, h: 20 })
 	})
 
 	it('does lock the aspect ratio if one of the shapes has a child with an incompatible aspect ratio', () => {
-		editor.updateShapes([
-			{ id: ids.boxC, type: 'geo', rotation: Math.PI + Math.PI / 180, parentId: ids.boxA },
-		])
+		editor.updateShapes([{ id: ids.boxC, rotation: Math.PI + Math.PI / 180, parentId: ids.boxA }])
 
 		editor.select(ids.boxA, ids.boxB, ids.boxD)
 		editor.pointerDown(50, 50, { target: 'selection', handle: 'bottom_right' }).pointerMove(100, 25)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -105,7 +105,7 @@ describe('Hovering shapes', () => {
 	})
 
 	it('hovers the margins or inside of filled shapes', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', props: { fill: 'solid' } })
+		editor.updateShape({ id: ids.box1, props: { fill: 'solid' } })
 		expect(editor.getHoveredShapeId()).toBe(null)
 		editor.pointerMove(-4, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
@@ -293,7 +293,7 @@ describe('when shape is hollow', () => {
 	})
 
 	it('missed on the label when the shape is locked', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', isLocked: true })
+		editor.updateShape({ id: ids.box1, isLocked: true })
 		editor.pointerMove(-100, -100)
 		expect(editor.getHoveredShapeId()).toBe(null)
 		expect(editor.getSelectedShapeIds()).toEqual([])
@@ -578,7 +578,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('misses on pointer down over shape, misses on pointer up on the edge when locked', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', isLocked: true })
+		editor.updateShape({ id: ids.box1, isLocked: true })
 		editor.pointerMove(25, 25)
 		editor.pointerDown() // on the edge of box1 (which is empty)
 		expect(editor.getSelectedShapeIds()).toEqual([])
@@ -587,7 +587,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('misses on pointer down over shape, misses on pointer up when locked', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', isLocked: true })
+		editor.updateShape({ id: ids.box1, isLocked: true })
 		editor.pointerMove(50, 50)
 		editor.pointerDown() // on the edge of box1 (which is empty)
 		expect(editor.getSelectedShapeIds()).toEqual([])
@@ -596,7 +596,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('misses on pointer down over shape label, misses on pointer up when locked', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', isLocked: true })
+		editor.updateShape({ id: ids.box1, isLocked: true })
 		editor.pointerMove(75, 75)
 		editor.pointerDown() // on the edge of box1 (which is empty)
 		expect(editor.getSelectedShapeIds()).toEqual([])

--- a/packages/tldraw/src/test/styles2.test.tsx
+++ b/packages/tldraw/src/test/styles2.test.tsx
@@ -67,7 +67,6 @@ describe('Editor.styles', () => {
 		editor.updateShapes([
 			{
 				id: defaultShapesIds.box1,
-				type: 'geo',
 				props: { h: 200, w: 200, color: 'red', dash: 'solid' },
 			},
 		])
@@ -132,14 +131,7 @@ describe('Editor.styles', () => {
 		const initialStyles = editor.getSharedStyles()
 
 		// update position of one of the shapes - not a style prop, so maps to same styles
-		editor.updateShapes([
-			{
-				id: defaultShapesIds.box1,
-				type: 'geo',
-				x: 1000,
-				y: 1000,
-			},
-		])
+		editor.updateShapes([{ id: defaultShapesIds.box1, x: 1000, y: 1000 }])
 
 		expect(editor.getSharedStyles()).toBe(initialStyles)
 	})

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -297,7 +297,7 @@ describe('When cloning...', () => {
 	})
 
 	it('clones a parent and its descendants and removes descendants when stopping cloning', () => {
-		editor.updateShapes([{ id: ids.line1, type: 'geo', parentId: ids.box2 }])
+		editor.updateShapes([{ id: ids.line1, parentId: ids.box2 }])
 		expect(editor.getShape(ids.line1)!.parentId).toBe(ids.box2)
 		editor.select(ids.box2).pointerDown(250, 250, ids.box2).pointerMove(250, 240) // [0, -10]
 
@@ -620,23 +620,21 @@ describe('snapping with single shapes', () => {
 
 	it('does not snap to shapes that are not visible in the viewport', () => {
 		// move A off screen
-		editor.updateShapes([{ id: ids.box1, type: 'geo', x: -20 }])
+		editor.updateShapes([{ id: ids.box1, x: -20 }])
 
 		editor.pointerDown(25, 5, ids.box2).pointerMove(36, 5, { ctrlKey: true })
 		expect(editor.snaps.getIndicators()!.length).toBe(0)
 
-		editor.updateShapes([{ id: ids.box1, type: 'geo', x: editor.getViewportScreenBounds().w + 10 }])
+		editor.updateShapes([{ id: ids.box1, x: editor.getViewportScreenBounds().w + 10 }])
 		editor.pointerMove(33, 5, { ctrlKey: true })
 
 		expect(editor.snaps.getIndicators()!.length).toBe(0)
-		editor.updateShapes([{ id: ids.box1, type: 'geo', y: -20 }])
+		editor.updateShapes([{ id: ids.box1, y: -20 }])
 
 		editor.pointerMove(5, 5, { ctrlKey: true })
 		expect(editor.snaps.getIndicators()!.length).toBe(0)
 
-		editor.updateShapes([
-			{ id: ids.box1, type: 'geo', x: 0, y: editor.getViewportScreenBounds().h + 10 },
-		])
+		editor.updateShapes([{ id: ids.box1, x: 0, y: editor.getViewportScreenBounds().h + 10 }])
 
 		editor.pointerMove(5, 5, { ctrlKey: true })
 		expect(editor.snaps.getIndicators()!.length).toBe(0)
@@ -649,7 +647,7 @@ describe('snapping with single shapes', () => {
 		// └──────┘
 
 		// move B up one pixel
-		editor.updateShapes([{ id: ids.box2, type: 'geo', y: editor.getShape(ids.box2)!.y - 1 }])
+		editor.updateShapes([{ id: ids.box2, y: editor.getShape(ids.box2)!.y - 1 }])
 
 		editor.pointerDown(25, 5, ids.box2).pointerMove(36, 5, { ctrlKey: true })
 
@@ -679,7 +677,7 @@ describe('snapping with single shapes', () => {
 		//  └──────┘                 ▼
 
 		// move B into place
-		editor.updateShapes([{ id: ids.box2, type: 'geo', x: 1, y: 20 }])
+		editor.updateShapes([{ id: ids.box2, x: 1, y: 20 }])
 
 		editor.pointerDown(6, 25, ids.box2).pointerMove(6, 35, { ctrlKey: true })
 
@@ -1593,7 +1591,7 @@ describe('translating a shape with a child', () => {
 		// │                   │
 		// └───────────────────┘
 		editor.createShapes([box(ids.box1, 0, 0, 50, 50), box(ids.box2, 1, 1)])
-		editor.updateShapes([{ id: ids.box2, type: 'geo', parentId: ids.box1 }])
+		editor.updateShapes([{ id: ids.box2, parentId: ids.box1 }])
 
 		editor.pointerDown(25, 25, ids.box1).pointerMove(50, 25, { ctrlKey: true })
 

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -1450,6 +1450,13 @@ export type TLShapePartial<T extends TLShape = TLShape> = T extends T ? {
 } & Partial<Omit<T, 'id' | 'meta' | 'props' | 'type'>> : never;
 
 // @public (undocumented)
+export type TLShapeUpdatePartial<T extends TLShape = TLShape> = T extends T ? {
+    id: TLShapeId;
+    meta?: Partial<T['meta']>;
+    props?: Partial<T['props']>;
+} & Partial<Omit<T, 'id' | 'meta' | 'props'>> : never;
+
+// @public (undocumented)
 export type TLStore = Store<TLRecord, TLStoreProps>;
 
 // @public (undocumented)

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -126,6 +126,7 @@ export {
 	type TLShape,
 	type TLShapeId,
 	type TLShapePartial,
+	type TLShapeUpdatePartial,
 	type TLUnknownShape,
 } from './records/TLShape'
 export {

--- a/packages/tlschema/src/records/TLShape.ts
+++ b/packages/tlschema/src/records/TLShape.ts
@@ -70,6 +70,15 @@ export type TLShapePartial<T extends TLShape = TLShape> = T extends T
 	: never
 
 /** @public */
+export type TLShapeUpdatePartial<T extends TLShape = TLShape> = T extends T
+	? {
+			id: TLShapeId
+			props?: Partial<T['props']>
+			meta?: Partial<T['meta']>
+		} & Partial<Omit<T, 'id' | 'props' | 'meta'>>
+	: never
+
+/** @public */
 export type TLShapeId = RecordId<TLUnknownShape>
 
 /** @public */


### PR DESCRIPTION
- Adds a new type `TLShapeUpdatePartial` which is just a copy of `TLShapePartial` `type` is optional.
- Updates all code that previously used `TLShapePartial` in updateShape codepaths to use `TLShapeUpdatePartial`.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Make the `type` property optional when calling `updateShape`, `updateShapes`, `animateShape`, and `animateShapes`.