### PR TITLE
Fix missing resize handles on groups

### DIFF
--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -21,7 +21,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	}
 
 	canResize() {
-		return false
+		return true
 	}
 
 	canResizeChildren() {


### PR DESCRIPTION
This PR fixes the missing resize handles on group shapes.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
