### PR TITLE
Fix minor typo in effect scheduler tests

### DIFF
--- a/packages/state/src/lib/__tests__/EffectScheduler.test.ts
+++ b/packages/state/src/lib/__tests__/EffectScheduler.test.ts
@@ -2,7 +2,7 @@ import { atom } from '../Atom'
 import { EffectScheduler } from '../EffectScheduler'
 
 describe(EffectScheduler, () => {
-	test('when you detatch and reattach, it retains the parents without rerunning', () => {
+       test('when you detach and reattach, it retains the parents without rerunning', () => {
 		const a = atom('a', 1)
 		let numReactions = 0
 		const scheduler = new EffectScheduler('test', () => {
@@ -22,7 +22,7 @@ describe(EffectScheduler, () => {
 		expect(numReactions).toBe(3)
 	})
 
-	test('when you detatch and reattach, it retains the parents while rerunning if the parent has changed', () => {
+       test('when you detach and reattach, it retains the parents while rerunning if the parent has changed', () => {
 		const a = atom('a', 1)
 		let numReactions = 0
 		const scheduler = new EffectScheduler('test', () => {

--- a/packages/state/src/lib/__tests__/EffectScheduler.test.ts
+++ b/packages/state/src/lib/__tests__/EffectScheduler.test.ts
@@ -2,7 +2,7 @@ import { atom } from '../Atom'
 import { EffectScheduler } from '../EffectScheduler'
 
 describe(EffectScheduler, () => {
-       test('when you detach and reattach, it retains the parents without rerunning', () => {
+	test('when you detach and reattach, it retains the parents without rerunning', () => {
 		const a = atom('a', 1)
 		let numReactions = 0
 		const scheduler = new EffectScheduler('test', () => {
@@ -22,7 +22,7 @@ describe(EffectScheduler, () => {
 		expect(numReactions).toBe(3)
 	})
 
-       test('when you detach and reattach, it retains the parents while rerunning if the parent has changed', () => {
+	test('when you detach and reattach, it retains the parents while rerunning if the parent has changed', () => {
 		const a = atom('a', 1)
 		let numReactions = 0
 		const scheduler = new EffectScheduler('test', () => {


### PR DESCRIPTION
## Summary
- fix spelling of `detach` in effect scheduler tests

## Testing
- `yarn workspace @tldraw/state test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684605ea2d108324b94f9478194f22ba