### PR TITLE
Disable currently broken docs links

### DIFF
--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -15,58 +15,64 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
-## Current release: [v3.10.0](/releases/v3.10.0)
+## Current release: [v3.11.0](/releases/v3.11.0)
 
-Welcome to the 3.10.0 release of tldraw. This month's SDK release's big news is adding rich text to all of our shapes.
-
-## What's new
-
-#### Rich text ([#4895](https://github.com/tldraw/tldraw/pull/4895))
-
-Tldraw now has the supports rich text as a first-class primitive within the Editor. After deliberating on which rich text editor to choose, we settled on using [TipTap](https://tiptap.dev/) as our out-of-the-box solution. Our basic implementation includes the TipTap [StarterKit](https://tiptap.dev/docs/editor/extensions/functionality/starterkit) extension along with a couple extra extensions to make the experience butter-smooth.
-
-Of course, we wouldn't be providing this functionality if it wasn't extensible and remixable by the community. There is a `textOptions` property now that lets you customize TipTap and add/remove extensions as per your needs.
-
-Take a look at our [Shapes documentation](https://tldraw.dev/docs/shapes#Editing) to learn more.
-
-Please do jump in the [Discord](https://discord.tldraw.com/?utm_source=docs&utm_medium=organic&utm_campaign=sociallink) if you have any feedback or bugs about this new feature.
+Welcome to the 3.11.0 release of tldraw. This release follows up our 3.10 release to mainly address rich text issues.
+We had fairly smooth release of our new transition to rich text as a first-class primitive in tldraw in general.
+Thanks to everyone for their continued feedback!
 
 #### Improvements
 
-- Ensure .tldr files with embedded base64 assets get their assets rehydrated back into the local db. [#5525](https://github.com/tldraw/tldraw/pull/5525)
-- Display BrokenAssetIcon when file upload fails [#5552](https://github.com/tldraw/tldraw/pull/5552)
+- Added a new minimum zoom step at 5% ([#5584](https://github.com/tldraw/tldraw/pull/5584))
+- Added new keyboard shortcuts for zoom in or out towards your cursor (Shift +, Shift -) ([#5584](https://github.com/tldraw/tldraw/pull/5584))
+- Style panel: be able to hit Enter to continue editing after selection ([#5705](https://github.com/tldraw/tldraw/pull/5705))
+- a11y: focus ring ([#5401](https://github.com/tldraw/tldraw/pull/5401))
+- Security: provide a way to pass through `nonce` to the editor ([#5607](https://github.com/tldraw/tldraw/pull/5607))
+- Improved performance related to rich text when there are a lot of shapes on the board. ([#5658](https://github.com/tldraw/tldraw/pull/5658))
+- Cleanup assets from the local indexedDB that are proactively deleted. ([#5628](https://github.com/tldraw/tldraw/pull/5628))
+- Allow embedding other multiplayer routes and also tldraw app routes ([#5326](https://github.com/tldraw/tldraw/pull/5326))
+- Improved performance on large projects when hiding / showing shape indicators. ([#5654](https://github.com/tldraw/tldraw/pull/5654))
+- Added `hideAll` and `showAll` props to the `ShapeIndicators` component props ([#5654](https://github.com/tldraw/tldraw/pull/5654))
+- Added keyboard shortcuts (option + arrows) for navigating between pages. ([#5654](https://github.com/tldraw/tldraw/pull/5654))
+- Adjusts distance for `stackShapes`. ([#5656](https://github.com/tldraw/tldraw/pull/5656))
+- Adds support for satellite mode in Google Map embeds ([#5630](https://github.com/tldraw/tldraw/pull/5630))
+- 'New user' -> 'Guest user' ([#5614](https://github.com/tldraw/tldraw/pull/5614))
+  - BREAKING CHANGE: `editor.user.getName()` no longer returns `'New user'` if the user has no name set. Instead it returns the empty string `''`.
+  - BREAKING CHANGE: `defaultUserPreferences.name` is no longer the string `'New user'`, it is now the empty string `''`
 
 #### API changes
 
-- Make collaboration hooks public (`usePeerIds` and `usePresence`) [#5541](https://github.com/tldraw/tldraw/pull/5541)
-- Pass userId to collaboration components [#5534](https://github.com/tldraw/tldraw/pull/5534)
+- Add `RichTextSVG` to the exports. [#5700](https://github.com/tldraw/tldraw/pull/5700)
 
 #### Bug fix
 
-- Fix a perf regression that caused slowness mainly when loading documents. [#5567](https://github.com/tldraw/tldraw/pull/5567)
-- Fix exports / style embedding for foreignObjects in Firefox [#5593](https://github.com/tldraw/tldraw/pull/5593)
-- Fix the reparentShapes() function to ensure that the original order of the shapes is preserved when reparenting. [#5565](https://github.com/tldraw/tldraw/pull/5565)
-- Fix a bug that could occur when resizing [#5292](https://github.com/tldraw/tldraw/pull/5292)
-- Fix a bug with pasting files from your computer in Safari [#5545](https://github.com/tldraw/tldraw/pull/5545)
-- Fix bug with loading TLDraw in an SSR environment by removing a core-js import [#5543](https://github.com/tldraw/tldraw/pull/5543)
-- Prevent text duplication when using IME with Enter key in Chrome [#5540](https://github.com/tldraw/tldraw/pull/5540)
+- Fix issue with rich text numbered lists escaping geometry bounds ([#5709](https://github.com/tldraw/tldraw/pull/5709))
+- Fix developing with StrictMode + React 19 when editing text. ([#5689](https://github.com/tldraw/tldraw/pull/5689))
+- Fix issue with exports embedding Inter and having excessive styling. ([#5676](https://github.com/tldraw/tldraw/pull/5676))
+- Fix a bug where `textOptions` was missing on `<TldrawImage />` ([#5649](https://github.com/tldraw/tldraw/pull/5649))
+- Fix labels for screen readers on toolbar buttons. Fix missing 'heart' string. ([#5632](https://github.com/tldraw/tldraw/pull/5632))
+- Fix missing i18n strings for latest rich text items [#5704](https://github.com/tldraw/tldraw/pull/5704)
+- Upgrade Yarn to 4.7 [#5687](https://github.com/tldraw/tldraw/pull/5687)
+
+#### Templates
+
+- Fix Bun server image uploads ([#5627](https://github.com/tldraw/tldraw/pull/5627))
+- Remove yarn.lock files (was keeping tldraw versions old) [#5690](https://github.com/tldraw/tldraw/pull/5690)
+- Fix Inter font on some of our templates. [#5626](https://github.com/tldraw/tldraw/pull/5626)
 
 #### Authors
 
 - alex ([@SomeHats](https://github.com/SomeHats))
 - David Sheldrick ([@ds300](https://github.com/ds300))
-- Josh Willis ([@bluedot74](https://github.com/bluedot74))
-- Lorenzo Lewis ([@lorenzolewis](https://github.com/lorenzolewis))
+- Jeff Astor ([@Jastor11](https://github.com/Jastor11))
 - Lu Wilson ([@TodePond](https://github.com/TodePond))
-- Mathieu Triay ([@MathieuLoutre](https://github.com/MathieuLoutre))
-- mimata kazutaka ([@kazu-2020](https://github.com/kazu-2020))
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
-- Qinghe Ban ([@banqinghe](https://github.com/banqinghe))
-- Riley ([@dodo-Riley](https://github.com/dodo-Riley))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
 
 ## Previous releases
+
+- [v3.10.0](/releases/v3.10.0)
 
 - [v3.9.0](/releases/v3.9.0)
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -50,7 +50,7 @@ import { TLStoreWithStatus } from './utils/sync/StoreWithStatus'
 
 /**
  * Props for the {@link tldraw#Tldraw} and {@link TldrawEditor} components, when passing in a
- * {@link store#TLStore} directly. If you would like tldraw to create a store for you, use
+ * `TLStore` directly. If you would like tldraw to create a store for you, use
  * {@link TldrawEditorWithoutStoreProps}.
  *
  * @public
@@ -64,7 +64,7 @@ export interface TldrawEditorWithStoreProps {
 
 /**
  * Props for the {@link tldraw#Tldraw} and {@link TldrawEditor} components, when not passing in a
- * {@link store#TLStore} directly. If you would like to pass in a store directly, use
+ * `TLStore` directly. If you would like to pass in a store directly, use
  * {@link TldrawEditorWithStoreProps}.
  *
  * @public

--- a/packages/state-react/src/lib/useValue.ts
+++ b/packages/state-react/src/lib/useValue.ts
@@ -20,7 +20,7 @@ export function useValue<Value>(value: Signal<Value>): Value
  * }
  * ```
  *
- * You can also pass a function to compute the value and it will be memoized as in {@link state#useComputed}:
+ * You can also pass a function to compute the value and it will be memoized as in `useComputed`:
  *
  * @example
  * ```ts

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -89,7 +89,7 @@ export function withDiff<Value, Diff>(value: Value, diff: Diff): WithDiff<Value,
 }
 
 /**
- * Options for creating computed signals. Used when calling {@link state#computed}.
+ * Options for creating computed signals. Used when calling `computed`.
  * @public
  */
 export interface ComputedOptions<Value, Diff> {
@@ -119,7 +119,7 @@ export interface ComputedOptions<Value, Diff> {
 }
 
 /**
- * A computed signal created via {@link state#computed}.
+ * A computed signal created via `computed`.
  *
  * @public
  */
@@ -393,7 +393,7 @@ function computedDecorator(
 const isComputedMethodKey = '@@__isComputedMethod__@@'
 
 /**
- * Retrieves the underlying computed instance for a given property created with the {@link state#computed}
+ * Retrieves the underlying computed instance for a given property created with the `computed`
  * decorator.
  *
  * @example

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -120,7 +120,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	/**
 	 * Makes this scheduler become 'actively listening' to its parents.
 	 * If it has been executed before it will immediately become eligible to receive 'maybeScheduleEffect' calls.
-	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling {@link state#EffectScheduler.execute}.
+	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling `EffectScheduler.execute`.
 	 * @public
 	 */
 	attach() {
@@ -132,7 +132,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 
 	/**
 	 * Makes this scheduler stop 'actively listening' to its parents.
-	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until {@link state#EffectScheduler.attach} is called again.
+	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until `EffectScheduler.attach` is called again.
 	 */
 	detach() {
 		this._isActivelyListening = false
@@ -233,14 +233,14 @@ export interface EffectScheduler<Result> {
 	/**
 	 * Makes this scheduler become 'actively listening' to its parents.
 	 * If it has been executed before it will immediately become eligible to receive 'maybeScheduleEffect' calls.
-	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling {@link state#EffectScheduler.execute}.
+	 * If it has not executed before it will need to be manually executed once to become eligible for scheduling, i.e. by calling `EffectScheduler.execute`.
 	 * @public
 	 */
 	attach(): void
 
 	/**
 	 * Makes this scheduler stop 'actively listening' to its parents.
-	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until {@link state#EffectScheduler.attach} is called again.
+	 * It will no longer be eligible to receive 'maybeScheduleEffect' calls until `EffectScheduler.attach` is called again.
 	 */
 	detach(): void
 
@@ -327,7 +327,7 @@ export interface Reactor<T = unknown> {
 }
 
 /**
- * Creates a {@link Reactor}, which is a thin wrapper around an {@link state#EffectScheduler}.
+ * Creates a {@link Reactor}, which is a thin wrapper around an `EffectScheduler`.
  *
  * @public
  */

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -12,7 +12,7 @@ export type RESET_VALUE = typeof RESET_VALUE
  * There are two types of signal:
  *
  * - Atomic signals, created using {@link atom}. These are mutable references to values that can be changed using {@link Atom.set}.
- * - Computed signals, created using {@link state#computed}. These are values that are computed from other signals. They are recomputed lazily if their dependencies change.
+ * - Computed signals, created using `computed`. These are values that are computed from other signals. They are recomputed lazily if their dependencies change.
  *
  * @public
  */
@@ -35,7 +35,7 @@ export interface Signal<Value, Diff = unknown> {
 	lastChangedEpoch: number
 	/**
 	 * Returns the sequence of diffs between the the value at the given epoch and the current value.
-	 * Returns the {@link state#RESET_VALUE} constant if there is not enough information to compute the diff sequence.
+	 * Returns the `RESET_VALUE` constant if there is not enough information to compute the diff sequence.
 	 * @param epoch - The epoch to get diffs since.
 	 */
 	getDiffSince(epoch: number): RESET_VALUE | Diff[]


### PR DESCRIPTION
Our API reference generator is failing to include some links. This PR disables those already-broken links until we fix this.

See: https://github.com/tldraw/tldraw/issues/5769
See: https://linear.app/tldraw/issue/INT-1015/fix-broken-links-in-api-reference

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
