### PR TITLE
kbd: on non-Mac, output the kbd shortcuts correctly

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiKbd.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiKbd.tsx
@@ -14,11 +14,9 @@ export function TldrawUiKbd({ children, visibleOnMobileLayout = false }: TLUiKbd
 	if (!visibleOnMobileLayout && breakpoint < PORTRAIT_BREAKPOINT.MOBILE) return null
 	return (
 		<kbd className="tlui-kbd">
-			{kbd(children)
-				// .split('')
-				.map((k, i) => (
-					<span key={i}>{k}</span>
-				))}
+			{kbd(children).map((k, i) => (
+				<span key={i}>{k}</span>
+			))}
 		</kbd>
 	)
 }

--- a/packages/tldraw/src/lib/ui/kbd-utils.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.ts
@@ -1,7 +1,8 @@
 import { tlenv } from '@tldraw/editor'
 
-const cmdKey = tlenv.isDarwin ? '⌘' : 'Ctrl'
-const altKey = tlenv.isDarwin ? '⌥' : 'Alt'
+// N.B. We rework these Windows placeholders down below.
+const cmdKey = tlenv.isDarwin ? '⌘' : '__CTRL__'
+const altKey = tlenv.isDarwin ? '⌥' : '__ALT__'
 
 /** @public */
 export function kbd(str: string) {
@@ -25,12 +26,16 @@ export function kbd(str: string) {
 							.replace(/\$/g, cmdKey)
 							.replace(/\?/g, altKey)
 							.replace(/!/g, '⇧')
-							.split('')
+							.match(/__CTRL__|__ALT__|./g) || []
 			)
 			.flat()
-			.map((sub) => {
-				return sub[0].toUpperCase() + sub.slice(1)
+			.map((sub, index) => {
+				if (sub === '__CTRL__') return 'Ctrl'
+				if (sub === '__ALT__') return 'Alt'
+				const modifiedKey = sub[0].toUpperCase() + sub.slice(1)
+				return tlenv.isDarwin || !index ? modifiedKey : ['+', modifiedKey]
 			})
+			.flat()
 	)
 }
 


### PR DESCRIPTION
Before:
![image-1 copy](https://github.com/user-attachments/assets/ff8b2a88-467b-4860-8ea9-896592ec4fbb)

After:
![Screenshot 2025-06-16 at 17 34 32](https://github.com/user-attachments/assets/ab9b2ecb-a1c8-452b-9a04-28844e6f1a18)


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix keyboard shortcuts on non-Mac.