### PR TITLE
Adds a `data-state` attribute with the current state-tree path to tl-container 

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -39,6 +39,7 @@ import { useForceUpdate } from './hooks/useForceUpdate'
 import { useShallowObjectIdentity } from './hooks/useIdentity'
 import { useLocalStore } from './hooks/useLocalStore'
 import { useRefState } from './hooks/useRefState'
+import { useStateAttribute } from './hooks/useStateAttribute'
 import { useZoomCss } from './hooks/useZoomCss'
 import { LicenseProvider } from './license/LicenseProvider'
 import { Watermark } from './license/Watermark'
@@ -646,6 +647,7 @@ function Layout({ children, onMount }: { children: ReactNode; onMount?: TLOnMoun
 	useCursor()
 	useDarkMode()
 	useForceUpdate()
+	useStateAttribute()
 	useOnMount((editor) => {
 		const teardownStore = editor.store.props.onMount(editor)
 		const teardownCallback = onMount?.(editor)

--- a/packages/editor/src/lib/hooks/useStateAttribute.ts
+++ b/packages/editor/src/lib/hooks/useStateAttribute.ts
@@ -1,0 +1,15 @@
+import { react } from '@tldraw/state'
+import { useLayoutEffect } from 'react'
+import { useEditor } from './useEditor'
+
+export function useStateAttribute() {
+	const editor = useEditor()
+
+	// we use a layout effect because we don't want there to be any perceptible delay between the
+	// editor mounting and this attribute being applied, because styles may depend on it:
+	useLayoutEffect(() => {
+		return react('stateAttribute', () => {
+			editor.getContainer().setAttribute('data-state', editor.getPath())
+		})
+	}, [editor])
+}


### PR DESCRIPTION
This means you can write CSS targeting certain tool states. e.g.

```css
/* only interactive in select.idle: */
.tl-container[data-state="select.idle"] .myThing {
  pointer-events: all;
}

/* interactive in all select substates: */
.tl-container[date-state^="select."] .myThing {
  pointer-events: all;
}
```

### Change type
- [x] `api`

### Release notes

- There's now a `data-state` attribute on `.tl-container` which contains the current state tree path. This makes it easier to write styles based on the current interaction state.