### PR TITLE
[fix] arrow label / indicator reactivity

### DIFF
--- a/apps/dotcom/client/e2e/tests/arrow-label-drag.spec.ts
+++ b/apps/dotcom/client/e2e/tests/arrow-label-drag.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '../fixtures/tla-test'
+
+test.beforeEach(async ({ editor }) => {
+	await editor.isLoaded()
+})
+
+test('can reposition arrow label by dragging', async ({ page, editor }) => {
+	// Close sidebar to have more space for testing
+	await editor.ensureSidebarClosed()
+
+	// Create an arrow shape
+	await test.step('Create arrow shape', async () => {
+		// Click on arrow tool
+		await page.getByTestId('tools.arrow').click()
+
+		// Draw arrow from point A to point B
+		await page.mouse.move(100, 100)
+		await page.mouse.down()
+		await page.mouse.move(300, 200)
+		await page.mouse.up()
+
+		// Switch back to select tool
+		await page.getByTestId('tools.select').click()
+	})
+
+	// Add text to the arrow to create a label
+	await test.step('Add label to arrow', async () => {
+		// Double-click on the arrow to start editing text
+		await page.mouse.dblclick(200, 150)
+
+		// Type some text for the label
+		await page.keyboard.type('Test Label')
+
+		// Press escape to finish editing
+		await page.keyboard.press('Escape')
+
+		// Ensure the label is visible
+		await expect(page.locator('text=Test Label')).toBeVisible()
+	})
+
+	// Get initial label position
+	let initialLabelPosition: { x: number; y: number }
+	await test.step('Record initial label position', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		await expect(labelElement).toBeVisible()
+
+		const labelBox = await labelElement.boundingBox()
+		expect(labelBox).not.toBeNull()
+
+		initialLabelPosition = {
+			x: labelBox!.x + labelBox!.width / 2,
+			y: labelBox!.y + labelBox!.height / 2,
+		}
+	})
+
+	// Drag the label to reposition it
+	await test.step('Drag label to new position', async () => {
+		// Click and hold on the label
+		await page.mouse.move(initialLabelPosition.x, initialLabelPosition.y)
+		await page.mouse.down()
+
+		// Drag the label to a new position (offset by 50 pixels in x direction)
+		const newX = initialLabelPosition.x + 50
+		const newY = initialLabelPosition.y
+
+		await page.mouse.move(newX, newY)
+		await page.mouse.up()
+	})
+
+	// Verify the label position has changed
+	await test.step('Verify label position changed', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		await expect(labelElement).toBeVisible()
+
+		const newLabelBox = await labelElement.boundingBox()
+		expect(newLabelBox).not.toBeNull()
+
+		const newLabelPosition = {
+			x: newLabelBox!.x + newLabelBox!.width / 2,
+			y: newLabelBox!.y + newLabelBox!.height / 2,
+		}
+
+		// Verify the label has moved horizontally
+		expect(Math.abs(newLabelPosition.x - initialLabelPosition.x)).toBeGreaterThan(30)
+
+		// Verify the text is still visible after repositioning
+		await expect(page.locator('text=Test Label')).toBeVisible()
+	})
+
+	// Verify the change persists after page reload
+	await test.step('Verify change persists after reload', async () => {
+		await page.reload()
+		await editor.isLoaded()
+
+		// The label should still be visible and in the new position
+		await expect(page.locator('text=Test Label')).toBeVisible()
+
+		const labelElement = page.locator('.tl-arrow-label').first()
+		await expect(labelElement).toBeVisible()
+
+		const reloadedLabelBox = await labelElement.boundingBox()
+		expect(reloadedLabelBox).not.toBeNull()
+
+		const reloadedLabelPosition = {
+			x: reloadedLabelBox!.x + reloadedLabelBox!.width / 2,
+			y: reloadedLabelBox!.y + reloadedLabelBox!.height / 2,
+		}
+
+		// Verify the label is still in the moved position
+		expect(Math.abs(reloadedLabelPosition.x - initialLabelPosition.x)).toBeGreaterThan(30)
+	})
+})
+
+test('can snap arrow label back to default position', async ({ page, editor }) => {
+	// Close sidebar to have more space for testing
+	await editor.ensureSidebarClosed()
+
+	// Create an arrow shape with label
+	await test.step('Create arrow with label', async () => {
+		// Click on arrow tool and create arrow
+		await page.getByTestId('tools.arrow').click()
+		await page.mouse.move(100, 100)
+		await page.mouse.down()
+		await page.mouse.move(300, 200)
+		await page.mouse.up()
+
+		// Switch to select tool and add label
+		await page.getByTestId('tools.select').click()
+		await page.mouse.dblclick(200, 150)
+		await page.keyboard.type('Snap Test')
+		await page.keyboard.press('Escape')
+	})
+
+	// Drag label away from center
+	await test.step('Move label away from center', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const labelBox = await labelElement.boundingBox()
+		expect(labelBox).not.toBeNull()
+
+		const labelCenter = {
+			x: labelBox!.x + labelBox!.width / 2,
+			y: labelBox!.y + labelBox!.height / 2,
+		}
+
+		// Drag label significantly away from default position
+		await page.mouse.move(labelCenter.x, labelCenter.y)
+		await page.mouse.down()
+		await page.mouse.move(labelCenter.x + 80, labelCenter.y)
+		await page.mouse.up()
+	})
+
+	// Drag label back near the center to test snapping
+	await test.step('Test snapping back to center', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const currentBox = await labelElement.boundingBox()
+		expect(currentBox).not.toBeNull()
+
+		const currentCenter = {
+			x: currentBox!.x + currentBox!.width / 2,
+			y: currentBox!.y + currentBox!.height / 2,
+		}
+
+		// Drag label close to the original center position
+		// The arrow should snap the label back to its default position
+		await page.mouse.move(currentCenter.x, currentCenter.y)
+		await page.mouse.down()
+		await page.mouse.move(200, 150) // Near the original arrow center
+		await page.mouse.up()
+
+		// The label should have snapped back to the default position
+		const finalBox = await labelElement.boundingBox()
+		expect(finalBox).not.toBeNull()
+
+		// Verify the label is now closer to the arrow center
+		const finalCenter = {
+			x: finalBox!.x + finalBox!.width / 2,
+			y: finalBox!.y + finalBox!.height / 2,
+		}
+
+		// The label should be reasonably close to the arrow's midpoint
+		expect(Math.abs(finalCenter.x - 200)).toBeLessThan(20)
+		expect(Math.abs(finalCenter.y - 150)).toBeLessThan(20)
+	})
+})

