### PR TITLE
Fix: Arrow labels can be truncated when exporting

### DIFF
--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -1,5 +1,6 @@
 import { useAtom, useValue } from '@tldraw/state-react'
 import {
+	TLArrowShape,
 	TLFrameShape,
 	TLGroupShape,
 	TLShape,
@@ -34,6 +35,7 @@ import { useEvent } from '../hooks/useEvent'
 import { suffixSafeId, useUniqueSafeId } from '../hooks/useSafeId'
 import { Box } from '../primitives/Box'
 import { Mat } from '../primitives/Mat'
+import { Geometry2dFilters } from '../primitives/geometry/Geometry2d'
 import { ExportDelay } from './ExportDelay'
 
 export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportOptions = {}) {
@@ -63,6 +65,14 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 		for (const { id } of renderingShapes) {
 			const maskedPageBounds = editor.getShapeMaskedPageBounds(id)
 			if (!maskedPageBounds) continue
+			if (editor.isShapeOfType<TLArrowShape>(editor.getShape(id)!, 'arrow')) {
+				// For arrows, apply a bounding box that includes the label.
+				const geometry = editor.getShapeGeometry(id)
+				const vertices = geometry.getVertices(Geometry2dFilters.INCLUDE_ALL)
+				const pageTransform = editor.getShapePageTransform(id)
+				const box = Box.FromPoints(pageTransform.applyToPoints(vertices))
+				maskedPageBounds.union(box)
+			}
 			if (bbox) {
 				bbox.union(maskedPageBounds)
 			} else {


### PR DESCRIPTION
This PR fixes an issue where shapes containing labeled arrows could be truncated when exported.
Fixes #5224.

A patch has been applied to the SVG export process to address this.
If this approach does not meet expectations, please feel free to close this PR.

|before|after|
|-----|-----|
| <img width="1344" height="756" alt="before" src="https://github.com/user-attachments/assets/bb749c25-6dbf-4452-9345-5e304f2e7320" /> | <img width="1360" height="778" alt="after" src="https://github.com/user-attachments/assets/d5af60ec-3c2e-4ebf-a58c-fc6740d9bb92" /> |

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Exported shapes as PNG with arrow labels extending beyond their bounding box (as shown above) to confirm they were not cut off.
2. Also tested a case where the arrow label did not protrude.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where shapes containing labeled arrows could be truncated when exported.