### PR TITLE
Fix keyboard shortcuts while cropping

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -204,7 +204,7 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 				elm.removeEventListener('keydown', handleKeyDown)
 			}
 		}
-	}, [editor, isManipulating])
+	}, [editor, isManipulating, onManipulatingEnd])
 
 	if (isManipulating) {
 		return (

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -183,6 +183,29 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 		}
 	}, [editor, isManipulating])
 
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (isManipulating) {
+				if (e.key === 'Escape') {
+					editor.cancel()
+					onManipulatingEnd()
+				} else if (e.key === 'Enter') {
+					editor.complete()
+					onManipulatingEnd()
+				}
+			}
+		}
+		const elm = sliderRef.current
+		if (elm) {
+			elm.addEventListener('keydown', handleKeyDown)
+		}
+		return () => {
+			if (elm) {
+				elm.removeEventListener('keydown', handleKeyDown)
+			}
+		}
+	}, [editor, isManipulating])
+
 	if (isManipulating) {
 		return (
 			<>


### PR DESCRIPTION
The image toolbar broke enter / escape for confirming or cancelling image crops. This PR restores it, though in a roundabout way given how the image toolbar needs to accept keyboard events.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
