### PR TITLE
Ellipse crop geometry / indicator

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1826,6 +1826,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     getDefaultProps(): TLImageShape['props'];
     // (undocumented)
+    getGeometry(shape: TLImageShape): Geometry2d;
+    // (undocumented)
     getInterpolatedProps(startShape: TLImageShape, endShape: TLImageShape, t: number): TLImageShapeProps;
     // (undocumented)
     indicator(shape: TLImageShape): JSX_2.Element | null;

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -1,10 +1,13 @@
 import {
 	BaseBoxShapeUtil,
 	Editor,
+	Ellipse2d,
 	FileHelpers,
+	Geometry2d,
 	HTMLContainer,
 	Image,
 	MediaHelpers,
+	Rectangle2d,
 	SvgExportContext,
 	TLAsset,
 	TLAssetId,
@@ -69,6 +72,22 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		}
 	}
 
+	override getGeometry(shape: TLImageShape): Geometry2d {
+		if (shape.props.crop?.isCircle) {
+			return new Ellipse2d({
+				width: shape.props.w,
+				height: shape.props.h,
+				isFilled: true,
+			})
+		}
+
+		return new Rectangle2d({
+			width: shape.props.w,
+			height: shape.props.h,
+			isFilled: true,
+		})
+	}
+
 	override getAriaDescriptor(shape: TLImageShape) {
 		return shape.props.altText
 	}
@@ -121,6 +140,18 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	indicator(shape: TLImageShape) {
 		const isCropping = this.editor.getCroppingShapeId() === shape.id
 		if (isCropping) return null
+
+		if (shape.props.crop?.isCircle) {
+			return (
+				<ellipse
+					cx={toDomPrecision(shape.props.w / 2)}
+					cy={toDomPrecision(shape.props.h / 2)}
+					rx={toDomPrecision(shape.props.w / 2)}
+					ry={toDomPrecision(shape.props.h / 2)}
+				/>
+			)
+		}
+
 		return <rect width={toDomPrecision(shape.props.w)} height={toDomPrecision(shape.props.h)} />
 	}
 

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -18,6 +18,7 @@ import {
 	getDefaultCrop,
 	MAX_ZOOM,
 } from '../../../shapes/shared/crop'
+import { kickoutOccludedShapes } from '../../../tools/SelectTool/selectHelpers'
 import { useActions } from '../../context/actions'
 import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
