### PR TITLE
style panel: be able to hit Enter to continue editing after selection

### DIFF
--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -189,9 +189,7 @@ test.describe('Focus', () => {
 		await page.waitForSelector('.tl-shape')
 
 		const blueButton = await page.$('.tlui-button[data-testid="style.color.blue"]')
-		await blueButton?.dispatchEvent('pointerdown')
 		await blueButton?.click()
-		await blueButton?.dispatchEvent('pointerup')
 
 		// Text should still be focused.
 		expect(

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -4,6 +4,7 @@ import {
 	StyleProp,
 	TLDefaultColorStyle,
 	TLDefaultColorTheme,
+	useEditor,
 } from '@tldraw/editor'
 import classNames from 'classnames'
 import { ReactElement, memo, useMemo, useRef } from 'react'
@@ -40,6 +41,7 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 		onHistoryMark,
 		theme,
 	} = props
+	const editor = useEditor()
 	const msg = useTranslation()
 
 	const rPointing = useRef(false)
@@ -64,6 +66,8 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 				(['TEXTAREA', 'INPUT'].includes(origActiveEl.nodeName) || origActiveEl.isContentEditable)
 			) {
 				origActiveEl.focus()
+			} else {
+				editor.getContainer().focus()
 			}
 			rPointingOriginalActiveElement.current = null
 		}
@@ -107,7 +111,7 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 			handleButtonPointerEnter,
 			handleButtonPointerUp,
 		}
-	}, [value, onHistoryMark, onValueChange, style])
+	}, [editor, value, onHistoryMark, onValueChange, style])
 
 	return (
 		<div data-testid={`style.${uiType}`} className={classNames('tlui-buttons__grid')}>


### PR DESCRIPTION
fixes #5644

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Style panel: be able to hit Enter to continue editing after selection