### PR TITLE
chore(sync): disable image uploads for sync demo

### DIFF
--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -127,7 +127,7 @@ export function useSyncDemo(
 function shouldDisallowUploads(host: string) {
 	const disallowedHosts = ['tldraw.com', 'tldraw.xyz']
 	return disallowedHosts.some(
-		(allowedHost) => host === allowedHost || host.endsWith(`.${allowedHost}`)
+		(disallowedHost) => host === disallowedHost || host.endsWith(`.${disallowedHost}`)
 	)
 }
 


### PR DESCRIPTION
Disable asset uploads for sync demo.

### Change type

- [x] `improvement` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Open the sync demo and verify that image uploads are disabled.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Disable image uploads for sync demo