### PR TITLE
rich text: fix up styling of empty lines and lists

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -969,6 +969,8 @@ input,
 
 .tl-rich-text p {
 	margin: 0;
+	/* Depending on the extensions, <p> tags can be empty, without a <br />. */
+	min-height: 1lh;
 }
 
 .tl-rich-text ul,
@@ -976,6 +978,8 @@ input,
 	text-align: left;
 	margin: 0;
 	padding-left: 3.25ch;
+	/* Some resets, like Tailwind, nix the list styling. */
+	list-style: revert;
 }
 
 .tl-rich-text ol:has(> li:nth-child(10)) {


### PR DESCRIPTION
fix https://github.com/tldraw/tldraw/issues/5881 and https://github.com/tldraw/tldraw/issues/5870

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- rich text: fix styling of empty lines in some cases and lists in some cases