### PR TITLE
Require modern browsers

### DIFF
--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -17,7 +17,7 @@ export class OptimisticAppStore {
 	constructor() {
 		// this is for the one guy in morocco who is still on firefox 102
 		if (!('findLastIndex' in Array.prototype)) {
-			window.alert('come on, update your browser')
+			window.alert('hey update your browser')
 			throw Error('browser too old')
 		}
 

--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -3,11 +3,6 @@ import { assert, assertExists, exhaustiveSwitchError, isEqual } from '@tldraw/ut
 import { schema } from './tlaSchema'
 import { ZRowUpdate, ZStoreData } from './types'
 
-// Some browsers don't support findLastIndex
-if (!('findLastIndex' in Array.prototype)) {
-	throw Error('Update your browser')
-}
-
 export class OptimisticAppStore {
 	private _gold_store = atom('zero store', null as null | ZStoreData, { isEqual })
 
@@ -20,6 +15,11 @@ export class OptimisticAppStore {
 
 	epoch = 0
 	constructor() {
+		// this is for the one guy in morocco who is still on firefox 102
+		if (!('findLastIndex' in Array.prototype)) {
+			throw Error('Update your browser')
+		}
+
 		react('update epoch', () => {
 			this._gold_store.get()
 			this._optimisticStore.get()

--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -3,6 +3,11 @@ import { assert, assertExists, exhaustiveSwitchError, isEqual } from '@tldraw/ut
 import { schema } from './tlaSchema'
 import { ZRowUpdate, ZStoreData } from './types'
 
+// Some browsers don't support findLastIndex
+if (!('findLastIndex' in Array.prototype)) {
+	throw Error('Update your browser')
+}
+
 export class OptimisticAppStore {
 	private _gold_store = atom('zero store', null as null | ZStoreData, { isEqual })
 

--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -17,7 +17,8 @@ export class OptimisticAppStore {
 	constructor() {
 		// this is for the one guy in morocco who is still on firefox 102
 		if (!('findLastIndex' in Array.prototype)) {
-			throw Error('Update your browser')
+			window.alert('come on, update your browser')
+			throw Error('browser too old')
 		}
 
 		react('update epoch', () => {


### PR DESCRIPTION

<img width="952" alt="image" src="https://github.com/user-attachments/assets/83f8aef1-aaaf-4de8-8c5a-fd33faeb1ff9" />


We use Array.findLastIndex which was shipped across browsers in 2023. We keep seeing this error from users with old browsers. At the moment the app just hangs indefinitely. You can reproduce it like this:

```ts
commitMutations(mutationIds: string[]) {
	this._optimisticStore.update((prev) => {
		if (!prev) return prev
		delete prev.prototype.findLastIndex
		const highestIndex = prev.findLastIndex((p) => mutationIds.includes(p.mutationId))
		return prev.slice(highestIndex + 1)
	})
}
```

Which will result in an infinite spinner as the error occurs behind the scenes. This PR at least tells the user to update. We could improve this experience though it's a very rare one.

Closes https://github.com/tldraw/tldraw/issues/6281

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Fixed a silent bug effecting out of date browsers. Update your browser!