### PR TITLE
[dotcom] Fix qr code links

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
@@ -21,7 +21,7 @@ export function QrCode({ url }: { url: string }) {
 			const blob = new Blob([svgString], { type: 'image/svg+xml' })
 			FileHelpers.blobToDataUrl(blob).then(setQrCode)
 		})
-	}, [url, setQrCode, qrCode, editor])
+	}, [url, setQrCode, editor])
 
 	// When qr code is there, set it as src
 	useLayoutEffect(() => {

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
@@ -15,14 +15,12 @@ export function QrCode({ url }: { url: string }) {
 	const editor = useGlobalEditor()
 
 	useEffect(() => {
-		if (!qrCode) {
-			if (!editor) return
+		if (!editor) return
 
-			createQRCodeImageDataString(url).then((svgString) => {
-				const blob = new Blob([svgString], { type: 'image/svg+xml' })
-				FileHelpers.blobToDataUrl(blob).then(setQrCode)
-			})
-		}
+		createQRCodeImageDataString(url).then((svgString) => {
+			const blob = new Blob([svgString], { type: 'image/svg+xml' })
+			FileHelpers.blobToDataUrl(blob).then(setQrCode)
+		})
 	}, [url, setQrCode, qrCode, editor])
 
 	// When qr code is there, set it as src

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaAnonCopyLinkTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaAnonCopyLinkTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { useLocation, useSearchParams } from 'react-router-dom'
 import { useEditor } from 'tldraw'
+import { useEditorDeepLink } from '../../../hooks/useDeepLink'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { copyTextToClipboard } from '../../../utils/copy'
 import { F } from '../../../utils/i18n'
@@ -9,14 +9,12 @@ import { QrCode } from '../QrCode'
 import { TlaShareMenuCopyButton } from '../file-share-menu-primitives'
 
 export function TlaAnonCopyLinkTab() {
-	const location = useLocation()
-	const [searchParams] = useSearchParams()
-	const href = `${window.location.origin}${location.pathname}?${searchParams.toString()}`
+	const url = useEditorDeepLink()
 	return (
 		<>
 			<TlaMenuSection>
-				<TlaAnonCopyLinkButton url={href} />
-				<QrCode url={href} />
+				<TlaAnonCopyLinkButton url={url ?? ''} />
+				<QrCode url={url ?? ''} />
 			</TlaMenuSection>
 		</>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { useEditor, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
+import { useEditorDeepLink } from '../../../hooks/useDeepLink'
 import { useIsFileOwner } from '../../../hooks/useIsFileOwner'
 import { useTldrawUser } from '../../../hooks/useUser'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
@@ -37,6 +38,7 @@ export function TlaInviteTab({ fileId }: { fileId: string }) {
 	)
 
 	const isOwner = useIsFileOwner(fileId)
+	const url = useEditorDeepLink()
 
 	return (
 		<>
@@ -48,7 +50,7 @@ export function TlaInviteTab({ fileId }: { fileId: string }) {
 					</TlaMenuControlGroup>
 				)}
 				{isShared && <TlaCopyLinkButton isShared={isShared} fileId={fileId} />}
-				{isShared && <QrCode url={routes.tlaFile(fileId, { asUrl: true })} />}
+				{isShared && <QrCode url={url ?? ''} />}
 			</TlaMenuSection>
 		</>
 	)

--- a/apps/dotcom/client/src/tla/hooks/useDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useDeepLink.tsx
@@ -1,14 +1,24 @@
-import { useValue } from 'tldraw'
+import { useEffect, useState } from 'react'
+import { react, throttle } from 'tldraw'
 import { globalEditor } from '../../utils/globalEditor'
 
+function getDeepLink() {
+	const editor = globalEditor.get()
+	if (!editor) return null
+	return editor.createDeepLink().toString()
+}
+
 export function useEditorDeepLink() {
-	return useValue(
-		'deepLink',
-		() => {
-			const editor = globalEditor.get()
-			if (!editor) return null
-			return editor.createDeepLink().toString()
-		},
-		[]
-	)
+	const [deepLink, setDeepLink] = useState(getDeepLink())
+	useEffect(() => {
+		const throttledSetDeepLink = throttle(setDeepLink, 300)
+		const unsub = react('setDeepLink', () => {
+			throttledSetDeepLink(getDeepLink())
+		})
+		return () => {
+			unsub()
+			throttledSetDeepLink.cancel()
+		}
+	}, [])
+	return deepLink
 }

--- a/apps/dotcom/client/src/tla/hooks/useDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useDeepLink.tsx
@@ -1,0 +1,14 @@
+import { useValue } from 'tldraw'
+import { globalEditor } from '../../utils/globalEditor'
+
+export function useEditorDeepLink() {
+	return useValue(
+		'deepLink',
+		() => {
+			const editor = globalEditor.get()
+			if (!editor) return null
+			return editor.createDeepLink().toString()
+		},
+		[]
+	)
+}


### PR DESCRIPTION
a couple of issues here

1. qr codes weren't updating in response to deep link updates
2. the file owner share menu didn't have the deep link query string added to the url


### Change type

- [x] `other`
