### PR TITLE
Export custom bg color for single frame exports

### DIFF
--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -365,6 +365,21 @@ function SvgExport({
 		onMount()
 	}, [onMount, shapeElements])
 
+	let backgroundColor = background ? theme.background : 'transparent'
+
+	if (singleFrameShapeId && background) {
+		const frameShapeUtil = editor.getShapeUtil('frame') as any as
+			| undefined
+			| { options: { showColors: boolean } }
+		if (frameShapeUtil?.options.showColors) {
+			const shape = editor.getShape(singleFrameShapeId)! as TLFrameShape
+			const color = theme[shape.props.color]
+			backgroundColor = color.frame.fill
+		} else {
+			backgroundColor = theme.solid
+		}
+	}
+
 	return (
 		<SvgExportContextProvider editor={editor} context={exportContext}>
 			<svg
@@ -375,13 +390,7 @@ function SvgExport({
 				viewBox={`${bbox.minX} ${bbox.minY} ${bbox.width} ${bbox.height}`}
 				strokeLinecap="round"
 				strokeLinejoin="round"
-				style={{
-					backgroundColor: background
-						? singleFrameShapeId
-							? theme.solid
-							: theme.background
-						: 'transparent',
-				}}
+				style={{ backgroundColor }}
 				data-color-mode={isDarkMode ? 'dark' : 'light'}
 				className={`tl-container tl-theme__force-sRGB ${isDarkMode ? 'tl-theme__dark' : 'tl-theme__light'}`}
 			>


### PR DESCRIPTION
Fixes #5990 

### Change type

- [x] `bugfix`

### Release notes

- When exporting an individual frame as an image, if the frame has a custom color set, use that color for the background.