### PR TITLE
Followups to examples cleanup

### DIFF
--- a/apps/docs/scripts/lib/generateSection.ts
+++ b/apps/docs/scripts/lib/generateSection.ts
@@ -190,10 +190,6 @@ function getArticleData({
 
 	const { content } = parsed
 
-	// if (sectionId === 'examples') {
-	// 	console.log('order', order, 'priority', priority)
-	// }
-
 	const article: Article = {
 		id: articleId,
 		type: 'article',

--- a/apps/examples/src/examples/hosted-images/README.md
+++ b/apps/examples/src/examples/hosted-images/README.md
@@ -3,7 +3,6 @@ title: Hosted images
 component: ./HostedImagesExample.tsx
 category: data/assets
 priority: 2
-hide: true
 keywords: [assets, video, image, png, jpg, file]
 ---
 

--- a/apps/examples/src/examples/inset-canvas/inset-canvas.css
+++ b/apps/examples/src/examples/inset-canvas/inset-canvas.css
@@ -1,6 +1,5 @@
 .tldraw__editor-with-inset-canvas .tl-canvas {
 	position: absolute;
-	/* inset: 100px; */
 	inset: 25%;
 	width: 50%;
 	height: 50%;

--- a/apps/examples/src/examples/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -1,9 +1,11 @@
+import { ReactElement } from 'react'
 import {
 	Geometry2d,
 	HTMLContainer,
 	RecordProps,
 	Rectangle2d,
 	ShapeUtil,
+	SvgExportContext,
 	T,
 	TLBaseShape,
 	Tldraw,
@@ -65,15 +67,15 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [1]
-	// override toSvg(
-	// 	shape: ICustomShape,
-	// 	ctx: SvgExportContext
-	// ): ReactElement | null | Promise<ReactElement | null> {
-	// 	// ctx.addExportDef(getFontDef(shape))
-	// 	const isDarkmode = ctx.isDarkMode
-	// 	const fill = isDarkmode ? DARK_FILL : LIGHT_FILL
-	// 	return this.getSvgRect(shape, { fill })
-	// }
+	override toSvg(
+		shape: ICustomShape,
+		ctx: SvgExportContext
+	): ReactElement | null | Promise<ReactElement | null> {
+		// ctx.addExportDef(getFontDef(shape))
+		const isDarkmode = ctx.isDarkMode
+		const fill = isDarkmode ? DARK_FILL : LIGHT_FILL
+		return this.getSvgRect(shape, { fill })
+	}
 
 	getSvgRect(shape: ICustomShape, props?: { fill: string }) {
 		return <rect width={shape.props.w} height={shape.props.h} {...props} />


### PR DESCRIPTION
This PR cleans up the examples clean up: #5977 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
