### PR TITLE
Increase the preview pruning timout

### DIFF
--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   deploy:
     name: Prune preview deploys
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     environment: deploy-staging
 


### PR DESCRIPTION
Pruning sst deploys is quite slow ([9m to prune on deploy](https://github.com/tldraw/tldraw/actions/runs/14255043270/job/39956053486)). Bumping this a bit.

### Change type

- [x] `improvement`
