### PR TITLE
Update validation.ts to allow blob: as src for Image

### DIFF
--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -974,7 +974,7 @@ export const linkUrl = string.check((value) => {
 })
 
 // N.B. asset: is a reference to the local indexedDB object store.
-const validSrcProtocols = new Set(['http:', 'https:', 'data:', 'asset:'])
+const validSrcProtocols = new Set(['http:', 'https:', 'data:', 'asset:', 'blob:'])
 
 /**
  * Validates that a valid is a url safe to load as an asset.


### PR DESCRIPTION
This allows local browser images to be used as a Source. 

  
![Screenshot 2025-03-25 at 22 34 22](https://github.com/user-attachments/assets/77b3fb7f-f78a-4c49-b370-40916991e9d4)

sorry for the unit test. I haven't made this repo work locally yet. 

### Change type

- [ x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. load image from a Blob 
2.

- [ ] Unit tests 
- [ ] End to end tests

### Release notes

- Fixed a bug to allow Blob to be use as Image/asset source 