### PR TITLE
[hotfix] don't show deleted files in sidebar

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -295,8 +295,9 @@ export class TldrawApp {
 		return files
 	}
 
+	@computed({ isEqual })
 	getUserFileStates() {
-		return this.fileStates$.get()
+		return this.fileStates$.get().filter((f) => !f.file.isDeleted)
 	}
 
 	lastRecentFileOrdering = null as null | Array<{


### PR DESCRIPTION
Somehow we have not been effectively cleaning up people's own file states when they delete their own files. This PR does not fix that but it does prevent the downstream issue where we still show deleted files in the sidebar.

Actually, in main, this PR is a no-op because the recent refactoring enabled filtering on the client already.

### Change type

- [x] `other`
