### PR TITLE
fix: duplicate page view events on tldraw.dev

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -59,7 +59,7 @@ export default function Analytics() {
 				api_host: 'https://analytics.tldraw.com/i',
 				ui_host: 'https://eu.i.posthog.com',
 				persistence: 'memory',
-				capture_pageview: 'history_change',
+				capture_pageview: false,
 			})
 
 			if (window.TL_GA4_MEASUREMENT_ID) {
@@ -82,7 +82,7 @@ export default function Analytics() {
 					ReactGA.gtag('config', window.TL_GOOGLE_ADS_ID)
 				}
 
-				ReactGA.send('pageview')
+				// Initial pageview will be sent via page() function to avoid duplicates
 			}
 
 			isConfigured = true


### PR DESCRIPTION
- Disable PostHog automatic pageview tracking (capture_pageview: false)
- Remove duplicate ReactGA.send('pageview') on initialization
- Add manual page view tracking in docs site using tlanalytics.page()
- Add Next.js route change detection for proper SPA navigation tracking
- Update TypeScript interfaces to include page() function

The duplicate events were caused by:
1. PostHog auto-capturing page views on history changes
2. ReactGA sending an initial pageview on load
3. Potential Next.js App Router automatic tracking

Now using single source of truth via tlanalytics.page() function which properly calls both PostHog and ReactGA pageview methods without duplication.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

### Change type

- [x] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
