### PR TITLE
Fix docs sidebar duplication bug

### DIFF
--- a/apps/docs/components/docs/docs-sidebar.tsx
+++ b/apps/docs/components/docs/docs-sidebar.tsx
@@ -21,13 +21,17 @@ export async function DocsSidebar({
 	if (sectionId === 'examples') {
 		const gettingStartedCategory = elements.find((v: any) => v?.url === '/examples/getting-started')
 		const collaborationCategory = elements.find((v: any) => v?.url === '/examples/collaboration')
-		const editorApiCategory = elements?.find((v: any) => v?.url === '/examples/editor-api')
-		const syncDemoExample = collaborationCategory?.children.find(
+		const editorApiCategory = elements.find((v: any) => v?.url === '/examples/editor-api')
+		const syncDemoExample = collaborationCategory.children.find(
 			(v: any) => v?.articleId === 'sync-demo'
 		)
-		const editorApiExample = editorApiCategory?.children.find((v: any) => v?.articleId === 'api')
-		gettingStartedCategory?.children.push(syncDemoExample)
-		gettingStartedCategory?.children.push(editorApiExample)
+		const editorApiExample = editorApiCategory.children.find((v: any) => v?.articleId === 'api')
+		if (!gettingStartedCategory.children.includes(syncDemoExample)) {
+			gettingStartedCategory.children.push(syncDemoExample)
+		}
+		if (!gettingStartedCategory.children.includes(editorApiExample)) {
+			gettingStartedCategory.children.push(editorApiExample)
+		}
 	}
 
 	return (


### PR DESCRIPTION
Fix a bug where hardcoded sidebar items could get duplicated. Annoyingly, this bug was only happening in production - not development.

<img width="202" alt="image" src="https://github.com/user-attachments/assets/78f0d679-ba1b-4fe8-8ad7-97818939c8e0" />

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
