### PR TITLE
Tweak example code snippet sizing

### DIFF
--- a/apps/docs/components/content/code-files.tsx
+++ b/apps/docs/components/content/code-files.tsx
@@ -28,7 +28,7 @@ export function CodeFiles({
 	return (
 		<TabGroup
 			className={cn(
-				'group relative not-prose bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:-mx-1 md:px-1 my-6 flex flex-col',
+				'max-h-[550px] group relative not-prose bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:-mx-1 md:px-1 my-6 flex flex-col',
 				'[td_&]:m-0 [td_&]:mb-2 [td_&]:p-0 [td_&]:bg-transparent [td_&]:rounded-none',
 				className
 			)}
@@ -50,7 +50,7 @@ export function CodeFiles({
 			</TabList>
 			<TabPanels
 				className={cn(
-					'bg-zinc-900 grow text-sm text-white shadow md:rounded-b-xl overflow-x-auto px-5 md:px-4 py-4',
+					'bg-zinc-900 grow text-sm text-white shadow md:rounded-b-xl overflow-x-auto px-5 md:px-4 py-0',
 					hideTabs && 'md:rounded-t-xl'
 				)}
 			>
@@ -61,7 +61,7 @@ export function CodeFiles({
 					return (
 						<TabPanel key={index}>
 							<pre
-								className="overflow-y-auto max-h-96"
+								className="overflow-y-auto p-4"
 								dangerouslySetInnerHTML={{
 									__html: hastToHtml(codeElem),
 								}}


### PR DESCRIPTION
This PR increases the size of code snippets on examples pages on tldraw.dev. They now match the size of the embedded example itself.

This PR also fixes a padding bug.

![image](https://github.com/user-attachments/assets/28f12dae-4471-40de-8728-8fea0230c99c)


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
