### PR TITLE
Fix control button wheel bug

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10214,7 +10214,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 					// If the camera behavior is "zoom" and the ctrl key is pressed, then pan;
 					// If the camera behavior is "pan" and the ctrl key is not pressed, then zoom
-					if (inputs.ctrlKey) behavior = wheelBehavior === 'pan' ? 'zoom' : 'pan'
+					if (info.ctrlKey) behavior = wheelBehavior === 'pan' ? 'zoom' : 'pan'
 
 					switch (behavior) {
 						case 'zoom': {


### PR DESCRIPTION
This PR fixes a bug with the scroll wheel while the camera wheel behavior is set to pan.

Rather than listening to the `inputs.ctrlKey`, which has a 150ms delay when the key is released (for reasons), we listen instead to the actual event being sent. 

Closes https://github.com/tldraw/tldraw/issues/4610

### Change type

- [x] `bugfix`

### Test plan

1. Set wheelBehavior to zoom
2. Hold down ctrl and pan with the scroll wheel or touchpad
3. Release ctrl and make sure you send at least one more wheel event, but no other events within 150ms of releasing ctrl
3. Now wheel/touchpad will zoom.

### Release notes

- Fixed a bug causing the control key to be seen as pressed even after releasing when wheeling