### PR TITLE
INT-1266 Remove GitHub CTA from SDK error dialogs

### DIFF
--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -168,16 +168,23 @@ My browser: ${navigator.userAgent}`
 				) : (
 					<>
 						<h2>Something went wrong</h2>
-						<p>Please refresh the page to continue.</p>
+						<p>Please try refreshing your browser to continue.</p>
 						<p>
-							If you keep seeing this screen, you can create a{' '}
-							<a href={url.toString()}>GitHub issue</a> or ask for help on{' '}
-							<a href="https://discord.tldraw.com/?utm_source=sdk&utm_medium=organic&utm_campaign=error-screen">
-								Discord
-							</a>
-							. If you are still stuck, you can reset the tldraw data on your machine. This may
-							erase the project you were working on, so try to get help first.
+							If the issue continues after refreshing, you may need to reset the tldraw data stored
+							on your device.
 						</p>
+						<p>
+							<strong>Note:</strong> Resetting will erase your current project and any unsaved work.
+						</p>
+						{process.env.NODE_ENV !== 'production' && (
+							<p>
+								If you're developing with the SDK and need help, join us on{' '}
+								<a href="https://discord.tldraw.com/?utm_source=sdk&utm_medium=organic&utm_campaign=error-screen">
+									Discord
+								</a>
+								.
+							</p>
+						)}
 						{shouldShowError && (
 							<>
 								Message:

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -178,7 +178,7 @@ My browser: ${navigator.userAgent}`
 						</p>
 						{process.env.NODE_ENV !== 'production' && (
 							<p>
-								If you're developing with the SDK and need help, join us on{' '}
+								If you&apos;re developing with the SDK and need help, join us on{' '}
 								<a href="https://discord.tldraw.com/?utm_source=sdk&utm_medium=organic&utm_campaign=error-screen">
 									Discord
 								</a>

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -168,7 +168,7 @@ My browser: ${navigator.userAgent}`
 				) : (
 					<>
 						<h2>Something went wrong</h2>
-						<p>Please try refreshing your browser to continue.</p>
+						<p>Please refresh your browser.</p>
 						<p>
 							If the issue continues after refreshing, you may need to reset the tldraw data stored
 							on your device.


### PR DESCRIPTION
Description:
This PR updates the SDK error dialog to remove links to GitHub and Discord in production builds. These calls to action were leading to a high volume of low-value support requests about unrelated products.

Key Changes:
- Removed GitHub and Discord support links from the error dialog when NODE_ENV === 'production'
- Rewrote the error message for clarity, focusing on actionable guidance (refreshing the page or resetting data)
- Mechanisms on [tldraw.com](https://tldraw.com/), should be unaffected

### Change type
- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
1. Create a controlled Error component in index.tsx
2.Add component on render of document.addEventListener('DOMContentLoaded', () => {
3. This should trigger an error and render the fallback `DefaultErrorFallback`

- [ ] Unit tests
- [ ] End to end tests

### Release notes
- Removed GitHub and Discord support prompts from SDK error dialogs
