### PR TITLE
Fix disposing order

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -326,7 +326,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.options = { ...defaultTldrawOptions, ...options }
 
 		this.store = store
-		this.disposables.add(this.store.dispose.bind(this.store))
 		this.history = new HistoryManager<TLRecord>({
 			store,
 			annotateError: (error) => {
@@ -956,6 +955,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	dispose() {
 		this.disposables.forEach((dispose) => dispose())
 		this.disposables.clear()
+		this.store.dispose()
 		this.isDisposed = true
 	}
 


### PR DESCRIPTION
I couldn't reproduce this, but after playing around with this it seems the issue is the following:
* Editor contains a `disposables` set, which contains everything that should be disposed together with the editor.
* When the editor is instantiated we immediately add the `store.dispose` to the disposables array (in the constructor).
* Other disposables are only added after this.
* When the editor then gets disposed we process the disposables in order, which means that the first thing that gets disposed is probably the store.
* Any other disposables that rely on it (like the `DragAndDropManager.dispose` which clears hinting shapes) get called after it, after the store is already disposed.

This moves the store disposing logic outside of the disposables array and makes sure that it is disposed after all the other disposables.

### Change type

- [x] `bugfix`

### Release notes

- Fix an issue that could occur when disposable logic that relied on the store being available was run after the store has already been disposed.