### PR TITLE
Fix dead link

### DIFF
--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -77,10 +77,6 @@ If you have purchased a [business license](https://tldraw.dev/#pricing), you can
 
 To learn more about the license and license key, visit [our pricing page](https://tldraw.dev/#pricing).
 
-## Usage in Frameworks
-
-Visit our [framework examples repository](https://github.com/tldraw/examples) to see examples of tldraw being used in various frameworks.
-
 ## Static Assets
 
 In order to use the [Tldraw](?) component, the app must be able to find certain assets. These are contained in the `embed-icons`, `fonts`, `icons`, and `translations` folders. We offer a few different ways of making these assets available to your app.


### PR DESCRIPTION
Remove dead link to frameworks in README.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`