### PR TITLE
sloppy `throttleToNextFrame`

### DIFF
--- a/packages/utils/src/lib/throttle.ts
+++ b/packages/utils/src/lib/throttle.ts
@@ -6,7 +6,7 @@ const isTest = () =>
 
 const fpsQueue: Array<() => void> = []
 const targetFps = 60
-const targetTimePerFrame = Math.floor(1000 / targetFps) // 16ms
+const targetTimePerFrame = Math.floor(1000 / targetFps) * 0.9 // ~15ms - we allow for some variance as browsers aren't that precise.
 let frameRaf: undefined | number
 let flushRaf: undefined | number
 let lastFlushTime = -targetTimePerFrame


### PR DESCRIPTION
Currently, `throttleToNextFrame` aims for frames to be _at least_ 16.66666...ms long. Browsers aren't that precise though - so frames are a bit longer, and some are a bit shorter. This means that we skip frames, even though everything is running fast enough to not need the skip. This diff introduces a little bit of sloppiness into the frame measurement, aiming for frames to be at least ~15ms instead. If you count frames of different durations while drawing over a 5 second period, you get something like this:

| Rounded frame length | Count before | Count after |
|-|-|-|
| 15ms | - | 14 |
| 16ms | 111 | 106 |
| 17ms | 106 | 146 |
| 18ms | 41 | 34 |
| ⚠️ 32ms | 9 | - |
| ⚠️ 33ms | 12 | - |
| **Total** | 279 | 300 |
| **Skipped frames** | 21 (7%) | 0 |

Allowing for individual frames to only take 15ms stops frames from getting unnecessarily dropped.

### Change type

- [x] `improvement`

### Release notes

- Prevent frames from sometimes getting dropped unnecessarily