### PR TITLE
dotcom/sdk sync-up: port back some of the new UI treatment to the SDK/examples

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -214,7 +214,6 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				onMount={handleMount}
 				onUiEvent={handleUiEvent}
 				components={components}
-				options={{ actionShortcutsLocation: 'toolbar' }}
 				deepLinks={deepLinks || undefined}
 				overrides={overrides}
 				isShapeHidden={isShapeHidden}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -110,7 +110,6 @@ function TlaEditorInner({
 				onUiEvent={handleUiEvent}
 				components={components}
 				deepLinks
-				options={{ actionShortcutsLocation: 'toolbar' }}
 			>
 				<ThemeUpdater />
 				<SneakyDarkModeSync />

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacySnapshotEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacySnapshotEditor.tsx
@@ -129,7 +129,6 @@ function TlaEditorInner({
 				onUiEvent={handleUiEvent}
 				components={components}
 				deepLinks
-				options={{ actionShortcutsLocation: 'toolbar' }}
 			>
 				<ThemeUpdater />
 				<SneakyDarkModeSync />

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -73,7 +73,6 @@ function LocalTldraw() {
 						}
 					})
 				}}
-				options={{ actionShortcutsLocation: 'toolbar' }}
 			>
 				<SneakyDarkModeSync />
 			</LocalEditor>

