### PR TITLE
Docs: Remove section on rich text exports

### DIFF
--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -282,11 +282,6 @@ export default function RichTextCustomExtensionExample() {
 
 On our [examples site](https://examples.tldraw.com/) please filter by "rich text" and you will find examples on how to add custom extensions or UI to tailor the rich text.
 
-#### Exports for rich text
-
-One of the other challenges right now with rich text is the exports. We use the SVG `foreignObject` to insert rich text into the shapes.
-This isn't ideal and we're looking in the future to help improve this.
-
 ### Migrations
 
 You can add migrations for your shape props by adding a `migrations` property to your shape's util class. See [the persistence docs](/docs/persistence#Shape-props-migrations) for more information.


### PR DESCRIPTION
This PR removes a small section about rich text exports that doesn't help much. Noticed it while looking through our docs and examples - pulled out this small change into its own PR.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