@@ -142,21 +143,23 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 	const handleAspectRatioChange = (aspectRatio: ASPECT_RATIO_OPTION) => {
 		const imageShape = editor.getShape<TLImageShape>(imageShapeId)
 		if (!imageShape) return
-		editor.setCurrentTool('select.crop.idle')
-		const change = getCroppedImageDataForAspectRatio(aspectRatio, imageShape)
-
-		editor.markHistoryStoppingPoint('aspect ratio')
-		editor.updateShape({
-			id: imageShapeId,
-			type: 'image',
-			x: change.x,
-			y: change.y,
-			props: {
-				crop: change.crop,
-				w: change.w,
-				h: change.h,
-			},
-		} as TLShapePartial)
+		editor.run(() => {
+			editor.setCurrentTool('select.crop.idle')
+			const change = getCroppedImageDataForAspectRatio(aspectRatio, imageShape)
+			editor.markHistoryStoppingPoint('aspect ratio')
+			editor.updateShape({
+				id: imageShapeId,
+				type: 'image',
+				x: change.x,
+				y: change.y,
+				props: {
+					crop: change.crop,
+					w: change.w,
+					h: change.h,
+				},
+			} as TLShapePartial)
+			kickoutOccludedShapes(editor, [imageShapeId])
+		})
 	}
 
 	const altText = useValue(

--- a/packages/tldraw/src/test/ImageShapeUtil.test.ts
+++ b/packages/tldraw/src/test/ImageShapeUtil.test.ts
@@ -1,0 +1,156 @@
+import { createShapeId, Ellipse2d, Rectangle2d, TLImageShape } from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+describe('ImageShapeUtil', () => {
+	describe('getGeometry', () => {
+		it('returns Rectangle2d for normal image shapes', () => {
+			const shapeId = createShapeId()
+			editor.createShapes([
+				{
+					id: shapeId,
+					type: 'image',
+					x: 0,
+					y: 0,
+					props: {
+						w: 100,
+						h: 80,
+						assetId: null,
+						playing: true,
+						url: '',
+						crop: null,
+						flipX: false,
+						flipY: false,
+						altText: '',
+					},
+				},
+			])
+
+			const shape = editor.getShape<TLImageShape>(shapeId)!
+			const util = editor.getShapeUtil(shape)
+			const geometry = util.getGeometry(shape)
+
+			expect(geometry).toBeInstanceOf(Rectangle2d)
+			expect(geometry.bounds.width).toBe(100)
+			expect(geometry.bounds.height).toBe(80)
+			expect(geometry.isFilled).toBe(true)
+		})
+
+		it('returns Rectangle2d for cropped image shapes that are not circular', () => {
+			const shapeId = createShapeId()
+			editor.createShapes([
+				{
+					id: shapeId,
+					type: 'image',
+					x: 0,
+					y: 0,
+					props: {
+						w: 100,
+						h: 80,
+						assetId: null,
+						playing: true,
+						url: '',
+						crop: {
+							topLeft: { x: 0.1, y: 0.1 },
+							bottomRight: { x: 0.9, y: 0.9 },
+							isCircle: false,
+						},
+						flipX: false,
+						flipY: false,
+						altText: '',
+					},
+				},
+			])
+
+			const shape = editor.getShape<TLImageShape>(shapeId)!
+			const util = editor.getShapeUtil(shape)
+			const geometry = util.getGeometry(shape)
+
+			expect(geometry).toBeInstanceOf(Rectangle2d)
+			expect(geometry.bounds.width).toBe(100)
+			expect(geometry.bounds.height).toBe(80)
+			expect(geometry.isFilled).toBe(true)
+		})
+
+		it('returns Ellipse2d for circle cropped image shapes', () => {
+			const shapeId = createShapeId()
+			editor.createShapes([
+				{
+					id: shapeId,
+					type: 'image',
+					x: 0,
+					y: 0,
+					props: {
+						w: 120,
+						h: 90,
+						assetId: null,
+						playing: true,
+						url: '',
+						crop: {
+							topLeft: { x: 0.1, y: 0.1 },
+							bottomRight: { x: 0.9, y: 0.9 },
+							isCircle: true,
+						},
+						flipX: false,
+						flipY: false,
+						altText: '',
+					},
+				},
+			])
+
+			const shape = editor.getShape<TLImageShape>(shapeId)!
+			const util = editor.getShapeUtil(shape)
+			const geometry = util.getGeometry(shape)
+
+			expect(geometry).toBeInstanceOf(Ellipse2d)
+			expect(geometry.bounds.width).toBe(120)
+			expect(geometry.bounds.height).toBe(90)
+			expect(geometry.isFilled).toBe(true)
+		})
+
+		it('returns Ellipse2d for circle cropped image shapes with different dimensions', () => {
+			const shapeId = createShapeId()
+			editor.createShapes([
+				{
+					id: shapeId,
+					type: 'image',
+					x: 0,
+					y: 0,
+					props: {
+						w: 200,
+						h: 150,
+						assetId: null,
+						playing: true,
+						url: '',
+						crop: {
+							topLeft: { x: 0, y: 0 },
+							bottomRight: { x: 1, y: 1 },
+							isCircle: true,
+						},
+						flipX: false,
+						flipY: false,
+						altText: '',
+					},
+				},
+			])
+
+			const shape = editor.getShape<TLImageShape>(shapeId)!
+			const util = editor.getShapeUtil(shape)
+			const geometry = util.getGeometry(shape)
+
+			expect(geometry).toBeInstanceOf(Ellipse2d)
+			expect(geometry.bounds.width).toBe(200)
+			expect(geometry.bounds.height).toBe(150)
+			expect(geometry.isFilled).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
This PR updates an image shape's geometry and indicator to reflect that it is an ellipse crop. Will also kick out shapes when the aspect ratio changes.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create an image shape
2. Make its crop an ellipse
3. Hover it to confirm the indicator
4. Drag an arrow to confirm that it attaches at the geometry

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Updated circle-cropped shapes to have circular geometry.