### PR TITLE
add custom shape wrapper component

### DIFF
--- a/apps/examples/src/examples/custom-shape-wrapper/CustomShapeWrapperExample.tsx
+++ b/apps/examples/src/examples/custom-shape-wrapper/CustomShapeWrapperExample.tsx
@@ -1,0 +1,131 @@
+import classNames from 'classnames'
+import { forwardRef } from 'react'
+import {
+	atom,
+	Editor,
+	TLComponents,
+	Tldraw,
+	TLShapeId,
+	TLShapeWrapperProps,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// There's a guide at the bottom of this file!
+
+// [1]
+const specialShapeId = atom<TLShapeId | null>('special shape id', null)
+
+// [2]
+const CustomShapeWrapper = forwardRef(function CustomShapeWrapper(
+	{ children, shape, isBackground }: TLShapeWrapperProps,
+	ref: React.Ref<HTMLDivElement>
+) {
+	// [a]
+	const isSpecial = useValue('is special', () => specialShapeId.get() === shape.id, [shape.id])
+
+	// [b]
+	const isFilledShape = 'fill' in shape.props && shape.props.fill !== 'none'
+
+	return (
+		<div
+			ref={ref}
+			className={classNames('tl-shape', {
+				'tl-shape-background': isBackground,
+				'custom-special-shape': isSpecial,
+			})}
+			data-shape-type={shape.type}
+			data-shape-is-filled={isBackground ? undefined : isFilledShape}
+			data-shape-id={shape.id}
+			draggable={false}
+		>
+			{children}
+		</div>
+	)
+})
+
+// [3]
+const components: TLComponents = {
+	ShapeWrapper: CustomShapeWrapper,
+}
+
+export default function BasicExample() {
+	return (
+		<div className="tldraw__editor">
+			<style>{`
+				.custom-special-shape {
+					filter: drop-shadow(0 0 3px rgba(255, 0, 0));
+				}
+			`}</style>
+			<Tldraw
+				components={components}
+				onMount={(editor) => {
+					createSomeRandomShapes(editor)
+
+					const timer = setInterval(() => {
+						const allShapes = editor.getCurrentPageShapesSorted()
+						const randomShape = allShapes[Math.floor(Math.random() * allShapes.length)]
+						specialShapeId.set(randomShape.id)
+					}, 1000)
+
+					return () => {
+						clearInterval(timer)
+					}
+				}}
+			/>
+		</div>
+	)
+}
+
+function createSomeRandomShapes(editor: Editor) {
+	const bounds = editor.getViewportPageBounds()
+	for (let i = 0; i < 10; i++) {
+		editor.createShape({
+			type: 'geo',
+			x: bounds.x + Math.random() * bounds.width,
+			y: bounds.y + Math.random() * bounds.height,
+		})
+	}
+}
+
+/*
+Introduction:
+
+You can customize how shapes are wrapped in tldraw by creating a custom shape wrapper component and
+passing it to the Tldraw component. In this example, we'll create a custom shape wrapper that adds a
+red drop shadow to a randomly selected shape every second.
+
+[1] We create an atom to store the ID of the currently "special" shape. Atoms are part of tldraw's
+reactive state system and allow us to create reactive values that can be observed and updated. This
+atom will hold the ID of the shape that should have the special styling applied to it.
+
+[2] This is our custom shape wrapper component. Shape wrappers are React components that wrap around
+every shape in the editor, allowing you to add custom styling, behavior, or data attributes to
+shapes. We use forwardRef to properly forward the ref that tldraw passes to us.
+
+    [a]
+    We use the useValue hook to create a reactive value that checks if the current shape is the "special" shape.
+    This will automatically update whenever the specialShapeId atom changes. We also check if the shape is filled
+    by looking at its props.
+
+    [b]
+    We return a div that wraps the shape's children. The logic here is adapted from the DefaultShapeWrapper, with
+	our special shape classadded.
+
+[3] We create a components object that tells tldraw to use our custom shape wrapper. The
+TLComponents type allows us to override various parts of the tldraw UI, including the ShapeWrapper
+component.
+
+[4] In the main component, we add CSS that applies a red drop shadow to any element with the
+'custom-special-shape' class. We also set up a timer that randomly selects a shape every second and
+makes it the "special" shape by updating the specialShapeId atom.
+
+The shape wrapper approach is useful when you want to:
+- Add custom styling to all shapes or specific shapes
+- Add data attributes for CSS targeting
+- Implement custom behavior that affects how shapes are rendered
+- Create visual effects that apply to the shape container rather than the shape content
+
+This is different from custom shapes (like in the CustomShapeExample) because it doesn't change what
+the shape is, only how it's wrapped and styled in the editor.
+*/

--- a/apps/examples/src/examples/custom-shape-wrapper/README.md
+++ b/apps/examples/src/examples/custom-shape-wrapper/README.md
@@ -1,0 +1,11 @@
+---
+title: Custom shape wrapper
+component: ./CustomShapeWrapperExample.tsx
+category: shapes/tools
+---
+
+Customize the wrapper used for each shape in the DOM.
+
+---
+
+Use a custom shape wrapper to apply a special class names to shapes.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -13,6 +13,7 @@ import { Editor as Editor_2 } from '@tiptap/core';
 import { EditorProviderProps as EditorProviderProps_2 } from '@tiptap/react';
 import EventEmitter from 'eventemitter3';
 import { ExoticComponent } from 'react';
+import { ForwardRefExoticComponent } from 'react';
 import { HistoryEntry } from '@tldraw/store';
 import { IndexKey } from '@tldraw/utils';
 import { JsonObject } from '@tldraw/utils';
@@ -29,6 +30,7 @@ import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RecordProps } from '@tldraw/tlschema';
 import { RecordsDiff } from '@tldraw/store';
