### PR TITLE
Fix hotfixing

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -96,9 +96,6 @@ Original Author: @${pr.user?.login}`,
 
 				nicelog(`Successfully merged hotfix PR #${createdPr.data.number}`)
 				break
-			} else if (prStatus.mergeable_state === 'blocked') {
-				nicelog(`PR #${createdPr.data.number} is blocked (likely failed checks)`)
-				throw new Error(`Hotfix PR #${createdPr.data.number} is blocked`)
 			} else if (prStatus.mergeable_state === 'unstable') {
 				nicelog(`PR #${createdPr.data.number} is unstable (some checks failed)`)
 				throw new Error(`Hotfix PR #${createdPr.data.number} is unstable`)


### PR DESCRIPTION
Let's not error on blocked status and continue polling for a while.

Example where this workflow failed https://github.com/tldraw/tldraw/actions/runs/16517667041/job/46711978567

### Change type

- [x] `bugfix`
