### PR TITLE
Fix focus manager when editing

### DIFF
--- a/packages/editor/src/lib/editor/managers/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager.ts
@@ -58,7 +58,8 @@ export class FocusManager {
 
 	private handleKeyDown(keyEvent: KeyboardEvent) {
 		const container = this.editor.getContainer()
-		if (document.activeElement === container) return
+		if (this.editor.isIn('select.editing_shape')) return
+		if (document.activeElement === container && this.editor.getSelectedShapeIds().length > 0) return
 		if (['Tab', 'ArrowUp', 'ArrowDown'].includes(keyEvent.key)) {
 			container.classList.remove('tl-container__no-focus-ring')
 		}

--- a/packages/editor/src/lib/editor/managers/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager.ts
@@ -58,6 +58,7 @@ export class FocusManager {
 
 	private handleKeyDown(keyEvent: KeyboardEvent) {
 		const container = this.editor.getContainer()
+		if (document.activeElement === container) return
 		if (['Tab', 'ArrowUp', 'ArrowDown'].includes(keyEvent.key)) {
 			container.classList.remove('tl-container__no-focus-ring')
 		}


### PR DESCRIPTION
This PR fixes a bug that was causing the FocusManager to trigger focus rings / focus mode when using normal keyboard shortcuts.

For example, you could trigger the sidebar menu icons by using the arrow keys to nudge content, or by pressing Tab while editing a shape.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Use the arrow keys inside of the canvas, focus mode should stay off
2. Use the tab key inside of an input, focus mode should stay off
3. Use the arrow keys outside of the canvas, focus mode should turn on
4. Use the tab key outside of an input, focus mode should turn on

### Release notes

- Fixed a bug with keyboard focus turning on accidentally