### PR TITLE
a11y: more fine-grained panning when in Hand tool

### DIFF
--- a/packages/tldraw/src/lib/tools/HandTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/Idle.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
+import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo, Vec } from '@tldraw/editor'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -14,4 +14,71 @@ export class Idle extends StateNode {
 	override onCancel() {
 		this.editor.setCurrentTool('select')
 	}
+
+	override onKeyDown(info: TLKeyboardEventInfo) {
+		switch (info.code) {
+			case 'ArrowLeft':
+			case 'ArrowRight':
+			case 'ArrowUp':
+			case 'ArrowDown': {
+				this.nudgeCamera()
+				return
+			}
+		}
+	}
+
+	override onKeyRepeat(info: TLKeyboardEventInfo) {
+		switch (info.code) {
+			case 'ArrowLeft':
+			case 'ArrowRight':
+			case 'ArrowUp':
+			case 'ArrowDown': {
+				this.nudgeCamera()
+				break
+			}
+		}
+	}
+
+	private nudgeCamera() {
+		const {
+			editor: {
+				inputs: { keys },
+			},
+		} = this
+
+		// The space key is used for panning the canvas by viewport size.
+		if (keys.has('Space')) return
+
+		// We want to use the "actual" shift key state,
+		// not the one that's in the editor.inputs.shiftKey,
+		// because that one uses a short timeout on release
+		const shiftKey = keys.has('ShiftLeft')
+
+		const delta = new Vec(0, 0)
+
+		if (keys.has('ArrowLeft')) delta.x -= 1
+		if (keys.has('ArrowRight')) delta.x += 1
+		if (keys.has('ArrowUp')) delta.y -= 1
+		if (keys.has('ArrowDown')) delta.y += 1
+
+		if (delta.equals(new Vec(0, 0))) return
+
+		const { gridSize } = this.editor.getDocumentSettings()
+
+		const step = this.editor.getInstanceState().isGridMode
+			? shiftKey
+				? gridSize * GRID_INCREMENT
+				: gridSize
+			: shiftKey
+				? MAJOR_NUDGE_FACTOR
+				: MINOR_NUDGE_FACTOR
+
+		const camera = this.editor.getCamera()
+		const next = { x: camera.x + delta.x * step, y: camera.y + delta.y * step, z: camera.z }
+		this.editor.setCamera(next, { immediate: true })
+	}
 }
+
+export const MAJOR_NUDGE_FACTOR = 10
+export const MINOR_NUDGE_FACTOR = 1
+export const GRID_INCREMENT = 5

--- a/packages/tldraw/src/test/commands/pan.test.ts
+++ b/packages/tldraw/src/test/commands/pan.test.ts
@@ -49,3 +49,34 @@ describe('When panning', () => {
 		)
 	})
 })
+
+describe('When in the Hand tool...', () => {
+	beforeEach(() => {
+		editor.setCurrentTool('hand')
+		editor.setCamera({ x: 10, y: 10, z: 1 })
+	})
+
+	it('nudges camera', () => {
+		editor.keyDown('ArrowUp')
+		expect(editor.getCamera()).toMatchObject({ x: 10, y: 9 })
+	})
+
+	it('nudges camera more with Shift key', () => {
+		editor.keyDown('Shift')
+		editor.keyDown('ArrowUp')
+		editor.keyUp('ArrowUp')
+
+		expect(editor.getCamera()).toMatchObject({ x: 10, y: 0 })
+	})
+
+	it('nudges camera and holds', () => {
+		editor.keyDown('ArrowUp')
+		editor.keyRepeat('ArrowUp')
+		editor.keyRepeat('ArrowUp')
+		editor.keyRepeat('ArrowUp')
+		editor.keyRepeat('ArrowUp')
+		editor.keyUp('ArrowUp')
+
+		expect(editor.getCamera()).toMatchObject({ x: 10, y: 5 })
+	})
+})


### PR DESCRIPTION
We have spacebar panning embedded in the Editor logic at the moment which moves the camera by viewport w/h. 
This is in addition to that logic to give more granular control to moving around.
I'm not _entirely_ convinced it's necessary but it does feel like some more fine-grained tooling would be needed here.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- a11y: provide more fine-grained camera controls via keyboard while in the Hand tool