### PR TITLE
Only records stats in production

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -26,6 +26,21 @@ export function getRoomDurableObject(env: Environment, roomId: string) {
 	) as any as TLDrawDurableObject
 }
 
+function shouldRecordStats(env: Environment): boolean {
+	return env.TLDRAW_ENV === 'production'
+}
+
 export function getStatsDurableObjct(env: Environment) {
-	return env.TL_STATS.get(env.TL_STATS.idFromName('stats')) as any as TLStatsDurableObject
+	if (shouldRecordStats(env)) {
+		return env.TL_STATS.get(env.TL_STATS.idFromName('stats')) as any as TLStatsDurableObject
+	}
+
+	return {
+		recordUserDoAbort: async () => {},
+		recordReplicatorBootRetry: async () => {},
+		recordReplicatorPostgresUpdate: async () => {},
+		unusualNumberOfUserDOAborts: async () => false,
+		unusualNumberOfReplicatorBootRetries: async () => false,
+		isReplicatorGettingUpdates: async () => true,
+	} as any as TLStatsDurableObject
 }


### PR DESCRIPTION
I noticed that some of the most used DO are the stats DOs. We don't need this in previews.
![CleanShot 2025-06-24 at 12 16 14@2x](https://github.com/user-attachments/assets/63b9129b-b9b7-4b11-917f-1647f6c25322)


### Change type

- [x] `improvement`
