### PR TITLE
Fix flickering when rotating arrow

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3913,9 +3913,9 @@ export interface TLRotationSnapshot {
     // (undocumented)
     initialCursorAngle: number;
     // (undocumented)
-    initialShapesRotation: number;
+    initialPageCenter: Vec;
     // (undocumented)
-    pageCenter: Vec;
+    initialShapesRotation: number;
     // (undocumented)
     shapeSnapshots: {
         initialPagePoint: Vec;

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -26,11 +26,13 @@ export function getRotationSnapshot({
 		return null
 	}
 
-	const pageCenter = rotatedPageBounds.center.clone().rotWith(rotatedPageBounds.point, rotation)
+	const initialPageCenter = rotatedPageBounds.center
+		.clone()
+		.rotWith(rotatedPageBounds.point, rotation)
 
 	return {
-		pageCenter,
-		initialCursorAngle: pageCenter.angle(editor.inputs.originPagePoint),
+		initialPageCenter,
+		initialCursorAngle: initialPageCenter.angle(editor.inputs.originPagePoint),
 		initialShapesRotation: rotation,
 		shapeSnapshots: shapes.map((shape) => ({
 			shape,
@@ -43,7 +45,7 @@ export function getRotationSnapshot({
  * @internal
  **/
 export interface TLRotationSnapshot {
-	pageCenter: Vec
+	initialPageCenter: Vec
 	initialCursorAngle: number
 	initialShapesRotation: number
 	shapeSnapshots: {
@@ -66,7 +68,7 @@ export function applyRotationToSnapshotShapes({
 	stage: 'start' | 'update' | 'end' | 'one-off'
 	centerOverride?: VecLike
 }) {
-	const { pageCenter, shapeSnapshots } = snapshot
+	const { initialPageCenter, shapeSnapshots } = snapshot
 
 	editor.updateShapes(
 		shapeSnapshots.map(({ shape, initialPagePoint }) => {
@@ -77,7 +79,7 @@ export function applyRotationToSnapshotShapes({
 				? editor.getShapePageTransform(shape.parentId)!
 				: Mat.Identity()
 
-			const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? pageCenter, delta)
+			const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? initialPageCenter, delta)
 
 			const newLocalPoint = Mat.applyToPoint(
 				// use the current parent transform in case it has moved/resized since the start

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -3,7 +3,6 @@ import {
 	StateNode,
 	TLPointerEventInfo,
 	TLRotationSnapshot,
-	VecModel,
 	applyRotationToSnapshotShapes,
 	degreesToRadians,
 	getRotationSnapshot,
@@ -23,7 +22,6 @@ export class Rotating extends StateNode {
 	info = {} as Extract<TLPointerEventInfo, { target: 'selection' }> & { onInteractionEnd?: string }
 
 	markId = ''
-	rotationCenter: VecModel = { x: 0, y: 0 }
 
 	override onEnter(info: TLPointerEventInfo & { target: 'selection'; onInteractionEnd?: string }) {
 		// Store the event information
@@ -31,10 +29,6 @@ export class Rotating extends StateNode {
 		this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 
 		this.markId = this.editor.markHistoryStoppingPoint('rotate start')
-
-		const selectionBounds = this.editor.getSelectionRotatedPageBounds()
-		if (!selectionBounds) return this.parent.transition('idle', this.info)
-		this.rotationCenter = selectionBounds.center
 
 		const snapshot = getRotationSnapshot({
 			editor: this.editor,


### PR DESCRIPTION
![Kapture 2025-04-24 at 16 22 02](https://github.com/user-attachments/assets/2ce1db16-550d-47a9-8fbb-c1b9ab1a37a3)

### Change type

- [x] `bugfix`

### Release notes

- Prevent bound arrows from flickering when you rotate them