### PR TITLE
a11y: fix focus ring on share menu/embed dialog; also slider/watermark

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaButton/TlaButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaButton/TlaButton.tsx
@@ -33,6 +33,7 @@ export const TlaButton = forwardRef<
 			ref={ref}
 			data-state={isLoading ? 'loading' : 'ready'}
 			className={classNames(
+				'tla-button',
 				styles.button,
 				{
 					[styles.cta]: variant === 'cta',

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
@@ -1,9 +1,8 @@
 import { ReactNode, useCallback } from 'react'
 import {
-	TldrawUiDropdownMenuContent,
-	TldrawUiDropdownMenuRoot,
-	TldrawUiDropdownMenuTrigger,
-	TldrawUiMenuContextProvider,
+	TldrawUiPopover,
+	TldrawUiPopoverContent,
+	TldrawUiPopoverTrigger,
 	preventDefault,
 	useValue,
 } from 'tldraw'
@@ -17,7 +16,6 @@ import { TlaAnonCopyLinkTab } from './Tabs/TlaAnonCopyLinkTab'
 import { TlaExportTab } from './Tabs/TlaExportTab'
 import { TlaInviteTab } from './Tabs/TlaInviteTab'
 import { TlaPublishTab } from './Tabs/TlaPublishTab'
-import styles from './file-share-menu.module.css'
 
 export function TlaFileShareMenu({
 	fileId,
@@ -79,63 +77,56 @@ export function TlaFileShareMenu({
 
 	return (
 		<div onPointerDown={preventDefault}>
-			<TldrawUiDropdownMenuRoot id={`share-${fileId}-${source}`}>
-				<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
-					<TldrawUiDropdownMenuTrigger>{children}</TldrawUiDropdownMenuTrigger>
-					<TldrawUiDropdownMenuContent
-						className={styles.shareMenu}
-						side="bottom"
-						alignOffset={-2}
-						sideOffset={4}
-					>
-						<TlaTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
-							<TlaTabsTabs>
-								{/* Disable share when on a scratchpad file */}
-								{okTabs.share && (
-									<TlaTabsTab id="share" data-testid="tla-share-tab-button-share">
-										<F defaultMessage="Invite" />
-									</TlaTabsTab>
-								)}
-								{okTabs['anon-share'] && (
-									<TlaTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
-										<F defaultMessage="Share" />
-									</TlaTabsTab>
-								)}
-								{/* Always show export */}
-								<TlaTabsTab id="export" data-testid="tla-share-tab-button-export">
-									<F defaultMessage="Export" />
+			<TldrawUiPopover id={`share-${fileId}-${source}`}>
+				<TldrawUiPopoverTrigger>{children}</TldrawUiPopoverTrigger>
+				<TldrawUiPopoverContent side="bottom" alignOffset={-2} sideOffset={4}>
+					<TlaTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
+						<TlaTabsTabs>
+							{/* Disable share when on a scratchpad file */}
+							{okTabs.share && (
+								<TlaTabsTab id="share" data-testid="tla-share-tab-button-share">
+									<F defaultMessage="Invite" />
 								</TlaTabsTab>
-								{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
-								{okTabs.publish && (
-									<TlaTabsTab id="publish" data-testid="tla-share-tab-button-publish">
-										<F defaultMessage="Publish" />
-									</TlaTabsTab>
-								)}
-							</TlaTabsTabs>
-							{okTabs.share && fileId && (
-								// We have a file and we're authenticated
-								<TlaTabsPage id="share" data-testid="tla-share-tab-page-share">
-									<TlaInviteTab fileId={fileId} />
-								</TlaTabsPage>
 							)}
 							{okTabs['anon-share'] && (
-								<TlaTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
-									<TlaAnonCopyLinkTab />
-								</TlaTabsPage>
+								<TlaTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
+									<F defaultMessage="Share" />
+								</TlaTabsTab>
 							)}
-							<TlaTabsPage id="export" data-testid="tla-share-tab-page-export">
-								<TlaExportTab />
+							{/* Always show export */}
+							<TlaTabsTab id="export" data-testid="tla-share-tab-button-export">
+								<F defaultMessage="Export" />
+							</TlaTabsTab>
+							{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
+							{okTabs.publish && (
+								<TlaTabsTab id="publish" data-testid="tla-share-tab-button-publish">
+									<F defaultMessage="Publish" />
+								</TlaTabsTab>
+							)}
+						</TlaTabsTabs>
+						{okTabs.share && fileId && (
+							// We have a file and we're authenticated
+							<TlaTabsPage id="share" data-testid="tla-share-tab-page-share">
+								<TlaInviteTab fileId={fileId} />
 							</TlaTabsPage>
-							{/* Only show the publish tab if the file is owned by the user */}
-							{okTabs.publish && file && (
-								<TlaTabsPage id="publish" data-testid="tla-share-tab-page-publish">
-									<TlaPublishTab file={file} />
-								</TlaTabsPage>
-							)}
-						</TlaTabsRoot>
-					</TldrawUiDropdownMenuContent>
-				</TldrawUiMenuContextProvider>
-			</TldrawUiDropdownMenuRoot>
+						)}
+						{okTabs['anon-share'] && (
+							<TlaTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
+								<TlaAnonCopyLinkTab />
+							</TlaTabsPage>
+						)}
+						<TlaTabsPage id="export" data-testid="tla-share-tab-page-export">
+							<TlaExportTab />
+						</TlaTabsPage>
+						{/* Only show the publish tab if the file is owned by the user */}
+						{okTabs.publish && file && (
+							<TlaTabsPage id="publish" data-testid="tla-share-tab-page-publish">
+								<TlaPublishTab file={file} />
+							</TlaTabsPage>
+						)}
+					</TlaTabsRoot>
+				</TldrawUiPopoverContent>
+			</TldrawUiPopover>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
@@ -1,7 +1,3 @@
-.shareMenu {
-	min-width: 240px;
-}
-
 /* Copy button */
 
 .copyButtonIcon {

--- a/apps/dotcom/client/src/tla/components/TlaSwitch/TlaSwitch.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSwitch/TlaSwitch.tsx
@@ -17,7 +17,7 @@ export function TlaSwitch({ checked, onChange, disabled, ...rest }: TlaSwitchPro
 	)
 
 	return (
-		<div className={classNames(styles.container, disabled && styles.disabled)}>
+		<div className={classNames('tla-switch', styles.container, disabled && styles.disabled)}>
 			<div className={styles.switch} data-checked={checked} />
 			<input
 				name="shared"

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -263,12 +263,10 @@
 
 /* --------------------- a11y --------------------- */
 
+/** Buttons/A tags */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	aside
+	:has(aside, [data-radix-popper-content-wrapper], .tlui-dialog__overlay)
 	button:not(.tla-button-text):focus-visible,
-.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	[data-radix-popper-content-wrapper]
-	button:focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {
 	border-radius: 10px;
@@ -276,6 +274,22 @@
 	outline-offset: -5px;
 }
 
+/** Switches */
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
+	aside .tla-switch:has(input:focus-visible) > div {
+	border-radius: 10px;
+	outline: 2px solid var(--color-focus);
+	outline-offset: 1px;
+}
+
+/** Comboboxes/select dropdowns */
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
+	aside button[role="combobox"]:not(.tlui-button):focus-visible {
+	border-radius: 0;
+	outline-offset: 0;
+}
+
+/** Text buttons, specifically from the cookie consent */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring)) aside a:focus-visible,
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
 	aside
@@ -283,6 +297,7 @@
 	outline: 2px solid var(--color-focus);
 }
 
+/** Primary buttons in the top area (e.g. Share, Sign in) */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
 	aside
 	.tla-primary-button:not(.tlui-button):focus-visible,
@@ -290,4 +305,15 @@
 	.tla-primary-button:not(.tlui-button):focus-visible {
 	border-radius: 8px;
 	outline-offset: 0;
+}
+
+/**
+ * omg there's two types of primary buttons
+ * This is for the buttons in the Share dialog.
+ */
+.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
+	aside
+	.tla-button:not(.tlui-button):focus-visible {
+	border-radius: var(--tla-radius-2);
+	outline-offset: 1px;
 }

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -276,7 +276,9 @@
 
 /** Switches */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	aside .tla-switch:has(input:focus-visible) > div {
+	aside
+	.tla-switch:has(input:focus-visible)
+	> div {
 	border-radius: 10px;
 	outline: 2px solid var(--color-focus);
 	outline-offset: 1px;
@@ -284,7 +286,8 @@
 
 /** Comboboxes/select dropdowns */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	aside button[role="combobox"]:not(.tlui-button):focus-visible {
+	aside
+	button[role='combobox']:not(.tlui-button):focus-visible {
 	border-radius: 0;
 	outline-offset: 0;
 }

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -1,6 +1,5 @@
 import { useValue } from '@tldraw/state-react'
 import { memo, useRef } from 'react'
-import { tlenv } from '../globals/environment'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
 import { usePassThroughWheelEvents } from '../hooks/usePassThroughWheelEvents'
@@ -57,31 +56,17 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 			draggable={false}
 			{...events}
 		>
-			{tlenv.isWebview ? (
-				<a
-					draggable={false}
-					role="button"
-					onPointerDown={(e) => {
-						stopEventPropagation(e)
-						preventDefault(e)
-					}}
-					title="made with tldraw"
-					onClick={() => runtime.openWindow(url, '_blank')}
-					style={{ mask: maskCss, WebkitMask: maskCss }}
-				/>
-			) : (
-				<a
-					href={url}
-					target="_blank"
-					rel="noreferrer"
-					draggable={false}
-					onPointerDown={(e) => {
-						stopEventPropagation(e)
-					}}
-					title="made with tldraw"
-					style={{ mask: maskCss, WebkitMask: maskCss }}
-				/>
-			)}
+			<button
+				draggable={false}
+				role="button"
+				onPointerDown={(e) => {
+					stopEventPropagation(e)
+					preventDefault(e)
+				}}
+				title="made with tldraw"
+				onClick={() => runtime.openWindow(url, '_blank')}
+				style={{ mask: maskCss, WebkitMask: maskCss }}
+			/>
 		</div>
 	)
 })
@@ -117,7 +102,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		box-sizing: content-box;
 	}
 
-	.${className} > a {
+	.${className} > button {
 		position: absolute;
 		width: 96px;
 		height: 32px;
@@ -125,6 +110,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		cursor: inherit;
 		color: var(--color-text);
 		opacity: .38;
+		border: 0;
 		background-color: currentColor;
 	}
 
@@ -139,13 +125,13 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		height: 48px;
 	}
 
-	.${className}[data-mobile='true'] > a {
+	.${className}[data-mobile='true'] > button {
 		width: 8px;
 		height: 32px;
 	}
 
 	@media (hover: hover) {
-		.${className} > a {
+		.${className} > button {
 			pointer-events: none;
 		}
 
@@ -155,12 +141,12 @@ To remove the watermark, please purchase a license at tldraw.dev.
 			transition-delay: 0.32s;
 		}
 
-		.${className}:hover > a {
+		.${className}:hover > button {
 			animation: delayed_link 0.2s forwards ease-in-out;
 			animation-delay: 0.32s;
 		}
 
-		.${className} > a:focus-visible {
+		.${className} > button:focus-visible {
 			opacity: 1;
 		}
 	}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -42,6 +42,16 @@ export const TldrawUiSlider = memo(function Slider({
 		onValueChange(value)
 	}, [value, onValueChange])
 
+	// N.B. Annoying. For a11y purposes, we need Tab to work.
+	// For some reason, Radix has some custom behavior here
+	// that interferes with tabbing past the slider and then
+	// you get stuck in the slider.
+	const handleKeyEvent = useCallback((event: React.KeyboardEvent) => {
+		if (event.key === 'Tab') {
+			event.stopPropagation()
+		}
+	}, [])
+
 	return (
 		<div className="tlui-slider__container">
 			<Root
@@ -56,6 +66,8 @@ export const TldrawUiSlider = memo(function Slider({
 				onPointerDown={handlePointerDown}
 				onValueChange={handleValueChange}
 				onPointerUp={handlePointerUp}
+				onKeyDownCapture={handleKeyEvent}
+				onKeyUpCapture={handleKeyEvent}
 				title={title + ' — ' + msg(label as TLUiTranslationKey)}
 			>
 				<Track className="tlui-slider__track" dir="ltr">


### PR DESCRIPTION
- fix dotcom share menu (we were using dropdown, and we should have used popover
- fix embed menu on dotcom
- fix slider and watermark capturing tab focus when shapes were selected

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
