### PR TITLE
Add @heroicons/react dependency and implement theme toggle in QuickAc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
 		"@types/node": "^22.15.31"
 	},
 	"dependencies": {
+		"@heroicons/react": "^2.2.0",
 		"@sentry/cli": "^2.41.1",
 		"@yarnpkg/types": "^4.0.0",
 		"cross-env": "^7.0.3",

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -46,6 +46,7 @@
 		"tldraw.css"
 	],
 	"dependencies": {
+		"@heroicons/react": "^2.2.0",
 		"@tiptap/core": "^2.9.1",
 		"@tiptap/extension-code": "^2.9.1",
 		"@tiptap/extension-highlight": "^2.9.1",

--- a/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/QuickActions/DefaultQuickActionsContent.tsx
@@ -1,4 +1,6 @@
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid'
 import { useEditor, useValue } from '@tldraw/editor'
+import { useActions } from '../../context/actions'
 import {
 	useCanRedo,
 	useCanUndo,
@@ -6,6 +8,7 @@ import {
 	useUnlockedSelectedShapesCount,
 } from '../../hooks/menu-hooks'
 import { useReadonly } from '../../hooks/useReadonly'
+import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiMenuActionItem } from '../primitives/menus/TldrawUiMenuActionItem'
 
 /** @public @react */
@@ -26,6 +29,7 @@ export function DefaultQuickActionsContent() {
 		<>
 			<UndoRedoGroup />
 			<DeleteDuplicateGroup />
+			<ThemeToggleGroup />
 		</>
 	)
 }
@@ -50,5 +54,27 @@ function UndoRedoGroup() {
 			<TldrawUiMenuActionItem actionId="undo" disabled={!canUndo} />
 			<TldrawUiMenuActionItem actionId="redo" disabled={!canRedo} />
 		</>
+	)
+}
+
+function ThemeToggleGroup() {
+	const editor = useEditor()
+	const isDarkMode = useValue('isDarkMode', () => editor.user.getIsDarkMode(), [editor])
+	const actions = useActions()
+	const toggleDarkModeAction = actions['toggle-dark-mode']
+
+	return (
+		<TldrawUiButton
+			type="icon"
+			title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+			onClick={() => toggleDarkModeAction?.onSelect('quick-actions')}
+			data-testid="quick-actions.toggle-dark-mode"
+		>
+			{isDarkMode ? (
+				<MoonIcon style={{ width: '18px', height: '18px' }} />
+			) : (
+				<SunIcon style={{ width: '18px', height: '18px' }} />
+			)}
+		</TldrawUiButton>
 	)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9356,6 +9356,7 @@ __metadata:
     "@eslint/compat": "npm:^1.2.5"
     "@eslint/eslintrc": "npm:^3.2.0"
     "@eslint/js": "npm:^9.19.0"
+    "@heroicons/react": "npm:^2.2.0"
     "@lingual/i18n-check": "npm:^0.5.5"
     "@microsoft/api-extractor": "npm:^7.49.1"
     "@next/eslint-plugin-next": "npm:^15.1.6"
@@ -28491,6 +28492,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tldraw@workspace:packages/tldraw"
   dependencies:
+    "@heroicons/react": "npm:^2.2.0"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@testing-library/jest-dom": "npm:^5.17.0"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION


## Change Type

- [ ]  bugfix
- [x]  improvement
- [ ]  feature
- [ ]  api
- [ ]  other

## ✨ Add Theme Toggle to Quick Actions Menu

### Summary

This PR introduces a **dark/light mode toggle** directly within the **Quick Actions menu** in `tldraw`, allowing users to quickly switch themes without navigating through the preferences panel.

### Motivation

The current workflow for changing the theme requires navigating to:

```
Preferences → Theme → Select Theme
```

While functional, this path can be cumbersome — especially for users who frequently switch between light and dark modes for testing, design evaluation, or personal preference. 

By adding a theme toggle to the Quick Actions menu, this PR significantly improves **accessibility**, **efficiency**, and **user experience**.

### Implementation Details

- Added a new `ToggleTheme` quick action.
- The action dynamically switches between `light` and `dark` modes.
- Uses the existing theme configuration logic under the hood.
- Icon updates based on the current theme (☀️ / 🌙).

### Demo

Please refer to the attached videos for a demonstration of the feature in action.

https://github.com/user-attachments/assets/415b7f27-2402-4035-b1a2-c19f4d6a4e76

### Notes

This enhancement maintains full compatibility with the existing preferences-based theme selection and introduces no breaking changes.
