### PR TITLE
isShapeHidden => getShapeVisibility, to allow children of hidden shapes to be visible

### DIFF
--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -719,7 +719,7 @@ You can prevent that by cleaning up the selection in a signal reaction that is s
 
 ```tsx
 <Tldraw
-	getShapeVisibility={(shape) => shape.meta.hidden ? 'hidden' : 'inherit'}
+	getShapeVisibility={(shape) => (shape.meta.hidden ? 'hidden' : 'inherit')}
 	onMount={(editor) => {
 		// We don't prevent hidden shapes from being selected out of the box, because there are some situations where it's desirable.
 		// If you want to prevent hidden shapes from being selected, you can do so like this:

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -696,7 +696,13 @@ editor.run(
 
 ### Hiding shapes
 
-You can pass a `isShapeHidden` predicate when configuring tldraw. This predicate will be called for each shape to determine if it should be hidden.
+You can pass a `getShapeVisibility` function when configuring tldraw. This will be called for each shape to determine whether it should be hidden.
+
+`getShapeVisibility` can return one of the following values
+
+- `'inherit' | undefined` - (default) The shape will be visible unless its parent is hidden.
+- `'hidden'` - The shape will be hidden.
+- `'visible'` - The shape will be visible.
 
 Hidden shapes will still be present in the store, but
 
@@ -707,13 +713,13 @@ Hidden shapes will still be present in the store, but
 
 Otherwise, they will behave as normal.
 
-One place where this might be problematic for you, depending on what features you're using `isShapeHidden` to implement, is that hidden shapes will still be selectable, e.g. via the `select-all` action (`Cmd+A` or `Ctrl+A`).
+One place where this might be problematic for you, depending on what features you're using `getShapeVisibility` to implement, is that hidden shapes will still be selectable, e.g. via the `select-all` action (`Cmd+A` or `Ctrl+A`).
 
 You can prevent that by cleaning up the selection in a signal reaction that is set up in the `onMount` callback:
 
 ```tsx
 <Tldraw
