### PR TITLE
feat(examples): add  for easier shape debugging

### DIFF
--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -108,6 +108,15 @@ export default function Develop() {
 				onMount={(editor) => {
 					;(window as any).app = editor
 					;(window as any).editor = editor
+
+					Object.defineProperty(window, '$s', {
+						get: function () {
+							return editor.getOnlySelectedShape()
+						},
+						configurable: true,
+						enumerable: true,
+					})
+
 					const dispose = editor.store.sideEffects.registerAfterChangeHandler(
 						'shape',
 						afterChangeHandler


### PR DESCRIPTION
Just for develop, something to assist in debugging so i don't have to type `editor.getOnlySelectedShape()` all the time :P

This is a paradigm that exists in the browser sphere as it is:
- `$0` - chrome dev tools for the current selected element in the DOM
- `$r` - react dev tools for the current selected React element

So, I'm proposing `$s` for the current selected shape!

![Screenshot 2025-06-26 at 14 13 23](https://github.com/user-attachments/assets/999ecc2f-0142-4336-b677-20903788cf6d)

### Change type

- [x] `other`

### Test plan

1. Open the develop example
2. Select a shape
3. Type `$s` in the console to verify it returns the selected shape

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added $s to the develop example for easier shape debugging in the console.