### PR TITLE
When editing a text shape, don't mount the text editor for non-editing empty shapes unless they're hovered

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -897,14 +897,15 @@ input,
 	cursor: var(--tl-cursor-default);
 }
 
+.tl-rich-text[data-is-ready-for-editing='true'],
+.tl-text-wrapper[data-is-ready-for-editing='true'] .tl-text-input {
+	cursor: var(--tl-cursor-text);
+}
+
 .tl-text-input::selection {
 	background: var(--color-selected);
 	color: var(--color-selected-contrast);
 	text-shadow: none;
-}
-
-.tl-rich-text[data-iseditinganything='true'] {
-	cursor: var(--tl-cursor-text);
 }
 
 .tl-rich-text .ProseMirror {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4207,8 +4207,8 @@ export function useEditablePlainText(shapeId: TLShapeId, type: string, text?: st
     handleInputPointerDown: (e: React_3.PointerEvent<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     isEditing: boolean;
-    isEditingAnythingAndHovering: boolean;
     isEmpty: boolean;
+    isReadyForEditing: boolean;
     rInput: React_3.RefObject<HTMLTextAreaElement>;
 };
 
@@ -4223,8 +4223,8 @@ export function useEditableRichText(shapeId: TLShapeId, type: string, richText?:
     handleInputPointerDown: (e: PointerEvent_2<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     isEditing: boolean;
-    isEditingAnythingAndHovering: boolean;
     isEmpty: boolean | undefined;
+    isReadyForEditing: boolean;
     rInput: RefObject<HTMLDivElement>;
 };
 

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4207,7 +4207,7 @@ export function useEditablePlainText(shapeId: TLShapeId, type: string, text?: st
     handleInputPointerDown: (e: React_3.PointerEvent<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     isEditing: boolean;
-    isEditingAnything: boolean;
+    isEditingAnythingAndHovering: boolean;
     isEmpty: boolean;
     rInput: React_3.RefObject<HTMLTextAreaElement>;
 };
@@ -4223,7 +4223,7 @@ export function useEditableRichText(shapeId: TLShapeId, type: string, richText?:
     handleInputPointerDown: (e: PointerEvent_2<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     isEditing: boolean;
-    isEditingAnything: boolean;
+    isEditingAnythingAndHovering: boolean;
     isEmpty: boolean | undefined;
     rInput: RefObject<HTMLDivElement>;
 };

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -31,7 +31,6 @@ import {
 	lerp,
 	toRichText,
 	useValue,
-	whyAmIRunning,
 } from '@tldraw/editor'
 
 import isEqual from 'lodash.isequal'
@@ -439,8 +438,6 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const isEmpty = isEmptyRichText(shape.props.richText)
 		const showHtmlContainer = isEditingAnythingAndHovering || !isEmpty
 		const isForceSolid = useValue('force solid', () => editor.getZoomLevel() < 0.2, [editor])
-
-		whyAmIRunning()
 
 		return (
 			<>

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -31,6 +31,7 @@ import {
 	lerp,
 	toRichText,
 	useValue,
+	whyAmIRunning,
 } from '@tldraw/editor'
 
 import isEqual from 'lodash.isequal'
@@ -50,6 +51,7 @@ import {
 } from '../shared/default-shape-constants'
 import { getFillDefForCanvas, getFillDefForExport } from '../shared/defaultStyleDefs'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
+import { useIsEditingAnythingAndHovering } from '../shared/useEditablePlainText'
 import { GeoShapeBody } from './components/GeoShapeBody'
 import {
 	cloudOutline,
@@ -433,10 +435,12 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 			() => shape.id === editor.getOnlySelectedShapeId(),
 			[editor]
 		)
-		const isEditingAnything = editor.getEditingShapeId() !== null
+		const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(editor, shape.id)
 		const isEmpty = isEmptyRichText(shape.props.richText)
-		const showHtmlContainer = isEditingAnything || !isEmpty
+		const showHtmlContainer = isEditingAnythingAndHovering || !isEmpty
 		const isForceSolid = useValue('force solid', () => editor.getZoomLevel() < 0.2, [editor])
+
+		whyAmIRunning()
 
 		return (
 			<>

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -50,7 +50,7 @@ import {
 } from '../shared/default-shape-constants'
 import { getFillDefForCanvas, getFillDefForExport } from '../shared/defaultStyleDefs'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
-import { useIsEditingAnythingAndHovering } from '../shared/useEditablePlainText'
+import { useIsReadyForEditing } from '../shared/useEditablePlainText'
 import { GeoShapeBody } from './components/GeoShapeBody'
 import {
 	cloudOutline,
@@ -434,9 +434,9 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 			() => shape.id === editor.getOnlySelectedShapeId(),
 			[editor]
 		)
-		const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(editor, shape.id)
+		const isReadyForEditing = useIsReadyForEditing(editor, shape.id)
 		const isEmpty = isEmptyRichText(shape.props.richText)
-		const showHtmlContainer = isEditingAnythingAndHovering || !isEmpty
+		const showHtmlContainer = isReadyForEditing || !isEmpty
 		const isForceSolid = useValue('force solid', () => editor.getZoomLevel() < 0.2, [editor])
 
 		return (

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -50,7 +50,7 @@ import {
 	renderPlaintextFromRichText,
 } from '../../utils/text/richText'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
-import { useIsEditingAnythingAndHovering } from '../shared/useEditablePlainText'
+import { useIsReadyForEditing } from '../shared/useEditablePlainText'
 import {
 	CLONE_HANDLE_MARGIN,
 	NOTE_CENTER_OFFSET,
@@ -276,7 +276,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 
-		const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(this.editor, shape.id)
+		const isReadyForEditing = useIsReadyForEditing(this.editor, shape.id)
 		const isEmpty = isEmptyRichText(richText)
 
 		return (
@@ -296,7 +296,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						boxShadow: hideShadows ? 'none' : getNoteShadow(shape.id, rotation, scale),
 					}}
 				>
-					{(isSelected || isEditingAnythingAndHovering || !isEmpty) && (
+					{(isSelected || isReadyForEditing || !isEmpty) && (
 						<RichTextLabel
 							shapeId={id}
 							type={type}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -50,6 +50,7 @@ import {
 	renderPlaintextFromRichText,
 } from '../../utils/text/richText'
 import { useDefaultColorTheme } from '../shared/useDefaultColorTheme'
+import { useIsEditingAnythingAndHovering } from '../shared/useEditablePlainText'
 import {
 	CLONE_HANDLE_MARGIN,
 	NOTE_CENTER_OFFSET,
@@ -275,6 +276,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 
+		const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(this.editor, shape.id)
+		const isEmpty = isEmptyRichText(richText)
+
 		return (
 			<>
 				<div
@@ -292,21 +296,23 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						boxShadow: hideShadows ? 'none' : getNoteShadow(shape.id, rotation, scale),
 					}}
 				>
-					<RichTextLabel
-						shapeId={id}
-						type={type}
-						font={font}
-						fontSize={(fontSizeAdjustment || LABEL_FONT_SIZES[size]) * scale}
-						lineHeight={TEXT_PROPS.lineHeight}
-						align={align}
-						verticalAlign={verticalAlign}
-						richText={richText}
-						isSelected={isSelected}
-						labelColor={labelColor === 'black' ? theme[color].note.text : theme[labelColor].fill}
-						wrap
-						padding={LABEL_PADDING * scale}
-						onKeyDown={handleKeyDown}
-					/>
+					{(isSelected || isEditingAnythingAndHovering || !isEmpty) && (
+						<RichTextLabel
+							shapeId={id}
+							type={type}
+							font={font}
+							fontSize={(fontSizeAdjustment || LABEL_FONT_SIZES[size]) * scale}
+							lineHeight={TEXT_PROPS.lineHeight}
+							align={align}
+							verticalAlign={verticalAlign}
+							richText={richText}
+							isSelected={isSelected}
+							labelColor={labelColor === 'black' ? theme[color].note.text : theme[labelColor].fill}
+							wrap
+							padding={LABEL_PADDING * scale}
+							onKeyDown={handleKeyDown}
+						/>
+					)}
 				</div>
 				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</>

--- a/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
@@ -61,7 +61,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 	textWidth,
 	textHeight,
 }: PlainTextLabelProps) {
-	const { rInput, isEmpty, isEditing, isEditingAnything, ...editableTextRest } =
+	const { rInput, isEmpty, isEditing, isEditingAnythingAndHovering, ...editableTextRest } =
 		useEditablePlainText(shapeId, type, plaintext)
 
 	const finalPlainText = TextHelpers.normalizeTextForDom(plaintext || '')
@@ -82,7 +82,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 			data-align={align}
 			data-hastext={!isEmpty}
 			data-isediting={isEditing}
-			data-iseditinganything={isEditingAnything}
+			data-iseditinganything={isEditingAnythingAndHovering}
 			data-textwrap={!!wrap}
 			data-isselected={isSelected}
 			style={{
@@ -111,7 +111,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 						</div>
 					))}
 				</div>
-				{(isEditingAnything || isSelected) && (
+				{(isEditingAnythingAndHovering || isSelected) && (
 					<PlainTextArea
 						// Fudge the ref type because we're using forwardRef and it's not typed correctly.
 						ref={rInput as any}

--- a/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
@@ -61,7 +61,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 	textWidth,
 	textHeight,
 }: PlainTextLabelProps) {
-	const { rInput, isEmpty, isEditing, isEditingAnythingAndHovering, ...editableTextRest } =
+	const { rInput, isEmpty, isEditing, isReadyForEditing, ...editableTextRest } =
 		useEditablePlainText(shapeId, type, plaintext)
 
 	const finalPlainText = TextHelpers.normalizeTextForDom(plaintext || '')
@@ -82,7 +82,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 			data-align={align}
 			data-hastext={!isEmpty}
 			data-isediting={isEditing}
-			data-iseditinganything={isEditingAnythingAndHovering}
+			data-is-ready-for-editing={isReadyForEditing}
 			data-textwrap={!!wrap}
 			data-isselected={isSelected}
 			style={{
@@ -111,7 +111,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 						</div>
 					))}
 				</div>
-				{(isEditingAnythingAndHovering || isSelected) && (
+				{(isReadyForEditing || isSelected) && (
 					<PlainTextArea
 						// Fudge the ref type because we're using forwardRef and it's not typed correctly.
 						ref={rInput as any}

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -71,8 +71,9 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 }: RichTextLabelProps) {
 	const editor = useEditor()
 	const isDragging = React.useRef(false)
-	const { rInput, isEmpty, isEditing, isEditingAnything, ...editableTextRest } =
+	const { rInput, isEmpty, isEditing, isEditingAnythingAndHovering, ...editableTextRest } =
 		useEditableRichText(shapeId, type, richText)
+
 	const html = useMemo(() => {
 		if (richText) {
 			return renderHtmlFromRichText(editor, richText)
@@ -117,9 +118,8 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 		}
 	}
 
-	if (!isEditing && isEmpty) {
-		return null
-	}
+	// Should be guarded higher up so that this doesn't render... but repeated here. This should never be true.
+	if (!isEditing && isEmpty) return null
 
 	// TODO: probably combine tl-text and tl-arrow eventually
 	const cssPrefix = classNamePrefix || 'tl-text'
@@ -130,7 +130,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			data-align={align}
 			data-hastext={!isEmpty}
 			data-isediting={isEditing}
-			data-iseditinganything={isEditingAnything}
+			data-iseditinganything={isEditingAnythingAndHovering}
 			data-textwrap={!!wrap}
 			data-isselected={isSelected}
 			style={{
@@ -160,12 +160,12 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}
-							data-iseditinganything={isEditingAnything}
+							data-iseditinganything={isEditingAnythingAndHovering}
 						/>
 					)}
 				</div>
 				{/* todo: it might be okay to have just isEditing here */}
-				{(isEditingAnything || isSelected) && (
+				{(isEditingAnythingAndHovering || isSelected) && (
 					<RichTextArea
 						// Fudge the ref type because we're using forwardRef and it's not typed correctly.
 						ref={rInput as any}

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -71,7 +71,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 }: RichTextLabelProps) {
 	const editor = useEditor()
 	const isDragging = React.useRef(false)
-	const { rInput, isEmpty, isEditing, isEditingAnythingAndHovering, ...editableTextRest } =
+	const { rInput, isEmpty, isEditing, isReadyForEditing, ...editableTextRest } =
 		useEditableRichText(shapeId, type, richText)
 
 	const html = useMemo(() => {
@@ -130,7 +130,6 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			data-align={align}
 			data-hastext={!isEmpty}
 			data-isediting={isEditing}
-			data-iseditinganything={isEditingAnythingAndHovering}
 			data-textwrap={!!wrap}
 			data-isselected={isSelected}
 			style={{
@@ -160,12 +159,11 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}
-							data-iseditinganything={isEditingAnythingAndHovering}
+							data-is-ready-for-editing={isReadyForEditing}
 						/>
 					)}
 				</div>
-				{/* todo: it might be okay to have just isEditing here */}
-				{(isEditingAnythingAndHovering || isSelected) && (
+				{(isReadyForEditing || isSelected) && (
 					<RichTextArea
 						// Fudge the ref type because we're using forwardRef and it's not typed correctly.
 						ref={rInput as any}

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -94,9 +94,9 @@ export function useEditablePlainText(shapeId: TLShapeId, type: string, text?: st
 }
 
 /** @internal */
-export function useIsEditingAnythingAndHovering(editor: Editor, shapeId: TLShapeId) {
+export function useIsReadyForEditing(editor: Editor, shapeId: TLShapeId) {
 	return useValue(
-		'is_editing_anything',
+		'isReadyForEditing',
 		() => {
 			const editingShapeId = editor.getEditingShapeId()
 			return (
@@ -113,7 +113,7 @@ export function useIsEditingAnythingAndHovering(editor: Editor, shapeId: TLShape
 export function useEditableTextCommon(shapeId: TLShapeId) {
 	const editor = useEditor()
 	const isEditing = useValue('isEditing', () => editor.getEditingShapeId() === shapeId, [editor])
-	const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(editor, shapeId)
+	const isReadyForEditing = useIsReadyForEditing(editor, shapeId)
 
 	const handleInputPointerDown = useCallback(
 		(e: React.PointerEvent) => {
@@ -146,7 +146,7 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 		handleInputPointerDown,
 		handleDoubleClick: stopEventPropagation,
 		isEditing,
-		isEditingAnythingAndHovering,
+		isReadyForEditing,
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -1,4 +1,5 @@
 import {
+	Editor,
 	TLShapeId,
 	TLUnknownShape,
 	getPointerInfo,
@@ -93,12 +94,26 @@ export function useEditablePlainText(shapeId: TLShapeId, type: string, text?: st
 }
 
 /** @internal */
+export function useIsEditingAnythingAndHovering(editor: Editor, shapeId: TLShapeId) {
+	return useValue(
+		'is_editing_anything',
+		() => {
+			const editingShapeId = editor.getEditingShapeId()
+			return (
+				// something's being editing... and either it's this shape OR this shape is hovered
+				editingShapeId !== null &&
+				(editingShapeId === shapeId || editor.getHoveredShapeId() === shapeId)
+			)
+		},
+		[editor, shapeId]
+	)
+}
+
+/** @internal */
 export function useEditableTextCommon(shapeId: TLShapeId) {
 	const editor = useEditor()
 	const isEditing = useValue('isEditing', () => editor.getEditingShapeId() === shapeId, [editor])
-	const isEditingAnything = useValue('isEditingAnything', () => !!editor.getEditingShapeId(), [
-		editor,
-	])
+	const isEditingAnythingAndHovering = useIsEditingAnythingAndHovering(editor, shapeId)
 
 	const handleInputPointerDown = useCallback(
 		(e: React.PointerEvent) => {
@@ -131,7 +146,7 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 		handleInputPointerDown,
 		handleDoubleClick: stopEventPropagation,
 		isEditing,
-		isEditingAnything,
+		isEditingAnythingAndHovering,
 	}
 }
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -921,15 +921,6 @@
 	transition: transform 0.15s ease-out 0.05s;
 }
 
-/*
- * On Android, when the virtual keyboard is up, we used to hide the tools.
- * However, we disabled for this now.
- */
-/* .tlui-layout__mobile[data-iseditinganything='true'] .tlui-toolbar {
-	transform: translate(0px, 120%);
-	transition: none;
-} */
-
 /* -------------------- Help Zone ------------------- */
 
 .tlui-help-menu {


### PR DESCRIPTION
This PR improves text editing.

## The bug

Previously, we would mount all of the text editors for all of the text-editable shapes when the user began editing any text-editable shape. For large projects this would block the main thread as all of those text editors were mounted. Even on my Very Fast Laptop this would introduce ~200-500ms of lag between when I press "Enter" to begin editing a shape and when the app would begin responding to my key strokes. This often dropped the first letter of whatever I was typing.

## The fix

We now mount the text editor for a shape if it's:
- editing; or
- has text; or
- is hovered

If a shape is neither of those, then we don't mount the text editor until the user hovers the shape. From a user perspective, the interactions are identical to what they were before.

## Proof

Before: (starting to edit a shape with ~1000 empty shapes on the page)

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/820908a2-21f0-4a3e-a5b9-5083e4ef6d66" />

After:

There's nothing to see, we don't drop any frames.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create many empty shapes
2. Begin editing any shape.

### Release notes

- Fixed a bug causing a performance delay when editing text.