-	isShapeHidden={(shape) => shape.meta.hidden}
+	getShapeVisibility={(shape) => shape.meta.hidden ? 'hidden' : 'inherit'}
 	onMount={(editor) => {
 		// We don't prevent hidden shapes from being selected out of the box, because there are some situations where it's desirable.
 		// If you want to prevent hidden shapes from being selected, you can do so like this:

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -84,7 +84,10 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	// i.e. where it appears that they are not present. so the user knows which ones failed.
 	// There's probably a better way of doing this but I couldn't think of one.
 	const hideAllShapes = useAtom('hideAllShapes', false)
-	const isShapeHidden = useCallback(() => hideAllShapes.get(), [hideAllShapes])
+	const getShapeVisibility = useCallback(
+		() => (hideAllShapes.get() ? 'hidden' : 'inherit'),
+		[hideAllShapes]
+	)
 	const remountImageShapes = useCallback(() => {
 		hideAllShapes.set(true)
 		requestAnimationFrame(() => {
@@ -221,7 +224,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				options={{ actionShortcutsLocation: 'toolbar' }}
 				deepLinks={deepLinks || undefined}
 				overrides={overrides}
-				isShapeHidden={isShapeHidden}
+				getShapeVisibility={getShapeVisibility}
 			>
 				<ThemeUpdater />
 				<SneakyDarkModeSync />

--- a/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
+++ b/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
@@ -36,7 +36,7 @@ export default function LayerPanelExample() {
 				persistenceKey="layer-panel-example"
 				components={components}
 				// [3]
-				isShapeHidden={(s) => !!s.meta.hidden}
+				isShapeHidden={(s) => (s.meta.force_show ? 'force_show' : !!s.meta.hidden)}
 				// this is just to provide some initial content, so visitors can see the layer panel in action
 				snapshot={snapshot as any as TLEditorSnapshot}
 			/>

--- a/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
+++ b/apps/examples/src/examples/layer-panel/LayerPanelExample.tsx
@@ -36,7 +36,9 @@ export default function LayerPanelExample() {
 				persistenceKey="layer-panel-example"
 				components={components}
 				// [3]
-				isShapeHidden={(s) => (s.meta.force_show ? 'force_show' : !!s.meta.hidden)}
+				getShapeVisibility={(s) =>
+					s.meta.force_show ? 'visible' : s.meta.hidden ? 'hidden' : 'inherit'
+				}
 				// this is just to provide some initial content, so visitors can see the layer panel in action
 				snapshot={snapshot as any as TLEditorSnapshot}
 			/>

--- a/apps/examples/src/examples/layer-panel/ShapeList.tsx
+++ b/apps/examples/src/examples/layer-panel/ShapeList.tsx
@@ -1,5 +1,5 @@
 import { capitalize } from 'lodash'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Editor, TLShapeId, useEditor, useValue } from 'tldraw'
 import { VisibilityOff, VisibilityOn } from '../../icons/icons'
 
@@ -30,6 +30,8 @@ function ShapeItem({
 
 	const [isEditingName, setIsEditingName] = useState(false)
 
+	const timeSinceLastVisibilityToggle = useRef(Date.now())
+
 	if (!shape) return null
 
 	return (
@@ -54,7 +56,7 @@ function ShapeItem({
 					}}
 					style={{
 						paddingLeft: 10 + depth * 20,
-						opacity: parentIsHidden || isHidden ? 0.5 : 1,
+						opacity: isHidden ? 0.5 : 1,
 						background: isSelected
 							? selectedBg
 							: parentIsSelected
@@ -90,7 +92,24 @@ function ShapeItem({
 					<button
 						className="shape-visibility-toggle"
 						onClick={(ev) => {
-							editor.updateShape({ ...shape, meta: { hidden: !shape.meta.hidden } })
+							const now = Date.now()
+							if (now - timeSinceLastVisibilityToggle.current < 200) {
+								editor.updateShape({
+									...shape,
+									meta: { hidden: false, force_show: true },
+								})
+								timeSinceLastVisibilityToggle.current = 0
+							} else {
+								editor.updateShape({
+									...shape,
+									meta: { hidden: !shape.meta.hidden, force_show: false },
+								})
+								timeSinceLastVisibilityToggle.current = now
+							}
+							ev.preventDefault()
+							ev.stopPropagation()
+						}}
+						onDoubleClickCapture={(ev) => {
 							ev.stopPropagation()
 						}}
 					>

--- a/apps/examples/src/examples/sync-private-content/SyncPrivateContentExample.tsx
+++ b/apps/examples/src/examples/sync-private-content/SyncPrivateContentExample.tsx
@@ -86,9 +86,12 @@ function App({ roomId }: { roomId: string }) {
 				store={store}
 				deepLinks
 				// [4]
-				isShapeHidden={(shape, editor) => {
+				getShapeVisibility={(shape, editor) => {
 					const userId = editor.user.getId()
-					return !!shape.meta.private && shape.meta.ownerId !== userId
+					if (!!shape.meta.private && shape.meta.ownerId !== userId) {
+						return 'hidden'
+					}
+					return 'inherit'
 				}}
 				onMount={(editor) => {
 					// [5]
@@ -136,7 +139,7 @@ export default function SyncPrivateContentExample({ roomId }: { roomId: string }
  * 1. We create a context to store the atom that will hold the state of the private drawing mode. We are using signals here but you can use any state management library you like.
  * 2. We override the `InFrontOfTheCanvas` component to add a tool panel at the top of the screen that allows the user to toggle private drawing mode on and off, and to make private shapes public.
  * 3. We use the context to get the atom that holds the state of the private drawing mode. We then have to call 'useValue' on the atom to get the current value in a reactive way.
- * 4. We override the `isShapeHidden` function to hide shapes that are private and not owned by the current user.
+ * 4. We override the `getShapeVisibility` function to hide shapes that are private and not owned by the current user.
  * 5. We register a side effect that adds the 'private' and 'ownerId' meta fields to each shape created. We set the 'private' field to the current value of the private drawing mode atom.
  * 6. We register a side effect that cleans up the selection by removing any hidden shapes from the selection. This re-runs whenever the selection or the hidden state of a selected shape changes.
  * 7. Child shapes (e.g inside groups and frames) do not inherit the 'private' meta property from their parent. So when making a shape public, we decide to also make all descendant shapes public since this is most likely what the user intended.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3164,7 +3164,7 @@ export interface TldrawEditorBaseProps {
     deepLinks?: TLDeepLinkOptions | true;
     inferDarkMode?: boolean;
     initialState?: string;
-    isShapeHidden?(shape: TLShape, editor: Editor): boolean;
+    isShapeHidden?(shape: TLShape, editor: Editor): 'force_show' | boolean;
     licenseKey?: string;
     onMount?: TLOnMountHandler;
     options?: Partial<TldrawOptions>;
@@ -3347,7 +3347,7 @@ export interface TLEditorOptions {
     getContainer(): HTMLElement;
     inferDarkMode?: boolean;
     initialState?: string;
-    isShapeHidden?(shape: TLShape, editor: Editor): boolean;
+    isShapeHidden?(shape: TLShape, editor: Editor): 'force_show' | boolean;
     // (undocumented)
     licenseKey?: string;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3162,7 +3162,7 @@ export interface TldrawEditorBaseProps {
     className?: string;
     components?: TLEditorComponents;
     deepLinks?: TLDeepLinkOptions | true;
-    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined | void;
+    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined;
     inferDarkMode?: boolean;
     initialState?: string;
     // @deprecated
@@ -3347,7 +3347,7 @@ export interface TLEditorOptions {
         [key: string]: string | undefined;
     };
     getContainer(): HTMLElement;
-    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined | void;
+    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined;
     inferDarkMode?: boolean;
     initialState?: string;
     // @deprecated

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -841,7 +841,7 @@ export class EdgeScrollManager {
 
 // @public (undocumented)
 export class Editor extends EventEmitter<TLEventMap> {
-    constructor({ store, user, shapeUtils, bindingUtils, tools, getContainer, cameraOptions, textOptions, initialState, autoFocus, inferDarkMode, options, isShapeHidden, fontAssetUrls, }: TLEditorOptions);
+    constructor({ store, user, shapeUtils, bindingUtils, tools, getContainer, cameraOptions, textOptions, initialState, autoFocus, inferDarkMode, options, isShapeHidden, getShapeVisibility, fontAssetUrls, }: TLEditorOptions);
     // @deprecated (undocumented)
     addOpenMenu(id: string): this;
     alignShapes(shapes: TLShape[] | TLShapeId[], operation: 'bottom' | 'center-horizontal' | 'center-vertical' | 'left' | 'right' | 'top'): this;
@@ -3162,9 +3162,11 @@ export interface TldrawEditorBaseProps {
     className?: string;
     components?: TLEditorComponents;
     deepLinks?: TLDeepLinkOptions | true;
+    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined | void;
     inferDarkMode?: boolean;
     initialState?: string;
-    isShapeHidden?(shape: TLShape, editor: Editor): 'force_show' | boolean;
+    // @deprecated
+    isShapeHidden?(shape: TLShape, editor: Editor): boolean;
     licenseKey?: string;
     onMount?: TLOnMountHandler;
     options?: Partial<TldrawOptions>;
@@ -3345,9 +3347,11 @@ export interface TLEditorOptions {
         [key: string]: string | undefined;
     };
     getContainer(): HTMLElement;
+    getShapeVisibility?(shape: TLShape, editor: Editor): 'hidden' | 'inherit' | 'visible' | null | undefined | void;
     inferDarkMode?: boolean;
     initialState?: string;
-    isShapeHidden?(shape: TLShape, editor: Editor): 'force_show' | boolean;
+    // @deprecated
+    isShapeHidden?(shape: TLShape, editor: Editor): boolean;
     // (undocumented)
     licenseKey?: string;
     // (undocumented)

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -207,6 +207,10 @@ export interface TldrawEditorBaseProps {
 	 * getShapeVisibility={(shape, editor) => shape.meta.hidden ? 'hidden' : 'inherit'}
 	 * ```
 	 *
+	 * - `'inherit' | undefined` - (default) The shape will be visible unless its parent is hidden.
+	 * - `'hidden'` - The shape will be hidden.
+	 * - `'visible'` - The shape will be visible.
+	 *
 	 * @param shape - The shape to check.
 	 * @param editor - The editor instance.
 	 */

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -213,7 +213,7 @@ export interface TldrawEditorBaseProps {
 	getShapeVisibility?(
 		shape: TLShape,
 		editor: Editor
-	): 'visible' | 'hidden' | 'inherit' | null | undefined | void
+	): 'visible' | 'hidden' | 'inherit' | null | undefined
 
 	/**
 	 * The URLs for the fonts to use in the editor.

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -191,13 +191,29 @@ export interface TldrawEditorBaseProps {
 	/**
 	 * Predicate for whether or not a shape should be hidden.
 	 *
+	 * @deprecated Use {@link TldrawEditorBaseProps#getShapeVisibility} instead.
+	 */
+	isShapeHidden?(shape: TLShape, editor: Editor): boolean
+
+	/**
+	 * Provides a way to hide shapes.
+	 *
 	 * Hidden shapes will not render in the editor, and they will not be eligible for hit test via
 	 * {@link Editor#getShapeAtPoint} and {@link Editor#getShapesAtPoint}. But otherwise they will
 	 * remain in the store and participate in all other operations.
 	 *
-	 * Return 'force_show' to show the shape even if it is the child of a hidden parent shape.
+	 * @example
+	 * ```ts
+	 * getShapeVisibility={(shape, editor) => shape.meta.hidden ? 'hidden' : 'inherit'}
+	 * ```
+	 *
+	 * @param shape - The shape to check.
+	 * @param editor - The editor instance.
 	 */
-	isShapeHidden?(shape: TLShape, editor: Editor): boolean | 'force_show'
+	getShapeVisibility?(
+		shape: TLShape,
+		editor: Editor
+	): 'visible' | 'hidden' | 'inherit' | null | undefined | void
 
 	/**
 	 * The URLs for the fonts to use in the editor.
@@ -389,7 +405,9 @@ function TldrawEditorWithReadyStore({
 	options,
 	licenseKey,
 	deepLinks: _deepLinks,
+	// eslint-disable-next-line @typescript-eslint/no-deprecated
 	isShapeHidden,
+	getShapeVisibility,
 	assetUrls,
 }: Required<
 	TldrawEditorProps & {
@@ -449,6 +467,7 @@ function TldrawEditorWithReadyStore({
 				options,
 				licenseKey,
 				isShapeHidden,
+				getShapeVisibility,
 				fontAssetUrls: assetUrls?.fonts,
 			})
 
@@ -484,6 +503,7 @@ function TldrawEditorWithReadyStore({
 			setEditor,
 			licenseKey,
 			isShapeHidden,
+			getShapeVisibility,
 			textOptions,
 			assetUrls,
 		]

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -194,8 +194,10 @@ export interface TldrawEditorBaseProps {
 	 * Hidden shapes will not render in the editor, and they will not be eligible for hit test via
 	 * {@link Editor#getShapeAtPoint} and {@link Editor#getShapesAtPoint}. But otherwise they will
 	 * remain in the store and participate in all other operations.
+	 *
+	 * Return 'force_show' to show the shape even if it is the child of a hidden parent shape.
 	 */
-	isShapeHidden?(shape: TLShape, editor: Editor): boolean
+	isShapeHidden?(shape: TLShape, editor: Editor): boolean | 'force_show'
 
 	/**
 	 * The URLs for the fonts to use in the editor.

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -257,6 +257,10 @@ export interface TLEditorOptions {
 	 * getShapeVisibility={(shape, editor) => shape.meta.hidden ? 'hidden' : 'inherit'}
 	 * ```
 	 *
+	 * - `'inherit' | undefined` - (default) The shape will be visible unless its parent is hidden.
+	 * - `'hidden'` - The shape will be hidden.
+	 * - `'visible'` - The shape will be visible.
+	 *
 	 * @param shape - The shape to check.
 	 * @param editor - The editor instance.
 	 */

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -263,7 +263,7 @@ export interface TLEditorOptions {
 	getShapeVisibility?(
 		shape: TLShape,
 		editor: Editor
-	): 'visible' | 'hidden' | 'inherit' | null | undefined | void
+	): 'visible' | 'hidden' | 'inherit' | null | undefined
 }
 
 /**

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -719,7 +719,7 @@ describe('dragging', () => {
 })
 
 describe('isShapeHidden', () => {
-	const isShapeHidden = jest.fn((shape: TLShape): boolean | 'force_show' => {
+	const isShapeHidden = jest.fn((shape: TLShape): boolean => {
 		return !!shape.meta.hidden
 	})
 
@@ -804,34 +804,6 @@ describe('isShapeHidden', () => {
 		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
-	})
-
-	it('allows children to override with force_show', () => {
-		isShapeHidden.mockImplementation((shape: TLShape) => {
-			if (shape.meta.force_show) return 'force_show'
-			return !!shape.meta.hidden
-		})
-		const groupId = createShapeId('group')
-		editor.groupShapes([ids.box1, ids.box2], { groupId })
-		editor.deleteShape(ids.box3)
-
-		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
-		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
-		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
-		expect(editor.isShapeHidden(editor.getShape(ids.box2)!)).toBe(true)
-
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { force_show: true } })
-		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
-		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
-		expect(editor.isShapeHidden(editor.getShape(ids.box2)!)).toBe(true)
-
-		expect(editor.getRenderingShapes().map((s) => s.id)).toEqual([ids.box1])
-
-		editor.select(ids.box1)
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-
-		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(1)
-		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
 	})
 
 	it('still allows hidden shapes to be selected', () => {

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -719,11 +719,12 @@ describe('dragging', () => {
 })
 
 describe('isShapeHidden', () => {
-	const isShapeHidden = jest.fn((shape: TLShape) => {
+	const isShapeHidden = jest.fn((shape: TLShape): boolean | 'force_show' => {
 		return !!shape.meta.hidden
 	})
 
 	beforeEach(() => {
+		isShapeHidden.mockClear()
 		editor = new TestEditor({ isShapeHidden })
 
 		editor.createShapes([
@@ -803,6 +804,34 @@ describe('isShapeHidden', () => {
 		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
+	})
+
+	it('allows children to override with force_show', () => {
+		isShapeHidden.mockImplementation((shape: TLShape) => {
+			if (shape.meta.force_show) return 'force_show'
+			return !!shape.meta.hidden
+		})
+		const groupId = createShapeId('group')
+		editor.groupShapes([ids.box1, ids.box2], { groupId })
+		editor.deleteShape(ids.box3)
+
+		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
+		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
+		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
+		expect(editor.isShapeHidden(editor.getShape(ids.box2)!)).toBe(true)
+
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { force_show: true } })
+		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
+		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
+		expect(editor.isShapeHidden(editor.getShape(ids.box2)!)).toBe(true)
+
+		expect(editor.getRenderingShapes().map((s) => s.id)).toEqual([ids.box1])
+
+		editor.select(ids.box1)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(1)
+		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
 	})
 
 	it('still allows hidden shapes to be selected', () => {

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -4,6 +4,7 @@ import {
 	PageRecordType,
 	TLGeoShapeProps,
 	TLShape,
+	TldrawEditorProps,
 	atom,
 	createShapeId,
 	debounce,
@@ -718,14 +719,14 @@ describe('dragging', () => {
 	})
 })
 
-describe('isShapeHidden', () => {
-	const isShapeHidden = jest.fn((shape: TLShape): boolean => {
-		return !!shape.meta.hidden
-	})
+describe('getShapeVisibility', () => {
+	const getShapeVisibility = jest.fn(((shape: TLShape) => {
+		return shape.meta.visibility as any
+	}) satisfies TldrawEditorProps['getShapeVisibility'])
 
 	beforeEach(() => {
-		isShapeHidden.mockClear()
-		editor = new TestEditor({ isShapeHidden })
+		getShapeVisibility.mockClear()
+		editor = new TestEditor({ getShapeVisibility })
 
 		editor.createShapes([
 			{
@@ -754,44 +755,44 @@ describe('isShapeHidden', () => {
 
 	it('can be directly used via editor.isShapeHidden', () => {
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
 	})
 
 	it('excludes hidden shapes from the rendering shapes array', () => {
 		expect(editor.getRenderingShapes().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.getRenderingShapes().length).toBe(2)
-		editor.updateShape({ id: ids.box2, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box2, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.getRenderingShapes().length).toBe(1)
 	})
 
 	it('excludes hidden shapes from hit testing', () => {
 		expect(editor.getShapeAtPoint({ x: 150, y: 150 })).toBeDefined()
 		expect(editor.getShapesAtPoint({ x: 150, y: 150 }).length).toBe(1)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.getShapeAtPoint({ x: 150, y: 150 })).not.toBeDefined()
 		expect(editor.getShapesAtPoint({ x: 150, y: 150 }).length).toBe(0)
 	})
 
 	it('uses the callback reactively', () => {
 		const isFilteringEnabled = atom('', true)
-		isShapeHidden.mockImplementation((shape: TLShape) => {
-			if (!isFilteringEnabled.get()) return false
-			return !!shape.meta.hidden
+		getShapeVisibility.mockImplementation((shape: TLShape) => {
+			if (!isFilteringEnabled.get()) return 'inherit'
+			return shape.meta.visibility
 		})
 		let renderingShapes = editor.getRenderingShapes()
 		react('setRenderingShapes', () => {
 			renderingShapes = editor.getRenderingShapes()
 		})
 		expect(renderingShapes.length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(renderingShapes.length).toBe(2)
 		isFilteringEnabled.set(false)
 		expect(renderingShapes.length).toBe(3)
 		isFilteringEnabled.set(true)
 		expect(renderingShapes.length).toBe(2)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: false } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'inherit' } })
 		expect(renderingShapes.length).toBe(3)
 	})
 
@@ -801,13 +802,13 @@ describe('isShapeHidden', () => {
 
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(false)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
-		editor.updateShape({ id: groupId, type: 'group', meta: { hidden: true } })
+		editor.updateShape({ id: groupId, type: 'group', meta: { visibility: 'hidden' } })
 		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
 	})
 
 	it('still allows hidden shapes to be selected', () => {
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		editor.select(ids.box1)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
@@ -815,14 +816,28 @@ describe('isShapeHidden', () => {
 
 	it('applies to getCurrentPageRenderingShapesSorted', () => {
 		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.getCurrentPageRenderingShapesSorted().length).toBe(2)
 	})
 
 	it('does not apply to getCurrentPageShapesSorted', () => {
 		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
-		editor.updateShape({ id: ids.box1, type: 'geo', meta: { hidden: true } })
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'hidden' } })
 		expect(editor.getCurrentPageShapesSorted().length).toBe(3)
+	})
+
+	it('allows overriding hidden parents with "visible" value', () => {
+		const groupId = createShapeId('group')
+		editor.groupShapes([ids.box1, ids.box2], { groupId })
+
+		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(false)
+		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
+		editor.updateShape({ id: groupId, type: 'group', meta: { visibility: 'hidden' } })
+		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
+		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(true)
+		editor.updateShape({ id: ids.box1, type: 'geo', meta: { visibility: 'visible' } })
+		expect(editor.isShapeHidden(editor.getShape(groupId)!)).toBe(true)
+		expect(editor.isShapeHidden(editor.getShape(ids.box1)!)).toBe(false)
 	})
 })
 


### PR DESCRIPTION
This PR was motivated by a very reasonable [discord request
](https://discord.com/channels/859816885297741824/1353628236487327857/1353628236487327857)

> We are working on a feature where we need to hide all of the shapes except for the "focused shape" (we are using isShapeHidden prop) - this is largely working as expected, except for one challenge - when the "focused shape" is child of a frame/ group shape, then hiding the parent shape also hides the "focused shape", which makes sense in general context, but we need the ability to hide the parent shape without hiding the "focused shape".

Ended up being a fairly small diff.

![Kapture 2025-03-27 at 12 00 09](https://github.com/user-attachments/assets/e2423d49-9908-4a7b-bdb0-fed96c3b25f5)

I'm not crazy about this 'force_show' API and would appreciate alternative suggestions if you have any.

### Change type

- [x] `other`

### Release notes

- Allow the children of a hidden shape to show themselves by returning a 'force_show' override from the `isShapeHidden` predicate.