### PR TITLE
Skip ci actions after we commit the extension

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -21,10 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # Prevent multiple runs from happening at the same time
     concurrency: vscode-extension-publish
-    # Skip if the commit was made by the bot to avoid infinite loops
-    if: github.event.head_commit.author.name != 'huppy-bot[bot]'
 
     steps:
       - name: Generate GH token

--- a/internal/scripts/publish-vscode-extension.ts
+++ b/internal/scripts/publish-vscode-extension.ts
@@ -70,7 +70,7 @@ async function copyExtensionToReleaseFolder(version: string) {
 
 	nicelog('Committing extension to git...')
 	await exec('git', ['add', '-f', targetPath])
-	await exec('git', ['commit', '-m', `Add VSCode extension v${version}`])
+	await exec('git', ['commit', '-m', `Add VSCode extension v${version} [skip ci]`])
 	nicelog('Pushing changes to remote repository...')
 	await exec('git', ['push'])
 }
@@ -80,6 +80,7 @@ async function packageAndPublish(version: string) {
 	switch (env.TLDRAW_ENV) {
 		case 'production':
 			await exec('yarn', ['package'], { pwd: EXTENSION_DIR })
+			await copyExtensionToReleaseFolder(version)
 			await exec('yarn', ['publish'], { pwd: EXTENSION_DIR })
 			return
 		case 'staging':


### PR DESCRIPTION
This should not trigger an additional push event for the branch and should prevent cycles / running actions twice.

### Change type

- [x] `bugfix`
