### PR TITLE
chore: improve changelog generation

### DIFF
--- a/internal/scripts/lib/auto-plugin.js
+++ b/internal/scripts/lib/auto-plugin.js
@@ -18,9 +18,10 @@ module.exports = class AutoPlugin {
 
 				const parseSection = (sectionHeader) => {
 					// Match the section between the header and the next header or any empty line or end of text.
-					const match = new RegExp(`${sectionHeader}\\n\\n([\\s\\S]*?)(?=\\n### |\\n\\n|$)`).exec(
-						body
-					)
+					const match = new RegExp(
+						`${sectionHeader}\\n\\n([\\s\\S]*?)(?=\\n### |\\n\\n|$)`,
+						'i'
+					).exec(body)
 					if (!match) return
 
 					const bulletPoints = match[1]
@@ -31,7 +32,7 @@ module.exports = class AutoPlugin {
 
 					if (bulletPoints.length === 0) return
 
-					const prefix = sectionHeader === '### API Changes' ? '[API Change]: ' : ''
+					const prefix = sectionHeader.toLowerCase() === '### api changes' ? '[API Change]: ' : ''
 					const formattedPoints = bulletPoints
 						.map((point) => {
 							return `- ${prefix}${point} [#${commit.pullRequest.number}](https://github.com/tldraw/tldraw/pull/${commit.pullRequest.number})`


### PR DESCRIPTION
Pull out api changes. Make sure we parse all the bullets and not just the first one.

### Change type

- [x] `other` 

### Test plan

1. Run the changelog generation script and verify it parses multiple bullets and API changes correctly.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Improved changelog generation to include API changes and multiple bullet points.