### PR TITLE
Only re-evaluate fonts when props.richText changes

### DIFF
--- a/packages/editor/src/lib/editor/managers/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager.ts
@@ -94,7 +94,11 @@ export class FontManager {
 				const shapeUtil = this.editor.getShapeUtil(shape)
 				return shapeUtil.getFontFaces(shape)
 			},
-			{ areResultsEqual: areArraysShallowEqual, areRecordsEqual: (a, b) => a.props === b.props }
+			{
+				areResultsEqual: areArraysShallowEqual,
+				// @ts-expect-error
+				areRecordsEqual: (a, b) => a.props.richText === b.props.richText,
+			}
 		)
 
 		this.shapeFontLoadStateCache = editor.store.createCache<(FontState | null)[], TLShape>(


### PR DESCRIPTION
As feared, the font recognition and caching code that we wrote for rich text has some ugly performance effects, especially when resizing shapes.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a few hundred shapes
2. Resize them

### Release notes

- Improved performance when resizing or editing many shapes.