### PR TITLE
allow `next` release tag

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   deploy:
-    name: 'Publish Canary Packages'
+    name: 'Publish Prerelease Packages'
     environment: npm deploy
     timeout-minutes: 60
     runs-on: ubuntu-latest-16-cores-open
@@ -24,7 +24,7 @@ jobs:
       - name: Run our setup
         uses: ./.github/actions/setup
 
-      - name: Publish Canary Packages
+      - name: Publish Prerelease Packages
         run: yarn tsx ./internal/scripts/publish-prerelease.ts ${{ github.ref == 'refs/heads/production' && 'next' || 'canary' }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/internal/scripts/publish-prerelease.ts
+++ b/internal/scripts/publish-prerelease.ts
@@ -24,7 +24,7 @@ if (args.length === 0) {
 	throw new Error('Usage: publish-prerelease.ts <releaseTag>')
 }
 const releaseTag = args[0]
-if (releaseTag !== 'canary' && releaseTag !== 'internal') {
-	throw new Error('releaseTag must be "canary" or "internal"')
+if (releaseTag !== 'canary' && releaseTag !== 'internal' && releaseTag !== 'next') {
+	throw new Error('releaseTag must be "canary", "internal", or "next"')
 }
 main(releaseTag)


### PR DESCRIPTION
We had an explicit check to prevent using anything other than 'canary' or 'internal'

### Change type


- [x] `other`
