### PR TITLE
fix: no tasks found matching build-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"build-types": "lazy inherit",
 		"build-api": "lazy build-api",
 		"build-i18n": "lazy build-i18n",
-		"build-package": "lazy build-package",
+		"build-package": "lazy run build --filter 'packages/*'",
 		"preview-app": "VITE_PREVIEW=1 yarn dev-app",
 		"lint": "lazy lint",
 		"format": "prettier --write --cache '**/*.{yml,yaml,json,md,mdx,html,css,js,jsx,ts,tsx,cjs,mjs}'",


### PR DESCRIPTION
### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. run fixed command
2. Verify that `packages/*` builds well and is compatible with build.
```bash
yarn build-package 

...

     Tasks:  26 successful, 26 total
    Cached:  13/26 cached
      Time:  12.34s
```

### Release notes

close #6018 
Fixed a bug that caused the `build-package` script to not work.
- change `build-package` : `lazy run build --filter 'packages/*'`