### PR TITLE
refactor: rename canEditOnly to canEditonly

### DIFF
--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -13,15 +13,12 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence - approximately monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible, but tldraw is actively evolving as we add new features. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
-
-
-
-
 {/* START AUTO-GENERATED CHANGELOG */}
 
 ## Current release: [v3.12.0](/releases/v3.12.0)
 
 ### Release Notes
+
 v3.12.0 of the tldraw SDK includes several bug fixes and API improvements. The main feature development focus was on accessibility, building on initial work in v3.11.0 which added a focus ring.
 
 ### Accessibility features
@@ -37,34 +34,34 @@ Accessibility is something we’ve been researching internally for a while now, 
 ### API additions
 
 - Frames can now have color. Set the `showColors` option on the `FrameShapeUtil` class to display colorful borders and labels for frames. ([#5283](https://github.com/tldraw/tldraw/pull/5283))
-    
-    ```tsx
-    import { FrameShapeUtil, Tldraw } from 'tldraw'
-    import 'tldraw/tldraw.css'
-    
-    const shapeUtils = [FrameShapeUtil.configure({ showColors: true })]
-    
-    export default function App() {
-    	return (
-    		`<div className="tldraw__editor">`
-    			<Tldraw shapeUtils={shapeUtils}>`</Tldraw>`
-    		`</div>`
-    	)
-    }
-    ```
-    
-- There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel).  ([#5762](https://github.com/tldraw/tldraw/pull/5762))
+
+  ```tsx
+  import { FrameShapeUtil, Tldraw } from 'tldraw'
+  import 'tldraw/tldraw.css'
+
+  const shapeUtils = [FrameShapeUtil.configure({ showColors: true })]
+
+  export default function App() {
+  	return (
+  		`<div className="tldraw__editor">`
+  			<Tldraw shapeUtils={shapeUtils}>`</Tldraw>`
+  		`</div>`
+  	)
+  }
+  ```
+
+- There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel). ([#5762](https://github.com/tldraw/tldraw/pull/5762))
 - The `Geometry2d` class has a couple of new helper methods for calculating intersection points (`intersectLineSegment` and `intersectCircle`), a new helper method for applying a transformation matrix (`transform`), and new filtering options to allow excluding certain parts of geometry from calculations. ([#5754](https://github.com/tldraw/tldraw/pull/5754))
 - We now individually export two of our default Tiptap extensions (for rich text) ([#5874](https://github.com/tldraw/tldraw/pull/5874))
-    - `KeyboardShiftEnterTweakExtension` which inserts a normal line break when pressing shift+enter (tldraw doesn’t support soft breaks).
-    - `TextDirection` which ensures the text directionality is saved and reinstated correctly.
+  - `KeyboardShiftEnterTweakExtension` which inserts a normal line break when pressing shift+enter (tldraw doesn’t support soft breaks).
+  - `TextDirection` which ensures the text directionality is saved and reinstated correctly.
 
 ### Other improvements
 
 - The syntax for defining keyboard shortcuts is now more intuitive ([#5605](https://github.com/tldraw/tldraw/pull/5605))
-    - e.g. `'?!l’` becomes `'alt+shift+l'` and `'$s'` becomes `'ctrl+s,cmd+s'`
-    - See https://tldraw.dev/reference/tldraw/TLUiToolItem#kbd
-    - The old syntax is still supported for now, but may be deprecated in the future.
+  - e.g. `'?!l’` becomes `'alt+shift+l'` and `'$s'` becomes `'ctrl+s,cmd+s'`
+  - See https://tldraw.dev/reference/tldraw/TLUiToolItem#kbd
+  - The old syntax is still supported for now, but may be deprecated in the future.
 - `Store.mergeRemoteChanges` is now atomic, and side effects are triggered in the correct scopes. ([#5801](https://github.com/tldraw/tldraw/pull/5801))
 - Drawing is now smoother on slower CPUs by using [getCoalescedEvents](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents). ([#5898](https://github.com/tldraw/tldraw/pull/5898))
 - We now allow overriding the asset urls for the icons used by the Embed shape to be null/empty in cases where the Embed shape is not needed. This prevents tldraw downloading a handful of icon assets that would never be used. ([#5736](https://github.com/tldraw/tldraw/pull/5736))
@@ -101,7 +98,7 @@ No breaking changes!
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
 - Trivikram Kamat ([@trivikr](https://github.com/trivikr))
 - Trygve Aaberge ([@trygve-aaberge-adsk](https://github.com/trygve-aaberge-adsk))
-						
+
 ## Previous releases
 
 - [v3.11.0](/releases/v3.11.0)
@@ -139,7 +136,3 @@ No breaking changes!
 - [v2.0.0](/releases/v2.0.0)
 
 {/* END AUTO-GENERATED CHANGELOG */}
-
-
-
-

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -13,12 +13,15 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 - Minor version bumps are released on a regular cadence - approximately monthly. **They may contain breaking changes**. We aim to make breaking changes as minimally disruptive as possible, but tldraw is actively evolving as we add new features. We recommend updating tldraw at a similar pace to our release cadence, and be sure to check the release notes.
 - Patch version bumps are for bugfixes and hotfixes that can't wait for the next cadence release.
 
+
+
+
+
 {/* START AUTO-GENERATED CHANGELOG */}
 
 ## Current release: [v3.12.0](/releases/v3.12.0)
 
 ### Release Notes
-
 v3.12.0 of the tldraw SDK includes several bug fixes and API improvements. The main feature development focus was on accessibility, building on initial work in v3.11.0 which added a focus ring.
 
 ### Accessibility features
@@ -34,34 +37,34 @@ Accessibility is something we’ve been researching internally for a while now, 
 ### API additions
 
 - Frames can now have color. Set the `showColors` option on the `FrameShapeUtil` class to display colorful borders and labels for frames. ([#5283](https://github.com/tldraw/tldraw/pull/5283))
-
-  ```tsx
-  import { FrameShapeUtil, Tldraw } from 'tldraw'
-  import 'tldraw/tldraw.css'
-
-  const shapeUtils = [FrameShapeUtil.configure({ showColors: true })]
-
-  export default function App() {
-  	return (
-  		`<div className="tldraw__editor">`
-  			<Tldraw shapeUtils={shapeUtils}>`</Tldraw>`
-  		`</div>`
-  	)
-  }
-  ```
-
-- There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel). ([#5762](https://github.com/tldraw/tldraw/pull/5762))
+    
+    ```tsx
+    import { FrameShapeUtil, Tldraw } from 'tldraw'
+    import 'tldraw/tldraw.css'
+    
+    const shapeUtils = [FrameShapeUtil.configure({ showColors: true })]
+    
+    export default function App() {
+    	return (
+    		`<div className="tldraw__editor">`
+    			<Tldraw shapeUtils={shapeUtils}>`</Tldraw>`
+    		`</div>`
+    	)
+    }
+    ```
+    
+- There’s a new `getShapeVisibility` prop to replace `isShapeHidden`, which is now deprecated. `getShapeVisibility` allows a child of a hidden parent to override its parent and become visible. See the [Layer Panel Example](https://tldraw.dev/examples/ui/layer-panel).  ([#5762](https://github.com/tldraw/tldraw/pull/5762))
 - The `Geometry2d` class has a couple of new helper methods for calculating intersection points (`intersectLineSegment` and `intersectCircle`), a new helper method for applying a transformation matrix (`transform`), and new filtering options to allow excluding certain parts of geometry from calculations. ([#5754](https://github.com/tldraw/tldraw/pull/5754))
 - We now individually export two of our default Tiptap extensions (for rich text) ([#5874](https://github.com/tldraw/tldraw/pull/5874))
-  - `KeyboardShiftEnterTweakExtension` which inserts a normal line break when pressing shift+enter (tldraw doesn’t support soft breaks).
-  - `TextDirection` which ensures the text directionality is saved and reinstated correctly.
+    - `KeyboardShiftEnterTweakExtension` which inserts a normal line break when pressing shift+enter (tldraw doesn’t support soft breaks).
+    - `TextDirection` which ensures the text directionality is saved and reinstated correctly.
 
 ### Other improvements
 
 - The syntax for defining keyboard shortcuts is now more intuitive ([#5605](https://github.com/tldraw/tldraw/pull/5605))
-  - e.g. `'?!l’` becomes `'alt+shift+l'` and `'$s'` becomes `'ctrl+s,cmd+s'`
-  - See https://tldraw.dev/reference/tldraw/TLUiToolItem#kbd
-  - The old syntax is still supported for now, but may be deprecated in the future.
+    - e.g. `'?!l’` becomes `'alt+shift+l'` and `'$s'` becomes `'ctrl+s,cmd+s'`
+    - See https://tldraw.dev/reference/tldraw/TLUiToolItem#kbd
+    - The old syntax is still supported for now, but may be deprecated in the future.
 - `Store.mergeRemoteChanges` is now atomic, and side effects are triggered in the correct scopes. ([#5801](https://github.com/tldraw/tldraw/pull/5801))
 - Drawing is now smoother on slower CPUs by using [getCoalescedEvents](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents). ([#5898](https://github.com/tldraw/tldraw/pull/5898))
 - We now allow overriding the asset urls for the icons used by the Embed shape to be null/empty in cases where the Embed shape is not needed. This prevents tldraw downloading a handful of icon assets that would never be used. ([#5736](https://github.com/tldraw/tldraw/pull/5736))
@@ -98,7 +101,7 @@ No breaking changes!
 - Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
 - Trivikram Kamat ([@trivikr](https://github.com/trivikr))
 - Trygve Aaberge ([@trygve-aaberge-adsk](https://github.com/trygve-aaberge-adsk))
-
+						
 ## Previous releases
 
 - [v3.11.0](/releases/v3.11.0)
@@ -136,3 +139,7 @@ No breaking changes!
 - [v2.0.0](/releases/v2.0.0)
 
 {/* END AUTO-GENERATED CHANGELOG */}
+
+
+
+

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2607,7 +2607,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canCrop(_shape: Shape): boolean;
     canDropShapes(_shape: Shape, _shapes: TLShape[]): boolean;
     canEdit(_shape: Shape): boolean;
-    canEditInReadOnly(_shape: Shape): boolean;
+    canEditInReadonly(_shape: Shape): boolean;
     canReceiveNewChildrenOfType(_shape: Shape, _type: TLShape['type']): boolean;
     canResize(_shape: Shape): boolean;
     canScroll(_shape: Shape): boolean;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -245,7 +245,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 *
 	 * @public
 	 */
-	canEditInReadOnly(_shape: Shape): boolean {
+	canEditInReadonly(_shape: Shape): boolean {
 		return false
 	}
 

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1042,7 +1042,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
     canEdit(): boolean;
     // (undocumented)
-    canEditInReadOnly(): boolean;
+    canEditInReadonly(): boolean;
     // (undocumented)
     canResize(shape: TLEmbedShape): boolean;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -70,7 +70,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	override canResize(shape: TLEmbedShape) {
 		return !!this.getEmbedDefinition(shape.props.url)?.definition?.doesResize
 	}
-	override canEditInReadOnly() {
+	override canEditInReadonly() {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -174,7 +174,7 @@ export class EditingShape extends StateNode {
 		if (hitShape.isLocked) return
 
 		if (this.editor.getIsReadonly()) {
-			if (!util.canEditInReadOnly(hitShape)) {
+			if (!util.canEditInReadonly(hitShape)) {
 				this.parent.transition('pointing_shape', info)
 				return
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -635,7 +635,7 @@ export class Idle extends StateNode {
 
 		const util = this.editor.getShapeUtil(shape)
 		if (this.editor.getIsReadonly()) {
-			if (!util.canEditInReadOnly(shape)) {
+			if (!util.canEditInReadonly(shape)) {
 				return
 			}
 		}
@@ -686,7 +686,7 @@ export class Idle extends StateNode {
 	private canInteractWithShapeInReadOnly(shape: TLShape) {
 		if (!this.editor.getIsReadonly()) return true
 		const util = this.editor.getShapeUtil(shape)
-		if (util.canEditInReadOnly(shape)) return true
+		if (util.canEditInReadonly(shape)) return true
 		return false
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -154,7 +154,7 @@ export class PointingShape extends StateNode {
 
 										const util = this.editor.getShapeUtil(selectingShape)
 										if (this.editor.getIsReadonly()) {
-											if (!util.canEditInReadOnly(selectingShape)) {
+											if (!util.canEditInReadonly(selectingShape)) {
 												return
 											}
 										}


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan
- build
- test

```bash
yarn workspaces foreach --all --include tldraw --include editor --topological run build && \
yarn workspaces foreach --all --include tldraw --include editor --topological run test

[tldraw]: Process started
[tldraw]: Process exited (exit code 0), completed in 2s 941ms

[tldraw]: Test Suites: 1 skipped, 128 passed, 128 of 129 total
[tldraw]: Tests:       14 skipped, 53 todo, 1633 passed, 1700 total
[tldraw]: Snapshots:   88 passed, 88 total
[tldraw]: Time:        14.27 s
[tldraw]: Ran all test suites.
[tldraw]: Process exited (exit code 0), completed in 15s 377ms


```


Just rename method, If it's built well, it's a success.

- [ ] Unit tests
- [ ] End to end tests

### Release notes
close #5899 
- Rename `CanEditOnly` to `CanEditonly` to standardize.
  - method in `packages/editor/src/lib/editor/shapes/ShapeUtil.ts` 
  - method in `packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx`
  - used in `packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts`
  - used in `packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts`
  - used in `packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts`