### PR TITLE
refactor(ui): remove isActive on image toolbar alt text

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -272,7 +272,6 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 			{(altText || !isReadonly) && (
 				<TldrawUiButton
 					type="normal"
-					isActive={!!altText}
 					title={msg('tool.media-alt-text')}
 					onClick={() => {
 						trackEvent('alt-text-start', { source })


### PR DESCRIPTION
This pull request removes the `isActive` prop from the `TldrawUiButton` component in the image toolbar, simplifying its configuration.

### Change type

- [x] `improvement`

### Test plan

1. Open an image's alt text menu in the toolbar.
2. Verify the button appearance and functionality remain correct.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Simplified image toolbar alt text button configuration.