### PR TITLE
perf: adaptive FPS

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
@@ -1,5 +1,6 @@
 import {
 	debugFlags,
+	getCurrentFps,
 	track,
 	useEditor,
 	usePassThroughWheelEvents,
@@ -110,7 +111,7 @@ function FPS() {
 					isSlow = !isSlow
 				}
 
-				fpsRef.current!.innerHTML = `FPS ${fps.toString()}`
+				fpsRef.current!.innerHTML = `FPS ${fps.toString()} (target: ${getCurrentFps()})`
 				fpsRef.current!.className =
 					`tlui-debug-panel__fps` + (isSlow ? ` tlui-debug-panel__fps__slow` : ``)
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -142,6 +142,9 @@ export function fpsThrottle(fn: {
 // @internal (undocumented)
 export function getChangedKeys<T extends object>(obj1: T, obj2: T): (keyof T)[];
 
+// @internal
+export function getCurrentFps(): number;
+
 // @internal (undocumented)
 export function getErrorAnnotations(error: Error): ErrorAnnotations;
 
@@ -430,6 +433,9 @@ type Required_2<T, K extends keyof T> = Expand<Omit<T, K> & {
 }>;
 export { Required_2 as Required }
 
+// @internal
+export function resetAdaptiveFps(): void;
+
 // @internal (undocumented)
 export function restoreUniqueId(): void;
 
@@ -464,6 +470,9 @@ export function setInLocalStorage(key: string, value: string): void;
 
 // @internal
 export function setInSessionStorage(key: string, value: string): void;
+
+// @internal
+export function setTargetFps(fps: number): void;
 
 // @internal (undocumented)
 export function sleep(ms: number): Promise<void>;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -89,7 +89,13 @@ export {
 	setInSessionStorage,
 } from './lib/storage'
 export { stringEnum } from './lib/stringEnum'
-export { fpsThrottle, throttleToNextFrame } from './lib/throttle'
+export {
+	fpsThrottle,
+	getCurrentFps,
+	resetAdaptiveFps,
+	setTargetFps,
+	throttleToNextFrame,
+} from './lib/throttle'
 export { Timers } from './lib/timers'
 export {
 	type Expand,


### PR DESCRIPTION
The throttle PR (https://github.com/tldraw/tldraw/pull/6409) reminded me of a wee conversation we had when the performance improvements went out last year (https://github.com/tldraw/tldraw/pull/2977#discussion_r1505742741) about how setting the FPS to be a constant 60 sort of short-changed the faster machines that could achieve 120fps.

When it hits 120 fps on my machine it starts feeling butter smooooth.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- perf: adaptive FPS