### PR TITLE
fix zoom speed for pinch gestures

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9749,10 +9749,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// todo: replace with new readonly mode?
 		if (this.getCrashingError()) return this
 
-		if (info.type === 'wheel' || info.type === 'pinch') {
-			console.log(info.name, info)
-		}
-
 		this.emit('before-event', info)
 
 		const { inputs } = this

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9749,6 +9749,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// todo: replace with new readonly mode?
 		if (this.getCrashingError()) return this
 
+		if (info.type === 'wheel' || info.type === 'pinch') {
+			console.log(info.name, info)
+		}
+
 		this.emit('before-event', info)
 
 		const { inputs } = this
@@ -9859,12 +9863,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.getCamera())
 
-						const { panSpeed, zoomSpeed } = cameraOptions
+						const { panSpeed } = cameraOptions
 						this._setCamera(
 							new Vec(
-								cx + (dx * panSpeed) / cz - x / cz + x / (z * zoomSpeed),
-								cy + (dy * panSpeed) / cz - y / cz + y / (z * zoomSpeed),
-								z * zoomSpeed
+								cx + (dx * panSpeed) / cz - x / cz + x / z,
+								cy + (dy * panSpeed) / cz - y / cz + y / z,
+								z
 							),
 							{ immediate: true }
 						)
@@ -9939,14 +9943,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 							}
 
 							const zoom = cz + (delta ?? 0) * zoomSpeed * cz
-							this._setCamera(
-								new Vec(
-									cx + (x / zoom - x) - (x / cz - x),
-									cy + (y / zoom - y) - (y / cz - y),
-									zoom
-								),
-								{ immediate: true }
-							)
+							this._setCamera(new Vec(cx + x / zoom - x / cz, cy + y / zoom - y / cz, zoom), {
+								immediate: true,
+							})
 							this.maybeTrackPerformance('Zooming')
 							return
 						}

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -239,7 +239,6 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 			switch (pinchState) {
 				case 'zooming': {
 					const currZoom = offset[0] ** editor.getCameraOptions().zoomSpeed
-					console.log(`curr zoom original = ${offset[0]} scaled = ${currZoom}`)
 
 					editor.dispatch({
 						type: 'pinch',
@@ -311,29 +310,14 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement>) {
 		pinch: {
 			from: () => {
 				const { zoomSpeed } = editor.getCameraOptions()
-				const level = editor.getZoomLevel()
-				console.log('from', {
-					original: level,
-					scaled: level ** (1 / zoomSpeed),
-				})
-				return [level ** (1 / zoomSpeed), 0]
+				const level = editor.getZoomLevel() ** (1 / zoomSpeed)
+				return [level, 0]
 			}, // Return the camera z to use when pinch starts
 			scaleBounds: () => {
 				const baseZoom = editor.getBaseZoom()
 				const { zoomSteps, zoomSpeed } = editor.getCameraOptions()
 				const zoomMin = zoomSteps[0] * baseZoom
 				const zoomMax = zoomSteps[zoomSteps.length - 1] * baseZoom
-
-				console.log('scale bounds', {
-					original: {
-						max: zoomMax,
-						min: zoomMin,
-					},
-					scaled: {
-						max: zoomMax ** (1 / zoomSpeed),
-						min: zoomMin ** (1 / zoomSpeed),
-					},
-				})
 
 				return {
 					max: zoomMax ** (1 / zoomSpeed),

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -320,7 +320,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 5, y: 10, z: 1 })
 	})
 
-	it('Effects pinch zooming (2x)', () => {
+	it('Does not effect pinch zooming (2x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2 })
 			.dispatch({
@@ -339,9 +339,9 @@ describe('CameraOptions.zoomSpeed', () => {
 			name: 'pinch_end',
 		})
 		editor.forceTick()
-		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 2 })
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
-	it('Effects pinch zooming (0.5x)', () => {
+	it('Does not effect pinch zooming (0.5x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5 })
 			.dispatch({
@@ -360,7 +360,7 @@ describe('CameraOptions.zoomSpeed', () => {
 			name: 'pinch_end',
 		})
 		editor.forceTick()
-		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 0.5 })
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
 	it('Does not effect zoom tool zooming (2x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2 })


### PR DESCRIPTION
Alternative take on #5749, aiming to fix #4945. 

The big issue here is that `useGesture` doesn't give us a zoom delta, it gives us its own calculated absolute zoom. This makes it really hard to apply `zoomSpeed` correctly - we don't have a delta to apply a speed to, and `useGesture` isn't expecting us to be applying changes different to the ones that it's supplying.

In #5749, we try to get the deltas out and scale them appropriately. In this diff, we instead counter-scale all of our inputs to `useGesture`, then scale them back afterwards. This means that if you have a zoom speed of 0.5, then scaling from 1 to 2 requires scaling from 1 to 4 in use-gesture land.

The big drawback to this is that where the rest of `cameraOptions` is applied in editor-land, this is applied to the events _before_ they get to the editor. This isn't really a big deal - i doubt many people are using the editor without the built-in use-gesture setup. In the future we'll probably move off of use-gesture and can apply this stuff in the editor once we do that.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Setting `zoomSpeed` in camera options no longer breaks zooming on safari trackpads and multitouch pinch to zoom.