### PR TITLE
Improve page menu interactions

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Editor.ts
+++ b/apps/dotcom/client/e2e/fixtures/Editor.ts
@@ -17,7 +17,7 @@ export class Editor {
 		this.sidebarToggle = this.page.getByTestId('tla-sidebar-toggle')
 		this.fileName = this.page.getByTestId('tla-file-name')
 		this.shapes = this.page.locator('.tl-shape')
-		this.pageMenu = this.page.getByTestId('tla-page-menu')
+		this.pageMenu = this.page.getByTestId('tla-main-menu')
 	}
 
 	async toggleSidebar() {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -124,7 +124,7 @@ export function TlaEditorTopLeftPanelAnonymous() {
 						<button
 							className={styles.topLeftMainMenuTrigger}
 							title={pageMenuLbl}
-							data-testid="tla-page-menu"
+							data-testid="tla-main-menu"
 						>
 							<TlaIcon icon="dots-vertical-strong" />
 						</button>
@@ -245,7 +245,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 					<button
 						className={styles.topLeftMainMenuTrigger}
 						title={pageMenuLbl}
-						data-testid="tla-page-menu"
+						data-testid="tla-main-menu"
 					>
 						<TlaIcon icon="dots-vertical-strong" />
 					</button>

--- a/apps/examples/e2e/tests/fixtures/menus/PageMenu.ts
+++ b/apps/examples/e2e/tests/fixtures/menus/PageMenu.ts
@@ -3,10 +3,26 @@ import { Locator, Page } from '@playwright/test'
 export class PageMenu {
 	readonly pagemenuButton: Locator
 	readonly header: Locator
+	readonly createButton: Locator
+	readonly editButton: Locator
+	readonly pageList: Locator
+	readonly pageItems: Locator
 
 	constructor(public readonly page: Page) {
 		this.page = page
 		this.pagemenuButton = this.page.getByTestId('page-menu.button')
 		this.header = this.page.getByRole('dialog').getByText('Pages')
+		this.createButton = this.page.getByTestId('page-menu.create')
+		this.editButton = this.page.getByTestId('page-menu.edit')
+		this.pageList = this.page.getByTestId('page-menu.list')
+		this.pageItems = this.page.getByTestId('page-menu.item')
+	}
+
+	async getPageItem(index: number) {
+		return this.pageItems.nth(index)
+	}
+
+	getPageItemByName(name: string) {
+		return this.page.getByTestId('page-menu.item').filter({ hasText: name })
 	}
 }

--- a/apps/examples/e2e/tests/test-page-menu.spec.ts
+++ b/apps/examples/e2e/tests/test-page-menu.spec.ts
@@ -219,6 +219,18 @@ test.describe('page menu', () => {
 			// Should have original name back
 			await expect(pageItem.getByRole('button').first()).toContainText(originalName || '')
 		})
+
+		test('When you create a new page, the new page is focused', async ({ page, pageMenu }) => {})
+
+		test('When you open the page menu, the current page is in view', async ({
+			page,
+			pageMenu,
+		}) => {})
+
+		test('When you open the page menu, the current page is focused', async ({
+			page,
+			pageMenu,
+		}) => {})
 	})
 
 	test.describe('You can drag and drop pages to reorder them', () => {

--- a/apps/examples/e2e/tests/test-page-menu.spec.ts
+++ b/apps/examples/e2e/tests/test-page-menu.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test'
+import { sleep } from 'tldraw'
 import { setup } from '../shared-e2e'
 import test from './fixtures/fixtures'
 
@@ -14,7 +15,421 @@ test.describe('page menu', () => {
 		await expect(header).toBeHidden()
 	})
 
-	// ...
-	// More tests here
-	// ...
+	test('You can change pages', async ({ page, pageMenu }) => {
+		const { pagemenuButton, pageItems } = pageMenu
+
+		await test.step('open page menu', async () => {
+			await pagemenuButton.click()
+			await expect(pageItems.first()).toBeVisible()
+		})
+
+		await test.step('create a second page', async () => {
+			const initialCount = await pageItems.count()
+			await pageMenu.createButton.click()
+			await expect(pageItems).toHaveCount(initialCount + 1)
+			await page.keyboard.press('Enter')
+			await page.keyboard.press('Escape')
+		})
+
+		await test.step('switch between pages', async () => {
+			await pagemenuButton.click()
+			await expect(pageItems).toHaveCount(2)
+
+			const firstPage = pageItems.nth(0)
+			const secondPage = pageItems.nth(1)
+
+			// Wait for both pages to be visible
+			await expect(firstPage).toBeVisible()
+			await expect(secondPage).toBeVisible()
+
+			await expect(
+				firstPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'false')
+			await expect(
+				secondPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'true')
+
+			// Click on second page
+			await secondPage.locator('button').first().click()
+			await expect(
+				firstPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'false')
+			await expect(
+				secondPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'true')
+
+			// Click on first page
+			await firstPage.locator('button').first().click()
+
+			await expect(
+				firstPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'true')
+			await expect(
+				secondPage.locator('.tlui-page-menu__item__button > .tlui-button__icon')
+			).toHaveAttribute('data-checked', 'false')
+		})
+	})
+
+	test('You can create a new page by pressing enter after opening the page menu', async ({
+		page,
+		pageMenu,
+	}) => {
+		const { pagemenuButton, pageItems, createButton } = pageMenu
+
+		await test.step('open page menu and get initial count', async () => {
+			await pagemenuButton.click()
+			await expect(pageItems.first()).toBeVisible()
+		})
+
+		await test.step('create new page using create button', async () => {
+			const initialCount = await pageItems.count()
+			await createButton.click()
+			await expect(pageItems).toHaveCount(initialCount + 1)
+		})
+
+		await test.step('confirm page creation with enter', async () => {
+			await page.keyboard.press('Enter')
+			await page.keyboard.press('Escape')
+		})
+	})
+
+	test.describe('You can rename a page', () => {
+		test('You can rename a page by double clicking its name', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('open page menu', async () => {
+				await pagemenuButton.click()
+				await expect(pageItems.first()).toBeVisible()
+			})
+
+			await test.step('double click to rename page', async () => {
+				const pageItem = await pageMenu.getPageItem(0)
+				await pageItem.getByRole('button').first().dblclick()
+
+				// Should be in edit mode - look for input field
+				await expect(pageItem.locator('input')).toBeVisible()
+			})
+
+			await test.step('enter new name', async () => {
+				const input = pageItems.first().locator('input')
+				await expect(input).toBeVisible()
+
+				// Clear the input field more reliably
+				await input.clear()
+				await input.fill('My New Page')
+				await page.keyboard.press('Enter')
+			})
+
+			await test.step('verify page was renamed', async () => {
+				// Wait for the input to disappear (edit mode ends)
+				await expect(pageItems.first().locator('input')).toBeHidden()
+
+				// Wait a bit more for the rename to process
+				await sleep(200)
+
+				const pageItem = await pageMenu.getPageItem(0)
+				await expect(pageItem).toContainText('My New Page')
+			})
+		})
+
+		test('You can press enter to confirm a rename without closing the menu', async ({
+			page,
+			pageMenu,
+		}) => {
+			const { pagemenuButton, pageItems, header } = pageMenu
+
+			await pagemenuButton.click()
+			await expect(pageItems.first()).toBeVisible()
+
+			// Double click to start editing
+			const pageItem = await pageMenu.getPageItem(0)
+			await pageItem.getByRole('button').first().dblclick()
+
+			// Wait for edit mode to activate
+			const input = pageItem.locator('input')
+			await expect(input).toBeVisible()
+
+			// Clear and type new name
+			await input.clear()
+			await input.fill('Renamed Page')
+			await page.keyboard.press('Enter')
+
+			// Wait for edit mode to end
+			await expect(input).toBeHidden()
+
+			// Menu should still be open
+			await expect(header).toBeVisible()
+			// Check that the page item now contains the new name
+			await expect(pageItem).toContainText('Renamed Page')
+		})
+
+		test('You can press enter after renaming a page to close the menu', async ({
+			page,
+			pageMenu,
+		}) => {
+			const { pagemenuButton, pageItems, header } = pageMenu
+
+			await pagemenuButton.click()
+			await expect(pageItems.first()).toBeVisible()
+
+			// Double click to start editing
+			const pageItem = await pageMenu.getPageItem(0)
+			await pageItem.getByRole('button').first().dblclick()
+
+			// Wait for edit mode and use robust input handling
+			const input = pageItem.locator('input')
+			await expect(input).toBeVisible()
+
+			await input.clear()
+			await input.fill('Another Renamed Page')
+			await page.keyboard.press('Enter')
+			await page.keyboard.press('Enter')
+
+			// Menu should be closed
+			await expect(header).toBeHidden()
+		})
+
+		test('You can press escape to cancel a page rename and restore the previous name', async ({
+			page,
+			pageMenu,
+		}) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await pagemenuButton.click()
+			await expect(pageItems.first()).toBeVisible()
+
+			// Get original page name
+			const pageItem = await pageMenu.getPageItem(0)
+			const originalName = await pageItem.getByRole('button').first().textContent()
+
+			// Double click to start editing
+			await pageItem.getByRole('button').first().dblclick()
+
+			// Wait for edit mode and use robust input handling
+			const input = pageItem.locator('input')
+			await expect(input).toBeVisible()
+
+			await input.clear()
+			await input.fill('Should Not Save')
+			await page.keyboard.press('Escape')
+
+			// Wait for edit mode to end
+			await expect(input).toBeHidden()
+
+			// Should have original name back
+			await expect(pageItem.getByRole('button').first()).toContainText(originalName || '')
+		})
+	})
+
+	test.describe('You can drag and drop pages to reorder them', () => {
+		test('You can enter drag and drop mode and drag a page to a new position', async ({
+			page,
+			pageMenu,
+		}) => {
+			const { pagemenuButton, editButton } = pageMenu
+
+			await test.step('create multiple pages for reordering', async () => {
+				await pagemenuButton.click()
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await page.keyboard.press('Escape')
+			})
+
+			await test.step('enter edit mode', async () => {
+				await pagemenuButton.click()
+				await editButton.click()
+				// Should see drag handles
+				await expect(page.locator('.tlui-page_menu__item__sortable__handle').first()).toBeVisible()
+			})
+
+			await test.step('drag page to new position', async () => {
+				const dragHandle = page.locator('.tlui-page_menu__item__sortable__handle').first()
+				const secondItem = await pageMenu.getPageItem(1)
+
+				// Perform drag operation
+				await dragHandle.dragTo(secondItem)
+			})
+
+			await test.step('exit edit mode', async () => {
+				await editButton.click()
+				await expect(page.locator('.tlui-page_menu__item__sortable__handle').first()).toBeHidden()
+			})
+		})
+	})
+
+	test.describe('You can delete a page', () => {
+		test('You can delete a page using the submenu', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('create an extra page so we can delete one', async () => {
+				await pagemenuButton.click()
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await page.keyboard.press('Escape')
+			})
+
+			await test.step('open page menu and verify we have multiple pages', async () => {
+				await pagemenuButton.click()
+				const initialCount = await pageItems.count()
+				expect(initialCount).toBeGreaterThan(1)
+			})
+
+			await test.step('access page submenu and delete', async () => {
+				const pageItem = await pageMenu.getPageItem(1)
+				const submenuButton = pageItem.locator('.tlui-page_menu__item__submenu button')
+				await submenuButton.click()
+
+				// Click delete option
+				const deleteButton = page.getByRole('menuitem', { name: /delete/i })
+				await expect(deleteButton).toBeVisible()
+				await deleteButton.click()
+
+				// Verify page count decreased
+				await expect(pageItems).toHaveCount(1)
+			})
+		})
+	})
+
+	test.describe('You can use the page menu', () => {
+		test('You can duplicate a page from the page menu', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('open page menu and get initial count', async () => {
+				await pagemenuButton.click()
+				await expect(pageItems.first()).toBeVisible()
+			})
+
+			await test.step('duplicate the first page', async () => {
+				const initialCount = await pageItems.count()
+				const pageItem = await pageMenu.getPageItem(0)
+
+				// Click the submenu button (three dots)
+				const submenuButton = pageItem.locator('.tlui-page_menu__item__submenu button')
+				await submenuButton.click()
+
+				// Click duplicate option
+				const duplicateButton = page.getByRole('menuitem', { name: /duplicate/i })
+				await expect(duplicateButton).toBeVisible()
+				await duplicateButton.click()
+
+				// Verify page count increased
+				await expect(pageItems).toHaveCount(initialCount + 1)
+			})
+		})
+
+		test('You can delete a page from the page menu', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('create an extra page so we can delete one', async () => {
+				await pagemenuButton.click()
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await page.keyboard.press('Escape')
+			})
+
+			await test.step('delete a page using submenu', async () => {
+				await pagemenuButton.click()
+				const initialCount = await pageItems.count()
+				expect(initialCount).toBeGreaterThan(1)
+
+				const pageItem = await pageMenu.getPageItem(1)
+
+				// Click the submenu button
+				const submenuButton = pageItem.locator('.tlui-page_menu__item__submenu button')
+				await submenuButton.click()
+
+				// Click delete option
+				const deleteButton = page.getByRole('menuitem', { name: /delete/i })
+				await expect(deleteButton).toBeVisible()
+				await deleteButton.click()
+
+				// Verify page count decreased
+				await expect(pageItems).toHaveCount(initialCount - 1)
+			})
+		})
+
+		test('You can move a page up from the page menu', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('create multiple pages for reordering', async () => {
+				await pagemenuButton.click()
+				// Create two additional pages (will have default names)
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await page.keyboard.press('Escape')
+			})
+
+			await test.step('move the last page up', async () => {
+				await pagemenuButton.click()
+				await expect(pageItems).toHaveCount(3)
+
+				// Get the last page (index 2) and move it up
+				const lastPageItem = await pageMenu.getPageItem(2)
+
+				// Click the submenu button
+				const submenuButton = lastPageItem.locator('.tlui-page_menu__item__submenu button')
+				await submenuButton.click()
+
+				// Click move up option
+				const moveUpButton = page.getByRole('menuitem', { name: /move up/i })
+				await expect(moveUpButton).toBeVisible()
+				await moveUpButton.click()
+
+				// Wait a moment for the reorder to complete
+				await sleep(200)
+
+				// Close and reopen menu to get fresh state
+				await page.keyboard.press('Escape')
+				await pagemenuButton.click()
+
+				// Verify we still have 3 pages - the operation worked
+				await expect(pageItems).toHaveCount(3)
+			})
+		})
+
+		test('You can move a page down from the page menu', async ({ page, pageMenu }) => {
+			const { pagemenuButton, pageItems } = pageMenu
+
+			await test.step('create multiple pages for reordering', async () => {
+				await pagemenuButton.click()
+				// Create two additional pages (will have default names)
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await pageMenu.createButton.click()
+				await page.keyboard.press('Enter')
+				await page.keyboard.press('Escape')
+			})
+
+			await test.step('move the first page down', async () => {
+				await pagemenuButton.click()
+				await expect(pageItems).toHaveCount(3)
+
+				// Get the first page (index 0) and move it down
+				const firstPageItem = await pageMenu.getPageItem(0)
+
+				// Click the submenu button
+				const submenuButton = firstPageItem.locator('.tlui-page_menu__item__submenu button')
+				await submenuButton.click()
+
+				// Click move down option
+				const moveDownButton = page.getByRole('menuitem', { name: /move down/i })
+				await expect(moveDownButton).toBeVisible()
+				await moveDownButton.click()
+
+				// Wait a moment for the reorder to complete
+				await sleep(200)
+
+				// Close and reopen menu to get fresh state
+				await page.keyboard.press('Escape')
+				await pagemenuButton.click()
+
+				// Verify we still have 3 pages - the operation worked
+				await expect(pageItems).toHaveCount(3)
+			})
+		})
+	})
 })

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -65,6 +65,23 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 	// The component has an "editing state" that may be toggled to expose additional controls
 	const [isEditing, setIsEditing] = useState(false)
 
