### PR TITLE
fix github workflow sometimes using sh instead of bash

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -9,6 +9,10 @@ permissions:
   pull-requests: write
   repository-projects: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   dedupe:
     name: Dedupe Dependabot PRs

--- a/.github/workflows/deploy-docs-on-release-edit.yml
+++ b/.github/workflows/deploy-docs-on-release-edit.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [edited]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: Deploy docs on release edit

--- a/.github/workflows/get-changelog.yml
+++ b/.github/workflows/get-changelog.yml
@@ -2,6 +2,10 @@ name: Get draft changelog
 
 on: workflow_dispatch
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: 'Get draft changlog'

--- a/.github/workflows/i18n-download-strings.yml
+++ b/.github/workflows/i18n-download-strings.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 10 * * 1'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   download:
     name: 'Download latest strings'

--- a/.github/workflows/i18n-upload-strings.yml
+++ b/.github/workflows/i18n-upload-strings.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   upload:
     name: 'Upload latest strings'

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: 'Publish Canary Packages'

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -9,6 +9,10 @@ concurrency:
 # Package publishing is manually triggered on github actions dashboard
 on: workflow_dispatch
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: '(Re)Publish public packages manually'

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -23,6 +23,10 @@ on:
         description: Version Override
         required: false
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: 'Publish new version of public packages'

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - 'v*.*.x'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     name: Publish patch release

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 . "$(dirname -- "$0")/_/husky.sh"
 
 set -e


### PR DESCRIPTION
I realized, after digging deeper, that the issues with this github action was because it was `sh` instead of `bash`.
This PR makes sure we're always using `bash`.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
