### PR TITLE
Remove auto switch to draw tool

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyToolSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyToolSwitcher.tsx
@@ -12,8 +12,6 @@ export function SneakyToolSwitcher() {
 		// orient themselves or move around the page
 		if (getIsCoarsePointer() && pageHasShapes) {
 			editor.setCurrentTool('hand')
-		} else if (!pageHasShapes) {
-			editor.setCurrentTool('draw')
 		}
 
 		// todo: if the user has never been to this page before on this device (how?) and they're on an empty part of it, do a "back to content"  automatically


### PR DESCRIPTION
This PR removes a change we added to dotcom that would switch to the draw tool automatically on empty pages.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
