### PR TITLE
Examples cleanup: Sidebar followup

### DIFF
--- a/apps/docs/components/docs/docs-sidebar-menus.tsx
+++ b/apps/docs/components/docs/docs-sidebar-menus.tsx
@@ -12,13 +12,20 @@ export function DocsSidebarMenus({ menus }: { menus: any }) {
 
 	useEffect(() => {
 		container.current?.scrollTo(0, scrollPosition)
-		const element = document.querySelector('.sidebar-link[data-active=true]') as HTMLElement | null
-		if (!element) return
-		const aboveView = container.current && element.offsetTop < container.current.scrollTop
-		const belowView =
-			container.current &&
-			element.offsetTop > container.current.scrollTop + container.current.clientHeight
-		if (aboveView || belowView) element.scrollIntoView({ block: 'center' })
+		const elements = document.querySelectorAll(
+			'.sidebar-link[data-active=true]'
+		) as NodeListOf<HTMLElement>
+		for (const element of elements) {
+			const aboveView = container.current && element.offsetTop < container.current.scrollTop
+			const belowView =
+				container.current &&
+				element.offsetTop > container.current.scrollTop + container.current.clientHeight
+			if (!aboveView && !belowView) {
+				return
+			}
+		}
+		const element = elements[0]
+		element?.scrollIntoView({ block: 'center' })
 	}, [pathname])
 
 	const onScroll: UIEventHandler<HTMLDivElement> = (e) => {

--- a/apps/docs/components/docs/docs-sidebar.tsx
+++ b/apps/docs/components/docs/docs-sidebar.tsx
@@ -17,12 +17,17 @@ export async function DocsSidebar({
 	// @ts-ignore
 	const elements = skipFirstLevel ? sidebar.links[0].children : sidebar.links
 
-	// Manually copy the sync demo example to the getting started category
+	// Manually copy the sync example and the editor API example to the getting started category
 	if (sectionId === 'examples') {
 		const gettingStartedCategory = elements.find((v: any) => v?.url === '/examples/getting-started')
 		const collaborationCategory = elements.find((v: any) => v?.url === '/examples/collaboration')
-		const syncDemoExample = collaborationCategory?.children[0]
+		const editorApiCategory = elements?.find((v: any) => v?.url === '/examples/editor-api')
+		const syncDemoExample = collaborationCategory?.children.find(
+			(v: any) => v?.articleId === 'sync-demo'
+		)
+		const editorApiExample = editorApiCategory?.children.find((v: any) => v?.articleId === 'api')
 		gettingStartedCategory?.children.push(syncDemoExample)
+		gettingStartedCategory?.children.push(editorApiExample)
 	}
 
 	return (

--- a/apps/examples/src/examples/api/README.md
+++ b/apps/examples/src/examples/api/README.md
@@ -1,5 +1,5 @@
 ---
-title: Control the editor
+title: Controlling the canvas
 component: ./APIExample.tsx
 category: editor-api
 priority: 0


### PR DESCRIPTION
This PR is a followup to the examples cleanup: #5977 

- Added the API example to the 'Getting started' category. Both Alex and Steve recommended this at various points.
- Fixed a bug where your scroll gets hijacked if you click one of the hardcoded 'cloned' examples in the sidebar.
- Renamed "Control the editor" to "Controlling the canvas" to make it consistent with the language we use in our Quick start guide.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
