### PR TITLE
Improve room history logic.

### DIFF
--- a/apps/dotcom/client/src/components/BoardHistoryLog/BoardHistoryLog.tsx
+++ b/apps/dotcom/client/src/components/BoardHistoryLog/BoardHistoryLog.tsx
@@ -9,6 +9,33 @@ interface BoardHistoryLogProps {
 	isLoading?: boolean
 }
 
+function getMonthYear(timestamp: string): string {
+	const date = new Date(timestamp)
+	return Intl.DateTimeFormat('en-GB', {
+		year: 'numeric',
+		month: 'long',
+	}).format(date)
+}
+
+function groupTimestampsByMonth(
+	timestamps: string[]
+): Array<{ month: string; timestamps: string[] }> {
+	const groups: { [key: string]: string[] } = {}
+
+	timestamps.forEach((timestamp) => {
+		const monthKey = getMonthYear(timestamp)
+		if (!groups[monthKey]) {
+			groups[monthKey] = []
+		}
+		groups[monthKey].push(timestamp)
+	})
+
+	return Object.entries(groups).map(([month, timestamps]) => ({
+		month,
+		timestamps,
+	}))
+}
+
 export function BoardHistoryLog({ data, hasMore, onLoadMore, isLoading }: BoardHistoryLogProps) {
 	if (data.length === 0) {
 		return (
@@ -18,20 +45,29 @@ export function BoardHistoryLog({ data, hasMore, onLoadMore, isLoading }: BoardH
 		)
 	}
 
+	const groupedData = groupTimestampsByMonth(data)
+
 	return (
 		<div className="board-history">
 			<h1>Board history</h1>
 			<p>Recent versions of this file. You can restore any previous version.</p>
-			<ol className="board-history__list">
-				{data.map((v, i) => {
-					const timeStamp = v.split('/').pop()
-					return (
-						<li key={i}>
-							<Link to={`./${timeStamp}`}>{formatDate(timeStamp!)}</Link>
-						</li>
-					)
-				})}
-			</ol>
+			<div className="board-history__list">
+				{groupedData.map((group, groupIndex) => (
+					<div key={groupIndex} className="board-history__month-group">
+						<h3 className="board-history__month-header">{group.month}</h3>
+						<ol className="board-history__list">
+							{group.timestamps.map((v, i) => {
+								const timeStamp = v.split('/').pop()
+								return (
+									<li key={i}>
+										<Link to={`./${timeStamp}`}>{formatDate(timeStamp!)}</Link>
+									</li>
+								)
+							})}
+						</ol>
+					</div>
+				))}
+			</div>
 			{hasMore && (
 				<div className="board-history__load-more">
 					<button

--- a/apps/dotcom/client/src/components/BoardHistoryLog/BoardHistoryLog.tsx
+++ b/apps/dotcom/client/src/components/BoardHistoryLog/BoardHistoryLog.tsx
@@ -2,7 +2,14 @@ import { Link } from 'react-router-dom'
 
 // todo: remove tailwind
 
-export function BoardHistoryLog({ data }: { data: string[] }) {
+interface BoardHistoryLogProps {
+	data: string[]
+	hasMore?: boolean
+	onLoadMore?(): void
+	isLoading?: boolean
+}
+
+export function BoardHistoryLog({ data, hasMore, onLoadMore, isLoading }: BoardHistoryLogProps) {
 	if (data.length === 0) {
 		return (
 			<div>
@@ -14,7 +21,7 @@ export function BoardHistoryLog({ data }: { data: string[] }) {
 	return (
 		<div className="board-history">
 			<h1>Board history</h1>
-			<p>All previous versions found for this file. You can restore any previous version.</p>
+			<p>Recent versions of this file. You can restore any previous version.</p>
 			<ol className="board-history__list">
 				{data.map((v, i) => {
 					const timeStamp = v.split('/').pop()
@@ -25,6 +32,17 @@ export function BoardHistoryLog({ data }: { data: string[] }) {
 					)
 				})}
 			</ol>
+			{hasMore && (
+				<div className="board-history__load-more">
+					<button
+						onClick={onLoadMore}
+						disabled={isLoading}
+						className="board-history__load-more-button"
+					>
+						{isLoading ? 'Loading...' : 'Load More'}
+					</button>
+				</div>
+			)}
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/pages/file-history.tsx
+++ b/apps/dotcom/client/src/tla/pages/file-history.tsx
@@ -82,7 +82,7 @@ export function Component({ error: _error }: { error?: unknown }) {
 	}
 
 	return (
-		<>
+		<div>
 			{error ? (
 				<TlaFileError error={error} />
 			) : (
@@ -95,6 +95,6 @@ export function Component({ error: _error }: { error?: unknown }) {
 					/>
 				</TlaAnonLayout>
 			)}
-		</>
+		</div>
 	)
 }

--- a/apps/dotcom/client/src/utils/fetchHistory.ts
+++ b/apps/dotcom/client/src/utils/fetchHistory.ts
@@ -1,0 +1,23 @@
+import { FILE_PREFIX, type HistoryResponseBody } from '@tldraw/dotcom-shared'
+import { fetch } from 'tldraw'
+
+// Helper function to fetch history data
+export async function fetchHistory(
+	fileSlug: string,
+	offset?: string
+): Promise<HistoryResponseBody | null> {
+	try {
+		const url = offset
+			? `/api/${FILE_PREFIX}/${fileSlug}/history?offset=${offset}`
+			: `/api/${FILE_PREFIX}/${fileSlug}/history`
+
+		const result = await fetch(url)
+
+		if (!result.ok) return null
+
+		return await result.json()
+	} catch (err) {
+		console.error('Failed to fetch history:', err)
+		return null
+	}
+}

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -184,14 +184,32 @@ a {
 }
 
 .board-history__list {
-	padding: 16px;
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.board-history__list > .board-history__month-group:first-child {
+	margin-top: 24px;
+}
+
+.board-history__month-group {
+	margin-bottom: 32px;
+}
+
+.board-history__month-header {
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--color-text-1);
+	margin: 0 0 8px 0;
+	padding: 0;
 }
 
 .board-history__list a {
-	padding: 8px 8px 8px 0px;
+	color: var(--color-text);
+	text-decoration: none;
+	padding: 8px 0;
+	display: block;
 }
 
 .board-history__list a:hover {

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -204,6 +204,38 @@ a {
 	right: 8px;
 }
 
+.board-history__load-more {
+	display: flex;
+	justify-content: center;
+	padding: 16px;
+}
+
+.board-history__load-more-button {
+	font-family: inherit;
+	font-size: inherit;
+	height: 36px;
+	border: 2px solid var(--color-selected);
+	border-radius: 8px;
+	background-color: var(--color-selected);
+	color: var(--color-selected-contrast);
+	text-shadow: none;
+	pointer-events: all;
+	position: relative;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.board-history__load-more-button:hover:not(:disabled) {
+	background-color: var(--color-selected);
+	opacity: 0.9;
+}
+
+.board-history__load-more-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
 /* ----------------- Iframe warning ----------------- */
 
 .iframe-warning__container {

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -1,3 +1,4 @@
+import { HistoryResponseBody } from '@tldraw/dotcom-shared'
 import { notFound } from '@tldraw/worker-shared'
 import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../r2'
@@ -6,7 +7,67 @@ import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { requireWriteAccessToFile } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
 
-// Returns the history of a room as a list of objects with timestamps
+function getMonthPrefix(date: Date): string {
+	return date.toISOString().split('T')[0].substring(0, 7)
+}
+
+function getPreviousMonth(date: Date): Date {
+	const prev = new Date(date)
+	prev.setMonth(prev.getMonth() - 1)
+	return prev
+}
+
+async function fetchTimestampsFromBatch(
+	bucket: R2Bucket,
+	roomKey: string,
+	prefix: string,
+	limit: number,
+	cursor?: string
+): Promise<{ timestamps: string[]; batch: any }> {
+	const fullPrefix = `${roomKey}/${prefix}`
+	const batch = await bucket.list({
+		prefix: fullPrefix,
+		limit,
+		cursor,
+	})
+
+	const timestamps = batch.objects
+		.map((o) => o.key.replace(roomKey + '/', ''))
+		.filter((timestamp) => timestamp && timestamp !== roomKey)
+
+	return { timestamps, batch }
+}
+
+async function fetchTimestampsForPrefix(
+	bucket: R2Bucket,
+	roomKey: string,
+	prefix: string,
+	limit?: number
+): Promise<string[]> {
+	const batchLimit = limit || 1000
+	// eslint-disable-next-line prefer-const
+	let { timestamps, batch } = await fetchTimestampsFromBatch(bucket, roomKey, prefix, batchLimit)
+
+	// Continue listing if there are more objects
+	while (batch.truncated && timestamps.length < (limit || Infinity)) {
+		const next = await fetchTimestampsFromBatch(bucket, roomKey, prefix, batchLimit, batch.cursor)
+		timestamps.push(...next.timestamps)
+		batch = next.batch
+	}
+
+	// Sort
+	return timestamps.sort((a, b) => b.localeCompare(a))
+}
+
+async function monthHasEntries(
+	bucket: R2Bucket,
+	roomKey: string,
+	monthPrefix: string
+): Promise<boolean> {
+	const timestamps = await fetchTimestampsForPrefix(bucket, roomKey, monthPrefix, 1)
+	return timestamps.length > 0
+}
+
 export async function getRoomHistory(
 	request: IRequest,
 	env: Environment,
@@ -25,29 +86,119 @@ export async function getRoomHistory(
 		return new Response('Not found', { status: 404 })
 	}
 
+	const offset = request.query?.offset as string // offset is the earliest timestamp from the previous page
+
 	const versionCacheBucket = env.ROOMS_HISTORY_EPHEMERAL
 	const bucketKey = getR2KeyForRoom({ slug: roomId, isApp })
 
-	let batch = await versionCacheBucket.list({
-		prefix: bucketKey,
-	})
-	const result = [...batch.objects.map((o) => o.key)]
+	let allTimestamps: string[] = []
 
-	// ✅ - use the truncated property to check if there are more
-	// objects to be returned
-	while (batch.truncated) {
-		const next = await versionCacheBucket.list({
-			cursor: batch.cursor,
-		})
-		result.push(...next.objects.map((o) => o.key))
+	let currentMonth = new Date()
+	let monthsChecked = 0
+	const maxMonthsToCheck = 12
+	const targetEntryCount = 100
 
-		batch = next
+	if (offset) {
+		try {
+			const offsetDate = new Date(offset)
+			currentMonth = new Date(offsetDate.getFullYear(), offsetDate.getMonth(), 1)
+		} catch (_e) {
+			currentMonth = new Date()
+		}
+	} else {
+		// If we don't have an offset we can check if the room doesn't have too many entries
+		const allTimestampsForRoom = await fetchTimestampsForPrefix(versionCacheBucket, bucketKey, '')
+
+		// If we have fewer than 1000 entries, return them all
+		if (allTimestampsForRoom.length < 1000) {
+			const roomHistory: HistoryResponseBody = {
+				timestamps: allTimestampsForRoom,
+				hasMore: false,
+			}
+			return new Response(JSON.stringify(roomHistory), {
+				headers: { 'content-type': 'application/json' },
+			})
+		}
 	}
 
-	// these are ISO timestamps, so they sort lexicographically
-	result.sort()
+	// Find the first month with entries
+	let foundMonthWithEntries = false
+	while (!foundMonthWithEntries && monthsChecked < maxMonthsToCheck) {
+		const monthPrefix = getMonthPrefix(currentMonth)
+		const hasEntries = await monthHasEntries(versionCacheBucket, bucketKey, monthPrefix)
 
-	return new Response(JSON.stringify(result), {
+		if (hasEntries) {
+			foundMonthWithEntries = true
+		} else {
+			currentMonth = getPreviousMonth(currentMonth)
+			monthsChecked++
+		}
+	}
+
+	// If we found a month with entries, start collecting timestamps
+	if (foundMonthWithEntries) {
+		let monthsCollected = 0
+		const maxMonthsToCollect = 12
+
+		// Collect timestamps from multiple months until we reach the target count
+		while (allTimestamps.length < targetEntryCount && monthsCollected < maxMonthsToCollect) {
+			const monthPrefix = getMonthPrefix(currentMonth)
+			const monthTimestamps = await fetchTimestampsForPrefix(
+				versionCacheBucket,
+				bucketKey,
+				monthPrefix
+			)
+
+			let filteredTimestamps = monthTimestamps
+			if (offset) {
+				// Only include timestamps that are strictly less than the offset
+				// This ensures no duplicates when paginating
+				filteredTimestamps = monthTimestamps.filter((ts) => ts < offset)
+			}
+
+			allTimestamps.push(...filteredTimestamps)
+
+			if (allTimestamps.length >= targetEntryCount) {
+				break
+			}
+
+			currentMonth = getPreviousMonth(currentMonth)
+			monthsCollected++
+		}
+
+		allTimestamps = allTimestamps.sort((a, b) => b.localeCompare(a)).slice(0, targetEntryCount)
+	}
+
+	let hasMore = false
+	if (allTimestamps.length > 0) {
+		// Check if there are more entries in previous months
+		let checkMonth = currentMonth
+		let monthsToCheck = 12
+
+		while (monthsToCheck > 0) {
+			const previousMonthPrefix = getMonthPrefix(checkMonth)
+			const hasMoreEntries = await monthHasEntries(
+				versionCacheBucket,
+				bucketKey,
+				previousMonthPrefix
+			)
+
+			if (hasMoreEntries) {
+				hasMore = true
+				break
+			}
+
+			checkMonth = getPreviousMonth(checkMonth)
+			monthsToCheck--
+		}
+	}
+
+	const response: HistoryResponseBody = {
+		timestamps: allTimestamps,
+		hasMore,
+	}
+
+	return new Response(JSON.stringify(response), {
 		headers: { 'content-type': 'application/json' },
 	})
 }

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -40,6 +40,11 @@ export interface GetReadonlySlugResponseBody {
 	isLegacy: boolean
 }
 
+export interface HistoryResponseBody {
+	timestamps: string[]
+	hasMore: boolean
+}
+
 /* ----------------------- App ---------------------- */
 
 export interface CreateFilesRequestBody {


### PR DESCRIPTION
There was an issue with rooms that have a large history. We tried to fetch all the timestaps (could be thousands) which caused the worker to take longer than 120s to respond, which means it's execution got canceled due to worker limits.

We now:
* Fetch an initial batch of 1000 items from the room history. If we have fewer than 1000 items we just return them. This keeps the old logic intact for rooms that don't have a big history.
* For rooms with more than 1000 history entries we start from the current month and work our way back to find the first month that has some history entries. Once we find that month we start collecting history entries. Once we get to 1000 (which could span multiple months), we return those.
* We also check if we have any older entries so that users can request more.

### Change type

- [x] `improvement`
