### PR TITLE
[dotcom] Fix indicator/selection skew at some browser zoom levels.

### DIFF
--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -52,7 +52,6 @@ video,
 canvas,
 svg {
 	display: block;
-	max-width: 100%;
 }
 /*
   6. Remove built-in form typography styles


### PR DESCRIPTION
This PR removes a spurious max-width setting for media elements that I discovered to be triggering this issue. I guess the SVG elements we use for the selection UI were being shrunk or otherwise corrupted by chrome when the `devicePixelRatio` got funky.

I could have just removed this setting for the svg elements but honestly I don't think it makes sense at all for a sassy app like ours, it seems more appropriate for a site with prose and multimedia content like dotdev.

### Change type

- [x] `other`