--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -1,7 +1,9 @@
 import * as Dialog from '@radix-ui/react-alert-dialog'
 import { Dispatch, createContext, useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { TldrawUiButton } from 'tldraw'
 import { Example, examples } from './examples'
+import { SidebarToggle } from './icons/icons'
 
 const dialogContext = createContext<{
 	example: Example | null
@@ -27,112 +29,131 @@ export function ExamplePage({
 	example: Example
 	children: React.ReactNode
 }) {
+	const [isSidebarOpen, setIsSidebarOpen] = useState(true)
 	const categories = examples.map((e) => e.id)
 	const [filterValue, setFilterValue] = useState('')
 	const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setFilterValue(e.target.value)
 	}
+
+	const sidebar = (
+		<div className="example__sidebar scroll-light">
+			<div className="example__sidebar__header">
+				<Link className="example__sidebar__header__logo" to="/">
+					<TldrawLogo />
+				</Link>
+				<div className="example__sidebar__header__socials">
+					<a
+						target="_blank"
+						href="https://twitter.com/tldraw"
+						rel="noopener noreferrer"
+						title="twitter"
+						className="hoverable"
+					>
+						<SocialIcon icon="twitter" />
+					</a>
+					<a
+						target="_blank"
+						href="https://github.com/tldraw/tldraw"
+						rel="noopener noreferrer"
+						title="github"
+						className="hoverable"
+					>
+						<SocialIcon icon="github" />
+					</a>
+					<a
+						target="_blank"
+						href="https://discord.tldraw.com/?utm_source=examples&utm_medium=organic&utm_campaign=examples"
+						rel="noopener noreferrer"
+						title="discord"
+						className="hoverable"
+					>
+						<SocialIcon icon="discord" />
+					</a>
+				</div>
+			</div>
+			<div className="example__sidebar__header-links">
+				<a className="example__sidebar__header-link" href="/develop">
+					Develop
+				</a>
+			</div>
+			<input
+				className="example__sidebar__filter"
+				placeholder="Filter…"
+				value={filterValue}
+				onChange={handleFilterChange}
+			/>
+			<ul className="example__sidebar__categories scroll-light">
+				{categories.map((currentCategory) => (
+					<li key={currentCategory} className="example__sidebar__category">
+						<h3 className="example__sidebar__category__header">{currentCategory}</h3>
+						<ul className="example__sidebar__category__items">
+							{examples
+								.find((category) => category.id === currentCategory)
+								?.value.filter((example) => {
+									const excludedWords = ['a', 'the', '', ' ']
+									const terms = filterValue
+										.toLowerCase()
+										.split(' ')
+										.filter((term) => !excludedWords.includes(term))
+									if (!terms.length) return true
+									return (
+										terms.some((term) => example.title.toLowerCase().includes(term)) ||
+										example.keywords.some((keyword) =>
+											terms.some((term) => keyword.toLowerCase().includes(term))
+										)
+									)
+								})
+								.map((sidebarExample) => (
+									<ExampleSidebarListItem
+										key={sidebarExample.path}
+										example={sidebarExample}
+										isActive={sidebarExample.path === example.path}
+									/>
+								))}
+						</ul>
+					</li>
+				))}
+			</ul>
+			<div className="example__sidebar__footer-links">
+				<a
+					className="example__sidebar__footer-link example__sidebar__footer-link--grey"
+					target="_blank"
+					rel="noopener noreferrer"
+					href="https://github.com/tldraw/tldraw/issues/new?assignees=&labels=Example%20Request&projects=&template=example_request.yml&title=%5BExample Request%5D%3A+"
+				>
+					Request an example
+				</a>
+				<a
+					className="example__sidebar__footer-link example__sidebar__footer-link--grey"
+					target="_blank"
+					rel="noopener noreferrer"
+					href="https://tldraw.dev/?utm_source=examples&utm_medium=organic&utm_campaign=examples"
+				>
+					Visit the docs
+				</a>
+			</div>
+		</div>
+	)
+
 	return (
 		<DialogContextProvider>
 			<div className="example">
-				<div className="example__sidebar scroll-light">
-					<div className="example__sidebar__header">
-						<Link className="example__sidebar__header__logo" to="/">
-							<TldrawLogo />
-						</Link>
-						<div className="example__sidebar__header__socials">
-							<a
-								target="_blank"
-								href="https://twitter.com/tldraw"
-								rel="noopener noreferrer"
-								title="twitter"
-								className="hoverable"
-							>
-								<SocialIcon icon="twitter" />
-							</a>
-							<a
-								target="_blank"
-								href="https://github.com/tldraw/tldraw"
-								rel="noopener noreferrer"
-								title="github"
-								className="hoverable"
-							>
-								<SocialIcon icon="github" />
-							</a>
-							<a
-								target="_blank"
-								href="https://discord.tldraw.com/?utm_source=examples&utm_medium=organic&utm_campaign=examples"
-								rel="noopener noreferrer"
-								title="discord"
-								className="hoverable"
-							>
-								<SocialIcon icon="discord" />
-							</a>
-						</div>
-					</div>
-					<div className="example__sidebar__header-links">
-						<a className="example__sidebar__header-link" href="/develop">
-							Develop
-						</a>
-					</div>
-					<input
-						className="example__sidebar__filter"
-						placeholder="Filter…"
-						value={filterValue}
-						onChange={handleFilterChange}
-					/>
-					<ul className="example__sidebar__categories scroll-light">
-						{categories.map((currentCategory) => (
-							<li key={currentCategory} className="example__sidebar__category">
-								<h3 className="example__sidebar__category__header">{currentCategory}</h3>
-								<ul className="example__sidebar__category__items">
-									{examples
-										.find((category) => category.id === currentCategory)
-										?.value.filter((example) => {
-											const excludedWords = ['a', 'the', '', ' ']
-											const terms = filterValue
-												.toLowerCase()
-												.split(' ')
-												.filter((term) => !excludedWords.includes(term))
-											if (!terms.length) return true
-											return (
-												terms.some((term) => example.title.toLowerCase().includes(term)) ||
-												example.keywords.some((keyword) =>
-													terms.some((term) => keyword.toLowerCase().includes(term))
-												)
-											)
-										})
-										.map((sidebarExample) => (
-											<ExampleSidebarListItem
-												key={sidebarExample.path}
-												example={sidebarExample}
-												isActive={sidebarExample.path === example.path}
-											/>
-										))}
-								</ul>
-							</li>
-						))}
-					</ul>
-					<div className="example__sidebar__footer-links">
-						<a
-							className="example__sidebar__footer-link example__sidebar__footer-link--grey"
-							target="_blank"
-							rel="noopener noreferrer"
-							href="https://github.com/tldraw/tldraw/issues/new?assignees=&labels=Example%20Request&projects=&template=example_request.yml&title=%5BExample Request%5D%3A+"
-						>
-							Request an example
-						</a>
-						<a
-							className="example__sidebar__footer-link example__sidebar__footer-link--grey"
-							target="_blank"
-							rel="noopener noreferrer"
-							href="https://tldraw.dev/?utm_source=examples&utm_medium=organic&utm_campaign=examples"
-						>
-							Visit the docs
-						</a>
-					</div>
-				</div>
+				{isSidebarOpen && sidebar}
 				<div className="example__content">
+					<TldrawUiButton
+						className="example__sidebar__toggle"
+						type="icon"
+						title="Toggle sidebar"
+						onClick={() => {
+							setIsSidebarOpen(!isSidebarOpen)
+						}}
+						style={{
+							top: example.multiplayer ? 42 : 0,
+						}}
+					>
+						<SidebarToggle />
+					</TldrawUiButton>
 					{children}
 					<Dialogs />
 				</div>
@@ -165,14 +186,6 @@ function ExampleSidebarListItem({
 					>
 						<InfoIcon />
 					</button>
-					<Link
-						to={`${example.path}/full`}
-						className="example__sidebar__item__button hoverable"
-						aria-label="Standalone"
-						title="View standalone example"
-					>
-						<StandaloneIcon />
-					</Link>
 				</div>
 			)}
 		</li>
@@ -236,19 +249,6 @@ function SocialIcon({ icon }: { icon: string }) {
 				height: 16,
 			}}
 		/>
-	)
-}
-
-function StandaloneIcon() {
-	return (
-		<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<path
-				d="M2 2.5C2 2.22386 2.22386 2 2.5 2H5.5C5.77614 2 6 2.22386 6 2.5C6 2.77614 5.77614 3 5.5 3H3V5.5C3 5.77614 2.77614 6 2.5 6C2.22386 6 2 5.77614 2 5.5V2.5ZM9 2.5C9 2.22386 9.22386 2 9.5 2H12.5C12.7761 2 13 2.22386 13 2.5V5.5C13 5.77614 12.7761 6 12.5 6C12.2239 6 12 5.77614 12 5.5V3H9.5C9.22386 3 9 2.77614 9 2.5ZM2.5 9C2.77614 9 3 9.22386 3 9.5V12H5.5C5.77614 12 6 12.2239 6 12.5C6 12.7761 5.77614 13 5.5 13H2.5C2.22386 13 2 12.7761 2 12.5V9.5C2 9.22386 2.22386 9 2.5 9ZM12.5 9C12.7761 9 13 9.22386 13 9.5V12.5C13 12.7761 12.7761 13 12.5 13H9.5C9.22386 13 9 12.7761 9 12.5C9 12.2239 9.22386 12 9.5 12H12V9.5C12 9.22386 12.2239 9 12.5 9Z"
-				fill="currentColor"
-				fillRule="evenodd"
-				clipRule="evenodd"
-			/>
-		</svg>
 	)
 }
 

