### PR TITLE
examples: put filter value into url

### DIFF
--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -1,5 +1,5 @@
 import { AlertDialog as _AlertDialog } from 'radix-ui'
-import { Dispatch, createContext, useContext, useState } from 'react'
+import { Dispatch, createContext, useContext, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Example, examples } from './examples'
 
@@ -31,7 +31,21 @@ export function ExamplePage({
 	const [filterValue, setFilterValue] = useState('')
 	const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setFilterValue(e.target.value)
+		history.replaceState(
+			{},
+			'',
+			e.target.value ? `/?filter=${encodeURIComponent(e.target.value)}` : '/'
+		)
 	}
+
+	useEffect(() => {
+		const urlParams = new URLSearchParams(window.location.search)
+		const filter = urlParams.get('filter')
+		if (filter) {
+			setFilterValue(decodeURIComponent(filter))
+		}
+	}, [])
+
 	return (
 		<DialogContextProvider>
 			<div className="example">


### PR DESCRIPTION
Sometimes I want to be able to show a user all the "toolbar" examples, not just one specific example. This lets our URL have a filter value.

![Screenshot 2025-06-17 at 11 15 31](https://github.com/user-attachments/assets/83b8e07c-8617-4d54-aa4c-fdf983b4f773)


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
