### PR TITLE
clipboard: fix up html entities being escaped

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -355,12 +355,7 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 									// First try parsing as plain JSON (version 2 format)
 									let json
 									try {
-										json = JSON.parse(
-											tldrawHtmlComment
-												.replace(/&gt;/g, '>')
-												.replace(/&lt;/g, '<')
-												.replace(/&amp;/g, '&')
-										)
+										json = JSON.parse(tldrawHtmlComment)
 									} catch {
 										// Fall back to LZ decompression (legacy format)
 										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -355,7 +355,12 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 									// First try parsing as plain JSON (version 2 format)
 									let json
 									try {
-										json = JSON.parse(tldrawHtmlComment)
+										json = JSON.parse(
+											tldrawHtmlComment
+												.replace(/&gt;/g, '>')
+												.replace(/&lt;/g, '<')
+												.replace(/&amp;/g, '&')
+										)
 									} catch {
 										// Fall back to LZ decompression (legacy format)
 										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -598,7 +598,7 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 	}
 
 	// Use versioned clipboard format for better compression
-	// Version 2: Don't compress assets, only compress other data
+	// Version 3: Don't compress assets, only compress other data
 	const { assets, ...otherData } = content
 	const clipboardData = {
 		type: 'application/tldraw',

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -383,13 +383,21 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 									if (json.version === 2) {
 										// Version 2: Assets are plain, decompress only other data
 										try {
-											r({ type: 'tldraw', data: json.data })
+											const otherData = JSON.parse(
+												lz.decompressFromBase64(json.data.otherCompressed) || '{}'
+											)
+											const reconstructedData = {
+												assets: json.data.assets || [],
+												...otherData,
+											}
+
+											r({ type: 'tldraw', data: reconstructedData })
 											return
 										} catch (error) {
 											r({
 												type: 'error',
 												data: json,
-												reason: `failed to parse version 2 clipboard data: ${error}`,
+												reason: `failed to decompress version 2 clipboard data: ${error}`,
 											})
 											return
 										}
@@ -584,13 +592,21 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 		return
 	}
 
-	// Version 2: Don't compress anything.
-	const stringifiedClipboard = JSON.stringify({
+	// Use versioned clipboard format for better compression
+	// Version 2: Don't compress assets, only compress other data
+	const { assets, ...otherData } = content
+	const clipboardData = {
 		type: 'application/tldraw',
 		kind: 'content',
 		version: 2,
-		data: content,
-	})
+		data: {
+			assets: assets || [], // Plain JSON, no compression
+			otherCompressed: lz.compressToBase64(JSON.stringify(otherData)), // Only compress non-asset data
+		},
+	}
+
+	// Don't compress the final structure - just use plain JSON
+	const stringifiedClipboard = JSON.stringify(clipboardData)
 
 	if (typeof navigator === 'undefined') {
 		return

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -32,6 +32,8 @@ const expectedPasteFileMimeTypes = [
 	'image/svg+xml',
 ] satisfies string[]
 
+const ENCODING_PLACEHOLDER = '__tldraw__html___entity__'
+
 /**
  * Strip HTML tags from a string.
  * @param html - The HTML to strip.
@@ -355,12 +357,13 @@ async function handleClipboardThings(editor: Editor, things: ClipboardThing[], p
 									// First try parsing as plain JSON (version 2 format)
 									let json
 									try {
-										json = JSON.parse(
-											tldrawHtmlComment
-												.replace(/&gt;/g, '>')
-												.replace(/&lt;/g, '<')
-												.replace(/&amp;/g, '&')
-										)
+										const createDecodeRegex = (str: string) =>
+											new RegExp(ENCODING_PLACEHOLDER + str + ENCODING_PLACEHOLDER, 'g')
+										const tldrawHtmlCommentDecoded = tldrawHtmlComment
+											.replace(createDecodeRegex('gt'), '>')
+											.replace(createDecodeRegex('lt'), '<')
+											.replace(createDecodeRegex('amp'), '&')
+										json = JSON.parse(tldrawHtmlCommentDecoded)
 									} catch {
 										// Fall back to LZ decompression (legacy format)
 										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
@@ -596,6 +599,11 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 		version: 2,
 		data: content,
 	})
+	const createEncodeStr = (str: string) => `${ENCODING_PLACEHOLDER}${str}${ENCODING_PLACEHOLDER}`
+	const encodedClipboard = stringifiedClipboard
+		.replace(/>/g, createEncodeStr('gt'))
+		.replace(/</g, createEncodeStr('lt'))
+		.replace(/&/g, createEncodeStr('amp'))
 
 	if (typeof navigator === 'undefined') {
 		return
@@ -609,7 +617,7 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 			.filter(isDefined)
 
 		if (navigator.clipboard?.write) {
-			const htmlBlob = new Blob([`<div data-tldraw>${stringifiedClipboard}</div>`], {
+			const htmlBlob = new Blob([`<div data-tldraw>${encodedClipboard}</div>`], {
 				type: 'text/html',
 			})
 
@@ -630,7 +638,7 @@ const handleNativeOrMenuCopy = async (editor: Editor) => {
 				}),
 			])
 		} else if (navigator.clipboard.writeText) {
-			navigator.clipboard.writeText(`<div data-tldraw>${stringifiedClipboard}</div>`)
+			navigator.clipboard.writeText(`<div data-tldraw>${encodedClipboard}</div>`)
 		}
 	}
 }


### PR DESCRIPTION
followup fix for https://github.com/tldraw/tldraw/pull/6344
because we don't base64 encode anymore, a knock-on effect is that any characters within this html blob gets treated as such. we need to unescape these upon paste.

hat-tip to Phil for the report.

![Screenshot 2025-07-04 at 17 40 56](https://github.com/user-attachments/assets/7b5a6b86-1797-4c0b-9c7c-66d47b9981bb)

this also fixes #6428

![Image](https://github.com/user-attachments/assets/d4ecdcfb-c484-40e5-8b65-a6d93bdb8dc2)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- clipboard: fix up html entities being escaped