### PR TITLE
fix translation perf regression from rich text font detection

### DIFF
--- a/packages/editor/src/lib/editor/managers/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager.ts
@@ -94,7 +94,7 @@ export class FontManager {
 				const shapeUtil = this.editor.getShapeUtil(shape)
 				return shapeUtil.getFontFaces(shape)
 			},
-			{ areResultsEqual: areArraysShallowEqual }
+			{ areResultsEqual: areArraysShallowEqual, areRecordsEqual: (a, b) => a.props === b.props }
 		)
 
 		this.shapeFontLoadStateCache = editor.store.createCache<(FontState | null)[], TLShape>(


### PR DESCRIPTION
We were re-computed this way too eagerly. We only need to check when the props change.

### Change type

- [x] `bugfix`

### Release notes

- Fix a performance regression when dragging many shapes at the same time.