### PR TITLE
Reverse sorted shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -233,7 +233,7 @@ describe('getShapesAtPoint', () => {
 		})
 	})
 
-	it('returns shapes at a point in order of their index', () => {
+	it('returns shapes at a point in reverse z-index order', () => {
 		// Point at (50, 50) should hit shape3's edge (since it's at 50,50 with size 100x100)
 		// This point is exactly at the top-left corner of shape3
 		const shapes = editor.getShapesAtPoint({ x: 50, y: 50 })
@@ -313,12 +313,12 @@ describe('getShapesAtPoint', () => {
 		const shapes = editor.getShapesAtPoint({ x: 100, y: 0 })
 		const shapeIds = shapes.map((s) => s.id)
 
-		// Both shapes should be detected at this overlapping point
-		expect(shapeIds).toEqual([ids.shape1, ids.shape2])
+		// Both shapes should be detected at this overlapping point (reversed order - top-most first)
+		expect(shapeIds).toEqual([ids.shape2, ids.shape1])
 		expect(shapes).toHaveLength(2)
 	})
 
-	it('maintains shape order from getCurrentPageShapesSorted', () => {
+	it('maintains reverse shape order and responds to z-index changes', () => {
 		// Create filled shape that overlaps with shape2
 		editor.createShape({
 			id: ids.shape5,
@@ -333,14 +333,14 @@ describe('getShapesAtPoint', () => {
 		const shapes = editor.getShapesAtPoint({ x: 120, y: 120 }, { hitInside: true })
 		const shapeIds = shapes.map((s) => s.id)
 
-		// All shapes that contain this point should be returned in z-index order
-		expect(shapeIds).toEqual([ids.shape1, ids.shape2, ids.shape3, ids.shape4, ids.shape5])
+		// All shapes that contain this point should be returned in reverse z-index order (top-most first)
+		expect(shapeIds).toEqual([ids.shape5, ids.shape4, ids.shape3, ids.shape2, ids.shape1])
 
-		// After bringing shape2 to front, order should change
+		// After bringing shape2 to front, order should change (shape2 becomes top-most)
 		editor.bringToFront([ids.shape2])
 		const shapes2 = editor.getShapesAtPoint({ x: 120, y: 120 }, { hitInside: true })
 		const shapeIds2 = shapes2.map((s) => s.id)
-		expect(shapeIds2).toEqual([ids.shape1, ids.shape3, ids.shape4, ids.shape5, ids.shape2])
+		expect(shapeIds2).toEqual([ids.shape2, ids.shape5, ids.shape4, ids.shape3, ids.shape1])
 	})
 
 	it('combines hitInside and margin options', () => {
@@ -361,7 +361,7 @@ describe('getShapesAtPoint', () => {
 		isShapeHiddenSpy.mockRestore()
 	})
 
-	it('returns multiple shapes at same point in z-index order', () => {
+	it('returns multiple shapes at same point in reverse z-index order', () => {
 		// Create two shapes at exactly the same position (away from existing shapes)
 		editor.createShape({
 			id: ids.overlap1,
@@ -383,8 +383,8 @@ describe('getShapesAtPoint', () => {
 		const shapes = editor.getShapesAtPoint({ x: 600, y: 600 })
 		const shapeIds = shapes.map((s) => s.id)
 
-		// Should return both shapes in z-index order
-		expect(shapeIds).toEqual([ids.overlap1, ids.overlap2])
+		// Should return both shapes in reverse z-index order (top-most first)
+		expect(shapeIds).toEqual([ids.overlap2, ids.overlap1])
 		expect(shapes).toHaveLength(2)
 	})
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5305,11 +5305,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @example
 	 * ```ts
 	 * editor.getShapesAtPoint({ x: 100, y: 100 })
-	 * editor.getShapesAtPoint({ x: 100, y: 100 }, { hitInside: true, exact: true })
+	 * editor.getShapesAtPoint({ x: 100, y: 100 }, { hitInside: true, margin: 8 })
 	 * ```
 	 *
 	 * @param point - The page point to test.
 	 * @param opts - The options for the hit point testing.
+	 *
+	 * @returns An array of shapes at the given point, sorted in reverse order of their absolute z-index (top-most shape first).
 	 *
 	 * @public
 	 */
@@ -5317,9 +5319,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		point: VecLike,
 		opts = {} as { margin?: number; hitInside?: boolean }
 	): TLShape[] {
-		return this.getCurrentPageShapesSorted().filter(
-			(shape) => !this.isShapeHidden(shape) && this.isPointInShape(shape, point, opts)
-		)
+		return this.getCurrentPageShapesSorted()
+			.filter((shape) => !this.isShapeHidden(shape) && this.isPointInShape(shape, point, opts))
+			.reverse()
 	}
 
 	/**


### PR DESCRIPTION
This PR reverses the returned sorted shapes in Editor.getShapesAtPoint so that the top-most shapes are first.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
