### PR TITLE
Fix two issues with examples refresh

### DIFF
--- a/apps/docs/components/docs/docs-mobile-sidebar.tsx
+++ b/apps/docs/components/docs/docs-mobile-sidebar.tsx
@@ -19,6 +19,23 @@ export async function DocsMobileSidebar({
 	// @ts-ignore
 	const elements = skipFirstLevel ? sidebar.links[0].children : sidebar.links
 
+	// Manually copy the sync example and the editor API example to the getting started category
+	if (sectionId === 'examples') {
+		const gettingStartedCategory = elements.find((v: any) => v?.url === '/examples/getting-started')
+		const collaborationCategory = elements.find((v: any) => v?.url === '/examples/collaboration')
+		const editorApiCategory = elements.find((v: any) => v?.url === '/examples/editor-api')
+		const syncDemoExample = collaborationCategory.children.find(
+			(v: any) => v?.articleId === 'sync-demo'
+		)
+		const editorApiExample = editorApiCategory.children.find((v: any) => v?.articleId === 'api')
+		if (!gettingStartedCategory.children.includes(syncDemoExample)) {
+			gettingStartedCategory.children.push(syncDemoExample)
+		}
+		if (!gettingStartedCategory.children.includes(editorApiExample)) {
+			gettingStartedCategory.children.push(editorApiExample)
+		}
+	}
+
 	return (
 		<Popover className="group/popover h-full grow">
 			<PopoverButton className="group/button focus:outline-none h-full w-full flex justify-start items-center">

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -98,6 +98,11 @@ const nextConfig = {
 				permanent: true,
 			},
 			{
+				source: '/examples/state-store',
+				destination: '/examples/signals',
+				permanent: true,
+			},
+			{
 				// For backwards compatibility with renamed examples
 				source: '/examples/basic/peristence-key',
 				destination: '/examples/persistence-key',

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -86,6 +86,12 @@ const nextConfig = {
 				permanent: true,
 			},
 			{
+				// For backwards compatibility with renamed examples
+				source: '/examples/basic/state-store',
+				destination: '/examples/signals',
+				permanent: true,
+			},
+			{
 				// For backwards compatibility with old examples links
 				source: '/examples/:categoryId/:articleId',
 				destination: '/examples/:articleId',
@@ -93,11 +99,6 @@ const nextConfig = {
 			},
 			{
 				// For backwards compatibility with renamed examples
-				source: '/examples/basic/state-store',
-				destination: '/examples/signals',
-				permanent: true,
-			},
-			{
 				source: '/examples/state-store',
 				destination: '/examples/signals',
 				permanent: true,


### PR DESCRIPTION
This PR fixes:

- Redirects from `tldraw.dev/examples/basic/state-store` to `tldraw.dev/examples/signals`
- Missing hardcoded examples in mobile menu

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
