### PR TITLE
ENG 3023 Add double-click to fit frame to content on edges and corners

### DIFF
--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -34,6 +34,7 @@ Accessibility is something we’ve been researching internally for a while now, 
 ### API additions
 
 - Frames can now have color. Set the `showColors` option on the `FrameShapeUtil` class to display colorful borders and labels for frames. ([#5283](https://github.com/tldraw/tldraw/pull/5283))
+
   ```tsx
   import { FrameShapeUtil, Tldraw } from 'tldraw'
   import 'tldraw/tldraw.css'
@@ -48,6 +49,7 @@ Accessibility is something we’ve been researching internally for a while now, 
   	)
   }
   ```
+
 - There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel). ([#5762](https://github.com/tldraw/tldraw/pull/5762))
 - The `Geometry2d` class has a couple of new helper methods for calculating intersection points (`intersectLineSegment` and `intersectCircle`), a new helper method for applying a transformation matrix (`transform`), and new filtering options to allow excluding certain parts of geometry from calculations. ([#5754](https://github.com/tldraw/tldraw/pull/5754))
 - We now individually export two of our default Tiptap extensions (for rich text) ([#5874](https://github.com/tldraw/tldraw/pull/5874))

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -15,62 +15,91 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
-## Current release: [v3.11.0](/releases/v3.11.0)
+## Current release: [v3.12.0](/releases/v3.12.0)
 
-Welcome to the 3.11.0 release of tldraw. This release follows up our 3.10 release to mainly address rich text issues.
-We had fairly smooth release of our new transition to rich text as a first-class primitive in tldraw in general.
-Thanks to everyone for their continued feedback!
+### Release Notes
 
-#### Improvements
+v3.12.0 of the tldraw SDK includes several bug fixes and API improvements. The main feature development focus was on accessibility, building on initial work in v3.11.0 which added a focus ring.
 
-- Added a new minimum zoom step at 5% ([#5584](https://github.com/tldraw/tldraw/pull/5584))
-- Added new keyboard shortcuts for zoom in or out towards your cursor (Shift +, Shift -) ([#5584](https://github.com/tldraw/tldraw/pull/5584))
-- Style panel: be able to hit Enter to continue editing after selection ([#5705](https://github.com/tldraw/tldraw/pull/5705))
-- a11y: focus ring ([#5401](https://github.com/tldraw/tldraw/pull/5401))
-- Security: provide a way to pass through `nonce` to the editor ([#5607](https://github.com/tldraw/tldraw/pull/5607))
-- Improved performance related to rich text when there are a lot of shapes on the board. ([#5658](https://github.com/tldraw/tldraw/pull/5658))
-- Cleanup assets from the local indexedDB that are proactively deleted. ([#5628](https://github.com/tldraw/tldraw/pull/5628))
-- Allow embedding other multiplayer routes and also tldraw app routes ([#5326](https://github.com/tldraw/tldraw/pull/5326))
-- Improved performance on large projects when hiding / showing shape indicators. ([#5654](https://github.com/tldraw/tldraw/pull/5654))
-- Added `hideAll` and `showAll` props to the `ShapeIndicators` component props ([#5654](https://github.com/tldraw/tldraw/pull/5654))
-- Added keyboard shortcuts (option + arrows) for navigating between pages. ([#5654](https://github.com/tldraw/tldraw/pull/5654))
-- Adjusts distance for `stackShapes`. ([#5656](https://github.com/tldraw/tldraw/pull/5656))
-- Adds support for satellite mode in Google Map embeds ([#5630](https://github.com/tldraw/tldraw/pull/5630))
-- 'New user' -> 'Guest user' ([#5614](https://github.com/tldraw/tldraw/pull/5614))
-  - BREAKING CHANGE: `editor.user.getName()` no longer returns `'New user'` if the user has no name set. Instead it returns the empty string `''`.
-  - BREAKING CHANGE: `defaultUserPreferences.name` is no longer the string `'New user'`, it is now the empty string `''`
+### Accessibility features
 
-#### API changes
+- You can now move your selection between shapes using the keyboard (using `Tab` and `Cmd/Ctrl`+`Arrow`) ([#5761](https://github.com/tldraw/tldraw/pull/5761))
+- Screen reader support for tool changes ([#5634](https://github.com/tldraw/tldraw/pull/5634))
+- Screen reader support for shape selection changes ([#5773](https://github.com/tldraw/tldraw/pull/5773))
+- Shapes can now be resized using the keyboard (using `Cmd`/`Ctrl`+`Alt`+`Shift` with the `+`/`-` keys) ([#5826](https://github.com/tldraw/tldraw/pull/5826))
+- More of our UI elements have the correct `role` applied, and use the correct semantic html5 tags ([#5847](https://github.com/tldraw/tldraw/pull/5847))
 
-- Add `RichTextSVG` to the exports. [#5700](https://github.com/tldraw/tldraw/pull/5700)
+Accessibility is something we’ve been researching internally for a while now, investing in some R&D projects to see what’s possible on a 2D canvas. We’re continuing to mature our processes around accessibility with an eye on achieving WCAG in the near future.
 
-#### Bug fix
+### API additions
 
-- Fix issue with rich text numbered lists escaping geometry bounds ([#5709](https://github.com/tldraw/tldraw/pull/5709))
-- Fix developing with StrictMode + React 19 when editing text. ([#5689](https://github.com/tldraw/tldraw/pull/5689))
-- Fix issue with exports embedding Inter and having excessive styling. ([#5676](https://github.com/tldraw/tldraw/pull/5676))
-- Fix a bug where `textOptions` was missing on `<TldrawImage />` ([#5649](https://github.com/tldraw/tldraw/pull/5649))
-- Fix labels for screen readers on toolbar buttons. Fix missing 'heart' string. ([#5632](https://github.com/tldraw/tldraw/pull/5632))
-- Fix missing i18n strings for latest rich text items [#5704](https://github.com/tldraw/tldraw/pull/5704)
-- Upgrade Yarn to 4.7 [#5687](https://github.com/tldraw/tldraw/pull/5687)
+- Frames can now have color. Set the `showColors` option on the `FrameShapeUtil` class to display colorful borders and labels for frames. ([#5283](https://github.com/tldraw/tldraw/pull/5283))
+  ```tsx
+  import { FrameShapeUtil, Tldraw } from 'tldraw'
+  import 'tldraw/tldraw.css'
 
-#### Templates
+  const shapeUtils = [FrameShapeUtil.configure({ showColors: true })]
 
-- Fix Bun server image uploads ([#5627](https://github.com/tldraw/tldraw/pull/5627))
-- Remove yarn.lock files (was keeping tldraw versions old) [#5690](https://github.com/tldraw/tldraw/pull/5690)
-- Fix Inter font on some of our templates. [#5626](https://github.com/tldraw/tldraw/pull/5626)
+  export default function App() {
+  	return (
+  		`<div className="tldraw__editor">`
+  			<Tldraw shapeUtils={shapeUtils}>`</Tldraw>`
+  		`</div>`
+  	)
+  }
+  ```
+- There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel). ([#5762](https://github.com/tldraw/tldraw/pull/5762))
+- The `Geometry2d` class has a couple of new helper methods for calculating intersection points (`intersectLineSegment` and `intersectCircle`), a new helper method for applying a transformation matrix (`transform`), and new filtering options to allow excluding certain parts of geometry from calculations. ([#5754](https://github.com/tldraw/tldraw/pull/5754))
+- We now individually export two of our default Tiptap extensions (for rich text) ([#5874](https://github.com/tldraw/tldraw/pull/5874))
+  - `KeyboardShiftEnterTweakExtension` which inserts a normal line break when pressing shift+enter (tldraw doesn’t support soft breaks).
+  - `TextDirection` which ensures the text directionality is saved and reinstated correctly.
 
-#### Authors
+### Other improvements
 
+- The syntax for defining keyboard shortcuts is now more intuitive ([#5605](https://github.com/tldraw/tldraw/pull/5605))
+  - e.g. `'?!l’` becomes `'alt+shift+l'` and `'$s'` becomes `'ctrl+s,cmd+s'`
+  - See https://tldraw.dev/reference/tldraw/TLUiToolItem#kbd
+  - The old syntax is still supported for now, but may be deprecated in the future.
+- `Store.mergeRemoteChanges` is now atomic, and side effects are triggered in the correct scopes. ([#5801](https://github.com/tldraw/tldraw/pull/5801))
+- Drawing is now smoother on slower CPUs by using [getCoalescedEvents](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents). ([#5898](https://github.com/tldraw/tldraw/pull/5898))
+- We now allow overriding the asset urls for the icons used by the Embed shape to be null/empty in cases where the Embed shape is not needed. This prevents tldraw downloading a handful of icon assets that would never be used. ([#5736](https://github.com/tldraw/tldraw/pull/5736))
+- YouTube embeds now support the t/start/loop parameters. ([#5726](https://github.com/tldraw/tldraw/pull/5726))
+
+### Bug fixes
+
+- SVGs can now be pasted in Firefox. ([#5789](https://github.com/tldraw/tldraw/pull/5789))
+- Text exports from pages that include TailwindCSS no longer have unexpected borders. ([#5792](https://github.com/tldraw/tldraw/pull/5792))
+- Pasting images now triggers just one ‘create’ effect per image shape, before it would trigger a ‘create’ and then immediately an ‘update’. ([#5800](https://github.com/tldraw/tldraw/pull/5800))
+- Pasting shapes from Miro no longer crashes tldraw. ([#5790](https://github.com/tldraw/tldraw/pull/5790))
+- Setting `zoomSpeed` in camera options no longer breaks zooming on safari trackpads and multitouch pinch to zoom. ([#5771](https://github.com/tldraw/tldraw/pull/5771))
+- Fix a minor style issue in the PeopleMenu component. ([#5753](https://github.com/tldraw/tldraw/pull/5753))
+- Resolve some performance regressions related to rich text. ([#5743](https://github.com/tldraw/tldraw/pull/5743)) ([#5735](https://github.com/tldraw/tldraw/pull/5735)) ([#5734](https://github.com/tldraw/tldraw/pull/5734))
+- `Group2D.getSvgPathData()` now sets the starting points of its children correctly. ([#5580](https://github.com/tldraw/tldraw/pull/5580))
+- Resolve a performance regression related to drawing on an iPad ([#5888](https://github.com/tldraw/tldraw/pull/5888))
+- Prevent a crash when trying to render UI for tools that have been removed ([#5849](https://github.com/tldraw/tldraw/pull/5849))
+
+### Breaking changes
+
+No breaking changes!
+
+### Authors
+
+- [@budatl](https://github.com/budatl)
 - alex ([@SomeHats](https://github.com/SomeHats))
 - David Sheldrick ([@ds300](https://github.com/ds300))
-- Jeff Astor ([@Jastor11](https://github.com/Jastor11))
+- Fabian Iwand ([@mootari](https://github.com/mootari))
+- Lorenzo Lewis ([@lorenzolewis](https://github.com/lorenzolewis))
 - Lu Wilson ([@TodePond](https://github.com/TodePond))
 - Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
 - Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
+- Slava Khanilo ([@khanilov](https://github.com/khanilov))
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
+- Trivikram Kamat ([@trivikr](https://github.com/trivikr))
+- Trygve Aaberge ([@trygve-aaberge-adsk](https://github.com/trygve-aaberge-adsk))
 
 ## Previous releases
+
+- [v3.11.0](/releases/v3.11.0)
 
 - [v3.10.0](/releases/v3.10.0)
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2648,6 +2648,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onClick?(shape: Shape): TLShapePartial<Shape> | void;
     onCrop?(shape: Shape, info: TLCropInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
     onDoubleClick?(shape: Shape): TLShapePartial<Shape> | void;
+    onDoubleClickCorner?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void;
     onDoubleClickEdge?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void;
     onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapePartial<Shape> | void;
     onDragShapesOut?(shape: Shape, shapes: TLShape[]): void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2648,7 +2648,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onClick?(shape: Shape): TLShapePartial<Shape> | void;
     onCrop?(shape: Shape, info: TLCropInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
     onDoubleClick?(shape: Shape): TLShapePartial<Shape> | void;
-    onDoubleClickEdge?(shape: Shape): TLShapePartial<Shape> | void;
+    onDoubleClickEdge?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void;
     onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapePartial<Shape> | void;
     onDragShapesOut?(shape: Shape, shapes: TLShape[]): void;
     onDragShapesOver?(shape: Shape, shapes: TLShape[]): void;
@@ -3194,6 +3194,12 @@ export interface TLDeepLinkOptions {
     getUrl?(editor: Editor): string | URL;
     onChange?(url: URL, editor: Editor): void;
     param?: string;
+}
+
+// @public (undocumented)
+export interface TLDoubleClickEdgeInfo<T extends TLShape> {
+    // (undocumented)
+    edge: SelectionEdge;
 }
 
 // @public (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2648,8 +2648,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onClick?(shape: Shape): TLShapePartial<Shape> | void;
     onCrop?(shape: Shape, info: TLCropInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
     onDoubleClick?(shape: Shape): TLShapePartial<Shape> | void;
-    onDoubleClickCorner?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void;
-    onDoubleClickEdge?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void;
+    onDoubleClickCorner?(shape: Shape, info: TLClickEventInfo): TLShapePartial<Shape> | void;
+    onDoubleClickEdge?(shape: Shape, info: TLClickEventInfo): TLShapePartial<Shape> | void;
     onDoubleClickHandle?(shape: Shape, handle: TLHandle): TLShapePartial<Shape> | void;
     onDragShapesOut?(shape: Shape, shapes: TLShape[]): void;
     onDragShapesOver?(shape: Shape, shapes: TLShape[]): void;
@@ -3195,12 +3195,6 @@ export interface TLDeepLinkOptions {
     getUrl?(editor: Editor): string | URL;
     onChange?(url: URL, editor: Editor): void;
     param?: string;
-}
-
-// @public (undocumented)
-export interface TLDoubleClickEdgeInfo<T extends TLShape> {
-    // (undocumented)
-    edge: SelectionEdge;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -200,7 +200,6 @@ export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseB
 export {
 	ShapeUtil,
 	type TLCropInfo,
-	type TLDoubleClickEdgeInfo,
 	type TLGeometryOpts,
 	type TLHandleDragInfo,
 	type TLResizeInfo,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -200,6 +200,7 @@ export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseB
 export {
 	ShapeUtil,
 	type TLCropInfo,
+	type TLDoubleClickEdgeInfo,
 	type TLGeometryOpts,
 	type TLHandleDragInfo,
 	type TLResizeInfo,
@@ -208,7 +209,6 @@ export {
 	type TLShapeUtilCanBindOpts,
 	type TLShapeUtilCanvasSvgDef,
 	type TLShapeUtilConstructor,
-	type TLDoubleClickEdgeInfo
 } from './lib/editor/shapes/ShapeUtil'
 export { GroupShapeUtil } from './lib/editor/shapes/group/GroupShapeUtil'
 export { getPerfectDashProps } from './lib/editor/shapes/shared/getPerfectDashProps'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -208,6 +208,7 @@ export {
 	type TLShapeUtilCanBindOpts,
 	type TLShapeUtilCanvasSvgDef,
 	type TLShapeUtilConstructor,
+	type TLDoubleClickEdgeInfo
 } from './lib/editor/shapes/ShapeUtil'
 export { GroupShapeUtil } from './lib/editor/shapes/group/GroupShapeUtil'
 export { getPerfectDashProps } from './lib/editor/shapes/shared/getPerfectDashProps'

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -11,7 +11,7 @@ import {
 	TLUnknownShape,
 } from '@tldraw/tlschema'
 import { ReactElement } from 'react'
-import { Box, SelectionEdge, SelectionHandle } from '../../primitives/Box'
+import { Box, SelectionHandle } from '../../primitives/Box'
 import { Vec } from '../../primitives/Vec'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import type { Editor } from '../Editor'
@@ -19,6 +19,7 @@ import { TLFontFace } from '../managers/FontManager'
 import { BoundsSnapGeometry } from '../managers/SnapManager/BoundsSnaps'
 import { HandleSnapGeometry } from '../managers/SnapManager/HandleSnaps'
 import { SvgExportContext } from '../types/SvgExportContext'
+import { TLClickEventInfo } from '../types/event-types'
 import { TLResizeHandle } from '../types/selection-types'
 
 /** @public */
@@ -671,25 +672,21 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * A callback called when a shape's edge is double clicked.
 	 *
 	 * @param shape - The shape.
+	 * @param info - Info about the edge.
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickEdge?(
-		shape: Shape,
-		info?: TLDoubleClickEdgeInfo<Shape>
-	): TLShapePartial<Shape> | void
+	onDoubleClickEdge?(shape: Shape, info: TLClickEventInfo): TLShapePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape's corner is double clicked.
 	 *
 	 * @param shape - The shape.
+	 * @param info - Info about the corner.
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickCorner?(
-		shape: Shape,
-		info?: TLDoubleClickEdgeInfo<Shape>
-	): TLShapePartial<Shape> | void
+	onDoubleClickCorner?(shape: Shape, info: TLClickEventInfo): TLShapePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape is double clicked.
@@ -774,9 +771,4 @@ export interface TLHandleDragInfo<T extends TLShape> {
 	handle: TLHandle
 	isPrecise: boolean
 	initial?: T | undefined
-}
-
-/** @public */
-export interface TLDoubleClickEdgeInfo<T extends TLShape> {
-	edge: SelectionEdge
 }

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -674,7 +674,22 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickEdge?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void
+	onDoubleClickEdge?(
+		shape: Shape,
+		info?: TLDoubleClickEdgeInfo<Shape>
+	): TLShapePartial<Shape> | void
+
+	/**
+	 * A callback called when a shape's corner is double clicked.
+	 *
+	 * @param shape - The shape.
+	 * @returns A change to apply to the shape, or void.
+	 * @public
+	 */
+	onDoubleClickCorner?(
+		shape: Shape,
+		info?: TLDoubleClickEdgeInfo<Shape>
+	): TLShapePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape is double clicked.

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -11,7 +11,7 @@ import {
 	TLUnknownShape,
 } from '@tldraw/tlschema'
 import { ReactElement } from 'react'
-import { Box, SelectionHandle } from '../../primitives/Box'
+import { Box, SelectionEdge, SelectionHandle } from '../../primitives/Box'
 import { Vec } from '../../primitives/Vec'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import type { Editor } from '../Editor'
@@ -674,7 +674,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @returns A change to apply to the shape, or void.
 	 * @public
 	 */
-	onDoubleClickEdge?(shape: Shape): TLShapePartial<Shape> | void
+	onDoubleClickEdge?(shape: Shape, info?: TLDoubleClickEdgeInfo<Shape>): TLShapePartial<Shape> | void
 
 	/**
 	 * A callback called when a shape is double clicked.
@@ -759,4 +759,9 @@ export interface TLHandleDragInfo<T extends TLShape> {
 	handle: TLHandle
 	isPrecise: boolean
 	initial?: T | undefined
+}
+
+/** @public */
+export interface TLDoubleClickEdgeInfo<T extends TLShape> {
+	edge: SelectionEdge
 }

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -118,7 +118,6 @@ import { TLSchema } from '@tldraw/editor';
 import { TLScribbleProps } from '@tldraw/editor';
 import { TLSelectionBackgroundProps } from '@tldraw/editor';
 import { TLSelectionForegroundProps } from '@tldraw/editor';
-import { TLSelectionHandle } from '@tldraw/editor';
 import { TLShape } from '@tldraw/editor';
 import { TLShapeCrop } from '@tldraw/editor';
 import { TLShapeId } from '@tldraw/editor';
@@ -1220,9 +1219,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
         type: "frame";
     };
     // (undocumented)
-    onDoubleClickEdge(shape: TLFrameShape, info: TLClickEventInfo & {
-        handle?: TLSelectionHandle;
-    }): {
+    onDoubleClickEdge(shape: TLFrameShape, info: TLClickEventInfo): {
         id: TLShapeId;
         props: {
             h: number;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1215,6 +1215,11 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
+    onDoubleClickCorner(shape: TLFrameShape): {
+        id: TLShapeId;
+        type: "frame";
+    };
+    // (undocumented)
     onDoubleClickEdge(shape: TLFrameShape, info: TLDoubleClickEdgeInfo<TLFrameShape>): {
         id: TLShapeId;
         type: "frame";

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -77,7 +77,7 @@ import { TLDefaultFontStyle } from '@tldraw/editor';
 import { TLDefaultHorizontalAlignStyle } from '@tldraw/editor';
 import { TLDefaultSizeStyle } from '@tldraw/editor';
 import { TLDefaultVerticalAlignStyle } from '@tldraw/editor';
-import { TLDoubleClickEdgeInfo } from '@tldraw/editor/src/lib/editor/shapes/ShapeUtil';
+import { TLDoubleClickEdgeInfo } from '@tldraw/editor';
 import { TldrawEditorBaseProps } from '@tldraw/editor';
 import { TldrawEditorStoreProps } from '@tldraw/editor';
 import { TLDrawShape } from '@tldraw/editor';

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -77,6 +77,7 @@ import { TLDefaultFontStyle } from '@tldraw/editor';
 import { TLDefaultHorizontalAlignStyle } from '@tldraw/editor';
 import { TLDefaultSizeStyle } from '@tldraw/editor';
 import { TLDefaultVerticalAlignStyle } from '@tldraw/editor';
+import { TLDoubleClickEdgeInfo } from '@tldraw/editor/src/lib/editor/shapes/ShapeUtil';
 import { TldrawEditorBaseProps } from '@tldraw/editor';
 import { TldrawEditorStoreProps } from '@tldraw/editor';
 import { TLDrawShape } from '@tldraw/editor';
@@ -1213,6 +1214,11 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     indicator(shape: TLFrameShape): JSX_2.Element;
     // (undocumented)
     static migrations: TLPropsMigrations;
+    // (undocumented)
+    onDoubleClickEdge(shape: TLFrameShape, info: TLDoubleClickEdgeInfo<TLFrameShape>): {
+        id: TLShapeId;
+        type: "frame";
+    } | undefined;
     // (undocumented)
     onDragShapesOut(_shape: TLFrameShape, shapes: TLShape[]): void;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -77,7 +77,6 @@ import { TLDefaultFontStyle } from '@tldraw/editor';
 import { TLDefaultHorizontalAlignStyle } from '@tldraw/editor';
 import { TLDefaultSizeStyle } from '@tldraw/editor';
 import { TLDefaultVerticalAlignStyle } from '@tldraw/editor';
-import { TLDoubleClickEdgeInfo } from '@tldraw/editor';
 import { TldrawEditorBaseProps } from '@tldraw/editor';
 import { TldrawEditorStoreProps } from '@tldraw/editor';
 import { TLDrawShape } from '@tldraw/editor';
@@ -119,6 +118,7 @@ import { TLSchema } from '@tldraw/editor';
 import { TLScribbleProps } from '@tldraw/editor';
 import { TLSelectionBackgroundProps } from '@tldraw/editor';
 import { TLSelectionForegroundProps } from '@tldraw/editor';
+import { TLSelectionHandle } from '@tldraw/editor';
 import { TLShape } from '@tldraw/editor';
 import { TLShapeCrop } from '@tldraw/editor';
 import { TLShapeId } from '@tldraw/editor';
@@ -1220,8 +1220,14 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
         type: "frame";
     };
     // (undocumented)
-    onDoubleClickEdge(shape: TLFrameShape, info: TLDoubleClickEdgeInfo<TLFrameShape>): {
+    onDoubleClickEdge(shape: TLFrameShape, info: TLClickEventInfo & {
+        handle?: TLSelectionHandle;
+    }): {
         id: TLShapeId;
+        props: {
+            h: number;
+            w: number;
+        };
         type: "frame";
     } | undefined;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -6,6 +6,7 @@ import {
 	Rectangle2d,
 	SVGContainer,
 	SvgExportContext,
+	TLDoubleClickEdgeInfo,
 	TLFrameShape,
 	TLFrameShapeProps,
 	TLGroupShape,
@@ -23,10 +24,9 @@ import {
 	resizeBox,
 	toDomPrecision,
 	useValue,
-	TLDoubleClickEdgeInfo,
 } from '@tldraw/editor'
 import classNames from 'classnames'
-import { getFrameChildrenBounds } from '../../utils/frames/frames'
+import { fitFrameToContent, getFrameChildrenBounds } from '../../utils/frames/frames'
 import {
 	TLCreateTextJsxFromSpansOpts,
 	createTextJsxFromSpans,
@@ -401,6 +401,14 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 			this.editor.updateShapes(changes)
 		})
 
+		return {
+			id: shape.id,
+			type: shape.type,
+		}
+	}
+
+	override onDoubleClickCorner(shape: TLFrameShape) {
+		fitFrameToContent(this.editor, shape.id, { padding: 10 })
 		return {
 			id: shape.id,
 			type: shape.type,

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -15,7 +15,6 @@ import {
 	TLShape,
 	TLShapePartial,
 	TLShapeUtilConstructor,
-	Vec,
 	clamp,
 	compact,
 	frameShapeMigrations,
@@ -383,7 +382,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		if (!children.length) return
 
 		const { dx, dy, w, h } = getFrameChildrenBounds(children, this.editor, { padding: 10 })
-		const diff = new Vec(dx, dy).rot(shape.rotation)
 
 		this.editor.run(() => {
 			const changes: TLShapePartial[] = childIds.map((childId) => {

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -11,7 +11,6 @@ import {
 	TLFrameShapeProps,
 	TLGroupShape,
 	TLResizeInfo,
-	TLSelectionHandle,
 	TLShape,
 	TLShapePartial,
 	TLShapeUtilConstructor,
@@ -365,10 +364,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		}
 	}
 
-	override onDoubleClickEdge(
-		shape: TLFrameShape,
-		info: TLClickEventInfo & { handle?: TLSelectionHandle }
-	) {
+	override onDoubleClickEdge(shape: TLFrameShape, info: TLClickEventInfo) {
+		if (info.target !== 'selection') return
 		const { handle } = info
 
 		// If handle is missing, we can't determine which edge was clicked

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -23,8 +23,8 @@ import {
 	resizeBox,
 	toDomPrecision,
 	useValue,
+	TLDoubleClickEdgeInfo,
 } from '@tldraw/editor'
-import { TLDoubleClickEdgeInfo } from '@tldraw/editor/src/lib/editor/shapes/ShapeUtil'
 import classNames from 'classnames'
 import { getFrameChildrenBounds } from '../../utils/frames/frames'
 import {

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -6,11 +6,12 @@ import {
 	Rectangle2d,
 	SVGContainer,
 	SvgExportContext,
-	TLDoubleClickEdgeInfo,
+	TLClickEventInfo,
 	TLFrameShape,
 	TLFrameShapeProps,
 	TLGroupShape,
 	TLResizeInfo,
+	TLSelectionHandle,
 	TLShape,
 	TLShapePartial,
 	TLShapeUtilConstructor,
@@ -365,8 +366,15 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		}
 	}
 
-	override onDoubleClickEdge(shape: TLFrameShape, info: TLDoubleClickEdgeInfo<TLFrameShape>) {
+	override onDoubleClickEdge(
+		shape: TLFrameShape,
+		info: TLClickEventInfo & { handle?: TLSelectionHandle }
+	) {
 		const { handle } = info
+
+		// If handle is missing, we can't determine which edge was clicked
+		if (!handle) return
+
 		const isHorizontalEdge = handle === 'left' || handle === 'right'
 		const isVerticalEdge = handle === 'top' || handle === 'bottom'
 

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -366,6 +366,10 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	override onDoubleClickEdge(shape: TLFrameShape, info: TLDoubleClickEdgeInfo<TLFrameShape>) {
+		const { handle } = info
+		const isHorizontalEdge = handle === 'left' || handle === 'right'
+		const isVerticalEdge = handle === 'top' || handle === 'bottom'
+
 		const childIds = this.editor.getSortedChildIdsForParent(shape.id)
 		const children = compact(childIds.map((id) => this.editor.getShape(id)))
 		if (!children.length) return
@@ -374,9 +378,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		const diff = new Vec(dx, dy).rot(shape.rotation)
 
 		this.editor.run(() => {
-			const isHorizontalEdge = info.edge === 'left' || info.edge === 'right'
-			const isVerticalEdge = info.edge === 'top' || info.edge === 'bottom'
-
 			const changes: TLShapePartial[] = childIds.map((childId) => {
 				const childShape = this.editor.getShape(childId)!
 				return {
@@ -387,23 +388,16 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 				}
 			})
 
-			changes.push({
-				id: shape.id,
-				type: shape.type,
-				x: isHorizontalEdge ? shape.x - diff.x : shape.x,
-				y: isVerticalEdge ? shape.y - diff.y : shape.y,
-				props: {
-					w: isHorizontalEdge ? w : shape.props.w,
-					h: isVerticalEdge ? h : shape.props.h,
-				},
-			})
-
 			this.editor.updateShapes(changes)
 		})
 
 		return {
 			id: shape.id,
 			type: shape.type,
+			props: {
+				w: isHorizontalEdge ? w : shape.props.w,
+				h: isVerticalEdge ? h : shape.props.h,
+			},
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -124,7 +124,7 @@ export class Idle extends StateNode {
 		if (!util) return
 
 		if (info.target === 'selection') {
-			util.onDoubleClickEdge?.(shape)
+			util.onDoubleClickEdge?.(shape, info)
 			return
 		}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -270,6 +270,20 @@ export class Idle extends StateNode {
 						}
 					}
 
+					if (
+						info.handle === 'top_left' ||
+						info.handle === 'top_right' ||
+						info.handle === 'bottom_right' ||
+						info.handle === 'bottom_left'
+					) {
+						const change = util.onDoubleClickCorner?.(onlySelectedShape)
+						if (change) {
+							this.editor.markHistoryStoppingPoint('double click corner')
+							this.editor.updateShapes([change])
+							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
+							return
+						}
+					}
 					// For corners OR edges but NOT rotation corners
 					if (
 						util.canCrop(onlySelectedShape) &&

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -261,7 +261,7 @@ export class Idle extends StateNode {
 						info.handle === 'top' ||
 						info.handle === 'bottom'
 					) {
-						const change = util.onDoubleClickEdge?.(onlySelectedShape, { edge: info.handle })
+						const change = util.onDoubleClickEdge?.(onlySelectedShape, info)
 						if (change) {
 							this.editor.markHistoryStoppingPoint('double click edge')
 							this.editor.updateShapes([change])
@@ -276,7 +276,7 @@ export class Idle extends StateNode {
 						info.handle === 'bottom_right' ||
 						info.handle === 'bottom_left'
 					) {
-						const change = util.onDoubleClickCorner?.(onlySelectedShape)
+						const change = util.onDoubleClickCorner?.(onlySelectedShape, info)
 						if (change) {
 							this.editor.markHistoryStoppingPoint('double click corner')
 							this.editor.updateShapes([change])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -261,7 +261,7 @@ export class Idle extends StateNode {
 						info.handle === 'top' ||
 						info.handle === 'bottom'
 					) {
-						const change = util.onDoubleClickEdge?.(onlySelectedShape)
+						const change = util.onDoubleClickEdge?.(onlySelectedShape, { edge: info.handle })
 						if (change) {
 							this.editor.markHistoryStoppingPoint('double click edge')
 							this.editor.updateShapes([change])


### PR DESCRIPTION
## Summary
This pull request adds a double-click interaction on frame edges and corners to trigger a "fit frame to content" resizing behavior. When a user double-clicks a frame’s edge or corner, the frame resizes to fit its child elements along the corresponding axis or axes.

## Changes
- **New double-click handlers:** Introduced optional `onDoubleClickEdge` and `onDoubleClickCorner` callbacks in the shape utilities, with a supporting `TLDoubleClickEdgeInfo` type to identify which edge was double-clicked.
- **Frame auto-resize behavior:** Implemented double-click handlers in `FrameShapeUtil`:
  - Double-clicking a **top** or **bottom** edge resizes the frame vertically based on the bounds of its children, maintaining standard padding.
  - Double-clicking a **left** or **right** edge resizes the frame horizontally.
  - Double-clicking a **corner** resizes the frame both vertically and horizontally.
  - Child elements retain their canvas positions during the resize operation; the frame’s position and dimensions are adjusted accordingly.
- **Selection tool updates:** Updated the selection tool’s idle state to detect double-click events on edge and corner handles:
  - Edge handles trigger `onDoubleClickEdge`.
  - Corner handles trigger `onDoubleClickCorner`.
- **Padding and rotation handling:** Resizing logic respects frame padding and correctly handles rotated frames.
- **Additional behaviors:**
  - Double-clicking an edge or corner has no effect if the frame has no children.
  - Shapes located entirely outside the new frame bounds after resizing are removed from the frame.

## Notes
- **User impact:** No breaking changes. Existing frame behaviors are unchanged.
- **Scope:** The double-click fit behavior is implemented for frames only. Other shapes are unaffected.
- **Related issue:** Resolves #5546.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test Plan

1. **Create a new frame.**
2. **Double-click on the edge of the frame.**
   - The frame should automatically resize based on its current contents.
3. **Add content (shapes, text, etc.) inside the frame.**
4. **Double-click on the frame's edge again.**
   - The frame should resize to fit the newly added content, adjusting appropriately on all sides.
5. **Create a second frame.**
6. **Add content inside the second frame.**
7. **Double-click any edge of the second frame.**
   - The frame should adjust its size on both the x-axis (width) and y-axis (height) to fit all enclosed content.

### Release notes
- Frames can now be resized to fit their contents by double-clicking their edges.