### PR TITLE
perf: cache rich text to html conversion

### DIFF
--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -62,6 +62,9 @@ export const tipTapDefaultExtensions: Extensions = [
 	TextDirection,
 ]
 
+// todo: bust this if the editor changes, too
+const htmlCache = new WeakCache<TLRichText, string>()
+
 /**
  * Renders HTML from a rich text string.
  *
@@ -71,11 +74,13 @@ export const tipTapDefaultExtensions: Extensions = [
  * @public
  */
 export function renderHtmlFromRichText(editor: Editor, richText: TLRichText) {
-	const tipTapExtensions =
-		editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-	const html = generateHTML(richText as JSONContent, tipTapExtensions)
-	// We replace empty paragraphs with a single line break to prevent the browser from collapsing them.
-	return html.replaceAll('<p dir="auto"></p>', '<p><br /></p>') ?? ''
+	return htmlCache.get(richText, () => {
+		const tipTapExtensions =
+			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
+		const html = generateHTML(richText as JSONContent, tipTapExtensions)
+		// We replace empty paragraphs with a single line break to prevent the browser from collapsing them.
+		return html.replaceAll('<p dir="auto"></p>', '<p><br /></p>') ?? ''
+	})
 }
 
 /**


### PR DESCRIPTION
This PR improves performance for resizing shapes with text in them and other situations where text is recomputed. Part of this is measurement, which is annoying slow, but the other part is just generating the raw html text, which is also relatively slow and which this PR improves through a weak cache.

### Change type

- [x] `improvement`

### Test plan

1. Create lots of shapes with labels
2. Resize them

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Improved performance of resizing