### PR TITLE
a11y: mark `<svg>` elements and text as aria-hidden

### DIFF
--- a/packages/editor/src/lib/components/SVGContainer.tsx
+++ b/packages/editor/src/lib/components/SVGContainer.tsx
@@ -7,7 +7,7 @@ export type SVGContainerProps = React.ComponentProps<'svg'>
 /** @public @react */
 export function SVGContainer({ children, className = '', ...rest }: SVGContainerProps) {
 	return (
-		<svg {...rest} className={classNames('tl-svg-container', className)}>
+		<svg {...rest} className={classNames('tl-svg-container', className)} aria-hidden="true">
 			{children}
 		</svg>
 	)

--- a/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultBrush.tsx
@@ -21,7 +21,7 @@ export const DefaultBrush = ({ brush, color, opacity, className }: TLBrushProps)
 	const h = toDomPrecision(Math.max(1, brush.h))
 
 	return (
-		<svg className="tl-overlays__item" ref={rSvg}>
+		<svg className="tl-overlays__item" ref={rSvg} aria-hidden="true">
 			{color ? (
 				<g className="tl-brush" opacity={opacity}>
 					<rect width={w} height={h} fill={color} opacity={0.75} />

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -139,7 +139,7 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 				data-testid="canvas"
 				{...events}
 			>
-				<svg className="tl-svg-context">
+				<svg className="tl-svg-context" aria-hidden="true">
 					<defs>
 						{shapeSvgDefs}
 						<CursorDef />

--- a/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
@@ -39,7 +39,7 @@ export function DefaultCollaboratorHint({
 	const cursorHintId = useSharedSafeId('cursor_hint')
 
 	return (
-		<svg ref={rSvg} className={classNames('tl-overlays__item', className)}>
+		<svg ref={rSvg} className={classNames('tl-overlays__item', className)} aria-hidden="true">
 			<use
 				href={`#${cursorHintId}`}
 				color={color}

--- a/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCursor.tsx
@@ -33,7 +33,7 @@ export const DefaultCursor = memo(function DefaultCursor({
 
 	return (
 		<div ref={rCursor} className={classNames('tl-overlays__item', className)}>
-			<svg className="tl-cursor">
+			<svg className="tl-cursor" aria-hidden="true">
 				<use href={`#${cursorId}`} color={color} />
 			</svg>
 			{chatMessage ? (

--- a/packages/editor/src/lib/components/default-components/DefaultGrid.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultGrid.tsx
@@ -16,7 +16,7 @@ export function DefaultGrid({ x, y, z, size }: TLGridProps) {
 	const editor = useEditor()
 	const { gridSteps } = editor.options
 	return (
-		<svg className="tl-grid" version="1.1" xmlns="http://www.w3.org/2000/svg">
+		<svg className="tl-grid" version="1.1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 			<defs>
 				{gridSteps.map(({ min, mid, step }, i) => {
 					const s = step * size * z

--- a/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultHandles.tsx
@@ -7,5 +7,9 @@ export interface TLHandlesProps {
 
 /** @public @react */
 export const DefaultHandles = ({ children }: TLHandlesProps) => {
-	return <svg className="tl-user-handles tl-overlays__item">{children}</svg>
+	return (
+		<svg className="tl-user-handles tl-overlays__item" aria-hidden="true">
+			{children}
+		</svg>
+	)
 }

--- a/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
@@ -86,7 +86,7 @@ export const DefaultShapeIndicator = memo(function DefaultShapeIndicator({
 	}, [hidden])
 
 	return (
-		<svg ref={rIndicator} className={classNames('tl-overlays__item', className)}>
+		<svg ref={rIndicator} className={classNames('tl-overlays__item', className)} aria-hidden="true">
 			<g className="tl-shape-indicator" stroke={color ?? 'var(--color-selected)'} opacity={opacity}>
 				<InnerIndicator editor={editor} id={shapeId} />
 			</g>

--- a/packages/editor/src/lib/components/default-components/DefaultSnapIndictor.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSnapIndictor.tsx
@@ -163,7 +163,7 @@ export interface TLSnapIndicatorProps {
 /** @public @react */
 export function DefaultSnapIndicator({ className, line, zoom }: TLSnapIndicatorProps) {
 	return (
-		<svg className={classNames('tl-overlays__item', className)}>
+		<svg className={classNames('tl-overlays__item', className)} aria-hidden="true">
 			{line.type === 'points' ? (
 				<PointsSnapIndicator {...line} zoom={zoom} />
 			) : line.type === 'gaps' ? (

--- a/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
@@ -20,7 +20,7 @@ export function TldrawCropHandles({
 	const msg = useTranslation()
 
 	return (
-		<svg className="tl-overlays__item">
+		<svg className="tl-overlays__item" aria-hidden="true">
 			{/* Top left */}
 			<polyline
 				className="tl-corner-crop-handle"

--- a/packages/tldraw/src/lib/canvas/TldrawHandles.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawHandles.tsx
@@ -23,5 +23,9 @@ export function TldrawHandles({ children }: TLHandlesProps) {
 
 	if (!shouldDisplayHandles) return null
 
-	return <svg className="tl-user-handles tl-overlays__item">{children}</svg>
+	return (
+		<svg className="tl-user-handles tl-overlays__item" aria-hidden="true">
+			{children}
+		</svg>
+	)
 }

--- a/packages/tldraw/src/lib/canvas/TldrawOverlays.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawOverlays.tsx
@@ -60,7 +60,7 @@ export function TldrawArrowHints() {
 			{ShapeIndicator && <ShapeIndicator shapeId={targetInfo.target.id} />}
 
 			{showEdgeHints && (
-				<svg className="tl-overlays__item">
+				<svg className="tl-overlays__item" aria-hidden="true">
 					<circle
 						cx={anchorInPageSpace.x}
 						cy={anchorInPageSpace.y}

--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -192,7 +192,11 @@ export const TldrawSelectionForeground = track(function TldrawSelectionForegroun
 		textHandleHeight * zoom >= 4
 
 	return (
-		<svg className="tl-overlays__item tl-selection__fg" data-testid="selection-foreground">
+		<svg
+			className="tl-overlays__item tl-selection__fg"
+			data-testid="selection-foreground"
+			aria-hidden="true"
+		>
 			<g ref={rSvg}>
 				{shouldDisplayBox && (
 					<rect

--- a/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
@@ -81,6 +81,7 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 	return (
 		<div
 			className={`${cssPrefix}-label tl-text-wrapper tl-plain-text-wrapper`}
+			aria-hidden="true"
 			data-font={font}
 			data-align={align}
 			data-hastext={!isEmpty}

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -128,6 +128,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 	return (
 		<div
 			className={`${cssPrefix}-label tl-text-wrapper tl-rich-text-wrapper`}
+			aria-hidden="true"
 			data-font={font}
 			data-align={align}
 			data-hastext={!isEmpty}


### PR DESCRIPTION
solves these issues for accessibility:
- https://linear.app/tldraw/issue/ACC-80/if-an-element-on-the-canvas-is-selected-its-rotate-and-resize-controls
- https://linear.app/tldraw/issue/ACC-78/text-elements-in-the-canvas-are-announced-by-screen-readers-before-any
- https://linear.app/tldraw/issue/ACC-77/some-screen-reader-and-browser-combos-announce-a-series-of-images

Basically, when using the Ctrl + Option + Left/Right the screen reader is navigating the accessibility tree directly.
- We have a bunch of `<svg>` elements which are used in rendering but are not meant for screen readers.
- Furthermore, we have handles on shapes that aren't meant to be tabbed through, we have keyboard shortcuts instead to use in their stead.
- Finally, the text shapes are rendered "outside" of the normal flow of things and they get read/included in tab order when they shouldn't be. We just want to programmatically control everything via our `aria-live` messaging system.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: mark `<svg>` elements and text as `aria-hidden` to avoid any confusion when navigating.