### PR TITLE
app: old browsers error page

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -40,6 +40,7 @@
   "5677e381d2": "We use analytics cookies to make tldraw better.",
   "56c34c6410": "Privacy policy",
   "5a95a425f7": "Share",
+  "5bec508475": "Old browser detected. Please update your browser to use this app.",
   "5d26ae7550": "We failed to upload some of the content you created before you signed in.",
   "5f3c333678": "Feedback submitted",
   "5fb63579fc": "Copy",

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -122,6 +122,9 @@
   "5a95a425f7": {
     "translation": "Share"
   },
+  "5bec508475": {
+    "translation": "Old browser detected. Please update your browser to use this app."
+  },
   "5d26ae7550": {
     "translation": "We failed to upload some of the content you created before you signed in."
   },

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -13,7 +13,7 @@ const LoginRedirectPage = lazy(() => import('./components/LoginRedirectPage/Logi
 export const router = createRoutesFromElements(
 	<Route
 		ErrorBoundary={() => {
-			const error = useRouteError() as any
+			const error = useRouteError()
 			useEffect(() => {
 				captureException(error)
 			}, [error])
@@ -56,7 +56,6 @@ export const router = createRoutesFromElements(
 					messages={{
 						header,
 						para1,
-						para2: error?.message && typeof error.message === 'string' ? error.message : undefined,
 					}}
 				/>
 			)

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -13,7 +13,7 @@ const LoginRedirectPage = lazy(() => import('./components/LoginRedirectPage/Logi
 export const router = createRoutesFromElements(
 	<Route
 		ErrorBoundary={() => {
-			const error = useRouteError()
+			const error = useRouteError() as any
 			useEffect(() => {
 				captureException(error)
 			}, [error])
@@ -56,6 +56,7 @@ export const router = createRoutesFromElements(
 					messages={{
 						header,
 						para1,
+						para2: error?.message && typeof error.message === 'string' ? error.message : undefined,
 					}}
 				/>
 			)

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -24,7 +24,7 @@ import { components } from '../components/TlaEditor/TlaEditor'
 import { AppStateProvider, useMaybeApp } from '../hooks/useAppState'
 import { UserProvider } from '../hooks/useUser'
 import '../styles/tla.css'
-import { IntlProvider, setupCreateIntl } from '../utils/i18n'
+import { IntlProvider, defineMessages, setupCreateIntl, useIntl } from '../utils/i18n'
 import {
 	clearLocalSessionState,
 	getLocalSessionState,
@@ -33,6 +33,12 @@ import {
 import { FileSidebarFocusContextProvider } from './FileInputFocusProvider'
 
 const assetUrls = getAssetUrlsByImport()
+
+export const appMessages = defineMessages({
+	oldBrowser: {
+		defaultMessage: 'Old browser detected. Please update your browser to use this app.',
+	},
+})
 
 // @ts-ignore this is fine
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
@@ -149,6 +155,7 @@ function SignedInProvider({
 	onLocaleChange(locale: string): void
 }) {
 	const auth = useAuth()
+	const intl = useIntl()
 	const { user, isLoaded: isUserLoaded } = useClerkUser()
 	const [currentLocale, setCurrentLocale] = useState<string>(
 		globalEditor.get()?.user.getUserPreferences().locale ?? 'en'
@@ -184,6 +191,11 @@ function SignedInProvider({
 				{children}
 			</ThemeContainer>
 		)
+	}
+
+	// Old browsers check.
+	if (!('findLastIndex' in Array.prototype)) {
+		throw new Error(intl.formatMessage(appMessages.oldBrowser))
 	}
 
 	return (

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -17,6 +17,7 @@ import {
 	useToasts,
 	useValue,
 } from 'tldraw'
+import { ErrorPage } from '../../components/ErrorPage/ErrorPage'
 import { SignedInAnalytics, SignedOutAnalytics } from '../../utils/analytics'
 import { globalEditor } from '../../utils/globalEditor'
 import { MaybeForceUserRefresh } from '../components/MaybeForceUserRefresh/MaybeForceUserRefresh'
@@ -184,6 +185,18 @@ function SignedInProvider({
 
 	if (!auth.isLoaded) return null
 
+	// Old browsers check.
+	if (!('findLastIndex' in Array.prototype)) {
+		return (
+			<ErrorPage
+				messages={{
+					header: intl.formatMessage(appMessages.oldBrowser),
+					para1: '',
+				}}
+			/>
+		)
+	}
+
 	if (!auth.isSignedIn || !user || !isUserLoaded) {
 		return (
 			<ThemeContainer onThemeChange={onThemeChange}>
@@ -191,11 +204,6 @@ function SignedInProvider({
 				{children}
 			</ThemeContainer>
 		)
-	}
-
-	// Old browsers check.
-	if (!('findLastIndex' in Array.prototype)) {
-		throw new Error(intl.formatMessage(appMessages.oldBrowser))
 	}
 
 	return (

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -193,6 +193,7 @@ function SignedInProvider({
 					header: intl.formatMessage(appMessages.oldBrowser),
 					para1: '',
 				}}
+				cta={null}
 			/>
 		)
 	}


### PR DESCRIPTION
alt take on https://github.com/tldraw/tldraw/pull/6282
- this gets us a translated string
- we shouldn't do the check in dotcom-shared, but at the app level, esp. since the checks will grow eventually to have other things, not just `findLastIndex`

![Screenshot 2025-06-23 at 16 00 12](https://github.com/user-attachments/assets/5a6e5db1-c23b-4103-a620-0066b6bdb7ec)



### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
