### PR TITLE
Show max shapes alert in more places

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -835,10 +835,11 @@ export function createEmptyBookmarkShape(
 	}
 
 	editor.run(() => {
-		if (editor.canCreateShape(partial)) {
-			editor.createShape(partial).select(partial.id)
-			centerSelectionAroundPoint(editor, position)
-		}
+		// Allow this to trigger the max shapes reached alert
+		editor.createShape(partial)
+		if (!editor.getShape(partial.id)) return
+		editor.select(partial.id)
+		centerSelectionAroundPoint(editor, position)
 	})
 
 	return editor.getShape(partial.id) as TLBookmarkShape

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -88,11 +88,6 @@ export class Pointing extends StateNode {
 					? { w: 300, h: 180 }
 					: { w: 200, h: 200 }
 
-		if (!this.editor.canCreateShape(id)) {
-			this.cancel()
-			return
-		}
-
 		this.editor.createShapes<TLGeoShape>([
 			{
 				id,

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -89,11 +89,6 @@ export class Pointing extends StateNode {
 
 			const newPoint = maybeSnapToGrid(currentPagePoint, this.editor)
 
-			if (!this.editor.canCreateShape(id)) {
-				this.cancel()
-				return
-			}
-
 			this.editor.createShapes<TLLineShape>([
 				{
 					id,
@@ -105,6 +100,11 @@ export class Pointing extends StateNode {
 					},
 				},
 			])
+
+			if (!this.editor.getShape(id)) {
+				this.cancel()
+				return
+			}
 
 			this.editor.select(id)
 			this.shape = this.editor.getShape(id)!


### PR DESCRIPTION
This PR rolls back some early returns when at max shapes.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
