### PR TITLE
analytics: bunch of fixes and wiring of gtag

### DIFF
--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"js-cookie": "^3.0.5",
-		"posthog-js": "^1.210.2",
+		"posthog-js": "^1.248.1",
 		"radix-ui": "^1.3.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/apps/analytics/src/index.ts
+++ b/apps/analytics/src/index.ts
@@ -28,6 +28,8 @@ declare global {
 		}
 		TL_GA4_MEASUREMENT_ID: string | undefined
 		Reo: any
+		posthog: any
+		dataLayer: any[]
 	}
 }
 

--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -26,6 +26,7 @@ declare global {
 			openPrivacySettings(): void
 		}
 		TL_GA4_MEASUREMENT_ID: string | undefined
+		posthog: any
 	}
 }
 

--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Analytics as VercelAnalytics } from '@vercel/analytics/react'
 import Script from 'next/script'
 import { useEffect } from 'react'
 
@@ -9,14 +10,17 @@ export default function Analytics() {
 	}, [])
 
 	return (
-		<Script
-			id="tldraw-analytics"
-			type="text/javascript"
-			strategy="afterInteractive"
-			async
-			defer
-			src="https://analytics.tldraw.com/tl-analytics.js"
-		/>
+		<>
+			<VercelAnalytics />
+			<Script
+				id="tldraw-analytics"
+				type="text/javascript"
+				strategy="afterInteractive"
+				async
+				defer
+				src="https://analytics.tldraw.com/tl-analytics.js"
+			/>
+		</>
 	)
 }
 

--- a/apps/docs/components/common/tldraw-link.tsx
+++ b/apps/docs/components/common/tldraw-link.tsx
@@ -10,7 +10,7 @@ export function TldrawLink(props: React.ComponentProps<'a'>) {
 	const [distinctId, setDistinctId] = useState(windowObject?.posthog?.get_distinct_id())
 
 	useEffect(() => {
-		if (sessionId) return
+		if (sessionId || !href?.includes('tldraw.com')) return
 
 		// XXX: have to wait a bit for posthog to be ready.
 		// there's unfortunately no event callback for this.
@@ -23,7 +23,7 @@ export function TldrawLink(props: React.ComponentProps<'a'>) {
 		return () => {
 			clearTimeout(timeout)
 		}
-	}, [sessionId, windowObject])
+	}, [sessionId, windowObject, href])
 
 	const isLocalUrl = href?.startsWith('/') || href?.startsWith('#')
 	let maybeParsedUrl

--- a/apps/docs/components/common/tldraw-link.tsx
+++ b/apps/docs/components/common/tldraw-link.tsx
@@ -5,8 +5,9 @@ import { useEffect, useState } from 'react'
 
 export function TldrawLink(props: React.ComponentProps<'a'>) {
 	const { href, children } = props
-	const [sessionId, setSessionId] = useState(window.posthog?.get_session_id())
-	const [distinctId, setDistinctId] = useState(window.posthog?.get_distinct_id())
+	const windowObject = typeof window !== 'undefined' ? window : null
+	const [sessionId, setSessionId] = useState(windowObject?.posthog?.get_session_id())
+	const [distinctId, setDistinctId] = useState(windowObject?.posthog?.get_distinct_id())
 
 	useEffect(() => {
 		if (sessionId) return
@@ -14,15 +15,15 @@ export function TldrawLink(props: React.ComponentProps<'a'>) {
 		// XXX: have to wait a bit for posthog to be ready.
 		// there's unfortunately no event callback for this.
 		const timeout = setInterval(() => {
-			setSessionId(window.posthog?.get_session_id())
-			setDistinctId(window.posthog?.get_distinct_id())
+			setSessionId(windowObject?.posthog?.get_session_id())
+			setDistinctId(windowObject?.posthog?.get_distinct_id())
 			clearTimeout(timeout)
 		}, 1000)
 
 		return () => {
 			clearTimeout(timeout)
 		}
-	}, [sessionId])
+	}, [sessionId, windowObject])
 
 	const isLocalUrl = href?.startsWith('/') || href?.startsWith('#')
 	let maybeParsedUrl

