### PR TITLE
Improve text measurement perf

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2845,6 +2845,7 @@ export class TextManager {
         fontStyle: string;
         fontWeight: string;
         lineHeight: number;
+        measureScrollWidth?: boolean;
         minWidth?: null | number;
         otherStyles?: Record<string, string>;
         padding: string;
@@ -2860,6 +2861,7 @@ export class TextManager {
         fontStyle: string;
         fontWeight: string;
         lineHeight: number;
+        measureScrollWidth?: boolean;
         minWidth?: null | number;
         padding: string;
     }): BoxModel & {

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -99,7 +99,7 @@ describe('TextManager', () => {
 		})
 
 		it('should handle empty text', () => {
-			const result = textManager.measureText('', defaultOpts)
+			const result = textManager.measureText('', { ...defaultOpts, measureScrollWidth: true })
 			expect(result).toHaveProperty('x', 0)
 			expect(result).toHaveProperty('y', 0)
 			expect(result).toHaveProperty('w')

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -45,7 +45,10 @@ export class TextManager {
 		this.baseElem = document.createElement('div')
 		this.baseElem.classList.add('tl-text')
 		this.baseElem.classList.add('tl-text-measure')
+		this.baseElem.setAttribute('dir', 'auto')
+		this.baseElem.style.setProperty('unicode-bidi', 'plaintext')
 		this.baseElem.tabIndex = -1
+		this.editor.getContainer().appendChild(this.baseElem)
 	}
 
 	measureText(
@@ -65,6 +68,7 @@ export class TextManager {
 			minWidth?: null | number
 			padding: string
 			disableOverflowWrapBreaking?: boolean
+			measureScrollWidth?: boolean
 		}
 	): BoxModel & { scrollWidth: number } {
 		const div = document.createElement('div')
@@ -90,18 +94,14 @@ export class TextManager {
 			otherStyles?: Record<string, string>
 			padding: string
 			disableOverflowWrapBreaking?: boolean
+			measureScrollWidth?: boolean
 		}
 	): BoxModel & { scrollWidth: number } {
-		// Duplicate our base element; we don't need to clone deep
-		const wrapperElm = this.baseElem.cloneNode() as HTMLDivElement
-		this.editor.getContainer().appendChild(wrapperElm)
+		const wrapperElm = this.baseElem as HTMLDivElement
 		wrapperElm.innerHTML = html
-		this.baseElem.insertAdjacentElement('afterend', wrapperElm)
 
-		wrapperElm.setAttribute('dir', 'auto')
 		// N.B. This property, while discouraged ("intended for Document Type Definition (DTD) designers")
 		// is necessary for ensuring correct mixed RTL/LTR behavior when exporting SVGs.
-		wrapperElm.style.setProperty('unicode-bidi', 'plaintext')
 		wrapperElm.style.setProperty('font-family', opts.fontFamily)
 		wrapperElm.style.setProperty('font-style', opts.fontStyle)
 		wrapperElm.style.setProperty('font-weight', opts.fontWeight)
@@ -120,9 +120,8 @@ export class TextManager {
 			}
 		}
 
-		const scrollWidth = wrapperElm.scrollWidth
+		const scrollWidth = opts.measureScrollWidth ? wrapperElm.scrollWidth : 0
 		const rect = wrapperElm.getBoundingClientRect()
-		wrapperElm.remove()
 
 		return {
 			x: 0,

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -446,6 +446,7 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 			fontSize: fontSizeAdjustment,
 			maxWidth: NOTE_SIZE - LABEL_PADDING * 2 - FUZZ,
 			disableOverflowWrapBreaking: true,
+			measureScrollWidth: true,
 		})
 
 		labelHeight = nextTextSize.h + LABEL_PADDING * 2

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -460,6 +460,7 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 				fontFamily: FONT_FAMILIES[shape.props.font],
 				fontSize: fontSizeAdjustment,
 				maxWidth: NOTE_SIZE - LABEL_PADDING * 2 - FUZZ,
+				measureScrollWidth: true,
 			})
 			labelHeight = nextTextSizeWithOverflowBreak.h + LABEL_PADDING * 2
 			labelWidth = nextTextSizeWithOverflowBreak.w + LABEL_PADDING * 2

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -62,6 +62,9 @@ export const tipTapDefaultExtensions: Extensions = [
 	TextDirection,
 ]
 
+// todo: bust this if the editor changes, too
+const htmlCache = new WeakCache<TLRichText, string>()
+
 /**
  * Renders HTML from a rich text string.
  *
@@ -71,11 +74,13 @@ export const tipTapDefaultExtensions: Extensions = [
  * @public
  */
 export function renderHtmlFromRichText(editor: Editor, richText: TLRichText) {
-	const tipTapExtensions =
-		editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-	const html = generateHTML(richText as JSONContent, tipTapExtensions)
-	// We replace empty paragraphs with a single line break to prevent the browser from collapsing them.
-	return html.replaceAll('<p dir="auto"></p>', '<p><br /></p>') ?? ''
+	return htmlCache.get(richText, () => {
+		const tipTapExtensions =
+			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
+		const html = generateHTML(richText as JSONContent, tipTapExtensions)
+		// We replace empty paragraphs with a single line break to prevent the browser from collapsing them.
+		return html.replaceAll('<p dir="auto"></p>', '<p><br /></p>') ?? ''
+	})
 }
 
 /**


### PR DESCRIPTION
This PR improves the performance of text measurement.

- reuses the same element for measurement rather than creating / mounting new elements for each measurement
- adds `measureScrollWidth` as an option to measureText because this is only used in note shapes.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape with a label
2. Resize it

### Release notes

- Improved rich text performance