### PR TITLE
Select offscreen shapes

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -14,8 +14,8 @@ import {
 	Vec,
 	pointInPolygon,
 	polygonsIntersect,
+	react,
 } from '@tldraw/editor'
-import { react } from '@tldraw/state'
 
 export class Brushing extends StateNode {
 	static override id = 'brushing'

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -15,6 +15,7 @@ import {
 	pointInPolygon,
 	polygonsIntersect,
 } from '@tldraw/editor'
+import { react } from '@tldraw/state'
 
 export class Brushing extends StateNode {
 	static override id = 'brushing'
@@ -25,13 +26,30 @@ export class Brushing extends StateNode {
 	excludedShapeIds = new Set<TLShapeId>()
 	isWrapMode = false
 
+	viewportDidChange = false
+	cleanupViewportChangeReactor() {
+		void null
+	} // cleanup function for the viewport reactor
+
 	// The shape that the brush started on
 	initialStartShape: TLShape | null = null
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
-		const { altKey, currentPagePoint } = this.editor.inputs
+		const { editor } = this
+		const { altKey, currentPagePoint } = editor.inputs
 
-		this.isWrapMode = this.editor.user.getIsWrapMode()
+		this.isWrapMode = editor.user.getIsWrapMode()
+
+		this.viewportDidChange = false
+
+		let isInitialCheck = true
+
+		this.cleanupViewportChangeReactor = react('viewport change while brushing', () => {
+			editor.getViewportPageBounds() // capture the viewport change
+			if (!isInitialCheck && !this.viewportDidChange) {
+				this.viewportDidChange = true
+			}
+		})
 
 		if (altKey) {
 			this.parent.transition('scribble_brushing', info)
@@ -39,25 +57,28 @@ export class Brushing extends StateNode {
 		}
 
 		this.excludedShapeIds = new Set(
-			this.editor
+			editor
 				.getCurrentPageShapes()
 				.filter(
 					(shape) =>
-						this.editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
-						this.editor.isShapeOrAncestorLocked(shape)
+						editor.isShapeOfType<TLGroupShape>(shape, 'group') ||
+						editor.isShapeOrAncestorLocked(shape)
 				)
 				.map((shape) => shape.id)
 		)
 
 		this.info = info
-		this.initialSelectedShapeIds = this.editor.getSelectedShapeIds().slice()
-		this.initialStartShape = this.editor.getShapesAtPoint(currentPagePoint)[0]
+		this.initialSelectedShapeIds = editor.getSelectedShapeIds().slice()
+		this.initialStartShape = editor.getShapesAtPoint(currentPagePoint)[0]
 		this.hitTestShapes()
+		isInitialCheck = false
 	}
 
 	override onExit() {
 		this.initialSelectedShapeIds = []
 		this.editor.updateInstanceState({ brush: null })
+
+		this.cleanupViewportChangeReactor()
 	}
 
 	override onTick({ elapsed }: TLTickEventInfo) {
@@ -124,11 +145,29 @@ export class Brushing extends StateNode {
 			pageTransform: Mat | undefined,
 			localCorners: Vec[]
 
-		const currentPageShapes = editor.getCurrentPageRenderingShapesSorted()
+		// Some notes on optimization. We could easily cache all of the shape positions at
+		// the start of the interaction and then do very fast checks against them, but that
+		// would mean changes introduced by other collaborators wouldn't be reflected—a user
+		// could select a shape by selecting where it _used_ to be.
+
+		// We still want to avoid hit tests as much as possible, however, so we test only the
+		// shapes that are on screen UNLESS: the user has scrolled their viewpor; or the user
+		// is dragging outside of the screen (e.g. in a window). In those cases, we need to
+		// test all shapes.
+
+		// On a page with ~5000 shapes, on-screen hit tests are about 2x faster than
+		// testing all shapes.
+
+		const brushBoxIsInsideViewport = editor.getViewportPageBounds().contains(brush)
+		const shapesToHitTest =
+			brushBoxIsInsideViewport && !this.viewportDidChange
+				? editor.getCurrentPageRenderingShapesSorted()
+				: editor.getCurrentPageShapesSorted()
+
 		const currentPageId = editor.getCurrentPageId()
 
-		testAllShapes: for (let i = 0, n = currentPageShapes.length; i < n; i++) {
-			shape = currentPageShapes[i]
+		testAllShapes: for (let i = 0, n = shapesToHitTest.length; i < n; i++) {
+			shape = shapesToHitTest[i]
 			if (excludedShapeIds.has(shape.id) || results.has(shape.id)) continue testAllShapes
 
 			pageBounds = editor.getShapePageBounds(shape)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -2229,16 +2229,16 @@ describe('brushing offscreen shapes', () => {
 			.createShapes([
 				{ id: ids.box1, type: 'geo', x: 100, y: 100 },
 				{ id: ids.box2, type: 'geo', x: 300, y: 300 },
-				{ id: ids.box3, type: 'geo', x: 2000, y: 300 },
+				{ id: ids.box3, type: 'geo', x: 2000, y: 2000 }, // outside of viewport but will be in the viewport after scrolling
+				{ id: ids.box4, type: 'geo', x: 100, y: 2000 }, // outside of both viewports but will be in the selection box
+				{ id: ids.box5, type: 'geo', x: 100, y: 2500 }, // outside of both viewports but and will not be in the selection box
 			])
 			.pointerMove(50, 50)
 			.pointerDown()
-			.wheel(-100, 0)
-			.wheel(-2000, 0)
-			// should hit box1 and box2, too
-			.pointerMove(2100, 400)
+			.wheel(-100, -100)
+			.wheel(-2000, -2000)
 
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2, ids.box3])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2, ids.box3, ids.box4])
 	})
 
 	it('selects shapes that were created / updated by a third party', () => {


### PR DESCRIPTION
This PR fixes a bug where off-screen shapes would not be selected while brushing.

Previously, we only hit-tested rendering shapes. This list always includes selected shapes, so scrolling away from your selected shapes did not immediately de-select them, however you could not select new shapes that existed off-screen or re-select off-screen shapes if your selection box no longer overlapped them.

This PR fixes this by testing off-screen shapes when necessary.

When brushing, if either the viewport has moved or the user's cursor is outside of the viewport bounds, then we hit test all shapes on the page. If neither are true, then the only shapes that the user could possibly select are the ones in the viewport, so we check only against rendering (not-culled) shapes.

![image](https://github.com/user-attachments/assets/03e29792-9470-4486-b8a3-2ce6becc4b7f)

![image](https://github.com/user-attachments/assets/27a0913f-8c77-4df9-9a95-cc60bf2d6ebe)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create four shapes in a square four times the size of the viewport
2. Scroll to the top left shape and begin selecting it
3. While still selecting, scroll to the bottom right and include the bottom right shape
4. All four shapes should be selected

- [x] Unit tests

### Release notes

- Fixed a bug with off-screen shapes not being selected.