### PR TITLE
Example: outline text (custom rich text plugin)

### DIFF
--- a/apps/examples/src/examples/outlined-text/OutlinedTextExample.css
+++ b/apps/examples/src/examples/outlined-text/OutlinedTextExample.css
@@ -1,0 +1,10 @@
+.outlined {
+	-webkit-text-stroke: 2px #000000;
+	text-stroke: 2px #000000;
+	color: transparent;
+	font-weight: bold;
+}
+
+.outlined.filled {
+	color: #ffffff;
+}

--- a/apps/examples/src/examples/outlined-text/OutlinedTextExample.tsx
+++ b/apps/examples/src/examples/outlined-text/OutlinedTextExample.tsx
@@ -1,0 +1,120 @@
+import { Mark, mergeAttributes } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import {
+	DefaultRichTextToolbar,
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	preventDefault,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './OutlinedTextExample.css'
+
+interface OutlineExtensionOptions {
+	HTMLAttributes: object
+}
+
+declare module '@tiptap/core' {
+	interface Commands<ReturnType> {
+		outline: {
+			setOutline(): ReturnType
+			toggleOutline(): ReturnType
+			unsetOutline(): ReturnType
+		}
+	}
+}
+
+const Outline = Mark.create<OutlineExtensionOptions>({
+	name: 'outline',
+
+	addOptions() {
+		return {
+			HTMLAttributes: {},
+		}
+	},
+
+	parseHTML() {
+		return [
+			{
+				tag: 'span.outlined',
+			},
+		]
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return [
+			'span',
+			mergeAttributes(this.options.HTMLAttributes, { class: 'outlined filled' }, HTMLAttributes),
+			0,
+		]
+	},
+
+	addCommands() {
+		return {
+			setOutline:
+				() =>
+				({ commands }) =>
+					commands.setMark(this.name),
+			toggleOutline:
+				() =>
+				({ commands }: any) =>
+					commands.toggleMark(this.name),
+			unsetOutline:
+				() =>
+				({ commands }) =>
+					commands.unsetMark(this.name),
+		}
+	},
+
+	onCreate() {
+		this.editor.commands.toggleMark('outline')
+	},
+})
+
+const components: TLComponents = {
+	RichTextToolbar: () => {
+		const editor = useEditor()
+		const textEditor = useValue('textEditor', () => editor.getRichTextEditor(), [editor])
+
+		return (
+			<DefaultRichTextToolbar>
+				<TldrawUiButton
+					type="icon"
+					onClick={() => {
+						textEditor?.chain().focus().toggleOutline().run()
+					}}
+					isActive={textEditor?.isActive('outline')}
+					onPointerDown={preventDefault}
+					title="Toggle text outline"
+				>
+					⬜
+				</TldrawUiButton>
+			</DefaultRichTextToolbar>
+		)
+	},
+}
+
+const textOptions = {
+	tipTapConfig: {
+		extensions: [StarterKit, Outline],
+	},
+}
+
+export default function OutlinedTextExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="outlined-text-example"
+				components={components}
+				textOptions={textOptions}
+			/>
+		</div>
+	)
+}
+
+/*
+This example shows how to add outlined text styling using a custom TipTap extension.
+The outline effect is created using CSS text-stroke properties.
+*/

--- a/apps/examples/src/examples/outlined-text/README.md
+++ b/apps/examples/src/examples/outlined-text/README.md
@@ -1,0 +1,13 @@
+---
+title: Outlined text example
+component: ./OutlinedTextExample.tsx
+category: shapes/tools
+priority: 21
+keywords: [text, outline, stroke, extension, toolbar, styling]
+---
+
+Add outlined text styling to the TipTap text editor with a custom extension.
+
+---
+
+This example shows how to add a text outline effect by creating a custom TipTap extension that applies CSS text-stroke styling to selected text. The example includes a custom toolbar button to toggle the outline effect on and off.


### PR DESCRIPTION
This PR adds an example that adds text-stroke as a rich text plugin.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
