### PR TITLE
Faster User DO Resume

### DIFF
--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -131,7 +131,15 @@ export type TLPostgresReplicatorRebootSource =
 export type TLPostgresReplicatorEvent =
 	| { type: 'reboot'; source: TLPostgresReplicatorRebootSource }
 	| { type: 'request_lsn_update' }
-	| { type: 'reboot_error' | 'register_user' | 'unregister_user' | 'get_file_record' | 'prune' }
+	| {
+			type:
+				| 'reboot_error'
+				| 'register_user'
+				| 'unregister_user'
+				| 'get_file_record'
+				| 'prune'
+				| 'resume_sequence'
+	  }
 	| { type: 'reboot_duration'; duration: number }
 	| { type: 'rpm'; rpm: number }
 	| { type: 'active_users'; count: number }


### PR DESCRIPTION
Our deploys have been overloading the replicator for a minute or two at busy times. I think the new history-log-based resume code (introduced in https://github.com/tldraw/tldraw/pull/6184) is significantly slower than what we had before.

This PR aims to reduce the amount of work the replicator needs to do during deploys by optimizing for the fairly common case that no relevant updates occurred during the brief window when active users' DOs were rebooting. If we store the sequence ID + number in the user DO snapshot, then we can check whether the user DO is up to date much much more quickly when registering.

This should do a lot to help ease the load on the replicator during a deploy 🤞🏼  

### Change type

- [x] `other`
