### PR TITLE
Fix SVG text outlines, add text option to disable outline

### DIFF
--- a/apps/examples/src/examples/custom-text-outline/CustomTextOutlineExample.tsx
+++ b/apps/examples/src/examples/custom-text-outline/CustomTextOutlineExample.tsx
@@ -1,0 +1,65 @@
+import { ArrowShapeUtil, TextShapeUtil, Tldraw, toRichText } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// Configure the arrow shape to disable text outline
+const CustomArrowShapeUtil = ArrowShapeUtil.configure({
+	showTextOutline: false,
+})
+
+// Configure the text shape to disable outline
+const CustomTextShapeUtil = TextShapeUtil.configure({
+	showOutline: false,
+})
+
+// Use the configured shape utilities
+const customShapeUtils = [CustomArrowShapeUtil, CustomTextShapeUtil]
+
+export default function CustomTextOutlineExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				// Use our custom shape utilities that have text outlines disabled
+				shapeUtils={customShapeUtils}
+				// Use a persistence key to save the state
+				persistenceKey="custom-text-outline-example"
+				onMount={(editor) => {
+					if (editor.getCurrentPageShapeIds().size > 0) return
+
+					const message = toRichText('very good whiteboard')
+
+					// Lots of overlapping text shapes. These would normally be differentiated a bit using the text outline!
+					editor.createShapes([
+						{
+							type: 'text',
+							x: 100,
+							y: 100,
+							props: { richText: message },
+						},
+						{
+							type: 'text',
+							x: 110,
+							y: 110,
+							props: { richText: message },
+						},
+						{
+							type: 'text',
+							x: 120,
+							y: 120,
+							props: { richText: message },
+						},
+						{
+							type: 'arrow',
+							x: 0,
+							y: 0,
+							props: {
+								text: 'hello world',
+								start: { x: 0, y: 0 },
+								end: { x: 200, y: 200 },
+							},
+						},
+					])
+				}}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/custom-text-outline/README.md
+++ b/apps/examples/src/examples/custom-text-outline/README.md
@@ -1,0 +1,17 @@
+---
+title: Custom text outline
+component: ./CustomTextOutlineExample.tsx
+category: configuration
+priority: 1
+---
+
+Disable text outlines on text and arrow labels.
+
+---
+
+This example shows how to configure the `ArrowShapeUtil` and `TextShapeUtil` to disable text outlines. By default, tldraw adds a text outline (using the canvas background color) to help text stand out when overlapping with other shapes. You can disable this feature by configuring the shape utilities.
+
+This is particularly useful for:
+
+- Performance optimization on certain browsers (we already skip on Safari)
+- Different visual styling preferences

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -946,6 +946,10 @@ input,
 	display: block;
 }
 
+.tl-text__no-outline {
+	text-shadow: none;
+}
+
 /* --------------------- Loading -------------------- */
 
 .tl-loading {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -227,6 +227,7 @@ export interface ArrowShapeOptions {
     readonly pointingPreciseTimeout: number;
     readonly shouldBeExact: (editor: Editor) => boolean;
     readonly shouldIgnoreTargets: (editor: Editor) => boolean;
+    readonly showTextOutline: boolean;
 }
 
 // @public (undocumented)
@@ -2620,6 +2621,7 @@ export const TextLabel: React_3.NamedExoticComponent<PlainTextLabelProps>;
 // @public (undocumented)
 export interface TextShapeOptions {
     extraArrowHorizontalPadding: number;
+    showOutline: boolean;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -44,6 +44,7 @@ import {
 	useSharedSafeId,
 	useValue,
 } from '@tldraw/editor'
+import classNames from 'classnames'
 import React, { useMemo } from 'react'
 import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
 import { PathBuilder } from '../shared/PathBuilder'
@@ -118,6 +119,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		shouldBeExact: (editor: Editor) => editor.inputs.altKey,
 		shouldIgnoreTargets: (editor: Editor) => editor.inputs.ctrlKey,
+
+		showTextOutline: true,
 	}
 
 	override canEdit() {
@@ -777,7 +780,10 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				{showArrowLabel && (
 					<PlainTextLabel
 						shapeId={shape.id}
-						classNamePrefix="tl-arrow"
+						classNamePrefix={classNames(
+							'tl-arrow',
+							!this.options.showTextOutline && 'tl-text__no-outline'
+						)}
 						type="arrow"
 						font={shape.props.font}
 						fontSize={getArrowLabelFontSize(shape)}

--- a/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
@@ -97,6 +97,8 @@ export interface ArrowShapeOptions {
 	 */
 	// eslint-disable-next-line @typescript-eslint/method-signature-style
 	readonly shouldIgnoreTargets: (editor: Editor) => boolean
+	/** Whether to show the outline of the arrow shape's label (using the same color as the canvas). This helps with overlapping shapes. It does not show up on Safari, where text outline is a performance issues. */
+	readonly showTextOutline: boolean
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -21,6 +21,7 @@ import {
 	toRichText,
 	useEditor,
 } from '@tldraw/editor'
+import classNames from 'classnames'
 import { useCallback } from 'react'
 import {
 	renderHtmlFromRichTextForMeasurement,
@@ -42,6 +43,8 @@ const sizeCache = createComputedCache(
 export interface TextShapeOptions {
 	/** How much addition padding should be added to the horizontal geometry of the shape when binding to an arrow? */
 	extraArrowHorizontalPadding: number
+	/** Whether to show the outline of the text shape (using the same color as the canvas). This helps with overlapping shapes. It does not show up on Safari, where text outline is a performance issues. */
+	showOutline: boolean
 }
 
 /** @public */
@@ -52,6 +55,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	override options: TextShapeOptions = {
 		extraArrowHorizontalPadding: 10,
+		showOutline: true,
 	}
 
 	getDefaultProps(): TLTextShape['props'] {
@@ -127,7 +131,10 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return (
 			<RichTextLabel
 				shapeId={id}
-				classNamePrefix="tl-text-shape"
+				classNamePrefix={classNames(
+					'tl-text-shape',
+					!this.options.showOutline && 'tl-text__no-outline'
+				)}
 				type="text"
 				font={font}
 				fontSize={FONT_SIZES[size]}


### PR DESCRIPTION
This PR adds an option to disable text outlines on text shapes and arrow labels.

<img width="661" alt="image" src="https://github.com/user-attachments/assets/6e9ccf2e-4d69-4464-9ead-9c1153ce93e4" />

It also fixes text outlines on exported SVG rich text. (@mimecuvalo to confirm whether this is a bug or intended behavior).

### Change type

- [x] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. See custom outline example

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with SVG text outlines on rich text
- Added option to Text and Arrow shapes to disable text outlines