### PR TITLE
More shapeutil callbacks

### DIFF
--- a/.cursor/rules/repo.mdc
+++ b/.cursor/rules/repo.mdc
@@ -32,3 +32,5 @@ The workspaces are:
 - packages/utils: internal utilities and helpers. generic things we use a lot, but that aren't part of the public sdk api.
 - packages/validate: lightweight zod-inspired validation library.
 - templates/\*: starting points for building tldraw applications. some of these are minimal starters showing tldraw in different frameworks, but other are more comprehensive mini-apps showing how tldraw can be adapted to a specific domain / vertical.
+
+Tldraw is written in typescript. If you want to check types, you can run `yarn typecheck` from the root of the repo.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2624,6 +2624,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onResizeStart?(shape: Shape): TLShapePartial<Shape> | void;
     onRotate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
+    onRotateCancel?(initial: Shape, current: Shape): void;
     onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onRotateStart?(shape: Shape): TLShapePartial<Shape> | void;
     onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2620,6 +2620,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onHandleDragEnd?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onHandleDragStart?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
+    onResizeCancel?(initial: Shape, current: Shape): void;
     onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onResizeStart?(shape: Shape): TLShapePartial<Shape> | void;
     onRotate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2616,6 +2616,8 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onEditEnd?(shape: Shape): void;
     onEditStart?(shape: Shape): void;
     onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
+    onHandleDragEnd?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
+    onHandleDragStart?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
     onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onResizeStart?(shape: Shape): TLShapePartial<Shape> | void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2626,6 +2626,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onRotateStart?(shape: Shape): TLShapePartial<Shape> | void;
     onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
+    onTranslateCancel?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onTranslateStart?(shape: Shape): TLShapePartial<Shape> | void;
     options: {};

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2616,6 +2616,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onEditEnd?(shape: Shape): void;
     onEditStart?(shape: Shape): void;
     onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
+    onHandleDragCancel?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onHandleDragEnd?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onHandleDragStart?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2616,7 +2616,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onEditEnd?(shape: Shape): void;
     onEditStart?(shape: Shape): void;
     onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
-    onHandleDragCancel?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
+    onHandleDragCancel?(current: Shape, info: TLHandleDragInfo<Shape>): void;
     onHandleDragEnd?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onHandleDragStart?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;
     onResize?(shape: Shape, info: TLResizeInfo<Shape>): Omit<TLShapePartial<Shape>, 'id' | 'type'> | undefined | void;
@@ -2626,7 +2626,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onRotateStart?(shape: Shape): TLShapePartial<Shape> | void;
     onTranslate?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
-    onTranslateCancel?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
+    onTranslateCancel?(initial: Shape, current: Shape): void;
     onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void;
     onTranslateStart?(shape: Shape): TLShapePartial<Shape> | void;
     options: {};

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -585,6 +585,15 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	onResizeEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
 
 	/**
+	 * A callback called when a shape resize is cancelled.
+	 *
+	 * @param initial - The shape at the start of the resize.
+	 * @param current - The current shape.
+	 * @public
+	 */
+	onResizeCancel?(initial: Shape, current: Shape): void
+
+	/**
 	 * A callback called when a shape starts being translated.
 	 *
 	 * @param shape - The shape.
@@ -614,6 +623,25 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	onTranslateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
 
 	/**
+	 * A callback called when a shape translation is cancelled.
+	 *
+	 * @param initial - The shape at the start of the translation.
+	 * @param current - The current shape.
+	 * @public
+	 */
+	onTranslateCancel?(initial: Shape, current: Shape): void
+
+	/**
+	 * A callback called when a shape's handle starts being dragged.
+	 *
+	 * @param shape - The shape.
+	 * @param info - An object containing the handle and whether the handle is 'precise' or not.
+	 * @returns A change to apply to the shape, or void.
+	 * @public
+	 */
+	onHandleDragStart?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void
+
+	/**
 	 * A callback called when a shape's handle changes.
 	 *
 	 * @param shape - The current shape.
@@ -622,6 +650,25 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @public
 	 */
 	onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void
