### PR TITLE
Skip scroll width text measure

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2845,6 +2845,7 @@ export class TextManager {
         fontStyle: string;
         fontWeight: string;
         lineHeight: number;
+        measureScrollWidth?: boolean;
         minWidth?: null | number;
         otherStyles?: Record<string, string>;
         padding: string;
@@ -2860,6 +2861,7 @@ export class TextManager {
         fontStyle: string;
         fontWeight: string;
         lineHeight: number;
+        measureScrollWidth?: boolean;
         minWidth?: null | number;
         padding: string;
     }): BoxModel & {

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -65,6 +65,7 @@ export class TextManager {
 			minWidth?: null | number
 			padding: string
 			disableOverflowWrapBreaking?: boolean
+			measureScrollWidth?: boolean
 		}
 	): BoxModel & { scrollWidth: number } {
 		const div = document.createElement('div')
@@ -90,6 +91,7 @@ export class TextManager {
 			otherStyles?: Record<string, string>
 			padding: string
 			disableOverflowWrapBreaking?: boolean
+			measureScrollWidth?: boolean
 		}
 	): BoxModel & { scrollWidth: number } {
 		// Duplicate our base element; we don't need to clone deep
@@ -120,7 +122,7 @@ export class TextManager {
 			}
 		}
 
-		const scrollWidth = wrapperElm.scrollWidth
+		const scrollWidth = opts.measureScrollWidth ? wrapperElm.scrollWidth : 0
 		const rect = wrapperElm.getBoundingClientRect()
 		wrapperElm.remove()
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -550,6 +550,21 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	}
 }
 
+// imperfect but good enough, should be the width of the W in the font / size combo
+const minWidths = {
+	s: 12,
+	m: 14,
+	l: 16,
+	xl: 20,
+}
+
+const extraPaddings = {
+	s: 2,
+	m: 3.5,
+	l: 5,
+	xl: 10,
+}
+
 function getUnscaledLabelSize(editor: Editor, shape: TLGeoShape) {
 	const { richText, font, size, w } = shape.props
 
@@ -557,32 +572,20 @@ function getUnscaledLabelSize(editor: Editor, shape: TLGeoShape) {
 		return { w: 0, h: 0 }
 	}
 
-	const minSize = editor.textMeasure.measureText('w', {
-		...TEXT_PROPS,
-		fontFamily: FONT_FAMILIES[font],
-		fontSize: LABEL_FONT_SIZES[size],
-		maxWidth: 100, // ?
-	})
-
-	// TODO: Can I get these from somewhere?
-	const sizes = {
-		s: 2,
-		m: 3.5,
-		l: 5,
-		xl: 10,
-	}
+	// way too expensive to be recomputing on every update
+	const minWidth = minWidths[size]
 
 	const html = renderHtmlFromRichTextForMeasurement(editor, richText)
 	const textSize = editor.textMeasure.measureHtml(html, {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[font],
 		fontSize: LABEL_FONT_SIZES[size],
-		minWidth: minSize.w,
+		minWidth: minWidth,
 		maxWidth: Math.max(
 			// Guard because a DOM nodes can't be less 0
 			0,
 			// A 'w' width that we're setting as the min-width
-			Math.ceil(minSize.w + sizes[size]),
+			Math.ceil(minWidth + extraPaddings[size]),
 			// The actual text size
 			Math.ceil(w / shape.props.scale - LABEL_PADDING * 2)
 		),

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -460,6 +460,7 @@ function getNoteLabelSize(editor: Editor, shape: TLNoteShape) {
 				fontFamily: FONT_FAMILIES[shape.props.font],
 				fontSize: fontSizeAdjustment,
 				maxWidth: NOTE_SIZE - LABEL_PADDING * 2 - FUZZ,
+				measureScrollWidth: true,
 			})
 			labelHeight = nextTextSizeWithOverflowBreak.h + LABEL_PADDING * 2
 			labelWidth = nextTextSizeWithOverflowBreak.w + LABEL_PADDING * 2


### PR DESCRIPTION
This PR adds a flag to measure the scrollwidth when measuring text elements. When false, scrollwidth is not measured. This should speed up parts of text measurement.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improved performance of measuring text.
- [SDK] Added `measureScrollWidth` option to text measurement options.