### PR TITLE
Improve resizing frames

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1573,7 +1573,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         src: string;
     }>;
     readonly user: UserPreferencesManager;
-    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId, parentShape: TLShape | undefined) => false | void): this;
+    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId, parentShape?: TLShape) => false | void): this;
     zoomIn(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomOut(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomToBounds(bounds: BoxLike, opts?: {
@@ -2603,6 +2603,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canEditInReadonly(_shape: Shape): boolean;
     canReceiveNewChildrenOfType(_shape: Shape, _type: TLShape['type']): boolean;
     canResize(_shape: Shape): boolean;
+    canResizeChildren(_shape: Shape): boolean;
     canScroll(_shape: Shape): boolean;
     canSnap(_shape: Shape): boolean;
     canTabTo(_shape: Shape): boolean;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1573,7 +1573,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         src: string;
     }>;
     readonly user: UserPreferencesManager;
-    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId) => false | void): this;
+    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId, parentShape: TLShape | undefined) => false | void): this;
     zoomIn(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomOut(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomToBounds(bounds: BoxLike, opts?: {

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1573,7 +1573,7 @@ export class Editor extends EventEmitter<TLEventMap> {
         src: string;
     }>;
     readonly user: UserPreferencesManager;
-    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId, parentShape?: TLShape) => false | void): this;
+    visitDescendants(parent: TLPage | TLParentId | TLShape, visitor: (id: TLShapeId) => false | void): this;
     zoomIn(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomOut(point?: Vec, opts?: TLCameraMoveOptions): this;
     zoomToBounds(bounds: BoxLike, opts?: {
@@ -1912,6 +1912,10 @@ export class Group2d extends Geometry2d {
 export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     canBind(): boolean;
+    // (undocumented)
+    canResize(): boolean;
+    // (undocumented)
+    canResizeChildren(): boolean;
     // (undocumented)
     component(shape: TLGroupShape): JSX_2.Element | null;
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5794,7 +5794,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	visitDescendants(
 		parent: TLParentId | TLPage | TLShape,
-		visitor: (id: TLShapeId, parentShape: TLShape | undefined) => void | false
+		visitor: (id: TLShapeId, parentShape?: TLShape) => void | false
 	): this {
 		const parentId = typeof parent === 'string' ? parent : parent.id
 		const children = this.getSortedChildIdsForParent(parentId)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5794,16 +5794,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	visitDescendants(
 		parent: TLParentId | TLPage | TLShape,
-		visitor: (id: TLShapeId, parentShape?: TLShape) => void | false
+		visitor: (id: TLShapeId) => void | false
 	): this {
-		const parentId = typeof parent === 'string' ? parent : parent.id
-		const children = this.getSortedChildIdsForParent(parentId)
-		const freshParentShape = this.getShape(parentId)
-		if (freshParentShape) {
-			for (const id of children) {
-				if (visitor(id, freshParentShape) === false) continue
-				this.visitDescendants(id, visitor)
-			}
+		const children = this.getSortedChildIdsForParent(parent)
+		for (const id of children) {
+			if (visitor(id) === false) continue
+			this.visitDescendants(id, visitor)
 		}
 		return this
 	}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5794,13 +5794,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	visitDescendants(
 		parent: TLParentId | TLPage | TLShape,
-		visitor: (id: TLShapeId) => void | false
+		visitor: (id: TLShapeId, parentShape: TLShape | undefined) => void | false
 	): this {
 		const parentId = typeof parent === 'string' ? parent : parent.id
 		const children = this.getSortedChildIdsForParent(parentId)
-		for (const id of children) {
-			if (visitor(id) === false) continue
-			this.visitDescendants(id, visitor)
+		const freshParentShape = this.getShape(parentId)
+		if (freshParentShape) {
+			for (const id of children) {
+				if (visitor(id, freshParentShape) === false) continue
+				this.visitDescendants(id, visitor)
+			}
 		}
 		return this
 	}

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -241,6 +241,15 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
+	 * When the shape is resized, whether the shape's children should also be resized.
+	 *
+	 * @public
+	 */
+	canResizeChildren(_shape: Shape): boolean {
+		return true
+	}
+
+	/**
 	 * Whether the shape can be edited in read-only mode.
 	 *
 	 * @public

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -20,6 +20,14 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 		return false
 	}
 
+	canResize() {
+		return false
+	}
+
+	canResizeChildren() {
+		return true
+	}
+
 	getDefaultProps(): TLGroupShape['props'] {
 		return {}
 	}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1412,6 +1412,10 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canReceiveNewChildrenOfType(shape: TLShape, _type: TLShape['type']): boolean;
     // (undocumented)
+    canResize(): boolean;
+    // (undocumented)
+    canResizeChildren(): boolean;
+    // (undocumented)
     component(shape: TLFrameShape): JSX_2.Element;
     // (undocumented)
     static configure<T extends TLShapeUtilConstructor<any, any>>(this: T, options: T extends new (...args: any[]) => {

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -352,6 +352,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	override onResize(shape: any, info: TLResizeInfo<any>) {
 		return resizeBox(shape, info)
 	}
+
 	override getInterpolatedProps(
 		startShape: TLFrameShape,
 		endShape: TLFrameShape,

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -90,6 +90,14 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return true
 	}
 
+	override canResize() {
+		return true
+	}
+
+	override canResizeChildren() {
+		return false
+	}
+
 	override getDefaultProps(): TLFrameShape['props'] {
 		return { w: 160 * 2, h: 90 * 2, name: '', color: 'black' }
 	}


### PR DESCRIPTION
This PR improves the logic around resizing frames, so that the children of frames do not resize when a frame is being resized with other shapes

![Kapture 2025-05-26 at 07 51 36](https://github.com/user-attachments/assets/34b14967-3c88-417c-b1c5-ad0470fa0045)

This PR also improves how accelKey is handled when resizing frames / multiple frames:

![Kapture 2025-05-26 at 08 05 55](https://github.com/user-attachments/assets/0f5f7e17-5408-4b4f-9a67-50a56ed3e846)


In this PR, we:
- clean up the resizing snapshot collection code
- add a `canResizeChildren` helper to ShapeUtil
- use `canResize` and `canResizeChildren` in the new resizing snapshot collection code
- handle accelKey resizing with frames when multiple frames are selected

## Background 

Resizing a frame does not resize its children. This is true and good. However, previously, when a frame was in a selection that included other shapes, resizing the frame would also resize its children. It would not resize _all_ of its descendants, just the direct children.

I did explore an alternative where all of the descendants would resize, however that felt even less appropriate.

### Change type

- [x] `bugfix`
- [x] `improvement`

### Release notes

- Fixed several bugs with resizing frames when more than one frame is selected.