### PR TITLE
Add solo sync mode

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -264,6 +264,9 @@ export interface TLPingRequest {
 }
 
 // @internal (undocumented)
+export type TLPresenceMode = 'full' | 'solo';
+
+// @internal (undocumented)
 export interface TLPushRequest<R extends UnknownRecord> {
     // (undocumented)
     clientClock: number;
@@ -439,6 +442,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
         onLoad(self: TLSyncClient<R, S>): void;
         onSyncError(reason: string): void;
         presence: Signal<null | R>;
+        presenceMode?: Signal<TLPresenceMode>;
         socket: TLPersistentClientSocket<R>;
         store: S;
     });
@@ -457,6 +461,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
     readonly onAfterConnect?: (self: this, details: {
         isReadonly: boolean;
     }) => void;
+    // (undocumented)
+    readonly presenceMode: Signal<TLPresenceMode> | undefined;
     // (undocumented)
     readonly presenceState: Signal<null | R> | undefined;
     // (undocumented)

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -38,6 +38,7 @@ export {
 	type SubscribingFn,
 	type TLPersistentClientSocket,
 	type TLPersistentClientSocketStatus,
+	type TLPresenceMode,
 	type TlSocketStatusChangeEvent,
 	type TLSocketStatusListener,
 } from './lib/TLSyncClient'

--- a/packages/sync-core/src/test/presenceMode.test.ts
+++ b/packages/sync-core/src/test/presenceMode.test.ts
@@ -1,0 +1,147 @@
+import { atom, computed, Signal } from '@tldraw/state'
+import { BaseRecord, createRecordType, RecordId, Store, StoreSchema } from '@tldraw/store'
+import { TLSyncClient } from '../lib/TLSyncClient'
+import { TestServer } from './TestServer'
+import { TestSocketPair } from './TestSocketPair'
+
+jest.mock('@tldraw/utils', () => {
+	return {
+		...jest.requireActual('@tldraw/utils'),
+		fpsThrottle: jest.fn((fn) => fn),
+	}
+})
+
+const disposables: Array<() => void> = []
+
+afterEach(() => {
+	for (const dispose of disposables) {
+		dispose()
+	}
+	disposables.length = 0
+})
+
+interface User extends BaseRecord<'user', RecordId<User>> {
+	name: string
+	age: number
+}
+
+interface Presence extends BaseRecord<'presence', RecordId<Presence>> {
+	name: string
+	age: number
+}
+
+const Presence = createRecordType<Presence>('presence', {
+	scope: 'presence',
+	validator: { validate: (value) => value as Presence },
+})
+
+const User = createRecordType<User>('user', {
+	scope: 'document',
+	validator: { validate: (value) => value as User },
+})
+
+type R = User | Presence
+
+const schema = StoreSchema.create<R>({ user: User, presence: Presence })
+
+class TestInstance {
+	server: TestServer<R>
+	socketPair: TestSocketPair<R>
+	client: TLSyncClient<R>
+
+	hasLoaded = false
+
+	constructor(presenceSignal: Signal<Presence | null>, presenceMode?: 'solo' | 'full') {
+		this.server = new TestServer(schema)
+		this.socketPair = new TestSocketPair('test_presence_mode', this.server)
+		this.socketPair.connect()
+
+		this.client = new TLSyncClient<R>({
+			store: new Store({ schema, props: {} }),
+			socket: this.socketPair.clientSocket,
+			onLoad: () => {
+				this.hasLoaded = true
+			},
+			onSyncError: jest.fn((reason) => {
+				throw new Error('onSyncError: ' + reason)
+			}),
+			presence: presenceSignal,
+			presenceMode: presenceMode ? computed('', () => presenceMode) : undefined,
+		})
+
+		disposables.push(() => {
+			this.client.close()
+		})
+	}
+
+	flush() {
+		this.server.flushDebouncingMessages()
+
+		while (this.socketPair.getNeedsFlushing()) {
+			this.socketPair.flushClientSentEvents()
+			this.socketPair.flushServerSentEvents()
+		}
+	}
+}
+
+test('presence is pushed on change when mode is full', () => {
+	const presence = Presence.create({ name: 'bob', age: 10 })
+	const presenceSignal = atom('', presence)
+
+	const t = new TestInstance(presenceSignal, 'full')
+	t.socketPair.connect()
+	t.flush()
+
+	const session = t.server.room.sessions.values().next().value
+	expect(session).toBeDefined()
+	expect(session?.presenceId).toBeDefined()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).toMatchObject({
+		name: 'bob',
+		age: 10,
+	})
+
+	presenceSignal.set(Presence.create({ name: 'bob', age: 11 }))
+	t.flush()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).toMatchObject({
+		name: 'bob',
+		age: 11,
+	})
+
+	presenceSignal.set(Presence.create({ name: 'bob', age: 12 }))
+	t.flush()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).toMatchObject({
+		name: 'bob',
+		age: 12,
+	})
+})
+
+test('presence is only pushed once on connect when mode is solo', () => {
+	const presence = Presence.create({ name: 'bob', age: 10 })
+	const presenceSignal = atom('', presence)
+
+	const t = new TestInstance(presenceSignal, 'solo')
+	t.socketPair.connect()
+	t.flush()
+
+	const session = t.server.room.sessions.values().next().value
+	expect(session).toBeDefined()
+	expect(session?.presenceId).toBeDefined()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).toMatchObject({
+		name: 'bob',
+		age: 10,
+	})
+
+	presenceSignal.set(Presence.create({ name: 'bob', age: 11 }))
+	t.flush()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).not.toMatchObject({
+		name: 'bob',
+		age: 11,
+	})
+
+	presenceSignal.set(Presence.create({ name: 'bob', age: 12 }))
+	t.flush()
+	expect(t.server.room.documents.get(session!.presenceId!)?.state).not.toMatchObject({
+		name: 'bob',
+		age: 12,
+	})
+})

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -166,12 +166,12 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			})
 		})
 
-		const otherUserPresences = store.query.records('instance_presence', () => ({
+		const otherUserPresences = store.query.ids('instance_presence', () => ({
 			userId: { neq: userPreferences.get().id },
 		}))
 
 		const presenceMode = computed<TLPresenceMode>('presenceMode', () => {
-			if (otherUserPresences.get().length === 0) return 'solo'
+			if (otherUserPresences.get().size === 0) return 'solo'
 			return 'full'
 		})
 

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -2,6 +2,7 @@ import { atom, isSignal, transact } from '@tldraw/state'
 import { useAtom } from '@tldraw/state-react'
 import {
 	ClientWebSocketAdapter,
+	TLPresenceMode,
 	TLRemoteSyncError,
 	TLSyncClient,
 	TLSyncErrorCloseEventReason,
@@ -165,6 +166,15 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			})
 		})
 
+		const otherUserPresences = store.query.records('instance_presence', () => ({
+			userId: { neq: userPreferences.get().id },
+		}))
+
+		const presenceMode = computed<TLPresenceMode>('presenceMode', () => {
+			if (otherUserPresences.get().length === 0) return 'solo'
+			return 'full'
+		})
+
 		const client = new TLSyncClient({
 			store,
 			socket,
@@ -210,6 +220,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				})
 			},
 			presence,
+			presenceMode,
 		})
 
 		return () => {


### PR DESCRIPTION
This makes it so that presence updates only send if someone else is in the room.

### Change type

- [x] `improvement`

### Release notes

- `useSync` now only sends presence updates, like mouse and camera positions, when there are more than one unique user in a room.

### API changes

Internal only