### PR TITLE
fix(editor): flatten child groups when creating group2d geometries

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Group2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.ts
@@ -17,13 +17,19 @@ export class Group2d extends Geometry2d {
 	) {
 		super({ ...config, isClosed: true, isFilled: false })
 
-		for (const child of config.children) {
-			if (child.ignore) {
-				this.ignoredChildren.push(child)
-			} else {
-				this.children.push(child)
+		const addChildren = (children: Geometry2d[]) => {
+			for (const child of children) {
+				if (child instanceof Group2d) {
+					addChildren(child.children)
+				} else if (child.ignore) {
+					this.ignoredChildren.push(child)
+				} else {
+					this.children.push(child)
+				}
 			}
 		}
+
+		addChildren(config.children)
 
 		if (this.children.length === 0) throw Error('Group2d must have at least one child')
 	}


### PR DESCRIPTION
There are a few places where we assume groups can't be nested. We should really fix those, but this is easier for now.

### Change type

- [x] `bugfix` 

### Test plan

1. Create nested groups and verify geometry calculation.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where nested groups were not correctly handled in 2D geometry calculations.