### PR TITLE
Include assetUrls in ExplodedExample

### DIFF
--- a/apps/examples/src/examples/exploded/ExplodedExample.tsx
+++ b/apps/examples/src/examples/exploded/ExplodedExample.tsx
@@ -13,6 +13,7 @@ import {
 	TldrawUi,
 	defaultAddFontsFromNode,
 	defaultBindingUtils,
+	defaultEditorAssetUrls,
 	defaultShapeTools,
 	defaultShapeUtils,
 	defaultTools,
@@ -57,6 +58,7 @@ export default function ExplodedExample() {
 				components={defaultComponents}
 				persistenceKey="exploded-example"
 				textOptions={defaultTextOptions}
+				assetUrls={defaultEditorAssetUrls}
 			>
 				<TldrawUi>
 					<InsideEditorAndUiContext />


### PR DESCRIPTION
Not including assetUrls meant that the exploded example didn't load fonts correctly. It would just try to load the fonts e.g. from /tldraw_draw.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape with text in the exploded example
2. Reload the page to make sure the fonts aren't loaded from previous requests
3. See that the font isn't loaded and the fallback font is used

- [ ] Unit tests
- [ ] End to end tests