### PR TITLE
Initial slides in the Slides Example

### DIFF
--- a/apps/examples/src/examples/slides/SlidesExample.tsx
+++ b/apps/examples/src/examples/slides/SlidesExample.tsx
@@ -8,6 +8,7 @@ import {
 	Tldraw,
 	TldrawUiMenuItem,
 	computed,
+	createShapeId,
 	track,
 	useIsToolSelected,
 	useTools,
@@ -101,6 +102,25 @@ const SlidesExample = track(() => {
 				tools={[SlideShapeTool]}
 				components={components}
 				overrides={overrides}
+				onMount={(editor) => {
+					const existingSlides = getSlides(editor)
+					if (existingSlides.length === 0) {
+						editor.createShape({
+							id: createShapeId(),
+							type: 'slide',
+							x: 100,
+							y: 100,
+							props: { w: 720, h: 480 },
+						})
+						editor.createShape({
+							id: createShapeId(),
+							type: 'slide',
+							x: 900,
+							y: 100,
+							props: { w: 720, h: 480 },
+						})
+					}
+				}}
 			/>
 		</div>
 	)


### PR DESCRIPTION
I was browsing examples and the "Slides" one felt broken because nothing appeared on the canvas. By comparison, the "Slideshow" example starts with initial slides so I wanted to make them look more uniform (and intuitive).

https://github.com/user-attachments/assets/798ce1dc-9792-4610-8bfa-57cc56b2a864

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [X] `other`