### PR TITLE
a11y: fix up incorrect role on toolbar items

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -218,7 +218,6 @@ export function TldrawUiMenuItem<
 						preventDefault(e)
 						onSelect('toolbar')
 					}}
-					role="option"
 					title={titleStr}
 					type="tool"
 				>
@@ -237,7 +236,6 @@ export function TldrawUiMenuItem<
 					data-value={id}
 					disabled={disabled}
 					onClick={() => onSelect('toolbar')}
-					role="option"
 					title={titleStr}
 					type="icon"
 				>


### PR DESCRIPTION
This was prbly some copy-pasta.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: fix up incorrect role on toolbar items