### PR TITLE
Improve navigation panel contrast / icons

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1108,20 +1108,6 @@
 	display: none;
 }
 
-.tlui-navigation-panel__toggle .tlui-icon {
-	opacity: 0.24;
-}
-
-.tlui-navigation-panel__toggle:active .tlui-icon {
-	opacity: 1;
-}
-
-@media (hover: hover) {
-	.tlui-navigation-panel__toggle:hover .tlui-icon {
-		opacity: 1;
-	}
-}
-
 /* Minimap */
 
 .tlui-minimap {

--- a/packages/tldraw/src/lib/ui/components/NavigationPanel/DefaultNavigationPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/NavigationPanel/DefaultNavigationPanel.tsx
@@ -45,7 +45,7 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 								title={`${msg(unwrapLabel(actions['zoom-out'].label))} ${kbdStr(actions['zoom-out'].kbd!)}`}
 								onClick={() => actions['zoom-out'].onSelect('navigation-zone')}
 							>
-								<TldrawUiButtonIcon icon="minus" />
+								<TldrawUiButtonIcon small icon="minus" />
 							</TldrawUiToolbarButton>
 						)}
 						{ZoomMenu && <ZoomMenu key="zoom-menu" />}
@@ -56,7 +56,7 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 								title={`${msg(unwrapLabel(actions['zoom-in'].label))} ${kbdStr(actions['zoom-in'].kbd!)}`}
 								onClick={() => actions['zoom-in'].onSelect('navigation-zone')}
 							>
-								<TldrawUiButtonIcon icon="plus" />
+								<TldrawUiButtonIcon small icon="plus" />
 							</TldrawUiToolbarButton>
 						)}
 						{Minimap && (
@@ -64,10 +64,9 @@ export const DefaultNavigationPanel = memo(function DefaultNavigationPanel() {
 								type="icon"
 								data-testid="minimap.toggle-button"
 								title={msg('navigation-zone.toggle-minimap')}
-								className="tlui-navigation-panel__toggle"
 								onClick={toggleMinimap}
 							>
-								<TldrawUiButtonIcon icon={collapsed ? 'chevrons-ne' : 'chevrons-sw'} />
+								<TldrawUiButtonIcon small icon={collapsed ? 'chevron-right' : 'chevron-left'} />
 							</TldrawUiToolbarButton>
 						)}
 					</>


### PR DESCRIPTION
This pull request includes changes to improve the user interface of the navigation panel in the `tldraw` application. The most important updates involve simplifying CSS styling and modifying button components for better consistency and usability.

### UI Styling Simplifications:
* Removed CSS rules for `.tlui-navigation-panel__toggle .tlui-icon`, eliminating opacity changes on hover and active states.

### Button Component Updates:
* Updated the `DefaultNavigationPanel` component to use the `small` variant of `TldrawUiButtonIcon` for the zoom-out button.
* Updated the `DefaultNavigationPanel` component to use the `small` variant of `TldrawUiButtonIcon` for the zoom-in button.
* Modified the minimap toggle button in `DefaultNavigationPanel` to use the `small` variant of `TldrawUiButtonIcon` and replaced the icons with `chevron-right` and `chevron-left` for a more intuitive representation.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improved icons contrast and design in the navigation panel