### PR TITLE
allow custom jsx for icons

### DIFF
--- a/apps/examples/src/examples/bounds-snapping-shape/ui-overrides.tsx
+++ b/apps/examples/src/examples/bounds-snapping-shape/ui-overrides.tsx
@@ -16,8 +16,8 @@ export const uiOverrides: TLUiOverrides = {
 	tools(editor, tools) {
 		// Create a tool item in the ui's context.
 		tools.PlayingCard = {
-			id: 'PlayingCard',
-			icon: 'color',
+			id: 'Playing Card',
+			icon: <span style={{ fontSize: '2em' }}>🃏</span>,
 			label: 'PlayingCard',
 			kbd: 'c',
 			onSelect: () => {

--- a/apps/examples/src/examples/bounds-snapping-shape/ui-overrides.tsx
+++ b/apps/examples/src/examples/bounds-snapping-shape/ui-overrides.tsx
@@ -16,9 +16,9 @@ export const uiOverrides: TLUiOverrides = {
 	tools(editor, tools) {
 		// Create a tool item in the ui's context.
 		tools.PlayingCard = {
-			id: 'Playing Card',
+			id: 'PlayingCard',
 			icon: <span style={{ fontSize: '2em' }}>🃏</span>,
-			label: 'PlayingCard',
+			label: 'Playing Card',
 			kbd: 'c',
 			onSelect: () => {
 				editor.setCurrentTool('PlayingCard')

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2556,7 +2556,7 @@ export interface StylePickerSetProps {
 
 // @public (undocumented)
 export type StyleValuesForUi<T> = readonly {
-    readonly icon: string;
+    readonly icon: string | TLUiIconJsx;
     readonly value: T;
 }[];
 
@@ -3171,7 +3171,7 @@ export interface TLUiActionItem<TransationKey extends string = string, IconType 
     // (undocumented)
     checkbox?: boolean;
     // (undocumented)
-    icon?: IconType;
+    icon?: IconType | React_2.ReactElement;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -3219,7 +3219,7 @@ export interface TLUiButtonCheckProps {
 // @public (undocumented)
 export interface TLUiButtonIconProps {
     // (undocumented)
-    icon: string;
+    icon: string | TLUiIconJsx;
     // (undocumented)
     invertIcon?: boolean;
     // (undocumented)
@@ -3801,6 +3801,9 @@ export interface TLUiHelpMenuProps {
 }
 
 // @public (undocumented)
+export type TLUiIconJsx = ReactElement<React.HTMLAttributes<HTMLDivElement>>;
+
+// @public (undocumented)
 export interface TLUiIconProps extends React.HTMLAttributes<HTMLDivElement> {
     // (undocumented)
     children?: undefined;
@@ -3809,7 +3812,7 @@ export interface TLUiIconProps extends React.HTMLAttributes<HTMLDivElement> {
     // (undocumented)
     crossOrigin?: 'anonymous' | 'use-credentials';
     // (undocumented)
-    icon: Exclude<string, TLUiIconType> | TLUiIconType;
+    icon: Exclude<string, TLUiIconType> | TLUiIconJsx | TLUiIconType;
     // (undocumented)
     invertIcon?: boolean;
     // (undocumented)
@@ -3904,7 +3907,7 @@ export interface TLUiMenuCheckboxItemProps<TranslationKey extends string = strin
     // (undocumented)
     disabled?: boolean;
     // (undocumented)
-    icon?: IconType;
+    icon?: IconType | TLUiIconJsx;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -3952,8 +3955,8 @@ export interface TLUiMenuGroupProps<TranslationKey extends string = string> {
 // @public (undocumented)
 export interface TLUiMenuItemProps<TranslationKey extends string = string, IconType extends string = string> {
     disabled?: boolean;
-    icon?: IconType;
-    iconLeft?: IconType;
+    icon?: IconType | TLUiIconJsx;
+    iconLeft?: IconType | TLUiIconJsx;
     // (undocumented)
     id: string;
     isSelected?: boolean;
@@ -4198,7 +4201,7 @@ export interface TLUiToolbarToggleItemProps extends React_3.HTMLAttributes<HTMLB
 // @public (undocumented)
 export interface TLUiToolItem<TranslationKey extends string = string, IconType extends string = string> {
     // (undocumented)
-    icon: IconType;
+    icon: IconType | TLUiIconJsx;
     // (undocumented)
     id: string;
     kbd?: string;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -382,7 +382,11 @@ export {
 	type TLUiDropdownMenuSubTriggerProps,
 	type TLUiDropdownMenuTriggerProps,
 } from './lib/ui/components/primitives/TldrawUiDropdownMenu'
-export { TldrawUiIcon, type TLUiIconProps } from './lib/ui/components/primitives/TldrawUiIcon'
+export {
+	TldrawUiIcon,
+	type TLUiIconJsx,
+	type TLUiIconProps,
+} from './lib/ui/components/primitives/TldrawUiIcon'
 export { TldrawUiInput, type TLUiInputProps } from './lib/ui/components/primitives/TldrawUiInput'
 export { TldrawUiKbd, type TLUiKbdProps } from './lib/ui/components/primitives/TldrawUiKbd'
 export {

--- a/packages/tldraw/src/lib/styles.tsx
+++ b/packages/tldraw/src/lib/styles.tsx
@@ -1,7 +1,9 @@
+import { TLUiIconJsx } from './ui/components/primitives/TldrawUiIcon'
+
 /** @public */
 export type StyleValuesForUi<T> = readonly {
 	readonly value: T
-	readonly icon: string
+	readonly icon: string | TLUiIconJsx
 }[]
 
 // todo: default styles prop?

--- a/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonIcon.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/Button/TldrawUiButtonIcon.tsx
@@ -1,8 +1,8 @@
-import { TldrawUiIcon } from '../TldrawUiIcon'
+import { TldrawUiIcon, TLUiIconJsx } from '../TldrawUiIcon'
 
 /** @public */
 export interface TLUiButtonIconProps {
-	icon: string
+	icon: string | TLUiIconJsx
 	small?: boolean
 	invertIcon?: boolean
 }

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
@@ -1,11 +1,14 @@
 import classNames from 'classnames'
-import { memo, useLayoutEffect, useRef } from 'react'
+import { cloneElement, memo, ReactElement, useLayoutEffect, useRef } from 'react'
 import { useAssetUrls } from '../../context/asset-urls'
 import { TLUiIconType } from '../../icon-types'
 
 /** @public */
+export type TLUiIconJsx = ReactElement<React.HTMLAttributes<HTMLDivElement>>
+
+/** @public */
 export interface TLUiIconProps extends React.HTMLAttributes<HTMLDivElement> {
-	icon: TLUiIconType | Exclude<string, TLUiIconType>
+	icon: TLUiIconType | Exclude<string, TLUiIconType> | TLUiIconJsx
 	label: string
 	small?: boolean
 	color?: string
@@ -16,6 +19,41 @@ export interface TLUiIconProps extends React.HTMLAttributes<HTMLDivElement> {
 
 /** @public @react */
 export const TldrawUiIcon = memo(function TldrawUiIcon({
+	label,
+	small,
+	invertIcon,
+	icon,
+	color,
+	className,
+	...props
+}: TLUiIconProps) {
+	if (typeof icon === 'string') {
+		return (
+			<TldrawUIIconInner
+				label={label}
+				small={small}
+				invertIcon={invertIcon}
+				icon={icon}
+				color={color}
+				className={className}
+				{...props}
+			/>
+		)
+	}
+
+	return cloneElement(icon, {
+		className: classNames({ 'tlui-icon__small': small }, className, icon.props.className),
+		'aria-label': label,
+		style: {
+			color,
+			transform: invertIcon ? 'scale(-1, 1)' : undefined,
+			...icon.props.style,
+		},
+		...props,
+	})
+})
+
+function TldrawUIIconInner({
 	label,
 	small,
 	invertIcon,
@@ -69,4 +107,4 @@ export const TldrawUiIcon = memo(function TldrawUiIcon({
 			}}
 		/>
 	)
-})
+}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiIcon.tsx
@@ -42,6 +42,7 @@ export const TldrawUiIcon = memo(function TldrawUiIcon({
 	}
 
 	return cloneElement(icon, {
+		...props,
 		className: classNames({ 'tlui-icon__small': small }, className, icon.props.className),
 		'aria-label': label,
 		style: {
@@ -49,7 +50,6 @@ export const TldrawUiIcon = memo(function TldrawUiIcon({
 			transform: invertIcon ? 'scale(-1, 1)' : undefined,
 			...icon.props.style,
 		},
-		...props,
 	})
 })
 
@@ -61,7 +61,7 @@ function TldrawUIIconInner({
 	color,
 	className,
 	...props
-}: TLUiIconProps) {
+}: TLUiIconProps & { icon: TLUiIconType | Exclude<string, TLUiIconType> }) {
 	const assetUrls = useAssetUrls()
 	const asset = assetUrls.icons[icon as TLUiIconType] ?? assetUrls.icons['question-mark-circle']
 	const ref = useRef<HTMLDivElement>(null)

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
@@ -5,7 +5,7 @@ import { TLUiEventSource } from '../../../context/events'
 import { useReadonly } from '../../../hooks/useReadonly'
 import { TLUiTranslationKey } from '../../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../../hooks/useTranslation/useTranslation'
-import { TldrawUiIcon } from '../TldrawUiIcon'
+import { TldrawUiIcon, TLUiIconJsx } from '../TldrawUiIcon'
 import { TldrawUiKbd } from '../TldrawUiKbd'
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
 
@@ -14,7 +14,7 @@ export interface TLUiMenuCheckboxItemProps<
 	TranslationKey extends string = string,
 	IconType extends string = string,
 > {
-	icon?: IconType
+	icon?: IconType | TLUiIconJsx
 	id: string
 	kbd?: string
 	title?: string

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -12,6 +12,7 @@ import { TldrawUiButton } from '../Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../Button/TldrawUiButtonIcon'
 import { TldrawUiButtonLabel } from '../Button/TldrawUiButtonLabel'
 import { TldrawUiDropdownMenuItem } from '../TldrawUiDropdownMenu'
+import { TLUiIconJsx } from '../TldrawUiIcon'
 import { TldrawUiKbd } from '../TldrawUiKbd'
 import { TldrawUiToolbarButton } from '../TldrawUiToolbar'
 import { useTldrawUiMenuContext } from './TldrawUiMenuContext'
@@ -25,11 +26,11 @@ export interface TLUiMenuItemProps<
 	/**
 	 * The icon to display on the item. Icons are only shown in certain menu types.
 	 */
-	icon?: IconType
+	icon?: IconType | TLUiIconJsx
 	/**
 	 * An icon to display to the left of the menu item.
 	 */
-	iconLeft?: IconType
+	iconLeft?: IconType | TLUiIconJsx
 	/**
 	 * The keyboard shortcut to display on the item.
 	 */

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -43,7 +43,7 @@ export interface TLUiActionItem<
 	TransationKey extends string = string,
 	IconType extends string = string,
 > {
-	icon?: IconType
+	icon?: IconType | React.ReactElement
 	id: string
 	kbd?: string
 	label?: TransationKey | { [key: string]: TransationKey }

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -1,6 +1,7 @@
 import { Editor, GeoShapeGeoStyle, useMaybeEditor } from '@tldraw/editor'
 import * as React from 'react'
 import { EmbedDialog } from '../components/EmbedDialog'
+import { TLUiIconJsx } from '../components/primitives/TldrawUiIcon'
 import { useA11y } from '../context/a11y'
 import { TLUiEventSource, useUiEvents } from '../context/events'
 import { TLUiIconType } from '../icon-types'
@@ -16,7 +17,7 @@ export interface TLUiToolItem<
 	id: string
 	label: TranslationKey
 	shortcutsLabel?: TranslationKey
-	icon: IconType
+	icon: IconType | TLUiIconJsx
 	onSelect(source: TLUiEventSource): void
 	/**
 	 * The keyboard shortcut for this tool. This is a string that can be a single key,


### PR DESCRIPTION
Something that often annoys me when extending our UI is that I can't pass a custom SVG or whatever when setting icons in our buttons, tools, and actions etc.

This diff adds support for passing in JSX to use in the place of icons. There's some trickiness here as our icons sometimes need to be made small, have aria-labels, or use special classnames, but this can be worked around with some `cloneElement` juggling.

### Change type

- [x] `improvement`

### Release notes

### API Changes

- You can now pass JSX elements into the `icon` slots of tldraw UI & overrides