### PR TITLE
Improve frame rendering performance by avoiding re-rendering frame shapes on zoom

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -219,9 +219,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 			[shape.id]
 		)
 
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const zoomLevel = useValue('zoom level', () => this.editor.getZoomLevel(), [this.editor])
-
 		const showFrameColors = this.options.showColors
 
 		const color = theme[shape.props.color]
@@ -236,12 +233,13 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 				<SVGContainer>
 					<rect
 						className={classNames('tl-frame__body', { 'tl-frame__creating': isCreating })}
-						width={shape.props.w + 1 / zoomLevel}
-						height={shape.props.h + 1 / zoomLevel}
 						fill={frameFill}
 						stroke={frameStroke}
-						y={-0.5 / zoomLevel}
-						x={-0.5 / zoomLevel}
+						style={{
+							width: `calc(${shape.props.w}px + 1px / var(--tl-zoom))`,
+							height: `calc(${shape.props.h}px + 1px / var(--tl-zoom))`,
+							transform: `translate(calc(-0.5px / var(--tl-zoom)), calc(-0.5px / var(--tl-zoom)))`,
+						}}
 					/>
 				</SVGContainer>
 				{isCreating ? null : (


### PR DESCRIPTION
Instead of reading the zoom level and setting attributes based on it, use css styles with the --tl-zoom variable instead. This improves performance a lot when there's many frames on a page.

For example on a page with 256 frames with my laptop in powersave when I'm zoomed in so just one frame shows and I zoom in/out it goes from 15-20 fps to 30-40 fps. This is just an example, it improves performance when you're zoomed out and it shows multiple frames too, the fps numbers are just different in that case.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create lots of frames
2. Zoom in/out

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve frame rendering performance by avoiding re-rendering frame shapes on zoom