### PR TITLE
docs: fix overscrolling from page links

### DIFF
--- a/apps/docs/components/common/page-title.tsx
+++ b/apps/docs/components/common/page-title.tsx
@@ -8,7 +8,12 @@ export function PageTitle({
 	className?: string
 }) {
 	return (
-		<h1 className={cn('font-black text-black dark:text-white text-3xl sm:text-4xl', className)}>
+		<h1
+			className={cn(
+				'font-black text-black dark:text-white text-3xl sm:text-4xl break-words max-w-full',
+				className
+			)}
+		>
 			{children}
 		</h1>
 	)

--- a/apps/docs/components/docs/docs-footer.tsx
+++ b/apps/docs/components/docs/docs-footer.tsx
@@ -7,7 +7,7 @@ export async function DocsFooter({ article }: { article: Article }) {
 	const links = await db.getArticleLinks(article)
 
 	return (
-		<section className="py-10 mt-12 border-t border-zinc-100 dark:border-zinc-800 flex justify-between gap-16">
+		<section className="py-10 mt-12 border-t border-zinc-100 dark:border-zinc-800 flex flex-wrap justify-between gap-8">
 			{links.prev ? (
 				<Link
 					href={links.prev.path!}
@@ -27,7 +27,7 @@ export async function DocsFooter({ article }: { article: Article }) {
 			{links.next ? (
 				<Link
 					href={links.next.path!}
-					className="group py-2 px-4 -mr-4 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 flex flex-col items-end gap-0.5"
+					className="group py-2 px-4 -mr-4 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 flex flex-col items-end gap-0.5 justify-self-end ml-auto"
 				>
 					<div className="flex items-center gap-1 text-xs group-hover:text-black dark:group-hover:text-white">
 						<span>Next</span>


### PR DESCRIPTION
Fixes overscrolling from long page links and titles on our docs site.

![image](https://github.com/user-attachments/assets/c55cba29-8350-4b60-9699-85f44c5b8b62)

![image](https://github.com/user-attachments/assets/02ed74d7-29fe-40b2-a8f0-612e32cda8be)

![image](https://github.com/user-attachments/assets/434072de-d847-4ed6-b145-b9ae9edccf43)

### Change type

- [x] `other`

### Test plan

1. Navigate to a documentation page with long titles or links.
2. Verify that the page no longer overscrolls horizontally.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where long page links and titles caused overscrolling on the documentation site.