### PR TITLE
people menu: fix overflow and follow buttons

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1625,6 +1625,7 @@
 }
 
 /* ------------------- People Menu ------------------- */
+
 .tlui-people-menu__avatars-button {
 	display: flex;
 	align-items: center;
@@ -1697,7 +1698,6 @@
 	width: 220px;
 	height: fit-content;
 	max-height: 50vh;
-	padding-bottom: 4px;
 }
 
 .tlui-people-menu__section {
@@ -1768,6 +1768,14 @@
 	gap: 8px;
 	height: 100%;
 	padding: 0px;
+}
+
+.tlui-people-menu__item {
+	position: relative;
+}
+
+.tlui-people-menu__item:last-of-type .tlui-button__menu {
+	margin-bottom: 0;
 }
 
 .tlui-people-menu__item__button {


### PR DESCRIPTION
@MitjaBezensek reportd that:
- the follow icons were all stacking on top of one another (effect of css changes in https://github.com/tldraw/tldraw/pull/5401/files )
- the people menu was getting a scrollbar now (although I'm not sure exactly the CSS that caused it, prbly some fit-content stuff afaict)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix people menu CSS.