### PR TITLE
stickies: make sure our custom tab behavior takes over the rich text behavior

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2040,6 +2040,8 @@ export interface RichTextLabelProps {
     // (undocumented)
     fontSize: number;
     // (undocumented)
+    hasCustomTabBehavior?: boolean;
+    // (undocumented)
     isSelected: boolean;
     // (undocumented)
     labelColor: string;
@@ -2186,6 +2188,8 @@ export interface TextAreaProps {
     handleInputPointerDown(e: React_3.PointerEvent<HTMLElement>): void;
     // (undocumented)
     handleKeyDown(e: KeyboardEvent): void;
+    // (undocumented)
+    hasCustomTabBehavior?: boolean;
     // (undocumented)
     isEditing: boolean;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -310,6 +310,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							labelColor={labelColor === 'black' ? theme[color].note.text : theme[labelColor].fill}
 							wrap
 							padding={LABEL_PADDING * scale}
+							hasCustomTabBehavior
 							onKeyDown={handleKeyDown}
 						/>
 					)}

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -41,6 +41,7 @@ export interface RichTextLabelProps {
 	textWidth?: number
 	textHeight?: number
 	padding?: number
+	hasCustomTabBehavior?: boolean
 }
 
 /**
@@ -68,6 +69,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 	style,
 	textWidth,
 	textHeight,
+	hasCustomTabBehavior,
 }: RichTextLabelProps) {
 	const editor = useEditor()
 	const isDragging = React.useRef(false)
@@ -171,6 +173,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 						isEditing={isEditing}
 						shapeId={shapeId}
 						{...editableTextRest}
+						hasCustomTabBehavior={hasCustomTabBehavior}
 						handleKeyDown={handleKeyDownCustom ?? editableTextRest.handleKeyDown}
 					/>
 				)}

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -29,6 +29,7 @@ export interface TextAreaProps {
 	handleChange(changeInfo: { plaintext?: string; richText?: TLRichText }): void
 	handleInputPointerDown(e: React.PointerEvent<HTMLElement>): void
 	handleDoubleClick(e: any): any
+	hasCustomTabBehavior?: boolean
 }
 
 /**
@@ -54,6 +55,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 		handleBlur,
 		handleKeyDown,
 		handleDoubleClick,
+		hasCustomTabBehavior,
 	},
 	ref
 ) {
@@ -161,7 +163,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 			},
 			editorProps: {
 				handleKeyDown: (view: EditorView, event: KeyboardEvent) => {
-					if (event.key === 'Tab') {
+					if (!hasCustomTabBehavior && event.key === 'Tab') {
 						handleTab(editor, view, event)
 					}
 
@@ -209,6 +211,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 		onKeyDown,
 		editor,
 		shapeId,
+		hasCustomTabBehavior,
 	])
 
 	if (!isEditing || !tipTapConfig) {

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -135,8 +135,6 @@ export class MediaHelpers {
 					// Sigh, Firefox doesn't have naturalWidth or naturalHeight for SVGs. :-/
 					// We have to attach to dom and use clientWidth/clientHeight.
 					document.body.appendChild(img)
-					// Sigh, Firefox doesn't have naturalWidth or naturalHeight for SVGs. :-/
-					// We have to attach to dom and use clientWidth/clientHeight.
 					dimensions = {
 						w: img.clientWidth,
 						h: img.clientHeight,


### PR DESCRIPTION
our stickies custom tab/shift+tab behavior is getting mixed up with indentation behavior in rich text, oops.


https://github.com/user-attachments/assets/753cc4f3-eaa1-4262-a47d-b2d8c0e1d058



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Added `hasCustomTabBehavior` prop to `RichTextLabel` so developers can also opt out of this behavior where necessary