### PR TITLE
don't call createId if id is overridden

### DIFF
--- a/packages/store/src/lib/RecordType.ts
+++ b/packages/store/src/lib/RecordType.ts
@@ -73,7 +73,10 @@ export class RecordType<
 	create(
 		properties: Expand<Pick<R, RequiredProperties> & Omit<Partial<R>, RequiredProperties>>
 	): R {
-		const result = { ...this.createDefaultProperties(), id: this.createId() } as any
+		const result = {
+			...this.createDefaultProperties(),
+			id: 'id' in properties ? properties.id : this.createId(),
+		} as any
 
 		for (const [k, v] of Object.entries(properties)) {
 			if (v !== undefined) {


### PR DESCRIPTION
Tiny bugfix for running tldraw stuff on cloudflare workers.

Basically if you call `RecordType.create({id: 'foo:bar'})` during initialization it would throw an error because workers can't do side effects during init and under the hood it used crypto.random to generate a record ID that wasn't actually being used because we were supplying our own.

This prevents generating an id if one was provided.

### Change type

- [x] `bugfix`
