### PR TITLE
A11y focus button fixes

### DIFF
--- a/assets/translations/main.json
+++ b/assets/translations/main.json
@@ -244,7 +244,7 @@
 	"tool.rich-text-link-remove": "Remove link",
 	"tool.rich-text-header": "Header",
 	"tool.rich-text-bulletList": "Bulleted list",
-	"a11y.skip-to-main-content": "Skip to first object on the board",
+	"a11y.skip-to-main-content": "Move focus to canvas",
 	"menu.title": "Menu",
 	"menu.theme": "Theme",
 	"menu.copy-as": "Copy as",

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1896,6 +1896,7 @@
 	padding: 8px 16px;
 	background-color: var(--color-text-0);
 	color: var(--color-background);
+	z-index: var(--layer-toasts);
 }
 
 .tl-skip-to-main-content:focus {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1891,14 +1891,12 @@
 
 .tl-skip-to-main-content {
 	position: fixed;
-	top: 42px;
+	top: 48px;
 	left: -9999px;
 	padding: 8px 16px;
-	background-color: var(--color-text-0);
-	color: var(--color-background);
 	z-index: var(--layer-toasts);
 }
 
 .tl-skip-to-main-content:focus {
-	left: 2px;
+	left: 8px;
 }

--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -1,5 +1,5 @@
-import { debugFlags, useEditor, useValue } from '@tldraw/editor'
-import { memo, useCallback, useEffect, useRef } from 'react'
+import { debugFlags, stopEventPropagation, useEditor, useValue } from '@tldraw/editor'
+import { MouseEvent, memo, useCallback, useEffect, useRef } from 'react'
 import { useA11y } from '../context/a11y'
 import { useTranslation } from '../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from './primitives/Button/TldrawUiButton'
@@ -9,22 +9,26 @@ export function SkipToMainContent() {
 	const msg = useTranslation()
 	const button = useRef<HTMLButtonElement>(null)
 
-	const handleNavigateToFirstShape = useCallback(() => {
-		button.current?.blur()
-		const shapes = editor.getCurrentPageShapesInReadingOrder()
-		if (!shapes.length) return
-		editor.setSelectedShapes([shapes[0].id])
-		editor.zoomToSelectionIfOffscreen(256, {
-			animation: {
-				duration: editor.options.animationMediumMs,
-			},
-			inset: 0,
-		})
+	const handleNavigateToFirstShape = useCallback(
+		(e: MouseEvent | KeyboardEvent) => {
+			stopEventPropagation(e)
+			button.current?.blur()
+			const shapes = editor.getCurrentPageShapesInReadingOrder()
+			if (!shapes.length) return
+			editor.setSelectedShapes([shapes[0].id])
+			editor.zoomToSelectionIfOffscreen(256, {
+				animation: {
+					duration: editor.options.animationMediumMs,
+				},
+				inset: 0,
+			})
 
-		// N.B. If we don't do this, then we go into editing mode for some reason...
-		// Not sure of a better solution at the moment...
-		editor.timers.setTimeout(() => editor.getContainer().focus(), 100)
-	}, [editor])
+			// N.B. If we don't do this, then we go into editing mode for some reason...
+			// Not sure of a better solution at the moment...
+			editor.timers.setTimeout(() => editor.getContainer().focus(), 100)
+		},
+		[editor]
+	)
 
 	return (
 		<TldrawUiButton

--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -29,7 +29,7 @@ export function SkipToMainContent() {
 	return (
 		<TldrawUiButton
 			ref={button}
-			type="normal"
+			type="low"
 			tabIndex={1}
 			className="tl-skip-to-main-content"
 			onClick={handleNavigateToFirstShape}

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
@@ -249,7 +249,7 @@ export const DEFAULT_TRANSLATION = {
 	'tool.rich-text-link-remove': 'Remove link',
 	'tool.rich-text-header': 'Header',
 	'tool.rich-text-bulletList': 'Bulleted list',
-	'a11y.skip-to-main-content': 'Skip to first object on the board',
+	'a11y.skip-to-main-content': 'Move focus to canvas',
 	'menu.title': 'Menu',
 	'menu.theme': 'Theme',
 	'menu.copy-as': 'Copy as',


### PR DESCRIPTION
This PR:

- changes the copy for the "Skip to first object on board" button to "Move focus to canvas"
- aligns the style for the "Move focus to canvas"
- fixes the z-index for the button
- prevent Enter from editing the focused object on keyup

### Change type

- [x] `bugfix`
- [x] `improvement`

### Test plan

1. Create a geo shape
2. Move to an empty part of the canvas
3. Press Tab to show the focus the canvas button
4. The button should be in front of the "Back to content" button
5. Press Enter on the button
6. The focus should move to the geo shape and not begin editing it

### Release notes

- no fixes to public code