### PR TITLE
Stop sending `first-connect-duration` event

### DIFF
--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -26,7 +26,6 @@ export class Zero {
 	private timeout: NodeJS.Timeout | undefined = undefined
 	private currentMutationId = uniqueId()
 	private clientTooOld = false
-	private instantiationTime = Date.now()
 	private didReceiveFirstMessage = false
 
 	constructor(
@@ -52,11 +51,6 @@ export class Zero {
 		this.socket.onReceiveMessage((_msg) => {
 			if (!this.didReceiveFirstMessage) {
 				this.didReceiveFirstMessage = true
-				const timeSinceInstantiation = Date.now() - this.instantiationTime
-				this.opts.trackEvent('first-connect-duration', {
-					duration: timeSinceInstantiation,
-					source: 'app',
-				})
 			}
 			if (this.clientTooOld) {
 				// ignore incoming messages if the client is not supported

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -60,7 +60,6 @@ export interface TLAppUiEventMap {
 	'sidebar-toggle': { value: boolean }
 	'click-file-link': null
 	'open-preview-sign-up-modal': null
-	'first-connect-duration': { duration: number }
 	'create-user': null
 }
 


### PR DESCRIPTION
We don't need to track this any longer.

### Change type

- [x] `improvement`
