### PR TITLE
rich text: add RichTextSVG to exports

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2021,6 +2021,31 @@ export interface RichTextLabelProps {
     wrap?: boolean;
 }
 
+// @public
+export function RichTextSVG({ bounds, richText, fontSize, font, align, verticalAlign, wrap, labelColor, padding, }: RichTextSVGProps): JSX_2.Element;
+
+// @public (undocumented)
+export interface RichTextSVGProps {
+    // (undocumented)
+    align: TLDefaultHorizontalAlignStyle;
+    // (undocumented)
+    bounds: Box;
+    // (undocumented)
+    font: TLDefaultFontStyle;
+    // (undocumented)
+    fontSize: number;
+    // (undocumented)
+    labelColor: string;
+    // (undocumented)
+    padding: number;
+    // (undocumented)
+    richText: TLRichText;
+    // (undocumented)
+    verticalAlign: TLDefaultVerticalAlignStyle;
+    // (undocumented)
+    wrap?: boolean;
+}
+
 // @public (undocumented)
 export function RotateCWMenuItem(): JSX_2.Element;
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -95,7 +95,12 @@ export {
 	TextLabel,
 	type PlainTextLabelProps,
 } from './lib/shapes/shared/PlainTextLabel'
-export { RichTextLabel, type RichTextLabelProps } from './lib/shapes/shared/RichTextLabel'
+export {
+	RichTextLabel,
+	RichTextSVG,
+	type RichTextLabelProps,
+	type RichTextSVGProps,
+} from './lib/shapes/shared/RichTextLabel'
 export {
 	getCropBox,
 	getDefaultCrop,


### PR DESCRIPTION
this should have been exported, it's an oversight

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Add `RichTextSVG` to the exports.