### PR TITLE
refactor: remove type casting to improve safety 

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5207,13 +5207,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			// Check labels first
 			if (
-				this.isShapeOfType<TLFrameShape>(shape, 'frame') ||
-				(this.isShapeOfType<TLArrowShape>(shape, 'arrow') && shape.props.text.trim()) ||
-				((this.isShapeOfType<TLNoteShape>(shape, 'note') ||
-					(this.isShapeOfType<TLGeoShape>(shape, 'geo') && shape.props.fill === 'none')) &&
-					this.getShapeUtil(shape).getText(shape)?.trim())
+				isGroup &&
+				(this.isShapeOfType<TLFrameShape>(shape, 'frame') ||
+					(this.isShapeOfType<TLArrowShape>(shape, 'arrow') && shape.props.text.trim()) ||
+					((this.isShapeOfType<TLNoteShape>(shape, 'note') ||
+						(this.isShapeOfType<TLGeoShape>(shape, 'geo') && shape.props.fill === 'none')) &&
+						this.getShapeUtil(shape).getText(shape)?.trim()))
 			) {
-				for (const childGeometry of (geometry as Group2d).children) {
+				for (const childGeometry of geometry.children) {
 					if (childGeometry.isLabel && childGeometry.isPointInBounds(pointInShapeSpace)) {
 						return shape
 					}


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

- Remove unnecessary type casting
- maybe?? (close) #6082 
- check for children more strictly via `isGroup`. `Geometry2d` does not have a `children` field.
- Increase stability

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

run test & everything is fine
(just about Editor)
```bash
Test Suites: 28 passed, 28 total
Tests:       197 passed, 197 total
Snapshots:   32 passed, 32 total
Time:        9.302 s
Ran all test suites.
```

### Release notes

- Remove unnecessary type casting in `Editor/getShapeAtPoint`