### PR TITLE
fix(examples): correct image overlay in image annotator

### DIFF
--- a/apps/examples/src/examples/image-annotator/image-annotator.css
+++ b/apps/examples/src/examples/image-annotator/image-annotator.css
@@ -51,6 +51,7 @@
 	fill: var(--color-background);
 	fill-opacity: 0.8;
 	stroke: none;
+	z-index: 200;
 }
 
 .ImageAnnotator .DoneButton {


### PR DESCRIPTION
Image overlay in the Image annotator example should now be correctly displayed.

### Change type

- [x] `bugfix` 

### Test plan

1. Open the Image Annotator example and verify the image overlay displays correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed image overlay display in the Image Annotator example.