### PR TITLE
Don't include json files in llms.txt outputs

### DIFF
--- a/apps/docs/scripts/lib/generateLllmsTxt.ts
+++ b/apps/docs/scripts/lib/generateLllmsTxt.ts
@@ -85,7 +85,7 @@ async function getMarkdownForExamples(db: DbType) {
 	return result
 }
 
-const ALLOWED_FILE_TYPES = ['tsx', 'ts', 'js', 'jsx', 'json', 'md', 'css', 'html']
+const ALLOWED_FILE_TYPES = ['tsx', 'ts', 'js', 'jsx', 'md', 'css', 'html']
 function getMarkdownForFile(fileName: string, fileContent: string) {
 	const type = fileName.split('.').pop()
 


### PR DESCRIPTION
This PR excludes json files from examples in our `llms` files. The only json files are snapshots, which are very large and aren't that helpful to LLMs. This saves on tokens, and makes things clearer.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
