### PR TITLE
Draw shape: Guard against zero pressure pointer events

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -168,7 +168,9 @@ export class Drawing extends StateNode {
 		const { z = 0.5 } = this.info.point
 
 		this.isPen = isPen
-		this.isPenOrStylus = isPen || (z > 0 && z < 0.5) || (z > 0.5 && z < 1)
+		// if z === 0 on the initial point, treat this pen as a mouse because it's likely a broken pen
+		// or a broken OS.
+		this.isPenOrStylus = (isPen && z !== 0) || (z > 0 && z < 0.5) || (z > 0.5 && z < 1)
 
 		const pressure = this.isPenOrStylus ? z * 1.25 : 0.5
 

--- a/packages/tldraw/src/lib/shapes/shared/freehand/getStrokePoints.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/getStrokePoints.ts
@@ -52,6 +52,11 @@ export function getStrokePoints(
 		}
 	}
 
+	// if we accidentally stripped out most of the line, revert to the original points
+	if (!simulatePressure && pts.length < rawInputPoints.length * 0.5) {
+		pts = rawInputPoints.map(Vec.From)
+	}
+
 	if (pts.length === 0)
 		return [
 			{


### PR DESCRIPTION
We had a user of a Xiaomi tablet report that they couldn't draw anything, and after [much debugging](https://discord.com/channels/859816885297741824/859816885801713728/1350835984736059455) we discovered that their tablet was setting the pen pressure to 0 for every point. Interesting choice.

This PR attempts to account for that in a couple of ways

1. if the first point on a line has a pressure of 0, assume the device is broken and use pressure simulation.
2. if most of the points on a line get stripped out when filtering for low pressure at the start and end of the line, use the original points as they were.

### Change type

- [x] `other`

### Release notes

- Tweaked the draw shape svg rendering to be more forgiving for tablets which report low pen pressures.
- Fix an edge case where some tablets report 0 pressure for all pointer move events.