### PR TITLE
Make flattened shapes image use a transparent background

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useFlatten.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useFlatten.ts
@@ -97,6 +97,7 @@ export async function flattenShapesToImages(
 		// get an image for the shapes
 		const svgResult = await editor.getSvgString(group.shapes, {
 			padding,
+			background: false,
 		})
 		if (!svgResult?.svg) continue
 


### PR DESCRIPTION
This PR forces flattened shapes to use transparent backgrounds on the resulting image.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Flatten shapes
2. The background should be transparent

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug causing flattened shapes to have opaque background colors.