### PR TITLE
Fix user following chains + add loop support

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2579,7 +2579,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	private getViewportPageBoundsForFollowing(): null | Box {
 		const followingUserId = this.getInstanceState().followingUserId
 		if (!followingUserId) return null
-		const leaderPresence = this.getCollaborators().find((c) => c.userId === followingUserId)
+		const collaborators = this.getCollaborators()
+		let leaderPresence = this.getCollaborators().find((c) => c.userId === followingUserId)
+		while (leaderPresence && leaderPresence.followingUserId) {
+			leaderPresence = collaborators.find((c) => c.userId === leaderPresence?.followingUserId)
+		}
 		if (!leaderPresence) return null
 
 		if (!leaderPresence.camera || !leaderPresence.screenBounds) return null


### PR DESCRIPTION
This PR reenables support for following chains. i.e. where at least three users form a chain where A follows B and B follows C.

This PR also adds support for following loops. e.g. where A follows B and B follows A. 

The behaviour for loops is just that the viewport doesn't move until one of the users in the loop moves themselves, thus breaking the loop.

### Change type

- [x] `other`

### Release notes

- Fixed viewport following for situations when there is a chain of at least three users following one another sequentially.