### PR TITLE
Prevent crash when creating shapes when max shapes is reached

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -820,6 +820,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): boolean;
     cancel(): this;
     cancelDoubleClick(): void;
+    canCreateShape<T extends TLUnknownShape>(shape: OptionalKeys<TLShapePartial<T>, 'id'> | T['id']): boolean;
+    canCreateShapes<T extends TLUnknownShape>(shapes: (OptionalKeys<TLShapePartial<T>, 'id'> | T['id'])[]): boolean;
     // @internal (undocumented)
     capturedPointerId: null | number;
     centerOnPoint(point: VecLike, opts?: TLCameraMoveOptions): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6303,10 +6303,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			})
 			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape }) => shape)
 
-			const maxShapesReached =
-				shapesToCreate.length + this.getCurrentPageShapeIds().size > this.options.maxShapesPerPage
-
-			if (maxShapesReached) {
+			if (!this.canCreateShapes(shapesToCreate)) {
 				alertMaxShapes(this)
 				return
 			}
@@ -7736,6 +7733,32 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
+	 * Get whether the provided shape can be created.
+	 *
+	 * @param shape - The shape or shape IDs to check.
+	 *
+	 * @public
+	 */
+	canCreateShape<T extends TLUnknownShape>(
+		shape: OptionalKeys<TLShapePartial<T>, 'id'> | T['id']
+	): boolean {
+		return this.canCreateShapes([shape])
+	}
+
+	/**
+	 * Get whether the provided shapes can be created.
+	 *
+	 * @param shapes - The shapes or shape IDs to create.
+	 *
+	 * @public
+	 */
+	canCreateShapes<T extends TLUnknownShape>(
+		shapes: (T['id'] | OptionalKeys<TLShapePartial<T>, 'id'>)[]
+	): boolean {
+		return shapes.length + this.getCurrentPageShapeIds().size <= this.options.maxShapesPerPage
+	}
+
+	/**
 	 * Create a single shape.
 	 *
 	 * @example
@@ -7781,6 +7804,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (maxShapesReached) {
 			// can't create more shapes than fit on the page
 			alertMaxShapes(this)
+			// todo: throw an error here? Otherwise we'll need to check every time whether the shapes were actually created
 			return this
 		}
 

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -241,7 +241,9 @@ export class HistoryManager<R extends UnknownRecord> {
 	}
 
 	bailToMark(id: string) {
-		this._undo({ pushToRedoStack: false, toMark: id })
+		if (id) {
+			this._undo({ pushToRedoStack: false, toMark: id })
+		}
 
 		return this
 	}

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -35,6 +35,12 @@ export class Pointing extends StateNode {
 				])
 				.select(id)
 
+			const shape = this.editor.getShape(id)
+			if (!shape) {
+				this.cancel()
+				return
+			}
+
 			const parent = this.parent as BaseBoxShapeTool
 			this.editor.setCurrentTool(
 				'select.resizing',

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -11,35 +11,33 @@ export class Pointing extends StateNode {
 	static override id = 'pointing'
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		if (this.editor.inputs.isDragging) {
-			const { originPagePoint } = this.editor.inputs
+		const { editor } = this
+		if (editor.inputs.isDragging) {
+			const { originPagePoint } = editor.inputs
 
 			const shapeType = (this.parent as BaseBoxShapeTool)!.shapeType
 
 			const id = createShapeId()
 
-			const creatingMarkId = this.editor.markHistoryStoppingPoint(`creating_box:${id}`)
-			const newPoint = maybeSnapToGrid(originPagePoint, this.editor)
-			this.editor
-				.createShapes<TLBaseBoxShape>([
-					{
-						id,
-						type: shapeType,
-						x: newPoint.x,
-						y: newPoint.y,
-						props: {
-							w: 1,
-							h: 1,
-						},
-					},
-				])
-				.select(id)
+			const creatingMarkId = editor.markHistoryStoppingPoint(`creating_box:${id}`)
+			const newPoint = maybeSnapToGrid(originPagePoint, editor)
 
-			const shape = this.editor.getShape(id)
-			if (!shape) {
-				this.cancel()
-				return
-			}
+			// Allow this to trigger the max shapes reached alert
+			this.editor.createShapes<TLBaseBoxShape>([
+				{
+					id,
+					type: shapeType,
+					x: newPoint.x,
+					y: newPoint.y,
+					props: {
+						w: 1,
+						h: 1,
+					},
+				},
+			])
+			const shape = editor.getShape(id)
+			if (!shape) this.cancel()
+			editor.select(id)
 
 			const parent = this.parent as BaseBoxShapeTool
 			this.editor.setCurrentTool(
@@ -85,6 +83,7 @@ export class Pointing extends StateNode {
 
 		this.editor.markHistoryStoppingPoint(`creating_box:${id}`)
 
+		// Allow this to trigger the max shapes reached alert
 		// todo: add scale here when dynamic size is enabled (is this still needed?)
 		this.editor.createShapes<TLBaseBoxShape>([
 			{

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -341,7 +341,9 @@ export function defaultHandleExternalEmbedContent<T>(
 		},
 	}
 
-	editor.createShapes([shapePartial]).select(id)
+	if (editor.canCreateShape(shapePartial)) {
+		editor.createShape(shapePartial).select(id)
+	}
 }
 
 /** @public */
@@ -497,9 +499,12 @@ export async function defaultHandleExternalTextContent(
 	}
 
 	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)
