### PR TITLE
Snap pasted text and embed content to the grid

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -24,6 +24,7 @@ import {
 	fetch,
 	getHashForBuffer,
 	getHashForString,
+	maybeSnapToGrid,
 	toRichText,
 } from '@tldraw/editor'
 import { EmbedDefinition } from './defaultEmbedDefinitions'
@@ -289,11 +290,15 @@ export function defaultHandleExternalEmbedContent<T>(
 
 	const id = createShapeId()
 
+	const newPoint = maybeSnapToGrid(
+		new Vec(position.x - (width || 450) / 2, position.y - (height || 450) / 2),
+		editor
+	)
 	const shapePartial: TLShapePartial = {
 		id,
 		type: 'embed',
-		x: position.x - (width || 450) / 2,
-		y: position.y - (height || 450) / 2,
+		x: newPoint.x,
+		y: newPoint.y,
 		props: {
 			w: width,
 			h: height,
@@ -509,12 +514,13 @@ export async function defaultHandleExternalTextContent(
 		p.y = editor.getViewportPageBounds().minY + 40 + h / 2
 	}
 
+	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)
 	editor.createShapes<TLTextShape>([
 		{
 			id: createShapeId(),
 			type: 'text',
-			x: p.x - w / 2,
-			y: p.y - h / 2,
+			x: newPoint.x,
+			y: newPoint.y,
 			props: {
 				richText: richTextToPaste,
 				// if the text has more than one line, align it to the left


### PR DESCRIPTION
When creating a shape from pasted text or embed content, it wasn't snapped to the grid. Now it is if the grid is enabled.

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Enable the grid.
2. Put some text or a URL to embeddable content on the clipboard.
3. Paste it on the canvas.
4. Observe that it's now snapped to the grid.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- When pasting text or embeddable links, snap the created shape to the grid if the grid is enabled.