### PR TITLE
feat: export additional components and methods

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1680,6 +1680,9 @@ export function getArrowTerminalsInArrowSpace(editor: Editor, shape: TLArrowShap
 };
 
 // @public (undocumented)
+export function getAssetInfo(file: File, options: TLDefaultExternalContentHandlerOpts, assetId?: TLAssetId): Promise<TLImageAsset | TLVideoAsset>;
+
+// @public (undocumented)
 export function getCropBox<T extends ShapeWithCrop>(shape: T, info: TLCropInfo<T>, opts?: CropBoxOptions): {
     id: TLShapeId;
     props: ShapeWithCrop['props'];
@@ -1693,6 +1696,9 @@ export function getDefaultCrop(): TLShapeCrop;
 
 // @public
 export function getEmbedInfo(definitions: readonly TLEmbedDefinition[], inputUrl: string): TLEmbedResult;
+
+// @public (undocumented)
+export function getHitShapeOnCanvasPointerDown(editor: Editor, hitLabels?: boolean): TLShape | undefined;
 
 // @public (undocumented)
 export function getMediaAssetInfoPartial(file: File, assetId: TLAssetId, isImageType: boolean, isVideoType: boolean, maxImageDimension?: number): Promise<TLImageAsset | TLVideoAsset>;
@@ -1997,6 +2003,9 @@ export interface LineToPathBuilderCommand extends PathBuilderCommandBase {
     // (undocumented)
     type: 'line';
 }
+
+// @public (undocumented)
+export function LockGroup(): JSX_2.Element;
 
 // @public (undocumented)
 export function MiscMenuGroup(): JSX_2.Element;
@@ -2861,6 +2870,21 @@ export interface TldrawBaseProps extends TldrawUiProps, TldrawEditorBaseProps, T
     assetUrls?: TLUiAssetUrlOverrides;
     components?: TLComponents;
     embeds?: TLEmbedDefinition[];
+}
+
+// @public (undocumented)
+export function TldrawCropHandles({ size, width, height, hideAlternateHandles, }: TldrawCropHandlesProps): JSX_2.Element;
+
+// @public (undocumented)
+export interface TldrawCropHandlesProps {
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    hideAlternateHandles: boolean;
+    // (undocumented)
+    size: number;
+    // (undocumented)
+    width: number;
 }
 
 // @public (undocumented)
@@ -4768,6 +4792,15 @@ export function ToggleReduceMotionItem(): JSX_2.Element;
 export function ToggleSnapModeItem(): JSX_2.Element;
 
 // @public (undocumented)
+export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonProps): JSX_2.Element | null;
+
+// @public (undocumented)
+export interface ToggleToolLockedButtonProps {
+    // (undocumented)
+    activeToolId?: string;
+}
+
+// @public (undocumented)
 export function ToggleToolLockItem(): JSX_2.Element;
 
 // @public (undocumented)
