### PR TITLE
a11y: fix up select dropdown in share; also error dialog

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSelect/TlaSelect.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSelect/TlaSelect.tsx
@@ -61,13 +61,13 @@ export function TlaSelect<T extends string>({
 					aria-label={label}
 					data-testid={dataTestId}
 				>
-					<span className={styles.label}>{label}</span>
+					<Select.Value className={styles.label} placeholder={label} />
 					<Select.Icon>
 						<TlaIcon icon="chevron-down" className={styles.chevron} />
 					</Select.Icon>
 				</Select.Trigger>
 				<Select.Content className={styles.content}>
-					<div>
+					<Select.Viewport>
 						{options.map((option) => (
 							<Select.Item key={option.value} className={styles.option} value={option.value}>
 								<Select.ItemText>{option.label}</Select.ItemText>
@@ -76,7 +76,7 @@ export function TlaSelect<T extends string>({
 								</Select.ItemIndicator>
 							</Select.Item>
 						))}
-					</div>
+					</Select.Viewport>
 				</Select.Content>
 			</Select.Root>
 		</div>

--- a/apps/dotcom/client/src/tla/components/TlaSelect/select.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSelect/select.module.css
@@ -16,7 +16,9 @@
 /* need to target the parent div, ugh, can't target via a className */
 div:has(> .content) {
 	position: absolute !important;
+	top: 12px;
 	right: 0;
+	left: auto !important;
 	z-index: 2 !important;
 }
 
@@ -32,6 +34,12 @@ div:has(> .content) {
 	padding: 8px 8px 8px 12px;
 	gap: 4px;
 	cursor: pointer;
+}
+
+:global(.tl-container__focused:not(.tl-container__no-focus-ring)) .option:focus-visible {
+	border-radius: 10px;
+	outline: 2px solid var(--color-focus);
+	outline-offset: -5px;
 }
 
 @media (hover: hover) {

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -272,7 +272,7 @@
 
 /** Buttons/A tags */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	:is(nav, .tlui-popover__content, .tlui-dialog__overlay)
+	:is(nav, .tlui-menu, .tlui-popover__content, .tlui-dialog__overlay)
 	button:not(.tla-button-text):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {
@@ -332,7 +332,7 @@
  * This is for the buttons in the Share dialog.
  */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	nav
+	:is(nav, #tla-tabpanel-export)
 	.tla-button:not(.tlui-button):focus-visible {
 	border-radius: var(--tla-radius-2);
 	outline-offset: 1px;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1710,6 +1710,12 @@ it from receiving any pointer events or affecting the cursor. */
 	background-color: var(--color-primary);
 	color: var(--color-selected-contrast);
 }
+.tl-container__focused:not(.tl-container__no-focus-ring)
+	.tlui-button.tl-error-boundary__refresh:focus-visible {
+	border-radius: 8px;
+	outline-offset: 0;
+}
+
 /* --------------------- Coarse --------------------- */
 
 .tl-hidden {

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -157,8 +157,10 @@ My browser: ${navigator.userAgent}`
 						<h2>Are you sure?</h2>
 						<p>Resetting your data will delete your drawing and cannot be undone.</p>
 						<div className="tl-error-boundary__content__actions">
-							<button onClick={() => setShouldShowResetConfirmation(false)}>Cancel</button>
-							<button className="tl-error-boundary__reset" onClick={resetLocalState}>
+							<button className="tlui-button" onClick={() => setShouldShowResetConfirmation(false)}>
+								Cancel
+							</button>
+							<button className="tlui-button tl-error-boundary__reset" onClick={resetLocalState}>
 								Reset data
 							</button>
 						</div>
@@ -187,22 +189,24 @@ My browser: ${navigator.userAgent}`
 									<pre>
 										<code>{errorStack ?? errorMessage}</code>
 									</pre>
-									<button onClick={copyError}>{didCopy ? 'Copied!' : 'Copy'}</button>
+									<button className="tlui-button" onClick={copyError}>
+										{didCopy ? 'Copied!' : 'Copy'}
+									</button>
 								</div>
 							</>
 						)}
 						<div className="tl-error-boundary__content__actions">
-							<button onClick={() => setShouldShowError(!shouldShowError)}>
+							<button className="tlui-button" onClick={() => setShouldShowError(!shouldShowError)}>
 								{shouldShowError ? 'Hide details' : 'Show details'}
 							</button>
 							<div className="tl-error-boundary__content__actions__group">
 								<button
-									className="tl-error-boundary__reset"
+									className="tlui-button tl-error-boundary__reset"
 									onClick={() => setShouldShowResetConfirmation(true)}
 								>
 									Reset data
 								</button>
-								<button className="tl-error-boundary__refresh" onClick={refresh}>
+								<button className="tlui-button tl-error-boundary__refresh" onClick={refresh}>
 									Refresh Page
 								</button>
 							</div>


### PR DESCRIPTION
- fix up both Select in the share dialog
- fix up error dialog buttons
- port over some of the tla.css fixes from https://github.com/tldraw/tldraw/pull/5872

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: fix some more components: Select and error dialog 