### PR TITLE
fix: add missing GA4 domains to CSP for non-EU regions

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -13,6 +13,9 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`https://*.ingest.sentry.io`,
 		`https://*.ingest.us.sentry.io`,
 		'https://*.analytics.google.com',
+		'https://www.google-analytics.com',
+		'https://*.googletagmanager.com',
+		'https://www.googletagmanager.com',
 		// for thumbnail server
 		'http://localhost:5002',
 		'https://*.clerk.accounts.dev',
@@ -41,6 +44,9 @@ export const cspDirectives: { [key: string]: string[] } = {
 		// embeds that have scripts
 		'https://gist.github.com',
 		'https://www.googletagmanager.com',
+		'https://*.googletagmanager.com',
+		'https://www.google-analytics.com',
+		'https://*.google-analytics.com',
 		'https://analytics.tldraw.com',
 		'https://static.reo.dev',
 	],


### PR DESCRIPTION
Updates Content Security Policy to include additional Google Analytics and Google Tag Manager domains required for GA4 functionality:

- Adds www.google-analytics.com and *.googletagmanager.com to connect-src
- Adds *.googletagmanager.com, www.google-analytics.com, and *.google-analytics.com to script-src

This resolves CSP blocking issues preventing GA4 from working properly in non-EU regions where analytics cookies are enabled.

Fixes ENG-3605

🤖 Generated with [Claude Code](https://claude.ai/code)

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…