### PR TITLE
disable auto flyio deploy since it's broken

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -56,8 +56,8 @@ jobs:
           elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-flyio-zero-deploy-please"; then
             echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
           elif git fetch origin "${GITHUB_BASE_REF}" && git diff --name-only origin/"${GITHUB_BASE_REF}"...HEAD | grep -q '^apps/dotcom/'; then
-            gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
-            echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
+            # gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
+            # echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
           else
             echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
           fi

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -58,6 +58,7 @@ jobs:
           elif git fetch origin "${GITHUB_BASE_REF}" && git diff --name-only origin/"${GITHUB_BASE_REF}"...HEAD | grep -q '^apps/dotcom/'; then
             # gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
             # echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
+            echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
           else
             echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
Flyio deploys are failing because we're trying to update the zero permissions table before zero has had a chance to init. Not sure how to fix but let's unblock folks in the meantime by disabling the flyio auto-labelling.

### Change type

- [x] `other`
