### PR TITLE
text: be able to add other styling to measure by if applicable

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2934,6 +2934,7 @@ export class TextManager {
         fontWeight: string;
         lineHeight: number;
         minWidth?: null | number;
+        otherStyles?: Record<string, string>;
         padding: string;
     }): BoxModel & {
         scrollWidth: number;
@@ -3775,6 +3776,8 @@ export interface TLMeasureTextSpanOpts {
     height: number;
     // (undocumented)
     lineHeight: number;
+    // (undocumented)
+    otherStyles?: Record<string, string>;
     // (undocumented)
     overflow: 'truncate-clip' | 'truncate-ellipsis' | 'wrap';
     // (undocumented)

--- a/packages/editor/src/lib/editor/managers/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager.ts
@@ -32,6 +32,7 @@ export interface TLMeasureTextSpanOpts {
 	fontStyle: string
 	lineHeight: number
 	textAlign: TLDefaultHorizontalAlignStyle
+	otherStyles?: Record<string, string>
 }
 
 const spaceCharacterRegex = /\s/
@@ -86,6 +87,7 @@ export class TextManager {
 			 */
 			maxWidth: null | number
 			minWidth?: null | number
+			otherStyles?: Record<string, string>
 			padding: string
 			disableOverflowWrapBreaking?: boolean
 		}
@@ -112,6 +114,11 @@ export class TextManager {
 			'overflow-wrap',
 			opts.disableOverflowWrapBreaking ? 'normal' : 'break-word'
 		)
+		if (opts.otherStyles) {
+			for (const [key, value] of Object.entries(opts.otherStyles)) {
+				wrapperElm.style.setProperty(key, value)
+			}
+		}
 
 		const scrollWidth = wrapperElm.scrollWidth
 		const rect = wrapperElm.getBoundingClientRect()
@@ -256,6 +263,11 @@ export class TextManager {
 		elm.style.setProperty('line-height', `${opts.lineHeight * opts.fontSize}px`)
 		elm.style.setProperty('text-align', textAlignmentsForLtr[opts.textAlign])
 		elm.style.setProperty('font-style', opts.fontStyle)
+		if (opts.otherStyles) {
+			for (const [key, value] of Object.entries(opts.otherStyles)) {
+				elm.style.setProperty(key, value)
+			}
+		}
 
 		const shouldTruncateToFirstLine =
 			opts.overflow === 'truncate-ellipsis' || opts.overflow === 'truncate-clip'


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/5966
We want to be able to specify things like `letter-spacing` in text measurement. However, at the same time, we don't need to enumerate the rest of the ~20 CSS text properties explicitly. (e.g. `font-optical-sizing`, `font-stretch`, etc.). So, this let's people specify any other styles that are relevant for measurement.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- text: be able to add other styling to measure by if applicable