### PR TITLE
Deploy zero on demand.

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Determine deploy target
         id: deploy_target
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/production" || "${GITHUB_REF}" == "refs/heads/main" ]]; then
             echo "DEPLOY_ZERO=sst" >> $GITHUB_ENV

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -36,23 +36,28 @@ jobs:
       #     webhook: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
       #     content: 'Preparing ${{ env.TLDRAW_ENV }} dotcom deploy: ${{ github.event.head_commit.message }} by ${{ github.event.head_commit.author.name }}'
 
-      - name: Determine deploy target
-        id: deploy_target
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/production" || "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "DEPLOY_TO=sst" >> $GITHUB_ENV
-          elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-sst-zero-deploy-please"; then
-            echo "DEPLOY_TO=sst" >> $GITHUB_ENV
-          else
-            echo "DEPLOY_TO=flyio" >> $GITHUB_ENV
-          fi
-
       - name: Check out code
         uses: actions/checkout@v3
         with:
           submodules: true
 
       - uses: ./.github/actions/setup
+
+      - name: Determine deploy target
+        id: deploy_target
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/production" || "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "DEPLOY_ZERO=sst" >> $GITHUB_ENV
+          elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-sst-zero-deploy-please"; then
+            echo "DEPLOY_ZERO=sst" >> $GITHUB_ENV
+          elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-flyio-zero-deploy-please"; then
+            echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
+          elif git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^apps/dotcom/'; then
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
+            echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
+          else
+            echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
+          fi
 
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3.1.3
@@ -82,18 +87,18 @@ jobs:
         run: yarn build-types
 
       - name: Configure AWS credentials using OIDC
-        if: env.DEPLOY_TO == 'sst'
+        if: env.DEPLOY_ZERO == 'sst'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_NUMBER }}:role/huppy-bot
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Fly cli
-        if: env.DEPLOY_TO == 'flyio'
+        if: env.DEPLOY_ZERO == 'flyio'
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Install PostgreSQL client
-        if: env.DEPLOY_TO == 'flyio'
+        if: env.DEPLOY_ZERO == 'flyio'
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql-client

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup
 
@@ -52,7 +53,7 @@ jobs:
             echo "DEPLOY_ZERO=sst" >> $GITHUB_ENV
           elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-flyio-zero-deploy-please"; then
             echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
-          elif git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^apps/dotcom/'; then
+          elif git fetch origin "${GITHUB_BASE_REF}" && git diff --name-only origin/"${GITHUB_BASE_REF}"...HEAD | grep -q '^apps/dotcom/'; then
             gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
             echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
           else

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Determine deploy target
+      - name: Determine zero deploy target
         id: deploy_target
         env:
           GH_TOKEN: ${{ github.token }}

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -82,7 +82,7 @@ const env = makeEnv([
 	'DEPLOY_ZERO',
 ])
 
-const deployZero = env.DEPLOY_ZERO as 'flyio' | 'sst' | false
+const deployZero = env.DEPLOY_ZERO === 'false' ? false : (env.DEPLOY_ZERO as 'flyio' | 'sst')
 const flyioAppName = deployZero === 'flyio' ? `${previewId}-zero-cache` : undefined
 
 const clerkJWKSUrl =

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -149,12 +149,6 @@ async function main() {
 	await discord.step('deploying multiplayer worker to cloudflare', async () => {
 		await deployTlsyncWorker({ dryRun: false })
 	})
-	if (deployZero !== false) {
-		// We need to deploy zero after `deployTlsyncWorker` because we need to run migrations first
-		await discord.step('deploying zero', async () => {
-			await deployZeroBackend()
-		})
-	}
 	await discord.step('deploying image resizer to cloudflare', async () => {
 		await deployImageResizeWorker({ dryRun: false })
 	})
@@ -267,6 +261,10 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 			BOTCOM_POSTGRES_POOLED_CONNECTION_STRING: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
 		},
 	})
+	// Deploy zero after the migrations but before the sync worker
+	if (!dryRun && deployZero !== false) {
+		await deployZeroBackend()
+	}
 	await wranglerDeploy({
 		location: worker,
 		dryRun,

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -200,7 +200,7 @@ function getZeroUrl() {
 			} else if (deployZero === 'sst') {
 				return `https://${previewId}.zero.tldraw.com/`
 			} else {
-				return undefined
+				return 'https://zero-backend-not-deployed.tldraw.com'
 			}
 		}
 		case 'staging':
@@ -208,14 +208,10 @@ function getZeroUrl() {
 		case 'production':
 			return 'https://production.zero.tldraw.com/'
 	}
-	return undefined
+	return 'https://zero-backend-not-deployed.tldraw.com'
 }
 
 async function prepareDotcomApp() {
-	const zeroUrl = getZeroUrl()
-	if (!zeroUrl) {
-		throw new Error('No zero URL found')
-	}
 	// pre-build the app:
 	await exec('yarn', ['build-app'], {
 		env: {
@@ -223,7 +219,7 @@ async function prepareDotcomApp() {
 			ASSET_UPLOAD: env.ASSET_UPLOAD,
 			IMAGE_WORKER: env.IMAGE_WORKER,
 			MULTIPLAYER_SERVER: env.MULTIPLAYER_SERVER,
-			ZERO_SERVER: zeroUrl,
+			ZERO_SERVER: getZeroUrl(),
 			NEXT_PUBLIC_GC_API_KEY: env.GC_MAPS_API_KEY,
 			SENTRY_AUTH_TOKEN: env.SENTRY_AUTH_TOKEN,
 			SENTRY_ORG: 'tldraw',


### PR DESCRIPTION
We don't want to deploy zero backends for PRs that have nothing to do with the dotcom app. This should help with that by:
* Not deploying zero by default.
* Deploying zero to flyio or sst if we have `preview-flyio-zero-deploy-please` or `preview-sst-zero-deploy-please` labels on the pr.
* It checks for changes to `apps/dotcom` folder. If there are any it automatically adds the `preview-flyio-zero-deploy-please` label. So we get automatic deploys when it's highly likely that we'd want them. 

Also moved the zero deployment right after migrating the db and before we deploy sync worker.

### Change type

- [x] `improvement`
