### PR TITLE
refactor(tldraw): merge util and binding within TldrawImage

### DIFF
--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -7,9 +7,9 @@ import {
 	TLPageId,
 	TLStoreSnapshot,
 	TLTextOptions,
+	mergeArraysAndReplaceDefaults,
 	useShallowArrayIdentity,
 	useTLStore,
-	mergeArraysAndReplaceDefaults,
 } from '@tldraw/editor'
 import { memo, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { defaultBindingUtils } from './defaultBindingUtils'


### PR DESCRIPTION
Merge util and binding within TldrawImage to prevent duplicate definition errors.

### Change type

- [x] `improvement`

### Test plan

1. Add a shape utils in TldrawImage
2. It should not throw the error that the util is defined more than once

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Merge shape utils and bindings within TldrawImage