### PR TITLE
fix(TldrawImage): ensure fonts load and asset URLs are passed

### DIFF
--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -140,6 +140,8 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 		const shapeIds = editor.getCurrentPageShapeIds()
 
 		async function setSvg() {
+			// We have to wait for the fonts to load so that we can correctly measure text sizes
+			await editor.fonts.loadRequiredFontsForCurrentPage(editor.options.maxFontsToLoadBeforeRender)
 			const imageResult = await editor.toImage([...shapeIds], {
 				bounds,
 				scale,


### PR DESCRIPTION
We weren't passing the asset urls and we weren't waiting for the fonts to load.

### Before
<img width="655" height="485" alt="image" src="https://github.com/user-attachments/assets/b96c5018-787c-4ab5-9c2f-c5300e774b55" />

### After
<img width="707" height="519" alt="image" src="https://github.com/user-attachments/assets/6302caed-2e18-4553-afca-1aa5b3e6f199" />

### Change type

- [x] `bugfix`

### Test plan

1. Open the image component example and verify fonts render correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where fonts would not load correctly in TldrawImage.