### PR TITLE
improvement(dotcom): use license in all editor instances

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -1,3 +1,4 @@
+import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
@@ -252,6 +253,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		<TlaEditorWrapper>
 			<Tldraw
 				className="tla-editor"
+				licenseKey={getLicenseKey()}
 				store={store}
 				assetUrls={assetUrls}
 				user={app?.tlUser}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaHistorySnapshotEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaHistorySnapshotEditor.tsx
@@ -1,6 +1,6 @@
-import { ROOM_PREFIX } from '@tldraw/dotcom-shared'
+import { getLicenseKey, ROOM_PREFIX } from '@tldraw/dotcom-shared'
 import { createContext, useCallback, useContext } from 'react'
-import { Editor, TLComponents, TLStoreSnapshot, Tldraw, fetch } from 'tldraw'
+import { Editor, fetch, TLComponents, Tldraw, TLStoreSnapshot } from 'tldraw'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
 import { useLegacyUrlParams } from '../../../hooks/useLegacyUrlParams'
 import { useHandleUiEvents } from '../../../utils/analytics'
@@ -10,12 +10,12 @@ import { useMaybeApp } from '../../hooks/useAppState'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { F } from '../../utils/i18n'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
-import { TlaEditorWrapper } from './TlaEditorWrapper'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { SneakyDarkModeSync } from './sneaky/SneakyDarkModeSync'
 import { SneakyTldrawFileDropHandler } from './sneaky/SneakyFileDropHandler'
 import { SneakyLegacySetDocumentTitle } from './sneaky/SneakyLegacytSetDocumentTitle'
 import { SneakySetDocumentTitle } from './sneaky/SneakySetDocumentTitle'
+import { TlaEditorWrapper } from './TlaEditorWrapper'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 const TlaHistorySnapshotEditorContext = createContext<{
@@ -120,6 +120,7 @@ function TlaEditorInner({ snapshot }: { snapshot: TLStoreSnapshot }) {
 		<TlaEditorWrapper>
 			<Tldraw
 				className="tla-editor"
+				licenseKey={getLicenseKey()}
 				snapshot={snapshot}
 				assetUrls={assetUrls}
 				onMount={handleMount}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -1,4 +1,9 @@
-import { ROOM_OPEN_MODE, RoomOpenMode, RoomOpenModeToPath } from '@tldraw/dotcom-shared'
+import {
+	getLicenseKey,
+	ROOM_OPEN_MODE,
+	RoomOpenMode,
+	RoomOpenModeToPath,
+} from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
 import { useCallback, useMemo } from 'react'
 import { Editor, TLComponents, Tldraw } from 'tldraw'
@@ -13,7 +18,6 @@ import { globalEditor } from '../../../utils/globalEditor'
 import { multiplayerAssetStore } from '../../../utils/multiplayerAssetStore'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
-import { TlaEditorWrapper } from './TlaEditorWrapper'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorLegacySharePanel } from './editor-components/TlaEditorLegacySharePanel'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
@@ -23,6 +27,7 @@ import { SneakyTldrawFileDropHandler } from './sneaky/SneakyFileDropHandler'
 import { SneakyLegacyModal } from './sneaky/SneakyLegacyModal'
 import { SneakyLegacySetDocumentTitle } from './sneaky/SneakyLegacytSetDocumentTitle'
 import { SneakySetDocumentTitle } from './sneaky/SneakySetDocumentTitle'
+import { TlaEditorWrapper } from './TlaEditorWrapper'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 /** @internal */
@@ -103,6 +108,7 @@ function TlaEditorInner({
 		<TlaEditorWrapper>
 			<Tldraw
 				className="tla-editor"
+				licenseKey={getLicenseKey()}
 				store={storeWithStatus}
 				assetUrls={assetUrls}
 				onMount={handleMount}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacySnapshotEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacySnapshotEditor.tsx
@@ -1,3 +1,4 @@
+import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useCallback } from 'react'
 import { Editor, TLComponents, TLStoreSnapshot, Tldraw } from 'tldraw'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
@@ -71,6 +72,7 @@ function TlaEditorInner({ snapshot }: { snapshot: TLStoreSnapshot }) {
 		<TlaEditorWrapper>
 			<Tldraw
 				className="tla-editor"
+				licenseKey={getLicenseKey()}
 				snapshot={snapshot}
 				assetUrls={assetUrls}
 				onMount={handleMount}


### PR DESCRIPTION
We found out that we were fetching the watermark track only when signed in. This adds the license to all the editor instances and makes this consistent regardless of the auth state.

### Change type

- [x] `improvement`

### Test plan

1. Verify watermark behavior when signed out vs signed in.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Ensure license and watermark consistency across all editor states.