### PR TITLE
laser: let hitting escape go back to Select tool

### DIFF
--- a/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
@@ -3,6 +3,10 @@ import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
 export class Idle extends StateNode {
 	static override id = 'idle'
 
+	override onCancel() {
+		this.editor.setCurrentTool('select')
+	}
+
 	override onPointerDown(info: TLPointerEventInfo) {
 		this.parent.transition('lasering', info)
 	}


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/5861

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- laser: let hitting escape go back to Select tool