### PR TITLE
Add "copy to clipboard" button to examples on tldraw.dev

### DIFF
--- a/apps/docs/components/content/code-files.tsx
+++ b/apps/docs/components/content/code-files.tsx
@@ -1,7 +1,10 @@
+'use client'
 import { cn } from '@/utils/cn'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
-
+import { CheckIcon } from '@heroicons/react/20/solid'
+import { ClipboardIcon } from '@heroicons/react/24/outline'
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript'
+import { useCallback, useState } from 'react'
 import { createHighlighterCoreSync, hastToHtml } from 'shiki/core'
 import css from 'shiki/dist/langs/css.mjs'
 import ts from 'shiki/dist/langs/typescript.mjs'
@@ -25,28 +28,50 @@ export function CodeFiles({
 	hideTabs?: boolean
 	className?: string
 }) {
+	const [copied, setCopied] = useState(false)
+	const [currentTab, setCurrentTab] = useState(0)
+
+	const handleCopy = useCallback(async () => {
+		const text = files[currentTab].content
+		await navigator.clipboard.writeText(text)
+		setCopied(true)
+		const timeout = setTimeout(() => setCopied(false), 1000)
+		return () => {
+			setCopied(false)
+			clearTimeout(timeout)
+		}
+	}, [currentTab, files])
+
+	const Icon = copied ? CheckIcon : ClipboardIcon
+
 	return (
 		<TabGroup
+			onChange={setCurrentTab}
 			className={cn(
 				'group relative not-prose bg-zinc-100 dark:bg-zinc-800 py-1 md:rounded-2xl -mx-5 md:-mx-1 md:px-1 my-6 flex flex-col',
 				'[td_&]:m-0 [td_&]:mb-2 [td_&]:p-0 [td_&]:bg-transparent [td_&]:rounded-none',
 				className
 			)}
 		>
-			<TabList
-				className={cn(
-					'bg-zinc-900 shrink-0 text-sm text-zinc-400 shadow md:rounded-t-xl border-b border-zinc-700/50 px-5 md:px-4 gap-4 flex',
-					hideTabs && 'hidden'
-				)}
-			>
-				{files.map(({ name }, index) => (
-					<Tab
-						key={index}
-						className="h-10 data-[selected]:text-white border-b border-transparent data-[selected]:border-white -mb-px focus:outline-none"
-					>
-						{name}
-					</Tab>
-				))}
+			<TabList className="flex gap-4 justify-between bg-zinc-900 shrink-0 text-sm text-zinc-400 shadow md:rounded-t-xl border-b border-zinc-700/50 px-5 md:px-4 w-full">
+				<div className={cn('flex gap-4', hideTabs && 'hidden')}>
+					{files.map(({ name }, index) => (
+						<Tab
+							key={index}
+							className="h-10 data-[selected]:text-white border-b border-transparent data-[selected]:border-white -mb-px focus:outline-none"
+						>
+							{name}
+						</Tab>
+					))}
+				</div>
+				<button
+					className="hidden w-8 m-[-8px] hover:text-zinc-100 md:flex items-center justify-center"
+					onClick={handleCopy}
+				>
+					<div className={cn('transition-opacity duration-300')}>
+						<Icon className="size-[1.15rem]" />
+					</div>
+				</button>
 			</TabList>
 			<TabPanels
 				className={cn(

--- a/apps/docs/components/content/code-files.tsx
+++ b/apps/docs/components/content/code-files.tsx
@@ -65,7 +65,7 @@ export function CodeFiles({
 					))}
 				</div>
 				<button
-					className="hidden w-8 m-[-8px] hover:text-zinc-100 md:flex items-center justify-center"
+					className="hidden w-8 mx-[-8px] hover:text-zinc-100 md:flex items-center justify-center"
 					onClick={handleCopy}
 				>
 					<div className={cn('transition-opacity duration-300')}>


### PR DESCRIPTION
This PR adds a "copy to clipboard" button to examples on tldraw.dev. I think there are still some scroll issues to fix when the example has lots of files, but to be fair those exist already even without this PR. I will take a look before merging.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…