### PR TITLE
[hotfix] analytics: add another domain for csp on dotcom (#6156)

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -24,6 +24,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'http://localhost:4848',
 		'https://analytics.tldraw.com',
 		'https://stats.g.doubleclick.net',
+		'https://*.google-analytics.com',
 	],
 	'font-src': [`'self'`, `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, 'data:'],
 	'frame-src': [`https:`],


### PR DESCRIPTION
this is a separate domain for when it's cookieless (analytics denied)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
