### PR TITLE
Remove unnecessary conditions

### DIFF
--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -33,7 +33,6 @@ export class Vec {
 	}
 
 	rot(r: number) {
-		if (r === 0) return this
 		const { x, y } = this
 		const s = Math.sin(r)
 		const c = Math.cos(r)
@@ -43,7 +42,6 @@ export class Vec {
 	}
 
 	rotWith(C: VecLike, r: number) {
-		if (r === 0) return this
 		const x = this.x - C.x
 		const y = this.y - C.y
 		const s = Math.sin(r)


### PR DESCRIPTION
`rot(0)` will not change anything, and will cause no problem, the if statements might be there for performance reasons if rotation 0 is common, if that's the case, then we should keep the ifs.

I was just skimming through the project when I saw it, and thought why not do a PR about it. Thanks.