### PR TITLE
fix(draw): handle closed draw shape with only 2 points

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -110,6 +110,15 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 			})
 		}
 
+		if (strokePoints.length === 1) {
+			return new Circle2d({
+				x: -sw,
+				y: -sw,
+				radius: sw,
+				isFilled: true,
+			})
+		}
+
 		// An open draw stroke
 		return new Polyline2d({
 			points: strokePoints,


### PR DESCRIPTION
Quick fix introduced by #6162 

### Change type

- [x] `bugfix` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where closed draw shapes with only two points could cause errors.