### PR TITLE
Use socket hibernation for user durable object

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -79,6 +79,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 
 		// debug logging in preview envs by default
 		this.log = new Logger(env, 'TLUserDurableObject', this.sentry)
+		this.log.debug('TLUserDurableObject constructor', this.ctx.getWebSockets().length)
 	}
 
 	private userId: string | null = null


### PR DESCRIPTION
This switches to using the socket hibernation api for the user durable to reduce the number of cloudflare CPU minutes used by idling browser tabs.

### Change type

- [x] `other`