--- a/apps/examples/e2e/tests/test-arrow-label-drag.spec.ts
+++ b/apps/examples/e2e/tests/test-arrow-label-drag.spec.ts
@@ -1,0 +1,215 @@
+import { expect } from '@playwright/test'
+import { setup } from '../shared-e2e'
+import test from './fixtures/fixtures'
+
+test.beforeEach(setup)
+
+test('can reposition arrow label by dragging', async ({ page }) => {
+	// Create an arrow shape
+	await test.step('Create arrow shape', async () => {
+		// Click on arrow tool
+		await page.locator('[data-testid="tools.arrow"]').click()
+
+		// Draw arrow from point A to point B
+		await page.mouse.move(100, 100)
+		await page.mouse.down()
+		await page.mouse.move(300, 200)
+		await page.mouse.up()
+
+		// Switch back to select tool
+		await page.locator('[data-testid="tools.select"]').click()
+	})
+
+	// Add text to the arrow to create a label
+	await test.step('Add label to arrow', async () => {
+		// Double-click on the arrow to start editing text
+		await page.mouse.dblclick(200, 150)
+
+		// Type some text for the label
+		await page.keyboard.type('Test Label')
+
+		// Press escape to finish editing
+		await page.keyboard.press('Escape')
+
+		// Ensure the label is visible
+		await expect(page.locator('.tl-arrow-label').locator('text=Test Label').first()).toBeVisible()
+	})
+
+	// Get initial label position
+	let initialLabelPosition: { x: number; y: number }
+	await test.step('Record initial label position', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		await expect(labelElement).toBeVisible()
+
+		const labelBox = await labelElement.boundingBox()
+		expect(labelBox).not.toBeNull()
+
+		initialLabelPosition = {
+			x: labelBox!.x + labelBox!.width / 2,
+			y: labelBox!.y + labelBox!.height / 2,
+		}
+	})
+
+	// Drag the label to reposition it
+	await test.step('Drag label to new position', async () => {
+		// Click and hold on the label
+		await page.mouse.move(initialLabelPosition.x + 10, initialLabelPosition.y + 10)
+		await page.mouse.down()
+
+		// Drag the label to a new position (offset by 50 pixels in x direction)
+		const newX = initialLabelPosition.x + 50
+		const newY = initialLabelPosition.y
+
+		await page.mouse.move(newX, newY)
+		await page.mouse.up()
+	})
+
+	// Verify the label position has changed
+	await test.step('Verify label position changed', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		await expect(labelElement).toBeVisible()
+
+		const newLabelBox = await labelElement.boundingBox()
+		expect(newLabelBox).not.toBeNull()
+
+		const newLabelPosition = {
+			x: newLabelBox!.x + 10 + newLabelBox!.width / 2,
+			y: newLabelBox!.y + 10 + newLabelBox!.height / 2,
+		}
+
+		// Verify the label has moved horizontally
+		expect(Math.abs(newLabelPosition.x - initialLabelPosition.x)).toBeGreaterThan(30)
+
+		// Verify the text is still visible after repositioning
+		await expect(
+			page.locator('.tl-arrow-label').first().locator('text=Test Label').first()
+		).toBeVisible()
+	})
+})
+
+test('can snap arrow label back to default position', async ({ page }) => {
+	// Create an arrow shape with label
+	await test.step('Create arrow with label', async () => {
+		// Click on arrow tool and create arrow
+		await page.locator('[data-testid="tools.arrow"]').click()
+		await page.mouse.move(100, 100)
+		await page.mouse.down()
+		await page.mouse.move(300, 200)
+		await page.mouse.up()
+
+		// Switch to select tool and add label
+		await page.locator('[data-testid="tools.select"]').click()
+		await page.mouse.dblclick(200, 150)
+		await page.keyboard.type('Snap Test')
+		await page.keyboard.press('Escape')
+	})
+
+	// Drag label away from center
+	await test.step('Move label away from center', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const labelBox = await labelElement.boundingBox()
+		expect(labelBox).not.toBeNull()
+
+		const labelCenter = {
+			x: labelBox!.x + labelBox!.width / 2,
+			y: labelBox!.y + labelBox!.height / 2,
+		}
+
+		// Drag label significantly away from default position
+		await page.mouse.move(labelCenter.x, labelCenter.y)
+		await page.mouse.down()
+		await page.mouse.move(labelCenter.x + 80, labelCenter.y)
+		await page.mouse.up()
+	})
+
+	// Drag label back near the center to test snapping
+	await test.step('Test snapping back to center', async () => {
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const currentBox = await labelElement.boundingBox()
+		expect(currentBox).not.toBeNull()
+
+		const currentCenter = {
+			x: currentBox!.x + currentBox!.width / 2,
+			y: currentBox!.y + currentBox!.height / 2,
+		}
+
+		// Drag label close to the original center position
+		// The arrow should snap the label back to its default position
+		await page.mouse.move(currentCenter.x, currentCenter.y)
+		await page.mouse.down()
+		await page.mouse.move(200, 150) // Near the original arrow center
+		await page.mouse.up()
+
+		// The label should have snapped back to the default position
+		const finalBox = await labelElement.boundingBox()
+		expect(finalBox).not.toBeNull()
+
+		// Verify the label is now closer to the arrow center
+		const finalCenter = {
+			x: finalBox!.x + finalBox!.width / 2,
+			y: finalBox!.y + finalBox!.height / 2,
+		}
+
+		// The label should be reasonably close to the arrow's midpoint
+		expect(Math.abs(finalCenter.x - 200)).toBeLessThan(30)
+		expect(Math.abs(finalCenter.y - 150)).toBeLessThan(30)
+	})
+})
+
+test('arrow label persists position after page operations', async ({ page }) => {
+	// Create arrow with label and move it
+	await test.step('Create and position arrow label', async () => {
+		// Create arrow
+		await page.locator('[data-testid="tools.arrow"]').click()
+		await page.mouse.move(100, 100)
+		await page.mouse.down()
+		await page.mouse.move(300, 200)
+		await page.mouse.up()
+
+		// Add label
+		await page.locator('[data-testid="tools.select"]').click()
+		await page.mouse.dblclick(200, 150)
+		await page.keyboard.type('Persistent Label')
+		await page.keyboard.press('Escape')
+
+		// Move label to a specific position
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const labelBox = await labelElement.boundingBox()
+		const labelCenter = {
+			x: labelBox!.x + labelBox!.width / 2,
+			y: labelBox!.y + labelBox!.height / 2,
+		}
+
+		await page.mouse.move(labelCenter.x, labelCenter.y)
+		await page.mouse.down()
+		await page.mouse.move(labelCenter.x + 60, labelCenter.y)
+		await page.mouse.up()
+	})
+
+	// Test that position persists through undo/redo
+	await test.step('Test undo/redo preserves position', async () => {
+		// Get position after moving
+		const labelElement = page.locator('.tl-arrow-label').first()
+		const movedBox = await labelElement.boundingBox()
+		const movedPosition = {
+			x: movedBox!.x + movedBox!.width / 2,
+			y: movedBox!.y + movedBox!.height / 2,
+		}
+
+		// Undo the move
+		await page.keyboard.press('Control+z')
+
+		// Redo the move
+		await page.keyboard.press('Control+y')
+
+		// Verify position is restored
+		const restoredBox = await labelElement.boundingBox()
+		const restoredPosition = {
+			x: restoredBox!.x + restoredBox!.width / 2,
+			y: restoredBox!.y + restoredBox!.height / 2,
+		}
+
+		expect(Math.abs(restoredPosition.x - movedPosition.x)).toBeLessThan(5)
+		expect(Math.abs(restoredPosition.y - movedPosition.y)).toBeLessThan(5)
+	})
+})

