### PR TITLE
always show elbow arrow outline

### DIFF
--- a/packages/tldraw/src/lib/canvas/TldrawOverlays.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawOverlays.tsx
@@ -54,11 +54,10 @@ export function TldrawArrowHints() {
 	const { handlesInPageSpace, snap, anchorInPageSpace, arrowKind, isExact, isPrecise } = targetInfo
 
 	const showEdgeHints = !isExact && arrowKind === 'elbow'
-	const showOutline = !showEdgeHints || snap === 'edge' || snap === 'center' || snap === null
 
 	return (
 		<>
-			{showOutline && ShapeIndicator && <ShapeIndicator shapeId={targetInfo.target.id} />}
+			{ShapeIndicator && <ShapeIndicator shapeId={targetInfo.target.id} />}
 
 			{showEdgeHints && (
 				<svg className="tl-overlays__item">


### PR DESCRIPTION
This wasn't showing sometimes on hover, but it should.

### Change type

- [x] `bugfix`

### Release notes

- When creating elbow arrows, make sure we show the indicator for the target shape on hover.