### PR TITLE
Fix export images bug

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -691,7 +691,7 @@ export class TldrawApp {
 			exportFormat: 'png',
 			exportTheme: 'light',
 			exportBackground: false,
-			exportPadding: false,
+			exportPadding: true,
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			flags: '',

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
@@ -80,7 +80,7 @@ export function TlaFileShareMenu({
 		<div onPointerDown={preventDefault}>
 			<TldrawUiPopover id={`share-${fileId}-${source}`}>
 				<TldrawUiPopoverTrigger>{children}</TldrawUiPopoverTrigger>
-				<TldrawUiPopoverContent side="bottom" alignOffset={-2} sideOffset={4}>
+				<TldrawUiPopoverContent side="bottom" align="end" alignOffset={-2} sideOffset={4}>
 					<div className={styles.shareMenu}>
 						<TlaTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
 							<TlaTabsTabs>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
@@ -52,9 +52,10 @@
 .exportPreviewInner {
 	width: auto;
 	height: auto;
-	max-height: 216px;
+	max-height: 100%;
+	max-width: 100%;
 	pointer-events: all;
-	border: 1px solid var(--tla-color-border);
+	outline: 1px solid var(--tla-color-border);
 	box-sizing: content-box;
 }
 


### PR DESCRIPTION
This PR fixes a bug in the exported image dimensions.

Before:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/c78ec1dc-993c-4387-a447-c64cfdfe1276" />

After:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/9c085913-a756-46a1-b25c-1fef6bafe3b9" />



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Select some shapes in a row
2. Open the export menu
3. Select some shapes in a column
4. Open the export menu

### Release notes

- Fixed a bug with the export menu image preview