### PR TITLE
Better error reporting for sync worker

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
@@ -33,23 +33,20 @@ export async function getPublishedFile(request: IRequest, env: Environment): Pro
 		return Response.json({ error: true, message: 'Room ID is required' }, { status: 400 })
 	}
 
-	try {
-		const publishedRoomSnapshot = await getPublishedRoomSnapshot(env, roomId)
-		if (!publishedRoomSnapshot) throw Error('not found')
+	const publishedRoomSnapshot = await getPublishedRoomSnapshot(env, roomId)
+	if (!publishedRoomSnapshot)
+		return Response.json({ error: true, message: 'Room not found' }, { status: 404 })
 
-		const { documents, schema } = publishedRoomSnapshot
+	const { documents, schema } = publishedRoomSnapshot
 
-		return new Response(
-			JSON.stringify({
-				records: documents.map((d) => d.state),
-				schema: schema,
-				error: false,
-			}),
-			{
-				headers: { 'content-type': 'application/json' },
-			}
-		)
-	} catch (e: any) {
-		return new Response(JSON.stringify({ error: true, message: e.message }), { status: 500 })
-	}
+	return new Response(
+		JSON.stringify({
+			records: documents.map((d) => d.state),
+			schema: schema,
+			error: false,
+		}),
+		{
+			headers: { 'content-type': 'application/json' },
+		}
+	)
 }

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -8,7 +8,13 @@ import {
 	createMutators,
 	schema,
 } from '@tldraw/dotcom-shared'
-import { createRouter, handleApiRequest, handleUserAssetGet, notFound } from '@tldraw/worker-shared'
+import {
+	createRouter,
+	createSentry,
+	handleApiRequest,
+	handleUserAssetGet,
+	notFound,
+} from '@tldraw/worker-shared'
 import { WorkerEntrypoint } from 'cloudflare:workers'
 import { cors, json } from 'itty-router'
 import {
@@ -138,17 +144,12 @@ const router = createRouter<Environment>()
 	.all('/app/admin/*', adminRoutes.fetch)
 	.post('/app/zero/push', async (req, env) => {
 		const auth = await requireAuth(req, env)
-		try {
-			const processor = new PushProcessor(
-				new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(makePostgresConnector(env)), schema),
-				'debug'
-			)
-			const result = await processor.process(createMutators(auth.userId), req)
-			return json(result)
-		} catch (e) {
-			console.error('Error processing push', e)
-			return new Response('Error', { status: 500 })
-		}
+		const processor = new PushProcessor(
+			new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(makePostgresConnector(env)), schema),
+			'debug'
+		)
+		const result = await processor.process(createMutators(auth.userId), req)
+		return json(result)
 	})
 	.all('*', notFound)
 
@@ -183,6 +184,15 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 				}
 				return newResponse
 			},
+		}).catch((err) => {
+			const sentry = createSentry(this.ctx, this.env, request)
+			if (sentry) {
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				sentry.captureException(err)
+			} else {
+				console.error(err)
+			}
+			throw err
 		})
 	}
 }


### PR DESCRIPTION
trying to investigate https://github.com/tldraw/tldraw/issues/5959 it seemed like the 500s weren't making their way to sentry, and in the cloudflare logs all we see is that an 'internal server error' occurred, it doesn't have a stack trace.

Hopefully this fixes that.

### Change type

- [x] `other`