+import { RefAttributes } from 'react';
 import { RefObject } from 'react';
 import { SerializedSchema } from '@tldraw/store';
 import { SerializedStore } from '@tldraw/store';
@@ -643,6 +645,9 @@ export const DefaultShapeIndicator: NamedExoticComponent<TLShapeIndicatorProps>;
 
 // @public (undocumented)
 export const DefaultShapeIndicators: NamedExoticComponent<TLShapeIndicatorsProps>;
+
+// @public (undocumented)
+export const DefaultShapeWrapper: ForwardRefExoticComponent<TLShapeWrapperProps & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export function DefaultSnapIndicator({ className, line, zoom }: TLSnapIndicatorProps): JSX_2.Element;
@@ -3365,6 +3370,8 @@ export interface TLEditorComponents {
     // (undocumented)
     ShapeIndicators?: ComponentType | null;
     // (undocumented)
+    ShapeWrapper?: ComponentType<TLShapeWrapperProps & RefAttributes<HTMLDivElement>> | null;
+    // (undocumented)
     SnapIndicator?: ComponentType<TLSnapIndicatorProps> | null;
     // (undocumented)
     Spinner?: ComponentType<React.SVGProps<SVGSVGElement>> | null;
@@ -4086,6 +4093,13 @@ export interface TLShapeUtilConstructor<T extends TLUnknownShape, U extends Shap
     props?: RecordProps<T>;
     // (undocumented)
     type: T['type'];
+}
+
+// @public (undocumented)
+export interface TLShapeWrapperProps {
+    children: ReactNode;
+    isBackground: boolean;
+    shape: TLShape;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -68,6 +68,10 @@ export {
 	type TLShapeIndicatorsProps,
 } from './lib/components/default-components/DefaultShapeIndicators'
 export {
+	DefaultShapeWrapper,
+	type TLShapeWrapperProps,
+} from './lib/components/default-components/DefaultShapeWrapper'
+export {
 	DefaultSnapIndicator,
 	type TLSnapIndicatorProps,
 } from './lib/components/default-components/DefaultSnapIndictor'

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -40,7 +40,7 @@ export const Shape = memo(function Shape({
 }) {
 	const editor = useEditor()
 
-	const { ShapeErrorFallback } = useEditorComponents()
+	const { ShapeErrorFallback, ShapeWrapper } = useEditorComponents()
 
 	const containerRef = useRef<HTMLDivElement>(null)
 	const bgContainerRef = useRef<HTMLDivElement>(null)
@@ -145,37 +145,22 @@ export const Shape = memo(function Shape({
 		[editor]
 	)
 
-	if (!shape) return null
-
-	const isFilledShape = 'fill' in shape.props && shape.props.fill !== 'none'
+	if (!shape || !ShapeWrapper) return null
 
 	return (
 		<>
 			{util.backgroundComponent && (
-				<div
-					ref={bgContainerRef}
-					className="tl-shape tl-shape-background"
-					data-shape-type={shape.type}
-					data-shape-id={shape.id}
-					draggable={false}
-				>
+				<ShapeWrapper ref={bgContainerRef} shape={shape} isBackground={true}>
 					<OptionalErrorBoundary fallback={ShapeErrorFallback} onError={annotateError}>
 						<InnerShapeBackground shape={shape} util={util} />
 					</OptionalErrorBoundary>
-				</div>
+				</ShapeWrapper>
 			)}
-			<div
-				ref={containerRef}
-				className="tl-shape"
-				data-shape-type={shape.type}
-				data-shape-is-filled={isFilledShape}
-				data-shape-id={shape.id}
-				draggable={false}
-			>
+			<ShapeWrapper ref={containerRef} shape={shape} isBackground={false}>
 				<OptionalErrorBoundary fallback={ShapeErrorFallback as any} onError={annotateError}>
 					<InnerShape shape={shape} util={util} />
 				</OptionalErrorBoundary>
-			</div>
+			</ShapeWrapper>
 		</>
 	)
 })

--- a/packages/editor/src/lib/components/default-components/DefaultShapeWrapper.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeWrapper.tsx
@@ -1,0 +1,33 @@
+import { TLShape } from '@tldraw/tlschema'
+import { forwardRef, ReactNode } from 'react'
+
+/** @public */
+export interface TLShapeWrapperProps {
+	/** The shape being rendered. */
+	shape: TLShape
+	/** Whether this is the shapes regular, or background component. */
+	isBackground: boolean
+	/** The shape's rendered component. */
+	children: ReactNode
+}
+
+/** @public @react */
+export const DefaultShapeWrapper = forwardRef(function DefaultShapeWrapper(
+	{ children, shape, isBackground }: TLShapeWrapperProps,
+	ref: React.Ref<HTMLDivElement>
+) {
+	const isFilledShape = 'fill' in shape.props && shape.props.fill !== 'none'
+
+	return (
+		<div
+			ref={ref}
+			className={isBackground ? 'tl-shape tl-shape-background' : 'tl-shape'}
+			data-shape-type={shape.type}
+			data-shape-is-filled={isBackground ? undefined : isFilledShape}
+			data-shape-id={shape.id}
+			draggable={false}
+		>
+			{children}
+		</div>
+	)
+})

--- a/packages/editor/src/lib/hooks/useEditorComponents.tsx
+++ b/packages/editor/src/lib/hooks/useEditorComponents.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode, createContext, useContext, useMemo } from 'react'
+import { ComponentType, ReactNode, RefAttributes, createContext, useContext, useMemo } from 'react'
 import { DefaultBackground } from '../components/default-components/DefaultBackground'
 import { DefaultBrush, TLBrushProps } from '../components/default-components/DefaultBrush'
 import {
@@ -38,6 +38,10 @@ import {
 } from '../components/default-components/DefaultShapeIndicatorErrorFallback'
 import { DefaultShapeIndicators } from '../components/default-components/DefaultShapeIndicators'
 import {
+	DefaultShapeWrapper,
+	TLShapeWrapperProps,
+} from '../components/default-components/DefaultShapeWrapper'
+import {
 	DefaultSnapIndicator,
 	TLSnapIndicatorProps,
 } from '../components/default-components/DefaultSnapIndictor'
@@ -68,6 +72,7 @@ export interface TLEditorComponents {
 	SelectionForeground?: ComponentType<TLSelectionForegroundProps> | null
 	ShapeIndicator?: ComponentType<TLShapeIndicatorProps> | null
 	ShapeIndicators?: ComponentType | null
+	ShapeWrapper?: ComponentType<TLShapeWrapperProps & RefAttributes<HTMLDivElement>> | null
 	SnapIndicator?: ComponentType<TLSnapIndicatorProps> | null
 	Spinner?: ComponentType<React.SVGProps<SVGSVGElement>> | null
 	SvgDefs?: ComponentType | null
@@ -114,6 +119,7 @@ export function EditorComponentsProvider({
 			SelectionForeground: DefaultSelectionForeground,
 			ShapeIndicator: DefaultShapeIndicator,
 			ShapeIndicators: DefaultShapeIndicators,
+			ShapeWrapper: DefaultShapeWrapper,
 			SnapIndicator: DefaultSnapIndicator,
 			Spinner: DefaultSpinner,
 			SvgDefs: DefaultSvgDefs,


### PR DESCRIPTION
Sometimes, it's useful to customize how shapes are rendered without digging into the shape itself - for example, to apply custom css classnames to a subset of shapes.

This diff introduces a `ShapeWrapper` component (extracted from the `Shape` component) and makes it overridable in the same way other editor components are. It also adds an example showing how this new API can be used to style a specific shape.

### Change type

- [x] `api`
- [ ] `other`

### Release notes

### API Changes

- Add `ShapeWrapper` to the `components` prop to allow customising how every single shape is rendered to the DOM.