### PR TITLE
Restore deleted margin in style panel

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -666,6 +666,7 @@
 }
 
 .tlui-style-panel__section__common:not(:only-child) {
+	margin-bottom: 7px;
 	border-bottom: 1px solid var(--color-divider);
 }
 


### PR DESCRIPTION
This was removed and it shouldn't have been.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
