### PR TITLE
a11y: add null check for bookmark asset descriptor

### DIFF
--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -51,9 +51,9 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 	override getAriaDescriptor(shape: TLBookmarkShape) {
 		const asset = (
 			shape.props.assetId ? this.editor.getAsset(shape.props.assetId) : null
-		) as TLBookmarkAsset
+		) as TLBookmarkAsset | null
 
-		if (!asset.props.title) return undefined
+		if (!asset?.props.title) return undefined
 
 		return (
 			convertCommonTitleHTMLEntities(asset.props.title) +


### PR DESCRIPTION
@ds300 noticed this in Sentry, adds null check

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix NPE for asset check in BookmarkShapeUtil