### PR TITLE
Reactive inputs

### DIFF
--- a/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch
+++ b/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/build/swc/options.js b/dist/build/swc/options.js
+index 11261f8669d61451a5eb98853271f59fa1cf057f..77d24b5e54a3c6eaf77e715599b53a77fea04806 100644
+--- a/dist/build/swc/options.js
++++ b/dist/build/swc/options.js
+@@ -48,7 +48,7 @@ function getParserOptions({ filename, jsConfig, ...rest }) {
+         ...rest,
+         syntax: hasTsSyntax ? "typescript" : "ecmascript",
+         dynamicImport: true,
+-        decorators: enableDecorators,
++        decorators: true,
+         // Exclude regular TypeScript files from React transformation to prevent e.g. generic parameters and angle-bracket type assertion from being interpreted as JSX tags.
+         [hasTsSyntax ? "tsx" : "jsx"]: !isTSFile,
+         importAssertions: true
+@@ -93,6 +93,7 @@ function getBaseSWCOptions({ filename, jest, development, hasReactRefresh, globa
+                 legacyDecorator: enableDecorators,
+                 decoratorMetadata: emitDecoratorMetadata,
+                 useDefineForClassFields: useDefineForClassFields,
++                decoratorVersion: "2022-03",
+                 react: {
+                     importSource: (jsConfig == null ? void 0 : (_jsConfig_compilerOptions4 = jsConfig.compilerOptions) == null ? void 0 : _jsConfig_compilerOptions4.jsxImportSource) ?? ((compilerOptions == null ? void 0 : compilerOptions.emotion) && !isReactServerLayer ? "@emotion/react" : "react"),
+                     runtime: "automatic",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -68,7 +68,7 @@
 		"gray-matter": "^4.0.3",
 		"instantsearch.js": "^4.77.1",
 		"js-cookie": "^3.0.5",
-		"next": "^14.2.23",
+		"next": "patch:next@npm%3A14.2.23#~/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch",
 		"next-mdx-remote": "^5.0.0",
 		"next-themes": "^0.3.0",
 		"openai": "^4.80.1",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -15,7 +15,6 @@
 		"emitDeclarationOnly": false,
 		"noEmit": true,
 		"isolatedModules": true,
-		"experimentalDecorators": true,
 		"jsx": "preserve"
 	},
 	"include": [

--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -68,7 +68,7 @@
 		"@types/node": "~20.11.30",
 		"@types/qrcode": "^1.5.5",
 		"@types/react": "^18.3.18",
-		"@vitejs/plugin-react-swc": "^3.7.2",
+		"@vitejs/plugin-react-swc": "^3.8.0",
 		"dotenv": "^16.4.7",
 		"eslint": "^9.19.0",
 		"eslint-plugin-formatjs": "^5.2.13",

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -91,6 +91,9 @@ export default defineConfig((env) => ({
 			ignored: ['**/playwright-report/**', '**/test-results/**'],
 		},
 	},
+	esbuild: {
+		target: 'es2022',
+	},
 	css: {
 		modules: {
 			scopeBehaviour: 'local',

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -27,7 +27,14 @@ function urlOrLocalFallback(mode: string, url: string | undefined, localFallback
 
 // https://vitejs.dev/config/
 export default defineConfig((env) => ({
-	plugins: [react({ tsDecorators: true })],
+	plugins: [
+		react({
+			useAtYourOwnRisk_mutateSwcOptions(options) {
+				options.jsc!.parser!.decorators = true
+				options.jsc!.transform!.decoratorVersion = '2022-03'
+			},
+		}),
+	],
 	publicDir: './public',
 	build: {
 		// output source maps to .map files and include //sourceMappingURL comments in JavaScript files

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -85,7 +85,7 @@ test.describe('camera', () => {
 	test('panning', async ({ isMobile, page }) => {
 		test.skip(!isMobile)
 		client = await page.context().newCDPSession(page)
-		expect(await page.evaluate(() => editor.inputs.currentPagePoint)).toEqual({
+		expect(await page.evaluate(() => editor.inputs.currentPagePoint.toJson())).toEqual({
 			x: 50,
 			y: 50,
 			z: 0,

--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -61,7 +61,7 @@
 	},
 	"devDependencies": {
 		"@types/lodash": "^4.17.14",
-		"@vitejs/plugin-react-swc": "^3.7.2",
+		"@vitejs/plugin-react-swc": "^3.8.0",
 		"dotenv": "^16.4.7",
 		"remark": "^15.0.1",
 		"remark-frontmatter": "^5.0.0",

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -47,7 +47,16 @@ const TLDRAW_BEMO_URL_STRING =
 				: undefined
 
 export default defineConfig(({ mode }) => ({
-	plugins: [react({ tsDecorators: true }), exampleReadmePlugin()],
+	plugins: [
+		react({
+			useAtYourOwnRisk_mutateSwcOptions(options) {
+				options.jsc!.parser!.decorators = true
+				options.jsc!.transform!.decoratorVersion = '2022-03'
+			},
+		}),
+		,
+		exampleReadmePlugin(),
+	],
 	root: path.join(__dirname, 'src'),
 	publicDir: path.join(__dirname, 'public'),
 	build: {

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -54,7 +54,6 @@ export default defineConfig(({ mode }) => ({
 				options.jsc!.transform!.decoratorVersion = '2022-03'
 			},
 		}),
-		,
 		exampleReadmePlugin(),
 	],
 	root: path.join(__dirname, 'src'),

--- a/internal/config/jest/node/jest-preset.js
+++ b/internal/config/jest/node/jest-preset.js
@@ -13,7 +13,7 @@ module.exports = {
 						decorators: true,
 					},
 					transform: {
-						legacyDecorator: true,
+						decoratorVersion: '2022-03',
 						decoratorMetadata: true,
 						react: {
 							runtime: 'automatic',

--- a/internal/scripts/api-check.ts
+++ b/internal/scripts/api-check.ts
@@ -26,6 +26,7 @@ async function main() {
 			rootDir: '.',
 			paths: {},
 			esModuleInterop: true,
+			target: 'es2015',
 		},
 		files: [],
 	}

--- a/internal/scripts/api-check.ts
+++ b/internal/scripts/api-check.ts
@@ -27,6 +27,8 @@ async function main() {
 			paths: {},
 			esModuleInterop: true,
 			target: 'es2015',
+			module: 'esnext',
+			moduleResolution: 'node',
 		},
 		files: [],
 	}

--- a/internal/scripts/lib/add-extensions.ts
+++ b/internal/scripts/lib/add-extensions.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'fs'
 import glob from 'glob'
 import path from 'path'
 import { parse, print, visit } from 'recast'
+import { recastTypescriptParser } from './recastTypescriptParser'
 
 const extensions = ['.js', '.mjs', '.cjs']
 function resolveRelativePath(importingFile: string, relativePath: string) {
@@ -44,7 +45,7 @@ function resolveRelativePath(importingFile: string, relativePath: string) {
 
 export function addJsExtensions(distDir: string) {
 	for (const file of glob.sync(path.join(distDir, '**/*.{mjs,cjs,js}'))) {
-		const code = parse(readFileSync(file, 'utf8'), { parser: require('recast/parsers/typescript') })
+		const code = parse(readFileSync(file, 'utf8'), { parser: recastTypescriptParser })
 
 		visit(code, {
 			visitImportDeclaration(path) {

--- a/internal/scripts/lib/recastTypescriptParser.ts
+++ b/internal/scripts/lib/recastTypescriptParser.ts
@@ -1,0 +1,11 @@
+import getBabelOptions from 'recast/parsers/_babel_options'
+import * as babel from 'recast/parsers/babel'
+
+export const recastTypescriptParser = {
+	parse: (source: string) => {
+		const options = getBabelOptions()
+		options.plugins.push('typescript')
+		options.plugins.push('decoratorAutoAccessors')
+		return babel.parser.parse(source, options)
+	},
+}

--- a/internal/scripts/lib/sort-unions.ts
+++ b/internal/scripts/lib/sort-unions.ts
@@ -3,10 +3,11 @@ import { readFileSync, writeFileSync } from 'fs'
 import glob from 'glob'
 import path from 'path'
 import { parse, print, visit } from 'recast'
+import { recastTypescriptParser } from './recastTypescriptParser'
 
 export function sortUnions(tsbuildDir: string) {
 	for (const file of glob.sync(path.join(tsbuildDir, '**/*.d.ts'))) {
-		const code = parse(readFileSync(file, 'utf8'), { parser: require('recast/parsers/typescript') })
+		const code = parse(readFileSync(file, 'utf8'), { parser: recastTypescriptParser })
 
 		visit(code, {
 			visitTSUnionType(path) {

--- a/internal/scripts/package.json
+++ b/internal/scripts/package.json
@@ -44,7 +44,7 @@
 		"kleur": "^4.1.5",
 		"lazyrepo": "0.0.0-alpha.27",
 		"prettier": "^3.4.2",
-		"recast": "^0.22.0",
+		"recast": "^0.23.11",
 		"rimraf": "^4.4.1",
 		"semver": "^7.6.3",
 		"svgo": "^3.3.2",

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -8,6 +8,7 @@
 
 import { Atom } from '@tldraw/state';
 import { atom } from '@tldraw/state';
+import { AtomSet } from '@tldraw/store';
 import { BoxModel } from '@tldraw/tlschema';
 import { ComponentType } from 'react';
 import { Computed } from '@tldraw/state';
@@ -164,6 +165,17 @@ export function areAnglesCompatible(a: number, b: number): boolean;
 export { Atom }
 
 export { atom }
+
+// @public
+export class AtomVec extends Vec {
+    constructor(name: string, x?: number, y?: number, z?: number);
+    // (undocumented)
+    _x: Atom<number>;
+    // (undocumented)
+    _y: Atom<number>;
+    // (undocumented)
+    _z: Atom<number>;
+}
 
 // @public (undocumented)
 export function average(A: VecLike, B: VecLike): string;
@@ -910,26 +922,24 @@ export class Editor extends EventEmitter<TLEventMap> {
             collaboratorCount: number;
             editingShape: TLUnknownShape | undefined;
             inputs: {
-                buttons: Set<number>;
-                keys: Set<string>;
-                originScreenPoint: Vec;
-                originPagePoint: Vec;
-                currentScreenPoint: Vec;
-                currentPagePoint: Vec;
-                previousScreenPoint: Vec;
-                previousPagePoint: Vec;
-                pointerVelocity: Vec;
-                altKey: boolean;
-                ctrlKey: boolean;
-                isPen: boolean;
-                metaKey: boolean;
-                shiftKey: boolean;
+                buttons: number[];
+                currentPagePoint: VecModel;
+                currentScreenPoint: VecModel;
                 isDragging: boolean;
                 isEditing: boolean;
                 isPanning: boolean;
+                isPen: boolean;
                 isPinching: boolean;
                 isPointing: boolean;
                 isSpacebarPanning: boolean;
+                keys: string[];
+                metaKey: boolean;
+                originPagePoint: VecModel;
+                originScreenPoint: VecModel;
+                pointerVelocity: VecModel;
+                previousPagePoint: VecModel;
+                previousScreenPoint: VecModel;
+                shiftKey: boolean;
             };
             instanceState: TLInstance;
             pageState: TLInstancePageState;
@@ -1376,28 +1386,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     protected readonly history: HistoryManager<TLRecord>;
     // (undocumented)
     readonly id: string;
-    inputs: {
-        buttons: Set<number>;
-        keys: Set<string>;
-        originScreenPoint: Vec;
-        originPagePoint: Vec;
-        currentScreenPoint: Vec;
-        currentPagePoint: Vec;
-        previousScreenPoint: Vec;
-        previousPagePoint: Vec;
-        pointerVelocity: Vec;
-        altKey: boolean;
-        ctrlKey: boolean;
-        isPen: boolean;
-        metaKey: boolean;
-        shiftKey: boolean;
-        isDragging: boolean;
-        isEditing: boolean;
-        isPanning: boolean;
-        isPinching: boolean;
-        isPointing: boolean;
-        isSpacebarPanning: boolean;
-    };
+    inputs: InputManager;
     interrupt(): this;
     isAncestorSelected(shape: TLShape | TLShapeId): boolean;
     isDisposed: boolean;
@@ -1534,6 +1523,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     readonly textMeasure: TextManager;
     // (undocumented)
     _tickCameraState(): void;
+    // @internal (undocumented)
+    readonly _tickManager: TickManager;
     readonly timers: {
         dispose: () => void;
         requestAnimationFrame: (callback: FrameRequestCallback) => number;
@@ -1985,6 +1976,54 @@ export type HTMLContainerProps = React_3.HTMLAttributes<HTMLDivElement>;
 // @public (undocumented)
 export const inlineBase64AssetStore: TLAssetStore;
 
+// @public (undocumented)
+export class InputManager {
+    constructor(editor: Editor);
+    accessor altKey: boolean;
+    readonly buttons: AtomSet<number>;
+    accessor ctrlKey: boolean;
+    readonly currentPagePoint: AtomVec;
+    readonly currentScreenPoint: AtomVec;
+    accessor isDragging: boolean;
+    accessor isEditing: boolean;
+    accessor isPanning: boolean;
+    accessor isPen: boolean;
+    accessor isPinching: boolean;
+    accessor isPointing: boolean;
+    accessor isSpacebarPanning: boolean;
+    readonly keys: AtomSet<string>;
+    accessor metaKey: boolean;
+    readonly originPagePoint: AtomVec;
+    readonly originScreenPoint: AtomVec;
+    readonly pointerVelocity: AtomVec;
+    readonly previousPagePoint: AtomVec;
+    readonly previousScreenPoint: AtomVec;
+    accessor shiftKey: boolean;
+    // (undocumented)
+    toJson(): {
+        buttons: number[];
+        currentPagePoint: VecModel;
+        currentScreenPoint: VecModel;
+        isDragging: boolean;
+        isEditing: boolean;
+        isPanning: boolean;
+        isPen: boolean;
+        isPinching: boolean;
+        isPointing: boolean;
+        isSpacebarPanning: boolean;
+        keys: string[];
+        metaKey: boolean;
+        originPagePoint: VecModel;
+        originScreenPoint: VecModel;
+        pointerVelocity: VecModel;
+        previousPagePoint: VecModel;
+        previousScreenPoint: VecModel;
+        shiftKey: boolean;
+    };
+    // (undocumented)
+    updateFromEvent(info: TLPinchEventInfo | TLPointerEventInfo | TLWheelEventInfo): void;
+}
+
 // @public
 export function intersectCircleCircle(c1: VecLike, r1: number, c2: VecLike, r2: number): Vec[];
 
@@ -2061,7 +2100,7 @@ export class LicenseManager {
     // (undocumented)
     isTest: boolean;
     // (undocumented)
-    state: Atom<"licensed-with-watermark" | "licensed" | "pending" | "unlicensed", unknown>;
+    accessor state: 'licensed-with-watermark' | 'licensed' | 'pending' | 'unlicensed';
     // (undocumented)
     verbose: boolean;
 }
@@ -2902,6 +2941,27 @@ export class TextManager {
         box: BoxModel;
         text: string;
     }[];
+}
+
+// @internal (undocumented)
+export class TickManager {
+    constructor(editor: Editor);
+    // (undocumented)
+    cancelRaf?: (() => void) | null;
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    editor: Editor;
+    // (undocumented)
+    isPaused: boolean;
+    // (undocumented)
+    now: number;
+    // (undocumented)
+    start(): void;
+    // (undocumented)
+    tick(): void;
+    // (undocumented)
+    updatePointerVelocity(elapsed: number): void;
 }
 
 // @public

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1999,7 +1999,7 @@ export class InputManager {
     readonly previousPagePoint: AtomVec;
     readonly previousScreenPoint: AtomVec;
     accessor shiftKey: boolean;
-    // (undocumented)
+    // @internal (undocumented)
     toJson(): {
         buttons: number[];
         currentPagePoint: VecModel;
@@ -2020,7 +2020,7 @@ export class InputManager {
         previousScreenPoint: VecModel;
         shiftKey: boolean;
     };
-    // (undocumented)
+    // @internal (undocumented)
     updateFromEvent(info: TLPinchEventInfo | TLPointerEventInfo | TLWheelEventInfo): void;
 }
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -169,12 +169,6 @@ export { atom }
 // @public
 export class AtomVec extends Vec {
     constructor(name: string, x?: number, y?: number, z?: number);
-    // (undocumented)
-    _x: Atom<number>;
-    // (undocumented)
-    _y: Atom<number>;
-    // (undocumented)
-    _z: Atom<number>;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -180,6 +180,7 @@ export {
 	type TLFontFaceSource,
 } from './lib/editor/managers/FontManager'
 export { HistoryManager } from './lib/editor/managers/HistoryManager'
+export { InputManager } from './lib/editor/managers/InputManager'
 export { ScribbleManager, type ScribbleItem } from './lib/editor/managers/ScribbleManager'
 export {
 	BoundsSnaps,
@@ -195,6 +196,7 @@ export {
 	type SnapIndicator,
 } from './lib/editor/managers/SnapManager/SnapManager'
 export { TextManager, type TLMeasureTextSpanOpts } from './lib/editor/managers/TextManager'
+export { TickManager } from './lib/editor/managers/TickManager'
 export { UserPreferencesManager } from './lib/editor/managers/UserPreferencesManager'
 export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseBoxShapeUtil'
 export {
@@ -352,7 +354,7 @@ export {
 	type SelectionHandle,
 } from './lib/primitives/Box'
 export { Mat, type MatLike, type MatModel } from './lib/primitives/Mat'
-export { Vec, type VecLike } from './lib/primitives/Vec'
+export { AtomVec, Vec, type VecLike } from './lib/primitives/Vec'
 export { EASINGS } from './lib/primitives/easings'
 export { Arc2d } from './lib/primitives/geometry/Arc2d'
 export { Circle2d } from './lib/primitives/geometry/Circle2d'

--- a/packages/editor/src/lib/components/GeometryDebuggingView.tsx
+++ b/packages/editor/src/lib/components/GeometryDebuggingView.tsx
@@ -1,22 +1,8 @@
 import { track } from '@tldraw/state-react'
 import { modulate } from '@tldraw/utils'
-import { useEffect, useState } from 'react'
 import { useEditor } from '../hooks/useEditor'
 import { Geometry2d } from '../primitives/geometry/Geometry2d'
 import { Group2d } from '../primitives/geometry/Group2d'
-
-function useTick(isEnabled = true) {
-	const [_, setTick] = useState(0)
-	const editor = useEditor()
-	useEffect(() => {
-		if (!isEnabled) return
-		const update = () => setTick((tick) => tick + 1)
-		editor.on('tick', update)
-		return () => {
-			editor.off('tick', update)
-		}
-	}, [editor, isEnabled])
-}
 
 export const GeometryDebuggingView = track(function GeometryDebuggingView({
 	showStroke = true,
@@ -28,8 +14,6 @@ export const GeometryDebuggingView = track(function GeometryDebuggingView({
 	showClosestPointOnOutline?: boolean
 }) {
 	const editor = useEditor()
-
-	useTick(showClosestPointOnOutline)
 
 	const zoomLevel = editor.getZoomLevel()
 	const renderingShapes = editor.getRenderingShapes()

--- a/packages/editor/src/lib/editor/managers/InputManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputManager.ts
@@ -51,6 +51,7 @@ export class InputManager {
 	/** Whether the user is spacebar panning. */
 	@atom accessor isSpacebarPanning = false
 
+	/** @internal */
 	updateFromEvent(info: TLPointerEventInfo | TLPinchEventInfo | TLWheelEventInfo) {
 		const {
 			pointerVelocity,
@@ -114,6 +115,7 @@ export class InputManager {
 		)
 	}
 
+	/** @internal */
 	toJson() {
 		return {
 			originPagePoint: this.originPagePoint.toJson(),

--- a/packages/editor/src/lib/editor/managers/InputManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputManager.ts
@@ -1,0 +1,139 @@
+import { atom, unsafe__withoutCapture } from '@tldraw/state'
+import { AtomSet } from '@tldraw/store'
+import { TLINSTANCE_ID, TLPOINTER_ID } from '@tldraw/tlschema'
+import { INTERNAL_POINTER_IDS } from '../../constants'
+import { AtomVec } from '../../primitives/Vec'
+import { Editor } from '../Editor'
+import { TLPinchEventInfo, TLPointerEventInfo, TLWheelEventInfo } from '../types/event-types'
+
+/** @public */
+export class InputManager {
+	constructor(private readonly editor: Editor) {}
+
+	/** The most recent pointer down's position in the current page space. */
+	readonly originPagePoint = new AtomVec('originPagePoint')
+	/** The most recent pointer down's position in screen space. */
+	readonly originScreenPoint = new AtomVec('originScreenPoint')
+	/** The previous pointer position in the current page space. */
+	readonly previousPagePoint = new AtomVec('previousPagePoint')
+	/** The previous pointer position in screen space. */
+	readonly previousScreenPoint = new AtomVec('previousScreenPoint')
+	/** The most recent pointer position in the current page space. */
+	readonly currentPagePoint = new AtomVec('currentPagePoint')
+	/** The most recent pointer position in screen space. */
+	readonly currentScreenPoint = new AtomVec('currentScreenPoint')
+	/** Velocity of mouse pointer, in pixels per millisecond */
+	readonly pointerVelocity = new AtomVec('pointerVelocity')
+	/** A set containing the currently pressed keys. */
+	readonly keys = new AtomSet<string>('keys')
+	/** A set containing the currently pressed buttons. */
+	readonly buttons = new AtomSet<number>('buttons')
+	/** Whether the input is from a pe. */
+	@atom accessor isPen = false
+	/** Whether the shift key is currently pressed. */
+	@atom accessor shiftKey = false
+	/** Whether the meta key is currently pressed. */
+	@atom accessor metaKey = false
+	/** Whether the control or command key is currently pressed. */
+	@atom accessor ctrlKey = false
+	/** Whether the alt or option key is currently pressed. */
+	@atom accessor altKey = false
+	/** Whether the user is dragging. */
+	@atom accessor isDragging = false
+	/** Whether the user is pointing. */
+	@atom accessor isPointing = false
+	/** Whether the user is pinching. */
+	@atom accessor isPinching = false
+	/** Whether the user is editing. */
+	@atom accessor isEditing = false
+	/** Whether the user is panning. */
+	@atom accessor isPanning = false
+	/** Whether the user is spacebar panning. */
+	@atom accessor isSpacebarPanning = false
+
+	updateFromEvent(info: TLPointerEventInfo | TLPinchEventInfo | TLWheelEventInfo) {
+		const {
+			pointerVelocity,
+			previousScreenPoint,
+			previousPagePoint,
+			currentScreenPoint,
+			currentPagePoint,
+		} = this
+
+		const { screenBounds } = this.editor.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
+		const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.editor.getCamera())
+
+		const sx = info.point.x - screenBounds.x
+		const sy = info.point.y - screenBounds.y
+		const sz = info.point.z ?? 0.5
+
+		previousScreenPoint.setTo(currentScreenPoint)
+		previousPagePoint.setTo(currentPagePoint)
+
+		// The "screen bounds" is relative to the user's actual screen.
+		// The "screen point" is relative to the "screen bounds";
+		// it will be 0,0 when its actual screen position is equal
+		// to screenBounds.point. This is confusing!
+		currentScreenPoint.set(sx, sy)
+		const nx = sx / cz - cx
+		const ny = sy / cz - cy
+		if (isFinite(nx) && isFinite(ny)) {
+			currentPagePoint.set(nx, ny, sz)
+		}
+
+		this.isPen = info.type === 'pointer' && info.isPen
+
+		// Reset velocity on pointer down, or when a pinch starts or ends
+		if (info.name === 'pointer_down' || this.isPinching) {
+			pointerVelocity.set(0, 0)
+			this.originScreenPoint.setTo(currentScreenPoint)
+			this.originPagePoint.setTo(currentPagePoint)
+		}
+
+		// todo: We only have to do this if there are multiple users in the document
+		this.editor.run(
+			() => {
+				this.editor.store.put([
+					{
+						id: TLPOINTER_ID,
+						typeName: 'pointer',
+						x: currentPagePoint.x,
+						y: currentPagePoint.y,
+						lastActivityTimestamp:
+							// If our pointer moved only because we're following some other user, then don't
+							// update our last activity timestamp; otherwise, update it to the current timestamp.
+							info.type === 'pointer' && info.pointerId === INTERNAL_POINTER_IDS.CAMERA_MOVE
+								? (this.editor.store.unsafeGetWithoutCapture(TLPOINTER_ID)?.lastActivityTimestamp ??
+									this.editor._tickManager.now)
+								: this.editor._tickManager.now,
+						meta: {},
+					},
+				])
+			},
+			{ history: 'ignore' }
+		)
+	}
+
+	toJson() {
+		return {
+			originPagePoint: this.originPagePoint.toJson(),
+			originScreenPoint: this.originScreenPoint.toJson(),
+			previousPagePoint: this.previousPagePoint.toJson(),
+			previousScreenPoint: this.previousScreenPoint.toJson(),
+			currentPagePoint: this.currentPagePoint.toJson(),
+			currentScreenPoint: this.currentScreenPoint.toJson(),
+			pointerVelocity: this.pointerVelocity.toJson(),
+			keys: Array.from(this.keys.values()),
+			buttons: Array.from(this.buttons.values()),
+			isPen: this.isPen,
+			shiftKey: this.shiftKey,
+			metaKey: this.metaKey,
+			isDragging: this.isDragging,
+			isPointing: this.isPointing,
+			isPinching: this.isPinching,
+			isEditing: this.isEditing,
+			isPanning: this.isPanning,
+			isSpacebarPanning: this.isSpacebarPanning,
+		}
+	}
+}

--- a/packages/editor/src/lib/editor/managers/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager.ts
@@ -13,6 +13,7 @@ const throttleToNextFrame =
 			}
 		: _throttleToNextFrame
 
+/** @internal */
 export class TickManager {
 	constructor(public editor: Editor) {
 		this.editor.disposables.add(this.dispose)
@@ -80,7 +81,7 @@ export class TickManager {
 		if (Math.abs(next.y) < 0.01) next.y = 0
 
 		if (!pointerVelocity.equals(next)) {
-			this.editor.inputs.pointerVelocity = next
+			this.editor.inputs.pointerVelocity.setTo(next)
 		}
 	}
 }

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -73,10 +73,8 @@ export class LicenseManager {
 	public isDevelopment: boolean
 	public isTest: boolean
 	public isCryptoAvailable: boolean
-	state = atom<'pending' | 'licensed' | 'licensed-with-watermark' | 'unlicensed'>(
-		'license state',
+	@atom accessor state: 'pending' | 'licensed' | 'licensed-with-watermark' | 'unlicensed' =
 		'pending'
-	)
 	public verbose = true
 
 	constructor(
@@ -97,11 +95,11 @@ export class LicenseManager {
 			}
 
 			if (isUnlicensed) {
-				this.state.set('unlicensed')
+				this.state = 'unlicensed'
 			} else if ((result as ValidLicenseKeyResult).isLicensedWithWatermark) {
-				this.state.set('licensed-with-watermark')
+				this.state = 'licensed-with-watermark'
 			} else {
-				this.state.set('licensed')
+				this.state = 'licensed'
 			}
 		})
 	}

--- a/packages/editor/src/lib/license/useLicenseManagerState.ts
+++ b/packages/editor/src/lib/license/useLicenseManagerState.ts
@@ -3,5 +3,5 @@ import { LicenseManager } from './LicenseManager'
 
 /** @internal */
 export function useLicenseManagerState(licenseManager: LicenseManager) {
-	return useValue('watermarkState', () => licenseManager.state.get(), [licenseManager])
+	return useValue('watermarkState', () => licenseManager.state, [licenseManager])
 }

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -1,3 +1,4 @@
+import { atom, Atom } from '@tldraw/state'
 import { VecModel } from '@tldraw/tlschema'
 import { EASINGS } from './easings'
 import { toFixed } from './utils'
@@ -592,6 +593,38 @@ export class Vec {
 	static SnapToGrid(A: VecLike, gridSize = 8) {
 		return new Vec(Math.round(A.x / gridSize) * gridSize, Math.round(A.y / gridSize) * gridSize)
 	}
+}
+
+/**
+ * A {@link Vec} backed by atoms. When the atom changes, anything reading its values will re-evaluate.
+ * @public
+ */
+export class AtomVec extends Vec {
+	constructor(name: string, x = 0, y = 0, z = 1) {
+		super(x, y, z)
+		this._x = atom(`${name}.x`, x)
+		this._y = atom(`${name}.y`, y)
+		this._z = atom(`${name}.z`, z)
+
+		Object.defineProperties(this, {
+			x: {
+				get: () => this._x.get(),
+				set: (value: number) => this._x.set(value),
+			},
+			y: {
+				get: () => this._y.get(),
+				set: (value: number) => this._y.set(value),
+			},
+			z: {
+				get: () => this._z.get(),
+				set: (value: number) => this._z.set(value),
+			},
+		})
+	}
+
+	_x: Atom<number>
+	_y: Atom<number>
+	_z: Atom<number>
 }
 
 const ease = (t: number) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t)

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -622,9 +622,9 @@ export class AtomVec extends Vec {
 		})
 	}
 
-	_x: Atom<number>
-	_y: Atom<number>
-	_z: Atom<number>
+	private _x: Atom<number>
+	private _y: Atom<number>
+	private _z: Atom<number>
 }
 
 const ease = (t: number) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t)

--- a/packages/state/api-report.api.md
+++ b/packages/state/api-report.api.md
@@ -27,10 +27,10 @@ export interface Atom<Value, Diff = unknown> extends Signal<Value, Diff> {
 }
 
 // @public
-export function atom<Value, Diff = unknown>(
-name: string,
-initialValue: Value,
-options?: AtomOptions<Value, Diff>): Atom<Value, Diff>;
+export function atom<Value, Diff = unknown>(name: string, initialValue: Value, options?: AtomOptions<Value, Diff>): Atom<Value, Diff>;
+
+// @public
+export function atom<This, Value>(target: ClassAccessorDecoratorTarget<This, Value>, ctx: ClassAccessorDecoratorContext<This, Value>): ClassAccessorDecoratorResult<This, Value>;
 
 // @public
 export interface AtomOptions<Value, Diff> {

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -1,3 +1,4 @@
+import { assert } from '@tldraw/utils'
 import { ArraySet } from './ArraySet'
 import { HistoryBuffer } from './HistoryBuffer'
 import { maybeCaptureParent } from './capture'
@@ -6,7 +7,7 @@ import { advanceGlobalEpoch, atomDidChange, getGlobalEpoch } from './transaction
 import { Child, ComputeDiff, RESET_VALUE, Signal } from './types'
 
 /**
- * The options to configure an atom, passed into the {@link atom} function.
+ * The options to configure an atom, passed into the {@link (atom:1)} function.
  * @public
  */
 export interface AtomOptions<Value, Diff> {
@@ -38,7 +39,7 @@ export interface AtomOptions<Value, Diff> {
 /**
  * An Atom is a signal that can be updated directly by calling {@link Atom.set} or {@link Atom.update}.
  *
- * Atoms are created using the {@link atom} function.
+ * Atoms are created using the {@link (atom:1)} function.
  *
  * @example
  * ```ts
@@ -160,6 +161,10 @@ export type _Atom = InstanceType<typeof _Atom>
  *
  * An Atom is a signal that can be updated directly by calling {@link Atom.set} or {@link Atom.update}.
  *
+ * @param name - A name for the signal. This is used for debugging and profiling purposes, it does not need to be unique.
+ * @param initialValue - The initial value of the signal.
+ * @param options - The options to configure the atom. See {@link AtomOptions}.
+ *
  * @example
  * ```ts
  * const name = atom('name', 'John')
@@ -174,20 +179,47 @@ export type _Atom = InstanceType<typeof _Atom>
  * @public
  */
 export function atom<Value, Diff = unknown>(
-	/**
-	 * A name for the signal. This is used for debugging and profiling purposes, it does not need to be unique.
-	 */
 	name: string,
-	/**
-	 * The initial value of the signal.
-	 */
 	initialValue: Value,
-	/**
-	 * The options to configure the atom. See {@link AtomOptions}.
-	 */
 	options?: AtomOptions<Value, Diff>
-): Atom<Value, Diff> {
-	return new _Atom(name, initialValue, options)
+): Atom<Value, Diff>
+/**
+ * Decorate an accessor property on a class to make it an backed by an {@link Atom}.
+ * @example
+ * ```ts
+ * class MyClass {
+ *     @atom accessor property = 'value'
+ * }
+ * ```
+ * @public
+ */
+export function atom<This, Value>(
+	target: ClassAccessorDecoratorTarget<This, Value>,
+	ctx: ClassAccessorDecoratorContext<This, Value>
+): ClassAccessorDecoratorResult<This, Value>
+export function atom(
+	...args:
+		| [name: string, initialValue: any, options?: AtomOptions<any, any>]
+		| [target: ClassAccessorDecoratorTarget<any, any>, ctx: ClassAccessorDecoratorContext<any, any>]
+): any {
+	if (typeof args[0] === 'string') {
+		return new _Atom(args[0], args[1], args[2])
+	}
+
+	const target = args[0]
+	const ctx = args[1]
+	assert(ctx.kind === 'accessor')
+	return {
+		get() {
+			return (target.get.call(this) as Atom<any>).get()
+		},
+		set(newValue: any) {
+			;(target.get.call(this) as Atom<any>).set(newValue)
+		},
+		init(initialValue: any) {
+			return atom(String(ctx.name), initialValue) as any
+		},
+	}
 }
 
 /**

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -11,7 +11,7 @@ export type RESET_VALUE = typeof RESET_VALUE
  *
  * There are two types of signal:
  *
- * - Atomic signals, created using {@link atom}. These are mutable references to values that can be changed using {@link Atom.set}.
+ * - Atomic signals, created using {@link (atom:1)}. These are mutable references to values that can be changed using {@link Atom.set}.
  * - Computed signals, created using {@link state#computed}. These are values that are computed from other signals. They are recomputed lazily if their dependencies change.
  *
  * @public

--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -20,7 +20,7 @@ export class AtomMap<K, V> implements Map<K, V> {
     [Symbol.iterator](): Generator<[K, V], undefined, unknown>;
     // (undocumented)
     [Symbol.toStringTag]: string;
-    constructor(name: string, entries?: Iterable<[K, V]>);
+    constructor(name: string, entries?: Iterable<readonly [K, V]>);
     // (undocumented)
     __unsafe__getWithoutCapture(key: K): undefined | V;
     // (undocumented)
@@ -51,6 +51,33 @@ export class AtomMap<K, V> implements Map<K, V> {
     update(key: K, updater: (value: V) => V): void;
     // (undocumented)
     values(): Generator<V, undefined, unknown>;
+}
+
+// @public
+export class AtomSet<T> {
+    // (undocumented)
+    [Symbol.iterator](): Generator<T, undefined, unknown>;
+    // (undocumented)
+    [Symbol.toStringTag]: string;
+    constructor(name: string, keys?: Iterable<T>);
+    // (undocumented)
+    add(value: T): this;
+    // (undocumented)
+    clear(): void;
+    // (undocumented)
+    delete(value: T): boolean;
+    // (undocumented)
+    entries(): Generator<[T, T], undefined, unknown>;
+    // (undocumented)
+    forEach(callbackfn: (value: T, value2: T, set: AtomSet<T>) => void, thisArg?: any): void;
+    // (undocumented)
+    has(value: T): boolean;
+    // (undocumented)
+    keys(): Generator<T, undefined, unknown>;
+    // (undocumented)
+    get size(): number;
+    // (undocumented)
+    values(): Generator<T, undefined, unknown>;
 }
 
 // @public

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,5 +1,6 @@
 import { registerTldrawLibraryVersion } from '@tldraw/utils'
 export { AtomMap } from './lib/AtomMap'
+export { AtomSet } from './lib/AtomSet'
 export type { BaseRecord, IdOf, RecordId, UnknownRecord } from './lib/BaseRecord'
 export { IncrementalSetConstructor } from './lib/IncrementalSetConstructor'
 export { RecordType, assertIdType, createRecordType, type RecordScope } from './lib/RecordType'

--- a/packages/store/src/lib/AtomMap.ts
+++ b/packages/store/src/lib/AtomMap.ts
@@ -11,7 +11,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 
 	constructor(
 		private readonly name: string,
-		entries?: Iterable<[K, V]>
+		entries?: Iterable<readonly [K, V]>
 	) {
 		let atoms = emptyMap<K, Atom<V>>()
 		if (entries) {

--- a/packages/store/src/lib/AtomSet.ts
+++ b/packages/store/src/lib/AtomSet.ts
@@ -1,0 +1,52 @@
+import { AtomMap } from './AtomMap'
+
+/**
+ * A drop-in replacement for Set that stores values in atoms and can be used in reactive contexts.
+ * @public
+ */
+export class AtomSet<T> {
+	private readonly map: AtomMap<T, T>
+	constructor(
+		private readonly name: string,
+		keys?: Iterable<T>
+	) {
+		const entries = keys ? Array.from(keys, (k) => [k, k] as const) : undefined
+		this.map = new AtomMap(name, entries)
+	}
+
+	add(value: T): this {
+		this.map.set(value, value)
+		return this
+	}
+	clear(): void {
+		this.map.clear()
+	}
+	delete(value: T): boolean {
+		return this.map.delete(value)
+	}
+	forEach(callbackfn: (value: T, value2: T, set: AtomSet<T>) => void, thisArg?: any): void {
+		for (const value of this) {
+			callbackfn.call(thisArg, value, value, this)
+		}
+	}
+	has(value: T): boolean {
+		return this.map.has(value)
+	}
+	// eslint-disable-next-line no-restricted-syntax
+	get size(): number {
+		return this.map.size
+	}
+	entries(): Generator<[T, T], undefined, unknown> {
+		return this.map.entries()
+	}
+	keys(): Generator<T, undefined, unknown> {
+		return this.map.keys()
+	}
+	values(): Generator<T, undefined, unknown> {
+		return this.map.keys()
+	}
+	[Symbol.iterator](): Generator<T, undefined, unknown> {
+		return this.map.keys()
+	}
+	[Symbol.toStringTag]: string = 'AtomSet'
+}

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
@@ -1,4 +1,4 @@
-import { IndexKey, TLArrowShape, TLShapeId, Vec, createShapeId } from '@tldraw/editor'
+import { IndexKey, TLArrowShape, TLShapeId, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
 import { getArrowBindings } from './shared'
 
@@ -138,7 +138,7 @@ describe('When pointing a start shape', () => {
 		expect(editor.getHintingShapeIds().length).toBe(1)
 
 		// Fake some velocity
-		editor.inputs.pointerVelocity = new Vec(1, 1)
+		editor.inputs.pointerVelocity.set(1, 1)
 
 		editor.pointerMove(375, 500)
 
@@ -183,7 +183,7 @@ describe('When pointing an end shape', () => {
 		expect(editor.getHintingShapeIds().length).toBe(0)
 
 		// Fake some velocity
-		editor.inputs.pointerVelocity = new Vec(1, 1)
+		editor.inputs.pointerVelocity.set(1, 1)
 
 		// Move onto shape
 		editor.pointerMove(375, 375)
@@ -221,7 +221,7 @@ describe('When pointing an end shape', () => {
 	it('unbinds and rebinds', () => {
 		editor.setCurrentTool('arrow').pointerDown(0, 0)
 
-		editor.inputs.pointerVelocity = new Vec(1, 1)
+		editor.inputs.pointerVelocity.set(1, 1)
 
 		editor.pointerMove(375, 375)
 
@@ -277,7 +277,7 @@ describe('When pointing an end shape', () => {
 		})
 
 		// Build up some velocity
-		editor.inputs.pointerVelocity = new Vec(1, 1)
+		editor.inputs.pointerVelocity.set(1, 1)
 		editor.pointerMove(325, 325)
 		expect(editor.getHintingShapeIds().length).toBe(1)
 
@@ -327,7 +327,7 @@ describe('When pointing an end shape', () => {
 
 	it('begins imprecise when moving quickly', () => {
 		editor.setCurrentTool('arrow').pointerDown(0, 0)
-		editor.inputs.pointerVelocity = new Vec(1, 1)
+		editor.inputs.pointerVelocity.set(1, 1)
 		editor.pointerMove(370, 370)
 
 		const arrow = editor.getCurrentPageShapes()[editor.getCurrentPageShapes().length - 1]
@@ -359,7 +359,7 @@ describe('When pointing an end shape', () => {
 
 		expect(editor.getHintingShapeIds().length).toBe(0)
 
-		editor.inputs.pointerVelocity = new Vec(0.001, 0.001)
+		editor.inputs.pointerVelocity.set(0.001, 0.001)
 		editor.pointerMove(375, 375)
 
 		arrow = editor.getCurrentPageShapes()[editor.getCurrentPageShapes().length - 1]

--- a/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
@@ -6,7 +6,7 @@ import {
 	useValue,
 	Vec,
 } from '@tldraw/editor'
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { useTldrawUiComponents } from '../context/components'
 
 /** @internal */
@@ -25,22 +25,7 @@ export const DefaultDebugPanel = memo(function DefaultDebugPanel() {
 	)
 })
 
-function useTick(isEnabled = true) {
-	const [_, setTick] = useState(0)
-	const editor = useEditor()
-	useEffect(() => {
-		if (!isEnabled) return
-		const update = () => setTick((tick) => tick + 1)
-		editor.on('tick', update)
-		return () => {
-			editor.off('tick', update)
-		}
-	}, [editor, isEnabled])
-}
-
 const CurrentState = track(function CurrentState() {
-	useTick()
-
 	const editor = useEditor()
 
 	const path = editor.getPath()

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -375,7 +375,10 @@ export class TestEditor extends Editor {
 			ctrlKey: this.inputs.ctrlKey,
 			altKey: this.inputs.altKey,
 			metaKey: this.inputs.metaKey,
-			accelKey: isAccelKey({ ...this.inputs, ...modifiers }),
+			accelKey: isAccelKey({
+				metaKey: this.inputs.metaKey,
+				ctrlKey: modifiers?.ctrlKey ?? this.inputs.ctrlKey,
+			}),
 			point: { x, y, z: null },
 			button: 0,
 			isPen: false,

--- a/templates/simple-server-example/package.json
+++ b/templates/simple-server-example/package.json
@@ -39,7 +39,7 @@
 		"@fastify/websocket": "^10.0.1",
 		"@tldraw/sync": "latest",
 		"@tldraw/sync-core": "latest",
-		"@vitejs/plugin-react-swc": "^3.7.0",
+		"@vitejs/plugin-react-swc": "^3.8.0",
 		"fastify": "^4.28.1",
 		"itty-router": "^5.0.17",
 		"react": "^18.2.0",

--- a/templates/sync-cloudflare/package.json
+++ b/templates/sync-cloudflare/package.json
@@ -36,7 +36,7 @@
 		"@types/react-dom": "^18.3.5",
 		"@typescript-eslint/eslint-plugin": "^8.11.0",
 		"@typescript-eslint/parser": "^8.11.0",
-		"@vitejs/plugin-react-swc": "^3.7.0",
+		"@vitejs/plugin-react-swc": "^3.8.0",
 		"concurrently": "^9.0.1",
 		"eslint": "^9.13.0",
 		"eslint-plugin-react-hooks": "^5.0.0",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -25,7 +25,7 @@
 		"@types/react-dom": "^18.3.5",
 		"@typescript-eslint/eslint-plugin": "^8.11.0",
 		"@typescript-eslint/parser": "^8.11.0",
-		"@vitejs/plugin-react-swc": "^3.7.0",
+		"@vitejs/plugin-react-swc": "^3.8.0",
 		"eslint": "^9.13.0",
 		"eslint-plugin-react-hooks": "^5.0.0",
 		"eslint-plugin-react-refresh": "^0.4.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7468,7 +7468,7 @@ __metadata:
     js-cookie: "npm:^3.0.5"
     linkinator: "npm:^6.1.2"
     mdast-util-mdx: "npm:^3.0.0"
-    next: "npm:^14.2.23"
+    next: "patch:next@npm%3A14.2.23#~/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch"
     next-mdx-remote: "npm:^5.0.0"
     next-themes: "npm:^0.3.0"
     octokit: "npm:^3.2.1"
@@ -19883,7 +19883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^14.2.23":
+"next@npm:14.2.23":
   version: 14.2.23
   resolution: "next@npm:14.2.23"
   dependencies:
@@ -19938,6 +19938,64 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: e22abb7a785f6498ca0706d20e3419402090579b538ef23b694c75af74643d0ad6e264a158403ab4692af32ce8db63ec41ac0924cdce94cfe15ca15ba8687fe4
+  languageName: node
+  linkType: hard
+
+"next@patch:next@npm%3A14.2.23#~/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch":
+  version: 14.2.23
+  resolution: "next@patch:next@npm%3A14.2.23#~/.yarn/patches/next-npm-14.2.23-eedfdbfae5.patch::version=14.2.23&hash=bec598"
+  dependencies:
+    "@next/env": "npm:14.2.23"
+    "@next/swc-darwin-arm64": "npm:14.2.23"
+    "@next/swc-darwin-x64": "npm:14.2.23"
+    "@next/swc-linux-arm64-gnu": "npm:14.2.23"
+    "@next/swc-linux-arm64-musl": "npm:14.2.23"
+    "@next/swc-linux-x64-gnu": "npm:14.2.23"
+    "@next/swc-linux-x64-musl": "npm:14.2.23"
+    "@next/swc-win32-arm64-msvc": "npm:14.2.23"
+    "@next/swc-win32-ia32-msvc": "npm:14.2.23"
+    "@next/swc-win32-x64-msvc": "npm:14.2.23"
+    "@swc/helpers": "npm:0.5.5"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
+    styled-jsx: "npm:5.1.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 9b3fbcda3e8e91d8db3ed6b448ceb36d6cdad6650bdb0c700a5af3db1153e80604c0e744452f221439a8d8e5ec3e3cf6f7402c0bcb1286f7df1b45933b5e6dc2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6811,24 +6811,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-darwin-arm64@npm:1.10.11"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@swc/core-darwin-arm64@npm:1.11.10":
   version: 1.11.10
   resolution: "@swc/core-darwin-arm64@npm:1.11.10"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@swc/core-darwin-x64@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-darwin-x64@npm:1.10.11"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -6839,24 +6825,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.10.11"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@swc/core-linux-arm-gnueabihf@npm:1.11.10":
   version: 1.11.10
   resolution: "@swc/core-linux-arm-gnueabihf@npm:1.11.10"
   conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@swc/core-linux-arm64-gnu@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.10.11"
-  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -6867,24 +6839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-linux-arm64-musl@npm:1.10.11"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@swc/core-linux-arm64-musl@npm:1.11.10":
   version: 1.11.10
   resolution: "@swc/core-linux-arm64-musl@npm:1.11.10"
   conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@swc/core-linux-x64-gnu@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-linux-x64-gnu@npm:1.10.11"
-  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -6895,24 +6853,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-linux-x64-musl@npm:1.10.11"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@swc/core-linux-x64-musl@npm:1.11.10":
   version: 1.11.10
   resolution: "@swc/core-linux-x64-musl@npm:1.11.10"
   conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@swc/core-win32-arm64-msvc@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.10.11"
-  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -6923,24 +6867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.10.11"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@swc/core-win32-ia32-msvc@npm:1.11.10":
   version: 1.11.10
   resolution: "@swc/core-win32-ia32-msvc@npm:1.11.10"
   conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@swc/core-win32-x64-msvc@npm:1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core-win32-x64-msvc@npm:1.10.11"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -6951,53 +6881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.10.11":
-  version: 1.10.11
-  resolution: "@swc/core@npm:1.10.11"
-  dependencies:
-    "@swc/core-darwin-arm64": "npm:1.10.11"
-    "@swc/core-darwin-x64": "npm:1.10.11"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.10.11"
-    "@swc/core-linux-arm64-gnu": "npm:1.10.11"
-    "@swc/core-linux-arm64-musl": "npm:1.10.11"
-    "@swc/core-linux-x64-gnu": "npm:1.10.11"
-    "@swc/core-linux-x64-musl": "npm:1.10.11"
-    "@swc/core-win32-arm64-msvc": "npm:1.10.11"
-    "@swc/core-win32-ia32-msvc": "npm:1.10.11"
-    "@swc/core-win32-x64-msvc": "npm:1.10.11"
-    "@swc/counter": "npm:^0.1.3"
-    "@swc/types": "npm:^0.1.17"
-  peerDependencies:
-    "@swc/helpers": "*"
-  dependenciesMeta:
-    "@swc/core-darwin-arm64":
-      optional: true
-    "@swc/core-darwin-x64":
-      optional: true
-    "@swc/core-linux-arm-gnueabihf":
-      optional: true
-    "@swc/core-linux-arm64-gnu":
-      optional: true
-    "@swc/core-linux-arm64-musl":
-      optional: true
-    "@swc/core-linux-x64-gnu":
-      optional: true
-    "@swc/core-linux-x64-musl":
-      optional: true
-    "@swc/core-win32-arm64-msvc":
-      optional: true
-    "@swc/core-win32-ia32-msvc":
-      optional: true
-    "@swc/core-win32-x64-msvc":
-      optional: true
-  peerDependenciesMeta:
-    "@swc/helpers":
-      optional: true
-  checksum: 249eaa3179ff2ae58d8b7214ea58f4e54b09fa9c7bc2bbfbf1e4d8094955a676c0cc4debab786487af43610771d13f9cefad802e4ce367a0d5f50f18c82fab50
-  languageName: node
-  linkType: hard
-
-"@swc/core@npm:^1.10.15":
+"@swc/core@npm:^1.10.11, @swc/core@npm:^1.10.15":
   version: 1.11.10
   resolution: "@swc/core@npm:1.11.10"
   dependencies:
@@ -7079,15 +6963,6 @@ __metadata:
   peerDependencies:
     "@swc/core": "*"
   checksum: bbec37079b4f5c1ff1c95aeec07d08277c646a0c5e16e057ea3a8fe5c6e2bd59bbfc4312e53ddd05d25fa4de20a03607be274f560f28bb5e229dd08124780e16
-  languageName: node
-  linkType: hard
-
-"@swc/types@npm:^0.1.17":
-  version: 0.1.17
-  resolution: "@swc/types@npm:0.1.17"
-  dependencies:
-    "@swc/counter": "npm:^0.1.3"
-  checksum: ddef1ad5bfead3acdfc41f14e79ba43a99200eb325afbad5716058dbe36358b0513400e9f22aff32432be84a98ae93df95a20b94192f69b8687144270e4eaa18
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6818,9 +6818,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-darwin-arm64@npm:1.11.10"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-x64@npm:1.10.11":
   version: 1.10.11
   resolution: "@swc/core-darwin-x64@npm:1.10.11"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-darwin-x64@npm:1.11.10"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6832,9 +6846,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.11.10"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-gnu@npm:1.10.11":
   version: 1.10.11
   resolution: "@swc/core-linux-arm64-gnu@npm:1.10.11"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.11.10"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -6846,9 +6874,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-linux-arm64-musl@npm:1.11.10"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-gnu@npm:1.10.11":
   version: 1.10.11
   resolution: "@swc/core-linux-x64-gnu@npm:1.10.11"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-linux-x64-gnu@npm:1.11.10"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -6860,9 +6902,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-linux-x64-musl@npm:1.11.10"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-arm64-msvc@npm:1.10.11":
   version: 1.10.11
   resolution: "@swc/core-win32-arm64-msvc@npm:1.10.11"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.11.10"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6874,6 +6930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.11.10"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-x64-msvc@npm:1.10.11":
   version: 1.10.11
   resolution: "@swc/core-win32-x64-msvc@npm:1.10.11"
@@ -6881,7 +6944,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.10.11, @swc/core@npm:^1.7.26":
+"@swc/core-win32-x64-msvc@npm:1.11.10":
+  version: 1.11.10
+  resolution: "@swc/core-win32-x64-msvc@npm:1.11.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.10.11":
   version: 1.10.11
   resolution: "@swc/core@npm:1.10.11"
   dependencies:
@@ -6924,6 +6994,52 @@ __metadata:
     "@swc/helpers":
       optional: true
   checksum: 249eaa3179ff2ae58d8b7214ea58f4e54b09fa9c7bc2bbfbf1e4d8094955a676c0cc4debab786487af43610771d13f9cefad802e4ce367a0d5f50f18c82fab50
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.10.15":
+  version: 1.11.10
+  resolution: "@swc/core@npm:1.11.10"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.11.10"
+    "@swc/core-darwin-x64": "npm:1.11.10"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.11.10"
+    "@swc/core-linux-arm64-gnu": "npm:1.11.10"
+    "@swc/core-linux-arm64-musl": "npm:1.11.10"
+    "@swc/core-linux-x64-gnu": "npm:1.11.10"
+    "@swc/core-linux-x64-musl": "npm:1.11.10"
+    "@swc/core-win32-arm64-msvc": "npm:1.11.10"
+    "@swc/core-win32-ia32-msvc": "npm:1.11.10"
+    "@swc/core-win32-x64-msvc": "npm:1.11.10"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.19"
+  peerDependencies:
+    "@swc/helpers": "*"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 4fcda5222fe4311dd6fe07586c72458f86a3a7ccee09cc7115ff3308f12d84a019d0b6996bcc778014f30f9a683de2d94a21498f69f8ed53941912c851716572
   languageName: node
   linkType: hard
 
@@ -6972,6 +7088,15 @@ __metadata:
   dependencies:
     "@swc/counter": "npm:^0.1.3"
   checksum: ddef1ad5bfead3acdfc41f14e79ba43a99200eb325afbad5716058dbe36358b0513400e9f22aff32432be84a98ae93df95a20b94192f69b8687144270e4eaa18
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.19":
+  version: 0.1.19
+  resolution: "@swc/types@npm:0.1.19"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 693147cc9b23147164ddff9cb89477c369fbeb103319584779352a9ff1c72e0a70b97a89dfd97629040db8956d668d7b7a8fed328ffea46a3e8c18577e396994
   languageName: node
   linkType: hard
 
@@ -7673,7 +7798,7 @@ __metadata:
     minimist: "npm:^1.2.8"
     prettier: "npm:^3.4.2"
     proper-lockfile: "npm:^4.1.2"
-    recast: "npm:^0.22.0"
+    recast: "npm:^0.23.11"
     rimraf: "npm:^4.4.1"
     semver: "npm:^7.6.3"
     svgo: "npm:^3.3.2"
@@ -9208,14 +9333,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react-swc@npm:^3.7.2":
-  version: 3.7.2
-  resolution: "@vitejs/plugin-react-swc@npm:3.7.2"
+"@vitejs/plugin-react-swc@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@vitejs/plugin-react-swc@npm:3.8.0"
   dependencies:
-    "@swc/core": "npm:^1.7.26"
+    "@swc/core": "npm:^1.10.15"
   peerDependencies:
     vite: ^4 || ^5 || ^6
-  checksum: eba981d831c83b81eba6515a8999f3811423769810dd7b36b9b0e5fffbfecc0354198e6efa7df0cd43950007d110aa9f42f0f3a0bd9f4bdc70d23d5177cfe95e
+  checksum: aa6e1aff93d3acce9d91d87b28914d541f370c0d992ef696f4d4a59f214df326ccef0ad827f7b12c7e8552a8976a48a2d52e31e7f0da9799312879f5fd2d6519
   languageName: node
   linkType: hard
 
@@ -10076,7 +10201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^2.0.0, assert@npm:^2.1.0":
+"assert@npm:^2.1.0":
   version: 2.1.0
   resolution: "assert@npm:2.1.0"
   dependencies:
@@ -10096,21 +10221,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:0.15.2":
-  version: 0.15.2
-  resolution: "ast-types@npm:0.15.2"
-  dependencies:
-    tslib: "npm:^2.0.1"
-  checksum: 81680bd5829cdec33524e9aa3434e23f3919c0c388927068a0ff2e8466f55b0f34eae53e0007b3668742910c289481ab4e1d486a5318f618ae2fc93b5e7e863b
-  languageName: node
-  linkType: hard
-
 "ast-types@npm:^0.14.2":
   version: 0.14.2
   resolution: "ast-types@npm:0.14.2"
   dependencies:
     tslib: "npm:^2.0.1"
   checksum: 7c74b3090c90aa600b49a7a8cecc99e329f190600bcaa75ad087472a1a5a7ef23795a17ea00a74c2a8e822b336cd4f874e2e1b815a9877b4dba5e401566b0433
+  languageName: node
+  linkType: hard
+
+"ast-types@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "ast-types@npm:0.16.1"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: f569b475eb1c8cb93888cb6e7b7e36dc43fa19a77e4eb132cbff6e3eb1598ca60f850db6e60b070e5a0ee8c1559fca921dac0916e576f2f104e198793b0bdd8d
   languageName: node
   linkType: hard
 
@@ -12310,7 +12435,7 @@ __metadata:
     "@types/react": "npm:^18.3.18"
     "@types/regexgen": "npm:^1.3.3"
     "@vercel/analytics": "npm:^1.4.1"
-    "@vitejs/plugin-react-swc": "npm:^3.7.2"
+    "@vitejs/plugin-react-swc": "npm:^3.8.0"
     browser-fs-access: "npm:^0.35.0"
     classnames: "npm:^2.5.1"
     dotenv: "npm:^16.4.7"
@@ -13939,7 +14064,7 @@ __metadata:
     "@tldraw/sync": "workspace:*"
     "@types/lodash": "npm:^4.17.14"
     "@vercel/analytics": "npm:^1.4.1"
-    "@vitejs/plugin-react-swc": "npm:^3.7.2"
+    "@vitejs/plugin-react-swc": "npm:^3.8.0"
     ag-grid-community: "npm:^32.3.3"
     ag-grid-react: "npm:^32.3.3"
     classnames: "npm:^2.5.1"
@@ -22434,16 +22559,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.22.0":
-  version: 0.22.0
-  resolution: "recast@npm:0.22.0"
+"recast@npm:^0.23.11":
+  version: 0.23.11
+  resolution: "recast@npm:0.23.11"
   dependencies:
-    assert: "npm:^2.0.0"
-    ast-types: "npm:0.15.2"
+    ast-types: "npm:^0.16.1"
     esprima: "npm:~4.0.0"
     source-map: "npm:~0.6.1"
+    tiny-invariant: "npm:^1.3.3"
     tslib: "npm:^2.0.1"
-  checksum: a383710369a14c13af216977cf016d5923b35ff98b8b10d669bc3404b38141579860ba7b4c211addf85f88467aeb7bb619f10409fec1550a2abdfe2e39758e43
+  checksum: a622b7848efe13a59a40c9a1a3a8178433eae1048780e04d7392406e2d67fc29e3efa84b3aa8cfda28fd58989f4b59fa968bed295b739987a666bd11cc57a5b2
   languageName: node
   linkType: hard
 
@@ -24757,6 +24882,13 @@ __metadata:
   dependencies:
     convert-hrtime: "npm:^3.0.0"
   checksum: 8bcecbda97142e804ba03acf52117cc771c2933277b299bdf2e8a949960fda3e70d8159b3ba5f49495d662c4b8cc15e30dbb1a703b1a735eecce11682b98e8f9
+  languageName: node
+  linkType: hard
+
+"tiny-invariant@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, `editor.inputs` stores a bunch of state in a big mutable object. This works pretty well, because that state is _mostly_ only accessed in event handlers. 

There are a few places in the UI where we access it, where we've previously relied on a `useTick` hook to re-render the component on every frame to get around our inability to subscribe to the input values. That's been fine though, because the only bits of UI that have used it have been in debug panels, so it hasn't really mattered.

With elbow arrows, I'm expecting that to change - we'll be using the current page position in the UI, and wanting it to update reactivly. This diff replaces the existing `editor.inputs` object with a new `InputManager` that has the exact same API, but is backed by atoms instead of plain mutable objects.

I don't expect that to be controversial, but the one thing this does add that might be is `@atom accessor foo = 'bar'` syntax, for creating a field on a class called foo, which is backed by an atom, and is initialised with `'bar'`. We've supported the new standards-based decorator syntax (as well as the legacy ts decorators syntax) for a little while, but to enable this syntax I've switched our transpilation tooling over to standards-based decorators too. There are a few places where we _could_ switch to this syntax, but I've only done so for the inputs where we needed it, and one other proof-of-concept in the license manager.

Typescript, esbuild, eslint, and prettier support this syntax out of the box. I've had to make some tweaks to enable it for recast, vite, jest, and next.

### Change type

- [x] `api`

### Release notes

The values in `editor.inputs` are now reactive.