### PR TITLE
docs: update landing page link to AI starter template

### DIFF
--- a/apps/docs/components/marketing/what-it-is-section.tsx
+++ b/apps/docs/components/marketing/what-it-is-section.tsx
@@ -75,7 +75,7 @@ export function WhatItIsSection() {
 				<SectionH3>Ready for AI</SectionH3>
 				<p>
 					Experimenting with AI? Try the{' '}
-					<BlueA newTab href="https://github.com/tldraw/ai">
+					<BlueA newTab href="https://github.com/tldraw/ai-template">
 						tldraw ai
 					</BlueA>{' '}
 					module. Create prompts, interpret content, and drive the canvas with language models. See


### PR DESCRIPTION
The auto-hotfix from #6226 failed so here's a manual one.

### Change type

- [x] `other`

### Test plan

1. Verify the landing page link in the 'what-it-is' section points to the correct AI starter template.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated the landing page link to the upcoming AI starter template.