### PR TITLE
Fix double dialogs.

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -31,6 +31,7 @@ export const components: TLComponents = {
 	SharePanel: TlaEditorLegacySharePanel,
 	TopPanel: TlaEditorTopPanel,
 	Dialogs: null,
+	Toasts: null,
 }
 
 export function TlaLegacyFileEditor({

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -30,6 +30,7 @@ export const components: TLComponents = {
 	MenuPanel: TlaEditorMenuPanel,
 	SharePanel: TlaEditorLegacySharePanel,
 	TopPanel: TlaEditorTopPanel,
+	Dialogs: null,
 }
 
 export function TlaLegacyFileEditor({


### PR DESCRIPTION
We were rendering dialogs twice. Once via the default dialog logic in `TldrawUiContent` and once in tldraw app in `InsideOfContainerContext`. Same for toasts.

### Change type

- [x] `bugfix`
