### PR TITLE
Add & fix missing state docs

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,6 +37,7 @@
 		"create-api-markdown": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/create-api-markdown.ts",
 		"refresh-content": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/refresh-content.ts",
 		"refresh-everything": "yarn fetch-api-source && yarn fetch-releases && yarn create-api-markdown && yarn refresh-content && yarn format && yarn update-algolia-index",
+		"refresh-api": "yarn fetch-api-source && yarn create-api-markdown && yarn refresh-content && yarn update-algolia-index",
 		"update-algolia-index": "yarn run -T tsx --tsconfig ./tsconfig.content.json ./scripts/update-algolia-index.ts",
 		"clean": "rm -rf node_modules .yarn",
 		"format": "yarn run -T prettier --write .",

--- a/packages/state-react/api-report.api.md
+++ b/packages/state-react/api-report.api.md
@@ -16,15 +16,12 @@ import { Signal } from '@tldraw/state';
 export function track<T extends FunctionComponent<any>>(baseComponent: T): React_2.NamedExoticComponent<React_2.ComponentProps<T>>;
 
 // @public
-export function useAtom<Value, Diff = unknown>(
-name: string,
-valueOrInitialiser: (() => Value) | Value,
-options?: AtomOptions<Value, Diff>): Atom<Value, Diff>;
-
-// @public
-export function useComputed<Value>(name: string, compute: () => Value, deps: any[]): Computed<Value>;
+export function useAtom<Value, Diff = unknown>(name: string, valueOrInitialiser: (() => Value) | Value, options?: AtomOptions<Value, Diff>): Atom<Value, Diff>;
 
 // @public (undocumented)
+export function useComputed<Value>(name: string, compute: () => Value, deps: any[]): Computed<Value>;
+
+// @public
 export function useComputed<Value, Diff = unknown>(name: string, compute: () => Value, opts: ComputedOptions<Value, Diff>, deps: any[]): Computed<Value>;
 
 // @public (undocumented)
@@ -36,10 +33,10 @@ export function useReactor(name: string, reactFn: () => void, deps?: any[] | und
 // @public
 export function useStateTracking<T>(name: string, render: () => T, deps?: unknown[]): T;
 
-// @public
+// @public (undocumented)
 export function useValue<Value>(value: Signal<Value>): Value;
 
-// @public (undocumented)
+// @public
 export function useValue<Value>(name: string, fn: () => Value, deps: unknown[]): Value;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/state-react/src/lib/useAtom.ts
+++ b/packages/state-react/src/lib/useAtom.ts
@@ -4,7 +4,7 @@ import { useState } from 'react'
 /**
  * Creates a new atom and returns it. The atom will be created only once.
  *
- * See {@link state#atom}
+ * See `atom`.
  *
  * @example
  * ```ts
@@ -15,20 +15,15 @@ import { useState } from 'react'
  * })
  * ```
  *
+ * @param name - The name of the atom. This does not need to be globally unique. It is used for debugging and performance profiling.
+ * @param valueOrInitialiser - The initial value of the atom. If this is a function, it will be called to get the initial value.
+ * @param options - Options for the atom.
+ *
  * @public
  */
 export function useAtom<Value, Diff = unknown>(
-	/**
-	 * The name of the atom. This does not need to be globally unique. It is used for debugging and performance profiling.
-	 */
 	name: string,
-	/**
-	 * The initial value of the atom. If this is a function, it will be called to get the initial value.
-	 */
 	valueOrInitialiser: Value | (() => Value),
-	/**
-	 * Options for the atom.
-	 */
 	options?: AtomOptions<Value, Diff>
 ): Atom<Value, Diff> {
 	return useState(() => {

--- a/packages/state-react/src/lib/useComputed.ts
+++ b/packages/state-react/src/lib/useComputed.ts
@@ -2,10 +2,11 @@
 import { Computed, ComputedOptions, computed } from '@tldraw/state'
 import { useMemo } from 'react'
 
+/** @public */
+export function useComputed<Value>(name: string, compute: () => Value, deps: any[]): Computed<Value>
+
 /**
  * Creates a new computed signal and returns it. The computed signal will be created only once.
- *
- * See {@link state#computed}
  *
  * @example
  * ```ts
@@ -22,8 +23,6 @@ import { useMemo } from 'react'
  *
  * @public
  */
-export function useComputed<Value>(name: string, compute: () => Value, deps: any[]): Computed<Value>
-/** @public */
 export function useComputed<Value, Diff = unknown>(
 	name: string,
 	compute: () => Value,

--- a/packages/state-react/src/lib/useStateTracking.ts
+++ b/packages/state-react/src/lib/useStateTracking.ts
@@ -6,6 +6,8 @@ import React from 'react'
  *
  * This allows you to use reactive values transparently.
  *
+ * See the `track` component wrapper, which uses this under the hood.
+ *
  * @example
  * ```ts
  * function MyComponent() {
@@ -16,7 +18,6 @@ import React from 'react'
  * }
  * ```
  *
- * @see the `track` component wrapper, which uses this under the hood.
  *
  * @public
  */

--- a/packages/state-react/src/lib/useValue.ts
+++ b/packages/state-react/src/lib/useValue.ts
@@ -2,6 +2,9 @@
 import { Signal, computed, react } from '@tldraw/state'
 import { useMemo, useRef, useSyncExternalStore } from 'react'
 
+/** @public */
+export function useValue<Value>(value: Signal<Value>): Value
+
 /**
  * Extracts the value from a signal and subscribes to it.
  *
@@ -37,9 +40,8 @@ import { useMemo, useRef, useSyncExternalStore } from 'react'
  *
  * @public
  */
-export function useValue<Value>(value: Signal<Value>): Value
-/** @public */
 export function useValue<Value>(name: string, fn: () => Value, deps: unknown[]): Value
+
 /** @public */
 export function useValue() {
 	const args = arguments

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -287,9 +287,9 @@ export function react(
 }
 
 /**
- * The reactor is a user-friendly interface for starting and stopping an {@link state#EffectScheduler}.
+ * The reactor is a user-friendly interface for starting and stopping an `EffectScheduler`.
  *
- * Calling .start() will attach the scheduler and execute the effect immediately the first time it is called.
+ * Calling `.start()` will attach the scheduler and execute the effect immediately the first time it is called.
  *
  * If the reactor is stopped, calling `.start()` will re-attach the scheduler but will only execute the effect if any of its parents have changed since it was stopped.
  *

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -230,7 +230,7 @@ export function advanceGlobalEpoch() {
  * A `rollback` callback is passed into the function.
  * Calling this will prevent the transaction from committing and will revert any signals that were updated during the transaction to their state before the transaction began.
  *
- *  * @example
+ * @example
  * ```ts
  * const firstName = atom('John')
  * const lastName = atom('Doe')
@@ -289,7 +289,7 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 }
 
 /**
- * Like [transaction](#transaction), but does not create a new transaction if there is already one in progress.
+ * Like {@link transaction}, but does not create a new transaction if there is already one in progress.
  *
  * @param fn - The function to run in a transaction.
  * @public


### PR DESCRIPTION
This PR adds and fixes some missing state docs on our API reference. It also adds a new command `yarn refresh-api`, which you can use within the `apps/docs` folder to quickly refresh local API pages (after running something like `yarn build-api` at root).

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Docs: Added more docs to the `@tldraw/state` and `@tldraw/state-react` API reference,