### PR TITLE
[INT-1278] Move Import file under File menu

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -131,5 +131,6 @@
   "f43fb62093": "Back to tldraw.",
   "fb15c53f22": "Viewer",
   "fd1be3efcf": "Are you sure you want to delete this file?",
-  "fed5ec05eb": "Copied link"
+  "fed5ec05eb": "Copied link",
+  "ffcd73e997": "Import file…"
 }

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -398,5 +398,8 @@
   },
   "fed5ec05eb": {
     "translation": "Copied link"
+  },
+  "ffcd73e997": {
+    "translation": "Import file…"
   }
 }

--- a/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAccountMenu/TlaAccountMenu.tsx
@@ -1,9 +1,6 @@
 import { useAuth } from '@clerk/clerk-react'
-import { fileOpen } from 'browser-fs-access'
 import { ReactNode, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
 import {
-	TLDRAW_FILE_EXTENSION,
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
@@ -11,10 +8,7 @@ import {
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
 } from 'tldraw'
-import { routes } from '../../../routeDefs'
-import { useMaybeApp } from '../../hooks/useAppState'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
-import { getCurrentEditor } from '../../utils/getCurrentEditor'
 import { defineMessages, useMsg } from '../../utils/i18n'
 import { clearLocalSessionState } from '../../utils/local-session-state'
 import { TlaAppMenuGroup } from '../TlaAppMenuGroup/TlaAppMenuGroup'
@@ -41,7 +35,6 @@ export function TlaAccountMenu({
 					alignOffset={0}
 					sideOffset={4}
 				>
-					<TlaAppActionsGroup />
 					<TlaAppMenuGroup />
 					<TldrawUiMenuGroup id="signout">
 						<SignOutMenuItem source={source} />
@@ -68,46 +61,6 @@ function SignOutMenuItem({ source }: { source: TLAppUiEventSource }) {
 	return (
 		<TldrawUiMenuGroup id="account-actions">
 			<TldrawUiMenuItem id="sign-out" label={label} readonlyOk onSelect={handleSignout} />
-		</TldrawUiMenuGroup>
-	)
-}
-
-function TlaAppActionsGroup() {
-	const trackEvent = useTldrawAppUiEvents()
-	const app = useMaybeApp()
-
-	const navigate = useNavigate()
-
-	return (
-		<TldrawUiMenuGroup id="app-actions">
-			<TldrawUiMenuItem
-				id="about"
-				label="help-menu.import-tldr-file"
-				icon="import"
-				readonlyOk
-				onSelect={async () => {
-					const editor = getCurrentEditor()
-					if (!editor) return
-					if (!app) return
-
-					trackEvent('import-tldr-file', { source: 'account-menu' })
-
-					try {
-						const tldrawFiles = await fileOpen({
-							extensions: [TLDRAW_FILE_EXTENSION],
-							multiple: true,
-							description: 'tldraw project',
-						})
-
-						app.uploadTldrFiles(tldrawFiles, (file) => {
-							navigate(routes.tlaFile(file.id), { state: { mode: 'create' } })
-						})
-					} catch {
-						// user cancelled
-						return
-					}
-				}}
-			/>
 		</TldrawUiMenuGroup>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -1,6 +1,7 @@
 /* ---------------------- Menu ---------------------- */
 
 import { FILE_PREFIX, TlaFile } from '@tldraw/dotcom-shared'
+import { fileOpen } from 'browser-fs-access'
 import { Fragment, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -20,18 +21,20 @@ import {
 } from 'tldraw'
 import { routes } from '../../../routeDefs'
 import { TldrawApp } from '../../app/TldrawApp'
-import { useApp } from '../../hooks/useAppState'
+import { useApp, useMaybeApp } from '../../hooks/useAppState'
 import { useIsFileOwner } from '../../hooks/useIsFileOwner'
 import { useIsFilePinned } from '../../hooks/useIsFilePinned'
 import { useFileSidebarFocusContext } from '../../providers/FileInputFocusProvider'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { copyTextToClipboard } from '../../utils/copy'
+import { getCurrentEditor } from '../../utils/getCurrentEditor'
 import { defineMessages, useMsg } from '../../utils/i18n'
 import { editorMessages } from '../TlaEditor/editor-messages'
 import { download } from '../TlaEditor/useFileEditorOverrides'
 import { TlaDeleteFileDialog } from '../dialogs/TlaDeleteFileDialog'
 
 const messages = defineMessages({
+	importFile: { defaultMessage: 'Import file…' },
 	copied: { defaultMessage: 'Copied link' },
 	copyLink: { defaultMessage: 'Copy link' },
 	delete: { defaultMessage: 'Delete' },
@@ -153,6 +156,7 @@ export function FileItems({
 		await download(editor, defaultName + TLDRAW_FILE_EXTENSION)
 	}, [app, editor, fileId, source, trackEvent, untitledProject])
 
+	const importFileMsg = useMsg(messages.importFile)
 	const copyLinkMsg = useMsg(messages.copyLink)
 	const renameMsg = useMsg(messages.rename)
 	const duplicateMsg = useMsg(messages.duplicate)
@@ -164,6 +168,7 @@ export function FileItems({
 	return (
 		<Fragment>
 			<TldrawUiMenuGroup id="file-actions">
+				<TlImportFileActionGroup label={importFileMsg} />
 				{/* todo: in published rooms, support copying link */}
 				<TldrawUiMenuItem
 					label={copyLinkMsg}
@@ -224,4 +229,44 @@ export function FileItemsWrapper({
 	}
 
 	return children
+}
+
+function TlImportFileActionGroup({ label }: { label: string }) {
+	const trackEvent = useTldrawAppUiEvents()
+	const app = useMaybeApp()
+
+	const navigate = useNavigate()
+
+	return (
+		<TldrawUiMenuGroup id="app-actions">
+			<TldrawUiMenuItem
+				id="about"
+				label={label}
+				icon="import"
+				readonlyOk
+				onSelect={async () => {
+					const editor = getCurrentEditor()
+					if (!editor) return
+					if (!app) return
+
+					trackEvent('import-tldr-file', { source: 'account-menu' })
+
+					try {
+						const tldrawFiles = await fileOpen({
+							extensions: [TLDRAW_FILE_EXTENSION],
+							multiple: true,
+							description: 'tldraw project',
+						})
+
+						app.uploadTldrFiles(tldrawFiles, (file) => {
+							navigate(routes.tlaFile(file.id), { state: { mode: 'create' } })
+						})
+					} catch {
+						// user cancelled
+						return
+					}
+				}}
+			/>
+		</TldrawUiMenuGroup>
+	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -191,6 +191,8 @@ export function FileItems({
 					readonlyOk
 					onSelect={handlePinUnpinClick}
 				/>
+			</TldrawUiMenuGroup>
+			<TldrawUiMenuGroup id="file-actions-2">
 				<TlImportFileActionGroup label={importFileMsg} />
 				<TldrawUiMenuItem
 					label={downloadFile}

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -168,7 +168,6 @@ export function FileItems({
 	return (
 		<Fragment>
 			<TldrawUiMenuGroup id="file-actions">
-				<TlImportFileActionGroup label={importFileMsg} />
 				{/* todo: in published rooms, support copying link */}
 				<TldrawUiMenuItem
 					label={copyLinkMsg}
@@ -192,6 +191,7 @@ export function FileItems({
 					readonlyOk
 					onSelect={handlePinUnpinClick}
 				/>
+				<TlImportFileActionGroup label={importFileMsg} />
 				<TldrawUiMenuItem
 					label={downloadFile}
 					id="download-file"


### PR DESCRIPTION
This MR updates the location of the Import File button within the canvas interface to improve accessibility and align with the overall UI layout changes. The button’s functionality remains unchanged—users can still import .tldr files as before

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
1. Open tldraw and confirm the Import File button is visible in its new location.
2. Click the button and verify that the file picker opens.
3. Select a valid .tldr file and ensure it imports successfully onto the canvas.
4. Confirm the button does not overlap or interfere with other UI elements.

### Release notes
- Updated the location of the Import File button to make it easier to find and use. Functionality remains the same.