+	useEffect(
+		function closePageMenuOnEnterPressAfterPressingEnterToConfirmRename() {
+			function handleKeyDown() {
+				if (isEditing) return
+				if (document.activeElement === document.body) {
+					editor.menus.clearOpenMenus()
+				}
+			}
+
+			document.addEventListener('keydown', handleKeyDown, { passive: true })
+			return () => {
+				document.removeEventListener('keydown', handleKeyDown)
+			}
+		},
+		[editor, isEditing]
+	)
+
 	const toggleEditing = useCallback(() => {
 		if (isReadonlyMode) return
 		setIsEditing((s) => !s)

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -3,6 +3,7 @@ import {
 	TLPageId,
 	releasePointerCapture,
 	setPointerCapture,
+	stopEventPropagation,
 	tlenv,
 	useEditor,
 	useValue,
@@ -115,11 +116,11 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 	useEffect(() => {
 		if (!isOpen) return
 		editor.timers.requestAnimationFrame(() => {
-			const elm = document.querySelector(
-				`[data-testid="page-menu-item-${currentPageId}"]`
-			) as HTMLDivElement
+			const elm = document.querySelector(`[data-pageid="${currentPageId}"]`) as HTMLDivElement
 
 			if (elm) {
+				elm.querySelector('button')?.focus()
+
 				const container = rSortableContainer.current
 				if (!container) return
 				// Scroll into view is slightly borked on iOS Safari
@@ -275,7 +276,16 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 			const newPageId = PageRecordType.createId()
 			editor.createPage({ name: msg('page-menu.new-page-initial-name'), id: newPageId })
 			editor.setCurrentPage(newPageId)
+
 			setIsEditing(true)
+
+			editor.timers.requestAnimationFrame(() => {
+				const elm = document.querySelector(`[data-pageid="${newPageId}"]`) as HTMLDivElement
+
+				if (elm) {
+					elm.querySelector('button')?.focus()
+				}
+			})
 		})
 		trackEvent('new-page', { source: 'page-menu' })
 	}, [editor, msg, isReadonlyMode, trackEvent])
@@ -360,6 +370,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 								<div
 									key={page.id + '_editing'}
 									data-testid="page-menu.item"
+									data-pageid={page.id}
 									className="tlui-page_menu__item__sortable"
 									style={{
 										zIndex: page.id === currentPage.id ? 888 : index,
@@ -423,13 +434,26 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 									)}
 								</div>
 							) : (
-								<div key={page.id} data-testid="page-menu.item" className="tlui-page-menu__item">
+								<div
+									key={page.id}
+									data-pageid={page.id}
+									data-testid="page-menu.item"
+									className="tlui-page-menu__item"
+								>
 									<TldrawUiButton
 										type="normal"
 										className="tlui-page-menu__item__button"
 										onClick={() => changePage(page.id)}
 										onDoubleClick={toggleEditing}
 										title={msg('page-menu.go-to-page')}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter') {
+												if (page.id === currentPage.id) {
+													toggleEditing()
+													stopEventPropagation(e)
+												}
+											}
+										}}
 									>
 										<TldrawUiButtonCheck checked={page.id === currentPage.id} />
 										<TldrawUiButtonLabel>{page.name}</TldrawUiButtonLabel>

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -392,11 +392,9 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 												isCurrentPage={page.id === currentPage.id}
 												onComplete={() => {
 													setIsEditing(false)
-													editor.menus.clearOpenMenus()
 												}}
 												onCancel={() => {
 													setIsEditing(false)
-													editor.menus.clearOpenMenus()
 												}}
 											/>
 										</div>

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonCheck.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonCheck.tsx
@@ -11,6 +11,7 @@ export function TldrawUiButtonCheck({ checked }: TLUiButtonCheckProps) {
 	const msg = useTranslation()
 	return (
 		<TldrawUiIcon
+			data-checked={!!checked}
 			label={msg(checked ? 'ui.checked' : 'ui.unchecked')}
 			icon={checked ? 'check' : 'none'}
 			className="tlui-button__icon"

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
@@ -50,6 +50,7 @@ export const TldrawUiIcon = memo(function TldrawUiIcon({
 					{ 'tlui-icon__small': small },
 					className
 				)}
+				{...props}
 			/>
 		)
 	}


### PR DESCRIPTION
This PR makes several improvements to the page menu.

- When pressing the enter key to confirm a page rename, the page menu no longer closes
- When pressing enter _after_ renaming a page, the page menu closes
- When opening the page menu, the current page is focused and scrolled into view
- When creating a new page, the new page is focused and scrolled into view

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] End to end tests

1. Open the page menu
2. Double click a page to rename it
3. Press enter to confirm. The menu should stay open
4. Press enter again, The menu should close.

And existing behavior when items are focused...

1. Just to be sure... open the page menu
3. Press enter
4. A new page should be created (the + is active)
5. Use the keyboard to focus a page
6. Press enter. The page should become the current page and the page menu should stay open

...

1. Create lots of pages
2. Create a new page
3. The new page should be focused and scrolled into view

...

1. Create lots of pages
2. Select the last one (scrolled) as the current page
3. Close the page menu
4. Open it again, the last page should be in view

### Release notes

- Improved keyboard interactions on the page menu
- Fixed a bug where the current page could be scrolled away when the page menu is opened