### PR TITLE
a11y: fix up watermark regression

### DIFF
--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -111,6 +111,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		color: var(--color-text);
 		opacity: .38;
 		border: 0;
+		padding: 0;
 		background-color: currentColor;
 	}
 


### PR DESCRIPTION
fix up watermark not being the right size on mobile, regression from https://github.com/tldraw/tldraw/pull/5837

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix mobile watermark.