### PR TITLE
Fix getSelectedShapes caching

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1705,8 +1705,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @readonly
 	 */
 	@computed getSelectedShapes(): TLShape[] {
-		const { selectedShapeIds } = this.getCurrentPageState()
-		return compact(selectedShapeIds.map((id) => this.store.get(id)))
+		return compact(this.getSelectedShapeIds().map((id) => this.store.get(id)))
 	}
 
 	/**


### PR DESCRIPTION

### Change type

- [x] `bugfix`

### Release notes

- Small perf fix to make sure `editor.getSelectedShapes` doesn't cause signals to fire too often.