### PR TITLE
Minor perf tweak to notVisibleShapes

### DIFF
--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -1,49 +1,48 @@
 import { computed, isUninitialized } from '@tldraw/state'
 import { TLShapeId } from '@tldraw/tlschema'
-import { Box } from '../../primitives/Box'
 import { Editor } from '../Editor'
 
-function isShapeNotVisible(editor: Editor, id: TLShapeId, viewportPageBounds: Box): boolean {
-	const maskedPageBounds = editor.getShapeMaskedPageBounds(id)
-	// if the shape is fully outside of its parent's clipping bounds...
-	if (maskedPageBounds === undefined) return true
-
-	// if the shape is fully outside of the viewport page bounds...
-	return !viewportPageBounds.includes(maskedPageBounds)
+function fromScratch(editor: Editor): Set<TLShapeId> {
+	const shapesIds = editor.getCurrentPageShapeIds()
+	const viewportPageBounds = editor.getViewportPageBounds()
+	const notVisibleShapes = new Set<TLShapeId>()
+	shapesIds.forEach((id) => {
+		// If the shape is fully outside of the viewport page bounds, add it to the set.
+		// We'll ignore masks here, since they're more expensive to compute and the overhead is not worth it.
+		const pageBounds = editor.getShapePageBounds(id)
+		if (pageBounds === undefined || !viewportPageBounds.includes(pageBounds)) {
+			notVisibleShapes.add(id)
+		}
+	})
+	return notVisibleShapes
 }
 
 /**
  * Incremental derivation of not visible shapes.
- * Non visible shapes are shapes outside of the viewport page bounds and shapes outside of parent's clipping bounds.
+ * Non visible shapes are shapes outside of the viewport page bounds.
  *
  * @param editor - Instance of the tldraw Editor.
  * @returns Incremental derivation of non visible shapes.
  */
-export const notVisibleShapes = (editor: Editor) => {
-	function fromScratch(editor: Editor): Set<TLShapeId> {
-		const shapes = editor.getCurrentPageShapeIds()
-		const viewportPageBounds = editor.getViewportPageBounds()
-		const notVisibleShapes = new Set<TLShapeId>()
-		shapes.forEach((id) => {
-			if (isShapeNotVisible(editor, id, viewportPageBounds)) {
-				notVisibleShapes.add(id)
-			}
-		})
-		return notVisibleShapes
-	}
-	return computed<Set<TLShapeId>>('notVisibleShapes', (prevValue) => {
-		if (isUninitialized(prevValue)) {
-			return fromScratch(editor)
-		}
-
+export function notVisibleShapes(editor: Editor) {
+	return computed<Set<TLShapeId>>('notVisibleShapes', function updateNotVisibleShapes(prevValue) {
 		const nextValue = fromScratch(editor)
 
+		if (isUninitialized(prevValue)) {
+			return nextValue
+		}
+
+		// If there are more or less shapes, we know there's a change
 		if (prevValue.size !== nextValue.size) return nextValue
+
+		// If any of the old shapes are not in the new set, we know there's a change
 		for (const prev of prevValue) {
 			if (!nextValue.has(prev)) {
 				return nextValue
 			}
 		}
+
+		// If we've made it here, we know that the set is the same
 		return prevValue
 	})
 }

--- a/packages/editor/src/lib/primitives/Box.ts
+++ b/packages/editor/src/lib/primitives/Box.ts
@@ -418,7 +418,7 @@ export class Box {
 	}
 
 	static Includes(A: Box, B: Box) {
-		return Box.Collides(A, B) || Box.Contains(A, B)
+		return Box.Collides(A, B)
 	}
 
 	static ContainsPoint(A: Box, B: VecLike, margin = 0) {


### PR DESCRIPTION
This PR drops the check for masked page bounds when analyzing notVisibleShapes. This isn't really needed and is one more computed for the system to check on a relatively hot path (e.g. getting the hovered shape on a crowded canvas).

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Slight performance improvement of complex boards.