### PR TITLE
Fix clickable area on form rows

### DIFF
--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -12,7 +12,6 @@
 .controlGroup {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
 }
 
 .controlGroup + .controlGroup {
@@ -23,7 +22,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	height: 32px;
+	height: 36px;
 	gap: 8px;
 }
 
@@ -41,7 +40,6 @@
 @media (hover: hover) {
 	.info:hover {
 		color: var(--color-text-1);
-		cursor: pointer;
 	}
 }
 

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -12,6 +12,7 @@
 .controlGroup {
 	display: flex;
 	flex-direction: column;
+	gap: 4px;
 }
 
 .controlGroup + .controlGroup {
@@ -22,7 +23,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	height: 36px;
+	height: 32px;
 	gap: 8px;
 }
 

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -23,9 +23,9 @@ export function TlaMenuControlGroup({ children }: { children: ReactNode }) {
 // A row for a single control, usually label + input
 export function TlaMenuControl({ children, title }: { children: ReactNode; title?: string }) {
 	return (
-		<label className={styles.control} title={title}>
+		<div className={classNames('tla-control', styles.control)} title={title}>
 			{children}
-		</label>
+		</div>
 	)
 }
 
@@ -71,7 +71,11 @@ export function TlaMenuControlInfoTooltip({
 
 // A label for a control
 export function TlaMenuControlLabel({ children }: { children: ReactNode }) {
-	return <div className={classNames(styles.label, 'tla-text_ui__medium')}>{children}</div>
+	return (
+		<label className={classNames('tla-control-label', styles.label, 'tla-text_ui__medium')}>
+			{children}
+		</label>
+	)
 }
 
 // A detail

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -71,11 +71,7 @@ export function TlaMenuControlInfoTooltip({
 
 // A label for a control
 export function TlaMenuControlLabel({ children }: { children: ReactNode }) {
-	return (
-		<label className={classNames('tla-control-label', styles.label, 'tla-text_ui__medium')}>
-			{children}
-		</label>
-	)
+	return <label className={classNames(styles.label, 'tla-text_ui__medium')}>{children}</label>
 }
 
 // A detail


### PR DESCRIPTION
This PR fixes a bug where the entire row in the exports menu would be clickable, though its cursor was not set to `pointer`. Actually the row should not have been clickable; and if it is, then we need to indicate it and disambiguate the hover state from the hover of the tooltip.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Hover items in the export menu
2. Hover / click the label of the export menu

### Release notes

- Fixed a bug with the clickable area of items in the export menu