### PR TITLE
a11y: dont go into edit mode when moving to canvas content

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
@@ -134,7 +134,7 @@ describe('When in the idle state', () => {
 		editor.pointerMove(100, 100)
 		editor.pointerUp(100, 100)
 
-		editor.keyUp('Enter')
+		editor.keyPress('Enter')
 		editor.expectToBeIn('select.editing_shape')
 	})
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -37,9 +37,12 @@ const SKIPPED_KEYS_FOR_AUTO_EDITING = [
 export class Idle extends StateNode {
 	static override id = 'idle'
 
+	selectedShapesOnKeyDown: TLShape[] = []
+
 	override onEnter() {
 		this.parent.setCurrentToolIdMask(undefined)
 		updateHoveredShapeId(this.editor)
+		this.selectedShapesOnKeyDown = []
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 	}
 
@@ -424,6 +427,8 @@ export class Idle extends StateNode {
 	}
 
 	override onKeyDown(info: TLKeyboardEventInfo) {
+		this.selectedShapesOnKeyDown = this.editor.getSelectedShapes()
+
 		switch (info.code) {
 			case 'ArrowLeft':
 			case 'ArrowRight':
@@ -497,6 +502,10 @@ export class Idle extends StateNode {
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		switch (info.code) {
 			case 'Enter': {
+				// Because Enter onKeyDown can happen outside the canvas (but then focus the canvas potentially),
+				// we need to check if the canvas was initially selecting something before continuing.
+				if (!this.selectedShapesOnKeyDown.length) return
+
 				const selectedShapes = this.editor.getSelectedShapes()
 
 				// On enter, if every selected shape is a group, then select all of the children of the groups

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -338,7 +338,7 @@ describe('When pressing enter on a selected shape', () => {
 			.selectNone()
 			.createShapes([{ id, type: 'geo' }])
 			.select(id)
-			.keyUp('Enter')
+			.keyPress('Enter')
 			.expectToBeIn('select.editing_shape')
 	})
 })
@@ -577,7 +577,7 @@ describe('When in readonly mode', () => {
 		editor.setSelectedShapes([ids.embed1])
 		expect(editor.getSelectedShapeIds().length).toBe(1)
 
-		editor.keyUp('Enter')
+		editor.keyPress('Enter')
 		expect(editor.getEditingShapeId()).toBe(ids.embed1)
 	})
 })

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -525,6 +525,12 @@ export class TestEditor extends Editor {
 		return this
 	}
 
+	keyPress(key: string, options = {} as Partial<Exclude<TLKeyboardEventInfo, 'key'>>) {
+		this.keyDown(key, options)
+		this.keyUp(key, options)
+		return this
+	}
+
 	keyDown(key: string, options = {} as Partial<Exclude<TLKeyboardEventInfo, 'key'>>) {
 		this.dispatch({ ...this.getKeyboardEventInfo(key, 'key_down', options) }).forceTick()
 		return this

--- a/packages/tldraw/src/test/commands/setCurrentPage.test.ts
+++ b/packages/tldraw/src/test/commands/setCurrentPage.test.ts
@@ -96,7 +96,7 @@ describe('setCurrentPage', () => {
 		const geoId = createShapeId()
 		editor.createShape({ type: 'geo', id: geoId, props: { w: 100, h: 100 } })
 		editor.select(geoId)
-		editor.keyUp('Enter')
+		editor.keyPress('Enter')
 
 		expect(editor.isIn('select.editing_shape')).toBe(true)
 


### PR DESCRIPTION
Steve reported this issue. This happens when you hold the Enter key a little longer than usual, then the keyup handler triggers an edit accidentally.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: don't go into edit mode when holding Enter for a long time.