### PR TITLE
image toolbar: readonly/locked modes, select all for alt text, aspect ratio tweak

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
@@ -25,6 +25,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 	const msg = useTranslation()
 	const ref = useRef<HTMLInputElement>(null)
 	const trackEvent = useUiEvents()
+	const isReadonly = editor.getIsReadonly()
 
 	const handleValueChange = (value: string) => setAltText(value)
 
@@ -46,7 +47,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 	const handleAltTextCancel = useCallback(() => onClose(), [onClose])
 
 	useEffect(() => {
-		ref.current?.focus()
+		ref.current?.select()
 
 		function handleKeyDown(event: KeyboardEvent) {
 			if (event.key === 'Escape') {
@@ -72,15 +73,18 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 				onValueChange={handleValueChange}
 				onComplete={handleComplete}
 				onCancel={handleAltTextCancel}
+				disabled={isReadonly}
 			/>
-			<TldrawUiButton
-				title={msg('tool.media-alt-text-confirm')}
-				type="icon"
-				onPointerDown={preventDefault}
-				onClick={handleConfirm}
-			>
-				<TldrawUiButtonIcon small icon="check" />
-			</TldrawUiButton>
+			{!isReadonly && (
+				<TldrawUiButton
+					title={msg('tool.media-alt-text-confirm')}
+					type="icon"
+					onPointerDown={preventDefault}
+					onClick={handleConfirm}
+				>
+					<TldrawUiButtonIcon small icon="check" />
+				</TldrawUiButton>
+			)}
 		</>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -54,6 +54,7 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 	const msg = useTranslation()
 	const source = 'image-toolbar'
 	const sliderRef = useRef<HTMLDivElement>(null)
+	const isReadonly = editor.getIsReadonly()
 
 	const crop = useValue('crop', () => editor.getShape<TLImageShape>(imageShapeId)!.props.crop, [
 		editor,
@@ -202,18 +203,22 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 					<TldrawUiDropdownMenuContent side="top" align="center">
 						{ASPECT_RATIO_OPTIONS.map((aspectRatio) => {
 							let checked = false
-							if (aspectRatio === 'circle' && crop) {
-								checked = !!crop.isCircle
-							} else if (aspectRatio === 'original') {
-								checked = isOriginalCrop
-							} else if (aspectRatio === 'square') {
-								checked =
-									!crop?.isCircle &&
-									approximately(shapeAspectRatio, ASPECT_RATIO_TO_VALUE[aspectRatio], 0.1)
+							if (isOriginalCrop) {
+								if (aspectRatio === 'original') {
+									checked = true
+								}
 							} else {
-								checked =
-									!isOriginalCrop &&
-									approximately(shapeAspectRatio, ASPECT_RATIO_TO_VALUE[aspectRatio], 0.01)
+								if (aspectRatio === 'circle') {
+									checked = !!crop.isCircle
+								} else if (aspectRatio === 'square') {
+									checked =
+										!crop?.isCircle &&
+										approximately(shapeAspectRatio, ASPECT_RATIO_TO_VALUE[aspectRatio], 0.1)
+								} else {
+									checked =
+										!isOriginalCrop &&
+										approximately(shapeAspectRatio, ASPECT_RATIO_TO_VALUE[aspectRatio], 0.01)
+								}
 							}
 
 							return (
@@ -245,12 +250,16 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 
 	return (
 		<>
-			<TldrawUiButton type="icon" title={msg('tool.replace-media')} onClick={handleImageReplace}>
-				<TldrawUiButtonIcon small icon="arrow-cycle" />
-			</TldrawUiButton>
-			<TldrawUiButton type="icon" title={msg('tool.image-crop')} onClick={onManipulatingStart}>
-				<TldrawUiButtonIcon small icon="crop" />
-			</TldrawUiButton>
+			{!isReadonly && (
+				<TldrawUiButton type="icon" title={msg('tool.replace-media')} onClick={handleImageReplace}>
+					<TldrawUiButtonIcon small icon="tool-media" />
+				</TldrawUiButton>
+			)}
+			{!isReadonly && (
+				<TldrawUiButton type="icon" title={msg('tool.image-crop')} onClick={onManipulatingStart}>
+					<TldrawUiButtonIcon small icon="crop" />
+				</TldrawUiButton>
+			)}
 			<TldrawUiButton
 				type="icon"
 				title={msg('action.download-original')}
@@ -258,17 +267,19 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 			>
 				<TldrawUiButtonIcon small icon="download" />
 			</TldrawUiButton>
-			<TldrawUiButton
-				type="normal"
-				isActive={!!altText}
-				title={msg('tool.media-alt-text')}
-				onClick={() => {
-					trackEvent('alt-text-start', { source })
-					onEditAltTextStart()
-				}}
-			>
-				<TldrawUiButtonIcon small icon="alt" />
-			</TldrawUiButton>
+			{(altText || !isReadonly) && (
+				<TldrawUiButton
+					type="normal"
+					isActive={!!altText}
+					title={msg('tool.media-alt-text')}
+					onClick={() => {
+						trackEvent('alt-text-start', { source })
+						onEditAltTextStart()
+					}}
+				>
+					<TldrawUiButtonIcon small icon="alt" />
+				</TldrawUiButton>
+			)}
 		</>
 	)
 })

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultVideoToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultVideoToolbarContent.tsx
@@ -21,6 +21,7 @@ export const DefaultVideoToolbarContent = track(function DefaultVideoToolbarCont
 	const trackEvent = useUiEvents()
 	const msg = useTranslation()
 	const source = 'video-toolbar'
+	const isReadonly = editor.getIsReadonly()
 
 	const actions = useActions()
 
@@ -42,9 +43,11 @@ export const DefaultVideoToolbarContent = track(function DefaultVideoToolbarCont
 
 	return (
 		<>
-			<TldrawUiButton type="icon" title={msg('tool.replace-media')} onClick={handleVideoReplace}>
-				<TldrawUiButtonIcon small icon="arrow-cycle" />
-			</TldrawUiButton>
+			{!isReadonly && (
+				<TldrawUiButton type="icon" title={msg('tool.replace-media')} onClick={handleVideoReplace}>
+					<TldrawUiButtonIcon small icon="arrow-cycle" />
+				</TldrawUiButton>
+			)}
 			<TldrawUiButton
 				type="icon"
 				title={msg('action.download-original')}
@@ -52,17 +55,19 @@ export const DefaultVideoToolbarContent = track(function DefaultVideoToolbarCont
 			>
 				<TldrawUiButtonIcon small icon="download" />
 			</TldrawUiButton>
-			<TldrawUiButton
-				type="normal"
-				isActive={!!altText}
-				title={msg('tool.media-alt-text')}
-				onClick={() => {
-					trackEvent('alt-text-start', { source })
-					onEditAltTextStart()
-				}}
-			>
-				<TldrawUiButtonIcon small icon="alt" />
-			</TldrawUiButton>
+			{(altText || !isReadonly) && (
+				<TldrawUiButton
+					type="normal"
+					isActive={!!altText}
+					title={msg('tool.media-alt-text')}
+					onClick={() => {
+						trackEvent('alt-text-start', { source })
+						onEditAltTextStart()
+					}}
+				>
+					<TldrawUiButtonIcon small icon="alt" />
+				</TldrawUiButton>
+			)}
 		</>
 	)
 })

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
@@ -59,6 +59,7 @@ export const TldrawUiInput = React.forwardRef<HTMLInputElement, TLUiInputProps>(
 			children,
 			value,
 			'data-testid': dataTestId,
+			disabled,
 		},
 		ref
 	) {
@@ -200,6 +201,7 @@ export const TldrawUiInput = React.forwardRef<HTMLInputElement, TLUiInputProps>(
 					placeholder={placeholder}
 					value={value}
 					data-testid={dataTestId}
+					disabled={disabled}
 				/>
 				{icon && (
 					<TldrawUiIcon label={iconLabel ? msg(iconLabel) : ''} icon={icon} small={!!label} />


### PR DESCRIPTION
followup fixes for media toolbars:
- readonly/locked fix
- aspect ratio (double checked sometimes)
- select all for alt text

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fix some readonly issues with media toolbars; tweak alt text and aspect ratio menus