### PR TITLE
Docs: Add slash keyboard shortcut to open search

### DIFF
--- a/apps/docs/components/search/SearchButton.tsx
+++ b/apps/docs/components/search/SearchButton.tsx
@@ -27,10 +27,11 @@ export function SearchButton({
 		if (layout !== 'desktop' && layout !== 'keyboard-shortcut-only') return
 
 		const onKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+			if (e.key === '/') {
+				setOpen(true)
+			} else if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
 				setOpen((open) => !open)
-			}
-			if (e.key === 'Escape') {
+			} else if (e.key === 'Escape') {
 				setOpen(false)
 			}
 		}


### PR DESCRIPTION
Currently you can open the search with Cmd+K. This PR adds `/` as an additional shortcut. It's present on many other docs sites, eg: [Tailwind](https://tailwindcss.com/), [Radix](https://www.radix-ui.com/primitives/docs/overview/introduction), so some developers have muscle memory for it (myself included). 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`


### Release notes

- Docs: The slash key now opens search (in addition to the existing Cmd+K shortcut).