### PR TITLE
Fix renaming from the main menu.

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -285,7 +285,8 @@ function TlaFileNameEditor({
 	const handleEditingEnd = useCallback(() => {
 		if (!onChange) return
 		setIsEditing(false)
-	}, [onChange])
+		onEnd?.()
+	}, [onChange, onEnd])
 
 	const handleEditingComplete = useCallback(
 		(name: string) => {


### PR DESCRIPTION
We had to call `onEnd` so that we would stop renaming in this case. Otherwise [this](https://github.com/tldraw/tldraw/blob/0e269ff1b1e8852afc97bcab6773fa70e05622b7/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx#L301-L306) `useEffect` would immediately put us back into renaming.

See the linked issue for bug description.

Fixes INT-1064
 
### Change type

- [x] `bugfix`
