### PR TITLE
don't lint .schema.js

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ export default [
 			'**/patchedJestJsDom.js',
 			'**/.clasp.json',
 			'**/*.mjs',
+			'**/.*.js',
 			'packages/assets/*',
 		],
 	},


### PR DESCRIPTION
we have this bundle for zero permissions called .schema.js in the zero-cache folder, and apparently sometimes we are calling yarn lint after this .schema.js file has been generated, which was erroring because of course.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
