### PR TITLE
image cropping: make sure we setCroppingShape to null when exiting the state machine

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -24,6 +24,7 @@ export class Idle extends StateNode {
 	}
 
 	override onExit() {
+		this.editor.setCroppingShape(null)
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 	}
 


### PR DESCRIPTION
we never noticed that finishing a crop sometimes leaves the cropping state in a half-state.


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

### Release notes

- Make sure we setCroppingShape to null when exiting the state machine.