### PR TITLE
Add GCSE canvas example

### DIFF
--- a/apps/examples/src/examples/gcse-canvas/GcseCanvasExample.tsx
+++ b/apps/examples/src/examples/gcse-canvas/GcseCanvasExample.tsx
@@ -1,0 +1,21 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './gcse-canvas.css'
+
+export default function GcseCanvasExample() {
+	return (
+		<div className="gcse-layout">
+			<div className="gcse-question">
+				<h1>GCSE Maths Question</h1>
+				<p>
+					Using ruler and compass construction, draw a triangle with sides 5&nbsp;cm, 7&nbsp;cm and
+					8&nbsp;cm.
+				</p>
+				<p>Draw your construction on the canvas.</p>
+			</div>
+			<div className="tldraw__editor gcse-canvas">
+				<Tldraw cameraOptions={{ isLocked: true }} />
+			</div>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/gcse-canvas/README.md
+++ b/apps/examples/src/examples/gcse-canvas/README.md
@@ -1,0 +1,9 @@
+---
+title: GCSE drawing question
+component: ./GcseCanvasExample.tsx
+category: use-cases
+priority: 1
+keywords: [education, layout, camera, locked]
+---
+
+A split layout showing a GCSE-style maths question beside a drawing canvas with a locked camera.

--- a/apps/examples/src/examples/gcse-canvas/gcse-canvas.css
+++ b/apps/examples/src/examples/gcse-canvas/gcse-canvas.css
@@ -1,0 +1,15 @@
+.gcse-layout {
+	display: flex;
+	height: 100%;
+}
+
+.gcse-question {
+	flex: 1;
+	padding: 24px;
+	overflow-y: auto;
+	background: var(--whiteboard);
+}
+
+.gcse-canvas {
+	flex: 1;
+}


### PR DESCRIPTION
## Summary
- add new example `gcse-canvas` under apps/examples
- split layout with maths question on left and tldraw canvas on right
- lock camera in the canvas so it can't pan/zoom

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_685d063d5db08324a99b41773d75e312