+
+	/**
+	 * A callback called when a shape's handle finishes being dragged.
+	 *
+	 * @param current - The current shape.
+	 * @param info - An object containing the handle and whether the handle is 'precise' or not.
+	 * @returns A change to apply to the shape, or void.
+	 * @public
+	 */
+	onHandleDragEnd?(current: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void
+
+	/**
+	 * A callback called when a shape's handle drag is cancelled.
+	 *
+	 * @param current - The current shape.
+	 * @param info - An object containing the handle and whether the handle is 'precise' or not.
+	 * @public
+	 */
+	onHandleDragCancel?(current: Shape, info: TLHandleDragInfo<Shape>): void
 
 	/**
 	 * A callback called when a shape starts being rotated.
@@ -651,6 +698,15 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	 * @public
 	 */
 	onRotateEnd?(initial: Shape, current: Shape): TLShapePartial<Shape> | void
+
+	/**
+	 * A callback called when a shape rotation is cancelled.
+	 *
+	 * @param initial - The shape at the start of the rotation.
+	 * @param current - The current shape.
+	 * @public
+	 */
+	onRotateCancel?(initial: Shape, current: Shape): void
 
 	/**
 	 * Not currently used.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1938,6 +1938,35 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
         typeName: "shape";
         x: number;
         y: number;
+    };
+    // (undocumented)
+    onHandleDragStart(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>): {
+        id: TLShapeId;
+        index: IndexKey;
+        isLocked: boolean;
+        meta: JsonObject;
+        opacity: TLOpacityType;
+        parentId: TLParentId;
+        props: {
+            color: TLDefaultColorStyle;
+            dash: TLDefaultDashStyle;
+            points: {
+                [x: string]: {
+                    id: IndexKey;
+                    index: IndexKey;
+                    x: number;
+                    y: number;
+                } | TLLineShapePoint;
+            };
+            scale: number;
+            size: TLDefaultSizeStyle;
+            spline: TLLineShapeSplineStyle;
+        };
+        rotation: number;
+        type: "line";
+        typeName: "shape";
+        x: number;
+        y: number;
     } | undefined;
     // (undocumented)
     onResize(shape: TLLineShape, info: TLResizeInfo<TLLineShape>): {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -145,8 +145,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	}
 
 	override onHandleDrag(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>) {
-		// we should only ever be dragging vertex handles
-		if (handle.type !== 'vertex') return
 		const newPoint = maybeSnapToGrid(new Vec(handle.x, handle.y), this.editor)
 		return {
 			...shape,
@@ -158,6 +156,25 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				},
 			},
 		}
+	}
+
+	override onHandleDragStart(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>) {
+		// For line shapes, if we're dragging a "create" handle, then
+		// create a new vertex handle at that point; and make this handle
+		// the handle that we're dragging.
+		if (handle.type === 'create') {
+			return {
+				...shape,
+				props: {
+					...shape.props,
+					points: {
+						...shape.props.points,
+						[handle.index]: { id: handle.index, index: handle.index, x: handle.x, y: handle.y },
+					},
+				},
+			}
+		}
+		return
 	}
 
 	component(shape: TLLineShape) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -251,10 +251,7 @@ export class DraggingHandle extends StateNode {
 				isPrecise: this.isPrecise,
 				initial: this.info.shape,
 			}
-			const cancelChanges = util.onHandleDragCancel?.(shape, handleDragInfo)
-			if (cancelChanges) {
-				this.editor.updateShapes([{ ...cancelChanges, id: shape.id, type: shape.type }])
-			}
+			util.onHandleDragCancel?.(shape, handleDragInfo)
 		}
 
 		this.editor.bailToMark(this.markId)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -242,10 +242,7 @@ export class DraggingHandle extends StateNode {
 	}
 
 	private cancel() {
-		this.editor.bailToMark(this.markId)
-		this.editor.snaps.clearIndicators()
-
-		// Call onHandleDragCancel callback
+		// Call onHandleDragCancel callback before bailing to mark
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -259,6 +256,9 @@ export class DraggingHandle extends StateNode {
 				this.editor.updateShapes([{ ...cancelChanges, id: shape.id, type: shape.type }])
 			}
 		}
+
+		this.editor.bailToMark(this.markId)
+		this.editor.snaps.clearIndicators()
 
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -216,16 +216,7 @@ export class DraggingHandle extends StateNode {
 		this.editor.snaps.clearIndicators()
 		kickoutOccludedShapes(this.editor, [this.shapeId])
 
-		const { onInteractionEnd } = this.info
-		if (this.editor.getInstanceState().isToolLocked && onInteractionEnd) {
-			// Return to the tool that was active before this one,
-			// but only if tool lock is turned on!
-			this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
-			return
-		}
-
-		this.parent.transition('idle')
-
+		// Call onHandleDragEnd callback before state transitions
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -239,6 +230,16 @@ export class DraggingHandle extends StateNode {
 				this.editor.updateShapes([{ ...endChanges, id: shape.id, type: shape.type }])
 			}
 		}
+
+		const { onInteractionEnd } = this.info
+		if (this.editor.getInstanceState().isToolLocked && onInteractionEnd) {
+			// Return to the tool that was active before this one,
+			// but only if tool lock is turned on!
+			this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
+			return
+		}
+
+		this.parent.transition('idle')
 	}
 
 	private cancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -1,4 +1,5 @@
 import {
+	Mat,
 	StateNode,
 	TLArrowShape,
 	TLHandle,
@@ -26,20 +27,20 @@ export type DraggingHandleInfo = TLPointerEventInfo & {
 export class DraggingHandle extends StateNode {
 	static override id = 'dragging_handle'
 
-	shapeId = '' as TLShapeId
-	initialHandle = {} as TLHandle
-	initialAdjacentHandle = null as TLHandle | null
-	initialPagePoint = {} as Vec
+	shapeId!: TLShapeId
+	initialHandle!: TLHandle
+	initialAdjacentHandle!: TLHandle | null
+	initialPagePoint!: Vec
 
-	markId = ''
-	initialPageTransform: any
-	initialPageRotation: any
+	markId!: string
+	initialPageTransform!: Mat
+	initialPageRotation!: number
 
-	info = {} as DraggingHandleInfo
+	info!: DraggingHandleInfo
 
 	isPrecise = false
-	isPreciseId = null as TLShapeId | null
-	pointingId = null as TLShapeId | null
+	isPreciseId: TLShapeId | null = null
+	pointingId: TLShapeId | null = null
 
 	override onEnter(info: DraggingHandleInfo) {
 		const { shape, isCreating, creatingMarkId, handle } = info
@@ -65,26 +66,6 @@ export class DraggingHandle extends StateNode {
 		}
 
 		this.initialHandle = structuredClone(handle)
-
-		if (this.editor.isShapeOfType<TLLineShape>(shape, 'line')) {
-			// For line shapes, if we're dragging a "create" handle, then
-			// create a new vertex handle at that point; and make this handle
-			// the handle that we're dragging.
-			if (this.initialHandle.type === 'create') {
-				this.editor.updateShape({
-					...shape,
-					props: {
-						points: {
-							...shape.props.points,
-							[handle.index]: { id: handle.index, index: handle.index, x: handle.x, y: handle.y },
-						},
-					},
-				})
-				const handlesAfter = this.editor.getShapeHandles(shape)!
-				const handleAfter = handlesAfter.find((h) => h.index === handle.index)!
-				this.initialHandle = structuredClone(handleAfter)
-			}
-		}
 
 		this.initialPageTransform = this.editor.getShapePageTransform(shape)!
 		this.initialPageRotation = this.initialPageTransform.rotation()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -135,6 +135,18 @@ export class DraggingHandle extends StateNode {
 		}
 		// -->
 
+		// Call onHandleDragStart callback
+		const handleDragInfo = {
+			handle: this.initialHandle,
+			isPrecise: this.isPrecise,
+			initial: shape,
+		}
+		const util = this.editor.getShapeUtil(shape)
+		const startChanges = util.onHandleDragStart?.(shape, handleDragInfo)
+		if (startChanges) {
+			this.editor.updateShapes([{ ...startChanges, id: shape.id, type: shape.type }])
+		}
+
 		this.update()
 
 		this.editor.select(this.shapeId)
@@ -213,6 +225,20 @@ export class DraggingHandle extends StateNode {
 		}
 
 		this.parent.transition('idle')
+
+		const shape = this.editor.getShape(this.shapeId)
+		if (shape) {
+			const util = this.editor.getShapeUtil(shape)
+			const handleDragInfo = {
+				handle: this.initialHandle,
+				isPrecise: this.isPrecise,
+				initial: this.info.shape,
+			}
+			const endChanges = util.onHandleDragEnd?.(shape, handleDragInfo)
+			if (endChanges) {
+				this.editor.updateShapes([{ ...endChanges, id: shape.id, type: shape.type }])
+			}
+		}
 	}
 
 	private cancel() {
@@ -228,6 +254,20 @@ export class DraggingHandle extends StateNode {
 		}
 
 		this.parent.transition('idle')
+
+		const shape = this.editor.getShape(this.shapeId)
+		if (shape) {
+			const util = this.editor.getShapeUtil(shape)
+			const handleDragInfo = {
+				handle: this.initialHandle,
+				isPrecise: this.isPrecise,
+				initial: this.info.shape,
+			}
+			const endChanges = util.onHandleDragEnd?.(shape, handleDragInfo)
+			if (endChanges) {
+				this.editor.updateShapes([{ ...endChanges, id: shape.id, type: shape.type }])
+			}
+		}
 	}
 
 	private update() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -245,6 +245,21 @@ export class DraggingHandle extends StateNode {
 		this.editor.bailToMark(this.markId)
 		this.editor.snaps.clearIndicators()
 
+		// Call onHandleDragCancel callback
+		const shape = this.editor.getShape(this.shapeId)
+		if (shape) {
+			const util = this.editor.getShapeUtil(shape)
+			const handleDragInfo = {
+				handle: this.initialHandle,
+				isPrecise: this.isPrecise,
+				initial: this.info.shape,
+			}
+			const cancelChanges = util.onHandleDragCancel?.(shape, handleDragInfo)
+			if (cancelChanges) {
+				this.editor.updateShapes([{ ...cancelChanges, id: shape.id, type: shape.type }])
+			}
+		}
+
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			// Return to the tool that was active before this one,
@@ -254,20 +269,6 @@ export class DraggingHandle extends StateNode {
 		}
 
 		this.parent.transition('idle')
-
-		const shape = this.editor.getShape(this.shapeId)
-		if (shape) {
-			const util = this.editor.getShapeUtil(shape)
-			const handleDragInfo = {
-				handle: this.initialHandle,
-				isPrecise: this.isPrecise,
-				initial: this.info.shape,
-			}
-			const endChanges = util.onHandleDragEnd?.(shape, handleDragInfo)
-			if (endChanges) {
-				this.editor.updateShapes([{ ...endChanges, id: shape.id, type: shape.type }])
-			}
-		}
 	}
 
 	private update() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -134,7 +134,6 @@ export class Resizing extends StateNode {
 		})
 
 		this.editor.bailToMark(this.markId)
-		this.editor.setCursor({ type: 'default', rotation: 0 })
 
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, {})

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -122,8 +122,20 @@ export class Resizing extends StateNode {
 	}
 
 	private cancel() {
-		// Restore initial models
+		// Call onResizeCancel callback before resetting
+		const { shapeSnapshots } = this.snapshot
+
+		shapeSnapshots.forEach(({ shape }) => {
+			const current = this.editor.getShape(shape.id)
+			if (current) {
+				const util = this.editor.getShapeUtil(shape)
+				util.onResizeCancel?.(shape, current)
+			}
+		})
+
 		this.editor.bailToMark(this.markId)
+		this.editor.setCursor({ type: 'default', rotation: 0 })
+
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, {})
 		} else {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -109,6 +109,17 @@ export class Rotating extends StateNode {
 	}
 
 	private cancel() {
+		// Call onRotateCancel callback before bailing to mark
+		const { shapeSnapshots } = this.snapshot
+
+		shapeSnapshots.forEach(({ shape }) => {
+			const current = this.editor.getShape(shape.id)
+			if (current) {
+				const util = this.editor.getShapeUtil(shape)
+				util.onRotateCancel?.(shape, current)
+			}
+		})
+
 		this.editor.bailToMark(this.markId)
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd, this.info)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -205,22 +205,14 @@ export class Translating extends StateNode {
 	private cancel() {
 		// Call onTranslateCancel callback before resetting
 		const { movingShapes } = this.snapshot
-		const changes: TLShapePartial[] = []
 
 		movingShapes.forEach((shape) => {
 			const current = this.editor.getShape(shape.id)
 			if (current) {
 				const util = this.editor.getShapeUtil(shape)
-				const change = util.onTranslateCancel?.(shape, current)
-				if (change) {
-					changes.push(change)
-				}
+				util.onTranslateCancel?.(shape, current)
 			}
 		})
-
-		if (changes.length > 0) {
-			this.editor.updateShapes(changes)
-		}
 
 		this.reset()
 		if (this.info.onInteractionEnd) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -203,6 +203,25 @@ export class Translating extends StateNode {
 	}
 
 	private cancel() {
+		// Call onTranslateCancel callback before resetting
+		const { movingShapes } = this.snapshot
+		const changes: TLShapePartial[] = []
+
+		movingShapes.forEach((shape) => {
+			const current = this.editor.getShape(shape.id)
+			if (current) {
+				const util = this.editor.getShapeUtil(shape)
+				const change = util.onTranslateCancel?.(shape, current)
+				if (change) {
+					changes.push(change)
+				}
+			}
+		})
+
+		if (changes.length > 0) {
+			this.editor.updateShapes(changes)
+		}
+
 		this.reset()
 		if (this.info.onInteractionEnd) {
 			this.editor.setCurrentTool(this.info.onInteractionEnd)

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -163,6 +163,57 @@ describe('When interacting with a shape...', () => {
 		expect(calls).toEqual(['start', 'change', 'change', 'end'])
 	})
 
+	it('Fires resizing cancel events', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+
+		const calls: string[] = []
+
+		util.onResizeStart = () => {
+			calls.push('start')
+		}
+
+		util.onResize = () => {
+			calls.push('change')
+		}
+
+		util.onResizeEnd = () => {
+			calls.push('end')
+		}
+
+		util.onResizeCancel = () => {
+			calls.push('cancel')
+		}
+
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
+
+		editor.pointerDown(300, 300, {
+			target: 'selection',
+			handle: 'bottom_right',
+		})
+
+		editor.expectToBeIn('select.pointing_resize_handle')
+
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
+		editor.pointerMove(200, 200)
+		editor.expectToBeIn('select.resizing')
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(200, 210)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
+		editor.cancel()
+
+		// Should have called cancel instead of end
+		expect(calls).toEqual(['start', 'change', 'change', 'cancel'])
+	})
+
 	it('Fires translating events', () => {
 		const util = editor.getShapeUtil<TLFrameShape>('frame')
 

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -73,16 +73,28 @@ describe('When interacting with a shape...', () => {
 		editor.selectAll()
 		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
 
-		editor
-			.pointerDown(300, 300, {
-				target: 'selection',
-				handle: 'bottom_right_rotate',
-			})
-			.pointerMove(200, 200)
-			.pointerUp(200, 200)
+		editor.pointerDown(300, 300, {
+			target: 'selection',
+			handle: 'bottom_right_rotate',
+		})
 
-		// Should have called start, change, and end in sequence
-		expect(calls).toEqual(['start', 'change', 'change', 'end'])
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
+		editor.pointerMove(200, 200)
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(200, 210)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
+		editor.pointerUp(200, 210)
+
+		// Should have called end once now
+		expect(calls).toEqual(['start', 'change', 'change', 'change', 'end'])
 	})
 
 	it('cleans up events', () => {
@@ -127,13 +139,25 @@ describe('When interacting with a shape...', () => {
 		})
 
 		editor.expectToBeIn('select.pointing_resize_handle')
+
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
 		editor.pointerMove(200, 200)
 		editor.expectToBeIn('select.resizing')
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
 		editor.pointerMove(200, 210)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
 		editor.pointerUp(200, 210)
 		editor.expectToBeIn('select.idle')
 
-		// Should have called start, change, and end in sequence
+		// Should have called end once now
 		expect(calls).toEqual(['start', 'change', 'change', 'end'])
 	})
 
@@ -158,10 +182,25 @@ describe('When interacting with a shape...', () => {
 		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
 
 		// Translate the shapes...
-		editor.pointerDown(50, 50, ids.box1).pointerMove(50, 40).pointerUp(50, 40)
+		editor.pointerDown(50, 50, ids.box1)
 
-		// Should have called start, change, and end in sequence
-		expect(calls).toEqual(['start', 'change', 'change', 'end'])
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
+		editor.pointerMove(50, 40)
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(50, 35)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
+		editor.pointerUp(50, 35)
+
+		// Should have called end once now
+		expect(calls).toEqual(['start', 'change', 'change', 'change', 'end'])
 	})
 
 	it('Uses the shape utils onClick handler', () => {

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -99,6 +99,54 @@ describe('When interacting with a shape...', () => {
 		expect(calls).toEqual(['start', 'change', 'change', 'change', 'end'])
 	})
 
+	it('fires rotate cancel events', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+
+		const calls: string[] = []
+
+		util.onRotateStart = () => {
+			calls.push('start')
+		}
+
+		util.onRotate = () => {
+			calls.push('change')
+		}
+
+		util.onRotateEnd = () => {
+			calls.push('end')
+		}
+
+		util.onRotateCancel = () => {
+			calls.push('cancel')
+		}
+
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
+
+		editor.pointerDown(300, 300, {
+			target: 'selection',
+			handle: 'bottom_right_rotate',
+		})
+
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
+		editor.pointerMove(200, 200)
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(200, 210)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
+		editor.cancel()
+
+		// Should have called cancel instead of end
+		expect(calls).toEqual(['start', 'change', 'change', 'cancel'])
+	})
+
 	it('cleans up events', () => {
 		const util = editor.getShapeUtil<TLGeoShape>('geo')
 		expect(util.onRotateStart).toBeUndefined()

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -297,7 +297,7 @@ describe('When interacting with a shape...', () => {
 		editor.pointerDown(handlePagePoint.x, handlePagePoint.y, {
 			target: 'handle',
 			shape: editor.getShape(lineShape.id)!,
-			handle: { id: 'a2', type: 'vertex', index: 'a2', x: 100, y: 100 },
+			handle: { id: 'a2', type: 'vertex', index: 'a2' as any, x: 100, y: 100 },
 		})
 
 		editor.expectToBeIn('select.pointing_handle')
@@ -380,7 +380,7 @@ describe('When interacting with a shape...', () => {
 		editor.pointerDown(handlePagePoint.x, handlePagePoint.y, {
 			target: 'handle',
 			shape: editor.getShape(lineShape.id)!,
-			handle: { id: 'a2', type: 'vertex', index: 'a2', x: 100, y: 100 },
+			handle: { id: 'a2', type: 'vertex', index: 'a2' as any, x: 100, y: 100 },
 		})
 
 		editor.expectToBeIn('select.pointing_handle')

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -205,6 +205,52 @@ describe('When interacting with a shape...', () => {
 		expect(calls).toEqual(['start', 'change', 'change', 'change', 'end'])
 	})
 
+	it('Fires translating cancel events', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+
+		const calls: string[] = []
+
+		util.onTranslateStart = () => {
+			calls.push('start')
+		}
+
+		util.onTranslate = () => {
+			calls.push('change')
+		}
+
+		util.onTranslateEnd = () => {
+			calls.push('end')
+		}
+
+		util.onTranslateCancel = () => {
+			calls.push('cancel')
+		}
+
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
+
+		// Translate the shapes...
+		editor.pointerDown(50, 50, ids.box1)
+
+		// Should not have called any callbacks yet
+		expect(calls).toEqual([])
+
+		editor.pointerMove(50, 40)
+
+		// Should have called start once and change at least once now
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(50, 35)
+
+		// Should have called start once and change multiple times
+		expect(calls).toEqual(['start', 'change', 'change'])
+
+		editor.cancel()
+
+		// Should have called cancel instead of end
+		expect(calls).toEqual(['start', 'change', 'change', 'cancel'])
+	})
+
 	it('Uses the shape utils onClick handler', () => {
 		const util = editor.getShapeUtil<TLFrameShape>('frame')
 

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -56,14 +56,19 @@ describe('When interacting with a shape...', () => {
 		// Set start / change / end events on only the geo shape
 		const util = editor.getShapeUtil<TLFrameShape>('frame')
 
-		const fnStart = jest.fn()
-		util.onRotateStart = fnStart
+		const calls: string[] = []
 
-		const fnChange = jest.fn()
-		util.onRotate = fnChange
+		util.onRotateStart = () => {
+			calls.push('start')
+		}
 
-		const fnEnd = jest.fn()
-		util.onRotateEnd = fnEnd
+		util.onRotate = () => {
+			calls.push('change')
+		}
+
+		util.onRotateEnd = () => {
+			calls.push('end')
+		}
 
 		editor.selectAll()
 		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
@@ -76,14 +81,8 @@ describe('When interacting with a shape...', () => {
 			.pointerMove(200, 200)
 			.pointerUp(200, 200)
 
-		// Once on start (for frame only)
-		expect(fnStart).toHaveBeenCalledTimes(1)
-
-		// Once on start, once during the move
-		expect(fnChange).toHaveBeenCalledTimes(2)
-
-		// Once on end
-		expect(fnEnd).toHaveBeenCalledTimes(1)
+		// Should have called start, change, and end in sequence
+		expect(calls).toEqual(['start', 'change', 'change', 'end'])
 	})
 
 	it('cleans up events', () => {
@@ -105,14 +104,19 @@ describe('When interacting with a shape...', () => {
 	it('Fires resisizing events', () => {
 		const util = editor.getShapeUtil<TLFrameShape>('frame')
 
-		const fnStart = jest.fn()
-		util.onResizeStart = fnStart
+		const calls: string[] = []
 
-		const fnChange = jest.fn()
-		util.onResize = fnChange
+		util.onResizeStart = () => {
+			calls.push('start')
+		}
 
-		const fnEnd = jest.fn()
-		util.onResizeEnd = fnEnd
+		util.onResize = () => {
+			calls.push('change')
+		}
+
+		util.onResizeEnd = () => {
+			calls.push('end')
+		}
 
 		editor.selectAll()
 		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
@@ -129,27 +133,26 @@ describe('When interacting with a shape...', () => {
 		editor.pointerUp(200, 210)
 		editor.expectToBeIn('select.idle')
 
-		// Once on start (for frame only)
-		expect(fnStart).toHaveBeenCalledTimes(1)
-
-		// Once on start, once during the resize
-		expect(fnChange).toHaveBeenCalledTimes(2)
-
-		// Once on end
-		expect(fnEnd).toHaveBeenCalledTimes(1)
+		// Should have called start, change, and end in sequence
+		expect(calls).toEqual(['start', 'change', 'change', 'end'])
 	})
 
 	it('Fires translating events', () => {
 		const util = editor.getShapeUtil<TLFrameShape>('frame')
 
-		const fnStart = jest.fn()
-		util.onTranslateStart = fnStart
+		const calls: string[] = []
 
-		const fnChange = jest.fn()
-		util.onTranslate = fnChange
+		util.onTranslateStart = () => {
+			calls.push('start')
+		}
 
-		const fnEnd = jest.fn()
-		util.onTranslateEnd = fnEnd
+		util.onTranslate = () => {
+			calls.push('change')
+		}
+
+		util.onTranslateEnd = () => {
+			calls.push('end')
+		}
 
 		editor.selectAll()
 		expect(editor.getSelectedShapeIds()).toMatchObject([ids.frame1, ids.box1])
@@ -157,14 +160,8 @@ describe('When interacting with a shape...', () => {
 		// Translate the shapes...
 		editor.pointerDown(50, 50, ids.box1).pointerMove(50, 40).pointerUp(50, 40)
 
-		// Once on start for frame
-		expect(fnStart).toHaveBeenCalledTimes(1)
-
-		// Once on start, once during the move
-		expect(fnChange).toHaveBeenCalledTimes(2)
-
-		// Once on end
-		expect(fnEnd).toHaveBeenCalledTimes(1)
+		// Should have called start, change, and end in sequence
+		expect(calls).toEqual(['start', 'change', 'change', 'end'])
 	})
 
 	it('Uses the shape utils onClick handler', () => {


### PR DESCRIPTION
* Adds start & end handle dragging callbacks to shape utils
* Adds cancel to to all long-running interaction callbacks in shape utils (handle dragging, translate, rotate, resize)

This is for completeness, but largely fell out of the needs of the workflow builder starter kit

### Change type

- [x] `api`

### Release notes

### API Changes
* Add `onHandleDragStart` and `onHandleDragEnd` to `ShapeUtil` to complement `onHandleDrag`
* Add `onTranslateCancel`, `onResizeCancel`, `onRotateCancel`, and `onHandleDragCancel` callbacks to `ShapeUtil`