### PR TITLE
Geometry2d Improvements

### DIFF
--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -360,7 +360,12 @@ export { CubicBezier2d } from './lib/primitives/geometry/CubicBezier2d'
 export { CubicSpline2d } from './lib/primitives/geometry/CubicSpline2d'
 export { Edge2d } from './lib/primitives/geometry/Edge2d'
 export { Ellipse2d } from './lib/primitives/geometry/Ellipse2d'
-export { Geometry2d, type Geometry2dOptions } from './lib/primitives/geometry/Geometry2d'
+export {
+	Geometry2d,
+	Geometry2dFilters,
+	TransformedGeometry2d,
+	type Geometry2dOptions,
+} from './lib/primitives/geometry/Geometry2d'
 export { Group2d } from './lib/primitives/geometry/Group2d'
 export { Point2d } from './lib/primitives/geometry/Point2d'
 export { Polygon2d } from './lib/primitives/geometry/Polygon2d'

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -2,8 +2,6 @@ import { TLGroupShape, groupShapeMigrations, groupShapeProps } from '@tldraw/tls
 import { SVGContainer } from '../../../components/SVGContainer'
 import { Geometry2d } from '../../../primitives/geometry/Geometry2d'
 import { Group2d } from '../../../primitives/geometry/Group2d'
-import { Polygon2d } from '../../../primitives/geometry/Polygon2d'
-import { Polyline2d } from '../../../primitives/geometry/Polyline2d'
 import { Rectangle2d } from '../../../primitives/geometry/Rectangle2d'
 import { ShapeUtil } from '../ShapeUtil'
 import { DashedOutlineBox } from './DashedOutlineBox'
@@ -35,19 +33,9 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 		return new Group2d({
 			children: children.map((childId) => {
 				const shape = this.editor.getShape(childId)!
-				const geometry = this.editor.getShapeGeometry(childId)
-				const points = this.editor.getShapeLocalTransform(shape)!.applyToPoints(geometry.vertices)
-
-				if (geometry.isClosed) {
-					return new Polygon2d({
-						points,
-						isFilled: true,
-					})
-				}
-
-				return new Polyline2d({
-					points,
-				})
+				return this.editor
+					.getShapeGeometry(childId)
+					.transform(this.editor.getShapeLocalTransform(shape)!)
 			}),
 		})
 	}

--- a/packages/editor/src/lib/primitives/geometry/Group2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.ts
@@ -81,7 +81,12 @@ export class Group2d extends Geometry2d {
 			.find((c) => c.hitTestPoint(point, margin, hitInside))
 	}
 
-	override hitTestLineSegment(A: Vec, B: Vec, zoom: number, filters?: Geometry2dFilters): boolean {
+	override hitTestLineSegment(
+		A: Vec,
+		B: Vec,
+		zoom: number,
+		filters = Geometry2dFilters.EXCLUDE_LABELS
+	): boolean {
 		return !!this.children
 			.filter((c) => !c.isExcludedByFilter(filters))
 			.find((c) => c.hitTestLineSegment(A, B, zoom))

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -154,24 +154,17 @@ function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLSh
 	}
 }
 