--- a/apps/examples/test-results/.last-run.json
+++ b/apps/examples/test-results/.last-run.json
@@ -1,7 +1,0 @@
-{
-	"status": "failed",
-	"failedTests": [
-		"637dbbe273755563ebf0-9605769a281c1f062144",
-		"637dbbe273755563ebf0-78305fcc62e005a1b365"
-	]
-}

--- a/apps/examples/test-results/.last-run.json
+++ b/apps/examples/test-results/.last-run.json
@@ -1,0 +1,7 @@
+{
+	"status": "failed",
+	"failedTests": [
+		"637dbbe273755563ebf0-9605769a281c1f062144",
+		"637dbbe273755563ebf0-78305fcc62e005a1b365"
+	]
+}

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -65,7 +65,7 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 
 	// when the shape an arrow is bound to changes
 	override onAfterChangeToShape({ binding }: BindingOnShapeChangeOptions<TLArrowBinding>): void {
-		reparentArrow(this.editor, binding.fromId)
+		maybeReparentArrow(this.editor, binding.fromId)
 	}
 
 	// when the arrow is isolated we need to update it's x,y positions
@@ -82,9 +82,10 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 	}
 }
 
-function reparentArrow(editor: Editor, arrowId: TLShapeId) {
+function maybeReparentArrow(editor: Editor, arrowId: TLShapeId) {
 	const arrow = editor.getShape<TLArrowShape>(arrowId)
 	if (!arrow) return
+
 	const bindings = getArrowBindings(editor, arrow)
 	const { start, end } = bindings
 	const startShape = start ? editor.getShape(start.toId) : undefined
@@ -188,7 +189,7 @@ function arrowDidUpdate(editor: Editor, arrow: TLArrowShape) {
 	}
 
 	// always check the arrow parents
-	reparentArrow(editor, arrow.id)
+	maybeReparentArrow(editor, arrow.id)
 }
 
 /** @internal */

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -760,6 +760,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			info,
 			this.editor.getShapeGeometry(shape)
 		)
