### PR TITLE
Fix zoom speed on pinch events

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9929,6 +9929,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							const { x, y } = this.inputs.currentScreenPoint
 							let delta = dz
 
+							// If we're forcing zoom, then we need to do the wheel normalization math here
 							if (wheelBehavior === 'zoom') {
 								if (Math.abs(dy) > 10) {
 									delta = (10 * Math.sign(dy)) / 100
@@ -9938,14 +9939,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 							}
 
 							const zoom = cz + (delta ?? 0) * zoomSpeed * cz
-							this._setCamera(
-								new Vec(
-									cx + (x / zoom - x) - (x / cz - x),
-									cy + (y / zoom - y) - (y / cz - y),
-									zoom
-								),
-								{ immediate: true }
-							)
+							this._setCamera(new Vec(cx + x / zoom - x / cz, cy + y / zoom - y / cz, zoom), {
+								immediate: true,
+							})
 							this.maybeTrackPerformance('Zooming')
 							return
 						}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9860,8 +9860,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						const { panSpeed, zoomSpeed } = cameraOptions
 						const zoom = cz + (delta ?? 0) * zoomSpeed * cz
-						console.log('touch deltaZ', delta)
-						console.log('touch zoom', zoom)
 
 						this._setCamera(
 							new Vec(
@@ -9904,7 +9902,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 			case 'wheel': {
 				if (cameraOptions.isLocked) return
-				console.log('wheel')
 				this._updateInputsFromEvent(info)
 
 				const { panSpeed, zoomSpeed, wheelBehavior } = cameraOptions


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ y] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
(I have done these steps, but you're more than welcome to recreate them)

1. Open TlDraw on either safari or on a touchscreen device
2. Navigate to /camera-options
3. Check that zooming & panning work as intended when using safari trackpad or pinching on touchscreen
4. Change around zoomSpeed & retest.
5. Consider also testing existing zooming & panning work when not using gestures

- [N/A] Unit tests
- [N/A] End to end tests

### Release notes

- Fixed a bug where gesture pinch events (e.g. safari trackpad, touchscreen) would not interact correctly with zoomSpeed, leading to jerky and unreliable motion.
[Issue](https://github.com/tldraw/tldraw/issues/4945)