### PR TITLE
css: restore some text-shape-label code

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -575,6 +575,23 @@ input,
 
 /* ---------------------- Text ---------------------- */
 
+.tl-text-shape-label {
+	position: relative;
+	font-weight: normal;
+	min-width: 1px;
+	padding: 0px;
+	margin: 0px;
+	border: none;
+	width: fit-content;
+	height: fit-content;
+	font-variant: normal;
+	font-style: normal;
+	pointer-events: all;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+	text-shadow: var(--tl-text-outline);
+}
+
 .tl-text-wrapper[data-font='draw'] {
 	font-family: var(--tl-font-draw);
 }


### PR DESCRIPTION
this was prbly not intentional but maybe you saw it wasn't doing something?
from: https://github.com/tldraw/tldraw/pull/6220/files#r2137221610

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Restore some css for text shapes.