### PR TITLE
a11y: fix some issues from the audit

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaLogo/TlaLogo.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaLogo/TlaLogo.tsx
@@ -21,6 +21,7 @@ export function TlaLogo(props: HTMLAttributes<HTMLDivElement>) {
 				mask: `url(/tldraw_sidebar_logo.svg) center 100% / 100% no-repeat`,
 				...props.style,
 			}}
+			aria-label="tldraw"
 			className={classNames(styles.logo, props.className)}
 		/>
 	)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -252,8 +252,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canSnap(): boolean;
     // (undocumented)
-    canTabTo(shape: TLArrowShape): boolean;
-    // (undocumented)
     component(shape: TLArrowShape): JSX_2.Element | null;
     // (undocumented)
     getCanvasSvgDefs(): TLShapeUtilCanvasSvgDef[];
@@ -1074,8 +1072,6 @@ export class DrawShapeTool extends StateNode {
 // @public (undocumented)
 export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
     // (undocumented)
-    canTabTo(): boolean;
-    // (undocumented)
     component(shape: TLDrawShape): JSX_2.Element;
     // (undocumented)
     expandSelectionOutlinePx(shape: TLDrawShape): number;
@@ -1774,8 +1770,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
     // (undocumented)
     backgroundComponent(shape: TLHighlightShape): JSX_2.Element;
     // (undocumented)
-    canTabTo(): boolean;
-    // (undocumented)
     component(shape: TLHighlightShape): JSX_2.Element;
     // (undocumented)
     getDefaultProps(): TLHighlightShape['props'];
@@ -1889,8 +1883,6 @@ export class LineShapeTool extends StateNode {
 
 // @public (undocumented)
 export class LineShapeUtil extends ShapeUtil<TLLineShape> {
-    // (undocumented)
-    canTabTo(): boolean;
     // (undocumented)
     component(shape: TLLineShape): JSX_2.Element;
     // (undocumented)
@@ -4185,6 +4177,8 @@ export interface TLUiToolbarToggleGroupProps extends React_3.HTMLAttributes<HTML
     dir?: 'ltr' | 'rtl';
     // (undocumented)
     type: 'multiple' | 'single';
+    // (undocumented)
+    value: any;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -130,10 +130,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	override canSnap() {
 		return false
 	}
-	override canTabTo(shape: TLArrowShape) {
-		const bindings = getArrowBindings(this.editor, shape)
-		return !!(bindings.start || bindings.end || shape.props.text)
-	}
 	override hideResizeHandles() {
 		return true
 	}

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -51,10 +51,6 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 		maxPointsPerShape: 600,
 	}
 
-	override canTabTo() {
-		return false
-	}
-
 	override hideResizeHandles(shape: TLDrawShape) {
 		return getIsDot(shape)
 	}

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -51,9 +51,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 		overlayOpacity: 0.35,
 	}
 
-	override canTabTo() {
-		return false
-	}
 	override hideResizeHandles(shape: TLHighlightShape) {
 		return getIsDot(shape)
 	}

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -35,9 +35,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	static override props = lineShapeProps
 	static override migrations = lineShapeMigrations
 
-	override canTabTo() {
-		return false
-	}
 	override hideResizeHandles() {
 		return true
 	}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -121,6 +121,7 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 			data-testid={`style.${uiType}`}
 			type="single"
 			className={classNames('tlui-buttons__grid')}
+			value={value.type === 'shared' ? value.value : undefined}
 		>
 			{items.map((item) => {
 				const label = title + ' — ' + msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
@@ -132,6 +133,7 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 						data-testid={`style.${uiType}.${item.value}`}
 						aria-label={label}
 						value={item.value}
+						data-state={value.type === 'shared' && value.value === item.value ? 'on' : 'off'}
 						data-isactive={value.type === 'shared' && value.value === item.value}
 						title={label}
 						className={classNames('tlui-button-grid__button')}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
@@ -59,6 +59,7 @@ export interface TLUiToolbarToggleGroupProps extends React.HTMLAttributes<HTMLDi
 	children?: React.ReactNode
 	className?: string
 	dir?: 'ltr' | 'rtl'
+	value: any
 	// TODO: fix up this type later
 	defaultValue?: any
 	type: 'single' | 'multiple'


### PR DESCRIPTION
- aria-label on logo
- fix `aria-checked` state on page load
- remove `canTabTo` overrides on shapes.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: fix some issues from the audit