### PR TITLE
Add upcoming release info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You can use the tldraw SDK in commercial or non-commercial projects so long as y
 
 Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
 
-## Distributions
+## Distribution
 
-You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?activeTab=versions).
+You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?activeTab=versions). For information about how we version tldraw and what we're working on, see [here](https://tldraw.dev/releases-versioning).
 
 ## Contribution
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence. At the time of writing that cadence is monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible by providing warnings several releases in advance, and by providing tooling to help you migrate your code. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
+## Upcoming releases
+
+Information about upcoming changes to the tldraw SDK can be found [here](https://tldraw.notion.site/upcoming-sdk-changes).
+
 ## How to publish a new major or minor release
 
 New cadence releases are published from `main`. You trigger a release manually by running the workflow defined in `publish-new.yml`.

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -13,6 +13,11 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence - approximately monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible, but tldraw is actively evolving as we add new features. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
+
+## Upcoming releases
+
+Information about upcoming changes to the tldraw SDK can be found [here](https://tldraw.notion.site/upcoming-sdk-changes).
+
 {/* START AUTO-GENERATED CHANGELOG */}
 
 ## Current release: [v3.11.0](/releases/v3.11.0)


### PR DESCRIPTION
Adding a link to the new upcoming changes page to the docs site page about versioning, and also linking to the docs site page about versioning from the README.

### Change type

- [x] `other`