--- a/apps/docs/components/common/tldraw-link.tsx
+++ b/apps/docs/components/common/tldraw-link.tsx
@@ -10,6 +10,8 @@ export function TldrawLink(props: React.ComponentProps<'a'>) {
 	const [distinctId, setDistinctId] = useState(windowObject?.posthog?.get_distinct_id())
 
 	useEffect(() => {
+		// Note this href check is intentionally loose, just to avoid
+		// doing this setInterval for every link. We do the real check below.
 		if (sessionId || !href?.includes('tldraw.com')) return
 
 		// XXX: have to wait a bit for posthog to be ready.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -71,7 +71,6 @@
 		"next-mdx-remote": "^5.0.0",
 		"next-themes": "^0.3.0",
 		"openai": "^4.80.1",
-		"posthog-js": "^1.210.2",
 		"query-string": "^9.1.1",
 		"radix-ui": "^1.3.4",
 		"react": "^18.3.1",

--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -44,7 +44,7 @@
 		"lodash.isequal": "^4.5.0",
 		"lodash.pick": "^4.4.0",
 		"md5": "^2.3.0",
-		"posthog-js": "^1.210.2",
+		"posthog-js": "^1.248.1",
 		"qrcode": "^1.5.4",
 		"radix-ui": "^1.3.4",
 		"react": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8904,7 +8904,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.5"
     "@vitejs/plugin-react": "npm:^4.3.4"
     js-cookie: "npm:^3.0.5"
-    posthog-js: "npm:^1.210.2"
+    posthog-js: "npm:^1.248.1"
     radix-ui: "npm:^1.3.4"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -8996,7 +8996,6 @@ __metadata:
     openai: "npm:^4.80.1"
     patch-package: "npm:^8.0.0"
     postcss: "npm:^8.5.1"
-    posthog-js: "npm:^1.210.2"
     postinstall-postinstall: "npm:^2.1.0"
     prettier: "npm:^3.4.2"
     prettier-plugin-organize-imports: "npm:^3.2.4"
@@ -14150,7 +14149,7 @@ __metadata:
     lodash.pick: "npm:^4.4.0"
     md5: "npm:^2.3.0"
     pg: "npm:^8.13.1"
-    posthog-js: "npm:^1.210.2"
+    posthog-js: "npm:^1.248.1"
     qrcode: "npm:^1.5.4"
     radix-ui: "npm:^1.3.4"
     react: "npm:^18.3.1"
@@ -23864,15 +23863,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"posthog-js@npm:^1.210.2":
-  version: 1.210.2
-  resolution: "posthog-js@npm:1.210.2"
+"posthog-js@npm:^1.248.1":
+  version: 1.248.1
+  resolution: "posthog-js@npm:1.248.1"
   dependencies:
     core-js: "npm:^3.38.1"
     fflate: "npm:^0.4.8"
     preact: "npm:^10.19.3"
-    web-vitals: "npm:^4.2.0"
-  checksum: 10/92d81a454617961912052e1e0a8eab381a557f5eba249e4818301b3cadacc11e2c4bea8e5eaaf5889e7f940c27684e93744e15f00768adcd0cee2c6abd6e913a
+    web-vitals: "npm:^4.2.4"
+  peerDependencies:
+    "@rrweb/types": 2.0.0-alpha.17
+    rrweb-snapshot: 2.0.0-alpha.17
+  peerDependenciesMeta:
+    "@rrweb/types":
+      optional: true
+    rrweb-snapshot:
+      optional: true
+  checksum: 10/b9a11b29eb13fac827138e5e9e008b07bad3f7e3cf0bbd5acdac662982006ccc525c7a4d728b81149642428745714ee4c47a01ab70ecff767714bf3161b6e587
   languageName: node
   linkType: hard
 
@@ -29173,7 +29180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:^4.2.0":
+"web-vitals@npm:^4.2.4":
   version: 4.2.4
   resolution: "web-vitals@npm:4.2.4"
   checksum: 10/68cd1c2625a04b26e7eab67110623396afc6c9ef8c3a76f4e780aefe5b7d4ca1691737a0b99119e1d1ca9a463c4d468c0f0090b1875b6d784589d3a4a8503313


### PR DESCRIPTION
- sets up gtag for consent mode
- loads posthog+GA with anonymized/non-cookie settings until consent is given
- make sure we don't double-load the dynamic script tags
- brings back VA for now while we test things on .dev
- fix the posthog session links on .dev, kind of annoying but have to keep checking until it's loaded

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
