### PR TITLE
Dot dev: Fix menu bar overlapping content

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({ params }: { params: { slug: string | string
 				categoryId={content.article.categoryId}
 				articleId={content.article.id}
 			/>
-			<div className="fixed z-10 flex items-center justify-between w-full h-12 px-5 bg-white border-b border-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 backdrop-blur md:hidden">
+			<div className="sticky top-14 z-10 flex items-center justify-between w-full h-12 px-5 bg-white border-b border-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 backdrop-blur md:hidden">
 				<DocsMobileSidebar
 					sectionId={content.article.sectionId}
 					categoryId={content.article.categoryId}
@@ -61,7 +61,7 @@ export default async function Page({ params }: { params: { slug: string | string
 			</div>
 			{content.article.sectionId === 'examples' ? (
 				<>
-					<main className="relative w-full px-5 pt-24 shrink md:pt-0 min-w-[1px]">
+					<main className="relative w-full px-5 pt-12 shrink md:pt-0 min-w-[1px]">
 						<DocsHeader article={content.article} />
 						<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />
 						<Example article={content.article} />
@@ -73,7 +73,7 @@ export default async function Page({ params }: { params: { slug: string | string
 				</>
 			) : (
 				<>
-					<main className="relative w-full max-w-3xl px-5 pt-24 shrink md:pr-0 lg:pl-12 xl:pr-12 md:pt-0 min-w-[1px]">
+					<main className="relative w-full max-w-3xl px-5 pt-12 shrink md:pr-0 lg:pl-12 xl:pr-12 md:pt-0 min-w-[1px]">
 						<DocsHeader article={content.article} />
 						<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />
 						<DocsFooter article={content.article} />


### PR DESCRIPTION
This PR fixes a visual issue with scrolling. See before and after:

![2025-03-24 at 11 10 59 - Gray Tyrannosaurus](https://github.com/user-attachments/assets/c089975a-3ee7-45eb-a46c-19cfff57f698)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. On the docs site...
2. Resize the window to make it smaller.
3. Overscroll upwards (or downwards).
4. Check that the menu bar is not overlapping any other page content.
5. Repeat this check for an examples page. 

- [ ] Unit tests
- [ ] End to end tests
