### PR TITLE
Store.atomic and Store.mergeRemoteChanges fixes

### DIFF
--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -394,7 +394,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
         runCallbacks?: boolean;
     }): void;
     // @internal (undocumented)
-    atomic<T>(fn: () => T, runCallbacks?: boolean): T;
+    atomic<T>(fn: () => T, runCallbacks?: boolean, isMergingRemoteChanges?: boolean): T;
     clear(): void;
     createCache<Result, Record extends R = R>(create: (id: IdOf<Record>, recordSignal: Signal<R>) => Signal<Result>): {
         get: (id: IdOf<Record>) => Result | undefined;

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -857,13 +857,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	}
 	private _isInAtomicOp = false
 	/** @internal */
-	atomic<T>(
-		fn: () => T,
-		runCallbacks = true,
-		// why do we pass this in rather than using this.isMergingRemoteChanges?
-		// to allow setting isMergingRemoteChanges to false before handling the
-		isMergingRemoteChanges = false
-	): T {
+	atomic<T>(fn: () => T, runCallbacks = true, isMergingRemoteChanges = false): T {
 		return transact(() => {
 			if (this._isInAtomicOp) {
 				if (!this.pendingAfterEvents) this.pendingAfterEvents = new Map()

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -866,7 +866,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 				if (!this.pendingAfterEvents) this.pendingAfterEvents = new Map()
 				const prevSideEffectsEnabled = this.sideEffects.isEnabled()
 				try {
-					// if we are in an atomic context with side effects ON allow switching them OFF.
+					// if we are in an atomic context with side effects ON allow switching before* callbacks OFF.
 					// but don't allow switching them ON if they had been marked OFF before.
 					if (prevSideEffectsEnabled && !runCallbacks) {
 						this.sideEffects.setIsEnabled(false)


### PR DESCRIPTION
This PR fixes a few things

- `mergeRemoteChanges` becomes atomic
- doing an `atomic(no callbacks)` inside of an `atomic(with callbacks)` will switch off `before*` callbacks during the inner `atomic`, but `after*` callbacks will still be handled by the outer `atomic`. This was needed to allow the tlsync `rebase` operation to run as it did before making `mergeRemoteChanges` atomic, but it feels like it should have always been this way?

### Change type

- [x] `improvement`

### Release notes

- Make `store.mergeRemoteChanges` atomic. This allows after* side effects to react to incoming changes and to propagate any effects to other clients via `'user'`-scoped store change events.