### PR TITLE
experiment: tip tap + react

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -38,6 +38,7 @@
 		"@tiptap/extension-font-family": "^2.9.1",
 		"@tiptap/extension-text-style": "^2.9.1",
 		"@tiptap/pm": "^2.9.1",
+		"@tiptap/react": "^2.9.1",
 		"@tiptap/starter-kit": "^2.9.1",
 		"@tldraw/assets": "workspace:*",
 		"@tldraw/dotcom-shared": "workspace:*",

--- a/apps/examples/src/examples/rich-text-react-extension/README.md
+++ b/apps/examples/src/examples/rich-text-react-extension/README.md
@@ -1,0 +1,15 @@
+---
+title: Rich text with react extension
+component: ./RichTextReactExtension.tsx
+category: shapes/tools
+priority: 20
+keywords: [text, tip, tap, extension, toolbar, react]
+---
+
+Extend the TipTap text editor by adding a custom react node type.
+
+---
+
+This example shows how to use TipTap's [Node views with
+React](https://tiptap.dev/docs/editor/extensions/custom-extensions/node-views/react) example in
+tldraw with `textOptions`.

--- a/apps/examples/src/examples/rich-text-react-extension/RichTextReactExtension.tsx
+++ b/apps/examples/src/examples/rich-text-react-extension/RichTextReactExtension.tsx
@@ -1,0 +1,101 @@
+import {
+	mergeAttributes,
+	Node,
+	NodeViewProps,
+	NodeViewWrapper,
+	ReactNodeViewRenderer,
+} from '@tiptap/react'
+import { createShapeId, tipTapDefaultExtensions, Tldraw, TLTextOptions } from 'tldraw'
+
+function MyReactComponent(props: NodeViewProps) {
+	const increase = () => {
+		props.updateAttributes({
+			count: props.node.attrs.count + 1,
+		})
+	}
+
+	return (
+		<NodeViewWrapper className="react-component">
+			<button onClick={increase}>
+				This react button has been clicked {props.node.attrs.count} times.
+			</button>
+		</NodeViewWrapper>
+	)
+}
+
+const MyReactComponentExtension = Node.create({
+	name: 'reactComponent',
+	group: 'block',
+	atom: true,
+	addAttributes() {
+		return {
+			count: {
+				default: 0,
+			},
+		}
+	},
+	parseHTML() {
+		return [
+			{
+				tag: 'react-component',
+			},
+		]
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['react-component', mergeAttributes(HTMLAttributes)]
+	},
+
+	addNodeView() {
+		return ReactNodeViewRenderer(MyReactComponent)
+	},
+})
+
+const textOptions: TLTextOptions = {
+	tipTapConfig: {
+		extensions: [...tipTapDefaultExtensions, MyReactComponentExtension],
+	},
+	alwaysRenderTipTap: true,
+}
+
+const defaultRichTextContent = {
+	type: 'doc',
+	content: [
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: 'This is a text shape with a react component in it.' }],
+		},
+		{
+			type: 'reactComponent',
+			attrs: { count: 0 },
+		},
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: 'We are really living in the future.' }],
+		},
+	],
+}
+
+export default function RichTextReactExtension() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				textOptions={textOptions}
+				onMount={(editor) => {
+					const sampleShapeId = createShapeId('sample shape')
+					editor
+						.deleteShape(sampleShapeId)
+						.createShape({
+							type: 'text',
+							id: sampleShapeId,
+							props: {
+								richText: defaultRichTextContent,
+							},
+						})
+						.selectAll()
+						.zoomToSelection()
+				}}
+			/>
+		</div>
+	)
+}

--- a/packages/editor/src/lib/utils/richText.ts
+++ b/packages/editor/src/lib/utils/richText.ts
@@ -23,6 +23,7 @@ export type TiptapNode = Node
 export interface TLTextOptions {
 	tipTapConfig?: EditorProviderProps
 	addFontsFromNode?: RichTextFontVisitor
+	alwaysRenderTipTap?: boolean
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -73,7 +73,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 }: RichTextLabelProps) {
 	const editor = useEditor()
 	const isDragging = React.useRef(false)
-	const { rInput, isEmpty, isEditing, isReadyForEditing, ...editableTextRest } =
+	const { rInput, isEmpty, isEditing, isReadyForEditing, shouldRenderTipTap, ...editableTextRest } =
 		useEditableRichText(shapeId, type, richText)
 
 	const html = useMemo(() => {
@@ -131,7 +131,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			data-font={font}
 			data-align={align}
 			data-hastext={!isEmpty}
-			data-isediting={isEditing}
+			data-isediting={isEditing || shouldRenderTipTap}
 			data-textwrap={!!wrap}
 			data-isselected={isSelected}
 			style={{
@@ -165,7 +165,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 						/>
 					)}
 				</div>
-				{(isReadyForEditing || isSelected) && (
+				{(shouldRenderTipTap || isSelected) && (
 					<RichTextArea
 						// Fudge the ref type because we're using forwardRef and it's not typed correctly.
 						ref={rInput as any}

--- a/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
@@ -8,6 +8,9 @@ export function useEditableRichText(shapeId: TLShapeId, type: string, richText?:
 	const commonUseEditableTextHandlers = useEditableTextCommon(shapeId)
 	const isEditing = commonUseEditableTextHandlers.isEditing
 	const editor = useEditor()
+	const shouldRenderTipTap =
+		commonUseEditableTextHandlers.isReadyForEditing ||
+		(editor.getTextOptions().alwaysRenderTipTap ?? false)
 	const rInput = useRef<HTMLDivElement>(null)
 	const isEmpty = richText && isEmptyRichText(richText)
 
@@ -61,6 +64,7 @@ export function useEditableRichText(shapeId: TLShapeId, type: string, richText?:
 		handleKeyDown,
 		handleChange,
 		isEmpty,
+		shouldRenderTipTap,
 		...commonUseEditableTextHandlers,
 	}
 }


### PR DESCRIPTION
Doing some investigation into #6090.

There are two major blockers to this:
1. We don't use `@tiptap/react`s `<EditorContent />` component, which sets up a bunch of hooks so react components get rendered as part of the same react root as the rest of the application.
2. TipTap's HTML serialiser doesn't render react components - instead it renders placeholder elements.

The first of these points is currently the easiest to work around - it's not too hard to set us up to provide the same `editor.contentComponent` interface that tiptap expects for rendering react components. This diff shows what that might look like. It might be possible for us to switch to `<EditorContent />` too, but the current solution was something we landed up after a lot of careful work to have the correct behaviour in and out of strict mode with different react versions. 

The second is a much larger issue. We use the HTML serialiser instead of creating tiptap instances for performance reasons in a number of places - text measurement, non-selected shape rendering, and exports, for example. To get full react components, we'd need to either mount a full tiptap instance in these places, or do something clever (like rendering a single tiptap instance for each rich text shape, and using that for measurement & cloning the rendered results into exports) to get the effect of a full tiptap instance. This diff starts to explore a `alwaysRenderTipTap` flag in text options that does some of this, but i didn't look at text measurement or exports yet because this stuff is so complicated.