--- a/apps/examples/src/icons/icons.tsx
+++ b/apps/examples/src/icons/icons.tsx
@@ -20,3 +20,20 @@ export function VisibilityOn({ fill = defaultFill }: { fill?: string }) {
 		</svg>
 	)
 }
+
+export function SidebarToggle() {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="none">
+			<rect
+				width="11.5"
+				height="11.5"
+				x="1.75"
+				y="1.75"
+				stroke="#000"
+				strokeWidth="1.5"
+				rx="1.25"
+			/>
+			<path fill="#000" d="M5 1h1.5v13H5z" />
+		</svg>
+	)
+}

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -500,3 +500,14 @@ a.example__sidebar__header-link {
 	position: relative;
 	flex: 1;
 }
+
+.example__content .tlui-menu-zone {
+	padding-left: 40px;
+}
+
+.example__sidebar__toggle {
+	position: absolute;
+	top: 0;
+	left: 4px;
+	z-index: 301;
+}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -702,7 +702,7 @@ export const DefaultSvgDefs: () => null;
 
 // @public (undocumented)
 export const defaultTldrawOptions: {
-    readonly actionShortcutsLocation: "swap";
+    readonly actionShortcutsLocation: "toolbar";
     readonly adjacentShapeMargin: 10;
     readonly animationMediumMs: 320;
     readonly cameraMovingTimeoutMs: 64;

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -121,7 +121,7 @@ export const defaultTldrawOptions = {
 	laserDelayMs: 1200,
 	maxExportDelayMs: 5000,
 	temporaryAssetPreviewLifetimeMs: 180000,
-	actionShortcutsLocation: 'swap',
+	actionShortcutsLocation: 'toolbar',
 	createTextOnCanvasDoubleClick: true,
 	exportProvider: Fragment,
 	enableToolbarKeyboardShortcuts: true,

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -281,6 +281,7 @@
 .tlui-buttons__horizontal {
 	display: flex;
 	flex-direction: row;
+	align-items: center;
 }
 .tlui-buttons__horizontal > * {
 	margin-left: -2px;
@@ -596,7 +597,7 @@
 	border-right: 2px solid var(--color-background);
 	border-bottom: 2px solid var(--color-background);
 	border-bottom-right-radius: var(--radius-4);
-	background-color: var(--color-low);
+	background-color: var(--color-background);
 }
 
 .tlui-menu-zone *[data-state='open']::after {
@@ -1256,7 +1257,23 @@
 	}
 }
 
-/* ------------------- Page Select ------------------ */
+/* ------------------- Main Menu and Page Select ------------------ */
+
+.tlui-main-menu {
+	color: var(--color-text-3);
+}
+
+.tlui-top-panel-separator {
+	color: var(--color-text-3);
+	pointer-events: none;
+	padding: 0 8px;
+}
+
+@media (hover: hover) {
+	.tlui-main-menu:hover {
+		color: var(--color-text-1);
+	}
+}
 
 .tlui-page-menu__wrapper {
 	position: relative;
@@ -1265,10 +1282,6 @@
 	width: 260px;
 	height: fit-content;
 	max-height: 50vh;
-}
-
-.tlui-page-menu__trigger {
-	width: 128px;
 }
 
 .tlui-page-menu__header {

--- a/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultMenuPanel.tsx
@@ -34,6 +34,7 @@ export const DefaultMenuPanel = memo(function MenuPanel() {
 				{PageMenu && !isSinglePageMode && <PageMenu />}
 				{showQuickActions ? (
 					<>
+						<span className="tlui-top-panel-separator">/</span>
 						{QuickActions && <QuickActions />}
 						{ActionsMenu && <ActionsMenu />}
 					</>

--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
@@ -27,8 +27,13 @@ export const DefaultMainMenu = memo(function DefaultMainMenu({ children }: TLUiM
 	return (
 		<_Dropdown.Root dir="ltr" open={isOpen} onOpenChange={onOpenChange} modal={false}>
 			<_Dropdown.Trigger asChild dir="ltr">
-				<TldrawUiButton type="icon" data-testid="main-menu.button" title={msg('menu.title')}>
-					<TldrawUiButtonIcon icon="menu" small />
+				<TldrawUiButton
+					type="icon"
+					className="tlui-main-menu"
+					data-testid="main-menu.button"
+					title={msg('menu.title')}
+				>
+					<TldrawUiButtonIcon icon="dots-vertical" small />
 				</TldrawUiButton>
 			</_Dropdown.Trigger>
 			<_Dropdown.Portal container={container}>

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -289,7 +289,6 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 					className="tlui-page-menu__trigger"
 				>
 					<div className="tlui-page-menu__name">{currentPage.name}</div>
-					<TldrawUiButtonIcon icon="chevron-down" small />
 				</TldrawUiButton>
 			</TldrawUiPopoverTrigger>
 			<TldrawUiPopoverContent


### PR DESCRIPTION
With the new dotcom release, our SDK styling has gotten a little crusty. Living in the examples/development mode, I'm stuck in the old world 😭 

- unifies the styling in the top-left area with the new dotcom look 💅 
- updates the `actionShortcutsLocation` to the new default of `toolbar` - let me know if this is controversial though...
- adds a regular sidebar toggle to our examples app instead of the "full" button which was hard to discover

![Screenshot 2025-03-18 at 14 03 38](https://github.com/user-attachments/assets/622a6d90-821e-466a-8cf6-250f49292b89)


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Update styling for our top-left menu area