### PR TITLE
fix error pasting shapes from Miro

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -479,7 +479,10 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 
 			// If the html is NOT a link, and we have NO OTHER texty content, then paste the html as text
 			if (!results.some((r) => r.type === 'text' && r.subtype !== 'html') && result.data.trim()) {
-				handleText(editor, stripHtml(result.data) ?? ' ', point, results)
+				const html = stripHtml(result.data) ?? ''
+				if (html) {
+					handleText(editor, stripHtml(result.data), point, results)
+				}
 				return
 			}
 

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -479,7 +479,7 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 
 			// If the html is NOT a link, and we have NO OTHER texty content, then paste the html as text
 			if (!results.some((r) => r.type === 'text' && r.subtype !== 'html') && result.data.trim()) {
-				handleText(editor, stripHtml(result.data), point, results)
+				handleText(editor, stripHtml(result.data) ?? ' ', point, results)
 				return
 			}
 


### PR DESCRIPTION
minor thing but b/c Miro is just an HTML string, we go down a path where we try to insert an empty string b/c all the HTML is stripped

![Screenshot 2025-04-01 at 16 08 58](https://github.com/user-attachments/assets/11d16632-6255-47d1-b3e8-8f8245a8d2dd)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix blowing up when pasting Miro shapes into tldraw.