### PR TITLE
docs: should be a nav, not aside

### DIFF
--- a/apps/docs/components/blog/blog-sidebar.tsx
+++ b/apps/docs/components/blog/blog-sidebar.tsx
@@ -1,14 +1,14 @@
 import { BlogCategoryMenu } from '@/components/blog/blog-category-menu'
-import { Aside } from '@/components/common/aside'
+import { Navigation } from '@/components/common/navigation'
 import { db } from '@/utils/ContentDatabase'
 
 export async function BlogSidebar({ children }: { children?: React.ReactNode }) {
 	const categories = await db.getCategoriesForSection('blog')
 
 	return (
-		<Aside className="hidden md:flex pr-12">
+		<Navigation className="hidden md:flex pr-12">
 			<BlogCategoryMenu categories={categories.filter((c) => !c.id.endsWith('ucg'))} />
 			{children}
-		</Aside>
+		</Navigation>
 	)
 }

--- a/apps/docs/components/blog/blog-table-of-contents.tsx
+++ b/apps/docs/components/blog/blog-table-of-contents.tsx
@@ -1,6 +1,6 @@
 import { BlogAuthors } from '@/components/blog/blog-authors'
-import { Navigation } from '@/components/common/navigation'
 import { BackToTopButton } from '@/components/common/back-to-top-button'
+import { Navigation } from '@/components/common/navigation'
 import { ShareButton } from '@/components/common/share-button'
 import { HeadingsMenu } from '@/components/navigation/headings-menu'
 import { Article } from '@/types/content-types'

--- a/apps/docs/components/blog/blog-table-of-contents.tsx
+++ b/apps/docs/components/blog/blog-table-of-contents.tsx
@@ -1,5 +1,5 @@
 import { BlogAuthors } from '@/components/blog/blog-authors'
-import { Aside } from '@/components/common/aside'
+import { Navigation } from '@/components/common/navigation'
 import { BackToTopButton } from '@/components/common/back-to-top-button'
 import { ShareButton } from '@/components/common/share-button'
 import { HeadingsMenu } from '@/components/navigation/headings-menu'
@@ -11,7 +11,7 @@ export async function BlogTableOfContents({ article }: { article: Article }) {
 	const headings = await db.getArticleHeadings(article.id)
 
 	return (
-		<Aside className="hidden xl:flex pl-12">
+		<Navigation className="hidden xl:flex pl-12">
 			<BlogAuthors article={article} />
 			<HeadingsMenu headings={headings} />
 			<ShareButton
@@ -20,6 +20,6 @@ export async function BlogTableOfContents({ article }: { article: Article }) {
 			<ExtraSideBarButtons>
 				<BackToTopButton />
 			</ExtraSideBarButtons>
-		</Aside>
+		</Navigation>
 	)
 }

--- a/apps/docs/components/common/navigation.tsx
+++ b/apps/docs/components/common/navigation.tsx
@@ -3,7 +3,13 @@
 import { cn } from '@/utils/cn'
 import { motion, useScroll, useTransform } from 'framer-motion'
 
-export function Navigation({ className, children }: { className?: string; children: React.ReactNode }) {
+export function Navigation({
+	className,
+	children,
+}: {
+	className?: string
+	children: React.ReactNode
+}) {
 	const { scrollY } = useScroll()
 	const offset = useTransform(scrollY, [0, 80], [80, 0])
 

--- a/apps/docs/components/common/navigation.tsx
+++ b/apps/docs/components/common/navigation.tsx
@@ -3,12 +3,12 @@
 import { cn } from '@/utils/cn'
 import { motion, useScroll, useTransform } from 'framer-motion'
 
-export function Aside({ className, children }: { className?: string; children: React.ReactNode }) {
+export function Navigation({ className, children }: { className?: string; children: React.ReactNode }) {
 	const { scrollY } = useScroll()
 	const offset = useTransform(scrollY, [0, 80], [80, 0])
 
 	return (
-		<aside
+		<nav
 			className={cn('w-52 lg:w-60 shrink-0 flex flex-col sticky top-24', className)}
 			style={{
 				height: 'calc(100vh - 6rem)',
@@ -16,6 +16,6 @@ export function Aside({ className, children }: { className?: string; children: R
 		>
 			{children}
 			<motion.div className="shrink-0" style={{ height: offset }} />
-		</aside>
+		</nav>
 	)
 }

--- a/apps/docs/components/docs/docs-sidebar.tsx
+++ b/apps/docs/components/docs/docs-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Aside } from '@/components/common/aside'
+import { Navigation } from '@/components/common/navigation'
 import { DocsCategoryMenu } from '@/components/docs/docs-category-menu'
 import { DocsSidebarMenus } from '@/components/docs/docs-sidebar-menus'
 import { db } from '@/utils/ContentDatabase'
@@ -18,9 +18,9 @@ export async function DocsSidebar({
 	const elements = skipFirstLevel ? sidebar.links[0].children : sidebar.links
 
 	return (
-		<Aside className="hidden md:flex">
+		<Navigation className="hidden md:flex">
 			<DocsCategoryMenu />
 			<DocsSidebarMenus menus={elements} />
-		</Aside>
+		</Navigation>
 	)
 }

--- a/apps/docs/components/docs/docs-table-of-contents.tsx
+++ b/apps/docs/components/docs/docs-table-of-contents.tsx
@@ -1,4 +1,4 @@
-import { Aside } from '@/components/common/aside'
+import { Navigation } from '@/components/common/navigation'
 import { DocsArticleInfo } from '@/components/docs/docs-article-info'
 import { DocsFeedbackWidget } from '@/components/docs/docs-feedback-widget'
 import { HeadingsMenu } from '@/components/navigation/headings-menu'
@@ -9,10 +9,10 @@ export async function DocsTableOfContents({ article }: { article: Article }) {
 	const headings = await db.getArticleHeadings(article.id)
 
 	return (
-		<Aside className="hidden xl:flex pl-12">
+		<Navigation className="hidden xl:flex pl-12">
 			<HeadingsMenu headings={headings} />
 			<DocsArticleInfo article={article} />
 			<DocsFeedbackWidget className="mb-12" />
-		</Aside>
+		</Navigation>
 	)
 }


### PR DESCRIPTION
minor thing on docs site, semantically this should be a `nav`; using `aside` is a common confusion with that html5 element.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
