### PR TITLE
Show max shapes alert when duplicating shapes.

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -513,7 +513,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 								}
 					}
 
-					if (!editor.canCreateShapes(ids)) return
 					editor.markHistoryStoppingPoint('duplicate shapes')
 					editor.duplicateShapes(ids, offset)
 


### PR DESCRIPTION
`editor.duplicateShapes` already does the check so we don't need to do an early return.


### Change type

- [x] `improvement`

### Release notes

- Alert that maximum shapes were reached when duplicating shapes. Until now we just silently rejected the duplication action.