### PR TITLE
Fix react root memory leak

### DIFF
--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { createElement } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, Root } from 'react-dom/client'
 import { onMounted, onUnmounted, useTemplateRef } from 'vue'
 import { TldrawWrapper } from './TldrawWrapper'
 
 const tldrawWrapperEl = useTemplateRef('tldraw')
-let root: any = null
+let root: Root | null = null
 
 onMounted(() => {
 	if (!tldrawWrapperEl.value) return

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
 import { createElement } from 'react'
 import { createRoot } from 'react-dom/client'
-import { onMounted, useTemplateRef } from 'vue'
+import { onMounted, onUnmounted, useTemplateRef } from 'vue'
 import { TldrawWrapper } from './TldrawWrapper'
 
 const tldrawWrapperEl = useTemplateRef('tldraw')
+let root: any = null
 
 onMounted(() => {
 	if (!tldrawWrapperEl.value) return
-	createRoot(tldrawWrapperEl.value).render(createElement(TldrawWrapper))
+	root = createRoot(tldrawWrapperEl.value)
+	root.render(createElement(TldrawWrapper))
+})
+
+onUnmounted(() => {
+	if (root) {
+		root.unmount()
+		root = null
+	}
 })
 </script>
 


### PR DESCRIPTION
```
This PR resolves a memory leak in `templates/vue/src/App.vue`. Previously, the React root created within the Vue component's `onMounted` hook was not unmounted when the Vue component was destroyed, leading to persistent DOM nodes and resources.

The fix ensures proper cleanup by:
- Storing the `Root` instance returned by `createRoot`.
- Using Vue's `onUnmounted` hook to call `root.unmount()` and nullify the `root` reference.
- Using the correct `Root` type from `react-dom/client` for improved type safety.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Run the Vue application (`npm run dev` in `templates/vue`).
2. Observe the `App.vue` component rendering the Tldraw wrapper.
3. (Optional) Use browser developer tools to inspect memory usage or DOM nodes to confirm proper cleanup upon component unmount.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a memory leak in the Vue integration where the React root was not unmounted on component destruction.
```