### PR TITLE
changes room name to avoid overcrowding

### DIFF
--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -82,7 +82,7 @@ import { useSyncDemo } from '@tldraw/sync'
 import 'tldraw/tldraw.css'
 
 export default function App() {
-	const store = useSyncDemo({ roomId: 'myapp-abc123' })
+	const store = useSyncDemo({ roomId: `${your_room_id}` })
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>

--- a/apps/docs/content/getting-started/quick-start.mdx
+++ b/apps/docs/content/getting-started/quick-start.mdx
@@ -82,7 +82,7 @@ import { useSyncDemo } from '@tldraw/sync'
 import 'tldraw/tldraw.css'
 
 export default function App() {
-	const store = useSyncDemo({ roomId: `${your_room_id}` })
+	const store = useSyncDemo({ roomId: 'insert-any-string-here' })
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>

--- a/apps/docs/content/getting-started/releases-versioning.mdx
+++ b/apps/docs/content/getting-started/releases-versioning.mdx
@@ -15,83 +15,93 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 {/* START AUTO-GENERATED CHANGELOG */}
 
-## Current release: [v3.13.0](/releases/v3.13.0)
+## Current release: [v3.15.0](/releases/v3.15.0)
 
-The big new feature in this months release is Elbow Arrows! These connectors supplement our existing arrow shape and are well suited to more technical diagramming type use-cases. We’re also been continuing to work on accessibility in tldraw, and there are plenty of other performance improvements too.
+This release adds `npm create tldraw` to bootstrap new tldraw projects. It also includes several small API additions, accessibility improvements, performance optimizations, and various bug fixes.
 
-#### Elbow arrows
+### `npm create tldraw`
 
-The arrow shape now supports elbow arrows! Instead of a single straight line or arc, these arrows get from A to B in a series straight lines joined at right angles. Access the new arrow type by selecting the arrow tool, and choosing the new option under the "Line" style.
+You can now run `npm create tldraw` in your terminal to bootstrap a new tldraw project from our starter templates.
 
-#### Accessibility features
+![npm create tldraw](https://github.com/user-attachments/assets/7141d2cc-fb24-44c4-b440-2e6e00d3606b)
 
-We’re continuing to work on accessibility in this release, as we make progress towards WCAG compliance.
+## Breaking changes
 
-- You can now focus the style panel with the ⌘⏎ keyboard shortcut. ([#5827](https://github.com/tldraw/tldraw/pull/5827))
-- More icons and handles in the UI now have labels. ([#6001](https://github.com/tldraw/tldraw/pull/6001))
-- ⌘⇧↓ and ⌘⇧↑ moves the selection in and out of container shapes, like frames and groups. ([#5973](https://github.com/tldraw/tldraw/pull/5973))
-- You can now tab into embed shapes. ([#5958](https://github.com/tldraw/tldraw/pull/5958))
-- The toolbars throughout tldraw are now keyboard navigable. ([#5872](https://github.com/tldraw/tldraw/pull/5872))
-- The shortcuts for rich text editing are shown in the keyboard shortcuts help menu. ([#5912](https://github.com/tldraw/tldraw/pull/5912))
+There are no breaking changes in this release.
 
-#### Breaking changes
+## User-facing changes
 
-- `ShapeUtil.canEditInReadOnly` has been renamed to `ShapeUtil.canEditInReadonly` - note the case-change on “only”. ([#6019](https://github.com/tldraw/tldraw/pull/6019))
+- Improve the 'Select All' action to select within the common parent of the current selection. For example, if you select a shape within a frame, it will select all the shapes within that frame but not the frame itself. ([#6386](https://github.com/tldraw/tldraw/pull/6386))
 
-#### Improvements
+- Add a user preference option to turn off keyboard shortcuts. ([#6363](https://github.com/tldraw/tldraw/pull/6363))
 
-- When editing the link on a shape, link text is now auto-selected for faster editing. ([#6072](https://github.com/tldraw/tldraw/pull/6072))
-- Pasted text and embeds are now snapped to the grid if it’s enabled. ([#6020](https://github.com/tldraw/tldraw/pull/6020))
-- Figma embed now also work with selection links. ([#6025](https://github.com/tldraw/tldraw/pull/6025))
-- When editing an arrow label, we now block off part of the arrow to show where your label will appear. ([#6029](https://github.com/tldraw/tldraw/pull/6029))
-- Exports of single frames now have the frame background color included in the export. ([#5993](https://github.com/tldraw/tldraw/pull/5993))
-- Standardised gradient and hover effects for open submenu items are standardised across the UI. ([#5974](https://github.com/tldraw/tldraw/pull/5974))
-- Frames can now be resized to fit their contents by double-clicking their edges. ([#5967](https://github.com/tldraw/tldraw/pull/5967))
+## API additions
 
-#### API additions
+- Add several new `ShapeUtil` callbacks for handle interactions. ([#6489](https://github.com/tldraw/tldraw/pull/6489))
+  - Handle drag start and end callbacks: `onHandleDragStart` and `onHandleDragEnd`.
+  - Interaction cancellation callbacks: `onTranslateCancel`, `onResizeCancel`, `onRotateCancel`, and `onHandleDragCancel`.
 
-- The text measurement API now accepts arbitrary styles to be applied to the text being measured. ([#6014](https://github.com/tldraw/tldraw/pull/6014))
-- A new `Overlays` component lets you add overlays on top of the canvas that still follow the camera. ([#5952](https://github.com/tldraw/tldraw/pull/5952))
-- `RichTextLabel` now accepts a `hasCustomTabBehavior` prop to disable our default tabbing logic where needed. ([#5908](https://github.com/tldraw/tldraw/pull/5908))
+- Allow custom JSX for icons in UI components. ([#6486](https://github.com/tldraw/tldraw/pull/6486))
 
-#### Other improvements
+  This applies to tool and action overrides as well as our button and menu item components.
 
-- Improve performance of a programatically rotating shape when it is selected ([#6023](https://github.com/tldraw/tldraw/pull/6023))
-- Dragging many shapes at once is now much faster. ([#5821](https://github.com/tldraw/tldraw/pull/5821))
-- Errors in tldraw no longer prompt users to open an issue on GitHub, as they were getting confused between tldraw and products that use the SDK. ([#5947](https://github.com/tldraw/tldraw/pull/5947))
-- License keys now support VS Code extensions. ([#5940](https://github.com/tldraw/tldraw/pull/5940))
+- Add the `StateNode.addChild` method for dynamically adding functionality to tools. ([#6485](https://github.com/tldraw/tldraw/pull/6485))
 
-#### Bug fixes
+- The `DefaultSpinner` component is now an SVG, and accepts SVG props like `width`, `height`, and `className`. ([#6459](https://github.com/tldraw/tldraw/pull/6459))
 
-- Flattened shapes no longer include an opaque background color. ([#6043](https://github.com/tldraw/tldraw/pull/6043))
-- Screenreader announcements are now only triggered in response to user actions. ([#6041](https://github.com/tldraw/tldraw/pull/6041))
-- The hand tool no longer takes pan speed into account, so it’s consistent with middle-mouse/spacebar panning. ([#6024](https://github.com/tldraw/tldraw/pull/6024))
-- Empty lines and list in text now render consistently. ([#6013](https://github.com/tldraw/tldraw/pull/6013))
-- The escape key now correctly exits the laser tool. ([#6015](https://github.com/tldraw/tldraw/pull/6015))
-- Offscreen shapes are now selected correctly while brushing. ([#6004](https://github.com/tldraw/tldraw/pull/6004))
-- `ShapeUtil.getGeometry` uses `shape.meta` as part of its cache key, instead of just `shape.props`. ([#5988](https://github.com/tldraw/tldraw/pull/5988))
-- Toolbar buttons reflect their active states correctly. ([#5981](https://github.com/tldraw/tldraw/pull/5981))
-- The control key gets released properly when wheeling. ([#5983](https://github.com/tldraw/tldraw/pull/5983))
-- Remove jitter from arrows & lines as their size changes in some browsers. ([#5975](https://github.com/tldraw/tldraw/pull/5975))
-- Long-pressing the enter key no longer enters edit mode. ([#5957](https://github.com/tldraw/tldraw/pull/5957))
-- Partially bound arrows don’t flicker when you rotate them. ([#5951](https://github.com/tldraw/tldraw/pull/5951))
-- `editor.getSelectedShapes` no longer causes re-evaluations unless it actually changed. ([#5928](https://github.com/tldraw/tldraw/pull/5928))
-- Chains of viewport followers now work as expected. ([#5924](https://github.com/tldraw/tldraw/pull/5924))
+- Add a missing export of `HeartToolbarItem`. ([#6438](https://github.com/tldraw/tldraw/pull/6438))
 
-#### Authors
+## Bug fixes
 
-- [@budatl](https://github.com/budatl)
-- alex ([@SomeHats](https://github.com/SomeHats))
-- Ante Sepic ([@OriginalEXE](https://github.com/OriginalEXE))
-- David Sheldrick ([@ds300](https://github.com/ds300))
-- Lu Wilson ([@TodePond](https://github.com/TodePond))
-- Mime Čuvalo ([@mimecuvalo](https://github.com/mimecuvalo))
-- Mitja Bezenšek ([@MitjaBezensek](https://github.com/MitjaBezensek))
-- Steve Ruiz ([@steveruizok](https://github.com/steveruizok))
-- Trygve Aaberge ([@trygve-aaberge-adsk](https://github.com/trygve-aaberge-adsk))
-- Younsang Na ([@nayounsang](https://github.com/nayounsang))
+- Fix HTML entities escaping in pasted content. ([#6396](https://github.com/tldraw/tldraw/pull/6396))
+
+- Fix measurement of fixed-size text shapes and labels. ([#6423](https://github.com/tldraw/tldraw/pull/6423))
+
+- Fix an issue where text measurement could be wrong due to styles being leaked between measurements. ([#6419](https://github.com/tldraw/tldraw/pull/6419))
+
+- Fix an issue that would cause arrows between circles to sometimes render incorrectly. ([#6417](https://github.com/tldraw/tldraw/pull/6417))
+
+- Fix text outline rendering in exported SVGs. ([#6371](https://github.com/tldraw/tldraw/pull/6371))
+
+- Fix some edge cases where errors were thrown after reaching the maximum number of shapes. ([#6359](https://github.com/tldraw/tldraw/pull/6359))
+
+- Fix image toolbar reacting to camera movement. ([#6375](https://github.com/tldraw/tldraw/pull/6375))
+
+- Update `fractional-indexing-jittered` to address an issue with certain null values. See [this PR](https://github.com/TMeerhof/fractional-indexing-jittered/pull/5). ([#6479](https://github.com/tldraw/tldraw/pull/6479))
+
+## Performance improvements
+
+- Prevent unnecessarily dropped frames. ([#6464](https://github.com/tldraw/tldraw/pull/6464)) ([#6409](https://github.com/tldraw/tldraw/pull/6409))
+
+- Optimize the `useValue` hook. ([#6405](https://github.com/tldraw/tldraw/pull/6405))
+
+- Optimize the `useReactor` hook. ([#6383](https://github.com/tldraw/tldraw/pull/6383))
+
+- Optimize frame rendering performance. ([#6415](https://github.com/tldraw/tldraw/pull/6415))
+
+## Accessibility improvements
+
+- Apply `aria-hidden` to more elements, and in more intelligent ways. ([#6471](https://github.com/tldraw/tldraw/pull/6471)) ([#6437](https://github.com/tldraw/tldraw/pull/6437))
+
+- Improve keyboard navigation. ([#6446](https://github.com/tldraw/tldraw/pull/6446))
+
+- Set `role="radiogroup"` on the `ToggleGroup` component. ([#6435](https://github.com/tldraw/tldraw/pull/6435))
+
+- Fix aria slider values and make dialogs scrollable via keyboard. ([#6431](https://github.com/tldraw/tldraw/pull/6431))
+
+- Fix several other minor accessibility issues. ([#6358](https://github.com/tldraw/tldraw/pull/6358))
+
+## Other improvements
+
+- Show max shapes alert when duplicating shapes. ([#6411](https://github.com/tldraw/tldraw/pull/6411))
+
+- Hide cropping toolbar while cropping. ([#6376](https://github.com/tldraw/tldraw/pull/6376))
 
 ## Previous releases
+
+- [v3.14.0](/releases/v3.14.0)
+
+- [v3.13.0](/releases/v3.13.0)
 
 - [v3.12.0](/releases/v3.12.0)
 


### PR DESCRIPTION
This PR introduces a cosmetic change in Quick Start that can otherwise be a blocker for users.

### Problem description

If you just copy-paste the code from the existing Quick Start, you may hit an overused room:

https://github.com/user-attachments/assets/cabd59f6-18db-41ed-8ed0-ca5a9074ef0b

Users who are not familiar with multi-player can have a hard time figuring out the way out.

### Solution

The current change makes it more explicit that the room should have a unique ID by making the example more explicit.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [X] `other`