### PR TITLE
Fix fixed-size text measurement

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -303,30 +303,26 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 }
 
 function getTextSize(editor: Editor, props: TLTextShape['props']) {
-	const { font, richText, autoSize, size, w } = props
+	const { font, richText, size, w } = props
 
 	const minWidth = 16
 	const fontSize = FONT_SIZES[size]
 
-	const manualWidth = autoSize ? null : Math.max(minWidth, Math.floor(w))
+	const maybeFixedWidth = props.autoSize ? null : Math.max(minWidth, Math.floor(w))
 
 	const html = renderHtmlFromRichTextForMeasurement(editor, richText)
 	const result = editor.textMeasure.measureHtml(html, {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[font],
 		fontSize: fontSize,
-		maxWidth: manualWidth,
+		maxWidth: maybeFixedWidth,
 	})
 
 	// If we're autosizing the measureText will essentially `Math.floor`
 	// the numbers so `19` rather than `19.3`, this means we must +1 to
 	// whatever we get to avoid wrapping.
-	if (autoSize) {
-		result.w += 1
-	}
-
 	return {
-		width: manualWidth ?? Math.max(minWidth, result.w),
+		width: maybeFixedWidth ?? Math.max(minWidth, result.w + 1),
 		height: Math.max(fontSize, result.h),
 	}
 }

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -305,20 +305,17 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 function getTextSize(editor: Editor, props: TLTextShape['props']) {
 	const { font, richText, autoSize, size, w } = props
 
-	const minWidth = autoSize ? 16 : Math.max(16, w)
+	const minWidth = 16
 	const fontSize = FONT_SIZES[size]
 
-	const cw = autoSize
-		? null
-		: // `measureText` floors the number so we need to do the same here to avoid issues.
-			Math.floor(Math.max(minWidth, w))
+	const manualWidth = autoSize ? null : Math.max(minWidth, Math.floor(w))
 
 	const html = renderHtmlFromRichTextForMeasurement(editor, richText)
 	const result = editor.textMeasure.measureHtml(html, {
 		...TEXT_PROPS,
 		fontFamily: FONT_FAMILIES[font],
 		fontSize: fontSize,
-		maxWidth: cw,
+		maxWidth: manualWidth,
 	})
 
 	// If we're autosizing the measureText will essentially `Math.floor`
@@ -329,7 +326,7 @@ function getTextSize(editor: Editor, props: TLTextShape['props']) {
 	}
 
 	return {
-		width: Math.max(minWidth, result.w),
+		width: manualWidth ?? Math.max(minWidth, result.w),
 		height: Math.max(fontSize, result.h),
 	}
 }


### PR DESCRIPTION
Before

![Kapture 2025-07-09 at 13 47 50](https://github.com/user-attachments/assets/f4a9bfb1-87ec-46a9-8da5-7a7d2a39f11e)

After

![Kapture 2025-07-09 at 13 53 20](https://github.com/user-attachments/assets/c35f5af3-9d34-4a44-a381-37ffcaff196d)


### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug where fixed-size text shapes were rendered with the wrong height.