### PR TITLE
Make sure the file exists before uploading it to the bucket.

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/tla/uploads.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/uploads.ts
@@ -29,7 +29,7 @@ export async function upload(request: IRequest, env: Environment): Promise<Respo
 		objectName: request.params.objectName,
 	})
 	if (res.status === 200) {
-		await db.insertInto('asset').values({ objectName, fileId }).execute()
+		await env.QUEUE.send({ type: 'asset-upload', objectName, fileId })
 	}
 	return res
 }

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -1,5 +1,6 @@
 // https://developers.cloudflare.com/analytics/analytics-engine/
 
+import { Queue } from '@cloudflare/workers-types'
 import type { RoomSnapshot } from '@tldraw/sync-core'
 import type { TLDrawDurableObject } from './TLDrawDurableObject'
 import type { TLLoggerDurableObject } from './TLLoggerDurableObject'
@@ -63,6 +64,8 @@ export interface Environment {
 	HEALTH_CHECK_BEARER_TOKEN: string | undefined
 
 	RATE_LIMITER: RateLimit
+
+	QUEUE: Queue<QueueMessage>
 }
 
 export function isDebugLogging(env: Environment) {
@@ -153,3 +156,9 @@ export type TLUserDurableObjectEvent =
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }
 	| { type: 'cold_start_time'; id: string; duration: number }
+
+export interface QueueMessage {
+	type: 'asset-upload'
+	objectName: string
+	fileId: string
+}

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -25,7 +25,7 @@ import {
 import { adminRoutes } from './adminRoutes'
 import { POSTHOG_URL } from './config'
 import { healthCheckRoutes } from './healthCheckRoutes'
-import { makePostgresConnector } from './postgres'
+import { createPostgresConnectionPool, makePostgresConnector } from './postgres'
 import { createRoomSnapshot } from './routes/createRoomSnapshot'
 import { extractBookmarkMetadata } from './routes/extractBookmarkMetadata'
 import { getReadonlySlug } from './routes/getReadonlySlug'
@@ -39,7 +39,7 @@ import { forwardRoomRequest } from './routes/tla/forwardRoomRequest'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
 import { upload } from './routes/tla/uploads'
 import { testRoutes } from './testRoutes'
-import { Environment, isDebugLogging } from './types'
+import { Environment, QueueMessage, isDebugLogging } from './types'
 import { getLogger, getReplicator, getUserDurableObject } from './utils/durableObjects'
 import { getAuth, requireAuth } from './utils/tla/getAuth'
 export { TLDrawDurableObject } from './TLDrawDurableObject'
@@ -51,6 +51,8 @@ export { TLUserDurableObject } from './TLUserDurableObject'
 const { preflight, corsify } = cors({
 	origin: isAllowedOrigin,
 })
+
+const QUEUE_BASE_DELAY = 2
 
 const router = createRouter<Environment>()
 	.all('*', preflight)
@@ -194,6 +196,21 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 			}
 			throw err
 		})
+	}
+
+	override async queue(batch: MessageBatch<QueueMessage>): Promise<void> {
+		const db = createPostgresConnectionPool(this.env, 'sync-worker-queue')
+		for (const message of batch.messages) {
+			const { objectName, fileId } = message.body
+			try {
+				await db.insertInto('asset').values({ objectName, fileId }).executeTakeFirstOrThrow()
+				message.ack()
+			} catch (_e) {
+				message.retry({
+					delaySeconds: QUEUE_BASE_DELAY ** message.attempts,
+				})
+			}
+		}
 	}
 }
 

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -54,7 +54,6 @@ name = "dev-tldraw-multiplayer"
 BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
 BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6432/postgres"
 TLDRAW_ENV = "development"
-SENTRY_DSN = "https://example.com"
 MULTIPLAYER_SERVER = "http://localhost:3000"
 
 # we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -345,29 +345,29 @@ simple = { limit = 300, period = 60 }
 
 #################### Queues ####################
 [[env.dev.queues.producers]]
