### PR TITLE
fix(dotcom): resolve CSP error in development

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -26,6 +26,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'https://stats.g.doubleclick.net',
 		'https://*.google-analytics.com',
 		'https://api.reo.dev',
+		'https://fonts.googleapis.com',
 	],
 	'font-src': [`'self'`, `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, 'data:'],
 	'frame-src': [`'self'`, `https:`],


### PR DESCRIPTION
Not sure why I only saw this error in dev, but I don't see it in prod.

I did see that we handle csp a bit differently in [head](https://github.com/tldraw/tldraw/blob/c5fa4794492228ee4dd7bdc149f7728438ace4ba/apps/dotcom/client/src/components/Head/Head.tsx#L27), so maybe that's it. @mimecuvalo maybe you have a better solution?

### Change type

- [x] `bugfix` 

### Test plan

1. <Manual test steps if applicable>

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fix a CSP error occurring in development environments.