### PR TITLE
Don't show the uploading progress bar if the upload failed already

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -744,7 +744,7 @@ export class TldrawApp {
 		let didFinishUploading = false
 
 		// give it a second before we show the toast, in case the upload is fast
-		setTimeout(() => {
+		const uploadingToastTimeout = setTimeout(() => {
 			if (didFinishUploading || this.abortController.signal.aborted) return
 			// if it's close to the end, don't show the progress toast
 			if (getApproxPercentage() > 50) return
@@ -780,6 +780,7 @@ export class TldrawApp {
 				updateProgress()
 			}).catch((e) => Result.err(e))
 			if (!res.ok) {
+				clearTimeout(uploadingToastTimeout)
 				if (uploadingToastId) this.toasts?.removeToast(uploadingToastId)
 				this.toasts?.addToast({
 					severity: 'error',


### PR DESCRIPTION
Felt strange that the progress bar pops up after the error message.

### Before

https://github.com/user-attachments/assets/8c0ed31e-1fca-45a1-843d-c9c3fbba54ba

### After

https://github.com/user-attachments/assets/6d6864b7-9eb5-4898-b697-a9969a73ad64

### Change type

- [x] `improvement`
