### PR TITLE
crop: improve preserving crop across aspect ratios and replacement

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -516,7 +516,7 @@ export function getCroppedImageDataForReplacedImage(
 		const maxRatioConversion = MAX_ZOOM / (MAX_ZOOM - 1)
 		if (ratioConversion > maxRatioConversion) {
 			const minDimension = 1 / MAX_ZOOM
-			if (1 / newRelativeHeight < minDimension) {
+			if (1 / newRelativeHeight < 1 / newRelativeWidth) {
 				const scale = newRelativeHeight / minDimension
 				newRelativeHeight = newRelativeHeight / scale
 				newRelativeWidth = newRelativeWidth / scale

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -106,7 +106,9 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 			//        z_out = 2 * z_in / (1 + 2 * z_in)
 			//    Solving for z_in gives:
 			//        z_in = z_out / (2 * (1 - z_out))
-			const zOut = sliderPercent * sliderPercent * (maxZoom ?? 1)
+			const maxDimension = 1 - 1 / MAX_ZOOM
+			const clampedMaxZoom = Math.min(maxDimension, maxZoom ?? maxDimension)
+			const zOut = sliderPercent * sliderPercent * clampedMaxZoom
 			const zoom = zOut >= 1 ? 1 : zOut / (2 * (1 - zOut))
 			const imageShape = editor.getShape<TLImageShape>(imageShapeId)
 			if (!imageShape) return

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiContextualToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiContextualToolbar.tsx
@@ -190,7 +190,7 @@ export function getToolbarScreenPosition(
 	toolbarElm: HTMLElement,
 	getSelectionBounds: () => Box | undefined
 ) {
-	const selectionBounds = getSelectionBounds()
+	const selectionBounds = getSelectionBounds()?.clone()
 	if (!selectionBounds) return
 
 	// Offset the selection bounds by the viewport screen bounds (if the editor is scrolled or inset, etc)

--- a/packages/tldraw/src/test/crop.test.ts
+++ b/packages/tldraw/src/test/crop.test.ts
@@ -2124,4 +2124,55 @@ describe('getCroppedImageDataForReplacedImage', () => {
 		expect(result.crop.bottomRight.x).toBeLessThanOrEqual(1)
 		expect(result.crop.bottomRight.y).toBeLessThanOrEqual(1)
 	})
+
+	it('handles real-world image replacement example 2', () => {
+		// Second real example: Twitter yeast image being replaced with screenshot
+		const originalShape: TLImageShape = {
+			...shape,
+			x: 100,
+			y: 100,
+			props: {
+				...shape.props,
+				w: 205.04988142156844,
+				h: 326.9950273786993,
+				crop: {
+					topLeft: {
+						x: 0.23316482887716639,
+						y: 0.38688411384568194,
+					},
+					bottomRight: {
+						x: 0.42665668980670746,
+						y: 0.720217447179015,
+					},
+					isCircle: false,
+				},
+			},
+		}
+
+		// Original asset: 942x872 (Twitter yeast image, aspect ratio ≈ 1.081)
+		// New asset: 1285x765 (Screenshot, aspect ratio ≈ 1.679)
+		const result = getCroppedImageDataForReplacedImage(originalShape, 1285, 765)
+
+		// Should preserve display dimensions
+		expect(result.w).toBeCloseTo(205.04988142156844, 1)
+		expect(result.h).toBeCloseTo(326.9950273786993, 1)
+
+		// Y coordinates should remain exactly the same (key requirement)
+		expect(result.crop.topLeft.y).toBeCloseTo(0.38688411384568194, 6)
+		expect(result.crop.bottomRight.y).toBeCloseTo(0.720217447179015, 6)
+
+		// X coordinates should adjust for the new image aspect ratio
+		// Going from wider to even wider image should adjust X coordinates
+		expect(result.crop.topLeft.x).toBeCloseTo(0.2677, 3) // Should be around 0.2677
+		expect(result.crop.bottomRight.x).toBeCloseTo(0.3921, 3) // Should be around 0.3921
+
+		// Should preserve circle setting
+		expect(result.crop.isCircle).toBe(false)
+
+		// Crop should be within valid bounds
+		expect(result.crop.topLeft.x).toBeGreaterThanOrEqual(0)
+		expect(result.crop.topLeft.y).toBeGreaterThanOrEqual(0)
+		expect(result.crop.bottomRight.x).toBeLessThanOrEqual(1)
+		expect(result.crop.bottomRight.y).toBeLessThanOrEqual(1)
+	})
 })


### PR DESCRIPTION
With our new image toolbar we have some new capabilities that needed some fine tuning. In particular:
- replacing images currently resets the crop
- changing aspect ratio also kinda resets the crop

This make it so that the crop's zoom + placement tries to be preserved with both aspect ratio and replacement.

Aspect ratios:

https://github.com/user-attachments/assets/d66be66c-e410-4fc8-a750-9098f38b04c9

Replacement:

https://github.com/user-attachments/assets/57fdf133-f4c1-4870-977a-ece6ad457318



### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Improve preserving crop across aspect ratios and replacement