### PR TITLE
Remove license key from dotcom

### DIFF
--- a/apps/dotcom/client/src/components/LocalEditor.tsx
+++ b/apps/dotcom/client/src/components/LocalEditor.tsx
@@ -1,4 +1,3 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { ReactNode } from 'react'
 import { Editor, TLComponents, Tldraw, TldrawOptions, useEvent } from 'tldraw'
 import { SneakyToolSwitcher } from '../tla/components/TlaEditor/sneaky/SneakyToolSwitcher'
@@ -38,7 +37,6 @@ export function LocalEditor({
 	return (
 		<div className="tldraw__editor" data-testid={dataTestId}>
 			<Tldraw
-				licenseKey={getLicenseKey()}
 				assetUrls={assetUrls}
 				persistenceKey={persistenceKey ?? getScratchPersistenceKey()}
 				onMount={handleMount}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
@@ -1,4 +1,3 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useMemo } from 'react'
 import { SerializedSchema, TLComponents, TLRecord, Tldraw } from 'tldraw'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
@@ -44,7 +43,6 @@ export function TlaPublishEditor({ schema, records }: TlaPublishEditorProps) {
 	return (
 		<div className={styles.editor} data-testid="tla-editor">
 			<Tldraw
-				licenseKey={getLicenseKey()}
 				assetUrls={assetUrls}
 				snapshot={snapshot}
 				overrides={[fileEditorOverrides]}

--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -1,4 +1,3 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
 import {
 	DefaultContextMenu,
 	DefaultContextMenuContent,
@@ -102,7 +101,6 @@ export default function Develop() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				licenseKey={getLicenseKey()}
 				overrides={[performanceOverrides, debuggingOverrides]}
 				persistenceKey="example"
 				onMount={(editor) => {

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -1,4 +1,3 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useEffect, useLayoutEffect } from 'react'
 import {
 	BaseBoxShapeUtil,
@@ -97,7 +96,6 @@ export default function EndToEnd() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				licenseKey={getLicenseKey()}
 				onMount={(editor) => {
 					;(window as any).app = editor
 					;(window as any).editor = editor

--- a/packages/dotcom-shared/src/index.ts
+++ b/packages/dotcom-shared/src/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable local/no-export-star */
 export * from './OptimisticAppStore'
 export * from './constants'
-export { default as getLicenseKey } from './license'
 export * from './mutators'
 export * from './routes'
 export * from './tlaSchema'

--- a/packages/dotcom-shared/src/license.ts
+++ b/packages/dotcom-shared/src/license.ts
@@ -1,4 +1,0 @@
-const getLicenseKey = () =>
-	process.env.TLDRAW_LICENSE ||
-	'tldraw-tldraw-2025-07-10/WyJocTUxVWM3RiIsWyIqLnRsZHJhdy5jb20iXSw5LCIyMDI1LTA3LTEwIl0.fcGEICPNGbpCjxyLkyRXjv7CfcenRjBRl06I/v6loCD8CijVePhVwsT3B+TgJr+x7ihZAa/cn6N43ty6yz/ZPg'
-export default getLicenseKey


### PR DESCRIPTION
Think we had this so that we didn't show missing license outputs for development and dotcom. I think this no longer applies as we now allow using the package without a license while showing the watermark (which is what we do on dotcom anyway).

@mimecuvalo the only consideration is that we will hit the watermark track, but I guess we filter our own webpage?

### Change type

- [x] `improvement`
