### PR TITLE
fix(dotcom): hide share label when file is not shared

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -46,7 +46,7 @@ export function TlaInviteTab({ fileId }: { fileId: string }) {
 				{isOwner && (
 					<TlaMenuControlGroup>
 						<TlaSharedToggle isShared={isShared} fileId={fileId} />
-						<TlaSelectSharedLinkType isShared={isShared} fileId={fileId} />
+						{isShared && <TlaSelectSharedLinkType fileId={fileId} />}
 					</TlaMenuControlGroup>
 				)}
 				{isShared && <TlaCopyLinkButton isShared={isShared} fileId={fileId} />}
@@ -90,7 +90,7 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 	)
 }
 
-function TlaSelectSharedLinkType({ isShared, fileId }: { isShared: boolean; fileId: string }) {
+function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 	const app = useApp()
 	const user = useTldrawUser()
 	const trackEvent = useTldrawAppUiEvents()
@@ -112,9 +112,7 @@ function TlaSelectSharedLinkType({ isShared, fileId }: { isShared: boolean; file
 		[app, fileId, trackEvent]
 	)
 
-	const label = useMsg(
-		isShared ? (sharedLinkType === 'edit' ? messages.editor : messages.viewer) : messages.noAccess
-	)
+	const label = useMsg(sharedLinkType === 'edit' ? messages.editor : messages.viewer)
 
 	return (
 		<TlaMenuControl>
@@ -124,13 +122,11 @@ function TlaSelectSharedLinkType({ isShared, fileId }: { isShared: boolean; file
 			<TlaMenuSelect
 				data-testid="shared-link-type-select"
 				label={label}
-				value={!isShared ? 'no-access' : sharedLinkType!}
-				disabled={!isShared}
+				value={sharedLinkType!}
 				onChange={handleSelectChange}
 				options={[
 					{ value: 'edit', label: <F defaultMessage="Editor" /> },
 					{ value: 'view', label: <F defaultMessage="Viewer" /> },
-					// { value: 'no-access', label: <F defaultMessage="No access" /> },
 				]}
 			/>
 		</TlaMenuControl>


### PR DESCRIPTION
Looks like some leftovers?

We could also bring back the `No access` option, but this feels better to me.

### Before

![image](https://github.com/user-attachments/assets/887dd776-d09a-4b44-8f82-5f9e35e6c433)


### After

![image](https://github.com/user-attachments/assets/6e067cf8-5df8-495c-89d1-0e466b78a4c3)


### Change type

- [x] `bugfix` 

### Test plan

1. Open the share menu for a file that is not shared.
2. Verify that the share label is no longer visible.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where a share label was incorrectly shown for unshared files.