### PR TITLE
fix(editor): restore missing CSS

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -774,6 +774,25 @@ input,
 	z-index: var(--layer-text-content);
 }
 
+.tl-text-label__inner > .tl-text-content {
+	position: relative;
+	top: 0px;
+	left: 0px;
+	padding: inherit;
+	height: fit-content;
+	width: fit-content;
+	border-radius: var(--radius-1);
+	max-width: 100%;
+}
+
+.tl-text-label__inner > .tl-text-input {
+	position: absolute;
+	inset: 0px;
+	height: 100%;
+	width: 100%;
+	padding: inherit;
+}
+
 .tl-text-wrapper[data-isselected='true'] .tl-text-input {
 	z-index: var(--layer-text-editor);
 	pointer-events: all;


### PR DESCRIPTION
This PR restores two CSS lines that were dropped in #6220.

### Change type

- [x] `bugfix` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Restored missing CSS styles in the editor.