### PR TITLE
optimize + fix useValue

### DIFF
--- a/packages/state-react/src/lib/useValue.test.tsx
+++ b/packages/state-react/src/lib/useValue.test.tsx
@@ -1,9 +1,35 @@
 import { RenderResult, act, render } from '@testing-library/react'
 import { Atom, Computed, atom } from '@tldraw/state'
-import { useState } from 'react'
+import { Component, ReactNode, useState } from 'react'
 import { useAtom } from './useAtom'
 import { useComputed } from './useComputed'
 import { useValue } from './useValue'
+
+// Error boundary component for testing
+class TestErrorBoundary extends Component<
+	{ children: ReactNode; onError?(error: Error): void },
+	{ hasError: boolean; error: Error | null }
+> {
+	constructor(props: { children: ReactNode; onError?(error: Error): void }) {
+		super(props)
+		this.state = { hasError: false, error: null }
+	}
+
+	static getDerivedStateFromError(error: Error) {
+		return { hasError: true, error }
+	}
+
+	override componentDidCatch(error: Error) {
+		this.props.onError?.(error)
+	}
+
+	override render() {
+		if (this.state.hasError) {
+			return <div data-testid="error-boundary">Error: {this.state.error?.message}</div>
+		}
+		return this.props.children
+	}
+}
 
 test('useValue returns a value from a computed', async () => {
 	let theComputed = null as null | Computed<number>
@@ -85,6 +111,7 @@ test('useValue returns a value from a compute function', async () => {
 
 test("useValue doesn't throw when used in a zombie-child component", async () => {
 	const theAtom = atom<Record<string, number>>('map', { a: 1, b: 2, c: 3 })
+	let numThrows = 0
 	function Parent() {
 		const ids = useValue('ids', () => Object.keys(theAtom.get()), [])
 		return (
@@ -99,7 +126,10 @@ test("useValue doesn't throw when used in a zombie-child component", async () =>
 		const value = useValue(
 			'value',
 			() => {
-				if (!(id in theAtom.get())) throw new Error('id not found!')
+				if (!(id in theAtom.get())) {
+					numThrows++
+					throw new Error('id not found!')
+				}
 				return theAtom.get()[id]
 			},
 			[id]
@@ -108,16 +138,71 @@ test("useValue doesn't throw when used in a zombie-child component", async () =>
 	}
 
 	let view: RenderResult
-	await act(() => {
+	act(() => {
 		view = render(<Parent />)
 	})
 
 	expect(view!.asFragment().textContent).toMatchInlineSnapshot('"123"')
 
+	expect(numThrows).toBe(0)
 	// remove id 'b' creating a zombie-child
-	await act(() => {
+	act(() => {
 		theAtom?.update(({ b: _, ...rest }) => rest)
 	})
 
 	expect(view!.asFragment().textContent).toMatchInlineSnapshot('"13"')
+
+	expect(numThrows).toBe(1)
+})
+
+test('useValue throws synchronously during render when the computed throws', async () => {
+	const theAtom = atom<Error | null>('map', null)
+	let caughtError = null as null | Error
+
+	// Suppress React's console.error for this test
+
+	function Component({ id }: { id: string }) {
+		const value = useValue(
+			'value',
+			() => {
+				const error = theAtom.get()
+				if (error) throw error
+				return 1
+			},
+			[id]
+		)
+		return <>{value}</>
+	}
+
+	let view: RenderResult
+	act(() => {
+		view = render(
+			<TestErrorBoundary
+				onError={(error) => {
+					caughtError = error
+				}}
+			>
+				<Component id="a" />
+			</TestErrorBoundary>
+		)
+	})
+
+	expect(view!.asFragment().textContent).toMatchInlineSnapshot('"1"')
+
+	// ignore console.error here because react will log the error to console.error
+	// even though it's caught by the error boundary
+	const originalError = console.error
+	console.error = jest.fn()
+	try {
+		act(() => {
+			theAtom.set(new Error('test'))
+		})
+	} finally {
+		console.error = originalError
+	}
+
+	expect(caughtError).toBeInstanceOf(Error)
+	expect(caughtError?.message).toBe('test')
+	expect(view!.getByTestId('error-boundary')).toBeTruthy()
+	expect(view!.getByTestId('error-boundary').textContent).toBe('Error: test')
 })

--- a/packages/state-react/src/lib/useValue.ts
+++ b/packages/state-react/src/lib/useValue.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-rest-params */
 import { Signal, computed, react } from '@tldraw/state'
-import { useMemo, useRef, useSyncExternalStore } from 'react'
+import { useMemo, useSyncExternalStore } from 'react'
 
 /** @public */
 export function useValue<Value>(value: Signal<Value>): Value
@@ -49,52 +49,27 @@ export function useValue() {
 	const deps = args.length === 3 ? args[2] : [args[0]]
 	const name = args.length === 3 ? args[0] : `useValue(${args[0].name})`
 
-	const isInRender = useRef(true)
-	isInRender.current = true
+	const { $val, subscribe, getSnapshot } = useMemo(() => {
+		const $val =
+			args.length === 1 ? (args[0] as Signal<any>) : (computed(name, args[1]) as Signal<any>)
 
-	const $val = useMemo(() => {
-		if (args.length === 1) {
-			return args[0]
+		return {
+			$val,
+			subscribe: (notify: () => void) => {
+				return react(`useValue(${name})`, () => {
+					try {
+						$val.get()
+					} catch {
+						// noop
+					}
+					notify()
+				})
+			},
+			getSnapshot: () => $val.lastChangedEpoch,
 		}
-		return computed(name, () => {
-			if (isInRender.current) {
-				return args[1]()
-			} else {
-				try {
-					return args[1]()
-				} catch {
-					// when getSnapshot is called outside of the render phase &
-					// subsequently throws an error, it might be because we're
-					// in a zombie-child state. in that case, we suppress the
-					// error and instead return a new dummy value to trigger a
-					// react re-render. if we were in a zombie child, react will
-					// unmount us instead of re-rendering so the error is
-					// irrelevant. if we're not in a zombie-child, react will
-					// call `getSnapshot` again in the render phase, and the
-					// error will be thrown as expected.
-					return {}
-				}
-			}
-		})
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, deps)
 
-	try {
-		const { subscribe, getSnapshot } = useMemo(() => {
-			return {
-				subscribe: (listen: () => void) => {
-					return react(`useValue(${name})`, () => {
-						$val.get()
-						listen()
-					})
-				},
-				getSnapshot: () => $val.get(),
-			}
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [$val])
-
-		return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-	} finally {
-		isInRender.current = false
-	}
+	useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+	return $val.__unsafe__getWithoutCapture()
 }


### PR DESCRIPTION
replaces #6394 

This both reduces the number of hooks and fixes a bug where useValue was sometimes swallowing legitimate errors that should have been thrown synchronously during render.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug that caused useValue to sometimes swallow errors that should have been thrown.