### PR TITLE
Improve search config

### DIFF
--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -4,6 +4,8 @@ status: published
 author: steveruizok
 date: 3/22/2023
 order: 1
+keywords:
+  - hello world
 ---
 
 To use the tldraw SDK, first install the `tldraw` package:

--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -4,6 +4,11 @@ status: published
 author: steveruizok
 date: 3/22/2023
 order: 0
+keywords:
+  - hello world
+  - intro
+  - start
+  - installation
 ---
 
 Have five minutes? Let's try out the tldraw SDK in a React project. If you're new to React, we recommend using a [Vite template](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) as a starter. We'll assume your project is already running locally.

--- a/apps/docs/scripts/update-algolia-index.ts
+++ b/apps/docs/scripts/update-algolia-index.ts
@@ -258,8 +258,22 @@ async function updateAlgoliaIndex() {
 				{ autoGenerateObjectIDIfNotExist: true }
 			)
 			await index.setSettings({
-				searchableAttributes: ['titleHeadingFirst', 'title', 'description', 'keywords', 'content'],
-				camelCaseAttributes: ['titleHeadingFirst', 'title', 'description', 'keywords', 'content'],
+				searchableAttributes: [
+					'section',
+					'titleHeadingFirst',
+					'title',
+					'description',
+					'keywords',
+					'content',
+				],
+				camelCaseAttributes: [
+					'section',
+					'titleHeadingFirst',
+					'title',
+					'description',
+					'keywords',
+					'content',
+				],
 				// these are only applied _after_ keyword search is complete. if two entries have
 				// the same keyword search score, this will be used to tiebreak them.
 				customRanking: [

--- a/apps/docs/scripts/update-algolia-index.ts
+++ b/apps/docs/scripts/update-algolia-index.ts
@@ -275,6 +275,7 @@ async function updateAlgoliaIndex() {
 				],
 				distinct: 4,
 				attributeForDistinct: 'section',
+				advancedSyntax: true,
 			})
 
 			const resultsToShowForEmptySearch = entries

--- a/apps/docs/scripts/update-algolia-index.ts
+++ b/apps/docs/scripts/update-algolia-index.ts
@@ -273,7 +273,7 @@ async function updateAlgoliaIndex() {
 					'asc(articleIndex)',
 					'asc(headingIndex)',
 				],
-				distinct: 4,
+				distinct: 3,
 				attributeForDistinct: 'section',
 				advancedSyntax: true,
 			})

--- a/apps/examples/src/examples/basic/README.md
+++ b/apps/examples/src/examples/basic/README.md
@@ -3,7 +3,7 @@ title: Tldraw component
 component: ./BasicExample.tsx
 category: basic
 priority: 1
-keywords: [basic, intro, simple, quick, start]
+keywords: [basic, intro, simple, quick, start, hello world, installation]
 ---
 
 ---


### PR DESCRIPTION
This PR changes our algolia config to fix some common failure cases and improve experience. It also adds some keywords to pages.

- Section name is now considered in search ranking. This means that searching for "Examples" will actually come up with examples first.
- We now group sections of results into threes instead of fours. This means you don't have to scroll so far down to find what you need (which is usually an example).
- We now support advanced search syntax, which means you can use quotes to search for an exact string. (You can also use a minus to specify something to exclude from the results).

![image](https://github.com/user-attachments/assets/dddf0e1b-8eda-443c-9b16-cb3b842948b6)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
