### PR TITLE
Remove references to Yjs and make clear our recommendations re: tldraw sync 

### DIFF
--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -83,8 +83,6 @@ To use tldraw sync in production, you will need to self-host the tldraw sync ser
 
 While tldraw sync is our recommended and best-supported backend for tldraw, we designed the tldraw SDK to work with any data solution.
 
-As a reference, our [tldraw-yjs example](https://github.com/tldraw/tldraw-yjs-example) shows an integration between tldraw and the [Yjs](https://yjs.dev) CRDT library.
-
 Whichever backend you choose, adding collaboration to tldraw will involve synchronizing data, sharing user presence, and handling user assets.
 
 ### Synchronizing data

--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -101,8 +101,6 @@ We provide a helper, [createPresenceStateDerivation](?), for constructing a reac
 
 To the editor, any `instance_presence` records that belong to other users (i.e. those with a different user id than the editor's configured user id) are considered "collaborators". The editor has two methods, `getCollaborators` and `getCollaboratorsOnCurrentPage`, which return reactive signals about the current collaborators.
 
-See the [yjs-example](https://github.com/tldraw/tldraw-yjs-example/blob/45dfe7589ae44e4aaf9bb7359d0372f3a88bd597/src/useYjsStore.ts) for an example of how these records may be created, shared, and updated.
-
 ### Collaboration UI
 
 The `tldraw` library includes several components specifically designed for collaboration.

--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -187,8 +187,6 @@ export default function () {
 }
 ```
 
-For a good example of this pattern, see the [yjs-example](https://github.com/tldraw/tldraw-yjs-example).
-
 ## Listening for changes
 
 You can listen for incremental updates to the document state by calling `editor.store.listen`, e.g.

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -48,7 +48,7 @@ Make sure you also read the section below about [deployment concerns](#deploymen
 
 ### Integrate tldraw sync into your own backend
 
-The `@tldraw/sync-core` library can be used to integrate tldraw sync into any JavaScript server environment that supports WebSockets.
+We recommend using Cloudflare, but the `@tldraw/sync-core` library can be used to integrate tldraw sync into any JavaScript server environment that supports WebSockets.
 
 We have a [simple server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
 


### PR DESCRIPTION
This PR removes three references to the old Yjs example, and it makes it clear that we recommend cloudflare.

This is based on me seeing several developers opting for yjs or the simple server example instead of tldraw sync deployed on cloudflare.

Thoughts?

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
