### PR TITLE
Use pg message bus for requesting lsn update

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -318,6 +318,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private async maybePrune() {
 		const now = Date.now()
 		if (now - this.lastUserPruneTime < PRUNE_INTERVAL) return
+		this.logEvent({ type: 'prune' })
 		const cutoffTime = now - PRUNE_INTERVAL
 		const usersWithoutRecentUpdates = this.ctx.storage.sql
 			.exec('SELECT id FROM active_user WHERE lastUpdatedAt < ?', cutoffTime)
@@ -950,6 +951,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			case 'register_user':
 			case 'unregister_user':
 			case 'request_lsn_update':
+			case 'prune':
 			case 'get_file_record':
 				this.writeEvent({
 					blobs: [event.type],

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -319,6 +319,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		const now = Date.now()
 		if (now - this.lastUserPruneTime < PRUNE_INTERVAL) return
 		this.logEvent({ type: 'prune' })
+		this.log.debug('pruning')
 		const cutoffTime = now - PRUNE_INTERVAL
 		const usersWithoutRecentUpdates = this.ctx.storage.sql
 			.exec('SELECT id FROM active_user WHERE lastUpdatedAt < ?', cutoffTime)

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -447,6 +447,10 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				this.reportPostgresUpdate()
 				const collator = new UserChangeCollator()
 				for (const _change of log.change) {
+					if (_change.kind === 'message' && (_change as any).prefix === 'requestLsnUpdate') {
+						this.requestLsnUpdate((_change as any).content)
+						continue
+					}
 					const change = this.parseChange(_change)
 					if (!change) {
 						this.log.debug('IGNORING CHANGE', _change)
@@ -909,7 +913,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		}
 	}
 
-	async requestLsnUpdate(userId: string) {
+	private async requestLsnUpdate(userId: string) {
 		try {
 			this.log.debug('requestLsnUpdate', userId)
 			this.logEvent({ type: 'request_lsn_update' })

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -136,7 +136,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 					clearInterval(this.interval)
 					this.interval = null
 				}
-			}, 1000)
+			}, 2000)
 		}
 	}
 

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -12,7 +12,7 @@ import {
 import { react, transact } from '@tldraw/state'
 import { ExecutionQueue, assert, promiseWithResolve, sleep, uniqueId } from '@tldraw/utils'
 import { createSentry } from '@tldraw/worker-shared'
-import { Kysely } from 'kysely'
+import { Kysely, sql } from 'kysely'
 import throttle from 'lodash.throttle'
 import { Logger } from './Logger'
 import {
@@ -509,7 +509,9 @@ export class UserDataSyncer {
 
 		if (this.lastLsnCommit < Date.now() - LSN_COMMIT_TIMEOUT) {
 			this.log.debug('requesting lsn update', this.userId)
-			getReplicator(this.env).requestLsnUpdate(this.userId)
+			sql`SELECT pg_logical_emit_message(true, 'requestLsnUpdate', ${this.userId});`.execute(
+				this.db
+			)
 		}
 	}
 }

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -128,7 +128,7 @@ export type TLPostgresReplicatorRebootSource =
 export type TLPostgresReplicatorEvent =
 	| { type: 'reboot'; source: TLPostgresReplicatorRebootSource }
 	| { type: 'request_lsn_update' }
-	| { type: 'reboot_error' | 'register_user' | 'unregister_user' | 'get_file_record' }
+	| { type: 'reboot_error' | 'register_user' | 'unregister_user' | 'get_file_record' | 'prune' }
 	| { type: 'reboot_duration'; duration: number }
 	| { type: 'rpm'; rpm: number }
 	| { type: 'active_users'; count: number }


### PR DESCRIPTION
After the deploy this morning we started getting a lot of 

> Error: Subrequest depth limit exceeded. This request recursed through Workers too many times. This can happen e.g. if you have a Worker or Durable Object that calls other Workers or objects recursively.

In sentry. All seeming to originate from the new RPC-based lsn update mechanism. No idea why, there's a back and forth but no real chain of recursion here, it's just running on a setInterval.

Anyway this cuts one side of the RPC link out so it can't possibly think there's a recursion chain.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
