### PR TITLE
rich text: tweak numbered list padding depending on # of items

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -953,6 +953,15 @@ input,
 .tl-rich-text ol {
 	text-align: left;
 	margin: 0;
+	padding-left: 3.25ch;
+}
+
+.tl-rich-text ol:has(> li:nth-child(10)) {
+	padding-left: 4.25ch;
+}
+
+.tl-rich-text ol:has(> li:nth-child(100)) {
+	padding-left: 5.25ch;
 }
 
 .tl-rich-text h1,


### PR DESCRIPTION
test board https://www.tldraw.com/f/eZo4vsgOxe0eRxXwBh-rR?d=v-2029.-1605.4020.3532.Eie2yK7xYj53B2IpFh5pn

fix issues like this:
![Screenshot 2025-03-20 at 11 21 26](https://github.com/user-attachments/assets/fb085a01-bdae-404e-9204-facbf6a389b7)


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix issue with rich text numbered lists escaping geometry bounds