### PR TITLE
a11y: fix up aria slider values and make dialogs scrollable via keyboard

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4049,6 +4049,8 @@ export interface TLUiSliderProps {
     // (undocumented)
     'data-testid'?: string;
     // (undocumented)
+    ariaValueModifier?: number;
+    // (undocumented)
     label: string;
     // (undocumented)
     min?: number;

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -451,6 +451,7 @@ export function OpacitySlider() {
 			steps={tldrawSupportedOpacities.length - 1}
 			title={msg('style-panel.opacity')}
 			onHistoryMark={onHistoryMark}
+			ariaValueModifier={25}
 		/>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDialog.tsx
@@ -65,7 +65,7 @@ export interface TLUiDialogBodyProps {
 /** @public @react */
 export function TldrawUiDialogBody({ className, children, style }: TLUiDialogBodyProps) {
 	return (
-		<div className={classNames('tlui-dialog__body', className)} style={style}>
+		<div className={classNames('tlui-dialog__body', className)} style={style} tabIndex={0}>
 			{children}
 		</div>
 	)

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -13,6 +13,7 @@ export interface TLUiSliderProps {
 	onValueChange(value: number): void
 	onHistoryMark(id: string): void
 	'data-testid'?: string
+	ariaValueModifier?: number
 }
 
 /** @public @react */
@@ -26,6 +27,7 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 		label,
 		onValueChange,
 		['data-testid']: testId,
+		ariaValueModifier = 1,
 	}: TLUiSliderProps,
 	ref
 ) {
@@ -81,7 +83,9 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 				</_Slider.Track>
 				{value !== null && (
 					<_Slider.Thumb
-						aria-label={msg('style-panel.opacity')}
+						aria-valuemin={(min ?? 0) * ariaValueModifier}
+						aria-valuenow={value * ariaValueModifier}
+						aria-valuemax={steps * ariaValueModifier}
 						className="tlui-slider__thumb"
 						dir="ltr"
 						ref={ref}


### PR DESCRIPTION


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: fix up aria slider values and make dialogs scrollable via keyboard

### API Changes

- Adds `ariaValueModifier` to `TldrawUiSlider`.