### PR TITLE
Remove `getShapePageGeometry`

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1256,7 +1256,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     // @internal
     getShapeNearestSibling(siblingShape: TLShape, targetShape: TLShape | undefined): TLShape | undefined;
     getShapePageBounds(shape: TLShape | TLShapeId): Box | undefined;
-    getShapePageGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, opts?: TLGeometryOpts): T;
     getShapePageTransform(shape: TLShape | TLShapeId): Mat;
     getShapeParent(shape?: TLShape | TLShapeId): TLShape | undefined;
     getShapeParentTransform(shape: TLShape | TLShapeId): Mat;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4643,44 +4643,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		)! as T
 	}
 
-	private _shapePageGeometryCaches: Record<string, ComputedCache<Geometry2d, TLShape>> = {}
-
-	/**
-	 * Get the geometry of a shape in page-space.
-	 *
-	 * @example
-	 * ```ts
-	 * editor.getShapePageGeometry(myShape)
-	 * editor.getShapePageGeometry(myShapeId)
-	 * editor.getShapePageGeometry(myShapeId, { context: "arrow" })
-	 * ```
-	 *
-	 * @param shape - The shape (or shape id) to get the geometry for.
-	 * @param opts - Additional options about the request for geometry. Passed to {@link ShapeUtil.getGeometry}.
-	 *
-	 * @public
-	 */
-	getShapePageGeometry<T extends Geometry2d>(shape: TLShape | TLShapeId, opts?: TLGeometryOpts): T {
-		const context = opts?.context ?? 'none'
-		if (!this._shapePageGeometryCaches[context]) {
-			this._shapePageGeometryCaches[context] = this.store.createComputedCache(
-				'bounds',
-				(shape) => {
-					const geometry = this.getShapeGeometry(shape.id, opts)
-					const pageTransform = this.getShapePageTransform(shape.id)
-					return geometry.transform(pageTransform)
-				},
-				{
-					// we only depend directly on the shape id, and changing geometry/transform will update us anyway
-					areRecordsEqual: () => true,
-				}
-			)
-		}
-		return this._shapePageGeometryCaches[context].get(
-			typeof shape === 'string' ? shape : shape.id
-		)! as T
-	}
-
 	/** @internal */
 	@computed private _getShapeHandlesCache(): ComputedCache<TLHandle[] | undefined, TLShape> {
 		return this.store.createComputedCache(

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -1,8 +1,6 @@
 import { TLParentId, TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
 import { IndexKey, compact, getIndicesBetween, sortByIndex } from '@tldraw/utils'
 import { Editor } from '../editor/Editor'
-import { Vec } from '../primitives/Vec'
-import { polygonsIntersect } from '../primitives/intersect'
 
 export function getReorderingShapesChanges(
 	editor: Editor,
@@ -155,19 +153,18 @@ function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLSh
 }
 
 function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
-	const movingVertices = Array.from(moving)
-		.map((shape) => {
-			const vertices = editor.getShapePageGeometry(shape).vertices
-			if (!vertices) return null
-			return { shape, vertices }
+	const movingBounds = compact(
+		Array.from(moving).map((shape) => {
+			const bounds = editor.getShapePageBounds(shape)
+			if (!bounds) return null
+			return { shape, bounds }
 		})
-		.filter(Boolean) as { shape: TLShape; vertices: Vec[] }[]
-
+	)
 	const isOverlapping = (child: TLShape) => {
-		const vertices = editor.getShapePageGeometry(child).vertices
-		if (!vertices) return false
-		return movingVertices.some((other) => {
-			return polygonsIntersect(other.vertices, vertices)
+		const bounds = editor.getShapePageBounds(child)
+		if (!bounds) return false
+		return movingBounds.some((other) => {
+			return other.bounds.includes(bounds)
 		})
 	}
 

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
@@ -71,13 +71,16 @@ export function getElbowArrowSnapLines(editor: Editor) {
 					if (!shapeBounds || !viewportBounds.includes(shapeBounds)) continue
 
 					const bindings = getArrowBindings(editor, shape)
+					const pageTransform = editor.getShapePageTransform(id)
+					if (!pageTransform) continue
 
-					const geometry = editor.getShapePageGeometry(id)
-					const vertices = geometry.getVertices({ includeInternal: false, includeLabels: false })
+					const geometry = editor.getShapeGeometry(id)
+					// do these HAVE to be in page space?
+					const pageVertices = pageTransform.applyToPoints(geometry.vertices)
 
-					for (let i = 1; i < vertices.length; i++) {
-						const prev = vertices[i - 1]
-						const curr = vertices[i]
+					for (let i = 1; i < pageVertices.length; i++) {
+						const prev = pageVertices[i - 1]
+						const curr = pageVertices[i]
 
 						let angle = Vec.Angle(prev, curr)
 

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
@@ -75,7 +75,7 @@ export function getElbowArrowSnapLines(editor: Editor) {
 					if (!pageTransform) continue
 
 					const geometry = editor.getShapeGeometry(id)
-					// do these HAVE to be in page space?
+
 					const pageVertices = pageTransform.applyToPoints(geometry.vertices)
 
 					for (let i = 1; i < pageVertices.length; i++) {


### PR DESCRIPTION
This PR removes `getShapePageGeometry`. 

### Background

Geometries are complex and so implement lots of internal caching to avoid recomputing vertices or bounds. These properties are often referenced many times during interactions like snapping, selecting, or translating.

Geometry transforms were added in https://github.com/tldraw/tldraw/pull/5754 while working on elbow arrows. When a geometry is transformed, its vertices etc and other things are no longer cached and they're recomputed instead. This is fine if the transform is part of the creation of the shape (as in the PathBuilder2d class) but not if we're creating new geometries as we access them, which is done by `getShapePageGeometry`.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
