### PR TITLE
fix: set git username and email for vscode extension publishing

### DIFF
--- a/internal/scripts/publish-vscode-extension.ts
+++ b/internal/scripts/publish-vscode-extension.ts
@@ -64,6 +64,10 @@ async function copyExtensionToReleaseFolder(version: string) {
 	nicelog(`Copying extension from ${sourcePath} to ${targetPath}`)
 	copyFileSync(sourcePath, targetPath)
 
+	nicelog('Setting git user identity...')
+	await exec('git', ['config', 'user.name', 'huppy'])
+	await exec('git', ['config', 'user.email', 'huppy@tldraw.com'])
+
 	nicelog('Committing extension to git...')
 	await exec('git', ['add', '-f', targetPath])
 	await exec('git', ['commit', '-m', `Add VSCode extension v${version}`])


### PR DESCRIPTION
We need to set the username and email.

### Change type

- [x] `other`

### Test plan

1. Run the publish script in a CI environment

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the VS Code extension publishing script failed due to missing git configuration.