### PR TITLE
Fix links and typos.

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -27,4 +27,4 @@ Have questions, comments or feedback? [Join our discord](https://discord.gg/rhsy
 
 ## Contact
 
-Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw) or email us at [mailto:hello@tldraw.com](hello@tldraw.com).
+Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw) or email us at [hello@tldraw.com](mailto:hello@tldraw.com).

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -44,7 +44,7 @@ const tolkeinId = Author.createCustomId('tolkein')
 
 store.put([
 	Author.create({
-		id: jrrTolkeinId,
+		id: tolkeinId,
 		name: 'J.R.R Tolkein',
 	}),
 ])
@@ -163,7 +163,7 @@ store.deserialize(serialized)
 
 ### `listen(listener: ((entry: HistoryEntry) => void): () => void`
 
-Add a new listener to the store The store will call the function each time the history changes. Returns a function to remove the listener.
+Add a new listener to the store. The store will call the function each time the history changes. Returns a function to remove the listener.
 
 ```ts
 store.listen((entry) => doSomethingWith(entry))

--- a/packages/tlschema/README.md
+++ b/packages/tlschema/README.md
@@ -26,7 +26,7 @@ If you are making a change that affects the structure of a record, shape, or ass
 
 If you are making a change that affects the structure of the store (e.g. renaming or deleting a type, consolidating two shape types into one, etc), add your changes in the migrations in `schema.ts`.
 
-After making your changes, add a new version number, using a meaninful name. For example, if you add a new property
+After making your changes, add a new version number, using a meaningful name. For example, if you add a new property
 to the `TLShape` type called `ownerId` that points to a user, you might do this:
 
 In `TLShape.ts`

--- a/templates/ai/README.md
+++ b/templates/ai/README.md
@@ -38,4 +38,4 @@ Have questions, comments or feedback? [Join our discord](https://discord.gg/rhsy
 
 ## Contact
 
-Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw) or email us at [mailto:hello@tldraw.com](hello@tldraw.com).
+Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw) or email us at [hello@tldraw.com](mailto:hello@tldraw.com).


### PR DESCRIPTION
Some docs links fixes and typos fixes. Will also use this to try the hotfix after the PR has been merged logic.

### Change type

- [x] `other`
