### PR TITLE
fix(dotcom): update feedback URL

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
@@ -77,7 +77,7 @@ function SignedInSubmitFeedbackDialog({ onClose }: { onClose(): void }) {
 			body: JSON.stringify({
 				allowContact: true,
 				description: rInput.current.value.trim(),
-				url: `please-be-mindful-${window.location.href}`,
+				url: window.location.href.replace('https', 'https-please-be-mindful'),
 			} satisfies SubmitFeedbackRequestBody),
 		})
 			.then((r) => {


### PR DESCRIPTION
Fix the feedback url. Discord still allowed easily clicking it.

### Change type

- [x] `bugfix` 

### Test plan

1. Open the feedback dialog and verify the new URL is correct.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated the feedback URL in the feedback dialog.