### PR TITLE
[dotcom] fix deep link handling for previously-seen files

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Editor.ts
+++ b/apps/dotcom/client/e2e/fixtures/Editor.ts
@@ -65,4 +65,22 @@ export class Editor {
 	async openPageMenu() {
 		await this.pageMenu.click()
 	}
+
+	@step
+	async createNewPage() {
+		await this.page.getByTestId('page-menu.button').click()
+		await expect(this.page.getByTestId('page-menu.item').first()).toBeVisible()
+		const count = await this.page.getByTestId('page-menu.item').count()
+		await this.page.getByTestId('page-menu.create').click()
+		await expect(this.page.getByTestId('page-menu.item')).toHaveCount(count + 1)
+		await this.page.keyboard.press('Enter')
+		await this.page.keyboard.press('Escape')
+	}
+
+	@step
+	async createTextShape(text: string) {
+		await this.page.locator('.tl-background').click({ clickCount: 2 })
+		await this.page.locator('div[contenteditable="true"]').fill(text)
+		await this.page.pause()
+	}
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -7,6 +7,7 @@ import {
 	TLUiDialogsContextType,
 	Tldraw,
 	createSessionStateSnapshotSignal,
+	parseDeepLinkString,
 	react,
 	throttle,
 	tltime,
@@ -107,11 +108,14 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			}
 
 			const fileState = app.getFileState(fileId)
-			if (fileState?.lastSessionState) {
+			const deepLink = new URLSearchParams(window.location.search).get('d')
+			if (fileState?.lastSessionState && !deepLink) {
 				editor.loadSnapshot(
 					{ session: JSON.parse(fileState.lastSessionState.trim() || 'null') },
 					{ forceOverwriteSessionState: true }
 				)
+			} else if (deepLink) {
+				editor.navigateToDeepLink(parseDeepLinkString(deepLink))
 			}
 			const sessionState$ = createSessionStateSnapshotSignal(editor.store)
 			const updateSessionState = throttle((state: TLSessionStateSnapshot) => {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1802,7 +1802,7 @@ export interface OverflowingToolbarProps {
 }
 
 // @public (undocumented)
-export const PageItemInput: ({ name, id, isCurrentPage, onCancel, }: PageItemInputProps) => JSX_2.Element;
+export const PageItemInput: ({ name, id, isCurrentPage, onCancel, onComplete }: PageItemInputProps) => JSX_2.Element;
 
 // @public (undocumented)
 export interface PageItemInputProps {
@@ -1814,6 +1814,8 @@ export interface PageItemInputProps {
     name: string;
     // (undocumented)
     onCancel(): void;
+    // (undocumented)
+    onComplete?(): void;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1802,7 +1802,7 @@ export interface OverflowingToolbarProps {
 }
 
 // @public (undocumented)
-export const PageItemInput: ({ name, id, isCurrentPage, onCancel, onComplete }: PageItemInputProps) => JSX_2.Element;
+export const PageItemInput: ({ name, id, isCurrentPage, onCancel, onComplete, }: PageItemInputProps) => JSX_2.Element;
 
 // @public (undocumented)
 export interface PageItemInputProps {

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -390,6 +390,10 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 												id={page.id}
 												name={page.name}
 												isCurrentPage={page.id === currentPage.id}
+												onComplete={() => {
+													setIsEditing(false)
+													editor.menus.clearOpenMenus()
+												}}
 												onCancel={() => {
 													setIsEditing(false)
 													editor.menus.clearOpenMenus()

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemInput.tsx
@@ -9,6 +9,7 @@ export interface PageItemInputProps {
 	id: TLPageId
 	isCurrentPage: boolean
 	onCancel(): void
+	onComplete?(): void
 }
 
 /** @public @react */
@@ -17,6 +18,7 @@ export const PageItemInput = function PageItemInput({
 	id,
 	isCurrentPage,
 	onCancel,
+	onComplete,
 }: PageItemInputProps) {
 	const editor = useEditor()
 	const trackEvent = useUiEvents()
@@ -49,6 +51,7 @@ export const PageItemInput = function PageItemInput({
 			ref={(el) => (rInput.current = el)}
 			defaultValue={name}
 			onValueChange={handleChange}
+			onComplete={onComplete}
 			onCancel={handleCancel}
 			onFocus={handleFocus}
 			shouldManuallyMaintainScrollPositionWhenFocused


### PR DESCRIPTION
We were overriding the deep links default behavior with the state from the database when the user had visited the file before. This fixes that.

### Change type

- [x] `other`
