### PR TITLE
Reapply coalesced events and fix the local dev issue

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2864,6 +2864,10 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
     transition(id: string, info?: any): this;
     // (undocumented)
     type: 'branch' | 'leaf' | 'root';
+    // (undocumented)
+    static useCoalescedEvents: boolean;
+    // (undocumented)
+    useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)
@@ -4078,6 +4082,8 @@ export interface TLStateNodeConstructor {
     initial?: string;
     // (undocumented)
     isLockable: boolean;
+    // (undocumented)
+    useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -38,6 +38,7 @@ export interface TLStateNodeConstructor {
 	initial?: string
 	children?(): TLStateNodeConstructor[]
 	isLockable: boolean
+	useCoalescedEvents: boolean
 }
 
 /** @public */
@@ -47,7 +48,8 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 		public editor: Editor,
 		parent?: StateNode
 	) {
-		const { id, children, initial, isLockable } = this.constructor as TLStateNodeConstructor
+		const { id, children, initial, isLockable, useCoalescedEvents } = this
+			.constructor as TLStateNodeConstructor
 
 		this.id = id
 		this._isActive = atom<boolean>('toolIsActive' + this.id, false)
@@ -83,6 +85,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			}
 		}
 		this.isLockable = isLockable
+		this.useCoalescedEvents = useCoalescedEvents
 		this.performanceTracker = new PerformanceTracker()
 	}
 
@@ -90,6 +93,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	static initial?: string
 	static children?: () => TLStateNodeConstructor[]
 	static isLockable = true
+	static useCoalescedEvents = false
 
 	id: string
 	type: 'branch' | 'leaf' | 'root'
@@ -97,6 +101,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 	initial?: string
 	children?: Record<string, StateNode>
 	isLockable: boolean
+	useCoalescedEvents: boolean
 	parent: StateNode
 
 	/**

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -53,7 +53,10 @@ export function useCanvasEvents() {
 
 				// For tools that benefit from a higher fidelity of events,
 				// we dispatch the coalesced events.
-				const events = currentTool.useCoalescedEvents ? e.nativeEvent.getCoalescedEvents() : [e]
+				let events: PointerEvent[] | React.PointerEvent<Element>[] = [e]
+				if (currentTool.useCoalescedEvents && e.nativeEvent.getCoalescedEvents) {
+					events = e.nativeEvent.getCoalescedEvents()
+				}
 				for (const singleEvent of events) {
 					editor.dispatch({
 						type: 'pointer',

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -921,6 +921,8 @@ export class DrawShapeTool extends StateNode {
     onExit(): void;
     // (undocumented)
     shapeType: string;
+    // (undocumented)
+    static useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)
@@ -1490,6 +1492,8 @@ export class HighlightShapeTool extends StateNode {
     onExit(): void;
     // (undocumented)
     shapeType: string;
+    // (undocumented)
+    static useCoalescedEvents: boolean;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.ts
@@ -7,6 +7,7 @@ export class DrawShapeTool extends StateNode {
 	static override id = 'draw'
 	static override initial = 'idle'
 	static override isLockable = false
+	static override useCoalescedEvents = true
 	static override children(): TLStateNodeConstructor[] {
 		return [Idle, Drawing]
 	}

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeTool.ts
@@ -7,6 +7,7 @@ import { Idle } from '../draw/toolStates/Idle'
 export class HighlightShapeTool extends StateNode {
 	static override id = 'highlight'
 	static override initial = 'idle'
+	static override useCoalescedEvents = true
 	static override children(): TLStateNodeConstructor[] {
 		return [Idle, Drawing]
 	}


### PR DESCRIPTION
Reapplies the reverted change in https://github.com/tldraw/tldraw/pull/5895 and fixes the local dev issue.

Looks like accessing local dev server via an ip address (instead of localhost) makes the browser not allow access to this function - it doesn't exists at all.

![image](https://github.com/user-attachments/assets/ed0833b3-0888-4524-a559-879c842b48d2)


### Change type

- [x] `improvement`

### Release notes

- Improve draw fluidity on slower CPUs by using getCoalescedEvents.
