### PR TITLE
fix(dotcom): show sign out menu in read-only rooms

### DIFF
--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -65,6 +65,7 @@ export function SignOutMenuItem() {
 				data-testid="tla-user-sign-out"
 				onSelect={handleSignout}
 				label={label}
+				readonlyOk
 			/>
 		</TldrawUiMenuGroup>
 	)


### PR DESCRIPTION
We didn't show the sign out menu in read-only rooms.

### Change type

- [x] `bugfix` 

### Test plan

1. Make a shared file view only.
2. Open it as another user.
3. You should be able to sign out.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the sign out menu was hidden in read-only rooms.