### PR TITLE
Truncate long page names on dotcom

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
@@ -40,6 +40,7 @@
 
 @media (min-width: 768px) {
 	.topLeftPanel {
+		max-width: 100%;
 		width: auto;
 	}
 	.topLeftPanelButtons {

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -230,9 +230,10 @@
 
 .tlui-page-menu__trigger {
 	flex-shrink: 0;
+	max-width: fit-content;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1080px) {
 	.tlui-page-menu__trigger {
 		width: fit-content;
 		max-width: 320px;

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -229,8 +229,14 @@
 }
 
 .tlui-page-menu__trigger {
-	width: fit-content;
 	flex-shrink: 0;
+}
+
+@media (min-width: 900px) {
+	.tlui-page-menu__trigger {
+		width: fit-content;
+		max-width: 320px;
+	}
 }
 
 /* Hide the icon on the page menu trigger button */


### PR DESCRIPTION
This PR truncates long page names on dotcom so that you can actually open the main menu.

This doesn't account for all cases (eg: large manually resized sidebar) but the default cases are now covered.

![image](https://github.com/user-attachments/assets/d35b4e53-0dd0-437f-b392-925736e56d4b)

![image](https://github.com/user-attachments/assets/128bb85c-5a73-463e-8037-e979478000d5)



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes

- Fixed long page names not getting truncated on tldraw.com