### PR TITLE
Highlight rectangle selection with custom color

### DIFF
--- a/apps/examples/src/examples/selection-color-condition/README.md
+++ b/apps/examples/src/examples/selection-color-condition/README.md
@@ -1,0 +1,46 @@
+---
+title: Selection Color Condition
+component: ./SelectionColorConditionExample.tsx
+category: ui
+priority: 3
+keywords: [selection, color, condition, rectangle, geo shapes]
+---
+
+Change the selection color based on the types of shapes selected.
+
+---
+
+This example shows how to change the selection color when the selection contains only rectangle geo shapes. The selection will appear red when all selected shapes are rectangles, and use the default blue color otherwise.
+
+The example uses the `react` function to listen for selection changes and updates the container's CSS class accordingly.
+
+## How it works
+
+1. **Listen for selection changes**: The `react` function is used to create a reactive effect that runs whenever the selection changes.
+
+2. **Check shape conditions**: The code checks if all selected shapes match a specific condition (in this case, being rectangle geo shapes).
+
+3. **Update CSS classes**: Based on the condition, the container's CSS class is added or removed.
+
+4. **Style with CSS**: The CSS uses CSS custom properties to override the default selection colors.
+
+## Customizing the condition
+
+You can modify the condition to check for different shape types:
+
+```typescript
+// Check for circle shapes
+const allAreCircles = selectedShapes.length > 0 && selectedShapes.every(shape => 
+	shape.type === 'geo' && shape.props.geo === 'ellipse'
+)
+
+// Check for text shapes
+const allAreText = selectedShapes.length > 0 && selectedShapes.every(shape => 
+	shape.type === 'text'
+)
+
+// Check for mixed conditions
+const hasRectanglesAndCircles = selectedShapes.length > 0 && selectedShapes.every(shape => 
+	shape.type === 'geo' && (shape.props.geo === 'rectangle' || shape.props.geo === 'ellipse')
+)
+```

--- a/apps/examples/src/examples/selection-color-condition/SelectionColorConditionExample.tsx
+++ b/apps/examples/src/examples/selection-color-condition/SelectionColorConditionExample.tsx
@@ -1,0 +1,35 @@
+import { Tldraw, react } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './selection-color-condition.css'
+
+export default function SelectionColorConditionExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="selection-color-condition"
+				onMount={(editor) => {
+					// Listen for selection changes using the react function
+					const stopListening = react('update selection classname', () => {
+						const selectedShapes = editor.getSelectedShapes()
+						
+						// Check if all selected shapes are rectangle geo shapes
+						// This condition can be customized for any shape type or combination
+						const allAreRectangles = selectedShapes.length > 0 && selectedShapes.every(shape => 
+							shape.type === 'geo' && shape.props.geo === 'rectangle'
+						)
+						
+						// Update the container's CSS class based on the condition
+						// The CSS will handle the visual styling
+						if (allAreRectangles) {
+							editor.getContainer().classList.add('rectangle-selection')
+						} else {
+							editor.getContainer().classList.remove('rectangle-selection')
+						}
+					})
+
+					return stopListening
+				}}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/selection-color-condition/selection-color-condition.css
+++ b/apps/examples/src/examples/selection-color-condition/selection-color-condition.css
@@ -1,0 +1,20 @@
+/* Custom selection color for rectangle shapes */
+.tl-container.rectangle-selection {
+	--color-selection: #ff4444;
+	--color-selection-stroke: #cc0000;
+}
+
+/* You can add more conditions for different shape types */
+/* Example for circle shapes:
+.tl-container.circle-selection {
+	--color-selection: #44ff44;
+	--color-selection-stroke: #00cc00;
+}
+*/
+
+/* Example for text shapes:
+.tl-container.text-selection {
+	--color-selection: #4444ff;
+	--color-selection-stroke: #0000cc;
+}
+*/


### PR DESCRIPTION
### Change selection color based on shape condition

This PR adds a new example called "Selection Color Condition" that demonstrates how to dynamically change the selection color based on the types of shapes currently selected.

When all selected shapes are rectangles, the selection color will turn red. Otherwise, it will revert to the default blue. This is achieved by:
1. Using `editor.react` to listen for selection changes.
2. Checking if all `editor.getSelectedShapes()` are of type 'geo' and 'rectangle'.
3. Adding/removing a CSS class (`rectangle-selection`) to the editor container.
4. Overriding `--color-selection` and `--color-selection-stroke` CSS variables in `selection-color-condition.css`.

The example includes comprehensive documentation in its `README.md` on how to customize the condition for other shape types (e.g., circles, text, or mixed selections).

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Navigate to the "Selection Color Condition" example.
2. Create several rectangle shapes.
3. Select only rectangles: Observe the selection outline and fill turn red.
4. Create other shapes (e.g., circles, text).
5. Select a mix of rectangles and other shapes: Observe the selection color remain default (blue).
6. Select only non-rectangle shapes: Observe the selection color remain default (blue).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a new example demonstrating how to dynamically change the selection color based on selected shape types.

---
<a href="https://cursor.com/background-agent?bcId=bc-3355ce7f-6cb4-4da0-9366-382314cc5a9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3355ce7f-6cb4-4da0-9366-382314cc5a9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

