### PR TITLE
Fix flyio app prunning and deployment.

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -263,7 +263,10 @@ async function deployPermissionsToFlyIo() {
 		'--output-file',
 		permissionsFile,
 	])
-	await exec('psql', [env.BOTCOM_POSTGRES_CONNECTION_STRING, '-f', permissionsFile])
+	const result = await exec('psql', [env.BOTCOM_POSTGRES_CONNECTION_STRING, '-f', permissionsFile])
+	if (result.toLowerCase().includes('error')) {
+		throw new Error('Error deploying permissions to fly.io')
+	}
 }
 
 let didUpdateTlsyncWorker = false

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -126,7 +126,7 @@ async function deletePreviewDatabase(branchName: string) {
 async function deleteFlyioPreviewApp(appName: string) {
 	const result = await exec('flyctl', ['apps', 'list', '-o', 'tldraw-gb-ltd'])
 	if (result.indexOf(appName) >= 0) {
-		await exec('flyctl', ['apps', 'destroy', appName])
+		await exec('flyctl', ['apps', 'destroy', appName, '-y'])
 	}
 }
 


### PR DESCRIPTION
Looks like we need to pass the `-y` flag to [accept the confirmation](https://fly.io/docs/flyctl/apps-destroy/#options) when pruning the apps. [Failure](https://github.com/tldraw/tldraw/actions/runs/14297908654/job/40067462974#step:6:346) of the last run.

Preview deploys were also failing to start correctly because of permissions deployment issue. We tried to deploy permissions before deploying zero, which failed since the zero hasn't had the chance to create the tables yet.

### Change type

- [x] `bugfix`
