### PR TITLE
Fix gradients / hovers for open submenus

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -86,18 +86,11 @@
 	position: absolute;
 	inset: 4px;
 	border-radius: var(--radius-2);
-	background-color: var(--color-muted-2);
+	background: var(--color-muted-2);
 	opacity: 0;
 }
 
-@media (hover: hover) {
-	.tlui-button:not(:disabled):hover::after {
-		opacity: 1;
-	}
-}
-
-.tlui-button__menu[data-highlighted]::after,
-.tlui-button[aria-expanded='true']::after {
+.tlui-button__menu[data-highlighted]::after {
 	opacity: 1;
 }
 
@@ -105,6 +98,17 @@
 .tlui-button[data-state='hinted']:not(:disabled, :focus-visible):active:after {
 	background: var(--color-hint);
 	opacity: 1;
+}
+
+.tlui-button[aria-expanded='true'][data-direction='left']:not(:hover)::after {
+	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	opacity: 1;
+}
+
+@media (hover: hover) {
+	.tlui-button:not(:disabled):hover::after {
+		opacity: 1;
+	}
 }
 
 .tlui-button__icon + .tlui-button__label {
@@ -609,8 +613,9 @@
 	background-color: var(--color-low);
 }
 
-.tlui-menu-zone *[data-state='open']::after {
+.tlui-menu-zone *[data-state='open']:not(:hover)::after {
 	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	opacity: 1;
 }
 
 /* ------------------- Style Panel ------------------ */
@@ -694,8 +699,9 @@
 	max-width: 100%;
 }
 
-.tlui-style-panel__section *[data-state='open']::after {
-	background: var(--color-muted-0);
+.tlui-style-panel .tlui-button[data-state='open']:not(:hover)::after {
+	opacity: 1;
+	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
 /* ---------------------- Input --------------------- */
@@ -922,7 +928,7 @@
 	padding: 0px;
 }
 
-.tlui-layout__mobile .tlui-toolbar *[data-state='open']::after {
+.tlui-toolbar *[data-state='open']:not(:hover)::after {
 	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
@@ -1003,12 +1009,12 @@
 }
 
 .tlui-menu__submenu__trigger[data-state='open']:not(:hover)::after {
-	border-radius: 0px;
+	opacity: 1;
 	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
 .tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
-	border-radius: 0px;
+	opacity: 1;
 	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 
@@ -1313,12 +1319,12 @@
 	position: relative;
 }
 
+.tlui-page_menu__item__submenu[data-isediting='true'] > .tlui-button[data-state='open'] {
+	opacity: 1;
+}
+
 @media (hover: hover) {
 	.tlui-page-menu__item:hover > .tlui-page_menu__item__submenu > .tlui-button {
-		opacity: 1;
-	}
-
-	.tlui-page_menu__item__submenu[data-isediting='true'] > .tlui-button[data-state='open'] {
 		opacity: 1;
 	}
 }
@@ -1432,8 +1438,7 @@
 	opacity: 1;
 }
 
-.tlui-page_menu__item__submenu > .tlui-button[data-state='open']::after {
-	border-radius: 0px;
+.tlui-page_menu__item__submenu > .tlui-button[data-state='open']:not(:hover)::after {
 	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
 }
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1317,6 +1317,10 @@
 	.tlui-page-menu__item:hover > .tlui-page_menu__item__submenu > .tlui-button {
 		opacity: 1;
 	}
+
+	.tlui-page_menu__item__submenu[data-isediting='true'] > .tlui-button[data-state='open'] {
+		opacity: 1;
+	}
 }
 
 .tlui-page-menu__item:nth-of-type(n + 2) {

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -59,7 +59,12 @@ function DropdownPickerInner<T extends string>({
 	return (
 		<TldrawUiPopover id={popoverId} open={isOpen} onOpenChange={setIsOpen}>
 			<TldrawUiPopoverTrigger>
-				<TldrawUiToolbarButton type={type} data-testid={`style.${uiType}`} title={titleStr}>
+				<TldrawUiToolbarButton
+					type={type}
+					data-testid={`style.${uiType}`}
+					data-direction="left"
+					title={titleStr}
+				>
 					{labelStr && <TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>}
 					<TldrawUiButtonIcon icon={(icon as TLUiIconType) ?? 'mixed'} />
 				</TldrawUiToolbarButton>


### PR DESCRIPTION
This PR fixes / standardizes the display of gradients and hover interactions on submenus.

Toolbar:
![Kapture 2025-04-29 at 12 25 58](https://github.com/user-attachments/assets/ab7cbb5d-e449-411f-bf30-57e8caad5000)

Submenu:
![Kapture 2025-04-29 at 12 27 43](https://github.com/user-attachments/assets/469495f9-6a3b-420b-97ad-d6bbc22b807a)

Page menu:
![Uploading Kapture 2025-04-29 at 12.30.58.gif…]()

### Change type

- [x] `bugfix`

### Test plan

1. Try submenu hovers

### Release notes

- Standardizes hovers in the UI for submenus items.