### PR TITLE
Fix pruning of queues and workers

### DIFF
--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -76,8 +76,7 @@ async function listPreviewWorkerDeployments() {
 		data.result
 			.map((r) => r.id)
 			.filter((id) => id.match(CLOUDFLARE_WORKER_REGEX))
-			// We want to delete the image optimizers first in order to clean up their service binding
-			// to the main sync worker, thus allowing us to delete them.
+			// We want to delete the image optimizers first since they have a service binding to the main workers
 			.sort((a, b) => {
 				if (a.includes('image-optimizer')) return -1
 				if (b.includes('image-optimizer')) return 1

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -19,6 +19,11 @@ interface ListWorkersResult {
 	result: { id: string }[]
 }
 
+interface ListQueuesResult {
+	success: boolean
+	result: { queue_id: string; queue_name: string; consumers: { consumer_id: string }[] }[]
+}
+
 const _isPrClosedCache = new Map<number, boolean>()
 async function isPrClosedForAWhile(prNumber: number) {
 	if (_isPrClosedCache.has(prNumber)) {
@@ -48,74 +53,89 @@ async function isPrClosedForAWhile(prNumber: number) {
 }
 
 const CLOUDFLARE_WORKER_REGEX = /^pr-(\d+)-/
+const CLOUDFLARE_SYNC_WORKER_REGEX = /^pr-\d+-tldraw-multiplayer$/
+
+async function cloudflareApi(endpoint: string, options: RequestInit = {}): Promise<Response> {
+	const url = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}${endpoint}`
+	return fetch(url, {
+		...options,
+		headers: {
+			Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+			'Content-Type': 'application/json',
+		},
+	})
+}
+
 async function listPreviewWorkerDeployments() {
-	const res = await fetch(
-		`https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/workers/scripts`,
-		{
-			headers: {
-				Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
-				'Content-Type': 'application/json',
-			},
-		}
-	)
-
+	const res = await cloudflareApi('/workers/scripts')
 	const data = (await res.json()) as ListWorkersResult
-
 	if (!data.success) {
 		throw new Error('Failed to list workers ' + JSON.stringify(data))
 	}
-
-	return data.result.map((r) => r.id).filter((id) => id.match(CLOUDFLARE_WORKER_REGEX))
+	return (
+		data.result
+			.map((r) => r.id)
+			.filter((id) => id.match(CLOUDFLARE_WORKER_REGEX))
+			// We want to delete the image optimizers first in order to clean up their service binding
+			// to the main sync worker, thus allowing us to delete them.
+			.sort((a, b) => {
+				if (a.includes('image-optimizer')) return -1
+				if (b.includes('image-optimizer')) return 1
+				return 0
+			})
+	)
 }
 
-async function deletePreviewWorkerDeployment(id: string) {
-	const prNumber = Number(id.match(CLOUDFLARE_WORKER_REGEX)?.[1])
-	const queueId = `tldraw-multiplayer-queue-pr-${prNumber}`
-	console.log('PR number', prNumber)
-	console.log('Queue id', queueId)
+async function deleteQueue(id: string) {
+	await cloudflareApi(`/queues/${id}`, { method: 'DELETE' })
+}
 
-	// Delete queue consumer
-	const queueConsumerDeleteUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/queues/${queueId}/consumers/${id}`
-	const queueConsumerDeleteReq = await fetch(queueConsumerDeleteUrl, {
-		method: 'DELETE',
-		headers: {
-			Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
-			'Content-Type': 'application/json',
-		},
-	})
-	if (!queueConsumerDeleteReq.ok) {
-		throw new Error(
-			'Failed to delete queue consumer ' + JSON.stringify(await queueConsumerDeleteReq.json())
-		)
-	}
+async function deleteQueueConsumer({ id, consumerId }: { id: string; consumerId: string }) {
+	await cloudflareApi(`/queues/${id}/consumers/${consumerId}`, { method: 'DELETE' })
+}
 
-	const url = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${id}`
-	nicelog('DELETE', url)
-	const res = await fetch(url, {
-		method: 'DELETE',
-		headers: {
-			Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
-			'Content-Type': 'application/json',
-		},
-	})
-	nicelog('status', res.status)
+async function deletePreviewWorker(id: string) {
+	const endpoint = `/workers/scripts/${id}`
+	nicelog(
+		'DELETE',
+		`https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}${endpoint}`
+	)
+	const res = await cloudflareApi(endpoint, { method: 'DELETE' })
 
 	if (!res.ok) {
 		throw new Error('Failed to delete worker ' + JSON.stringify(await res.json()))
 	}
+}
 
-	const queueUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/queues/${queueId}`
-	const queueRes = await fetch(queueUrl, {
-		method: 'DELETE',
-		headers: {
-			Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
-			'Content-Type': 'application/json',
-		},
-	})
-	if (!queueRes.ok) {
-		// This might happen for old PRs that didn't have queues yet
-		console.log('Failed to delete queue ' + JSON.stringify(await queueRes.json()))
+async function deletePreviewWorkerDeployment(id: string) {
+	// We want to delete the queue consumer and the queue only once. We'll do it just before we delete the worker
+	if (id.match(CLOUDFLARE_SYNC_WORKER_REGEX)) {
+		const prNumber = Number(id.match(CLOUDFLARE_WORKER_REGEX)?.[1])
+		const queueName = `tldraw-multiplayer-queue-pr-${prNumber}`
+		const queueInfo = queuesMap.get(queueName)
+		if (queueInfo) {
+			const { id, consumerId } = queueInfo
+			if (consumerId) {
+				await deleteQueueConsumer({ id, consumerId })
+			}
+			await deleteQueue(id)
+		}
 	}
+	await deletePreviewWorker(id)
+}
+
+const queuesMap = new Map<string, { id: string; consumerId: string | undefined }>()
+
+async function getQueues() {
+	const res = await cloudflareApi('/queues')
+	const data = (await res.json()) as ListQueuesResult
+	if (!data.success) {
+		throw new Error('Failed to get queues ' + JSON.stringify(data))
+	}
+	data.result.forEach((queue) => {
+		const { queue_id: id, queue_name: name, consumers } = queue
+		queuesMap.set(name, { id, consumerId: consumers[0]?.consumer_id })
+	})
 }
 
 const neonHeaders = {
@@ -218,6 +238,8 @@ async function deleteSstPreviewApp(stage: string) {
 }
 
 async function main() {
+	nicelog('Getting queues information')
+	await getQueues()
 	nicelog('Pruning preview deployments')
 	await processItems(listPreviewWorkerDeployments, deletePreviewWorkerDeployment)
 	nicelog('\nPruning preview databases')


### PR DESCRIPTION
Fixes pruning of workers and queues:
* The main problem was that cloudflare api requires you to specify queue id and not the name.
* For the queue consumer you have to specify the consumer id - the worker name does not work on this case. We now fetch the info for all the queues. We then use this info to get queue ids and queue consumer ids.
* Also fixed the issue for cases where we deleted the main sync worker before the image optimizier. That didn't work since the image optimizer had a service binding to the main worker.

Alternative would be to use the `force=true` option for the worker delete request, which should delete all the associated services. It looks like that doesn't work with queues though 🤷‍♂️

### Change type

- [x] `bugfix`
