### PR TITLE
Fix dragging within multiple editors

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -151,9 +151,6 @@ export function useCanvasEvents() {
 		let lastX: number, lastY: number
 
 		function onPointerMove(e: PointerEvent) {
-			if ((e as any).isKilled) return
-			;(e as any).isKilled = true
-
 			if (e.clientX === lastX && e.clientY === lastY) return
 			lastX = e.clientX
 			lastY = e.clientY


### PR DESCRIPTION
This PR fixes dragging interactions when using multiple tldraw components on the same page. eg: [Inset editors with fixed sizes](https://examples-canary.tldraw.com/inline) and [Common practices with inset editors](https://examples-canary.tldraw.com/inline-behavior)

The bug happened because we're now handling pointer move events on a document basis, not an editor-by-editor basis. This meant that different tldraw editors were killing the pointer move event, preventing other editors from handling it.
This PR fixes the bug by *no longer killing the event*. If we do need to kill the event, perhaps we could kill the event on an editor-by-editor basis by tracking this as a map instead of a boolean or something.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Try the "Inset editor (fixed sizes)" and "Inset editor (common practices)" examples.
2. Try drawing in multiple editors. Make sure you can draw in more than just one of them.

- [ ] Unit tests
- [ ] End to end tests
