### PR TITLE
Update the tldraw sync server readme

### DIFF
--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -17,7 +17,7 @@ This is a production-ready backend for [tldraw sync](https://tldraw.dev/docs/syn
   server instance for every single active room, we've never needed to worry about scale. Cloudflare
   handles the tricky infrastructure work of ensuring there's only ever one instance of each room, and
   making sure that every user gets connected to that instance. We've found that with this approach,
-  each room is able to handle about 30 simultaneous collaborators.
+  each room is able to handle about 50 simultaneous collaborators.
 
 ## Overview
 


### PR DESCRIPTION
This PR updates the number of connections in the readme (from 30 to 50)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [X] `other`