### PR TITLE
Fix active states for buttons in toolbars

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -101,8 +101,8 @@
 	opacity: 1;
 }
 
-.tlui-button[data-state='hinted']::after,
-.tlui-button[data-state='hinted']:not(:disabled, :focus-visible):active:after {
+.tlui-button[data-isactive='true']:not(:disabled, :focus-visible, :hover)::after,
+.tlui-button[data-isactive='true']:not(:disabled, :focus-visible):active:after {
 	background: var(--color-hint);
 	opacity: 1;
 }

--- a/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceColorPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceColorPicker.tsx
@@ -108,7 +108,7 @@ export const UserPresenceColorPicker = track(function UserPresenceColorPicker() 
 								data-id={item}
 								data-testid={item}
 								aria-label={item}
-								data-state={value === item ? 'hinted' : undefined}
+								isActive={value === item}
 								title={item}
 								className={'tlui-button-grid__button'}
 								style={{ color: item }}

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -64,7 +64,7 @@ function DropdownPickerInner<T extends string>({
 					<TldrawUiButtonIcon icon={(icon as TLUiIconType) ?? 'mixed'} />
 				</TldrawUiToolbarButton>
 			</TldrawUiPopoverTrigger>
-			<TldrawUiPopoverContent side="left" align="center" alignOffset={0}>
+			<TldrawUiPopoverContent side="left" align="center">
 				<TldrawUiToolbar
 					label={labelStr}
 					className={classNames('tlui-buttons__grid', `tlui-buttons__${stylePanelType}`)}
@@ -81,6 +81,7 @@ function DropdownPickerInner<T extends string>({
 										' — ' +
 										msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
 									}
+									isActive={icon === item.icon}
 									onClick={() => {
 										editor.markHistoryStoppingPoint('select style dropdown item')
 										onValueChange(style, item.value)

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -132,9 +132,7 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 						data-testid={`style.${uiType}.${item.value}`}
 						aria-label={label}
 						value={item.value}
-						data-state={
-							value.type === 'shared' && value.value === item.value ? 'hinted' : undefined
-						}
+						data-isactive={value.type === 'shared' && value.value === item.value}
 						title={label}
 						className={classNames('tlui-button-grid__button')}
 						style={


### PR DESCRIPTION
This PR fixes a bug where active items were not shown in style panel toolbars.

Before:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/14024942-41b7-4054-917e-f37e466636fd" />

After:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/4f92add6-e1ad-439f-9d73-2a62749cec4e" />


### Change type

- [x] `bugfix`

### Test plan

1. Open some menus

### Release notes

- Fixed a bug in the UI where active items in dropdowns weren't displayed as active