### PR TITLE
Delete page shapes before deleting the page itself

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -666,6 +666,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 							])
 						}
 					},
+					beforeDelete: (record) => {
+						store.remove(this.getSortedChildIdsForParent(record.id))
+					},
 					afterDelete: (record, source) => {
 						// page was deleted, need to check whether it's the current page and select another one if so
 						if (this.getInstanceState()?.currentPageId === record.id) {
@@ -4408,6 +4411,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const next = pages[index - 1] ?? pages[index + 1]
 				this.setCurrentPage(next.id)
 			}
+
 			this.store.remove([deletedPage.id])
 		})
 		return this


### PR DESCRIPTION
I can't quite believe that we never caught this before now 😳 

When you delete a page the shapes on that page don't get deleted and just hang around invisibly but taking up space forever.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug when deleting pages that prevented the shapes on that page from being garbage collected.