### PR TITLE
Fix icon preload crossOrigin handling

### DIFF
--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -16,22 +16,22 @@ export function AssetUrlsProvider({
 	children: React.ReactNode
 }) {
 	useEffect(() => {
-                for (const src of Object.values(assetUrls.icons)) {
-                        if (!src) continue
+		for (const src of Object.values(assetUrls.icons)) {
+			if (!src) continue
 
-                        const image = new Image()
-                        image.crossOrigin = 'anonymous'
-                        image.src = src
-                        image.decode()
-                }
-                for (const src of Object.values(assetUrls.embedIcons)) {
-                        if (!src) continue
+			const image = Image()
+			image.crossOrigin = 'anonymous'
+			image.src = src
+			image.decode()
+		}
+		for (const src of Object.values(assetUrls.embedIcons)) {
+			if (!src) continue
 
-                        const image = new Image()
-                        image.crossOrigin = 'anonymous'
-                        image.src = src
-                        image.decode()
-                }
+			const image = Image()
+			image.crossOrigin = 'anonymous'
+			image.src = src
+			image.decode()
+		}
 	}, [assetUrls])
 
 	return <AssetUrlsContext.Provider value={assetUrls}>{children}</AssetUrlsContext.Provider>

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -16,20 +16,22 @@ export function AssetUrlsProvider({
 	children: React.ReactNode
 }) {
 	useEffect(() => {
-		for (const src of Object.values(assetUrls.icons)) {
-			if (!src) continue
+                for (const src of Object.values(assetUrls.icons)) {
+                        if (!src) continue
 
-			const image = Image()
-			image.src = src
-			image.decode()
-		}
-		for (const src of Object.values(assetUrls.embedIcons)) {
-			if (!src) continue
+                        const image = new Image()
+                        image.crossOrigin = 'anonymous'
+                        image.src = src
+                        image.decode()
+                }
+                for (const src of Object.values(assetUrls.embedIcons)) {
+                        if (!src) continue
 
-			const image = Image()
-			image.src = src
-			image.decode()
-		}
+                        const image = new Image()
+                        image.crossOrigin = 'anonymous'
+                        image.src = src
+                        image.decode()
+                }
 	}, [assetUrls])
 
 	return <AssetUrlsContext.Provider value={assetUrls}>{children}</AssetUrlsContext.Provider>


### PR DESCRIPTION
## Summary
- set `crossOrigin="anonymous"` when preloading icon images

------
https://chatgpt.com/codex/tasks/task_b_6845fd857d8083249989c30c643bb111