### PR TITLE
Fix `useIsToolSelected`, add remove tool example

### DIFF
--- a/apps/examples/src/examples/remove-tool/README.md
+++ b/apps/examples/src/examples/remove-tool/README.md
@@ -1,0 +1,12 @@
+---
+title: Remove tool from UI
+component: ./RemoveToolExample.tsx
+category: basic
+keywords: [remove, tool]
+---
+
+You can remove a tool from the user interface.
+
+---
+
+Using overrides, you can remove a tool from the toolbar, keyboard shortcuts, and other parts of the user interface. The tool will still be present in the application but not accessible to the user.

--- a/apps/examples/src/examples/remove-tool/RemoveToolExample.tsx
+++ b/apps/examples/src/examples/remove-tool/RemoveToolExample.tsx
@@ -1,0 +1,21 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+export default function RemoveToolExample() {
+	return (
+		<>
+			<div className="tldraw__editor">
+				<Tldraw
+					overrides={{
+						tools: (_editor, tools) => {
+							console.log(tools)
+							// Remove the text tool
+							delete tools.text
+							return tools
+						},
+					}}
+				/>
+			</div>
+		</>
+	)
+}

--- a/apps/examples/src/examples/remove-tool/RemoveToolExample.tsx
+++ b/apps/examples/src/examples/remove-tool/RemoveToolExample.tsx
@@ -8,7 +8,6 @@ export default function RemoveToolExample() {
 				<Tldraw
 					overrides={{
 						tools: (_editor, tools) => {
-							console.log(tools)
 							// Remove the text tool
 							delete tools.text
 							return tools

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
@@ -41,15 +41,16 @@ export function DefaultToolbarContent() {
 /** @public */
 export function useIsToolSelected(tool: TLUiToolItem) {
 	const editor = useEditor()
-	const geo = tool.meta?.geo
+	const geo = tool?.meta?.geo
 	return useValue(
 		'is tool selected',
 		() => {
+			if (!tool) return false
 			const activeToolId = editor.getCurrentToolId()
 			const geoState = editor.getSharedStyles().getAsKnownValue(GeoShapeGeoStyle)
 			return geo ? activeToolId === 'geo' && geoState === geo : activeToolId === tool.id
 		},
-		[editor, tool.id, geo]
+		[editor, tool?.id, geo]
 	)
 }
 


### PR DESCRIPTION
This PR adds an example to show how to remove tools. It fixes a bug present if the tool does not exist.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. See example

### Release notes

- Fixed a bug with `useIsToolSelected`
- Adds example for removing a tool