### PR TITLE
ci: add tldraw@next releases from production branch

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,8 +1,8 @@
-name: Publish Canary Packages
+name: Publish Prerelease Packages
 
 on:
   push:
-    branches: [main]
+    branches: [main, production]
 
 defaults:
   run:
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Publish Canary Packages
-        run: yarn tsx ./internal/scripts/publish-prerelease.ts canary
+        run: yarn tsx ./internal/scripts/publish-prerelease.ts ${{ github.ref == 'refs/heads/production' && 'next' || 'canary' }}
         env:
           GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Satisfies https://linear.app/tldraw/issue/INT-1685/dotcom-release-label

Adds a SDK prerelease tag (`next`) to deploy alongside dotcom, via the production branch.

### Change type

- [x] `other` 

### Test plan

1. Verify workflow triggers correctly on production branch

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added @next prerelease tag for SDK deployments from the production branch