+
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 		const isEditing = this.editor.getEditingShapeId() === shape.id
 		const showArrowLabel = isEditing || shape.props.text
@@ -1200,7 +1201,7 @@ function ArrowIndicator({ shape }: { shape: TLArrowShape }) {
 	const isEditing = useIsEditing(shape.id)
 	const clipPathId = useSharedSafeId(shape.id + '_clip')
 
-	const info = getArrowInfo(editor, shape)
+	const info = useValue('arrow info', () => getArrowInfo(editor, shape.id), [editor, shape.id])
 	if (!info) return null
 
 	const { start, end } = getArrowTerminalsInArrowSpace(editor, shape, info?.bindings)

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -239,7 +239,8 @@ export function getArrowLabelPosition(
 	if (
 		prev &&
 		prev.shape.props.text === shape.props.text &&
-		prev.geom.bounds.prettyMuchEquals(bodyGeom.bounds)
+		prev.geom.bounds.prettyMuchEquals(bodyGeom.bounds) &&
+		prev.shape.props.labelPosition === shape.props.labelPosition
 	) {
 		return prev.position
 	}


### PR DESCRIPTION
This PR fixes a bug where the arrow indicator and label position would not update correctly.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create an arrow bound to a shape
2. Resize the shape
3. The arrow indicator should update correctly

1. Create an arrow with a label
2. Drag the arrow's label
3. The arrow's label should move

- [x] Unit tests
