### PR TITLE
Fix spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6315,7 +6315,7 @@ add star history and contributor list to README.
 
 - Allow users to name their documents.
 
-#### Fix some problem under Windows OS development enviroment ([#2722](https://github.com/tldraw/tldraw/pull/2722))
+#### Fix some problem under Windows OS development environment ([#2722](https://github.com/tldraw/tldraw/pull/2722))
 
 - stablize language.ts when running under different OS language.
 - add isWin32() and posixPath() to format the parameter of glob.sync().
@@ -6455,7 +6455,7 @@ add star history and contributor list to README.
 
 #### 🏠 Internal
 
-- Fix some problem under Windows OS development enviroment [#2722](https://github.com/tldraw/tldraw/pull/2722) ([@Rokixy](https://github.com/Rokixy))
+- Fix some problem under Windows OS development environment [#2722](https://github.com/tldraw/tldraw/pull/2722) ([@Rokixy](https://github.com/Rokixy))
 - fix typo(examples/hosted-images) [#2849](https://github.com/tldraw/tldraw/pull/2849) ([@pocari](https://github.com/pocari))
 - ✋ humans.txt [#2842](https://github.com/tldraw/tldraw/pull/2842) ([@mimecuvalo](https://github.com/mimecuvalo))
 - examples: rename ui events and increase priority [#2840](https://github.com/tldraw/tldraw/pull/2840) ([@mimecuvalo](https://github.com/mimecuvalo))

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -121,7 +121,9 @@ class MyIdleState extends StateNode {
 class MyTool extends StateNode {
 	static override id = 'my-tool'
 	static override initial = 'my-idle-state'
-	static override children = [MyIdleState]
+	static override children() {
+		return [MyIdleState]
+	}
 
 	onPointerDown(info: TLPointerEventInfo) {
 		editor.setCurrentTool('select')

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
 		trace: 'on-first-retry',
 		video: 'retain-on-failure',
 		launchOptions: {
-			// Uncomment this to make the browser slow down. Usefull when debugging in the headed mode.
+			// Uncomment this to make the browser slow down. Useful when debugging in the headed mode.
 			// slowMo: 1000,
 		},
 	},

--- a/apps/examples/src/examples/prevent-shape-change/README.md
+++ b/apps/examples/src/examples/prevent-shape-change/README.md
@@ -10,4 +10,4 @@ Prevent changes to a shape's properties.
 
 ---
 
-You can use Editor's side effects API to prevent certain changes from occuring in a shape. In this example, we prevent any changes to the shape's position, rotation, or size.
+You can use Editor's side effects API to prevent certain changes from occurring in a shape. In this example, we prevent any changes to the shape's position, rotation, or size.

--- a/apps/examples/src/examples/snapshots/SnapshotExample.tsx
+++ b/apps/examples/src/examples/snapshots/SnapshotExample.tsx
@@ -88,7 +88,7 @@ You probably need to store these separately if you're building a multi-user app,
 For this example we'll just store them together in localStorage.
 
 [4] Call `loadSnapshot()` to load a snapshot into the editor
-You can omit the `session` state, or load it later on it's own.
+You can omit the `session` state, or load it later on its own.
 e.g.
 	loadSnapshot(editor.store, { document })
 then optionally later

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7859,7 +7859,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 					const prevParentId = partial.parentId
 
-					// a shape cannot be it's own parent. This was a rare issue with frames/groups in the syncFuzz tests.
+					// a shape cannot be its own parent. This was a rare issue with frames/groups in the syncFuzz tests.
 					if (parentId === partial.id) {
 						parentId = focusedGroupId
 					}

--- a/packages/tldraw/CHANGELOG.md
+++ b/packages/tldraw/CHANGELOG.md
@@ -3581,7 +3581,7 @@ Fix textbox direction when it contains both RTL and LTR languages
 
 #### Removing frames and adding elements to frames ([#2219](https://github.com/tldraw/tldraw/pull/2219))
 
-- Allow users to remove the frame, but keep it's children. Allow the users to add shapes to the frame directly when creating a frame.
+- Allow users to remove the frame, but keep its children. Allow the users to add shapes to the frame directly when creating a frame.
 
 #### Fix missing padding-right in toast ([#2251](https://github.com/tldraw/tldraw/pull/2251))
 

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 	editor = new TestEditor({})
 
 	editor.createShapes([
-		// on it's own
+		// on its own
 		{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
 		// in a frame
 		{ id: ids.frame1, type: 'frame', x: 100, y: 100, props: { w: 100, h: 100 } },

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -1941,7 +1941,7 @@ describe('snapping', () => {
 		expect(editor.snaps.getIndicators().length).toBe(0)
 	})
 
-	it('does not happen between children and thier group', () => {
+	it('does not happen between children and their group', () => {
 		editor.select(ids.boxD)
 		editor.pointerDown(65, 5, ids.boxD)
 		editor.pointerMove(80, 105, ids.boxD, { ctrlKey: true })

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -151,7 +151,7 @@ describe('When translating...', () => {
 		editor
 			// The change is bigger than expected because the camera moves
 			.expectShapeToMatch({ id: ids.box1, x: -65, y: 10 })
-			// We'll continue moving in the x postion, but now we'll also move in the y position.
+			// We'll continue moving in the x position, but now we'll also move in the y position.
 			// The speed in the y position is smaller since we are further away from the edge.
 			.pointerMove(0, 25)
 		jest.advanceTimersByTime(100)

--- a/templates/ai/README.md
+++ b/templates/ai/README.md
@@ -4,7 +4,7 @@ This repo is a starter for projects that use the [tldraw ai module](https://gith
 
 To use:
 
-1. Create a `.dev.vars` file in the root direectory.
+1. Create a `.dev.vars` file in the root directory.
 2. Add your OpenAI key to that file as an environment variable, i.e. `OPENAI_API_KEY=sk-your-key`.
 3. Install dependencies with `pnpm i`
 4. Run `pnpm run dev`


### PR DESCRIPTION
Fixes various spelling mistakes across the codebase in documentation, comments, and test descriptions.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

No specific test plan is required beyond verifying the corrected spellings in the affected files.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed "occuring" to "occurring" in `apps/examples/src/examples/prevent-shape-change/README.md`.
- Fixed "thier" to "their" in `packages/tldraw/src/test/groups.test.tsx`.
- Fixed "postion" to "position" in `packages/tldraw/src/test/translating.test.ts`.
- Fixed "Usefull" to "Useful" in `apps/dotcom/client/playwright.config.ts`.
- Fixed "enviroment" to "environment" (two occurrences) in `CHANGELOG.md`.