### PR TITLE
feat(api): add isCreatingShape to ShapeUtil handle drag callbacks

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3674,6 +3674,8 @@ export interface TLHandleDragInfo<T extends TLShape> {
     // (undocumented)
     initial?: T | undefined;
     // (undocumented)
+    isCreatingShape: boolean;
+    // (undocumented)
     isPrecise: boolean;
 }
 

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -875,5 +875,6 @@ export interface TLResizeInfo<T extends TLShape> {
 export interface TLHandleDragInfo<T extends TLShape> {
 	handle: TLHandle
 	isPrecise: boolean
+	isCreatingShape: boolean
 	initial?: T | undefined
 }

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -118,6 +118,7 @@ export class Pointing extends StateNode {
 		const change = util.onHandleDrag?.(shape, {
 			handle: { ...startHandle, x: 0, y: 0 },
 			isPrecise: true,
+			isCreatingShape: true,
 			initial: initial,
 		})
 
@@ -145,6 +146,7 @@ export class Pointing extends StateNode {
 			const change = util.onHandleDrag?.(shape, {
 				handle: { ...startHandle, x: 0, y: 0 },
 				isPrecise: this.isPrecise,
+				isCreatingShape: true,
 				initial: initial,
 			})
 
@@ -162,6 +164,7 @@ export class Pointing extends StateNode {
 			const change = util.onHandleDrag?.(this.editor.getShape(shape)!, {
 				handle: { ...endHandle, x: point.x, y: point.y },
 				isPrecise: false,
+				isCreatingShape: true,
 				initial: initial,
 			})
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -120,6 +120,7 @@ export class DraggingHandle extends StateNode {
 		const handleDragInfo = {
 			handle: this.initialHandle,
 			isPrecise: this.isPrecise,
+			isCreatingShape: !!this.info.isCreating,
 			initial: shape,
 		}
 		const util = this.editor.getShapeUtil(shape)
@@ -204,6 +205,7 @@ export class DraggingHandle extends StateNode {
 			const handleDragInfo = {
 				handle: this.initialHandle,
 				isPrecise: this.isPrecise,
+				isCreatingShape: !!this.info.isCreating,
 				initial: this.info.shape,
 			}
 			const endChanges = util.onHandleDragEnd?.(shape, handleDragInfo)
@@ -231,6 +233,7 @@ export class DraggingHandle extends StateNode {
 			const handleDragInfo = {
 				handle: this.initialHandle,
 				isPrecise: this.isPrecise,
+				isCreatingShape: !!this.info.isCreating,
 				initial: this.info.shape,
 			}
 			util.onHandleDragCancel?.(shape, handleDragInfo)
@@ -304,6 +307,7 @@ export class DraggingHandle extends StateNode {
 		const changes = util.onHandleDrag?.(shape, {
 			handle: nextHandle,
 			isPrecise: this.isPrecise || altKey,
+			isCreatingShape: !!this.info.isCreating,
 			initial: initial,
 		})
 

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -562,6 +562,7 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 										y: point.y,
 									},
 									isPrecise: point.x !== 0.5 || point.y !== 0.5,
+									isCreatingShape: true,
 								})
 
 								if (change) {


### PR DESCRIPTION
Extracted from workflow builder work

### Change type

- [x] `api`

### Test plan

1. Verify that handle drag callbacks now receive the isCreatingShape parameter.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Pass `isCreatingShape` to `ShapeUtil.onHandleDrag` and other handle drag callbacks. This will be true if the current interaction is creating the shape in question.