### PR TITLE
Fix shift key opening link

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
@@ -1,5 +1,6 @@
 import { stopEventPropagation, useEditor, useValue } from '@tldraw/editor'
 import classNames from 'classnames'
+import { PointerEventHandler, useCallback } from 'react'
 
 const LINK_ICON =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' fill='none'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 5H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6M19 5h6m0 0v6m0-6L13 17'/%3E%3C/svg%3E"
@@ -7,6 +8,12 @@ const LINK_ICON =
 export function HyperlinkButton({ url }: { url: string }) {
 	const editor = useEditor()
 	const hideButton = useValue('zoomLevel', () => editor.getZoomLevel() < 0.32, [editor])
+	const useStopPropagationOnShiftKey = useCallback<PointerEventHandler>(
+		(e) => {
+			if (!editor.inputs.shiftKey) stopEventPropagation(e)
+		},
+		[editor]
+	)
 	return (
 		<a
 			className={classNames('tl-hyperlink-button', {
@@ -15,8 +22,8 @@ export function HyperlinkButton({ url }: { url: string }) {
 			href={url}
 			target="_blank"
 			rel="noopener noreferrer"
-			onPointerDown={stopEventPropagation}
-			onPointerUp={stopEventPropagation}
+			onPointerDown={useStopPropagationOnShiftKey}
+			onPointerUp={useStopPropagationOnShiftKey}
 			title={url}
 			draggable={false}
 		>


### PR DESCRIPTION
This PR fixes a bug where holding the shift key while clicking a link would open the link. (This is often accidental while adding a shape to the user's selection).

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a bookmark shape
2. Hold shift and click the hyperlink icon

### Release notes

- Fixed a bug with opening bookmark hyperlinks accidentally while holding shift