### PR TITLE
Fix LoadingScreen context usage

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -7,6 +7,7 @@ import {
 	TldrawEditor,
 	TldrawEditorBaseProps,
 	TldrawEditorStoreProps,
+	defaultUserPreferences,
 	mergeArraysAndReplaceDefaults,
 	useEditor,
 	useEditorComponents,
@@ -33,12 +34,17 @@ import { defaultTools } from './defaultTools'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
 import { allDefaultFontFaces } from './shapes/shared/defaultFonts'
 import { TldrawUi, TldrawUiProps } from './ui/TldrawUi'
-import { TLUiAssetUrlOverrides } from './ui/assetUrls'
+import { TLUiAssetUrlOverrides, useDefaultUiAssetUrlsWithOverrides } from './ui/assetUrls'
 import { LoadingScreen } from './ui/components/LoadingScreen'
 import { Spinner } from './ui/components/Spinner'
+import { AssetUrlsProvider } from './ui/context/asset-urls'
 import { TLUiComponents, useTldrawUiComponents } from './ui/context/components'
 import { useToasts } from './ui/context/toasts'
-import { useTranslation } from './ui/hooks/useTranslation/useTranslation'
+import {
+	TldrawUiTranslationProvider,
+	useTranslation,
+} from './ui/hooks/useTranslation/useTranslation'
+import { useMergedTranslationOverrides } from './ui/overrides'
 import { useDefaultEditorAssetsWithOverrides } from './utils/static-assets/assetUrls'
 import { defaultAddFontsFromNode, tipTapDefaultExtensions } from './utils/text/richText'
 
@@ -175,27 +181,37 @@ export function Tldraw(props: TldrawProps) {
 	}
 
 	return (
-		<TldrawEditor
-			initialState="select"
-			{...rest}
-			components={componentsWithDefault}
-			shapeUtils={shapeUtilsWithDefaults}
-			bindingUtils={bindingUtilsWithDefaults}
-			tools={toolsWithDefaults}
-			textOptions={textOptionsWithDefaults}
-			assetUrls={assets}
-		>
-			<TldrawUi {...rest} components={componentsWithDefault} mediaMimeTypes={mediaMimeTypes}>
-				<InsideOfEditorAndUiContext
-					maxImageDimension={maxImageDimension}
-					maxAssetSize={maxAssetSize}
-					acceptedImageMimeTypes={_imageMimeTypes}
-					acceptedVideoMimeTypes={_videoMimeTypes}
-					onMount={onMount}
-				/>
-				{children}
-			</TldrawUi>
-		</TldrawEditor>
+		// We provide an extra higher layer of asset+translations providers here so that
+		// loading UI (which is rendered outside of TldrawUi) may be translated.
+		// Ideally we would refactor to hoist all the UI context providers we can up here. Maybe later.
+		<AssetUrlsProvider assetUrls={useDefaultUiAssetUrlsWithOverrides(rest.assetUrls)}>
+			<TldrawUiTranslationProvider
+				overrides={useMergedTranslationOverrides(rest.overrides)}
+				locale={rest.user?.userPreferences.get().locale ?? defaultUserPreferences.locale}
+			>
+				<TldrawEditor
+					initialState="select"
+					{...rest}
+					components={componentsWithDefault}
+					shapeUtils={shapeUtilsWithDefaults}
+					bindingUtils={bindingUtilsWithDefaults}
+					tools={toolsWithDefaults}
+					textOptions={textOptionsWithDefaults}
+					assetUrls={assets}
+				>
+					<TldrawUi {...rest} components={componentsWithDefault} mediaMimeTypes={mediaMimeTypes}>
+						<InsideOfEditorAndUiContext
+							maxImageDimension={maxImageDimension}
+							maxAssetSize={maxAssetSize}
+							acceptedImageMimeTypes={_imageMimeTypes}
+							acceptedVideoMimeTypes={_videoMimeTypes}
+							onMount={onMount}
+						/>
+						{children}
+					</TldrawUi>
+				</TldrawEditor>
+			</TldrawUiTranslationProvider>
+		</AssetUrlsProvider>
 	)
 }
 

--- a/packages/tldraw/src/lib/ui/components/LoadingScreen.tsx
+++ b/packages/tldraw/src/lib/ui/components/LoadingScreen.tsx
@@ -1,12 +1,7 @@
 import { LoadingScreen as LoadingScreenContainer, useEditorComponents } from '@tldraw/editor'
-import { TldrawUiContextProvider } from '../context/TldrawUiContextProvider'
 
 /** @public @react */
 export const LoadingScreen = () => {
 	const { Spinner } = useEditorComponents()
-	return (
-		<TldrawUiContextProvider>
-			<LoadingScreenContainer>{Spinner ? <Spinner /> : null}</LoadingScreenContainer>
-		</TldrawUiContextProvider>
-	)
+	return <LoadingScreenContainer>{Spinner ? <Spinner /> : null}</LoadingScreenContainer>
 }


### PR DESCRIPTION
The LoadingScreen component was recently altered to include the tldraw ui context, so that the spinner could have a localized aria label, only problem is that the ui context provider was not configured according to the user's tldraw config so it was ignoring asset url overrides for the translation files, as well as triggering loading of the 0_merged.svg from the default cdn url.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug where tldraw was ignoring custom asset URL configuration for the LoadingScreen component, causing spurious requests to cdn.tldraw.com.