### PR TITLE
Fix tool overrides

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -147,7 +147,7 @@ export function Tldraw(props: TldrawProps) {
 
 	const _tools = useShallowArrayIdentity(tools)
 	const toolsWithDefaults = useMemo(
-		() => mergeArraysAndReplaceDefaults('id', allDefaultTools, _tools),
+		() => mergeArraysAndReplaceDefaults('id', _tools, allDefaultTools),
 		[_tools]
 	)
 

--- a/packages/utils/src/lib/array.test.ts
+++ b/packages/utils/src/lib/array.test.ts
@@ -1,0 +1,77 @@
+import { mergeArraysAndReplaceDefaults } from './array'
+
+describe('mergeArraysAndReplaceDefaults', () => {
+	it('should merge custom entries with defaults, allowing custom entries to override defaults', () => {
+		const defaults = [
+			{ id: 'select', name: 'Default Select' },
+			{ id: 'draw', name: 'Default Draw' },
+			{ id: 'eraser', name: 'Default Eraser' },
+		]
+
+		const customEntries = [
+			{ id: 'select', name: 'Custom Select' },
+			{ id: 'custom-tool', name: 'Custom Tool' },
+		]
+
+		const result = mergeArraysAndReplaceDefaults('id', customEntries, defaults)
+
+		expect(result).toEqual([
+			{ id: 'draw', name: 'Default Draw' },
+			{ id: 'eraser', name: 'Default Eraser' },
+			{ id: 'select', name: 'Custom Select' },
+			{ id: 'custom-tool', name: 'Custom Tool' },
+		])
+	})
+
+	it('should handle empty custom entries', () => {
+		const defaults = [
+			{ id: 'select', name: 'Default Select' },
+			{ id: 'draw', name: 'Default Draw' },
+		]
+
+		const customEntries: typeof defaults = []
+
+		const result = mergeArraysAndReplaceDefaults('id', customEntries, defaults)
+
+		expect(result).toEqual(defaults)
+	})
+
+	it('should handle empty defaults', () => {
+		const defaults: Array<{ id: string; name: string }> = []
+
+		const customEntries = [{ id: 'custom-tool', name: 'Custom Tool' }]
+
+		const result = mergeArraysAndReplaceDefaults('id', customEntries, defaults)
+
+		expect(result).toEqual(customEntries)
+	})
+
+	it('should handle both empty arrays', () => {
+		const defaults: Array<{ id: string; name: string }> = []
+		const customEntries: Array<{ id: string; name: string }> = []
+
+		const result = mergeArraysAndReplaceDefaults('id', customEntries, defaults)
+
+		expect(result).toEqual([])
+	})
+
+	it('should work with different key names', () => {
+		const defaults = [
+			{ type: 'text', name: 'Default Text' },
+			{ type: 'geo', name: 'Default Geo' },
+		]
+
+		const customEntries = [
+			{ type: 'text', name: 'Custom Text' },
+			{ type: 'custom', name: 'Custom Shape' },
+		]
+
+		const result = mergeArraysAndReplaceDefaults('type', customEntries, defaults)
+
+		expect(result).toEqual([
+			{ type: 'geo', name: 'Default Geo' },
+			{ type: 'text', name: 'Custom Text' },
+			{ type: 'custom', name: 'Custom Shape' },
+		])
+	})
+})


### PR DESCRIPTION
these were being merged in the wrong order

closes #6320 

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug where overriding builtin tools was not working.