### PR TITLE
clipboard: only compress non-assets for greatly improved perf

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -352,25 +352,57 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 
 							if (tldrawHtmlComment) {
 								try {
-									// If we've found tldraw content in the html string, use that as JSON
-									const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
-									if (jsonComment === null) {
+									// First try parsing as plain JSON (version 2 format)
+									let json
+									try {
+										json = JSON.parse(tldrawHtmlComment)
+									} catch {
+										// Fall back to LZ decompression (legacy format)
+										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
+										if (jsonComment === null) {
+											r({
+												type: 'error',
+												data: null,
+												reason: `found tldraw data comment but could not parse`,
+											})
+											return
+										}
+										json = JSON.parse(jsonComment)
+									}
+
+									if (json.type !== 'application/tldraw') {
 										r({
 											type: 'error',
-											data: jsonComment,
-											reason: `found tldraw data comment but could not parse base64`,
+											data: json,
+											reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
 										})
 										return
-									} else {
-										const json = JSON.parse(jsonComment)
-										if (json.type !== 'application/tldraw') {
+									}
+
+									// Handle versioned clipboard format
+									if (json.version === 2) {
+										// Version 2: Assets are plain, decompress only other data
+										try {
+											const otherData = JSON.parse(
+												lz.decompressFromBase64(json.data.otherCompressed) || '{}'
+											)
+											const reconstructedData = {
+												assets: json.data.assets || [],
+												...otherData,
+											}
+
+											r({ type: 'tldraw', data: reconstructedData })
+											return
+										} catch (error) {
 											r({
 												type: 'error',
 												data: json,
-												reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
+												reason: `failed to decompress version 2 clipboard data: ${error}`,
 											})
+											return
 										}
-
+									} else {
+										// Version 1 or no version: Legacy format
 										if (typeof json.data === 'string') {
 											r({
 												type: 'error',
@@ -560,13 +592,21 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 		return
 	}
 
-	const stringifiedClipboard = lz.compressToBase64(
-		JSON.stringify({
-			type: 'application/tldraw',
-			kind: 'content',
-			data: content,
-		})
-	)
+	// Use versioned clipboard format for better compression
+	// Version 2: Don't compress assets, only compress other data
+	const { assets, ...otherData } = content
+	const clipboardData = {
+		type: 'application/tldraw',
+		kind: 'content',
+		version: 2,
+		data: {
+			assets: assets || [], // Plain JSON, no compression
+			otherCompressed: lz.compressToBase64(JSON.stringify(otherData)), // Only compress non-asset data
+		},
+	}
+
+	// Don't compress the final structure - just use plain JSON
+	const stringifiedClipboard = JSON.stringify(clipboardData)
 
 	if (typeof navigator === 'undefined') {
 		return


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/5095

I created a versioning scheme so that this doesn't break copy/paste from other tldraw boards. Adding the versioning will help any future changes, if any.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improve perf of copy+paste when copying lots of large images.