@@ -4990,6 +5023,9 @@ export function useTranslation(): (id?: Exclude<string, TLUiTranslationKey> | st
 
 // @public (undocumented)
 export function useUiEvents(): TLUiEventContextType;
+
+// @public
+export function useUnlockedSelectedShapesCount(min?: number, max?: number): boolean | number;
 
 // @public (undocumented)
 export interface VideoShapeOptions {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -41,6 +41,7 @@ export { TldrawUiTranslationProvider } from './lib/ui/hooks/useTranslation/useTr
 // eslint-disable-next-line local/no-export-star
 export * from '@tldraw/editor'
 export { ArrowBindingUtil } from './lib/bindings/arrow/ArrowBindingUtil'
+export { TldrawCropHandles, type TldrawCropHandlesProps } from './lib/canvas/TldrawCropHandles'
 export { TldrawHandles } from './lib/canvas/TldrawHandles'
 export { TldrawArrowHints, TldrawOverlays } from './lib/canvas/TldrawOverlays'
 export { TldrawScribble } from './lib/canvas/TldrawScribble'
@@ -71,6 +72,7 @@ export {
 	defaultHandleExternalTldrawContent,
 	defaultHandleExternalUrlAsset,
 	defaultHandleExternalUrlContent,
+	getAssetInfo,
 	getMediaAssetInfoPartial,
 	registerDefaultExternalContentHandlers,
 	type TLDefaultExternalContentHandlerOpts,
@@ -183,6 +185,7 @@ export { TldrawImage, type TldrawImageProps } from './lib/TldrawImage'
 export { EraserTool } from './lib/tools/EraserTool/EraserTool'
 export { HandTool } from './lib/tools/HandTool/HandTool'
 export { LaserTool } from './lib/tools/LaserTool/LaserTool'
+export { getHitShapeOnCanvasPointerDown } from './lib/tools/selection-logic/getHitShapeOnCanvasPointerDown'
 export { SelectTool } from './lib/tools/SelectTool/SelectTool'
 export { ZoomTool } from './lib/tools/ZoomTool/ZoomTool'
 export {
@@ -250,6 +253,7 @@ export {
 	EditSubmenu,
 	ExportFileContentSubMenu,
 	ExtrasGroup,
+	LockGroup,
 	MiscMenuGroup,
 	PreferencesGroup,
 	UndoRedoGroup,
@@ -500,6 +504,10 @@ export {
 	type OverflowingToolbarProps,
 } from './lib/ui/components/Toolbar/OverflowingToolbar'
 export {
+	ToggleToolLockedButton,
+	type ToggleToolLockedButtonProps,
+} from './lib/ui/components/Toolbar/ToggleToolLockedButton'
+export {
 	CenteredTopPanelContainer,
 	type CenteredTopPanelContainerProps,
 } from './lib/ui/components/TopPanel/CenteredTopPanelContainer'
@@ -568,7 +576,7 @@ export {
 	type TLUiToastsContextType,
 	type TLUiToastsProviderProps,
 } from './lib/ui/context/toasts'
-export { useCanRedo, useCanUndo } from './lib/ui/hooks/menu-hooks'
+export { useCanRedo, useCanUndo, useUnlockedSelectedShapesCount } from './lib/ui/hooks/menu-hooks'
 export { useMenuClipboardEvents, useNativeClipboardEvents } from './lib/ui/hooks/useClipboardEvents'
 export {
 	useCollaborationStatus,

--- a/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
@@ -2,6 +2,7 @@ import { toDomPrecision } from '@tldraw/editor'
 import classNames from 'classnames'
 import { useTranslation } from '../ui/hooks/useTranslation/useTranslation'
 
+/** @public */
 export interface TldrawCropHandlesProps {
 	size: number
 	width: number
@@ -9,6 +10,7 @@ export interface TldrawCropHandlesProps {
 	hideAlternateHandles: boolean
 }
 
+/** @public */
 export function TldrawCropHandles({
 	size,
 	width,

--- a/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawCropHandles.tsx
@@ -10,7 +10,7 @@ export interface TldrawCropHandlesProps {
 	hideAlternateHandles: boolean
 }
 
-/** @public */
+/** @public @react */
 export function TldrawCropHandles({
 	size,
 	width,

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -915,7 +915,8 @@ function runFileChecks(file: File, options: TLDefaultExternalContentHandlerOpts)
 	return true
 }
 
-async function getAssetInfo(
+/** @public */
+export async function getAssetInfo(
 	file: File,
 	options: TLDefaultExternalContentHandlerOpts,
 	assetId?: TLAssetId

--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -1,5 +1,6 @@
 import { Editor, TLShape } from '@tldraw/editor'
 
+/** @public */
 export function getHitShapeOnCanvasPointerDown(
 	editor: Editor,
 	hitLabels = false

--- a/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
@@ -6,10 +6,12 @@ import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 
-interface ToggleToolLockedButtonProps {
+/** @public */
+export interface ToggleToolLockedButtonProps {
 	activeToolId?: string
 }
 
+/** @public */
 export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonProps) {
 	const editor = useEditor()
 	const breakpoint = useBreakpoint()

--- a/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/ToggleToolLockedButton.tsx
@@ -11,7 +11,7 @@ export interface ToggleToolLockedButtonProps {
 	activeToolId?: string
 }
 
-/** @public */
+/** @public @react */
 export function ToggleToolLockedButton({ activeToolId }: ToggleToolLockedButtonProps) {
 	const editor = useEditor()
 	const breakpoint = useBreakpoint()

--- a/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
+++ b/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
@@ -123,6 +123,7 @@ export function useAnySelectedShapesCount(min?: number, max?: number) {
 
 /**
  * Returns true if the number of UNLOCKED selected shapes is at least min or at most max.
+ * @public
  */
 export function useUnlockedSelectedShapesCount(min?: number, max?: number) {
 	const editor = useEditor()


### PR DESCRIPTION
This PR resolves #6501 and exports several internal components, methods, and hooks that were previously only available internally.

### API changes
I have exported the below methods, hooks, and components -
- `TldrawCropHandles` component and `TldrawCropHandlesProps` interface
- `ToggleToolLockedButton` component and `ToggleToolLockedButtonProps` interface
- `getHitShapeOnCanvasPointerDown` method
- `getAssetInfo` method
- `useUnlockedSelectedShapesCount` hook
- `LockGroup` component

All exports are properly documented with JSDoc `@public` tags.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Import any of the newly exported components/methods from `tldraw`/ `@tldraw/tldraw`

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Added public exports for `TldrawCropHandles`, `ToggleToolLockedButton`, `getHitShapeOnCanvasPointerDown`, `getAssetInfo`, `useUnlockedSelectedShapesCount`, and `LockGroup` to support external customization use cases.