-function getVerticesInPageSpace(editor: Editor, shape: TLShape) {
-	const geo = editor.getShapeGeometry(shape)
-	const pageTransform = editor.getShapePageTransform(shape)
-	if (!geo || !pageTransform) return null
-	return pageTransform.applyToPoints(geo.vertices)
-}
-
 function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
 	const movingVertices = Array.from(moving)
 		.map((shape) => {
-			const vertices = getVerticesInPageSpace(editor, shape)
+			const vertices = editor.getShapePageGeometry(shape).vertices
 			if (!vertices) return null
 			return { shape, vertices }
 		})
 		.filter(Boolean) as { shape: TLShape; vertices: Vec[] }[]
 
 	const isOverlapping = (child: TLShape) => {
-		const vertices = getVerticesInPageSpace(editor, child)
+		const vertices = editor.getShapePageGeometry(child).vertices
 		if (!vertices) return false
 		return movingVertices.some((other) => {
 			return polygonsIntersect(other.vertices, vertices)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -40,7 +40,6 @@ import {
 } from '@tldraw/editor'
 import React from 'react'
 import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
-
 import { PlainTextLabel } from '../shared/PlainTextLabel'
 import { ShapeFill } from '../shared/ShapeFill'
 import { SvgTextLabel } from '../shared/SvgTextLabel'

--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -9,8 +9,6 @@ import {
 	centerOfCircleFromThreePoints,
 	clockwiseAngleDist,
 	counterClockwiseAngleDist,
-	intersectCirclePolygon,
-	intersectCirclePolyline,
 	isSafeFloat,
 } from '@tldraw/editor'
 import { TLArcInfo, TLArrowInfo } from './arrow-types'
@@ -118,13 +116,15 @@ export function getCurvedArrowInfo(
 		const endInStartShapeLocalSpace = Mat.applyToPoint(inverseTransform, endInPageSpace)
 
 		const { isClosed } = startShapeInfo
-		const fn = isClosed ? intersectCirclePolygon : intersectCirclePolyline
-
 		let point: VecLike | undefined
+		let intersections = Array.from(
+			startShapeInfo.geometry.intersectCircle(centerInStartShapeLocalSpace, handleArc.radius, {
+				includeLabels: false,
+				includeInternal: false,
+			})
+		)
 
-		let intersections = fn(centerInStartShapeLocalSpace, handleArc.radius, startShapeInfo.outline)
-
-		if (intersections) {
+		if (intersections.length) {
 			const angleToStart = centerInStartShapeLocalSpace.angle(startInStartShapeLocalSpace)
 			const angleToEnd = centerInStartShapeLocalSpace.angle(endInStartShapeLocalSpace)
 			const dAB = distFn(angleToStart, angleToEnd)
@@ -187,11 +187,13 @@ export function getCurvedArrowInfo(
 		const endInEndShapeLocalSpace = Mat.applyToPoint(inverseTransform, endInPageSpace)
 
 		const isClosed = endShapeInfo.isClosed
-		const fn = isClosed ? intersectCirclePolygon : intersectCirclePolyline
-
 		let point: VecLike | undefined
-
-		let intersections = fn(centerInEndShapeLocalSpace, handleArc.radius, endShapeInfo.outline)
+		let intersections = Array.from(
+			endShapeInfo.geometry.intersectCircle(centerInEndShapeLocalSpace, handleArc.radius, {
+				includeLabels: false,
+				includeInternal: false,
+			})
+		)
 
 		if (intersections) {
 			const angleToStart = centerInEndShapeLocalSpace.angle(startInEndShapeLocalSpace)

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -1,6 +1,6 @@
 import {
 	Editor,
-	Group2d,
+	Geometry2d,
 	Mat,
 	TLArrowBinding,
 	TLArrowBindingProps,
@@ -25,7 +25,7 @@ export interface BoundShapeInfo<T extends TLShape = TLShape> {
 	isExact: boolean
 	isClosed: boolean
 	transform: Mat
-	outline: Vec[]
+	geometry: Geometry2d
 }
 
 export function getBoundShapeInfoForTerminal(
@@ -46,19 +46,13 @@ export function getBoundShapeInfoForTerminal(
 		terminalName === 'start' ? { context: '@tldraw/arrow-start' } : undefined
 	)
 
-	// This is hacky: we're only looking at the first child in the group. Really the arrow should
-	// consider all items in the group which are marked as snappable as separate polygons with which
-	// to intersect, in the case of a group that has multiple children which do not overlap; or else
-	// flatten the geometry into a set of polygons and intersect with that.
-	const outline = geometry instanceof Group2d ? geometry.children[0].vertices : geometry.vertices
-
 	return {
 		shape: boundShape,
 		transform,
 		isClosed: geometry.isClosed,
 		isExact: binding.props.isExact,
 		didIntersect: false,
-		outline,
+		geometry,
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -1,13 +1,4 @@
-import {
-	Editor,
-	Mat,
-	MatModel,
-	TLArrowShape,
-	Vec,
-	VecLike,
-	intersectLineSegmentPolygon,
-	intersectLineSegmentPolyline,
-} from '@tldraw/editor'
+import { Editor, Mat, MatModel, TLArrowShape, Vec, VecLike } from '@tldraw/editor'
 import { TLArrowInfo } from './arrow-types'
 import {
 	BOUND_ARROW_OFFSET,
@@ -240,17 +231,19 @@ function updateArrowheadPointWithBoundShape(
 	const targetFrom = Mat.applyToPoint(Mat.Inverse(targetShapeInfo.transform), pageFrom)
 	const targetTo = Mat.applyToPoint(Mat.Inverse(targetShapeInfo.transform), pageTo)
 
-	const isClosed = targetShapeInfo.isClosed
-	const fn = isClosed ? intersectLineSegmentPolygon : intersectLineSegmentPolyline
-
-	const intersection = fn(targetFrom, targetTo, targetShapeInfo.outline)
+	const intersection = Array.from(
+		targetShapeInfo.geometry.intersectLineSegment(targetFrom, targetTo, {
+			includeLabels: false,
+			includeInternal: false,
+		})
+	)
 
 	let targetInt: VecLike | undefined
 
-	if (intersection !== null) {
+	if (intersection.length) {
 		targetInt =
 			intersection.sort((p1, p2) => Vec.Dist2(p1, targetFrom) - Vec.Dist2(p2, targetFrom))[0] ??
-			(isClosed ? undefined : targetTo)
+			(targetShapeInfo.isClosed ? undefined : targetTo)
 	}
 
 	if (targetInt === undefined) {

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -400,7 +400,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 			case 'triangle':
 			case 'x-box':
 				// poly-line type shapes hand snap points for each vertex & the center
-				return { outline: outline, points: [...outline.getVertices(), geometry.bounds.center] }
+				return { outline: outline, points: [...outline.vertices, geometry.bounds.center] }
 			case 'cloud':
 			case 'ellipse':
 			case 'heart':


### PR DESCRIPTION
This diff adds a number of `Geometry2d` improvements back-ported from my work on elbow arrows.

1. Intersection helpers. We have hit tests, distance to, nearest point etc. on geometry, but no intersections. This diff adds support for `Geometry2d.intersectLineSegment` and `Geometry2d.intersectCircle`. We previously were using these downstream in kind of a hack way, but having them directly on the geometry and able to play nicer with groups etc. is very helpful.
2. Transformation. `Geometry2d.transform` allows you to efficiently transform a geometry by some matrix. Where possible, we avoid transforming every single point and instead forward the methods to the original untransformed geometry. This also allows for some efficiency gains by e.g. caching geometries in page space. For now, I've only ported some really obvious / simple use-cases over to using this, but there are many parts of the code that could now be simplified by switching to transformed geometries.
3. Filters. Almost all geometry methods do some sort of filtering - e.g. to ignore labels, etc. Sometimes this was hard-coded, sometimes method accepted an optional boolean `includeFilters` parameter. Now, all methods than can have filters applied accept a filters argument which determines which parts do/don't get included in the shape. New here (& motivating this change) is a new way of designating parts of a group as "internal" geometry - e.g. the lines within a geo shape that we might not want to partake in arrow binding. 

### Change type

- [x] `api`

### Release notes

- It's now easier to work with `Geometry2d` objects, with methods for intersections, transforming geometries, and filtering.