### PR TITLE
Fix edge hitting on arrows

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1245,12 +1245,14 @@ export class Editor extends EventEmitter<TLEventMap> {
     getShapeAncestors(shape: TLShape | TLShapeId, acc?: TLShape[]): TLShape[];
     getShapeAndDescendantIds(ids: TLShapeId[]): Set<TLShapeId>;
     getShapeAtPoint(point: VecLike, opts?: {
+        debug?: boolean;
         filter?(shape: TLShape): boolean;
         hitFrameInside?: boolean;
         hitInside?: boolean;
         hitLabels?: boolean;
         hitLocked?: boolean;
-        margin?: number;
+        insideMargin?: number;
+        margin?: [number, number] | number;
         renderingOnly?: boolean;
     }): TLShape | undefined;
     getShapeClipPath(shape: TLShape | TLShapeId): string | undefined;

--- a/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
@@ -94,7 +94,8 @@ export function updateArrowTargetState({
 	const target = editor.getShapeAtPoint(pointInPageSpace, {
 		hitInside: true,
 		hitFrameInside: true,
-		margin: arrowKind === 'elbow' ? 8 : 0,
+		margin: arrowKind === 'elbow' ? 8 : [8, 0],
+		debug: true,
 		filter: (targetShape) => {
 			return (
 				!targetShape.isLocked &&
@@ -187,6 +188,7 @@ export function updateArrowTargetState({
 	}
 
 	const shouldSnapCenter = !isExact && precise && targetGeometryInTargetSpace.isClosed
+	// const shouldSnapEdges = !isExact && (precise || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdges =
 		!isExact && ((precise && arrowKind === 'elbow') || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdgePoints =


### PR DESCRIPTION
This pull request adds the ability to separate inner and outer margins for shape detection. It fixes a bug where hollow shapes could not be bound-to by arrows when overlapping solid filled shapes.

https://github.com/user-attachments/assets/3866a869-90f3-4400-b20d-02774b71cab0

### Change type

- [x] `bugfix`

### Test plan

1. Create a solid shape
2. Create a hollow shape on top
3. Bind an arrow to the hollow shape

- [x] Unit tests

### Release notes

- Fixed a bug where hollow shapes could not be bound-to by arrows when overlapping a filled shape.