### PR TITLE
Change a slideshow example title to have slightly clearer wording

### DIFF
--- a/apps/examples/src/examples/slides/README.md
+++ b/apps/examples/src/examples/slides/README.md
@@ -1,5 +1,5 @@
 ---
-title: Slideshow (moving camera)
+title: Slideshow (free camera)
 component: ./SlidesExample.tsx
 category: use-cases
 priority: 0


### PR DESCRIPTION
**Slideshow (moving camera)** -> **Slideshow (free camera)**

I think it makes it clearer what it does in relation to the other slideshow example, **Slideshow (fixed camera)**

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
