### PR TITLE
stickies: fix our text tweaks on dotcom

### DIFF
--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -62,18 +62,6 @@ textarea,
 select {
 	font: inherit;
 }
-/*
-  7. Avoid text overflows
-*/
-p,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	overflow-wrap: break-word;
-}
 
 html {
 	height: 100%;


### PR DESCRIPTION
Similarly to https://github.com/tldraw/tldraw/pull/5851 we have some custom rules on dotcom that break our shit 🤦 
This breaks our sticky notes resizing the text as you type (for long words, like "amsterdam").

Makes me question the rest of this globals.css reset stuff...ugh

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- fix up stickies on dotco 