### PR TITLE
Bump again. (#5972)

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -31,7 +31,7 @@
 		"@radix-ui/react-popover": "^1.1.5",
 		"@radix-ui/react-select": "^2.1.5",
 		"@radix-ui/react-tooltip": "^1.1.7",
-		"@rocicorp/zero": "0.19.2025042502",
+		"@rocicorp/zero": "0.19.2025042700",
 		"@sentry/integrations": "^7.120.3",
 		"@sentry/react": "^7.120.3",
 		"@tldraw/assets": "workspace:*",

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"@clerk/backend": "^1.23.7",
-		"@rocicorp/zero": "0.19.2025042502",
+		"@rocicorp/zero": "0.19.2025042700",
 		"@supabase/auth-helpers-remix": "^0.2.6",
 		"@supabase/supabase-js": "^2.48.1",
 		"@tldraw/dotcom-shared": "workspace:*",

--- a/apps/dotcom/sync-worker/src/postgres.ts
+++ b/apps/dotcom/sync-worker/src/postgres.ts
@@ -1,7 +1,7 @@
-import type {
-	PostgresSQL,
-	PostgresTransaction,
-} from '@rocicorp/zero/out/zero-pg/src/postgres-connection'
+import {
+	PostgresJSClient,
+	PostgresJSTransaction,
+} from '@rocicorp/zero/out/zero-pg/src/zql-postgresjs-provider'
 import { DB } from '@tldraw/dotcom-shared'
 import { Kysely, PostgresDialect } from 'kysely'
 import * as pg from 'pg'
@@ -29,7 +29,7 @@ export function createPostgresConnectionPool(env: Environment, name: string, max
 	return db
 }
 
-export function makePostgresConnector(env: Environment): PostgresSQL<any> {
+export function makePostgresConnector(env: Environment): PostgresJSClient<any> {
 	const pool = new pg.Pool({
 		connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
 		application_name: 'zero-pg',
@@ -42,7 +42,7 @@ export function makePostgresConnector(env: Environment): PostgresSQL<any> {
 			const res = await pool.query(sqlString, params)
 			return res.rows
 		},
-		async begin(fn: (tx: PostgresTransaction) => Promise<any>): Promise<any> {
+		async begin(fn: (tx: PostgresJSTransaction) => Promise<any>): Promise<any> {
 			const client = await pool.connect()
 			try {
 				await client.query('BEGIN')

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -13,7 +13,8 @@ import { WorkerEntrypoint } from 'cloudflare:workers'
 import { cors, json } from 'itty-router'
 import {
 	PushProcessor,
-	connectionProvider,
+	ZQLDatabaseProvider,
+	ZQLPostgresJSAdapter,
 } from '../../../../node_modules/@rocicorp/zero/out/zero/src/pg'
 import { adminRoutes } from './adminRoutes'
 import { POSTHOG_URL } from './config'
@@ -139,8 +140,7 @@ const router = createRouter<Environment>()
 		const auth = await requireAuth(req, env)
 		try {
 			const processor = new PushProcessor(
-				schema,
-				connectionProvider(makePostgresConnector(env)),
+				new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(makePostgresConnector(env)), schema),
 				'debug'
 			)
 			const result = await processor.process(createMutators(auth.userId), req, await req.json())

--- a/apps/dotcom/zero-cache/flyio.template.toml
+++ b/apps/dotcom/zero-cache/flyio.template.toml
@@ -34,3 +34,4 @@ ZERO_CHANGE_DB = "__BOTCOM_POSTGRES_CONNECTION_STRING"
 ZERO_AUTH_JWKS_URL = "https://clerk.staging.tldraw.com/.well-known/jwks.json"
 LOG_LEVEL = "debug"
 ZERO_PUSH_URL = "__ZERO_PUSH_URL"
+ZERO_RUN_LAZILY = 'true'

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -23,7 +23,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "0.19.2025042502",
+		"@rocicorp/zero": "0.19.2025042700",
 		"kysely": "^0.27.5",
 		"pg": "^8.13.1"
 	},

--- a/packages/dotcom-shared/package.json
+++ b/packages/dotcom-shared/package.json
@@ -9,7 +9,7 @@
 	"files": [],
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "0.19.2025042502",
+		"@rocicorp/zero": "0.19.2025042700",
 		"@tldraw/state": "workspace:*",
 		"@tldraw/store": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6492,9 +6492,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocicorp/zero@npm:0.19.2025042502":
-  version: 0.19.2025042502
-  resolution: "@rocicorp/zero@npm:0.19.2025042502"
+"@rocicorp/zero@npm:0.19.2025042700":
+  version: 0.19.2025042700
+  resolution: "@rocicorp/zero@npm:0.19.2025042700"
   dependencies:
     "@badrap/valita": "npm:0.3.11"
     "@databases/escape-identifier": "npm:^1.0.3"
@@ -6547,7 +6547,7 @@ __metadata:
     zero-cache: out/zero/src/cli.js
     zero-cache-dev: out/zero/src/zero-cache-dev.js
     zero-deploy-permissions: out/zero/src/deploy-permissions.js
-  checksum: 10/44871a58fd6c01e7852e744a2eba2be518e80244825b1661249fa2060f418a62793671f74e82950b186fe29f6e2285a59de470e27647a34964cd235cef3ce717
+  checksum: 10/5b92b3f108e9eb8b766c821bcf9079fea29b1d99338e4d2a917b0b9f9d252a32507b41f660cd12c9cbc7d7fb0ce46f613d3a383088bcf97fb21ef6264c313358
   languageName: node
   linkType: hard
 
@@ -8579,7 +8579,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/dotcom-shared@workspace:packages/dotcom-shared"
   dependencies:
-    "@rocicorp/zero": "npm:0.19.2025042502"
+    "@rocicorp/zero": "npm:0.19.2025042700"
     "@tldraw/state": "workspace:*"
     "@tldraw/store": "workspace:*"
     "@tldraw/tlschema": "workspace:*"
@@ -8602,7 +8602,7 @@ __metadata:
   dependencies:
     "@clerk/backend": "npm:^1.23.7"
     "@cloudflare/workers-types": "npm:^4.20250224.0"
-    "@rocicorp/zero": "npm:0.19.2025042502"
+    "@rocicorp/zero": "npm:0.19.2025042700"
     "@supabase/auth-helpers-remix": "npm:^0.2.6"
     "@supabase/supabase-js": "npm:^2.48.1"
     "@tldraw/dotcom-shared": "workspace:*"
@@ -8961,7 +8961,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/zero-cache@workspace:apps/dotcom/zero-cache"
   dependencies:
-    "@rocicorp/zero": "npm:0.19.2025042502"
+    "@rocicorp/zero": "npm:0.19.2025042700"
     concurrently: "npm:^9.1.2"
     dotenv: "npm:^16.4.7"
     esbuild: "npm:^0.24.2"
@@ -13658,7 +13658,7 @@ __metadata:
     "@radix-ui/react-popover": "npm:^1.1.5"
     "@radix-ui/react-select": "npm:^2.1.5"
     "@radix-ui/react-tooltip": "npm:^1.1.7"
-    "@rocicorp/zero": "npm:0.19.2025042502"
+    "@rocicorp/zero": "npm:0.19.2025042700"
     "@sentry/cli": "npm:^2.41.1"
     "@sentry/integrations": "npm:^7.120.3"
     "@sentry/react": "npm:^7.120.3"


### PR DESCRIPTION
Bump zero again. Looks like the previous version had an issue with getting deployed to regions other than us-east-1.

Saw this issue and managed to find a conversation about this on zero:

>
{"timestamp":"2025-04-29T07:39:22.523281477Z","level":"ERROR","message":"failed to run","worker":"litestream","error":"cannot fetch generations: cannot lookup bucket region: Forbidden: Forbidden\n\tstatus code: 403, request id: SVB6A1Y3X2F7VNWC, host id:
KXXdXNkPzyRO8PYGCqtXnCgdIP8BFVRxLNTl+8+hB2Aqw/H8pv49DLpJCtkL4NUPy2/27jjmXaODfoxAvY0shMJ+QZiNBrEQ"}


https://discord.com/channels/830183651022471199/1288232858795769917/1365126106621149255


### Change type

- [x] `bugfix`

