### PR TITLE
Revert "events: explore using getCoalescedEvents (#5554)"

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2864,10 +2864,6 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     transition(id: string, info?: any): this;
     // (undocumented)
     type: 'branch' | 'leaf' | 'root';
-    // (undocumented)
-    static useCoalescedEvents: boolean;
-    // (undocumented)
-    useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)
@@ -4082,8 +4078,6 @@ export interface TLStateNodeConstructor {
     initial?: string;
     // (undocumented)
     isLockable: boolean;
-    // (undocumented)
-    useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -38,7 +38,6 @@ export interface TLStateNodeConstructor {
 	initial?: string
 	children?(): TLStateNodeConstructor[]
 	isLockable: boolean
-	useCoalescedEvents: boolean
 }
 
 /** @public */
@@ -48,8 +47,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 		public editor: Editor,
 		parent?: StateNode
 	) {
-		const { id, children, initial, isLockable, useCoalescedEvents } = this
-			.constructor as TLStateNodeConstructor
+		const { id, children, initial, isLockable } = this.constructor as TLStateNodeConstructor
 
 		this.id = id
 		this._isActive = atom<boolean>('toolIsActive' + this.id, false)
@@ -85,7 +83,6 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			}
 		}
 		this.isLockable = isLockable
-		this.useCoalescedEvents = useCoalescedEvents
 		this.performanceTracker = new PerformanceTracker()
 	}
 
@@ -93,7 +90,6 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	static initial?: string
 	static children?: () => TLStateNodeConstructor[]
 	static isLockable = true
-	static useCoalescedEvents = false
 
 	id: string
 	type: 'branch' | 'leaf' | 'root'
@@ -101,7 +97,6 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	initial?: string
 	children?: Record<string, StateNode>
 	isLockable: boolean
-	useCoalescedEvents: boolean
 	parent: StateNode
 
 	/**

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -1,4 +1,3 @@
-import { useValue } from '@tldraw/state-react'
 import React, { useMemo } from 'react'
 import { RIGHT_MOUSE_BUTTON } from '../constants'
 import {
@@ -12,7 +11,6 @@ import { useEditor } from './useEditor'
 
 export function useCanvasEvents() {
 	const editor = useEditor()
-	const currentTool = useValue('current tool', () => editor.getCurrentTool(), [editor])
 
 	const events = useMemo(
 		function canvasEvents() {
@@ -51,17 +49,12 @@ export function useCanvasEvents() {
 				lastX = e.clientX
 				lastY = e.clientY
 
-				// For tools that benefit from a higher fidelity of events,
-				// we dispatch the coalesced events.
-				const events = currentTool.useCoalescedEvents ? e.nativeEvent.getCoalescedEvents() : [e]
-				for (const singleEvent of events) {
-					editor.dispatch({
-						type: 'pointer',
-						target: 'canvas',
-						name: 'pointer_move',
-						...getPointerInfo(singleEvent),
-					})
-				}
+				editor.dispatch({
+					type: 'pointer',
+					target: 'canvas',
+					name: 'pointer_move',
+					...getPointerInfo(e),
+				})
 			}
 
 			function onPointerUp(e: React.PointerEvent) {
@@ -166,7 +159,7 @@ export function useCanvasEvents() {
 				onClick,
 			}
 		},
-		[editor, currentTool]
+		[editor]
 	)
 
 	return events

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -921,8 +921,6 @@ export class DrawShapeTool extends StateNode {
     onExit(): void;
     // (undocumented)
     shapeType: string;
-    // (undocumented)
-    static useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)
@@ -1492,8 +1490,6 @@ export class HighlightShapeTool extends StateNode {
     onExit(): void;
     // (undocumented)
     shapeType: string;
-    // (undocumented)
-    static useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
@@ -7,7 +7,6 @@ export class DrawShapeTool extends StateNode {
 	static override id = 'draw'
 	static override initial = 'idle'
 	static override isLockable = false
-	static override useCoalescedEvents = true
 	static override children(): TLStateNodeConstructor[] {
 		return [Idle, Drawing]
 	}

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeTool.ts
@@ -7,7 +7,6 @@ import { Idle } from '../draw/toolStates/Idle'
 export class HighlightShapeTool extends StateNode {
 	static override id = 'highlight'
 	static override initial = 'idle'
-	static override useCoalescedEvents = true
 	static override children(): TLStateNodeConstructor[] {
 		return [Idle, Drawing]
 	}


### PR DESCRIPTION
This reverts commit 3aafabe5ce31c4c0aba762638eb8e10699c8629a.

Reverting this for now, it might be causing issues in some cases on iPad+local development.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Revert coalesced events for now until we investigate further.