### PR TITLE
Use a different api to get the checks.

### DIFF
--- a/.github/workflows/trigger-dotcom-hotfix.yml
+++ b/.github/workflows/trigger-dotcom-hotfix.yml
@@ -14,8 +14,6 @@ defaults:
 permissions:
   contents: write
   pull-requests: write
-  checks: read
-  statuses: read
 
 jobs:
   trigger:

--- a/.github/workflows/trigger-dotcom-hotfix.yml
+++ b/.github/workflows/trigger-dotcom-hotfix.yml
@@ -14,6 +14,8 @@ defaults:
 permissions:
   contents: write
   pull-requests: write
+  checks: read
+  statuses: read
 
 jobs:
   trigger:

--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -48,7 +48,7 @@ async function main() {
 		await exec('git', ['push', 'origin', hotfixBranchName])
 	})
 
-	await discord.step('Creating hotfix PR and adding to merge queue', async () => {
+	await discord.step('Creating hotfix PR and waiting for checks to pass', async () => {
 		const prTitle = `[HOTFIX] ${pr.title}`
 		const prBody = `This is an automated hotfix PR for dotcom deployment.
 
@@ -72,20 +72,40 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		nicelog(`Created hotfix PR: ${hotfixBranchName} -> hotfixes`)
 		nicelog(`Waiting for PR #${createdPr.data.number} to be ready for merge...`)
 
-		// Wait for 4 minutes initially, then check every 15 seconds (our checks take at least 4 mins)
-		await new Promise((resolve) => setTimeout(resolve, 4 * 60 * 1000))
+		// Wait for 5 minutes initially, then check every 15 seconds (our checks take at least 5 mins)
+		await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000))
 
 		while (true) {
 			const prStatus = await getPrDetailsByNumber(octokit, createdPr.data.number)
-			// Check if GitHub has finished calculating the merge status
+
 			if (prStatus.mergeable === null) {
-				nicelog(`PR #${createdPr.data.number} status still being calculated, waiting...`)
+				nicelog(`PR #${createdPr.data.number} merge status still being calculated, waiting...`)
 				await new Promise((resolve) => setTimeout(resolve, 15 * 1000))
 				continue
 			}
 
-			// GitHub has finished calculating, now check the result
-			if (prStatus.mergeable) {
+			if (!prStatus.mergeable) {
+				nicelog(`PR #${createdPr.data.number} has conflicts and cannot be merged`)
+				throw new Error(`Hotfix PR #${createdPr.data.number} cannot be merged`)
+			}
+
+			// Get the combined status of all checks
+			const status = await octokit.rest.repos.getCombinedStatusForRef({
+				owner: 'tldraw',
+				repo: 'tldraw',
+				ref: prStatus.head.sha,
+			})
+
+			nicelog(`PR #${createdPr.data.number} status: ${status.data.state}`)
+			nicelog(`Total checks: ${status.data.total_count}`)
+			nicelog(
+				`Successful checks: ${status.data.statuses.filter((s) => s.state === 'success').length}`
+			)
+			nicelog(`Failed checks: ${status.data.statuses.filter((s) => s.state === 'failure').length}`)
+			nicelog(`Pending checks: ${status.data.statuses.filter((s) => s.state === 'pending').length}`)
+
+			// Check if all status checks have passed
+			if (status.data.state === 'success') {
 				nicelog(`PR #${createdPr.data.number} is ready for merge`)
 				await octokit.rest.pulls.merge({
 					owner: 'tldraw',
@@ -101,9 +121,22 @@ Original Author: @${pr.user?.login}`,
 
 				nicelog(`Successfully merged hotfix PR #${createdPr.data.number}`)
 				break
+			} else if (status.data.state === 'failure') {
+				nicelog(`PR #${createdPr.data.number} has failed checks:`)
+				status.data.statuses
+					.filter((s) => s.state === 'failure')
+					.forEach((check) => {
+						nicelog(`  - ${check.context}: ${check.description || 'Failed'}`)
+					})
+				throw new Error(`Hotfix PR #${createdPr.data.number} has failed checks`)
+			} else if (status.data.state === 'pending') {
+				nicelog(`PR #${createdPr.data.number} checks still pending, waiting...`)
+				await new Promise((resolve) => setTimeout(resolve, 15 * 1000))
+				continue
 			} else {
-				nicelog(`PR #${createdPr.data.number} has conflicts and cannot be merged`)
-				throw new Error(`Hotfix PR #${createdPr.data.number} cannot be merged`)
+				nicelog(`PR #${createdPr.data.number} has unknown status: ${status.data.state}`)
+				await new Promise((resolve) => setTimeout(resolve, 15 * 1000))
+				continue
 			}
 		}
 	})

--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -72,6 +72,16 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		nicelog(`Created hotfix PR: ${hotfixBranchName} -> hotfixes`)
 		nicelog(`Waiting for PR #${createdPr.data.number} to be ready for merge...`)
 
+		// Get the branch protection rules to find required contexts
+		const branchProtection = await octokit.rest.repos.getBranchProtection({
+			owner: 'tldraw',
+			repo: 'tldraw',
+			branch: 'hotfixes',
+		})
+
+		const requiredContexts = branchProtection.data.required_status_checks?.contexts || []
+		nicelog(`Required contexts: ${requiredContexts.join(', ')}`)
+
 		// Wait for 5 minutes initially, then check every 15 seconds (our checks take at least 5 mins)
 		await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000))
 
@@ -96,16 +106,37 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 				ref: prStatus.head.sha,
 			})
 
