### PR TITLE
Simplify UI of education example

### DIFF
--- a/apps/examples/src/examples/education-canvas/EducationCanvasExample.tsx
+++ b/apps/examples/src/examples/education-canvas/EducationCanvasExample.tsx
@@ -1,5 +1,17 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
-import { Box, Editor, TLCameraOptions, TLComponents, Tldraw, track, useEditor } from 'tldraw'
+import {
+	Box,
+	DefaultToolbar,
+	Editor,
+	TLCameraOptions,
+	TLComponents,
+	Tldraw,
+	TldrawUiMenuItem,
+	track,
+	useEditor,
+	useIsToolSelected,
+	useTools,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 import './education-canvas.css'
 
@@ -118,8 +130,31 @@ const CartesianGrid = memo(function CartesianGrid() {
 	)
 })
 
+function CustomToolbar() {
+	const tools = useTools()
+	const isSelectToolSelected = useIsToolSelected(tools['select'])
+	const isHandToolSelected = useIsToolSelected(tools['hand'])
+	const isDrawToolSelected = useIsToolSelected(tools['draw'])
+	const isEraserToolSelected = useIsToolSelected(tools['eraser'])
+	const isLineToolSelected = useIsToolSelected(tools['line'])
+	const isTextToolSelected = useIsToolSelected(tools['text'])
+	return (
+		<div>
+			<DefaultToolbar>
+				<TldrawUiMenuItem {...tools['select']} isSelected={isSelectToolSelected} />
+				<TldrawUiMenuItem {...tools['hand']} isSelected={isHandToolSelected} />
+				<TldrawUiMenuItem {...tools['draw']} isSelected={isDrawToolSelected} />
+				<TldrawUiMenuItem {...tools['eraser']} isSelected={isEraserToolSelected} />
+				<TldrawUiMenuItem {...tools['line']} isSelected={isLineToolSelected} />
+				<TldrawUiMenuItem {...tools['text']} isSelected={isTextToolSelected} />
+			</DefaultToolbar>
+		</div>
+	)
+}
+
 const components: TLComponents = {
-	OnTheCanvas: () => <CartesianGrid />,
+	OnTheCanvas: CartesianGrid,
+	Toolbar: CustomToolbar,
 }
 
 export default function EducationCanvasExample() {
@@ -269,7 +304,12 @@ export default function EducationCanvasExample() {
 			{/* Canvas Panel - Right Half */}
 			<div className="canvas-panel">
 				<div className="canvas-container">
-					<Tldraw persistenceKey="education-canvas" components={components} onMount={handleMount}>
+					<Tldraw
+						options={{ maxPages: 1 }}
+						persistenceKey="education-canvas"
+						components={components}
+						onMount={handleMount}
+					>
 						<CameraSetup />
 					</Tldraw>
 				</div>


### PR DESCRIPTION
This PR removes the pages menu and most tools from the education example to simplify it.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
