### PR TITLE
chore(analytics): use ReactGA gtag

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -12,11 +12,6 @@ let storedProperties: { [key: string]: any } | undefined = undefined
 let storedHasConsent: CookieConsent = 'unknown'
 window.posthog = posthog
 
-window.dataLayer = window.dataLayer || []
-function gtag(...rest: any[]) {
-	window.dataLayer.push(rest)
-}
-
 // Add theme detection
 function getTheme() {
 	const html = document.documentElement
@@ -68,7 +63,7 @@ export default function Analytics() {
 			})
 
 			if (window.TL_GA4_MEASUREMENT_ID) {
-				gtag('consent', 'default', {
+				ReactGA.gtag('consent', 'default', {
 					ad_storage: 'denied',
 					ad_user_data: 'denied',
 					ad_personalization: 'denied',
@@ -76,19 +71,6 @@ export default function Analytics() {
 					// Wait for our cookie to load.
 					wait_for_update: 500,
 				})
-
-				gtag('js', new Date())
-				gtag('config', window.TL_GA4_MEASUREMENT_ID)
-
-				// Add GTM
-				if (!document.getElementById('gtm-script-loader')) {
-					const gtmScriptTag = document.createElement('script')
-					gtmScriptTag.id = 'gtm-script-loader'
-					gtmScriptTag.src = `https://www.googletagmanager.com/gtag/js?id=${window.TL_GA4_MEASUREMENT_ID}`
-					gtmScriptTag.defer = true
-					document.head.appendChild(gtmScriptTag)
-				}
-
 				ReactGA.initialize(window.TL_GA4_MEASUREMENT_ID, {
 					gaOptions: {
 						anonymize_ip: true,
@@ -106,7 +88,7 @@ export default function Analytics() {
 			posthog.opt_in_capturing()
 			ReactGA.set({ anonymize_ip: false })
 
-			gtag('consent', 'update', {
+			ReactGA.gtag('consent', 'update', {
 				ad_user_data: 'granted',
 				ad_personalization: 'granted',
 				ad_storage: 'granted',
@@ -142,7 +124,7 @@ export default function Analytics() {
 			posthog.opt_out_capturing()
 			ReactGA.reset()
 			ReactGA.set({ anonymize_ip: true })
-			gtag('consent', 'update', {
+			ReactGA.gtag('consent', 'update', {
 				ad_user_data: 'denied',
 				ad_personalization: 'denied',
 				ad_storage: 'denied',

--- a/apps/analytics/src/index.ts
+++ b/apps/analytics/src/index.ts
@@ -29,7 +29,6 @@ declare global {
 		TL_GA4_MEASUREMENT_ID: string | undefined
 		Reo: any
 		posthog: any
-		dataLayer: any[]
 	}
 }
 

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -77,23 +77,14 @@ function configurePosthog(options: AnalyticsOptions) {
 	eventBufferPosthog?.forEach((event) => posthog.capture(event.name, event.data))
 	eventBufferPosthog = null
 }
-declare global {
-	interface Window {
-		dataLayer: any[]
-	}
-}
 
-window.dataLayer = window.dataLayer || []
-function gtag(...rest: any[]) {
-	window.dataLayer.push(rest)
-}
 let currentOptionsGA4: AnalyticsOptions | null = null
 let eventBufferGA4: null | Array<{ name: string; data: Properties | null | undefined }> = []
 function configureGA4(options: AnalyticsOptions) {
 	if (!shouldUseGA4) return
 
 	if (!currentOptionsGA4) {
-		gtag('consent', 'default', {
+		ReactGA.gtag('consent', 'default', {
 			ad_storage: 'denied',
 			ad_user_data: 'denied',
 			ad_personalization: 'denied',
@@ -102,25 +93,13 @@ function configureGA4(options: AnalyticsOptions) {
 			wait_for_update: 500,
 		})
 
-		gtag('js', new Date())
-		gtag('config', GA4_MEASUREMENT_ID)
-
-		// Add GTM
-		if (!document.getElementById('gtm-script-loader')) {
-			const gtmScriptTag = document.createElement('script')
-			gtmScriptTag.id = 'gtm-script-loader'
-			gtmScriptTag.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`
-			gtmScriptTag.defer = true
-			document.head.appendChild(gtmScriptTag)
-		}
-
 		ReactGA.initialize(GA4_MEASUREMENT_ID)
 		ReactGA.send('pageview')
 	}
 
 	if (options.optedIn) {
 		ReactGA.set({ userId: options.user.id, anonymize_ip: false })
-		gtag('consent', 'update', {
+		ReactGA.gtag('consent', 'update', {
 			ad_user_data: 'granted',
 			ad_personalization: 'granted',
 			ad_storage: 'granted',
@@ -130,7 +109,7 @@ function configureGA4(options: AnalyticsOptions) {
 		ReactGA.set({ anonymize_ip: true })
 		ReactGA.reset()
 
-		gtag('consent', 'update', {
+		ReactGA.gtag('consent', 'update', {
 			ad_user_data: 'denied',
 			ad_personalization: 'denied',
 			ad_storage: 'denied',


### PR DESCRIPTION
This PR updates the analytics implementation to use ReactGA gtag directly.

### Change type

- [x] `other`

### Test plan

1. Verify analytics events are still being sent correctly in the dotcom environment.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Internal analytics implementation updates.