### PR TITLE
Prevent duplication of locked shapes, and unlock pasted locked shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6211,11 +6211,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	duplicateShapes(shapes: TLShapeId[] | TLShape[], offset?: VecLike): this {
 		this.run(() => {
-			const ids =
+			const _ids =
 				typeof shapes[0] === 'string'
 					? (shapes as TLShapeId[])
 					: (shapes as TLShape[]).map((s) => s.id)
 
+			const ids = this._shouldIgnoreShapeLock ? _ids : this._getUnlockedShapeIds(_ids)
 			if (ids.length <= 0) return this
 
 			const initialIds = new Set(ids)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -515,6 +515,14 @@ export async function defaultHandleExternalTldrawContent(
 	editor.run(() => {
 		const selectionBoundsBefore = editor.getSelectionPageBounds()
 		editor.markHistoryStoppingPoint('paste')
+
+		// Unlock any locked root shapes on paste
+		for (const shape of content.shapes) {
+			if (content.rootShapeIds.includes(shape.id)) {
+				shape.isLocked = false
+			}
+		}
+
 		editor.putContentOntoCurrentPage(content, {
 			point: point,
 			select: true,

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -41,6 +41,26 @@ it('duplicates a shape with an offset', () => {
 	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
 })
 
+it("doesn't duplicate locked shapes", () => {
+	editor
+		.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		.createShape({
+			id: ids.box2,
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+			isLocked: true,
+		})
+
+	editor.select(ids.box1, ids.box2)
+	editor.duplicateShapes(editor.getSelectedShapeIds(), { x: 10, y: 10 })
+	expect(editor.getCurrentPageShapes().length).toBe(3) // 1 original + 1 duplicate of box1
+	expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0 })
+	expect(editor.getShape(ids.box2)).toMatchObject({ x: 200, y: 200, isLocked: true })
+	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
+})
+
 it('creates new bindings for arrows when pasting', async () => {
 	editor
 		.selectAll()


### PR DESCRIPTION
This PR makes it so that...
- You can't duplicate locked shapes anymore. We were already disabling the button. Now the keyboard shortcut's behavior reflects that too.
- When you paste a locked shape, it now unlocks the pasted shape. Note: Only root level shapes get unlocked. If you paste a  frame that... say... has a locked child inside it, the pasted locked child will stay locked.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Prevented duplication of locked shapes.
- Pasting a locked shape onto the canvas now unlocks it.