### PR TITLE
[work in progress] Add an AI page to docs site

### DIFF
--- a/apps/docs/content/docs/ai.mdx
+++ b/apps/docs/content/docs/ai.mdx
@@ -1,0 +1,54 @@
+---
+title: AI models
+status: published
+author: todepond
+date: 6/3/2025
+order: 8
+keywords:
+  - ai
+  - llm
+  - genai
+  - generative
+---
+
+You can use AI models alongside tldraw in various ways.
+
+## Products
+
+We build free AI products to illustrate and explore the possibilities of combining AI with tldraw.
+
+### Make Real
+
+[Make Real](https://makereal.tldraw.com) turns your wireframe drawings into working websites.
+
+<Video
+	lazy
+	autoplay
+	src="/images/blog/F-5SomuWoAERTCa.mp4"
+	thumbnail="/images/blog/8bf096e3-2487-46ee-af8c-db3cf4bacc03/transcoded_00001.png"
+/>
+
+Read the full [blog post](/blog/product/make-real-the-story-so-far), or build your own version by [forking the template](https://github.com/tldraw/make-real-starter).
+
+### tldraw computer
+
+[tldraw computer](https://computer.tldraw.com) lets you build AI workflows on the canvas and run them in real-time.
+
+<Video lazy autoplay src="/images/ai/computer.mp4" />
+
+Read Google's full blog post about tldraw computer [here](https://ai.google.dev/showcase/tldraw).
+
+#### Teach
+
+**[Teach](https://teach.tldraw.com) is a proof-of-concept for getting an AI model to create canvas content.**
+
+#### Tech demos
+
+- **[Autocomplete for canvas](https://www.youtube.com/watch?v=r6ls8Gw9MmY) is a tech demo that**
+- **[Draw Fast](https://drawfast.tldraw.com) was an exploration of using AI to generate drawings based on text prompts.** Clone the [repo](https://github.com/tldraw/draw-fast) to run it locally.
+
+Try out our AI products like [Make Real](https://makereal.tldraw.com) and [tldraw computer](https://computer.tldraw.com).
+
+## AI module
+
+## LLMs.txt


### PR DESCRIPTION
This PR *will* add an AI page to the docs site containing info about:
- Our AI products
- AI module
- LLMs.txt
- Simple 'getting started' guide for common use-cases, eg: Sending a screenshot to a model

It's not done yet though and I don't like how it's structured currently - too messy etc. To be continued tomorrow..

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Docs: Added a page on AI use.