+	const shapeId = createShapeId()
+
+	// Allow this to trigger the max shapes reached alert
 	editor.createShapes<TLTextShape>([
 		{
-			id: createShapeId(),
+			id: shapeId,
 			type: 'text',
 			x: newPoint.x,
 			y: newPoint.y,
@@ -737,14 +742,17 @@ export async function createShapesForAssets(
 		const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
 
 		editor.store.atomic(() => {
-			if (assetsToCreate.length) {
-				editor.createAssets(assetsToCreate)
-			}
-			// Create the shapes
-			editor.createShapes(partials).select(...partials.map((p) => p.id))
+			if (editor.canCreateShapes(partials)) {
+				if (assetsToCreate.length) {
+					editor.createAssets(assetsToCreate)
+				}
 
-			// Re-position shapes so that the center of the group is at the provided point
-			centerSelectionAroundPoint(editor, position)
+				// Create the shapes
+				editor.createShapes(partials).select(...partials.map((p) => p.id))
+
+				// Re-position shapes so that the center of the group is at the provided point
+				centerSelectionAroundPoint(editor, position)
+			}
 		})
 	})
 
@@ -827,8 +835,10 @@ export function createEmptyBookmarkShape(
 	}
 
 	editor.run(() => {
-		editor.createShapes([partial]).select(partial.id)
-		centerSelectionAroundPoint(editor, position)
+		if (editor.canCreateShape(partial)) {
+			editor.createShape(partial).select(partial.id)
+			centerSelectionAroundPoint(editor, position)
+		}
 	})
 
 	return editor.getShape(partial.id) as TLBookmarkShape

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -27,6 +27,10 @@ export class Pointing extends StateNode {
 
 		if (!targetState) {
 			this.createArrowShape()
+			if (!this.shape) {
+				this.cancel()
+				return
+			}
 		}
 
 		this.startPreciseTimeout()
@@ -44,7 +48,10 @@ export class Pointing extends StateNode {
 				this.createArrowShape()
 			}
 
-			if (!this.shape) throw Error(`expected shape`)
+			if (!this.shape) {
+				this.cancel()
+				return
+			}
 
 			this.updateArrowShapeEndHandle()
 
@@ -100,7 +107,7 @@ export class Pointing extends StateNode {
 		})
 
 		const shape = this.editor.getShape<TLArrowShape>(id)
-		if (!shape) throw Error(`expected shape`)
+		if (!shape) return
 
 		const handles = this.editor.getShapeHandles(shape)
 		if (!handles) throw Error(`expected handles for arrow`)

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -249,6 +249,7 @@ export class Drawing extends StateNode {
 		this.pagePointWhereCurrentSegmentChanged = originPagePoint.clone()
 		const id = createShapeId()
 
+		// Allow this to trigger the max shapes reached alert
 		this.editor.createShapes<DrawableShape>([
 			{
 				id,
@@ -637,6 +638,7 @@ export class Drawing extends StateNode {
 
 					const props = this.editor.getShape<DrawableShape>(id)!.props
 
+					if (!this.editor.canCreateShapes([newShapeId])) return this.cancel()
 					this.editor.createShapes<DrawableShape>([
 						{
 							id: newShapeId,

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -39,15 +39,22 @@ export class Pointing extends StateNode {
 					},
 				])
 				.select(id)
-				.setCurrentTool('select.resizing', {
-					...info,
-					target: 'selection',
-					handle: 'bottom_right',
-					isCreating: true,
-					creatingMarkId,
-					creationCursorOffset: { x: 1, y: 1 },
-					onInteractionEnd: 'geo',
-				})
+
+			const shape = this.editor.getShape(id)
+			if (!shape) {
+				this.cancel()
+				return
+			}
+
+			this.editor.setCurrentTool('select.resizing', {
+				...info,
+				target: 'selection',
+				handle: 'bottom_right',
+				isCreating: true,
+				creatingMarkId,
+				creationCursorOffset: { x: 1, y: 1 },
+				onInteractionEnd: 'geo',
+			})
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -88,6 +88,11 @@ export class Pointing extends StateNode {
 					? { w: 300, h: 180 }
 					: { w: 200, h: 200 }
 
+		if (!this.editor.canCreateShape(id)) {
+			this.cancel()
+			return
+		}
+
 		this.editor.createShapes<TLGeoShape>([
 			{
 				id,
@@ -103,7 +108,10 @@ export class Pointing extends StateNode {
 		])
 
 		const shape = this.editor.getShape<TLGeoShape>(id)!
-		if (!shape) return
+		if (!shape) {
+			this.cancel()
+			return
+		}
 
 		const { w, h } = shape.props
 

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -88,6 +88,12 @@ export class Pointing extends StateNode {
 			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${id}`)
 
 			const newPoint = maybeSnapToGrid(currentPagePoint, this.editor)
+
+			if (!this.editor.canCreateShape(id)) {
+				this.cancel()
+				return
+			}
+
 			this.editor.createShapes<TLLineShape>([
 				{
 					id,

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -41,7 +41,12 @@ export class Pointing extends StateNode {
 		if (offset) {
 			center.sub(offset)
 		}
-		this.shape = createNoteShape(this.editor, id, center)
+		const shape = createNoteShape(this.editor, id, center)
+		if (shape) {
+			this.shape = shape
+		} else {
+			this.cancel()
+		}
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
@@ -124,7 +129,11 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 		})
 		.select(id)
 
-	const shape = editor.getShape<TLNoteShape>(id)!
+	const shape = editor.getShape<TLNoteShape>(id)
+	if (!shape) {
+		return
+	}
+
 	const bounds = editor.getShapeGeometry(shape).bounds
 	const newPoint = maybeSnapToGrid(
 		new Vec(shape.x - bounds.width / 2, shape.y - bounds.height / 2),
@@ -141,5 +150,5 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 		},
 	])
 
-	return editor.getShape<TLNoteShape>(id)!
+	return editor.getShape<TLNoteShape>(id)
 }

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -41,6 +41,7 @@ export class Pointing extends StateNode {
 		if (offset) {
 			center.sub(offset)
 		}
+		if (!editor.canCreateShape({ id, type: 'note' })) this.cancel()
 		const shape = createNoteShape(this.editor, id, center)
 		if (shape) {
 			this.shape = shape
@@ -117,22 +118,19 @@ export function getNoteShapeAdjacentPositionOffset(editor: Editor, center: Vec, 
 }
 
 export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
-	editor
-		.createShape({
-			id,
-			type: 'note',
-			x: center.x,
-			y: center.y,
-			props: {
-				scale: editor.user.getIsDynamicResizeMode() ? 1 / editor.getZoomLevel() : 1,
-			},
-		})
-		.select(id)
+	editor.createShape({
+		id,
+		type: 'note',
+		x: center.x,
+		y: center.y,
+		props: {
+			scale: editor.user.getIsDynamicResizeMode() ? 1 / editor.getZoomLevel() : 1,
+		},
+	})
 
 	const shape = editor.getShape<TLNoteShape>(id)
-	if (!shape) {
-		return
-	}
+	// Should never happen since we just checked, but just in case
+	if (!shape) return
 
 	const bounds = editor.getShapeGeometry(shape).bounds
 	const newPoint = maybeSnapToGrid(

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -41,7 +41,8 @@ export class Pointing extends StateNode {
 		if (offset) {
 			center.sub(offset)
 		}
-		if (!editor.canCreateShape({ id, type: 'note' })) this.cancel()
+
+		// Allow this to trigger the max shapes reached alert
 		const shape = createNoteShape(this.editor, id, center)
 		if (shape) {
 			this.shape = shape
@@ -132,6 +133,7 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 	// Should never happen since we just checked, but just in case
 	if (!shape) return
 
+	editor.select(id)
 	const bounds = editor.getShapeGeometry(shape).bounds
 	const newPoint = maybeSnapToGrid(
 		new Vec(shape.x - bounds.width / 2, shape.y - bounds.height / 2),

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -625,6 +625,7 @@ export class Idle extends StateNode {
 
 		const { x, y } = this.editor.inputs.currentPagePoint
 
+		// Allow this to trigger the max shapes reached alert
 		this.editor.createShapes<TLTextShape>([
 			{
 				id,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -93,7 +93,7 @@ export class Translating extends StateNode {
 		if (!this.isCreating) {
 			if (this.editor.inputs.altKey) {
 				this.startCloning()
-				return
+				if (this.isCloning) return
 			}
 		}
 
@@ -123,7 +123,7 @@ export class Translating extends StateNode {
 	override onKeyDown() {
 		if (this.editor.inputs.altKey && !this.isCloning) {
 			this.startCloning()
-			return
+			if (this.isCloning) return
 		}
 
 		// need to update in case user pressed a different modifier key
@@ -154,6 +154,10 @@ export class Translating extends StateNode {
 
 	protected startCloning() {
 		if (this.isCreating) return
+		const shapeIds = Array.from(this.editor.getSelectedShapeIds())
+
+		// If we can't create the shapes, don't even start cloning
+		if (!this.editor.canCreateShapes(shapeIds)) return
 
 		this.isCloning = true
 		this.reset()

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -292,6 +292,7 @@ function createNShapes(editor: Editor, n: number) {
 	}
 
 	editor.run(() => {
+		// allow this to trigger the max shapes alert
 		editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))
 	})
 }

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -408,6 +408,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						}
 
 						editor.markHistoryStoppingPoint('convert shapes to bookmark')
+
+						// Should be able to create the shape since we're about to delete the other other
 						editor.deleteShapes(deleteList)
 						editor.createShapes(createList)
 					})
@@ -500,6 +502,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 								}
 					}
 
+					if (!editor.canCreateShapes(ids)) return
 					editor.markHistoryStoppingPoint('duplicate shapes')
 					editor.duplicateShapes(ids, offset)
 


### PR DESCRIPTION
The non-null assertion after creating the note shape caused it to crash when max shapes is reached, as the shape would not exist after createShape in that case.

I looked at how the text shape handles this, and handled it similarly.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Set `maxShapesPerPage: 0` in `CustomOptionsExample.tsx`
2. Open the example and try to create a note.

Before this PR it would crash, now it shows the max shapes reach toast.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Prevent crash when creating notes when max shapes is reached