### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tldraw
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tldraw/tldraw)
+
 Welcome to the public monorepo for [tldraw](https://github.com/tldraw/tldraw). tldraw is a library for creating infinite canvas experiences in React. It's the software behind the digital whiteboard [tldraw.com](https://tldraw.com).
 
 - Read the docs and learn more at [tldraw.dev](https://tldraw.dev).


### PR DESCRIPTION
Thoughts on adding this?

Adding this badge means that our [page on DeepWiki](https://deepwiki.com/tldraw/tldraw) will stay up-to-date. Or is it too intrusive? If so, we could put it at the bottom of the page or something. 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
