### PR TITLE
a11y: fix some dotcom issues

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
@@ -16,6 +16,7 @@ import { TlaAnonCopyLinkTab } from './Tabs/TlaAnonCopyLinkTab'
 import { TlaExportTab } from './Tabs/TlaExportTab'
 import { TlaInviteTab } from './Tabs/TlaInviteTab'
 import { TlaPublishTab } from './Tabs/TlaPublishTab'
+import styles from './file-share-menu.module.css'
 
 export function TlaFileShareMenu({
 	fileId,
@@ -80,51 +81,53 @@ export function TlaFileShareMenu({
 			<TldrawUiPopover id={`share-${fileId}-${source}`}>
 				<TldrawUiPopoverTrigger>{children}</TldrawUiPopoverTrigger>
 				<TldrawUiPopoverContent side="bottom" alignOffset={-2} sideOffset={4}>
-					<TlaTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
-						<TlaTabsTabs>
-							{/* Disable share when on a scratchpad file */}
-							{okTabs.share && (
-								<TlaTabsTab id="share" data-testid="tla-share-tab-button-share">
-									<F defaultMessage="Invite" />
+					<div className={styles.shareMenu}>
+						<TlaTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
+							<TlaTabsTabs>
+								{/* Disable share when on a scratchpad file */}
+								{okTabs.share && (
+									<TlaTabsTab id="share" data-testid="tla-share-tab-button-share">
+										<F defaultMessage="Invite" />
+									</TlaTabsTab>
+								)}
+								{okTabs['anon-share'] && (
+									<TlaTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
+										<F defaultMessage="Share" />
+									</TlaTabsTab>
+								)}
+								{/* Always show export */}
+								<TlaTabsTab id="export" data-testid="tla-share-tab-button-export">
+									<F defaultMessage="Export" />
 								</TlaTabsTab>
+								{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
+								{okTabs.publish && (
+									<TlaTabsTab id="publish" data-testid="tla-share-tab-button-publish">
+										<F defaultMessage="Publish" />
+									</TlaTabsTab>
+								)}
+							</TlaTabsTabs>
+							{okTabs.share && fileId && (
+								// We have a file and we're authenticated
+								<TlaTabsPage id="share" data-testid="tla-share-tab-page-share">
+									<TlaInviteTab fileId={fileId} />
+								</TlaTabsPage>
 							)}
 							{okTabs['anon-share'] && (
-								<TlaTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
-									<F defaultMessage="Share" />
-								</TlaTabsTab>
+								<TlaTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
+									<TlaAnonCopyLinkTab />
+								</TlaTabsPage>
 							)}
-							{/* Always show export */}
-							<TlaTabsTab id="export" data-testid="tla-share-tab-button-export">
-								<F defaultMessage="Export" />
-							</TlaTabsTab>
-							{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
-							{okTabs.publish && (
-								<TlaTabsTab id="publish" data-testid="tla-share-tab-button-publish">
-									<F defaultMessage="Publish" />
-								</TlaTabsTab>
+							<TlaTabsPage id="export" data-testid="tla-share-tab-page-export">
+								<TlaExportTab />
+							</TlaTabsPage>
+							{/* Only show the publish tab if the file is owned by the user */}
+							{okTabs.publish && file && (
+								<TlaTabsPage id="publish" data-testid="tla-share-tab-page-publish">
+									<TlaPublishTab file={file} />
+								</TlaTabsPage>
 							)}
-						</TlaTabsTabs>
-						{okTabs.share && fileId && (
-							// We have a file and we're authenticated
-							<TlaTabsPage id="share" data-testid="tla-share-tab-page-share">
-								<TlaInviteTab fileId={fileId} />
-							</TlaTabsPage>
-						)}
-						{okTabs['anon-share'] && (
-							<TlaTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
-								<TlaAnonCopyLinkTab />
-							</TlaTabsPage>
-						)}
-						<TlaTabsPage id="export" data-testid="tla-share-tab-page-export">
-							<TlaExportTab />
-						</TlaTabsPage>
-						{/* Only show the publish tab if the file is owned by the user */}
-						{okTabs.publish && file && (
-							<TlaTabsPage id="publish" data-testid="tla-share-tab-page-publish">
-								<TlaPublishTab file={file} />
-							</TlaTabsPage>
-						)}
-					</TlaTabsRoot>
+						</TlaTabsRoot>
+					</div>
 				</TldrawUiPopoverContent>
 			</TldrawUiPopover>
 		</div>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
@@ -1,3 +1,7 @@
+.shareMenu {
+	min-width: 240px;
+}
+
 /* Copy button */
 
 .copyButtonIcon {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -62,7 +62,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 	const { onDrop, onDragOver, onDragEnter, onDragLeave, isDraggingOver } = useTldrFileDrop()
 
 	return (
-		<div ref={sidebarRef}>
+		<nav ref={sidebarRef}>
 			<button
 				className={styles.sidebarOverlayMobile}
 				data-visiblemobile={isSidebarOpenMobile}
@@ -95,6 +95,6 @@ export const TlaSidebar = memo(function TlaSidebar() {
 					<TlaSidebarUserLink />
 				</div>
 			</div>
-		</div>
+		</nav>
 	)
 })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -420,16 +420,16 @@
 	.linkMenu {
 		display: none;
 	}
-	:global(.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))) .linkMenu {
-		display: flex;
-	}
 	/*
 		For guest files we show a guest icon at the end of the filename
 		but we don't want it to jump out of the way when the user hovers
 	*/
-
 	.link[data-is-own-file='false'] .linkMenu {
 		visibility: hidden;
+		display: flex;
+	}
+	:global(.tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))) .linkMenu {
+		visibility: visible;
 		display: flex;
 	}
 

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -158,7 +158,7 @@ export function TlaSidebarLayout({
 	}, [])
 
 	return (
-		<nav
+		<div
 			ref={rLayoutContainer}
 			className={styles.layout}
 			data-sidebar={!isEmbed && isSidebarOpen}
@@ -189,6 +189,6 @@ export function TlaSidebarLayout({
 					)}
 				</>
 			)}
-		</nav>
+		</div>
 	)
 }


### PR DESCRIPTION
some more dotcom tweaks for a11y:
- we put `<nav>` in the wrong spot, oops
- the Share menu lost it's min-width accidentally
- files shared by others didn't show the menu when tabbing through

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
