### PR TITLE
Make image pasting atomic

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -743,11 +743,13 @@ export async function createShapesForAssets(
 			editor.createAssets(assetsToCreate)
 		}
 
-		// Create the shapes
-		editor.createShapes(partials).select(...partials.map((p) => p.id))
+		editor.store.atomic(() => {
+			// Create the shapes
+			editor.createShapes(partials).select(...partials.map((p) => p.id))
 
-		// Re-position shapes so that the center of the group is at the provided point
-		centerSelectionAroundPoint(editor, position)
+			// Re-position shapes so that the center of the group is at the provided point
+			centerSelectionAroundPoint(editor, position)
+		})
 	})
 
 	return partials.map((p) => p.id)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -739,11 +739,11 @@ export async function createShapesForAssets(
 	editor.run(() => {
 		// Create any assets
 		const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
-		if (assetsToCreate.length) {
-			editor.createAssets(assetsToCreate)
-		}
 
 		editor.store.atomic(() => {
+			if (assetsToCreate.length) {
+				editor.createAssets(assetsToCreate)
+			}
 			// Create the shapes
 			editor.createShapes(partials).select(...partials.map((p) => p.id))
 


### PR DESCRIPTION
When you paste images, they are first added to the store, and then immediately repositioned. This leads to confusing behavior for people using the onAfterCreate side effect because it fires before the image has actually finished creating.


### Change type

- [x] `improvement`


### Release notes

- Cleans up image creation side effects, coalescing create + update effects into a single create effect.