### PR TITLE
images: fix not being able to insert SVGs into Firefox

### DIFF
--- a/packages/tldraw/src/lib/utils/assets/assets.ts
+++ b/packages/tldraw/src/lib/utils/assets/assets.ts
@@ -58,11 +58,14 @@ export async function downsizeImage(
 	height: number,
 	opts = {} as { type?: string; quality?: number }
 ): Promise<Blob> {
-	const image = await MediaHelpers.usingObjectURL(blob, MediaHelpers.loadImage)
+	const { w, h, image } = await MediaHelpers.usingObjectURL(
+		blob,
+		MediaHelpers.getImageAndDimensions
+	)
 	const { type = blob.type, quality = 0.85 } = opts
 	const [desiredWidth, desiredHeight] = clampToBrowserMaxCanvasSize(
-		Math.min(width * 2, image.naturalWidth),
-		Math.min(height * 2, image.naturalHeight)
+		Math.min(width * 2, w),
+		Math.min(height * 2, h)
 	)
 
 	const canvas = document.createElement('canvas')

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -271,6 +271,11 @@ export function measureDuration(_target: any, propertyKey: string, descriptor: P
 
 // @public
 export class MediaHelpers {
+    static getImageAndDimensions(src: string): Promise<{
+        h: number;
+        image: HTMLImageElement;
+        w: number;
+    }>;
     static getImageSize(blob: Blob): Promise<{
         h: number;
         w: number;
@@ -291,7 +296,6 @@ export class MediaHelpers {
     static isStaticImageType(mimeType: null | string): boolean;
     // (undocumented)
     static isVectorImageType(mimeType: null | string): boolean;
-    static loadImage(src: string): Promise<HTMLImageElement>;
     static loadVideo(src: string): Promise<HTMLVideoElement>;
     // (undocumented)
     static usingObjectURL<T>(blob: Blob, fn: (url: string) => Promise<T>): Promise<T>;

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -151,11 +151,11 @@ export class MediaHelpers {
 			}
 			img.crossOrigin = 'anonymous'
 			img.referrerPolicy = 'strict-origin-when-cross-origin'
-			img.src = src
 			img.style.visibility = 'hidden'
 			img.style.position = 'absolute'
 			img.style.opacity = '0'
 			img.style.zIndex = '-9999'
+			img.src = src
 		})
 	}
 

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -125,14 +125,24 @@ export class MediaHelpers {
 		return new Promise((resolve, reject) => {
 			const img = Image()
 			img.onload = () => {
-				document.body.appendChild(img)
-				// Sigh, Firefox doesn't have naturalWidth or naturalHeight for SVGs. :-/
-				// We have to attach to dom and use clientWidth/clientHeight.
-				const dimensions = {
-					w: img.naturalWidth || img.clientWidth,
-					h: img.naturalHeight || img.clientHeight,
+				let dimensions
+				if (img.naturalWidth) {
+					dimensions = {
+						w: img.naturalWidth,
+						h: img.naturalHeight,
+					}
+				} else {
+					// Sigh, Firefox doesn't have naturalWidth or naturalHeight for SVGs. :-/
+					// We have to attach to dom and use clientWidth/clientHeight.
+					document.body.appendChild(img)
+					// Sigh, Firefox doesn't have naturalWidth or naturalHeight for SVGs. :-/
+					// We have to attach to dom and use clientWidth/clientHeight.
+					dimensions = {
+						w: img.clientWidth,
+						h: img.clientHeight,
+					}
+					document.body.removeChild(img)
 				}
-				document.body.removeChild(img)
 				resolve({ ...dimensions, image: img })
 			}
 			img.onerror = (e) => {


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/5527

Not a pretty fix, sigh. @SomeHats lemme know if you have thoughts.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix not being able to insert SVGs into Firefox