### PR TITLE
less eager hard reboot

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -614,6 +614,9 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 					doubles: [event.duration],
 				})
 				break
+			case 'reboot':
+				this.writeEvent({ blobs: [event.type, event.id, event.cause] })
+				break
 
 			default:
 				this.writeEvent({ blobs: [event.type, event.id] })
@@ -635,7 +638,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 	async admin_forceHardReboot(userId: string) {
 		if (this.cache) {
-			await this.cache?.reboot({ hard: true, delay: false })
+			await this.cache?.reboot({ hard: true, delay: false, cause: 'admin' })
 		} else {
 			await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
 		}

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -179,8 +179,7 @@ export class UserDataSyncer {
 				this.boot(hard).then(() => 'ok' as const),
 				sleep(10000).then(() => 'timeout' as const),
 			]).catch((e) => {
-				// don't log if the replicator failed
-				// just retry
+				// don't log if the replicator failed, this is captured during boot
 				if (e === REPLICATOR_FAIL) {
 					return 'replicator_fail' as const
 				}
@@ -194,7 +193,7 @@ export class UserDataSyncer {
 				this.numConsecutiveReboots = 0
 			} else {
 				const hard = this.numConsecutiveReboots >= 3
-				this.reboot({ hard, delay: true, cause: hard ? 'retry_hard' : 'retry' })
+				this.reboot({ hard, delay: true, cause: res + hard ? '_hard' : '' })
 			}
 		})
 	}

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -163,7 +163,7 @@ export class UserDataSyncer {
 
 	async reboot({ delay, hard, cause }: { delay: boolean; hard: boolean; cause: string }) {
 		this.numConsecutiveReboots++
-		if (this.numConsecutiveReboots > 10) {
+		if (this.numConsecutiveReboots > 5) {
 			this.logEvent({ type: 'user_do_abort', id: this.userId })
 			getStatsDurableObjct(this.env).recordUserDoAbort()
 			this.ctx.abort()
@@ -193,7 +193,7 @@ export class UserDataSyncer {
 			if (res === 'ok') {
 				this.numConsecutiveReboots = 0
 			} else {
-				const hard = this.numConsecutiveReboots >= 5
+				const hard = this.numConsecutiveReboots >= 3
 				this.reboot({ hard, delay: true, cause: hard ? 'retry_hard' : 'retry' })
 			}
 		})

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -176,18 +176,18 @@ export class UserDataSyncer {
 				await sleep(3000)
 			}
 			const res = await Promise.race([
-				this.boot(hard).then(() => 'ok'),
-				sleep(5000).then(() => 'timeout'),
+				this.boot(hard).then(() => 'ok' as const),
+				sleep(10000).then(() => 'timeout' as const),
 			]).catch((e) => {
 				// don't log if the replicator failed
 				// just retry
 				if (e === REPLICATOR_FAIL) {
-					return 'error'
+					return 'replicator_fail' as const
 				}
 				this.logEvent({ type: 'reboot_error', id: this.userId })
 				this.log.debug('reboot error', e.stack)
 				this.captureException(e)
-				return 'error'
+				return 'error' as const
 			})
 			this.log.debug('rebooted', res)
 			if (res === 'ok') {

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -136,7 +136,6 @@ export type TLPostgresReplicatorEvent =
 export type TLUserDurableObjectEvent =
 	| {
 			type:
-				| 'reboot'
 				| 'full_data_fetch'
 				| 'full_data_fetch_hard'
 				| 'found_snapshot'
@@ -149,7 +148,9 @@ export type TLUserDurableObjectEvent =
 				| 'connect_retry'
 				| 'user_do_abort'
 				| 'not_enough_history_for_fast_reboot'
+				| 'register_user_error'
 			id: string
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }
 	| { type: 'cold_start_time'; id: string; duration: number }
+	| { type: 'reboot'; id: string; cause: string }

--- a/apps/dotcom/sync-worker/src/utils/analytics.ts
+++ b/apps/dotcom/sync-worker/src/utils/analytics.ts
@@ -1,3 +1,4 @@
+import { createSentry } from '@tldraw/worker-shared'
 import { Analytics, Environment } from '../types'
 
 export interface EventData {
@@ -7,16 +8,27 @@ export interface EventData {
 }
 
 export function writeDataPoint(
+	sentry: ReturnType<typeof createSentry>,
 	measure: Analytics | undefined,
 	env: Environment,
 	name: string,
 	{ blobs, indexes, doubles }: EventData
 ) {
-	measure?.writeDataPoint({
-		// We put the worker name in the second spot for legacy reasons: when we first introduced analytics
-		// we only included the name. If we were to change the order it would be hard to query old data.
-		blobs: [name, env.WORKER_NAME ?? 'development-tldraw-multiplayer', ...(blobs ?? [])],
-		doubles,
-		indexes,
-	})
+	try {
+		measure?.writeDataPoint({
+			// We put the worker name in the second spot for legacy reasons: when we first introduced analytics
+			// we only included the name. If we were to change the order it would be hard to query old data.
+			blobs: [name, env.WORKER_NAME ?? 'development-tldraw-multiplayer', ...(blobs ?? [])],
+			doubles,
+			indexes,
+		})
+	} catch (e) {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		sentry?.withScope((scope) => {
+			scope.setExtra('name', name)
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			sentry.captureException(e)
+		})
+		console.error('Failed to write data point', e)
+	}
 }

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -965,7 +965,7 @@ export type StoreObjectRecordType<Context extends StoreObject<any>> =
 	Context extends Store<infer R> ? R : Context extends { store: Store<infer R> } ? R : never
 
 /**
- * Free version of {@link Store.createComputedCache}.
+ * Freestanding version of {@link Store.createComputedCache}.
  *
  * @example
  * ```ts


### PR DESCRIPTION
Looking at what was going on during the deploy yesterday, I noticed that there were thousands of hard reboots while there were only a handful of times where the replicator specifically requested a hard reboot. That meant we were being too eager to do a full hard reboot when encountering errors during deploys. We didn't see any errors on sentry during the last deploy so it seems like literally all of the failures we interpreted as 'errors' during deploy were due to timeouts, i.e. the replicator taking more than 5 seconds to service user registration requests. This makes sense. if we have 1500 users connected during a deploy and let's be very optimistic and say it takes 50ms to service a registration request, that's already 75 seconds if done serially, and parallelism isn't going to cut down enough to make it < 5 seconds guaranteed if all the user DOs are restarting over the course of a short span of time (10 seconds to a minute ish?)

So yes, we do need to go a bit easier on the replicator while there's only one of them, and we shouldn't immediately do a hard reboot if there was a timeout while trying to connect, that will only exacerbate the problem.

This pr

- bumps the boot timeout from 5s to 10s
- makes is so that booting needs to fail 4 times to trigger a hard reboot, instead of just 1 time.
- adds some more nuanced tracking for the reboot event

### Change type

- [x] `other`
