### PR TITLE
feat(analytics): add Edit event to signal when boards are edited

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3426,6 +3426,12 @@ export interface TLEventMap {
     // (undocumented)
     'before-event': [TLEventInfo];
     // (undocumented)
+    'created-shapes': [TLRecord[]];
+    // (undocumented)
+    'deleted-shapes': [TLShapeId[]];
+    // (undocumented)
+    'edited-shapes': [TLRecord[]];
+    // (undocumented)
     'max-shapes': [{
         count: number;
         name: string;
@@ -3453,6 +3459,8 @@ export interface TLEventMap {
     crash: [{
         error: unknown;
     }];
+    // (undocumented)
+    edit: [];
     // (undocumented)
     event: [TLEventInfo];
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7937,6 +7937,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				}
 			})
 
+			this.emit('created-shapes', shapeRecordsToCreate)
+			this.emit('edit')
 			this.store.put(shapeRecordsToCreate)
 		})
 
@@ -8331,6 +8333,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				updates.push(updated)
 			}
 
+			this.emit('edited-shapes', updates)
+			this.emit('edit')
 			this.store.put(updates)
 		})
 	}
@@ -8380,6 +8384,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			})
 		}
 
+		this.emit('deleted-shapes', [...allShapeIdsToDelete])
+		this.emit('edit')
 		return this.run(() => this.store.remove([...allShapeIdsToDelete]))
 	}
 

--- a/packages/editor/src/lib/editor/types/emit-types.ts
+++ b/packages/editor/src/lib/editor/types/emit-types.ts
@@ -18,6 +18,10 @@ export interface TLEventMap {
 	frame: [number]
 	'select-all-text': [{ shapeId: TLShapeId }]
 	'place-caret': [{ shapeId: TLShapeId; point: { x: number; y: number } }]
+	'created-shapes': [TLRecord[]]
+	'edited-shapes': [TLRecord[]]
+	'deleted-shapes': [TLShapeId[]]
+	edit: []
 }
 
 /** @public */

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3784,6 +3784,8 @@ export interface TLUiEventMap {
     // (undocumented)
     cut: null;
     // (undocumented)
+    edit: null;
+    // (undocumented)
     paste: null;
     // (undocumented)
     print: null;

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -37,6 +37,7 @@ import { TLUiAssetUrlOverrides } from './ui/assetUrls'
 import { LoadingScreen } from './ui/components/LoadingScreen'
 import { Spinner } from './ui/components/Spinner'
 import { TLUiComponents, useTldrawUiComponents } from './ui/context/components'
+import { useUiEvents } from './ui/context/events'
 import { useToasts } from './ui/context/toasts'
 import { useTranslation } from './ui/hooks/useTranslation/useTranslation'
 import { useDefaultEditorAssetsWithOverrides } from './utils/static-assets/assetUrls'
@@ -212,6 +213,7 @@ function InsideOfEditorAndUiContext({
 	const editor = useEditor()
 	const toasts = useToasts()
 	const msg = useTranslation()
+	const trackEvent = useUiEvents()
 
 	useOnMount(() => {
 		const unsubs: (void | (() => void) | undefined)[] = []
@@ -223,6 +225,8 @@ function InsideOfEditorAndUiContext({
 		// won't be directly used, but mean that when adding text the user can switch between fonts
 		// quickly, without having to wait for them to load in.
 		editor.fonts.requestFonts(allDefaultFontFaces)
+
+		editor.once('edit', () => trackEvent('edit', { source: 'unknown' }))
 
 		// for content handling, first we register the default handlers...
 		registerDefaultExternalContentHandlers(editor, {

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -137,6 +137,7 @@ export interface TLUiEventMap {
 			| 'heading'
 			| 'bulletList'
 	}
+	edit: null
 }
 
 /** @public */


### PR DESCRIPTION
### Change type

- [x] `api`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- analytics: add Edit event to signal when boards are edited