### PR TITLE
Prevent announcements during interactions

### DIFF
--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -142,6 +142,8 @@ export const useSelectedShapesAnnouncer = () => {
 	useEffect(() => {
 		if (!editor) return
 
+		let prevSelectedShapeIds = editor.getSelectedShapeIds()
+
 		const announceSelectedShapes = (selectedShapeIds: TLShapeId[]) => {
 			const a11yLive = generateShapeAnnouncementMessage({
 				editor,
@@ -155,8 +157,12 @@ export const useSelectedShapesAnnouncer = () => {
 		}
 
 		const stopListening = react('useSelectedShapesAnnouncer', () => {
-			const selectedShapes = editor.getSelectedShapeIds()
-			announceSelectedShapes(selectedShapes)
+			const isInSelecting = editor.isIn('select.idle')
+			const selectedShapeIds = editor.getSelectedShapeIds()
+			if (isInSelecting && selectedShapeIds !== prevSelectedShapeIds) {
+				prevSelectedShapeIds = selectedShapeIds
+				announceSelectedShapes(selectedShapeIds)
+			}
 		})
 
 		return () => {

--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -156,6 +156,9 @@ export const useSelectedShapesAnnouncer = () => {
 			}
 		}
 
+		// We only want to announce when:
+		// 1. the user returns to the select tool; and
+		// 2. the selected shapes have changed
 		const stopListening = react('useSelectedShapesAnnouncer', () => {
 			const isInSelecting = editor.isIn('select.idle')
 			const selectedShapeIds = editor.getSelectedShapeIds()


### PR DESCRIPTION
This PR fixes a bug causing accessibility announcements to occur too often. The code as written was firing during interactions (translating a shape, etc) and on hover/unhovers, due to the announcement function being captured. This narrows it to only when appropriate.

This announcement isn't free so if there's a way to know whether the user is consuming this announcements, we can turn them off until that's true.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Turn on screenreader
2. Drag a shape around
3. Select it
4. Deselect it

### Release notes

- Fixed a bug causing too many screenreader announcements