### PR TITLE
Add glass theme example

### DIFF
--- a/apps/examples/src/examples/glass-theme/GlassThemeExample.tsx
+++ b/apps/examples/src/examples/glass-theme/GlassThemeExample.tsx
@@ -1,0 +1,11 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './glass-theme.css'
+
+export default function GlassThemeExample() {
+    return (
+        <div className="tldraw__editor glass-theme">
+            <Tldraw />
+        </div>
+    )
+}

--- a/apps/examples/src/examples/glass-theme/README.md
+++ b/apps/examples/src/examples/glass-theme/README.md
@@ -1,0 +1,13 @@
+---
+title: Glass theme
+component: ./GlassThemeExample.tsx
+category: ui
+priority: 3
+keywords: [theme, css, glass, aero, style]
+---
+
+Make the tldraw interface look like frosted glass.
+
+---
+
+This example applies a heavy glassmorphism style inspired by Windows Aero using plain CSS.

--- a/apps/examples/src/examples/glass-theme/glass-theme.css
+++ b/apps/examples/src/examples/glass-theme/glass-theme.css
@@ -1,0 +1,10 @@
+.glass-theme {
+    background: linear-gradient(135deg, rgba(180,200,255,0.5), rgba(255,255,255,0.5));
+}
+
+.glass-theme [class^='tlui-'] {
+    background: rgba(255, 255, 255, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.15);
+    backdrop-filter: blur(30px) saturate(180%);
+}


### PR DESCRIPTION
## Summary
- add a `glass-theme` example showing how to apply an over-the-top glassmorphic look to the tldraw UI using CSS

## Testing
- `yarn lint` *(fails: process hung or was interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68484f221a708330a7f8f6f7b54effe0