### PR TITLE
Fix inconsistent panning.

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10343,12 +10343,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (this.inputs.isPanning && this.inputs.isPointing) {
 							// Handle spacebar / middle mouse button panning
 							const { currentScreenPoint, previousScreenPoint } = this.inputs
-							const { panSpeed } = cameraOptions
 							const offset = Vec.Sub(currentScreenPoint, previousScreenPoint)
-							this.setCamera(
-								new Vec(cx + (offset.x * panSpeed) / cz, cy + (offset.y * panSpeed) / cz, cz),
-								{ immediate: true }
-							)
+							this.setCamera(new Vec(cx + offset.x / cz, cy + offset.y / cz, cz), {
+								immediate: true,
+							})
 							this.maybeTrackPerformance('Panning')
 							return
 						}

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -206,7 +206,7 @@ describe('CameraOptions.wheelBehavior', () => {
 })
 
 describe('CameraOptions.panSpeed', () => {
-	it('Effects wheel panning (2x)', () => {
+	it('Affects wheel panning (2x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 2, wheelBehavior: 'pan' })
 			.dispatch({
@@ -217,7 +217,7 @@ describe('CameraOptions.panSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 10, y: 20, z: 1 })
 	})
 
-	it('Effects wheel panning (.5x)', () => {
+	it('Affects wheel panning (.5x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 0.5, wheelBehavior: 'pan' })
 			.dispatch({
@@ -228,7 +228,7 @@ describe('CameraOptions.panSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 2.5, y: 5, z: 1 })
 	})
 
-	it('Does not effect zoom mouse wheeling', () => {
+	it('Does not affect zoom mouse wheeling', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 2, wheelBehavior: 'zoom' })
 			.dispatch({
@@ -239,33 +239,33 @@ describe('CameraOptions.panSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1.01 }) // 1 + 1
 	})
 
-	it('Does not effect hand tool panning', () => {
+	it('Does not affect hand tool panning', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 2 })
 		editor.setCurrentTool('hand').pointerDown(0, 0).pointerMove(5, 10).forceTick()
 		expect(editor.getCamera()).toMatchObject({ x: 5, y: 10, z: 1 })
 	})
 
-	it('Effects spacebar panning (2x)', () => {
+	it('Does not affect spacebar panning (2x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 2 })
 		editor
 			.dispatch({ ...keyBoardEvent, key: ' ', code: 'Space' })
 			.pointerDown(0, 0)
 			.pointerMove(5, 10)
 			.forceTick()
-		expect(editor.getCamera()).toMatchObject({ x: 10, y: 20, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: 5, y: 10, z: 1 })
 	})
 
-	it('Effects spacebar panning (0.5x)', () => {
+	it('Does not affect spacebar panning (0.5x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, panSpeed: 0.5 })
 		editor
 			.dispatch({ ...keyBoardEvent, key: ' ', code: 'Space' })
 			.pointerDown(0, 0)
 			.pointerMove(5, 10)
 			.forceTick()
-		expect(editor.getCamera()).toMatchObject({ x: 2.5, y: 5, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: 5, y: 10, z: 1 })
 	})
 
-	it('Does not effect edge scroll panning', () => {
+	it('Does not affect edge scroll panning', () => {
 		const shapeId = createShapeId()
 		const viewportScreenBounds = editor.getViewportScreenBounds()
 		editor.user.updateUserPreferences({ edgeScrollSpeed: 1 })
@@ -287,7 +287,7 @@ describe('CameraOptions.panSpeed', () => {
 })
 
 describe('CameraOptions.zoomSpeed', () => {
-	it('Effects wheel zooming (2x)', () => {
+	it('Affects wheel zooming (2x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2, wheelBehavior: 'zoom' })
 			.dispatch({
@@ -298,7 +298,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1.02 }) // 1 + (.01 * 2)
 	})
 
-	it('Effects wheel zooming (.5x)', () => {
+	it('Affects wheel zooming (.5x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5, wheelBehavior: 'zoom' })
 			.dispatch({
@@ -309,7 +309,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1.005 }) // 1 + (.01 * .5)
 	})
 
-	it('Does not effect mouse wheel panning', () => {
+	it('Does not affect mouse wheel panning', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5, wheelBehavior: 'pan' })
 			.dispatch({
@@ -320,7 +320,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 5, y: 10, z: 1 })
 	})
 
-	it('Does not effect pinch zooming (2x)', () => {
+	it('Does not affect pinch zooming (2x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2 })
 			.dispatch({
@@ -341,7 +341,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		editor.forceTick()
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
-	it('Does not effect pinch zooming (0.5x)', () => {
+	it('Does not affect pinch zooming (0.5x)', () => {
 		editor
 			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5 })
 			.dispatch({
@@ -362,21 +362,21 @@ describe('CameraOptions.zoomSpeed', () => {
 		editor.forceTick()
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
-	it('Does not effect zoom tool zooming (2x)', () => {
+	it('Does not affect zoom tool zooming (2x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2 })
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 		editor.setCurrentTool('zoom').click()
 		jest.advanceTimersByTime(300)
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 2 })
 	})
-	it('Does not effect zoom tool zooming (0.5x)', () => {
+	it('Does not affect zoom tool zooming (0.5x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5 })
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 		editor.setCurrentTool('zoom').click()
 		jest.advanceTimersByTime(300)
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 2 })
 	})
-	it('Does not effect editor zoom method (2x)', () => {
+	it('Does not affect editor zoom method (2x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 2 })
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 		editor.zoomIn(new Vec(0, 0), { immediate: true })
@@ -384,7 +384,7 @@ describe('CameraOptions.zoomSpeed', () => {
 		editor.zoomOut(new Vec(0, 0), { immediate: true })
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
-	it('Does not effect editor zoom method (0.5x)', () => {
+	it('Does not affect editor zoom method (0.5x)', () => {
 		editor.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, zoomSpeed: 0.5 })
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 		editor.zoomIn(new Vec(0, 0), { immediate: true })


### PR DESCRIPTION
Makes the pan speed consistent between the hand tool and space / middle mouse button panning.

After talking to Steve we decided to go with the [suggestion](https://github.com/tldraw/tldraw/issues/5387) of keeping the panning at speed 1 for those two actions and only take panning speed into account for mouse wheel / trackpad panning. Otherwise the contents of the canvas drift underneath your cursor, which feels wrong.

### Change type

- [x] `bugfix`

### Test plan

1. Use the camera options example.
2. Increase / decrease the pan speed.
3. Panning should be consistent between the hand tool and space bar / middle mouse button panning. It should use pan speed of 1 (shapes should not drift away from the hand cursor when doing it).
4. Panning speed should still be taken into account for wheel panning and trackpad panning.


### Release notes

- Don't take pan speed into account for hand tool panning so that it's consistent with middle mouse button / spacebar panning.