### PR TITLE
fix sentry csp

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -11,6 +11,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`https://cdn.tldraw.com`,
 		`https://*.tldraw.workers.dev`,
 		`https://*.ingest.sentry.io`,
+		`https://*.ingest.*.sentry.io`,
 		// for thumbnail server
 		'http://localhost:5002',
 		'https://*.clerk.accounts.dev',

--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -11,7 +11,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`https://cdn.tldraw.com`,
 		`https://*.tldraw.workers.dev`,
 		`https://*.ingest.sentry.io`,
-		`https://*.ingest.*.sentry.io`,
+		`https://*.ingest.us.sentry.io`,
 		// for thumbnail server
 		'http://localhost:5002',
 		'https://*.clerk.accounts.dev',


### PR DESCRIPTION
seems like sentry is using this other domain, at least on our preview envs

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/eb453626-d2d8-4ee6-810d-f2e0b74af260" />


### Change type

- [x] `other`