-			nicelog(`PR #${createdPr.data.number} status: ${status.data.state}`)
-			nicelog(`Total checks: ${status.data.total_count}`)
-			nicelog(
-				`Successful checks: ${status.data.statuses.filter((s) => s.state === 'success').length}`
+			// Filter to only check required contexts
+			const requiredStatuses = status.data.statuses.filter((check) =>
+				requiredContexts.includes(check.context)
 			)
-			nicelog(`Failed checks: ${status.data.statuses.filter((s) => s.state === 'failure').length}`)
-			nicelog(`Pending checks: ${status.data.statuses.filter((s) => s.state === 'pending').length}`)
 
-			// Check if all status checks have passed
-			if (status.data.state === 'success') {
+			nicelog(`PR #${createdPr.data.number} status: ${status.data.state}`)
+			nicelog(`Total required checks: ${requiredStatuses.length}`)
+			nicelog(
+				`Successful required checks: ${requiredStatuses.filter((s) => s.state === 'success').length}`
+			)
+			nicelog(
+				`Failed required checks: ${requiredStatuses.filter((s) => s.state === 'failure').length}`
+			)
+			nicelog(
+				`Pending required checks: ${requiredStatuses.filter((s) => s.state === 'pending').length}`
+			)
+
+			// Check if all required status checks have passed
+			const allRequiredPassed = requiredStatuses.every((check) => check.state === 'success')
+			const anyRequiredFailed = requiredStatuses.some((check) => check.state === 'failure')
+			const anyRequiredPending = requiredStatuses.some((check) => check.state === 'pending')
+
+			if (anyRequiredFailed) {
+				nicelog(`PR #${createdPr.data.number} has failed required checks:`)
+				requiredStatuses
+					.filter((s) => s.state === 'failure')
+					.forEach((check) => {
+						nicelog(`  - ${check.context}: ${check.description || 'Failed'}`)
+					})
+				throw new Error(`Hotfix PR #${createdPr.data.number} has failed required checks`)
+			} else if (allRequiredPassed && requiredStatuses.length > 0) {
 				nicelog(`PR #${createdPr.data.number} is ready for merge`)
 				await octokit.rest.pulls.merge({
 					owner: 'tldraw',
@@ -121,20 +152,15 @@ Original Author: @${pr.user?.login}`,
 
 				nicelog(`Successfully merged hotfix PR #${createdPr.data.number}`)
 				break
-			} else if (status.data.state === 'failure') {
-				nicelog(`PR #${createdPr.data.number} has failed checks:`)
-				status.data.statuses
-					.filter((s) => s.state === 'failure')
-					.forEach((check) => {
-						nicelog(`  - ${check.context}: ${check.description || 'Failed'}`)
-					})
-				throw new Error(`Hotfix PR #${createdPr.data.number} has failed checks`)
-			} else if (status.data.state === 'pending') {
-				nicelog(`PR #${createdPr.data.number} checks still pending, waiting...`)
+			} else if (anyRequiredPending) {
+				nicelog(`PR #${createdPr.data.number} required checks still pending, waiting...`)
 				await new Promise((resolve) => setTimeout(resolve, 15 * 1000))
 				continue
+			} else if (requiredStatuses.length === 0) {
+				nicelog(`PR #${createdPr.data.number} has no required checks configured`)
+				throw new Error(`Hotfix PR #${createdPr.data.number} has no required checks configured`)
 			} else {
-				nicelog(`PR #${createdPr.data.number} has unknown status: ${status.data.state}`)
+				nicelog(`PR #${createdPr.data.number} has unknown status for required checks`)
 				await new Promise((resolve) => setTimeout(resolve, 15 * 1000))
 				continue
 			}


### PR DESCRIPTION
The current logic does not correctly check whether all the required statuses have passed. We were only checking the `mergeable` status on the PR, but it seems that only reports whether the PR does not contain merge conflicts.

With this update we use a different api for checking if the required checks have passed. This uses:
- branch api to get the `hotfixes` [branch protections](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#get-branch-protection)
- commit statuses via the [combined status for ref api](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference)
- then check the commit statuses against the required branch protections to make sure all the required checks passed

### Change type

- [x] `other`

