### PR TITLE
fix error pasting shapes from Miro, pt 2

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -482,21 +482,24 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 				const html = stripHtml(result.data) ?? ''
 				if (html) {
 					handleText(editor, stripHtml(result.data), point, results)
+					return
 				}
-				return
 			}
 
 			// If the html is NOT a link, and we have other texty content, then paste the html as a text shape
 			if (results.some((r) => r.type === 'text' && r.subtype !== 'html')) {
-				editor.markHistoryStoppingPoint('paste')
-				editor.putExternalContent({
-					type: 'text',
-					text: stripHtml(result.data),
-					html: result.data,
-					point,
-					sources: results,
-				})
-				return
+				const html = stripHtml(result.data) ?? ''
+				if (html) {
+					editor.markHistoryStoppingPoint('paste')
+					editor.putExternalContent({
+						type: 'text',
+						text: html,
+						html: result.data,
+						point,
+						sources: results,
+					})
+					return
+				}
 			}
 		}
 


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/5790

cc @ds300  thanks for the heads up

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix blowing up when pasting Miro shapes into tldraw.