### PR TITLE
rich text: export some of our custom extensions

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -20,6 +20,7 @@ import { ComponentType } from 'react';
 import { CSSProperties } from 'react';
 import { CubicSpline2d } from '@tldraw/editor';
 import { Editor } from '@tldraw/editor';
+import { Extension } from '@tiptap/core';
 import { Extensions } from '@tiptap/core';
 import { Geometry2d } from '@tldraw/editor';
 import { Group2d } from '@tldraw/editor';
@@ -1571,6 +1572,9 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 }
 
 // @public (undocumented)
+export const KeyboardShiftEnterTweakExtension: Extension<any, any>;
+
+// @public (undocumented)
 export function KeyboardShortcutsMenuItem(): JSX_2.Element | null;
 
 // @internal (undocumented)
@@ -2195,6 +2199,9 @@ export interface TextAreaProps {
     // (undocumented)
     text?: string;
 }
+
+// @public (undocumented)
+export const TextDirection: Extension<any, any>;
 
 // @public @deprecated (undocumented)
 export const TextLabel: React_3.NamedExoticComponent<PlainTextLabelProps>;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -535,6 +535,7 @@ export {
 	type TLEditorAssetUrls,
 } from './lib/utils/static-assets/assetUrls'
 export {
+	KeyboardShiftEnterTweakExtension,
 	defaultAddFontsFromNode,
 	renderHtmlFromRichText,
 	renderHtmlFromRichTextForMeasurement,
@@ -543,6 +544,7 @@ export {
 	tipTapDefaultExtensions,
 } from './lib/utils/text/richText'
 export { truncateStringWithEllipsis } from './lib/utils/text/text'
+export { TextDirection } from './lib/utils/text/textDirection'
 export {
 	TLV1AlignStyle,
 	TLV1AssetType,

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -20,9 +20,10 @@ import {
 	WeakCache,
 } from '@tldraw/editor'
 import { DefaultFontFaces } from '../../shapes/shared/defaultFonts'
-import TextDirection from './textDirection'
+import { TextDirection } from './textDirection'
 
-const KeyboardShiftEnterTweakExtension = Extension.create({
+/** @public */
+export const KeyboardShiftEnterTweakExtension = Extension.create({
 	name: 'keyboardShiftEnterHandler',
 	addKeyboardShortcuts() {
 		return {

--- a/packages/tldraw/src/lib/utils/text/textDirection.ts
+++ b/packages/tldraw/src/lib/utils/text/textDirection.ts
@@ -1,6 +1,9 @@
 import { Extension } from '@tiptap/core'
 
-const TextDirection = Extension.create({
+/**
+ * @public
+ */
+export const TextDirection = Extension.create({
 	name: 'textDirection',
 
 	addGlobalAttributes() {
@@ -27,5 +30,3 @@ const TextDirection = Extension.create({
 		]
 	},
 })
-
-export default TextDirection


### PR DESCRIPTION
Address some of the concerns in https://github.com/tldraw/tldraw/issues/5870

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Export some of the custom rich text extensions we have by default to enable inclusion in custom extension lists.