### PR TITLE
publish-templates.yml: Fix ai template repo name

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -141,6 +141,6 @@ jobs:
         with:
           source-directory: 'templates/ai'
           destination-github-username: 'tldraw'
-          destination-repository-name: 'tldraw-ai'
+          destination-repository-name: 'ai-template'
           user-email: steve+github.actions@tldraw.com
           target-branch: main


### PR DESCRIPTION
this was wrong

### Change type


- [x] `other`
