### PR TITLE
Improve the clean script 

### DIFF
--- a/internal/scripts/clean.sh
+++ b/internal/scripts/clean.sh
@@ -35,6 +35,7 @@ rm -rf {packages,apps}/*/*.tgz
 rm -rf {packages,apps}/vscode/extension/temp
 rm -rf {packages,apps}/vscode/extension/editor
 rm -rf apps/docs/content.json
+rm -rf apps/dotcom/client/e2e/.auth
 
 npm i -g corepack
 yarn


### PR DESCRIPTION
If you don't run e2e tests for a while you might get into this strange state where e2e tests might not be able to properly authenticate. 

This cleans the auth state when using `yarn clean` since that's often the first thing people try to make it work.

### Change type

- [x] `improvement`
