### PR TITLE
[VSCode] Allow users to drag files from the sidebar.

### DIFF
--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -22,6 +22,7 @@ import { FileOpen } from './FileOpen'
 import { FullPageMessage } from './FullPageMessage'
 import { Links } from './Links'
 import { onCreateAssetFromUrl } from './utils/bookmarks'
+import { rpc } from './utils/rpc'
 import { vscode } from './utils/vscode'
 
 setRuntimeOverrides({
@@ -121,11 +122,33 @@ const components: TLComponents = {
 		</DefaultMainMenu>
 	),
 }
+
 function TldrawInner({ uri, assetSrc, isDarkMode, fileContents }: TLDrawInnerProps) {
 	const assetUrls = useMemo(() => getAssetUrlsByImport({ baseUrl: assetSrc }), [assetSrc])
 
 	const handleMount = useCallback((editor: Editor) => {
 		editor.registerExternalAssetHandler('url', onCreateAssetFromUrl)
+		const currentFilesContentHandler = editor.externalContentHandlers['files']
+		const currentUrlContentHandler = editor.externalContentHandlers['url']
+		editor.registerExternalContentHandler('url', async (info) => {
+			// This happens when you shift drag a file from the file explorer to the editor
+			if (info.url.startsWith('file://')) {
+				// We cannot fetch the file directly since we are sandboxed, we have to ask the extension manager to get it for us
+				const data = await rpc('vscode:get-file', { url: info.url })
+
+				const uint8Array = new Uint8Array(data.file)
+				const blob = new Blob([uint8Array], { type: data.mimeType })
+				const file = new File([blob], data.fileName, { type: data.mimeType })
+				currentFilesContentHandler?.({
+					type: 'files',
+					files: [file],
+					ignoreParent: false,
+				})
+			} else {
+				// default logic if it's a regular url
+				currentUrlContentHandler?.(info)
+			}
+		})
 	}, [])
 
 	const licenseKey =

--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -122,7 +122,6 @@ const components: TLComponents = {
 		</DefaultMainMenu>
 	),
 }
-
 function TldrawInner({ uri, assetSrc, isDarkMode, fileContents }: TLDrawInnerProps) {
 	const assetUrls = useMemo(() => getAssetUrlsByImport({ baseUrl: assetSrc }), [assetSrc])
 

--- a/apps/vscode/editor/src/utils/externalUrlContentHandler.ts
+++ b/apps/vscode/editor/src/utils/externalUrlContentHandler.ts
@@ -9,7 +9,6 @@ export function registerExternalUrlContentHandler(editor: Editor) {
 		if (info.url.startsWith('file://')) {
 			// We cannot fetch the file directly since we are sandboxed, we have to ask the extension manager to get it for us
 			const data = await rpc('vscode:get-file', { url: info.url })
-
 			const uint8Array = new Uint8Array(data.file)
 			const blob = new Blob([uint8Array], { type: data.mimeType })
 			const file = new File([blob], data.fileName, { type: data.mimeType })

--- a/apps/vscode/editor/src/utils/externalUrlContentHandler.ts
+++ b/apps/vscode/editor/src/utils/externalUrlContentHandler.ts
@@ -1,0 +1,26 @@
+import { Editor } from 'tldraw'
+import { rpc } from './rpc'
+
+export function registerExternalUrlContentHandler(editor: Editor) {
+	const currentFilesContentHandler = editor.externalContentHandlers['files']
+	const currentUrlContentHandler = editor.externalContentHandlers['url']
+	editor.registerExternalContentHandler('url', async (info) => {
+		// This happens when you shift drag a file from the file explorer to the editor
+		if (info.url.startsWith('file://')) {
+			// We cannot fetch the file directly since we are sandboxed, we have to ask the extension manager to get it for us
+			const data = await rpc('vscode:get-file', { url: info.url })
+
+			const uint8Array = new Uint8Array(data.file)
+			const blob = new Blob([uint8Array], { type: data.mimeType })
+			const file = new File([blob], data.fileName, { type: data.mimeType })
+			currentFilesContentHandler?.({
+				type: 'files',
+				files: [file],
+				ignoreParent: false,
+			})
+		} else {
+			// default logic if it's a regular url
+			currentUrlContentHandler?.(info)
+		}
+	})
+}

--- a/apps/vscode/editor/src/utils/rpc.ts
+++ b/apps/vscode/editor/src/utils/rpc.ts
@@ -1,5 +1,5 @@
 import { uniqueId } from 'tldraw'
-import type { VscodeMessagePairs } from '../../../messages'
+import type { VscodeMessage, VscodeMessagePairs } from '../../../messages'
 import { vscode } from './vscode'
 
 interface SimpleRpcOpts {
@@ -15,20 +15,20 @@ class SimpleRpcError extends Error {
 	}
 }
 
-export function rpc(
-	id: keyof VscodeMessagePairs,
-	data: Omit<VscodeMessagePairs[typeof id]['request'], 'uuid'>['data'],
+export function rpc<T extends keyof VscodeMessagePairs>(
+	id: T,
+	data: VscodeMessagePairs[T]['request']['data'],
 	opts: SimpleRpcOpts = { timeout: 5 * 1000 }
-) {
+): Promise<VscodeMessagePairs[typeof id]['response']['data']> {
 	const { timeout } = opts
-	type RequestType = VscodeMessagePairs[typeof id]['request']
-	type ResponseType = VscodeMessagePairs[typeof id]['response']
-	type ErrorType = VscodeMessagePairs[typeof id]['error']
+	type RequestType = VscodeMessagePairs[T]['request']
+	type ResponseType = VscodeMessagePairs[T]['response']
+	type ErrorType = VscodeMessagePairs[T]['error']
 
 	const type = (id + '/request') as RequestType['type']
 	const uuid = uniqueId()
 	return new Promise<ResponseType['data']>((resolve, reject) => {
-		const inMessage = {
+		const inMessage: VscodeMessage = {
 			uuid,
 			type,
 			data,

--- a/apps/vscode/editor/src/utils/rpc.ts
+++ b/apps/vscode/editor/src/utils/rpc.ts
@@ -19,7 +19,7 @@ export function rpc<T extends keyof VscodeMessagePairs>(
 	id: T,
 	data: VscodeMessagePairs[T]['request']['data'],
 	opts: SimpleRpcOpts = { timeout: 5 * 1000 }
-): Promise<VscodeMessagePairs[typeof id]['response']['data']> {
+) {
 	const { timeout } = opts
 	type RequestType = VscodeMessagePairs[T]['request']
 	type ResponseType = VscodeMessagePairs[T]['response']

--- a/apps/vscode/extension/src/WebViewMessageHandler.ts
+++ b/apps/vscode/extension/src/WebViewMessageHandler.ts
@@ -6,6 +6,7 @@ import { loadFile } from './file'
 import { UnknownRecord } from 'tldraw'
 // @ts-ignore
 import type { VscodeMessage } from '../../messages'
+import { getMimeTypeFromPath } from './media'
 import { unfurl } from './unfurl'
 import { nicelog } from './utils'
 
@@ -218,23 +219,4 @@ export class WebViewMessageHandler {
 			}
 		}
 	}
-}
-
-function getMimeTypeFromPath(filePath: string): string {
-	const extension = filePath.split('.').pop()?.toLowerCase()
-	if (!extension) throw new Error('No extension found in file path')
-
-	const mimeTypes: Record<string, string> = {
-		jpg: 'image/jpeg',
-		jpeg: 'image/jpeg',
-		png: 'image/png',
-		webp: 'image/webp',
-		gif: 'image/gif',
-		apng: 'image/apng',
-		avif: 'image/avif',
-		svg: 'image/svg+xml',
-	}
-	const mimeType = mimeTypes[extension]
-	if (mimeType) return mimeType
-	throw new Error(`Unsupported file type: ${extension}`)
 }

--- a/apps/vscode/extension/src/media.ts
+++ b/apps/vscode/extension/src/media.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SUPPORTED_MEDIA_TYPES } from '@tldraw/utils/src/lib/media/media'
+import { DEFAULT_SUPPORTED_MEDIA_TYPES } from 'tldraw'
 
 const EXTENSION_TO_DEFAULT_MIME_TYPE = {
 	// Vector image extensions

--- a/apps/vscode/extension/src/media.ts
+++ b/apps/vscode/extension/src/media.ts
@@ -1,0 +1,50 @@
+import { DEFAULT_SUPPORTED_MEDIA_TYPES } from '@tldraw/utils/src/lib/media/media'
+
+const DEFAULT_EXTENSION_TO_MIME_TYPE = {
+	// Vector image extensions
+	svg: 'image/svg+xml',
+
+	// Static image extensions
+	jpeg: 'image/jpeg',
+	png: 'image/png',
+	webp: 'image/webp',
+
+	// Animated image extensions
+	gif: 'image/gif',
+	apng: 'image/apng',
+	avif: 'image/avif',
+
+	// Video extensions
+	mp4: 'video/mp4',
+	webm: 'video/webm',
+	mov: 'video/quicktime',
+	qt: 'video/quicktime',
+} as const
+
+type DefaultSupportedMimeType = (typeof DEFAULT_SUPPORTED_MEDIA_TYPES)[number]
+type DefaultSupportedExtensions = keyof typeof DEFAULT_EXTENSION_TO_MIME_TYPE
+
+// We use these types to enforce that we don't have any extra mime types in the EXTENSION_TO_MIME_TYPE map
+// and that we don't miss any mime types in the DEFAULT_SUPPORTED_MEDIA_TYPES array
+type ExtensionMapMimeTypes =
+	(typeof DEFAULT_EXTENSION_TO_MIME_TYPE)[keyof typeof DEFAULT_EXTENSION_TO_MIME_TYPE]
+type _CheckMimeTypesCovered = DefaultSupportedMimeType extends ExtensionMapMimeTypes ? true : never
+type _CheckNoExtraMimeTypes = ExtensionMapMimeTypes extends DefaultSupportedMimeType ? true : never
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mimeTypesCovered: _CheckMimeTypesCovered = true
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const noExtraMimeTypes: _CheckNoExtraMimeTypes = true
+
+function isSupportedExtension(extension: string): extension is DefaultSupportedExtensions {
+	return extension in DEFAULT_EXTENSION_TO_MIME_TYPE
+}
+
+export function getMimeTypeFromPath(filePath: string): string {
+	const extension = filePath.split('.').pop()?.toLowerCase()
+	if (!extension) throw new Error('No extension found in file path')
+
+	if (isSupportedExtension(extension)) {
+		return DEFAULT_EXTENSION_TO_MIME_TYPE[extension]
+	}
+	throw new Error(`Unsupported file type: ${extension}`)
+}

--- a/apps/vscode/extension/src/media.ts
+++ b/apps/vscode/extension/src/media.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SUPPORTED_MEDIA_TYPES } from '@tldraw/utils/src/lib/media/media'
 
-const DEFAULT_EXTENSION_TO_MIME_TYPE = {
+const EXTENSION_TO_DEFAULT_MIME_TYPE = {
 	// Vector image extensions
 	svg: 'image/svg+xml',
 
@@ -22,12 +22,12 @@ const DEFAULT_EXTENSION_TO_MIME_TYPE = {
 } as const
 
 type DefaultSupportedMimeType = (typeof DEFAULT_SUPPORTED_MEDIA_TYPES)[number]
-type DefaultSupportedExtensions = keyof typeof DEFAULT_EXTENSION_TO_MIME_TYPE
+type DefaultSupportedExtensions = keyof typeof EXTENSION_TO_DEFAULT_MIME_TYPE
 
 // We use these types to enforce that we don't have any extra mime types in the EXTENSION_TO_MIME_TYPE map
 // and that we don't miss any mime types in the DEFAULT_SUPPORTED_MEDIA_TYPES array
 type ExtensionMapMimeTypes =
-	(typeof DEFAULT_EXTENSION_TO_MIME_TYPE)[keyof typeof DEFAULT_EXTENSION_TO_MIME_TYPE]
+	(typeof EXTENSION_TO_DEFAULT_MIME_TYPE)[keyof typeof EXTENSION_TO_DEFAULT_MIME_TYPE]
 type _CheckMimeTypesCovered = DefaultSupportedMimeType extends ExtensionMapMimeTypes ? true : never
 type _CheckNoExtraMimeTypes = ExtensionMapMimeTypes extends DefaultSupportedMimeType ? true : never
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,7 +36,7 @@ const mimeTypesCovered: _CheckMimeTypesCovered = true
 const noExtraMimeTypes: _CheckNoExtraMimeTypes = true
 
 function isSupportedExtension(extension: string): extension is DefaultSupportedExtensions {
-	return extension in DEFAULT_EXTENSION_TO_MIME_TYPE
+	return extension in EXTENSION_TO_DEFAULT_MIME_TYPE
 }
 
 export function getMimeTypeFromPath(filePath: string): string {
@@ -44,7 +44,7 @@ export function getMimeTypeFromPath(filePath: string): string {
 	if (!extension) throw new Error('No extension found in file path')
 
 	if (isSupportedExtension(extension)) {
-		return DEFAULT_EXTENSION_TO_MIME_TYPE[extension]
+		return EXTENSION_TO_DEFAULT_MIME_TYPE[extension]
 	}
 	throw new Error(`Unsupported file type: ${extension}`)
 }

--- a/apps/vscode/messages.ts
+++ b/apps/vscode/messages.ts
@@ -25,9 +25,36 @@ type BookmarkError = {
 	}
 }
 
+type GetFileRequest = {
+	type: 'vscode:get-file/request'
+	uuid: string
+	data: {
+		url: string
+	}
+}
+
+type GetFileResponse = {
+	type: 'vscode:get-file/response'
+	uuid: string
+	data: {
+		fileName: string
+		file: number[]
+		mimeType: string
+	}
+}
+
+type GetFileError = {
+	type: 'vscode:get-file/error'
+	uuid: string
+	data: {
+		error: string
+	}
+}
+
 /** @public */
 export type VscodeMessagePairs = {
 	'vscode:bookmark': { request: BookmarkRequest; response: BookmarkResponse; error: BookmarkError }
+	'vscode:get-file': { request: GetFileRequest; response: GetFileResponse; error: GetFileError }
 }
 
 /** @public */
@@ -89,3 +116,5 @@ export type VscodeMessage =
 	| { type: 'vscode:hard-reset' }
 	| BookmarkRequest
 	| BookmarkResponse
+	| GetFileRequest
+	| GetFileResponse

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -47,10 +47,10 @@ export function debounce<T extends unknown[], U>(callback: (...args: T) => Promi
 export function dedupe<T>(input: T[], equals?: (a: any, b: any) => boolean): T[];
 
 // @public (undocumented)
-export const DEFAULT_SUPPORT_VIDEO_TYPES: readonly string[];
+export const DEFAULT_SUPPORT_VIDEO_TYPES: readonly ("video/mp4" | "video/quicktime" | "video/webm")[];
 
 // @public (undocumented)
-export const DEFAULT_SUPPORTED_IMAGE_TYPES: readonly string[];
+export const DEFAULT_SUPPORTED_IMAGE_TYPES: readonly ("image/apng" | "image/avif" | "image/gif" | "image/jpeg" | "image/png" | "image/svg+xml" | "image/webp")[];
 
 // @public (undocumented)
 export const DEFAULT_SUPPORTED_MEDIA_TYPE_LIST: string;
@@ -291,7 +291,7 @@ export class MediaHelpers {
     // (undocumented)
     static isAnimatedImageType(mimeType: null | string): boolean;
     // (undocumented)
-    static isImageType(mimeType: string): boolean;
+    static isImageType(mimeType: null | string): boolean;
     // (undocumented)
     static isStaticImageType(mimeType: null | string): boolean;
     // (undocumented)

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -55,6 +55,9 @@ export const DEFAULT_SUPPORTED_IMAGE_TYPES: readonly ("image/apng" | "image/avif
 // @public (undocumented)
 export const DEFAULT_SUPPORTED_MEDIA_TYPE_LIST: string;
 
+// @public (undocumented)
+export const DEFAULT_SUPPORTED_MEDIA_TYPES: readonly ("image/apng" | "image/avif" | "image/gif" | "image/jpeg" | "image/png" | "image/svg+xml" | "image/webp" | "video/mp4" | "video/quicktime" | "video/webm")[];
+
 // @internal
 export function deleteFromLocalStorage(key: string): void;
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -291,7 +291,7 @@ export class MediaHelpers {
     // (undocumented)
     static isAnimatedImageType(mimeType: null | string): boolean;
     // (undocumented)
-    static isImageType(mimeType: null | string): boolean;
+    static isImageType(mimeType: string): boolean;
     // (undocumented)
     static isStaticImageType(mimeType: null | string): boolean;
     // (undocumented)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -37,6 +37,7 @@ export { getFirstFromIterable } from './lib/iterable'
 export type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from './lib/json-value'
 export {
 	DEFAULT_SUPPORTED_IMAGE_TYPES,
+	DEFAULT_SUPPORTED_MEDIA_TYPES,
 	DEFAULT_SUPPORTED_MEDIA_TYPE_LIST,
 	DEFAULT_SUPPORT_VIDEO_TYPES,
 	MediaHelpers,

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -7,18 +7,18 @@ import { PngHelpers } from './png'
 import { isWebpAnimated } from './webp'
 
 /** @public */
-export const DEFAULT_SUPPORTED_VECTOR_IMAGE_TYPES = Object.freeze(['image/svg+xml'])
+export const DEFAULT_SUPPORTED_VECTOR_IMAGE_TYPES = Object.freeze(['image/svg+xml' as const])
 /** @public */
 export const DEFAULT_SUPPORTED_STATIC_IMAGE_TYPES = Object.freeze([
-	'image/jpeg',
-	'image/png',
-	'image/webp',
+	'image/jpeg' as const,
+	'image/png' as const,
+	'image/webp' as const,
 ])
 /** @public */
 export const DEFAULT_SUPPORTED_ANIMATED_IMAGE_TYPES = Object.freeze([
-	'image/gif',
-	'image/apng',
-	'image/avif',
+	'image/gif' as const,
+	'image/apng' as const,
+	'image/avif' as const,
 ])
 /** @public */
 export const DEFAULT_SUPPORTED_IMAGE_TYPES = Object.freeze([
@@ -28,15 +28,17 @@ export const DEFAULT_SUPPORTED_IMAGE_TYPES = Object.freeze([
 ])
 /** @public */
 export const DEFAULT_SUPPORT_VIDEO_TYPES = Object.freeze([
-	'video/mp4',
-	'video/webm',
-	'video/quicktime',
+	'video/mp4' as const,
+	'video/webm' as const,
+	'video/quicktime' as const,
 ])
 /** @public */
-export const DEFAULT_SUPPORTED_MEDIA_TYPE_LIST = [
+export const DEFAULT_SUPPORTED_MEDIA_TYPES = Object.freeze([
 	...DEFAULT_SUPPORTED_IMAGE_TYPES,
 	...DEFAULT_SUPPORT_VIDEO_TYPES,
-].join(',')
+])
+/** @public */
+export const DEFAULT_SUPPORTED_MEDIA_TYPE_LIST = DEFAULT_SUPPORTED_MEDIA_TYPES.join(',')
 
 /**
  * Helpers for media
@@ -229,19 +231,19 @@ export class MediaHelpers {
 	}
 
 	static isAnimatedImageType(mimeType: string | null): boolean {
-		return DEFAULT_SUPPORTED_ANIMATED_IMAGE_TYPES.includes(mimeType || '')
+		return DEFAULT_SUPPORTED_ANIMATED_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 
 	static isStaticImageType(mimeType: string | null): boolean {
-		return DEFAULT_SUPPORTED_STATIC_IMAGE_TYPES.includes(mimeType || '')
+		return DEFAULT_SUPPORTED_STATIC_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 
 	static isVectorImageType(mimeType: string | null): boolean {
-		return DEFAULT_SUPPORTED_VECTOR_IMAGE_TYPES.includes(mimeType || '')
+		return DEFAULT_SUPPORTED_VECTOR_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 
-	static isImageType(mimeType: string): boolean {
-		return DEFAULT_SUPPORTED_IMAGE_TYPES.includes(mimeType)
+	static isImageType(mimeType: string | null): boolean {
+		return DEFAULT_SUPPORTED_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 
 	static async usingObjectURL<T>(blob: Blob, fn: (url: string) => Promise<T>): Promise<T> {

--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -242,7 +242,7 @@ export class MediaHelpers {
 		return DEFAULT_SUPPORTED_VECTOR_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 
-	static isImageType(mimeType: string | null): boolean {
+	static isImageType(mimeType: string): boolean {
 		return DEFAULT_SUPPORTED_IMAGE_TYPES.includes((mimeType as any) || '')
 	}
 


### PR DESCRIPTION
This allows users to drag image files from the sidebar into the editor. In this case we don't get the files (so the files content handler does not get called). Instead we get an url prefixed by `file://`. We have to send the url to the extension, since the webview runs in a sandbox and does not have file system access. The extension gets the file and sends it back.

Resolves ENG-3111

### Change type

- [x] `bugfix`