-queue = "queue-dev"
+queue = "tldraw-multiplayer-queue-dev"
 binding = "QUEUE"
 
 [[env.dev.queues.consumers]]
-queue = "queue-dev"
+queue = "tldraw-multiplayer-queue-dev"
 
 [[env.preview.queues.producers]]
-queue = "queue-preview"
+queue = "tldraw-multiplayer-queue-preview"
 binding = "QUEUE"
 
 [[env.preview.queues.consumers]]
-queue = "queue-preview"
+queue = "tldraw-multiplayer-queue-preview"
 
 [[env.staging.queues.producers]]
-queue = "queue-staging"
+queue = "tldraw-multiplayer-queue-staging"
 binding = "QUEUE"
 
 [[env.staging.queues.consumers]]
-queue = "queue-staging"
+queue = "tldraw-multiplayer-queue-staging"
 
 [[env.production.queues.producers]]
-queue = "queue"
+queue = "tldraw-multiplayer-queue"
 binding = "QUEUE"
 
 [[env.production.queues.consumers]]
-queue = "queue"
+queue = "tldraw-multiplayer-queue"

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -54,6 +54,7 @@ name = "dev-tldraw-multiplayer"
 BOTCOM_POSTGRES_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6543/postgres"
 BOTCOM_POSTGRES_POOLED_CONNECTION_STRING = "postgresql://user:password@127.0.0.1:6432/postgres"
 TLDRAW_ENV = "development"
+SENTRY_DSN = "https://example.com"
 MULTIPLAYER_SERVER = "http://localhost:3000"
 
 # we don't have a hard-coded name for preview. we instead have to generate it at build time and append it to this file.
@@ -342,3 +343,32 @@ name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1004"
 simple = { limit = 300, period = 60 }
+
+#################### Queues ####################
+[[env.dev.queues.producers]]
+queue = "queue-dev"
+binding = "QUEUE"
+
+[[env.dev.queues.consumers]]
+queue = "queue-dev"
+
+[[env.preview.queues.producers]]
+queue = "queue-preview"
+binding = "QUEUE"
+
+[[env.preview.queues.consumers]]
+queue = "queue-preview"
+
+[[env.staging.queues.producers]]
+queue = "queue-staging"
+binding = "QUEUE"
+
+[[env.staging.queues.consumers]]
+queue = "queue-staging"
+
+[[env.production.queues.producers]]
+queue = "queue"
+binding = "QUEUE"
+
+[[env.production.queues.consumers]]
+queue = "queue"

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -350,6 +350,7 @@ binding = "QUEUE"
 
 [[env.dev.queues.consumers]]
 queue = "tldraw-multiplayer-queue-dev"
+max_retries = 10
 
 [[env.preview.queues.producers]]
 queue = "tldraw-multiplayer-queue-preview"
@@ -357,6 +358,7 @@ binding = "QUEUE"
 
 [[env.preview.queues.consumers]]
 queue = "tldraw-multiplayer-queue-preview"
+max_retries = 10
 
 [[env.staging.queues.producers]]
 queue = "tldraw-multiplayer-queue-staging"
@@ -364,6 +366,7 @@ binding = "QUEUE"
 
 [[env.staging.queues.consumers]]
 queue = "tldraw-multiplayer-queue-staging"
+max_retries = 10
 
 [[env.production.queues.producers]]
 queue = "tldraw-multiplayer-queue"
@@ -371,3 +374,5 @@ binding = "QUEUE"
 
 [[env.production.queues.consumers]]
 queue = "tldraw-multiplayer-queue"
+max_retries = 10
+dead_letter_queue = 'tldraw-multiplayer-dlq'


### PR DESCRIPTION
This makes sure that the file exists before we upload an asset to the R2 bucket. Otherwise you could upload assets and not have them be associated with a file.

This also uses a queue for inserting the asset <> file association. Otherwise the insert might fail and we might still not correctly associate assets to files. Using a queue allows us to retry the inserts with an exponential backoff.

### Change type

- [x] `improvement`