### PR TITLE
Not preload empty `embedIcons`

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2683,7 +2683,7 @@ export type TLUiAssetUrlOverrides = RecursivePartial<TLUiAssetUrls>;
 // @public (undocumented)
 export interface TLUiAssetUrls extends TLEditorAssetUrls {
     // (undocumented)
-    embedIcons: Record<(typeof DEFAULT_EMBED_DEFINITIONS)[number]['type'], string>;
+    embedIcons: Partial<Record<(typeof DEFAULT_EMBED_DEFINITIONS)[number]['type'], string>>;
     // (undocumented)
     icons: Record<Exclude<string, TLUiIconType> | TLUiIconType, string>;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/assetUrls.ts
+++ b/packages/tldraw/src/lib/ui/assetUrls.ts
@@ -7,7 +7,7 @@ import { TLUiIconType, iconTypes } from './icon-types'
 export interface TLUiAssetUrls extends TLEditorAssetUrls {
 	icons: Record<TLUiIconType | Exclude<string, TLUiIconType>, string>
 	translations: Record<(typeof LANGUAGES)[number]['locale'], string>
-	embedIcons: Record<(typeof DEFAULT_EMBED_DEFINITIONS)[number]['type'], string>
+	embedIcons: Partial<Record<(typeof DEFAULT_EMBED_DEFINITIONS)[number]['type'], string>>
 }
 
 /** @public */
@@ -39,7 +39,7 @@ export function setDefaultUiAssetUrls(urls: TLUiAssetUrls) {
 
 /** @internal */
 export function useDefaultUiAssetUrlsWithOverrides(
-	overrides?: RecursivePartial<TLUiAssetUrls>
+	overrides?: RecursivePartial<TLUiAssetUrlOverrides>
 ): TLUiAssetUrls {
 	if (!overrides) return defaultUiAssetUrls
 

--- a/packages/tldraw/src/lib/ui/assetUrls.ts
+++ b/packages/tldraw/src/lib/ui/assetUrls.ts
@@ -39,7 +39,7 @@ export function setDefaultUiAssetUrls(urls: TLUiAssetUrls) {
 
 /** @internal */
 export function useDefaultUiAssetUrlsWithOverrides(
-	overrides?: RecursivePartial<TLUiAssetUrlOverrides>
+	overrides?: TLUiAssetUrlOverrides
 ): TLUiAssetUrls {
 	if (!overrides) return defaultUiAssetUrls
 

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -17,14 +17,14 @@ export function AssetUrlsProvider({
 }) {
 	useEffect(() => {
 		for (const src of Object.values(assetUrls.icons)) {
+			if (!src) continue
+
 			const image = Image()
 			image.src = src
 			image.decode()
 		}
 		for (const src of Object.values(assetUrls.embedIcons)) {
-			if (!src) {
-				continue
-			}
+			if (!src) continue
 
 			const image = Image()
 			image.src = src

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -22,6 +22,10 @@ export function AssetUrlsProvider({
 			image.decode()
 		}
 		for (const src of Object.values(assetUrls.embedIcons)) {
+			if (!src) {
+				continue
+			}
+
 			const image = Image()
 			image.src = src
 			image.decode()


### PR DESCRIPTION
In our tldraw integration we are not using embeds, however embed icons still loaded on Tldraw mount. We wanted to get rid of that preload, and used [approach recommended in Discord channel](https://discord.com/channels/859816885297741824/1316236102352375819/1316236102352375819). However it didn't work.

I updated preload logic to ignore empty `embedIcons` from preloading.
I updated `TLUiAssetUrls.embedIcons` type to better reflect the value it actually can store.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Check that default tldraw playground preloads and displays embed icons correctly.
2. Override `embedIcons[string]` to be undefined and check that they no longer preloaded. 

### Release notes

- Allow to remove unused `embedIcons` from preload