### PR TITLE
Fix border radius on focused buttons

### DIFF
--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -276,7 +276,6 @@
 	button:not(.tla-button-text):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {
-	border-radius: 10px;
 	outline: 2px solid var(--color-focus);
 	outline-offset: -5px;
 }
@@ -286,7 +285,6 @@
 	:is(nav, .tlui-popover__content, .tlui-dialog__overlay)
 	.tla-switch:has(input:focus-visible)
 	> div {
-	border-radius: 10px;
 	outline: 2px solid var(--color-focus);
 	outline-offset: 1px;
 }
@@ -296,7 +294,6 @@
 	:is(nav, .tlui-popover__content, .tlui-dialog__overlay)
 	.tla-form-checkbox:has(input:focus-visible)
 	> label {
-	border-radius: 10px;
 	outline: 2px solid var(--color-focus);
 	outline-offset: 1px;
 }
@@ -305,7 +302,6 @@
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
 	:is(nav, .tlui-popover__content, .tlui-dialog__overlay)
 	button[role='combobox']:not(.tlui-button):focus-visible {
-	border-radius: 0;
 	outline-offset: 0;
 }
 
@@ -323,7 +319,6 @@
 	.tla-primary-button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring)
 	.tla-primary-button:not(.tlui-button):focus-visible {
-	border-radius: 8px;
 	outline-offset: 0;
 }
 
@@ -334,6 +329,5 @@
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
 	:is(nav, #tla-tabpanel-export)
 	.tla-button:not(.tlui-button):focus-visible {
-	border-radius: var(--tla-radius-2);
 	outline-offset: 1px;
 }

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -58,6 +58,7 @@ const WatermarkInner = memo(function WatermarkInner({ src }: { src: string }) {
 		>
 			<button
 				draggable={false}
+				className="no-focus-ring"
 				role="button"
 				onPointerDown={(e) => {
 					stopEventPropagation(e)


### PR DESCRIPTION
The focus styles are setting border radius on elements. Our buttons etc should determine their own radius.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed a bug with focused buttons in the application UI receiving a border radius