### PR TITLE
a11y: fix up focus ring on dotcom

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaCtaButton/TlaCtaButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaCtaButton/TlaCtaButton.tsx
@@ -9,7 +9,7 @@ export const TlaCtaButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<H
 				ref={ref}
 				type="button"
 				draggable={false}
-				className={classNames(styles.ctaButton)}
+				className={classNames('tla-primary-button', styles.ctaButton)}
 				{...props}
 			/>
 		)

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -35,7 +35,7 @@ export function TlaEditorTopRightPanel({
 	if (isAnonUser) {
 		return (
 			<div ref={ref} className={classNames(styles.topRightPanel)}>
-				<PeopleMenu displayUserWhenAlone={false} />
+				<PeopleMenu />
 				<TlaSignedOutShareButton fileId={fileId} context={context} />
 				<SignInButton
 					mode="modal"
@@ -55,7 +55,7 @@ export function TlaEditorTopRightPanel({
 
 	return (
 		<div ref={ref} className={styles.topRightPanel}>
-			<PeopleMenu displayUserWhenAlone={false} />
+			<PeopleMenu />
 			{context === 'legacy' && <LegacyImportButton />}
 			<TlaFileShareMenu fileId={fileId!} source="file-header" context={context}>
 				<TlaCtaButton

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCookieConsent.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCookieConsent.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { memo, useCallback } from 'react'
 import { useDialogs, useValue } from 'tldraw'
 import { useApp } from '../../../hooks/useAppState'
@@ -40,15 +41,21 @@ export const TlaSidebarCookieConsent = memo(function TlaSidebarCookieConsent() {
 				/>
 			</p>
 			<div className={styles.cookieButtons}>
-				<button className={styles.cookieButton} onClick={handleCustomize}>
+				<button
+					className={classNames('tla-button-text', styles.cookieButton)}
+					onClick={handleCustomize}
+				>
 					<F defaultMessage="Privacy settings" />
 				</button>
 				<div className={styles.cookieActions}>
-					<button className={styles.cookieButton} onClick={handleReject}>
+					<button
+						className={classNames('tla-button-text', styles.cookieButton)}
+						onClick={handleReject}
+					>
 						<F defaultMessage="Opt out" />
 					</button>
 					<button
-						className={`${styles.cookieButton} ${styles.acceptButton}`}
+						className={`${classNames('tla-button-text', styles.cookieButton)} ${styles.acceptButton}`}
 						onClick={handleAccept}
 					>
 						<F defaultMessage="Accept" />

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -176,6 +176,7 @@ export function TlaSidebarFileLinkInner({
 			<Link
 				ref={linkRef}
 				onKeyDown={handleKeyDown}
+				aria-label={fileName}
 				onClick={(event) => {
 					// Don't navigate if we are already on the file page
 					// unless the user is holding ctrl or cmd to open in a new tab

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLinkMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLinkMenu.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { useMsg } from '../../../utils/i18n'
 import { TlaFileMenu } from '../../TlaFileMenu/TlaFileMenu'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
@@ -19,7 +20,10 @@ export function TlaSidebarFileLinkMenu({
 			source="sidebar"
 			onRenameAction={onRenameAction}
 			trigger={
-				<button className={styles.linkMenu} title={fileMenuLbl}>
+				<button
+					className={classNames('tla-sidebar-file-menu', styles.linkMenu)}
+					title={fileMenuLbl}
+				>
 					<TlaIcon icon="dots-vertical-strong" />
 				</button>
 			}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
@@ -7,7 +7,7 @@ export function TlaSidebarWorkspaceLink() {
 
 	return (
 		<div className={styles.workspace} data-testid="tla-sidebar-logo-icon">
-			<TlaIconWrapper data-size="m">
+			<TlaIconWrapper aria-label="tldraw" data-size="m">
 				<TlaIcon className="tla-tldraw-sidebar-icon" icon="tldraw" />
 			</TlaIconWrapper>
 			<div className={classNames(styles.label, 'tla-text_ui__title', 'notranslate')}>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -420,6 +420,9 @@
 	.linkMenu {
 		display: none;
 	}
+	:global(.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))) .linkMenu {
+		display: flex;
+	}
 	/*
 		For guest files we show a guest icon at the end of the filename
 		but we don't want it to jump out of the way when the user hovers

--- a/apps/dotcom/client/src/tla/components/TlaSignedOutShareButton/signed-out-share-button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSignedOutShareButton/signed-out-share-button.module.css
@@ -21,7 +21,6 @@
 	position: absolute;
 	inset: 2px 2px;
 	border-radius: 6px;
-	background-color: var(--color-background);
 	z-index: 0;
 	pointer-events: none;
 }

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -158,7 +158,7 @@ export function TlaSidebarLayout({
 	}, [])
 
 	return (
-		<div
+		<aside
 			ref={rLayoutContainer}
 			className={styles.layout}
 			data-sidebar={!isEmbed && isSidebarOpen}
@@ -189,6 +189,6 @@ export function TlaSidebarLayout({
 					)}
 				</>
 			)}
-		</div>
+		</aside>
 	)
 }

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -260,3 +260,25 @@
 .tla-lang-highlight-missing .i18n-msg * {
 	text-shadow: none;
 }
+
+/* --------------------- a11y --------------------- */
+
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) aside button:not(.tla-button-text):focus-visible,
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) [data-radix-popper-content-wrapper] button:focus-visible,
+.tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
+.tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {
+	border-radius: 10px;
+	outline: 2px solid var(--color-focus);
+	outline-offset: -5px;
+}
+
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) aside a:focus-visible,
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) aside .tla-button-text:focus-visible {
+	outline: 2px solid var(--color-focus);
+}
+
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) aside .tla-primary-button:not(.tlui-button):focus-visible,
+.tl-container__focused:not(.tl-container__no-focus-ring) .tla-primary-button:not(.tlui-button):focus-visible  {
+	border-radius: 8px;
+	outline-offset: 0;
+}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1885,14 +1885,12 @@ export function parseTldrawJsonFile({ json, schema, }: {
 export function PasteMenuItem(): JSX_2.Element;
 
 // @public (undocumented)
-export function PeopleMenu({ displayUserWhenAlone, children }: PeopleMenuProps): JSX_2.Element;
+export function PeopleMenu({ children }: PeopleMenuProps): JSX_2.Element | null;
 
 // @public (undocumented)
 export interface PeopleMenuProps {
     // (undocumented)
     children?: ReactNode;
-    // (undocumented)
-    displayUserWhenAlone: boolean;
 }
 
 // @public

--- a/packages/tldraw/src/lib/ui/components/SharePanel/DefaultSharePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/DefaultSharePanel.tsx
@@ -4,7 +4,7 @@ import { PeopleMenu } from './PeopleMenu'
 export function DefaultSharePanel() {
 	return (
 		<div className="tlui-share-zone" draggable={false}>
-			<PeopleMenu displayUserWhenAlone />
+			<PeopleMenu />
 		</div>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
@@ -10,12 +10,11 @@ import { UserPresenceEditor } from './UserPresenceEditor'
 
 /** @public */
 export interface PeopleMenuProps {
-	displayUserWhenAlone: boolean
 	children?: ReactNode
 }
 
 /** @public @react */
-export function PeopleMenu({ displayUserWhenAlone, children }: PeopleMenuProps) {
+export function PeopleMenu({ children }: PeopleMenuProps) {
 	const msg = useTranslation()
 
 	const container = useContainer()
@@ -27,6 +26,8 @@ export function PeopleMenu({ displayUserWhenAlone, children }: PeopleMenuProps) 
 
 	const [isOpen, onOpenChange] = useMenuIsOpen('people menu')
 
+	if (!userIds.length) return null
+
 	return (
 		<Popover.Root onOpenChange={onOpenChange} open={isOpen}>
 			<Popover.Trigger dir="ltr" asChild>
@@ -36,7 +37,7 @@ export function PeopleMenu({ displayUserWhenAlone, children }: PeopleMenuProps) 
 						{userIds.slice(-5).map((userId) => (
 							<PeopleMenuAvatar key={userId} userId={userId} />
 						))}
-						{(displayUserWhenAlone || userIds.length > 0) && (
+						{userIds.length > 0 && (
 							<div
 								className="tlui-people-menu__avatar"
 								style={{


### PR DESCRIPTION
This brings dotcom up to speed with our latest focus ring work.
- [x] sidebar buttons/links
- [x] toggle sidebar
- [x] file list
- [x] profile menu
- [x] cookie menu settings
- [x] tldraw logo

also @MitjaBezensek lemme know about this `displayUserWhenAlone` if it's really necessary. It looks like the menu was always present (you could tab to it) even though it was hidden.

still to do in a separate PR:
- [ ] share panel 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`