### PR TITLE
[dotcom backend] Wrap writeDataPoint in try/catch to make it safe

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -940,7 +940,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	}
 
 	private writeEvent(eventData: EventData) {
-		writeDataPoint(this.measure, this.env, 'replicator', eventData)
+		writeDataPoint(this.sentry, this.measure, this.env, 'replicator', eventData)
 	}
 
 	logEvent(event: TLPostgresReplicatorEvent) {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -597,7 +597,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	private writeEvent(eventData: EventData) {
-		writeDataPoint(this.measure, this.env, 'user_durable_object', eventData)
+		writeDataPoint(this.sentry, this.measure, this.env, 'user_durable_object', eventData)
 	}
 
 	logEvent(event: TLUserDurableObjectEvent) {

--- a/apps/dotcom/sync-worker/src/utils/analytics.ts
+++ b/apps/dotcom/sync-worker/src/utils/analytics.ts
@@ -1,3 +1,4 @@
+import { createSentry } from '@tldraw/worker-shared'
 import { Analytics, Environment } from '../types'
 
 export interface EventData {
@@ -7,16 +8,27 @@ export interface EventData {
 }
 
 export function writeDataPoint(
+	sentry: ReturnType<typeof createSentry>,
 	measure: Analytics | undefined,
 	env: Environment,
 	name: string,
 	{ blobs, indexes, doubles }: EventData
 ) {
-	measure?.writeDataPoint({
-		// We put the worker name in the second spot for legacy reasons: when we first introduced analytics
-		// we only included the name. If we were to change the order it would be hard to query old data.
-		blobs: [name, env.WORKER_NAME ?? 'development-tldraw-multiplayer', ...(blobs ?? [])],
-		doubles,
-		indexes,
-	})
+	try {
+		measure?.writeDataPoint({
+			// We put the worker name in the second spot for legacy reasons: when we first introduced analytics
+			// we only included the name. If we were to change the order it would be hard to query old data.
+			blobs: [name, env.WORKER_NAME ?? 'development-tldraw-multiplayer', ...(blobs ?? [])],
+			doubles,
+			indexes,
+		})
+	} catch (e) {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		sentry?.withScope((scope) => {
+			scope.setExtra('name', name)
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			sentry.captureException(e)
+		})
+		console.error('Failed to write data point', e)
+	}
 }


### PR DESCRIPTION
This seems to have been causing errors since the deploy yesterday

We were disptaching more analytics events than normal it seems? And this was throwing errors in our business logic and making things reset when they shouldn't.


### Change type

- [x] `other`
