### PR TITLE
improvement(dotcom): bump max files and add signout route

### DIFF
--- a/apps/dotcom/client/src/pages/signout.tsx
+++ b/apps/dotcom/client/src/pages/signout.tsx
@@ -1,9 +1,0 @@
-import { SignOutButton } from '@clerk/clerk-react'
-
-export function Component() {
-	return (
-		<div>
-			<SignOutButton />
-		</div>
-	)
-}

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -97,7 +97,6 @@ export const router = createRoutesFromElements(
 				{/* Views that require login */}
 				<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>
 				<Route path="/admin" lazy={() => import('./pages/admin')} />
-				<Route path="/signout" lazy={() => import('./pages/signout')} />
 			</Route>
 		</Route>
 		<Route path="/__debug-tail" lazy={() => import('./tla/pages/worker-debug-tail')} />


### PR DESCRIPTION
This PR bumps the max files from 100 to 200.

This PR also adds a secret /signout route, which I keep reaching for in development (and sometimes have to reset application data instead).

### Change type

- [x] `improvement`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Increased the maximum files for users on tldraw.com