### PR TITLE
SDK changes to the AI module

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -5,10 +5,13 @@ import { registerTldrawLibraryVersion } from 'tldraw'
 // eslint-disable-next-line local/no-export-star
 export type * from './lib/types'
 
+export { defaultApplyChange } from './lib/defaultApplyChange'
 export { TldrawAiModule, type TldrawAiModuleOptions } from './lib/TldrawAiModule'
 export { TldrawAiTransform, type TldrawAiTransformConstructor } from './lib/TldrawAiTransform'
 export {
 	useTldrawAi,
+	type TldrawAi,
+	type TldrawAiApplyFn,
 	type TldrawAiGenerateFn,
 	type TldrawAiOptions,
 	type TldrawAiPromptOptions,

--- a/packages/ai/src/lib/TldrawAiModule.ts
+++ b/packages/ai/src/lib/TldrawAiModule.ts
@@ -1,19 +1,14 @@
-import {
-	Box,
-	Editor,
-	exhaustiveSwitchError,
-	FileHelpers,
-	structuredClone,
-	TLShapePartial,
-} from 'tldraw'
+import { Box, Editor, FileHelpers, structuredClone } from 'tldraw'
 import { TldrawAiTransformConstructor } from './TldrawAiTransform'
-import { TLAiChange, TLAiContent, TLAiMessages, TLAiPrompt } from './types'
+import { TLAiChange, TLAiContent, TLAiPrompt } from './types'
+import { TldrawAiApplyFn, TldrawAiPromptOptions } from './useTldrawAi'
 import { asMessage } from './utils'
 
 /** @public */
 export interface TldrawAiModuleOptions {
 	editor: Editor
 	transforms?: TldrawAiTransformConstructor[]
+	apply: TldrawAiApplyFn
 }
 
 /**
@@ -32,18 +27,17 @@ export class TldrawAiModule {
 	 * Creates and prepare a prompt, returning the prompt
 	 * and a function to handle changes.
 	 *
-	 * @param prompt - The user's message or a configuration for the prompt
+	 * @param options - The user's message or a configuration for the prompt
 	 */
-	async generate(prompt: string | { message: TLAiMessages; stream?: boolean }) {
+	async generate(options: TldrawAiPromptOptions) {
 		const { transforms: _transformCtors = [] } = this.opts
 		const transforms = _transformCtors.map((ctor) => new ctor(this.opts.editor))
 
-		const message = typeof prompt === 'string' ? prompt : prompt.message
-		let _prompt = await this.getPrompt(message)
+		let prompt = await this.getPrompt(options)
 
 		for (const transform of transforms) {
 			if (transform.transformPrompt) {
-				_prompt = transform.transformPrompt(_prompt)
+				prompt = transform.transformPrompt(prompt)
 			}
 		}
 
@@ -64,10 +58,14 @@ export class TldrawAiModule {
 					changes = transform.transformChanges(changes)
 				}
 			}
+
+			for (const change of changes) {
+				this.applyChange(change)
+			}
 		}
 
 		return {
-			prompt: _prompt,
+			prompt,
 			handleChange,
 			handleChanges,
 		}
@@ -79,71 +77,31 @@ export class TldrawAiModule {
 	 * @param change - The change to apply
 	 */
 	applyChange(change: TLAiChange) {
-		const { editor } = this.opts
-
-		if (editor.isDisposed) return
-
-		try {
-			switch (change.type) {
-				case 'createShape': {
-					editor.createShape(change.shape)
-					break
-				}
-				case 'updateShape': {
-					editor.updateShape(change.shape as TLShapePartial)
-					break
-				}
-				case 'deleteShape': {
-					editor.deleteShape(change.shapeId)
-					break
-				}
-				case 'createBinding': {
-					editor.createBinding(change.binding)
-					break
-				}
-				case 'updateBinding': {
-					editor.updateBinding(change.binding)
-					break
-				}
-				case 'deleteBinding': {
-					editor.deleteBinding(change.bindingId)
-					break
-				}
-				default:
-					exhaustiveSwitchError(change)
-			}
-		} catch (e) {
-			console.error('Error handling change:', e)
-		}
+		this.opts.apply({ change, editor: this.opts.editor })
 	}
 
 	/**
 	 * Create the prompt to be sent to the AI.
 	 *
-	 * @param prompt - The user's prompt
-	 * @param options - Options to generate the input
+	 * @param options - The options to generate the prompt
 	 */
-	async getPrompt(
-		prompt: TLAiMessages,
-		options = {} as Partial<Pick<TLAiPrompt, 'canvasContent' | 'contextBounds' | 'promptBounds'>>
-	): Promise<TLAiPrompt> {
+	async getPrompt(options: TldrawAiPromptOptions): Promise<TLAiPrompt> {
 		const { editor } = this.opts
-		const {
-			contextBounds = editor.getViewportPageBounds(),
-			promptBounds = editor.getViewportPageBounds(),
-		} = options
 
-		const content = options.canvasContent ?? this.getContent(promptBounds)
+		const _options = typeof options === 'string' ? { message: options } : options
 
-		// Get image from the content
-		const image = await this.getImage(content)
+		const contextBounds = _options.contextBounds ?? editor.getViewportPageBounds()
+		const promptBounds = _options.promptBounds ?? editor.getViewportPageBounds()
+		const content = _options.canvasContent ?? this.getContent(contextBounds)
+		const image = _options.image ?? (await this.getImage(content))
 
 		return {
-			message: asMessage(prompt),
+			message: asMessage(_options.message ?? ''),
 			canvasContent: content,
 			contextBounds: roundBox(contextBounds),
 			promptBounds: roundBox(promptBounds),
 			image,
+			meta: _options.meta,
 		}
 	}
 
@@ -154,9 +112,6 @@ export class TldrawAiModule {
 	 */
 	private getContent(bounds: Box): TLAiContent {
 		const { editor } = this.opts
-
-		// Get the page content (same as what we put on the clipboard when a user copies) for the shapes
-		// that are included (contained or colliding with) the provided bounds
 
 		let content: TLAiContent | undefined = {
 			bindings: [],
@@ -200,7 +155,7 @@ export class TldrawAiModule {
 			format: 'jpeg',
 			background: false,
 			darkMode: false,
-			padding: 0, // will the context bounds take into account the padding?
+			padding: 10, // will the context bounds take into account the padding?
 		})
 
 		return await FileHelpers.blobToDataUrl(result.blob)

--- a/packages/ai/src/lib/defaultApplyChange.ts
+++ b/packages/ai/src/lib/defaultApplyChange.ts
@@ -1,0 +1,54 @@
+import { Editor, TLShapeId, TLShapePartial, exhaustiveSwitchError } from 'tldraw'
+import { TLAiChange } from './types'
+
+/**
+ * Apply an AI change to the canvas.
+ * This is the default apply function for the AI module.
+ *
+ * @param change - The change to apply
+ * @param editor - The editor to apply the change to
+ *
+ * @public
+ */
+export function defaultApplyChange({ change, editor }: { change: TLAiChange; editor: Editor }) {
+	if (editor.isDisposed) return
+
+	try {
+		switch (change.type) {
+			case 'createShape': {
+				const util = editor.getShapeUtil(change.shape.type)
+				const shape = {
+					...change.shape,
+					opacity: 1,
+					props: { ...util?.getDefaultProps(), ...change.shape.props },
+				}
+				editor.createShape(shape as TLShapePartial)
+				break
+			}
+			case 'updateShape': {
+				editor.updateShape(change.shape as TLShapePartial)
+				break
+			}
+			case 'deleteShape': {
+				editor.deleteShape(change.shapeId as TLShapeId)
+				break
+			}
+			case 'createBinding': {
+				editor.createBinding(change.binding)
+				break
+			}
+			case 'updateBinding': {
+				editor.updateBinding(change.binding)
+				break
+			}
+			case 'deleteBinding': {
+				editor.deleteBinding(change.bindingId)
+				break
+			}
+			default:
+				exhaustiveSwitchError(change)
+		}
+	} catch (e) {
+		console.error('Error handling change:', e)
+	}
+}

--- a/packages/ai/src/lib/types.ts
+++ b/packages/ai/src/lib/types.ts
@@ -41,9 +41,9 @@ export interface TLAiPrompt {
 	image?: string
 	/** The content pulled from the editor */
 	canvasContent: TLAiContent
-	/** The bounds of the context in the editor */
+	/** The bounds of the context in the editor (what the model can see) */
 	contextBounds: Box
-	/** The bounds of the prompt in the editor */
+	/** The bounds of the prompt in the editor (where the model can act) */
 	promptBounds: Box
 	/** Any additional information. Must be JSON serializable! */
 	meta?: any
@@ -54,9 +54,9 @@ export interface TLAiPrompt {
  * @public
  */
 export interface TLAiSerializedPrompt extends Omit<TLAiPrompt, 'contextBounds' | 'promptBounds'> {
-	/** The bounds of the context in the editor */
+	/** The bounds of the context in the editor (what the model can see) */
 	contextBounds: BoxModel
-	/** The bounds of the prompt in the editor */
+	/** The bounds of the prompt in the editor (where the model can act) */
 	promptBounds: BoxModel
 }
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -736,6 +736,9 @@ export const defaultUserPreferences: Readonly<{
 // @public
 export function degreesToRadians(d: number): number;
 
+// @public
+export function doesGeometryOverlapPolygon(geometry: Geometry2d, parentCornersInShapeSpace: Vec[]): boolean;
+
 // @public (undocumented)
 export const EASINGS: {
     readonly easeInCubic: (t: number) => number;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -457,7 +457,11 @@ export { hardResetEditor } from './lib/utils/hardResetEditor'
 export { isAccelKey } from './lib/utils/keyboard'
 export { normalizeWheel } from './lib/utils/normalizeWheel'
 export { refreshPage } from './lib/utils/refreshPage'
-export { getDroppedShapesToNewParents, kickoutOccludedShapes } from './lib/utils/reparenting'
+export {
+	doesGeometryOverlapPolygon,
+	getDroppedShapesToNewParents,
+	kickoutOccludedShapes,
+} from './lib/utils/reparenting'
 export {
 	getFontsFromRichText,
 	type RichTextFontVisitor,

--- a/packages/editor/src/lib/utils/reparenting.ts
+++ b/packages/editor/src/lib/utils/reparenting.ts
@@ -194,6 +194,12 @@ function getOverlappingShapes<T extends TLShape[] | TLShapeId[]>(
 }
 
 /**
+ * Check if a geometry overlaps a polygon.
+ *
+ * @param geometry - The geometry to check.
+ * @param parentCornersInShapeSpace - The corners of the parent in the shape's space.
+ * @returns True if the geometry overlaps the polygon, false otherwise.
+ *
  * @public
  */
 export function doesGeometryOverlapPolygon(


### PR DESCRIPTION
This PR contains all of the SDK changes to the AI module from the agent starter PR (#6496).

- The `applyChange` function is no longer hardcoded. You can now specify how AI changes are applied (or not) by passing an `apply` function in the same way that you pass your own `generate` and `stream` functions. In the agent template, we use this to extract the diffs from those applied changes and putting them into chat history. The old behavior is exported as `defaultApplyChange`, which is what the option defaults to.
- There's a new `TldrawAi` type. It's the object you get from calling `useTldrawAi`. Having this as a named type makes it easier to pass around the `ai` object into other functions and components.
- The `generate` and `getPrompt` functions now both accept `TldrawAiPromptOptions` as their argument, similar to the `prompt` function. This is partly for consistency and partly so we can pass through more properties, ie: `meta`.
- Speaking of which... the `meta` property is now passed all the way through. It doesn't get abandoned halfway through anymore.
- When using `ai.prompt`, the `message` property is now optional. For example, you might want to prompt with the canvas contents, but no messages.
- Fixed the returned `handleChanges` function so that it actually applies changes now.
- You can now specify the context bounds and prompt bounds of your request. Previously, the `ai.prompt` function didn't accept them as options, so you were effectively hardcoded to the viewport.
- Added some padding to the generated image so that it doesn't error out when you prompt with zero-height/width shapes. Note: We should *actually* be getting an image of the context bounds, including any empty space. That could be a future improvement.
- Errors that happen during generation now get passed back all the way up.
- Some JSDoc comments were moved so that they get picked up by API extractor.

There's also one function, `doesGeometryOverlapPolygon`, that is now exported from the editor, with JSDoc comments.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`
