### PR TITLE
[backend] check wake up behavior

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -434,7 +434,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	async handleReplicationEvent(event: ZReplicationEvent) {
 		this.logEvent({ type: 'replication_event', id: this.userId ?? 'anon' })
 		this.log.debug('replication event', event, !!this.cache)
-		if (await this.notActive()) {
+		if (!this.cache) {
+			this.logEvent({ type: 'woken_up_by_replication_event', id: this.userId ?? 'anon' })
 			this.log.debug('requesting to unregister')
 			return 'unregister'
 		}
@@ -446,10 +447,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		}
 
 		return 'ok'
-	}
-
-	async notActive() {
-		return !this.cache
 	}
 
 	/* --------------  */

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -160,6 +160,7 @@ export type TLUserDurableObjectEvent =
 				| 'connect_retry'
 				| 'user_do_abort'
 				| 'not_enough_history_for_fast_reboot'
+				| 'woken_up_by_replication_event'
 			id: string
 	  }
 	| { type: 'reboot_duration'; id: string; duration: number }


### PR DESCRIPTION
The new faster resume thingy seems to be successful 90%+ of the time during off-peak hours and maybe only 50% during peak hours. I suspect that's because the user durable objects are being woken up by replication events (which prevents fast resume from working) before being woken up by socket reconnects.

This PR adds an analytics event to validate my suspicion. If I'm right we could allow recently-shut-down user DOs to handle being woken up gracefully, by loading the cache and processing the replication event. I think we'd need to do this to give me peace of mind that removing the history-log-based catchup mechanism would be fine.


### Change type

- [x] `other`
