### PR TITLE
namespace css variables

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
@@ -141,7 +141,7 @@
 		position: absolute;
 		inset: 0px 4px;
 		border-radius: 6px;
-		background-color: var(--color-muted-2);
+		background-color: var(--tl-color-muted-2);
 	}
 }
 

--- a/apps/dotcom/client/src/tla/components/TlaCtaButton/cta-button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaCtaButton/cta-button.module.css
@@ -47,7 +47,7 @@
 	content: '';
 	position: absolute;
 	inset: 0px;
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 	border-radius: 8px;
 	z-index: 1;
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/SlurpFailure.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/SlurpFailure.tsx
@@ -35,7 +35,7 @@ export function SlurpFailure({
 					maxWidth: 350,
 					display: 'flex',
 					flexDirection: 'column',
-					gap: 'var(--space-4)',
+					gap: 'var(--tl-space-4)',
 				}}
 			>
 				<p>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/editor.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/editor.module.css
@@ -4,7 +4,7 @@
 	height: 100%;
 	overflow: hidden;
 	z-index: 1;
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 }
 
 .editorWrapper {
@@ -12,7 +12,7 @@
 	flex-grow: 2;
 	overflow: hidden;
 	border-top: 1px solid var(--tla-color-border);
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 }
 
 .editorWrapper > .tldraw__editor {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
@@ -11,14 +11,14 @@
 
 .topLeftPanel {
 	flex: 0 0 auto;
-	border-top: 4px solid var(--color-background);
+	border-top: 4px solid var(--tl-color-background);
 	height: 44px;
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	pointer-events: all;
 	white-space: nowrap;
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 	border-bottom-right-radius: 11px;
 	padding-left: 2px;
 	width: 100%;
@@ -54,7 +54,7 @@
 }
 
 .topLeftPanelSeparator {
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	pointer-events: none;
 	padding: 0px 4px;
 	flex-shrink: 0;
@@ -131,7 +131,7 @@ button.topLeftInputNameWidthSetter {
 }
 
 .topLeftInputWrapper input:focus-visible {
-	outline: 1px solid var(--color-primary);
+	outline: 1px solid var(--tl-color-primary);
 	border-radius: 10px;
 	outline-offset: -5px;
 }
@@ -142,7 +142,7 @@ button.topLeftInputNameWidthSetter {
 	position: absolute;
 	inset: 4px;
 	background-color: transparent;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .topLeftInputWrapperEditable button {
@@ -151,12 +151,12 @@ button.topLeftInputNameWidthSetter {
 
 @media (hover: hover) {
 	.topLeftInputWrapperEditable:hover:not(:focus-within)::after {
-		background-color: var(--color-muted-2);
+		background-color: var(--tl-color-muted-2);
 	}
 }
 
 /* .inputWrapper:focus-within::after {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 } */
 
 /* -------------------- Main Menu ------------------- */
@@ -171,7 +171,7 @@ button.topLeftInputNameWidthSetter {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	flex: 0 0 auto;
 	z-index: 3;
 	padding: 0px;
@@ -180,7 +180,7 @@ button.topLeftInputNameWidthSetter {
 }
 
 .topLeftMainMenuTrigger:focus-visible {
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -5px;
 	border-radius: 10px;
 }
@@ -189,7 +189,7 @@ button.topLeftInputNameWidthSetter {
 	content: '';
 	position: absolute;
 	inset: 4px;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 @media (hover: hover) {
@@ -198,12 +198,12 @@ button.topLeftInputNameWidthSetter {
 	}
 
 	.topLeftMainMenuTrigger:hover::after {
-		background-color: var(--color-muted-2);
+		background-color: var(--tl-color-muted-2);
 	}
 }
 
 .topLeftMainMenuTrigger[data-state='open']::after {
-	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 }
 
 .offlineIndicatorWrapper {
@@ -288,7 +288,7 @@ button.topLeftInputNameWidthSetter {
 }
 
 .topRightAnonShareButton[data-state='open']::after {
-	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	visibility: visible;
 }
 

--- a/apps/dotcom/client/src/tla/components/TlaLogo/logo.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaLogo/logo.module.css
@@ -2,7 +2,7 @@
 	display: flex;
 	position: relative;
 	flex-shrink: 0;
-	background-color: var(--color-text-1);
+	background-color: var(--tl-color-text-1);
 	height: 19px;
 	width: 70px;
 	z-index: 1;

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -53,7 +53,7 @@
 
 @media (min-width: 768px) {
 	.sidebar {
-		border-right: 1px solid var(--color-low);
+		border-right: 1px solid var(--tl-color-low);
 	}
 	.sidebar[data-visible='true'] {
 		transform: translate(100%, 0px);
@@ -170,7 +170,7 @@
 .sidebarToggle:focus-visible {
 	border-radius: 8px;
 	outline-offset: -4px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 }
 
 @media (hover: hover) {
@@ -541,7 +541,7 @@
 
 .sidebarFileListItemRenameInputWrapper {
 	background-color: var(--tla-color-sidebar);
-	outline: 1px solid var(--color-primary);
+	outline: 1px solid var(--tl-color-primary);
 	outline-offset: -2px;
 	border-radius: 6px;
 }
@@ -636,7 +636,7 @@
 
 .sidebarFileLinkRenameInputWrapper {
 	background-color: var(--tla-color-sidebar);
-	outline: 1px solid var(--color-primary);
+	outline: 1px solid var(--tl-color-primary);
 	outline-offset: -2px;
 	border-radius: 6px;
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -7,18 +7,18 @@
 .dialogBody {
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-4);
+	gap: var(--tl-space-4);
 	max-width: 500px;
 }
 
 /* ----------------- Feedback dialog ---------------- */
 
 .feedbackDialogTextArea {
-	border: 1px solid var(--color-muted-2);
-	border-radius: var(--radius-2) var(--radius-2) 0px var(--radius-2);
-	background-color: var(--color-muted-0);
-	color: var(--color-text-0);
-	padding: var(--space-3) var(--space-4);
+	border: 1px solid var(--tl-color-muted-2);
+	border-radius: var(--tl-radius-2) var(--tl-radius-2) 0px var(--tl-radius-2);
+	background-color: var(--tl-color-muted-0);
+	color: var(--tl-color-text-0);
+	padding: var(--tl-space-3) var(--tl-space-4);
 	resize: vertical;
 	width: 100%;
 	min-height: 100px;
@@ -26,5 +26,5 @@
 }
 
 .feedbackDialogTextArea::placeholder {
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 }

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -42,12 +42,12 @@
 	flex-shrink: 0;
 	height: 40px;
 	width: 40px;
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	cursor: pointer;
 }
 
 .menuInfoTrigger a {
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	text-decoration: none;
 }
 
@@ -55,8 +55,8 @@
 	display: block;
 	content: '';
 	position: absolute;
-	border-radius: var(--radius-2);
-	background: var(--color-muted-2);
+	border-radius: var(--tl-radius-2);
+	background: var(--tl-color-muted-2);
 	inset: 6px;
 	border-radius: 100%;
 	opacity: 0;
@@ -64,7 +64,7 @@
 }
 
 .menuInfoTrigger:focus-visible {
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -10px;
 	border-radius: 100%;
 }
@@ -130,7 +130,7 @@
 	content: '';
 	display: block;
 	position: absolute;
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	inset: -4px;
 	border-radius: 6px;
 	opacity: 0;
@@ -146,9 +146,9 @@ div:has(> .menuSelectContent) {
 }
 
 .menuSelectContent {
-	border-radius: var(--radius-3);
-	background-color: var(--color-panel);
-	box-shadow: var(--shadow-3);
+	border-radius: var(--tl-radius-3);
+	background-color: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-3);
 }
 
 .menuSelectOption {
@@ -176,7 +176,7 @@ div:has(> .menuSelectContent) {
 	inset: 4px;
 	display: block;
 	position: absolute;
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	opacity: 0;
 	border-radius: 6px;
 }
@@ -197,7 +197,7 @@ div:has(> .menuSelectContent) {
 
 :global(.tl-container__focused:not(.tl-container__no-focus-ring)) .menuSelectOption:focus-visible {
 	border-radius: 10px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -5px;
 }
 
@@ -302,7 +302,7 @@ div:has(> .menuSelectContent) {
 
 .menuSwitchContainer:has(input:focus-visible) > div {
 	outline-offset: 2px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 }
 
 @media (hover: hover) {

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
@@ -7,7 +7,7 @@
 	height: 100%;
 	/* disable transition while dragging */
 	transition: padding-left 0.16s ease-in-out;
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 }
 .layout[data-resizing='true'] {
 	pointer-events: none;

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -294,7 +294,7 @@
 	button:not(.tla-button-text):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 }
 
 /** We use tldraw components in some places, and menu sub-groups with checkbox items are also here. */
@@ -302,7 +302,7 @@
 	:is(.tlui-menu, .tlui-menu__group)
 	.tlui-button__menu:focus-visible {
 	border-radius: 10px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -5px;
 }
 
@@ -311,7 +311,7 @@
 	:is(nav, .tlui-popover__content, .tlui-dialog__overlay)
 	.tla-form-checkbox:has(input:focus-visible)
 	> label {
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 }
 
 /** Text buttons, specifically from the cookie consent */
@@ -319,7 +319,7 @@
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
 	nav
 	.tla-button-text:focus-visible {
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 }
 
 /** Primary buttons in the top area (e.g. Share, Sign in) */

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -200,13 +200,13 @@ a {
 .board-history__month-header {
 	font-size: 16px;
 	font-weight: 600;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	margin: 0 0 8px 0;
 	padding: 0;
 }
 
 .board-history__list a {
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	text-decoration: none;
 	padding: 8px 0;
 	display: block;
@@ -232,10 +232,10 @@ a {
 	font-family: inherit;
 	font-size: inherit;
 	height: 36px;
-	border: 2px solid var(--color-selected);
+	border: 2px solid var(--tl-color-selected);
 	border-radius: 8px;
-	background-color: var(--color-selected);
-	color: var(--color-selected-contrast);
+	background-color: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
 	text-shadow: none;
 	pointer-events: all;
 	position: relative;
@@ -245,7 +245,7 @@ a {
 }
 
 .board-history__load-more-button:hover:not(:disabled) {
-	background-color: var(--color-selected);
+	background-color: var(--tl-color-selected);
 	opacity: 0.9;
 }
 
@@ -314,10 +314,10 @@ a {
 	font-family: inherit;
 	font-size: inherit;
 	height: 36px;
-	border: 2px solid var(--color-background);
+	border: 2px solid var(--tl-color-background);
 	border-radius: 8px;
-	background-color: var(--color-selected);
-	color: var(--color-selected-contrast);
+	background-color: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
 	text-shadow: none;
 	pointer-events: all;
 	position: relative;
@@ -328,10 +328,10 @@ a {
 	font-family: inherit;
 	font-size: inherit;
 	height: 36px;
-	border: 2px solid var(--color-text);
+	border: 2px solid var(--tl-color-text);
 	border-radius: 8px;
-	background-color: var(--color-text);
-	color: var(--color-selected-contrast);
+	background-color: var(--tl-color-text);
+	color: var(--tl-color-selected-contrast);
 	text-shadow: none;
 	pointer-events: all;
 	position: relative;
@@ -343,24 +343,24 @@ a {
 	display: block;
 	content: '';
 	inset: 0px;
-	background-color: var(--color-background);
-	border-top-left-radius: var(--radius-3);
-	border-bottom-right-radius: var(--radius-3);
-	border-bottom-left-radius: var(--radius-3);
+	background-color: var(--tl-color-background);
+	border-top-left-radius: var(--tl-radius-3);
+	border-bottom-right-radius: var(--tl-radius-3);
+	border-bottom-left-radius: var(--tl-radius-3);
 	z-index: -1;
 }
 
 .tlui-share-zone__button:active {
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 }
 
 @media (hover: hover) {
 	.tlui-share-zone__button:hover {
-		color: var(--color-selected-contrast);
+		color: var(--tl-color-selected-contrast);
 	}
 
 	.tlui-share-zone__button:not(:disabled, :focus-visible):hover {
-		color: var(--color-selected-contrast);
+		color: var(--tl-color-selected-contrast);
 	}
 }
 
@@ -378,7 +378,7 @@ a {
 	height: 200px;
 	cursor: pointer;
 	background: none;
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	background-size: cover;
 	border: none;
 }
@@ -394,8 +394,8 @@ a {
 .tlui-share-zone__details {
 	font-size: 11px;
 	font-weight: 400;
-	padding: var(--space-4);
-	color: var(--color-text-1);
+	padding: var(--tl-space-4);
+	color: var(--tl-color-text-1);
 	line-height: 1.5;
 	margin: 0px;
 }
@@ -425,8 +425,8 @@ a {
 /* Document Name */
 
 .tlui-document-name__inner {
-	border-radius: calc(var(--radius-2) + var(--space-2));
-	background-color: var(--color-background);
+	border-radius: calc(var(--tl-radius-2) + var(--tl-space-2));
+	background-color: var(--tl-color-background);
 	padding: 0;
 	display: flex;
 	align-items: center;
@@ -435,8 +435,8 @@ a {
 	margin-top: 4px;
 	padding-left: 4px;
 	max-width: 100%;
-	color: var(--color-text);
-	text-shadow: 1px 1px 0px var(--color-background);
+	color: var(--tl-color-text);
+	text-shadow: 1px 1px 0px var(--tl-color-background);
 	pointer-events: all;
 }
 
@@ -449,7 +449,7 @@ a {
 
 .tlui-document-name__input,
 .tlui-document-name__text {
-	padding: var(--space-2) var(--space-3);
+	padding: var(--tl-space-2) var(--tl-space-3);
 	white-space: pre;
 	line-height: 24px;
 	min-width: 62px;
@@ -457,21 +457,21 @@ a {
 
 .tlui-document-name__input {
 	position: absolute;
-	padding: var(--space-1) var(--space-3);
+	padding: var(--tl-space-1) var(--tl-space-3);
 	margin-top: 2px;
 	width: 100%;
-	border-radius: var(--radius-2);
-	color: var(--color-text);
+	border-radius: var(--tl-radius-2);
+	color: var(--tl-color-text);
 	background: transparent;
 }
 .tlui-document-name__input:focus {
-	box-shadow: inset 0px 0px 0px 1px var(--color-selected);
+	box-shadow: inset 0px 0px 0px 1px var(--tl-color-selected);
 	border: none;
 }
 
 .tlui-document-name__text {
 	width: 100%;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
+++ b/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
@@ -72,7 +72,7 @@ const PaddingDisplay = track(() => {
 				left: px,
 				width: `calc(100% - ${px * 2}px)`,
 				height: `calc(100% - ${py * 2}px)`,
-				border: '1px dotted var(--color-text)',
+				border: '1px dotted var(--tl-color-text)',
 				pointerEvents: 'none',
 			}}
 		/>
@@ -105,7 +105,7 @@ const BoundsDisplay = track(() => {
 					width: w,
 					height: h,
 					// grey and white stripes
-					border: '1px dashed var(--color-text)',
+					border: '1px dashed var(--tl-color-text)',
 					backgroundImage: `
 			
 				`,

--- a/apps/examples/src/examples/drag-and-drop-tray/drag-and-drop-tray.css
+++ b/apps/examples/src/examples/drag-and-drop-tray/drag-and-drop-tray.css
@@ -2,9 +2,9 @@
 	position: absolute;
 	left: 10px;
 	top: 50px;
-	background: var(--color-panel);
+	background: var(--tl-color-panel);
 	border-radius: 9px;
-	box-shadow: var(--shadow-1);
+	box-shadow: var(--tl-shadow-1);
 	z-index: 1000;
 	pointer-events: all;
 	overflow: hidden;

--- a/apps/examples/src/examples/editor-focus/editor-focus.css
+++ b/apps/examples/src/examples/editor-focus/editor-focus.css
@@ -1,3 +1,3 @@
 .tl-container__focused {
-	outline: 1px solid var(--color-primary);
+	outline: 1px solid var(--tl-color-primary);
 }

--- a/apps/examples/src/examples/image-annotator/image-annotator.css
+++ b/apps/examples/src/examples/image-annotator/image-annotator.css
@@ -48,23 +48,23 @@
 
 .ImageAnnotator .ImageOverlayScreen {
 	pointer-events: none;
-	fill: var(--color-background);
+	fill: var(--tl-color-background);
 	fill-opacity: 0.8;
 	stroke: none;
 }
 
 .ImageAnnotator .DoneButton {
 	font: inherit;
-	background: var(--color-primary);
+	background: var(--tl-color-primary);
 	border: none;
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	font-size: 1rem;
 	padding: 0.5rem 1rem;
 	border-radius: 6px;
 	margin: 6px;
 	pointer-events: all;
-	z-index: var(--layer-panels);
-	border: 2px solid var(--color-background);
+	z-index: var(--tl-layer-panels);
+	border: 2px solid var(--tl-color-background);
 	cursor: pointer;
 }
 .ImageAnnotator .DoneButton:hover {

--- a/apps/examples/src/examples/pdf-editor/pdf-editor.css
+++ b/apps/examples/src/examples/pdf-editor/pdf-editor.css
@@ -34,29 +34,29 @@
 
 .PdfEditor .PageOverlayScreen-screen {
 	pointer-events: none;
-	fill: var(--color-background);
+	fill: var(--tl-color-background);
 	fill-opacity: 0.8;
 	stroke: none;
 }
 .PdfEditor .PageOverlayScreen-outline {
 	position: absolute;
 	pointer-events: none;
-	/* border: 1px solid var(--color-overlay); */
-	box-shadow: var(--shadow-2);
+	/* border: 1px solid var(--tl-color-overlay); */
+	box-shadow: var(--tl-shadow-2);
 }
 .PdfEditor .ExportPdfButton {
 	font: inherit;
-	background: var(--color-primary);
+	background: var(--tl-color-primary);
 	border: none;
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	font-size: 1rem;
 	padding: 0.5rem 1rem;
 	border-radius: 6px;
 	margin: 6px;
 	margin-bottom: 0;
 	pointer-events: all;
-	z-index: var(--layer-panels);
-	border: 2px solid var(--color-background);
+	z-index: var(--tl-layer-panels);
+	border: 2px solid var(--tl-color-background);
 	cursor: pointer;
 }
 .PdfEditor .ExportPdfButton:hover {

--- a/apps/examples/src/examples/screenshot-tool/ScreenshotToolExample.tsx
+++ b/apps/examples/src/examples/screenshot-tool/ScreenshotToolExample.tsx
@@ -95,7 +95,7 @@ function ScreenshotBox() {
 				transform: `translate(${screenshotBrush.x}px, ${screenshotBrush.y}px)`,
 				width: screenshotBrush.w,
 				height: screenshotBrush.h,
-				border: '1px solid var(--color-text-0)',
+				border: '1px solid var(--tl-color-text-0)',
 				zIndex: 999,
 			}}
 		/>

--- a/apps/examples/src/examples/shape-with-custom-styles/ShapeWithCustomStylesExample.tsx
+++ b/apps/examples/src/examples/shape-with-custom-styles/ShapeWithCustomStylesExample.tsx
@@ -58,7 +58,7 @@ class MyShapeUtil extends BaseBoxShapeUtil<IMyShape> {
 		return (
 			<HTMLContainer
 				id={shape.id}
-				style={{ backgroundColor: 'var(--color-low-border)', overflow: 'hidden' }}
+				style={{ backgroundColor: 'var(--tl-color-low-border)', overflow: 'hidden' }}
 			>
 				{stars}
 			</HTMLContainer>

--- a/apps/examples/src/examples/shape-with-tldraw-styles/ShapeWithTldrawStylesExample.tsx
+++ b/apps/examples/src/examples/shape-with-tldraw-styles/ShapeWithTldrawStylesExample.tsx
@@ -60,7 +60,7 @@ class MyShapeUtil extends BaseBoxShapeUtil<IMyShape> {
 		return (
 			<HTMLContainer
 				id={shape.id}
-				style={{ backgroundColor: 'var(--color-low-border)', overflow: 'hidden' }}
+				style={{ backgroundColor: 'var(--tl-color-low-border)', overflow: 'hidden' }}
 			>
 				<div
 					style={{

--- a/apps/examples/src/examples/slides/SlideShapeUtil.tsx
+++ b/apps/examples/src/examples/slides/SlideShapeUtil.tsx
@@ -92,7 +92,7 @@ export class SlideShapeUtil extends ShapeUtil<SlideShape> {
 				<SVGContainer>
 					<g
 						style={{
-							stroke: 'var(--color-text)',
+							stroke: 'var(--tl-color-text)',
 							strokeWidth: 'calc(1px * var(--tl-scale))',
 							opacity: 0.25,
 						}}

--- a/apps/examples/src/examples/slides/SlidesPanel.tsx
+++ b/apps/examples/src/examples/slides/SlidesPanel.tsx
@@ -19,8 +19,9 @@ export const SlidesPanel = track(() => {
 						className="slides-panel-button"
 						onClick={() => moveToSlide(editor, slide)}
 						style={{
-							background: currentSlide?.id === slide.id ? 'var(--color-background)' : 'transparent',
-							outline: isSelected ? 'var(--color-selection-stroke) solid 1.5px' : 'none',
+							background:
+								currentSlide?.id === slide.id ? 'var(--tl-color-background)' : 'transparent',
+							outline: isSelected ? 'var(--tl-color-selection-stroke) solid 1.5px' : 'none',
 						}}
 					>
 						{`Slide ${i + 1}`}

--- a/apps/examples/src/examples/slides/slides.css
+++ b/apps/examples/src/examples/slides/slides.css
@@ -5,28 +5,28 @@
 	max-height: calc(100% - 110px);
 	margin: 50px 0px;
 	padding: 4px;
-	background-color: var(--color-low);
+	background-color: var(--tl-color-low);
 	pointer-events: all;
-	border-top-right-radius: var(--radius-4);
-	border-bottom-right-radius: var(--radius-4);
+	border-top-right-radius: var(--tl-radius-4);
+	border-bottom-right-radius: var(--tl-radius-4);
 	overflow: auto;
-	border-right: 2px solid var(--color-background);
-	border-bottom: 2px solid var(--color-background);
-	border-top: 2px solid var(--color-background);
+	border-right: 2px solid var(--tl-color-background);
+	border-bottom: 2px solid var(--tl-color-background);
+	border-top: 2px solid var(--tl-color-background);
 }
 
 .slides-panel-button {
-	border-radius: var(--radius-4);
+	border-radius: var(--tl-radius-4);
 	outline-offset: -1px;
 }
 
 .slide-shape-label {
 	pointer-events: all;
 	position: absolute;
-	background: var(--color-low);
+	background: var(--tl-color-low);
 	padding: calc(12px * var(--tl-scale));
-	border-bottom-right-radius: calc(var(--radius-4) * var(--tl-scale));
+	border-bottom-right-radius: calc(var(--tl-radius-4) * var(--tl-scale));
 	font-size: calc(12px * var(--tl-scale));
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	white-space: nowrap;
 }

--- a/apps/examples/src/examples/text-search/text-search.css
+++ b/apps/examples/src/examples/text-search/text-search.css
@@ -5,33 +5,33 @@
 	max-height: calc(100% - 110px);
 	margin: 50px 0px;
 	padding: 4px;
-	background-color: var(--color-low);
+	background-color: var(--tl-color-low);
 	pointer-events: all;
-	border-top-right-radius: var(--radius-4);
-	border-bottom-right-radius: var(--radius-4);
+	border-top-right-radius: var(--tl-radius-4);
+	border-bottom-right-radius: var(--tl-radius-4);
 	overflow: auto;
-	border-right: 2px solid var(--color-background);
-	border-bottom: 2px solid var(--color-background);
-	border-top: 2px solid var(--color-background);
+	border-right: 2px solid var(--tl-color-background);
+	border-bottom: 2px solid var(--tl-color-background);
+	border-top: 2px solid var(--tl-color-background);
 }
 
 .text-search-panel-button {
-	border-radius: var(--radius-4);
+	border-radius: var(--tl-radius-4);
 	outline-offset: -1px;
 }
 
 .text-search-shape-label {
 	pointer-events: all;
 	position: absolute;
-	background: var(--color-low);
+	background: var(--tl-color-low);
 	padding: calc(12px * var(--tl-scale));
-	border-bottom-right-radius: calc(var(--radius-4) * var(--tl-scale));
+	border-bottom-right-radius: calc(var(--tl-radius-4) * var(--tl-scale));
 	font-size: calc(12px * var(--tl-scale));
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	white-space: nowrap;
 }
 
 .text-search-input {
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 	margin: 4px;
 }

--- a/apps/vscode/editor/public/index.css
+++ b/apps/vscode/editor/public/index.css
@@ -42,5 +42,5 @@ html,
 	width: 100%;
 	height: 100%;
 	overflow: hidden;
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 }

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -5,57 +5,57 @@
 	height: 100%;
 	font-size: 12px;
 	/* Spacing */
-	--space-1: 2px;
-	--space-2: 4px;
-	--space-3: 8px;
-	--space-4: 12px;
-	--space-5: 16px;
-	--space-6: 20px;
-	--space-7: 28px;
-	--space-8: 32px;
-	--space-9: 64px;
-	--space-10: 72px;
+	--tl-space-1: 2px;
+	--tl-space-2: 4px;
+	--tl-space-3: 8px;
+	--tl-space-4: 12px;
+	--tl-space-5: 16px;
+	--tl-space-6: 20px;
+	--tl-space-7: 28px;
+	--tl-space-8: 32px;
+	--tl-space-9: 64px;
+	--tl-space-10: 72px;
 	/* Radius */
-	--radius-0: 2px;
-	--radius-1: 4px;
-	--radius-2: 6px;
-	--radius-3: 9px;
-	--radius-4: 11px;
+	--tl-radius-0: 2px;
+	--tl-radius-1: 4px;
+	--tl-radius-2: 6px;
+	--tl-radius-3: 9px;
+	--tl-radius-4: 11px;
 
 	/* Canvas z-index */
-	--layer-canvas-hidden: -999999;
-	--layer-canvas-background: 100;
-	--layer-canvas-grid: 150;
-	--layer-watermark: 200;
-	--layer-canvas-shapes: 300;
-	--layer-canvas-overlays: 500;
-	--layer-canvas-blocker: 10000;
+	--tl-layer-canvas-hidden: -999999;
+	--tl-layer-canvas-background: 100;
+	--tl-layer-canvas-grid: 150;
+	--tl-layer-watermark: 200;
+	--tl-layer-canvas-shapes: 300;
+	--tl-layer-canvas-overlays: 500;
+	--tl-layer-canvas-blocker: 10000;
 
 	/* Canvas overlays z-index */
-	--layer-overlays-collaborator-scribble: 10;
-	--layer-overlays-collaborator-brush: 20;
-	--layer-overlays-collaborator-shape-indicator: 30;
-	--layer-overlays-user-scribble: 40;
-	--layer-overlays-user-brush: 50;
-	--layer-overlays-user-snapline: 90;
-	--layer-overlays-selection-fg: 100;
+	--tl-layer-overlays-collaborator-scribble: 10;
+	--tl-layer-overlays-collaborator-brush: 20;
+	--tl-layer-overlays-collaborator-shape-indicator: 30;
+	--tl-layer-overlays-user-scribble: 40;
+	--tl-layer-overlays-user-brush: 50;
+	--tl-layer-overlays-user-snapline: 90;
+	--tl-layer-overlays-selection-fg: 100;
 	/* User handles need to be above selection edges / corners, matters for sticky note clone handles */
-	--layer-overlays-user-handles: 105;
-	--layer-overlays-user-indicator-hint: 110;
-	--layer-overlays-custom: 115;
-	--layer-overlays-collaborator-cursor-hint: 120;
-	--layer-overlays-collaborator-cursor: 130;
+	--tl-layer-overlays-user-handles: 105;
+	--tl-layer-overlays-user-indicator-hint: 110;
+	--tl-layer-overlays-custom: 115;
+	--tl-layer-overlays-collaborator-cursor-hint: 120;
+	--tl-layer-overlays-collaborator-cursor: 130;
 
 	/* Text editor z-index */
-	--layer-text-container: 1;
-	--layer-text-content: 3;
-	--layer-text-editor: 4;
+	--tl-layer-text-container: 1;
+	--tl-layer-text-content: 3;
+	--tl-layer-text-editor: 4;
 
 	/* Error fallback z-index */
-	--layer-error-overlay: 1;
-	--layer-error-canvas: 2;
-	--layer-error-canvas-after: 3;
-	--layer-error-content: 4;
+	--tl-layer-error-overlay: 1;
+	--tl-layer-error-canvas: 2;
+	--tl-layer-error-canvas-after: 3;
+	--tl-layer-error-content: 4;
 
 	/* Misc */
 	--tl-zoom: 1;
@@ -120,12 +120,15 @@
 	--tl-font-serif: 'tldraw_serif', serif;
 	--tl-font-mono: 'tldraw_mono', monospace;
 	/* text outline */
-	--a: calc(min(0.5, 1 / var(--tl-zoom)) * 2px);
-	--b: calc(min(0.5, 1 / var(--tl-zoom)) * -2px);
+	--tl-text-outline-a: calc(min(0.5, 1 / var(--tl-zoom)) * 2px);
+	--tl-text-outline-b: calc(min(0.5, 1 / var(--tl-zoom)) * -2px);
 	--tl-text-outline-reference:
-		0 var(--b) 0 var(--color-background), 0 var(--a) 0 var(--color-background),
-		var(--b) var(--b) 0 var(--color-background), var(--a) var(--b) 0 var(--color-background),
-		var(--a) var(--a) 0 var(--color-background), var(--b) var(--a) 0 var(--color-background);
+		0 var(--tl-text-outline-b) 0 var(--tl-color-background),
+		0 var(--tl-text-outline-a) 0 var(--tl-color-background),
+		var(--tl-text-outline-b) var(--tl-text-outline-b) 0 var(--tl-color-background),
+		var(--tl-text-outline-a) var(--tl-text-outline-b) 0 var(--tl-color-background),
+		var(--tl-text-outline-a) var(--tl-text-outline-a) 0 var(--tl-color-background),
+		var(--tl-text-outline-b) var(--tl-text-outline-a) 0 var(--tl-color-background);
 	--tl-text-outline: var(--tl-text-outline-reference);
 	/* own properties */
 	position: relative;
@@ -133,118 +136,118 @@
 	height: 100%;
 	width: 100%;
 	overflow: clip;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 }
 
 .tl-theme__light {
 	/* Canvas */
-	--color-snap: hsl(0, 76%, 60%);
-	--color-selection-fill: hsl(210, 100%, 56%, 24%);
-	--color-selection-stroke: hsl(214, 84%, 56%);
-	--color-background: hsl(210, 20%, 98%);
-	--color-brush-fill: hsl(0, 0%, 56%, 10.2%);
-	--color-brush-stroke: hsl(0, 0%, 56%, 25.1%);
-	--color-grid: hsl(0, 0%, 43%);
+	--tl-color-snap: hsl(0, 76%, 60%);
+	--tl-color-selection-fill: hsl(210, 100%, 56%, 24%);
+	--tl-color-selection-stroke: hsl(214, 84%, 56%);
+	--tl-color-background: hsl(210, 20%, 98%);
+	--tl-color-brush-fill: hsl(0, 0%, 56%, 10.2%);
+	--tl-color-brush-stroke: hsl(0, 0%, 56%, 25.1%);
+	--tl-color-grid: hsl(0, 0%, 43%);
 	/* UI */
-	--color-low: hsl(204, 16%, 94%);
-	--color-low-border: hsl(204, 16%, 92%);
-	--color-culled: hsl(204, 14%, 93%);
-	--color-muted-none: hsl(0, 0%, 0%, 0%);
-	--color-muted-0: hsl(0, 0%, 0%, 2%);
-	--color-muted-1: hsl(0, 0%, 0%, 10%);
-	--color-muted-2: hsl(0, 0%, 0%, 4.3%);
-	--color-hint: hsl(0, 0%, 0%, 5.5%);
-	--color-overlay: hsl(0, 0%, 0%, 20%);
-	--color-divider: hsl(0, 0%, 91%);
-	--color-panel: hsl(0, 0%, 99%);
-	--color-panel-contrast: hsl(0, 0%, 100%);
-	--color-panel-overlay: hsl(0, 0%, 100%, 82%);
-	--color-panel-transparent: hsla(0, 0%, 99%, 0%);
-	--color-selected: hsl(214, 84%, 56%);
-	--color-selected-contrast: hsl(0, 0%, 100%);
-	--color-focus: hsl(219, 65%, 50%);
-	--color-tooltip: hsla(200, 14%, 4%, 1);
+	--tl-color-low: hsl(204, 16%, 94%);
+	--tl-color-low-border: hsl(204, 16%, 92%);
+	--tl-color-culled: hsl(204, 14%, 93%);
+	--tl-color-muted-none: hsl(0, 0%, 0%, 0%);
+	--tl-color-muted-0: hsl(0, 0%, 0%, 2%);
+	--tl-color-muted-1: hsl(0, 0%, 0%, 10%);
+	--tl-color-muted-2: hsl(0, 0%, 0%, 4.3%);
+	--tl-color-hint: hsl(0, 0%, 0%, 5.5%);
+	--tl-color-overlay: hsl(0, 0%, 0%, 20%);
+	--tl-color-divider: hsl(0, 0%, 91%);
+	--tl-color-panel: hsl(0, 0%, 99%);
+	--tl-color-panel-contrast: hsl(0, 0%, 100%);
+	--tl-color-panel-overlay: hsl(0, 0%, 100%, 82%);
+	--tl-color-panel-transparent: hsla(0, 0%, 99%, 0%);
+	--tl-color-selected: hsl(214, 84%, 56%);
+	--tl-color-selected-contrast: hsl(0, 0%, 100%);
+	--tl-color-focus: hsl(219, 65%, 50%);
+	--tl-color-tooltip: hsla(200, 14%, 4%, 1);
 	/* Text */
-	--color-text: hsl(0, 0%, 0%);
-	--color-text-0: hsl(0, 0%, 11%);
-	--color-text-1: hsl(0, 0%, 18%);
-	--color-text-3: hsl(204, 4%, 45%);
-	--color-text-shadow: hsl(0, 0%, 100%);
-	--color-text-highlight: hsl(52, 100%, 50%);
-	--color-text-highlight-p3: color(display-p3 0.972 0.8205 0.05);
+	--tl-color-text: hsl(0, 0%, 0%);
+	--tl-color-text-0: hsl(0, 0%, 11%);
+	--tl-color-text-1: hsl(0, 0%, 18%);
+	--tl-color-text-3: hsl(204, 4%, 45%);
+	--tl-color-text-shadow: hsl(0, 0%, 100%);
+	--tl-color-text-highlight: hsl(52, 100%, 50%);
+	--tl-color-text-highlight-p3: color(display-p3 0.972 0.8205 0.05);
 	/* Named */
-	--color-primary: hsl(214, 84%, 56%);
-	--color-success: hsl(123, 46%, 34%);
-	--color-info: hsl(201, 98%, 41%);
-	--color-warning: hsl(27, 98%, 47%);
-	--color-danger: hsl(0, 90%, 43%);
-	--color-laser: hsl(0, 100%, 50%);
+	--tl-color-primary: hsl(214, 84%, 56%);
+	--tl-color-success: hsl(123, 46%, 34%);
+	--tl-color-info: hsl(201, 98%, 41%);
+	--tl-color-warning: hsl(27, 98%, 47%);
+	--tl-color-danger: hsl(0, 90%, 43%);
+	--tl-color-laser: hsl(0, 100%, 50%);
 	/* Shadows */
-	--shadow-1: 0px 1px 2px hsl(0, 0%, 0%, 25%), 0px 1px 3px hsl(0, 0%, 0%, 9%);
-	--shadow-2:
+	--tl-shadow-1: 0px 1px 2px hsl(0, 0%, 0%, 25%), 0px 1px 3px hsl(0, 0%, 0%, 9%);
+	--tl-shadow-2:
 		0px 0px 2px hsl(0, 0%, 0%, 16%), 0px 2px 3px hsl(0, 0%, 0%, 24%),
-		0px 2px 6px hsl(0, 0%, 0%, 0.1), inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-3:
+		0px 2px 6px hsl(0, 0%, 0%, 0.1), inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
+	--tl-shadow-3:
 		0px 1px 2px hsl(0, 0%, 0%, 28%), 0px 2px 6px hsl(0, 0%, 0%, 14%),
-		inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-4:
+		inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
+	--tl-shadow-4:
 		0px 0px 3px hsl(0, 0%, 0%, 19%), 0px 5px 4px hsl(0, 0%, 0%, 16%),
-		0px 2px 16px hsl(0, 0%, 0%, 6%), inset 0px 0px 0px 1px var(--color-panel-contrast);
+		0px 2px 16px hsl(0, 0%, 0%, 6%), inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
 }
 
 .tl-theme__dark {
 	/* Canvas */
-	--color-snap: hsl(0, 76%, 60%);
-	--color-selection-fill: hsl(209, 100%, 57%, 20%);
-	--color-selection-stroke: hsl(214, 84%, 56%);
-	--color-background: hsl(240, 5%, 6.5%);
-	--color-brush-fill: hsl(0, 0%, 71%, 5.1%);
-	--color-brush-stroke: hsl(0, 0%, 71%, 25.1%);
-	--color-grid: hsl(0, 0%, 40%);
+	--tl-color-snap: hsl(0, 76%, 60%);
+	--tl-color-selection-fill: hsl(209, 100%, 57%, 20%);
+	--tl-color-selection-stroke: hsl(214, 84%, 56%);
+	--tl-color-background: hsl(240, 5%, 6.5%);
+	--tl-color-brush-fill: hsl(0, 0%, 71%, 5.1%);
+	--tl-color-brush-stroke: hsl(0, 0%, 71%, 25.1%);
+	--tl-color-grid: hsl(0, 0%, 40%);
 	/* UI */
-	--color-low: hsl(260, 4.5%, 10.5%);
-	--color-low-border: hsl(207, 10%, 10%);
-	--color-culled: hsl(210, 11%, 19%);
-	--color-muted-none: hsl(0, 0%, 100%, 0%);
-	--color-muted-0: hsl(0, 0%, 100%, 2%);
-	--color-muted-1: hsl(0, 0%, 100%, 10%);
-	--color-muted-2: hsl(0, 0%, 100%, 5%);
-	--color-hint: hsl(0, 0%, 100%, 7%);
-	--color-overlay: hsl(0, 0%, 0%, 50%);
-	--color-divider: hsl(240, 9%, 22%);
-	--color-panel: hsl(235, 6.8%, 13.5%);
-	--color-panel-contrast: hsl(245, 12%, 23%);
-	--color-panel-overlay: hsl(210, 10%, 24%, 82%);
-	--color-panel-transparent: hsla(235, 6.8%, 13.5%, 0%);
-	--color-selected: hsl(217, 89%, 61%);
-	--color-selected-contrast: hsl(0, 0%, 100%);
-	--color-focus: hsl(217, 76%, 80%);
-	--color-tooltip: hsla(0, 0%, 100%, 1);
+	--tl-color-low: hsl(260, 4.5%, 10.5%);
+	--tl-color-low-border: hsl(207, 10%, 10%);
+	--tl-color-culled: hsl(210, 11%, 19%);
+	--tl-color-muted-none: hsl(0, 0%, 100%, 0%);
+	--tl-color-muted-0: hsl(0, 0%, 100%, 2%);
+	--tl-color-muted-1: hsl(0, 0%, 100%, 10%);
+	--tl-color-muted-2: hsl(0, 0%, 100%, 5%);
+	--tl-color-hint: hsl(0, 0%, 100%, 7%);
+	--tl-color-overlay: hsl(0, 0%, 0%, 50%);
+	--tl-color-divider: hsl(240, 9%, 22%);
+	--tl-color-panel: hsl(235, 6.8%, 13.5%);
+	--tl-color-panel-contrast: hsl(245, 12%, 23%);
+	--tl-color-panel-overlay: hsl(210, 10%, 24%, 82%);
+	--tl-color-panel-transparent: hsla(235, 6.8%, 13.5%, 0%);
+	--tl-color-selected: hsl(217, 89%, 61%);
+	--tl-color-selected-contrast: hsl(0, 0%, 100%);
+	--tl-color-focus: hsl(217, 76%, 80%);
+	--tl-color-tooltip: hsla(0, 0%, 100%, 1);
 	/* Text */
-	--color-text: hsl(210, 17%, 98%);
-	--color-text-0: hsl(0, 9%, 94%);
-	--color-text-1: hsl(0, 0%, 85%);
-	--color-text-3: hsl(204, 4%, 75%);
-	--color-text-shadow: hsl(210, 13%, 18%);
-	--color-text-highlight: hsl(52, 100%, 41%);
-	--color-text-highlight-p3: color(display-p3 0.8078 0.6225 0.0312);
+	--tl-color-text: hsl(210, 17%, 98%);
+	--tl-color-text-0: hsl(0, 9%, 94%);
+	--tl-color-text-1: hsl(0, 0%, 85%);
+	--tl-color-text-3: hsl(204, 4%, 75%);
+	--tl-color-text-shadow: hsl(210, 13%, 18%);
+	--tl-color-text-highlight: hsl(52, 100%, 41%);
+	--tl-color-text-highlight-p3: color(display-p3 0.8078 0.6225 0.0312);
 	/* Named */
-	--color-primary: hsl(214, 84%, 56%);
-	--color-success: hsl(123, 38%, 57%);
-	--color-info: hsl(199, 92%, 56%);
-	--color-warning: hsl(36, 100%, 57%);
-	--color-danger: hsl(0, 82%, 66%);
-	--color-laser: hsl(0, 100%, 50%);
+	--tl-color-primary: hsl(214, 84%, 56%);
+	--tl-color-success: hsl(123, 38%, 57%);
+	--tl-color-info: hsl(199, 92%, 56%);
+	--tl-color-warning: hsl(36, 100%, 57%);
+	--tl-color-danger: hsl(0, 82%, 66%);
+	--tl-color-laser: hsl(0, 100%, 50%);
 	/* Shadows */
-	--shadow-1:
+	--tl-shadow-1:
 		0px 1px 2px hsl(0, 0%, 0%, 16.1%), 0px 1px 3px hsl(0, 0%, 0%, 22%),
-		inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-2:
+		inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
+	--tl-shadow-2:
 		0px 1px 3px hsl(0, 0%, 0%, 66.6%), 0px 2px 6px hsl(0, 0%, 0%, 33%),
-		inset 0px 0px 0px 1px var(--color-panel-contrast);
-	--shadow-3:
+		inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
+	--tl-shadow-3:
 		0px 1px 3px hsl(0, 0%, 0%, 50%), 0px 2px 12px hsl(0, 0%, 0%, 50%),
-		inset 0px 0px 0px 1px var(--color-panel-contrast);
+		inset 0px 0px 0px 1px var(--tl-color-panel-contrast);
 }
 
 .tl-counter-scaled {
@@ -270,7 +273,7 @@
 }
 
 .tl-container__focused {
-	outline: 1px solid var(--color-low);
+	outline: 1px solid var(--tl-color-low);
 }
 
 input,
@@ -286,7 +289,7 @@ input,
 	inset: 0px;
 	height: 100%;
 	width: 100%;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	cursor: var(--tl-cursor);
 	overflow: clip;
 	content-visibility: auto;
@@ -296,7 +299,7 @@ input,
 
 .tl-shapes {
 	position: relative;
-	z-index: var(--layer-canvas-shapes);
+	z-index: var(--tl-layer-canvas-shapes);
 }
 
 .tl-overlays {
@@ -307,7 +310,7 @@ input,
 	width: 100%;
 	contain: strict;
 	pointer-events: none;
-	z-index: var(--layer-canvas-overlays);
+	z-index: var(--tl-layer-canvas-overlays);
 }
 
 .tl-overlays__item {
@@ -331,7 +334,7 @@ input,
 /* ------------------- Background ------------------- */
 
 .tl-background__wrapper {
-	z-index: var(--layer-canvas-background);
+	z-index: var(--tl-layer-canvas-background);
 	position: absolute;
 	inset: 0px;
 	height: 100%;
@@ -339,7 +342,7 @@ input,
 }
 
 .tl-background {
-	background-color: var(--color-background);
+	background-color: var(--tl-color-background);
 	width: 100%;
 	height: 100%;
 }
@@ -353,12 +356,12 @@ input,
 	height: 100%;
 	touch-action: none;
 	pointer-events: none;
-	z-index: var(--layer-canvas-grid);
+	z-index: var(--tl-layer-canvas-grid);
 	contain: strict;
 }
 
 .tl-grid-dot {
-	fill: var(--color-grid);
+	fill: var(--tl-color-grid);
 }
 
 /* --------------------- Layers --------------------- */
@@ -376,54 +379,54 @@ input,
 
 /* back of the stack, behind user's stuff */
 .tl-collaborator__scribble {
-	z-index: var(--layer-overlays-collaborator-scribble);
+	z-index: var(--tl-layer-overlays-collaborator-scribble);
 }
 
 .tl-collaborator__brush {
-	z-index: var(--layer-overlays-collaborator-brush);
+	z-index: var(--tl-layer-overlays-collaborator-brush);
 }
 
 .tl-collaborator__shape-indicator {
-	z-index: var(--layer-overlays-collaborator-shape-indicator);
+	z-index: var(--tl-layer-overlays-collaborator-shape-indicator);
 }
 
 .tl-user-scribble {
-	z-index: var(--layer-overlays-user-scribble);
+	z-index: var(--tl-layer-overlays-user-scribble);
 }
 
 .tl-user-brush {
-	z-index: var(--layer-overlays-user-brush);
+	z-index: var(--tl-layer-overlays-user-brush);
 }
 
 .tl-user-handles {
-	z-index: var(--layer-overlays-user-handles);
+	z-index: var(--tl-layer-overlays-user-handles);
 }
 
 .tl-user-snapline {
-	z-index: var(--layer-overlays-user-snapline);
+	z-index: var(--tl-layer-overlays-user-snapline);
 }
 
 .tl-selection__fg {
 	pointer-events: none;
-	z-index: var(--layer-overlays-selection-fg);
+	z-index: var(--tl-layer-overlays-selection-fg);
 }
 
 .tl-user-indicator__hint {
-	z-index: var(--layer-overlays-user-indicator-hint);
+	z-index: var(--tl-layer-overlays-user-indicator-hint);
 	stroke-width: calc(2.5px * var(--tl-scale));
 }
 
 .tl-custom-overlays {
-	z-index: var(--layer-overlays-custom);
+	z-index: var(--tl-layer-overlays-custom);
 }
 
 /* behind collaborator cursor */
 .tl-collaborator__cursor-hint {
-	z-index: var(--layer-overlays-collaborator-cursor-hint);
+	z-index: var(--tl-layer-overlays-collaborator-cursor-hint);
 }
 
 .tl-collaborator__cursor {
-	z-index: var(--layer-overlays-collaborator-cursor);
+	z-index: var(--tl-layer-overlays-collaborator-cursor);
 }
 
 .tl-cursor {
@@ -444,32 +447,32 @@ input,
 .tl-selection__fg__outline {
 	fill: none;
 	pointer-events: none;
-	stroke: var(--color-selection-stroke);
+	stroke: var(--tl-color-selection-stroke);
 	stroke-width: calc(1.5px * var(--tl-scale));
 }
 
 .tl-corner-handle {
 	pointer-events: none;
-	stroke: var(--color-selection-stroke);
-	fill: var(--color-background);
+	stroke: var(--tl-color-selection-stroke);
+	fill: var(--tl-color-background);
 	stroke-width: calc(1.5px * var(--tl-scale));
 }
 
 .tl-text-handle {
 	pointer-events: none;
-	fill: var(--color-selection-stroke);
+	fill: var(--tl-color-selection-stroke);
 }
 
 .tl-corner-crop-handle {
 	pointer-events: none;
 	fill: none;
-	stroke: var(--color-selection-stroke);
+	stroke: var(--tl-color-selection-stroke);
 }
 
 .tl-corner-crop-edge-handle {
 	pointer-events: none;
 	fill: none;
-	stroke: var(--color-selection-stroke);
+	stroke: var(--tl-color-selection-stroke);
 }
 
 .tl-mobile-rotate__bg {
@@ -479,8 +482,8 @@ input,
 
 .tl-mobile-rotate__fg {
 	pointer-events: none;
-	stroke: var(--color-selection-stroke);
-	fill: var(--color-background);
+	stroke: var(--tl-color-selection-stroke);
+	fill: var(--tl-color-background);
 	stroke-width: calc(1.5px * var(--tl-scale));
 }
 
@@ -510,8 +513,8 @@ input,
 	text-overflow: ellipsis;
 	font-size: 12px;
 	font-family: var(--font-body);
-	border-radius: var(--radius-2);
-	color: var(--color-selected-contrast);
+	border-radius: var(--tl-radius-2);
+	color: var(--tl-color-selected-contrast);
 }
 
 .tl-nametag-title {
@@ -529,7 +532,7 @@ input,
 	font-size: 12px;
 	font-family: var(--font-body);
 	text-shadow: var(--tl-text-outline);
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 }
 
 .tl-nametag-chat {
@@ -538,31 +541,31 @@ input,
 	left: 13px;
 	width: fit-content;
 	height: fit-content;
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	white-space: nowrap;
 	position: absolute;
 	padding: 3px 6px;
 	font-size: 12px;
 	font-family: var(--font-body);
 	opacity: 1;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .tl-cursor-chat {
 	position: absolute;
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	white-space: nowrap;
 	padding: 3px 6px;
 	font-size: 12px;
 	font-family: var(--font-body);
 	pointer-events: none;
-	z-index: var(--layer-cursor);
+	z-index: var(--tl-layer-cursor);
 	margin-top: 16px;
 	margin-left: 13px;
 	opacity: 1;
 	border: none;
 	user-select: text;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .tl-cursor-chat .tl-cursor-chat__bubble {
@@ -570,13 +573,13 @@ input,
 }
 
 .tl-cursor-chat::selection {
-	background: var(--color-selected);
-	color: var(--color-selected-contrast);
+	background: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
 	text-shadow: none;
 }
 
 .tl-cursor-chat::placeholder {
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	opacity: 0.7;
 }
 
@@ -647,7 +650,7 @@ input,
 	background: none;
 	border-image: none;
 	border: 0px;
-	caret-color: var(--color-text);
+	caret-color: var(--tl-color-text);
 	color: inherit;
 	column-count: initial !important;
 	display: inline-block;
@@ -679,7 +682,7 @@ input,
 
 .tl-text-measure {
 	position: absolute;
-	z-index: var(--layer-canvas-hidden);
+	z-index: var(--tl-layer-canvas-hidden);
 	top: 0px;
 	left: 0px;
 	opacity: 0;
@@ -742,8 +745,8 @@ input,
 }
 
 .tl-text-input::selection {
-	background: var(--color-selected);
-	color: var(--color-selected-contrast);
+	background: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
 	text-shadow: none;
 }
 
@@ -753,7 +756,7 @@ input,
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	text-shadow: var(--tl-text-outline);
 	line-height: inherit;
 	position: absolute;
@@ -797,7 +800,7 @@ input,
 
 .tl-text-wrapper .tl-text-content {
 	pointer-events: all;
-	z-index: var(--layer-text-content);
+	z-index: var(--tl-layer-text-content);
 }
 
 .tl-text-label__inner > .tl-text-content {
@@ -807,7 +810,7 @@ input,
 	padding: inherit;
 	height: fit-content;
 	width: fit-content;
-	border-radius: var(--radius-1);
+	border-radius: var(--tl-radius-1);
 	max-width: 100%;
 }
 
@@ -820,7 +823,7 @@ input,
 }
 
 .tl-text-wrapper[data-isselected='true'] .tl-text-input {
-	z-index: var(--layer-text-editor);
+	z-index: var(--tl-layer-text-editor);
 	pointer-events: all;
 }
 
@@ -915,7 +918,7 @@ input,
 }
 
 .tl-rich-text a {
-	color: var(--color-primary);
+	color: var(--tl-color-primary);
 	text-decoration: underline;
 }
 
@@ -938,14 +941,14 @@ input,
 }
 
 .tl-theme__dark .tl-rich-text mark {
-	background-color: var(--color-text-highlight);
+	background-color: var(--tl-color-text-highlight);
 	color: currentColor;
 }
 
 @supports (color: color(display-p3 1 1 1)) {
 	@media (color-gamut: p3) {
 		.tl-container:not(.tl-theme__force-sRGB) .tl-rich-text mark {
-			background-color: var(--color-text-highlight-p3);
+			background-color: var(--tl-color-text-highlight-p3);
 		}
 	}
 }
@@ -957,15 +960,15 @@ input,
 /* --------------------- Loading -------------------- */
 
 .tl-loading {
-	background-color: var(--color-background);
-	color: var(--color-text-1);
+	background-color: var(--tl-color-background);
+	color: var(--tl-color-text-1);
 	height: 100%;
 	width: 100%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	gap: var(--space-2);
+	gap: var(--tl-space-2);
 	font-size: 14px;
 	font-weight: 500;
 	opacity: 0;
@@ -973,7 +976,7 @@ input,
 	animation-delay: 0.2s;
 	position: absolute;
 	inset: 0px;
-	z-index: var(--layer-canvas-blocker);
+	z-index: var(--tl-layer-canvas-blocker);
 }
 
 @keyframes tl-fade-in {
@@ -1006,8 +1009,8 @@ input,
 }
 
 .tl-brush__default {
-	stroke: var(--color-brush-stroke);
-	fill: var(--color-brush-fill);
+	stroke: var(--tl-color-brush-stroke);
+	fill: var(--tl-color-brush-fill);
 }
 
 /* -------------------- Scribble -------------------- */
@@ -1022,13 +1025,13 @@ input,
 /* ---------------------- Snaps --------------------- */
 
 .tl-snap-indicator {
-	stroke: var(--color-snap);
+	stroke: var(--tl-color-snap);
 	stroke-width: calc(1px * var(--tl-scale));
 	fill: none;
 }
 
 .tl-snap-point {
-	stroke: var(--color-snap);
+	stroke: var(--tl-color-snap);
 	stroke-width: calc(1px * var(--tl-scale));
 	fill: none;
 }
@@ -1048,7 +1051,7 @@ input,
 	justify-content: center;
 	font-size: 12px;
 	font-weight: 400;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	padding: 13px;
 	cursor: var(--tl-cursor-pointer);
 	border: none;
@@ -1066,13 +1069,13 @@ input,
 	display: block;
 	width: calc(100% - 12px);
 	height: calc(100% - 12px);
-	border-radius: var(--radius-1);
-	background-color: var(--color-background);
+	border-radius: var(--tl-radius-1);
+	background-color: var(--tl-color-background);
 	pointer-events: none;
 }
 
 .tl-hyperlink-button:focus-visible {
-	color: var(--color-selected);
+	color: var(--tl-color-selected);
 }
 
 .tl-hyperlink__icon {
@@ -1099,8 +1102,8 @@ input,
 }
 
 .tl-handle__fg {
-	fill: var(--color-selected-contrast);
-	stroke: var(--color-selection-stroke);
+	fill: var(--tl-color-selected-contrast);
+	stroke: var(--tl-color-selection-stroke);
 	stroke-width: calc(1.5px * var(--tl-scale));
 	pointer-events: none;
 }
@@ -1110,7 +1113,7 @@ input,
 }
 
 .tl-handle__clone > .tl-handle__fg {
-	fill: var(--color-selection-stroke);
+	fill: var(--tl-color-selection-stroke);
 	stroke: none;
 }
 
@@ -1120,7 +1123,7 @@ input,
 
 @media (pointer: coarse) {
 	.tl-handle__bg:active {
-		fill: var(--color-selection-fill);
+		fill: var(--tl-color-selection-fill);
 	}
 
 	.tl-handle__create {
@@ -1176,13 +1179,13 @@ input,
 	stroke-linejoin: round;
 	/* content-visibility: auto; */
 	transform-origin: top left;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 }
 
 /* -------------------- Group shape ------------------ */
 
 .tl-group {
-	stroke: var(--color-text);
+	stroke: var(--tl-color-text);
 	stroke-width: calc(1px * var(--tl-scale));
 	opacity: 0.5;
 }
@@ -1200,12 +1203,12 @@ input,
 	justify-content: center;
 	align-items: center;
 	text-align: center;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	text-shadow: var(--tl-text-outline);
 }
 
 .tl-shape[data-shape-type='arrow'] .tl-text-label__inner {
-	border-radius: var(--radius-1);
+	border-radius: var(--tl-radius-1);
 	box-sizing: content-box;
 	height: max-content;
 	width: max-content;
@@ -1216,22 +1219,22 @@ input,
 }
 
 .tl-arrow-hint {
-	stroke: var(--color-text-1);
+	stroke: var(--tl-color-text-1);
 	fill: none;
 	stroke-linecap: round;
 	overflow: visible;
 }
 
 .tl-arrow-hint-handle {
-	fill: var(--color-selected-contrast);
-	stroke: var(--color-selection-stroke);
+	fill: var(--tl-color-selected-contrast);
+	stroke: var(--tl-color-selection-stroke);
 	stroke-width: calc(1.5px * var(--tl-scale));
 	r: calc(4px * var(--tl-scale));
 }
 
 .tl-arrow-hint-snap {
 	stroke: transparent;
-	fill: var(--color-selection-fill);
+	fill: var(--tl-color-selection-fill);
 	r: calc(12px * var(--tl-scale));
 }
 
@@ -1251,40 +1254,40 @@ input,
 	width: 100%;
 	height: 100%;
 	position: relative;
-	border: 1px solid var(--color-panel-contrast);
-	background-color: var(--color-panel);
-	border-radius: var(--radius-2);
+	border: 1px solid var(--tl-color-panel-contrast);
+	background-color: var(--tl-color-panel);
+	border-radius: var(--tl-radius-2);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 }
 
 .tl-bookmark__container--safariExport {
-	border: 1px solid var(--color-divider);
+	border: 1px solid var(--tl-color-divider);
 }
 
 .tl-bookmark__image_container {
 	flex: 1 1 100%;
 	overflow: hidden;
-	border-top-left-radius: var(--radius-1);
-	border-top-right-radius: var(--radius-1);
+	border-top-left-radius: var(--tl-radius-1);
+	border-top-right-radius: var(--tl-radius-1);
 	width: 100%;
 	height: 100%;
 	display: flex;
 	justify-content: flex-end;
 	align-items: flex-start;
-	box-shadow: inset 0px 0px 0px 1px var(--color-divider);
+	box-shadow: inset 0px 0px 0px 1px var(--tl-color-divider);
 }
 
 .tl-bookmark__image_container > .tl-hyperlink-button::after {
-	background-color: var(--color-panel);
+	background-color: var(--tl-color-panel);
 }
 
 .tl-bookmark__placeholder {
 	width: 100%;
 	height: 100%;
-	background-color: var(--color-muted-2);
-	border-bottom: 1px solid var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
+	border-bottom: 1px solid var(--tl-color-muted-2);
 }
 
 .tl-bookmark__image {
@@ -1292,12 +1295,12 @@ input,
 	height: 100%;
 	object-fit: cover;
 	object-position: center;
-	border-bottom: 1px solid var(--color-muted-2);
+	border-bottom: 1px solid var(--tl-color-muted-2);
 }
 
 .tl-bookmark__copy_container {
-	background-color: var(--color-muted-0);
-	padding: var(--space-4);
+	background-color: var(--tl-color-muted-0);
+	padding: var(--tl-space-4);
 	pointer-events: all;
 	display: flex;
 	flex-direction: column;
@@ -1317,7 +1320,7 @@ input,
 	font-size: 16px;
 	line-height: 1.6;
 	font-weight: bold;
-	padding-bottom: var(--space-2);
+	padding-bottom: var(--tl-space-2);
 	overflow: hidden;
 	max-height: calc((16px * 1.6) * 2);
 	-webkit-box-orient: vertical;
@@ -1337,19 +1340,19 @@ input,
 	line-clamp: 3;
 	text-overflow: ellipsis;
 	display: -webkit-box;
-	color: var(--color-text-2);
-	margin: var(--space-2) 0px;
+	color: var(--tl-color-text-2);
+	margin: var(--tl-space-2) 0px;
 }
 
 .tl-bookmark__heading + .tl-bookmark__link,
 .tl-bookmark__description + .tl-bookmark__link {
-	margin-top: var(--space-3);
+	margin-top: var(--tl-space-3);
 }
 .tl-bookmark__link {
 	font-size: 12px;
 	pointer-events: all;
 	display: flex;
-	color: var(--color-text-2);
+	color: var(--tl-color-text-2);
 	align-items: center;
 	cursor: var(--tl-cursor-pointer);
 	width: fit-content;
@@ -1391,7 +1394,7 @@ input,
 	width: 100%;
 	height: 100%;
 	pointer-events: all;
-	/* background-color: var(--color-background); */
+	/* background-color: var(--tl-color-background); */
 
 	display: flex;
 	justify-content: center;
@@ -1420,7 +1423,7 @@ input,
 	height: 100%;
 	pointer-events: all;
 	opacity: 1;
-	z-index: var(--layer-text-container);
+	z-index: var(--tl-layer-text-container);
 	border-radius: 1px;
 }
 
@@ -1436,7 +1439,7 @@ input,
 }
 
 .tl-frame__creating {
-	stroke: var(--color-selected);
+	stroke: var(--tl-color-selected);
 	fill: none;
 }
 
@@ -1466,7 +1469,7 @@ input,
 	height: var(--frame-height);
 	width: 100%;
 	align-items: center;
-	border-radius: var(--radius-1);
+	border-radius: var(--tl-radius-1);
 }
 
 .tl-frame-label {
@@ -1474,7 +1477,7 @@ input,
 	overflow: hidden;
 	text-overflow: ellipsis;
 	padding: 0px var(--frame-padding-x);
-	border-radius: var(--radius-1);
+	border-radius: var(--tl-radius-1);
 	position: relative;
 	font-size: inherit;
 	white-space: pre;
@@ -1487,9 +1490,9 @@ input,
 	min-width: var(--frame-minimum-width);
 	height: 100%;
 	overflow: visible;
-	background-color: var(--color-panel);
-	border-color: var(--color-selected);
-	box-shadow: inset 0px 0px 0px 1.5px var(--color-selected);
+	background-color: var(--tl-color-panel);
+	border-color: var(--tl-color-selected);
+	box-shadow: inset 0px 0px 0px 1.5px var(--tl-color-selected);
 }
 
 .tl-frame-name-input {
@@ -1505,8 +1508,8 @@ input,
 	font-family: inherit;
 	font-weight: inherit;
 	width: 100%;
-	color: var(--color-text-1);
-	border-radius: var(--radius-1);
+	color: var(--tl-color-text-1);
+	border-radius: var(--tl-radius-1);
 	user-select: all;
 	-webkit-user-select: text;
 	white-space: pre;
@@ -1526,7 +1529,7 @@ input,
 
 .tl-embed {
 	border: none;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 /* -------------- Shape error boundary -------------- */
@@ -1534,11 +1537,11 @@ input,
 .tl-shape-error-boundary {
 	width: 100%;
 	height: 100%;
-	background-color: var(--color-muted-1);
+	background-color: var(--tl-color-muted-1);
 	border-width: calc(1px * var(--tl-scale));
-	border-color: var(--color-muted-1);
+	border-color: var(--tl-color-muted-1);
 	border-style: solid;
-	border-radius: calc(var(--radius-1) * var(--tl-scale));
+	border-radius: calc(var(--tl-radius-1) * var(--tl-scale));
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -1547,7 +1550,7 @@ input,
 	position: relative;
 	pointer-events: all;
 	overflow: hidden;
-	padding: var(--space-2);
+	padding: var(--tl-space-2);
 }
 
 .tl-shape-error-boundary::before {
@@ -1555,7 +1558,7 @@ input,
 	content: 'Error';
 	font-size: 12px;
 	font-family: inherit;
-	color: var(--color-text-0);
+	color: var(--tl-color-text-0);
 }
 
 /* ----------------- Error boundary ----------------- */
@@ -1566,9 +1569,9 @@ input,
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: var(--space-4);
-	background-color: var(--color-background);
-	color: var(--color-text-1);
+	padding: var(--tl-space-4);
+	background-color: var(--tl-color-background);
+	color: var(--tl-color-text-1);
 	position: absolute;
 }
 
@@ -1577,8 +1580,8 @@ input,
 	inset: 0px;
 	height: 100%;
 	width: 100%;
-	z-index: var(--layer-error-overlay);
-	background-color: var(--color-overlay);
+	z-index: var(--tl-layer-error-overlay);
+	background-color: var(--tl-color-overlay);
 }
 
 .tl-error-boundary__content * {
@@ -1593,7 +1596,7 @@ input,
 	inset: 0px;
 	height: 100%;
 	width: 100%;
-	z-index: var(--layer-error-canvas);
+	z-index: var(--tl-layer-error-canvas);
 }
 
 /* some browsers seem to have some weird interactions between stacking contexts
@@ -1606,7 +1609,7 @@ it from receiving any pointer events or affecting the cursor. */
 	inset: 0px;
 	height: 100%;
 	width: 100%;
-	z-index: var(--layer-error-canvas-after);
+	z-index: var(--tl-layer-error-canvas-after);
 	pointer-events: all;
 }
 
@@ -1616,16 +1619,16 @@ it from receiving any pointer events or affecting the cursor. */
 	max-width: 100%;
 	width: 400px;
 	max-height: 100%;
-	background-color: var(--color-panel);
+	background-color: var(--tl-color-panel);
 	padding: 16px;
 	border-radius: 16px;
-	box-shadow: var(--shadow-2);
+	box-shadow: var(--tl-shadow-2);
 	font-size: 14px;
 	font-weight: 400;
 	display: flex;
 	flex-direction: column;
 	overflow: auto;
-	z-index: var(--layer-error-content);
+	z-index: var(--tl-layer-error-content);
 	gap: 12px;
 }
 
@@ -1640,10 +1643,10 @@ it from receiving any pointer events or affecting the cursor. */
 }
 
 .tl-error-boundary__content h4 {
-	border: 1px solid var(--color-low-border);
+	border: 1px solid var(--tl-color-low-border);
 	margin: -6px 0 0 0;
-	padding: var(--space-5);
-	border-radius: var(--radius-2);
+	padding: var(--tl-space-5);
+	border-radius: var(--tl-radius-2);
 	font-weight: normal;
 }
 
@@ -1653,10 +1656,10 @@ it from receiving any pointer events or affecting the cursor. */
 }
 
 .tl-error-boundary__content pre {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	margin-top: 0;
-	padding: var(--space-5);
-	border-radius: var(--radius-2);
+	padding: var(--tl-space-5);
+	border-radius: var(--tl-radius-2);
 	overflow: auto;
 	font-size: 12px;
 	max-height: 320px;
@@ -1668,15 +1671,15 @@ it from receiving any pointer events or affecting the cursor. */
 	font-family: inherit;
 	font-size: 14px;
 	font-weight: 500;
-	padding: var(--space-4);
-	border-radius: var(--radius-3);
+	padding: var(--tl-space-4);
+	border-radius: var(--tl-radius-3);
 	cursor: var(--tl-cursor-pointer);
 	color: inherit;
 	background-color: transparent;
 }
 
 .tl-error-boundary__content a {
-	color: var(--color-selected);
+	color: var(--tl-color-selected);
 	font-weight: 500;
 	text-decoration: none;
 }
@@ -1688,31 +1691,31 @@ it from receiving any pointer events or affecting the cursor. */
 
 .tl-error-boundary__content__error button {
 	position: absolute;
-	top: var(--space-2);
-	right: var(--space-2);
+	top: var(--tl-space-2);
+	right: var(--tl-space-2);
 	font-size: 12px;
-	padding: var(--space-2) var(--space-3);
-	background-color: var(--color-panel);
-	border-radius: var(--radius-1);
+	padding: var(--tl-space-2) var(--tl-space-3);
+	background-color: var(--tl-color-panel);
+	border-radius: var(--tl-radius-1);
 }
 
 .tl-error-boundary__content__actions {
 	display: flex;
 	justify-content: space-between;
-	gap: var(--space-4);
+	gap: var(--tl-space-4);
 	margin: 0px;
 	margin-left: -4px;
 }
 .tl-error-boundary__content__actions__group {
 	display: flex;
-	gap: var(--space-4);
+	gap: var(--tl-space-4);
 }
 .tl-error-boundary__content .tl-error-boundary__reset {
-	color: var(--color-danger);
+	color: var(--tl-color-danger);
 }
 .tl-error-boundary__content .tl-error-boundary__refresh {
-	background-color: var(--color-primary);
-	color: var(--color-selected-contrast);
+	background-color: var(--tl-color-primary);
+	color: var(--tl-color-selected-contrast);
 }
 .tl-container__focused:not(.tl-container__no-focus-ring)
 	.tlui-button.tl-error-boundary__refresh:focus-visible {
@@ -1724,7 +1727,7 @@ it from receiving any pointer events or affecting the cursor. */
 
 .tl-hit-test-blocker {
 	position: absolute;
-	z-index: var(--layer-canvas-blocker);
+	z-index: var(--tl-layer-canvas-blocker);
 	inset: 0px;
 	width: 100%;
 	height: 100%;
@@ -1744,32 +1747,32 @@ it from receiving any pointer events or affecting the cursor. */
 
 	.tl-handle__bg:hover {
 		cursor: var(--tl-cursor-grab);
-		fill: var(--color-selection-fill);
+		fill: var(--tl-color-selection-fill);
 	}
 
 	.tl-bookmark__link:hover {
-		color: var(--color-selected);
+		color: var(--tl-color-selected);
 	}
 
 	.tl-hyperlink-button:hover {
-		color: var(--color-selected);
+		color: var(--tl-color-selected);
 	}
 
 	.tl-error-boundary__content button:hover {
-		background-color: var(--color-low);
+		background-color: var(--tl-color-low);
 	}
 	.tl-error-boundary__content a:hover {
-		color: var(--color-text-1);
+		color: var(--tl-color-text-1);
 	}
 	.tl-error-boundary__content .tl-error-boundary__refresh:hover {
-		background-color: var(--color-primary);
+		background-color: var(--tl-color-primary);
 		opacity: 0.9;
 	}
 
 	/* These three rules help preserve clicking into specific points in text areas *while*
  * already in edit mode when jumping from shape to shape. */
 	.tl-canvas[data-iseditinganything='true'] .tl-text-wrapper:hover .tl-text-input {
-		z-index: var(--layer-text-editor);
+		z-index: var(--tl-layer-text-editor);
 		pointer-events: all;
 	}
 }

--- a/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCollaboratorHint.tsx
@@ -44,7 +44,7 @@ export function DefaultCollaboratorHint({
 				href={`#${cursorHintId}`}
 				color={color}
 				strokeWidth={3}
-				stroke="var(--color-background)"
+				stroke="var(--tl-color-background)"
 			/>
 			<use href={`#${cursorHintId}`} color={color} opacity={opacity} />
 		</svg>

--- a/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultScribble.tsx
@@ -21,7 +21,7 @@ export function DefaultScribble({ scribble, zoom, color, opacity, className }: T
 			<path
 				className="tl-scribble"
 				d={getSvgPathFromPoints(scribble.points, false)}
-				stroke={color ?? `var(--color-${scribble.color})`}
+				stroke={color ?? `var(--tl-color-${scribble.color})`}
 				fill="none"
 				strokeWidth={8 / zoom}
 				opacity={opacity ?? scribble.opacity}

--- a/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeIndicator.tsx
@@ -87,7 +87,11 @@ export const DefaultShapeIndicator = memo(function DefaultShapeIndicator({
 
 	return (
 		<svg ref={rIndicator} className={classNames('tl-overlays__item', className)} aria-hidden="true">
-			<g className="tl-shape-indicator" stroke={color ?? 'var(--color-selected)'} opacity={opacity}>
+			<g
+				className="tl-shape-indicator"
+				stroke={color ?? 'var(--tl-color-selected)'}
+				opacity={opacity}
+			>
 				<InnerIndicator editor={editor} id={shapeId} />
 			</g>
 		</svg>

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -86,15 +86,15 @@ To remove the watermark, please purchase a license at tldraw.dev.
 
 	.${className} {
 		position: absolute;
-		bottom: var(--space-2);
-		right: var(--space-2);
+		bottom: var(--tl-space-2);
+		right: var(--tl-space-2);
 		width: 96px;
 		height: 32px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		z-index: var(--layer-watermark) !important;
-		background-color: color-mix(in srgb, var(--color-background) 62%, transparent);
+		z-index: var(--tl-layer-watermark) !important;
+		background-color: color-mix(in srgb, var(--tl-color-background) 62%, transparent);
 		opacity: 1;
 		border-radius: 5px;
 		pointer-events: all;
@@ -108,7 +108,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		height: 32px;
 		pointer-events: all;
 		cursor: inherit;
-		color: var(--color-text);
+		color: var(--tl-color-text);
 		opacity: .38;
 		border: 0;
 		padding: 0;
@@ -137,7 +137,7 @@ To remove the watermark, please purchase a license at tldraw.dev.
 		}
 
 		.${className}:hover {
-			background-color: var(--color-background);
+			background-color: var(--tl-color-background);
 			transition: background-color 0.2s ease-in-out;
 			transition-delay: 0.32s;
 		}

--- a/packages/tldraw/src/lib/canvas/TldrawScribble.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawScribble.tsx
@@ -31,7 +31,7 @@ export function TldrawScribble({ scribble, zoom, color, opacity, className }: TL
 			<path
 				className="tl-scribble"
 				d={d}
-				fill={color ?? `var(--color-${scribble.color})`}
+				fill={color ?? `var(--tl-color-${scribble.color})`}
 				opacity={opacity ?? scribble.opacity}
 			/>
 		</svg>

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/ElbowArrowDebug.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/ElbowArrowDebug.tsx
@@ -98,7 +98,7 @@ export function ElbowArrowDebug({ arrow }: { arrow: TLArrowShape }) {
 				y={fullBox.minY - 3}
 				fontSize={10}
 				fill="black"
-				stroke="var(--color-background)"
+				stroke="var(--tl-color-background)"
 				strokeWidth={2}
 				paintOrder="stroke"
 			>
@@ -109,7 +109,7 @@ export function ElbowArrowDebug({ arrow }: { arrow: TLArrowShape }) {
 				y={info.A.expanded.y}
 				fontSize={10}
 				fill="black"
-				stroke="var(--color-background)"
+				stroke="var(--tl-color-background)"
 				strokeWidth={2}
 				paintOrder="stroke"
 			>
@@ -121,7 +121,7 @@ export function ElbowArrowDebug({ arrow }: { arrow: TLArrowShape }) {
 				y={info.B.expanded.y}
 				fontSize={10}
 				fill="black"
-				stroke="var(--color-background)"
+				stroke="var(--tl-color-background)"
 				strokeWidth={2}
 				paintOrder="stroke"
 			>

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -144,7 +144,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 							border: 0,
 							boxShadow: getRotatedBoxShadow(pageRotation),
 							borderRadius: embedInfo?.definition.overrideOutlineRadius ?? 8,
-							background: embedInfo?.definition.backgroundColor ?? 'var(--color-background)',
+							background: embedInfo?.definition.backgroundColor ?? 'var(--tl-color-background)',
 							width: w,
 							height: h,
 						}}

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -314,9 +314,9 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 					overflow: 'hidden',
 					width: shape.props.w,
 					height: shape.props.h,
-					color: 'var(--color-text-3)',
-					backgroundColor: 'var(--color-low)',
-					border: '1px solid var(--color-low-border)',
+					color: 'var(--tl-color-text-3)',
+					backgroundColor: 'var(--tl-color-low)',
+					border: '1px solid var(--tl-color-low-border)',
 				}}
 			>
 				<div

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -142,9 +142,9 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 			<HTMLContainer
 				id={shape.id}
 				style={{
-					color: 'var(--color-text-3)',
-					backgroundColor: asset ? 'transparent' : 'var(--color-low)',
-					border: asset ? 'none' : '1px solid var(--color-low-border)',
+					color: 'var(--tl-color-text-3)',
+					backgroundColor: asset ? 'transparent' : 'var(--tl-color-low)',
+					border: asset ? 'none' : '1px solid var(--tl-color-low-border)',
 				}}
 			>
 				<div className="tl-counter-scaled">

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1,15 +1,15 @@
 /* @tldraw/ui */
 
 .tl-container {
-	--layer-above: 1;
-	--layer-focused-input: 10;
-	--layer-menu-click-capture: 250;
-	--layer-panels: 300;
-	--layer-menus: 400;
-	--layer-toasts: 650;
-	--layer-cursor: 700;
-	--layer-header-footer: 999;
-	--layer-following-indicator: 1000;
+	--tl-layer-above: 1;
+	--tl-layer-focused-input: 10;
+	--tl-layer-menu-click-capture: 250;
+	--tl-layer-panels: 300;
+	--tl-layer-menus: 400;
+	--tl-layer-toasts: 650;
+	--tl-layer-cursor: 700;
+	--tl-layer-header-footer: 999;
+	--tl-layer-following-indicator: 1000;
 }
 
 /* Button */
@@ -33,23 +33,23 @@
 	text-rendering: optimizeLegibility;
 	font-size: 12px;
 	gap: 0px;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	z-index: 0;
 }
 
 .tlui-button:disabled {
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	text-shadow: none;
 	cursor: default;
 }
 
 .tlui-button:disabled .tlui-kbd {
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 }
 
 .tlui-button > * {
 	position: relative;
-	z-index: var(--layer-above);
+	z-index: var(--tl-layer-above);
 }
 
 .tlui-button__label {
@@ -65,7 +65,7 @@
  */
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-button:focus-visible {
 	border-radius: 10px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -5px;
 }
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-button__tool:focus-visible {
@@ -73,7 +73,7 @@
 }
 .tlui-slider__container:has(.tlui-slider__thumb:focus-visible) {
 	border-radius: 10px;
-	outline: 2px solid var(--color-focus);
+	outline: 2px solid var(--tl-color-focus);
 	outline-offset: -5px;
 }
 
@@ -82,8 +82,8 @@
 	content: '';
 	position: absolute;
 	inset: 4px;
-	border-radius: var(--radius-2);
-	background: var(--color-muted-2);
+	border-radius: var(--tl-radius-2);
+	background: var(--tl-color-muted-2);
 	opacity: 0;
 }
 
@@ -93,18 +93,18 @@
 
 .tlui-button[data-isactive='true']::after,
 .tlui-button[data-isactive='true']:not(:disabled, :focus-visible):active:after {
-	background: var(--color-hint);
+	background: var(--tl-color-hint);
 	opacity: 1;
 }
 
 .tlui-button[aria-expanded='true'][data-direction='left'] {
-	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	opacity: 1;
 }
 
 @media (hover: hover) {
 	.tlui-button[aria-expanded='true'][data-direction='left']:not(:hover)::after {
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 		opacity: 1;
 	}
 
@@ -118,18 +118,18 @@
 }
 
 .tlui-button__icon + .tlui-button__label {
-	margin-left: var(--space-2);
+	margin-left: var(--tl-space-2);
 }
 
 /* Low button  */
 
 .tlui-button__low {
-	border-radius: var(--radius-3);
-	background-color: var(--color-low);
+	border-radius: var(--tl-radius-3);
+	background-color: var(--tl-color-low);
 }
 
 .tlui-button__low::after {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	opacity: 0;
 }
 
@@ -142,21 +142,21 @@
 /* Primary / danger buttons */
 
 .tlui-button__primary {
-	color: var(--color-primary);
+	color: var(--tl-color-primary);
 }
 
 .tlui-button__danger {
-	color: var(--color-danger);
+	color: var(--tl-color-danger);
 	text-shadow: none;
 }
 
 @media (hover: hover) {
 	.tlui-button__primary:not(:disabled, :focus-visible):hover {
-		color: var(--color-primary);
+		color: var(--tl-color-primary);
 	}
 
 	.tlui-button__danger:not(:disabled, :focus-visible):hover {
-		color: var(--color-danger);
+		color: var(--tl-color-danger);
 		text-shadow: none;
 	}
 }
@@ -173,7 +173,7 @@
 
 .tlui-button__menu::after {
 	inset: 4px;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .tlui-button__menu > .tlui-icon + .tlui-button__label {
@@ -209,7 +209,7 @@
 	height: 40px;
 	width: 40px;
 	min-width: 0px;
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .tlui-main-toolbar__lock-button::after {
@@ -232,15 +232,15 @@
 }
 
 .tlui-button__tool[aria-pressed='true'] {
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 }
 
 .tlui-button__tool[aria-pressed='true']:not(:disabled, :focus-visible):active {
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 }
 
 .tlui-button__tool[aria-pressed='true']:not(:disabled)::after {
-	background: var(--color-selected);
+	background: var(--tl-color-selected);
 	opacity: 1;
 }
 
@@ -301,9 +301,9 @@
 	pointer-events: none;
 	user-select: none;
 	contain: strict;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	transform: translate3d(0, 0, 0);
-	--sab: env(safe-area-inset-bottom);
+	--tl-sab: env(safe-area-inset-bottom);
 	font-weight: 500;
 	line-height: 1.6;
 	-webkit-font-smoothing: antialiased;
@@ -356,11 +356,11 @@
 	justify-content: flex-start;
 	align-items: flex-start;
 	width: min-content;
-	gap: var(--space-3);
-	margin: var(--space-2) var(--space-3);
+	gap: var(--tl-space-3);
+	margin: var(--tl-space-2) var(--tl-space-3);
 	white-space: nowrap;
 	pointer-events: none;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 }
 
 /* ---------------------- Icon ---------------------- */
@@ -388,7 +388,7 @@
 
 .tlui-slider__container {
 	width: 100%;
-	padding: 0px var(--space-4);
+	padding: 0px var(--tl-space-4);
 }
 
 .tlui-slider {
@@ -414,7 +414,7 @@
 	content: '';
 	height: 3px;
 	width: 100%;
-	background-color: var(--color-muted-1);
+	background-color: var(--tl-color-muted-1);
 	border-radius: 14px;
 }
 
@@ -423,7 +423,7 @@
 	top: calc(50% - 2px);
 	left: 0px;
 	height: 3px;
-	background-color: var(--color-selected);
+	background-color: var(--tl-color-selected);
 	border-radius: 14px;
 }
 
@@ -435,16 +435,16 @@
 	height: 18px;
 	position: relative;
 	top: -1px;
-	background-color: var(--color-panel);
+	background-color: var(--tl-color-panel);
 	border-radius: 999px;
-	box-shadow: inset 0px 0px 0px 2px var(--color-text-1);
+	box-shadow: inset 0px 0px 0px 2px var(--tl-color-text-1);
 }
 
 .tlui-slider__thumb:active {
 	cursor: grabbing;
 	box-shadow:
-		inset 0px 0px 0px 2px var(--color-text-1),
-		var(--shadow-1);
+		inset 0px 0px 0px 2px var(--tl-color-text-1),
+		var(--tl-shadow-1);
 }
 
 /* ---------------------- Input --------------------- */
@@ -453,7 +453,7 @@
 	background: none;
 	margin: 0px;
 	position: relative;
-	z-index: var(--layer-above);
+	z-index: var(--tl-layer-above);
 	height: 40px;
 	max-height: 40px;
 	display: flex;
@@ -462,8 +462,8 @@
 	font-family: inherit;
 	font-size: 12px;
 	font-weight: inherit;
-	color: var(--color-text-1);
-	padding: var(--space-4);
+	color: var(--tl-color-text-1);
+	padding: var(--tl-space-4);
 	padding-left: 0px;
 	border: none;
 	outline: none;
@@ -479,8 +479,8 @@
 	height: 44px;
 	display: flex;
 	align-items: center;
-	gap: var(--space-4);
-	color: var(--color-text);
+	gap: var(--tl-space-4);
+	color: var(--tl-color-text);
 }
 
 .tlui-input__wrapper > .tlui-icon {
@@ -512,7 +512,7 @@
 	grid-auto-columns: minmax(1em, auto);
 	align-self: bottom;
 	color: currentColor;
-	margin-left: var(--space-4);
+	margin-left: var(--tl-space-4);
 }
 
 .tlui-kbd > span {
@@ -529,13 +529,13 @@
 }
 
 .tlui-kbd:not(:last-child) {
-	margin-right: var(--space-2);
+	margin-right: var(--tl-space-2);
 }
 
 /* Focus Mode Button */
 
 .tlui-focus-button {
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	pointer-events: all;
 }
 
@@ -546,16 +546,16 @@
 }
 
 .tlui-menu {
-	z-index: var(--layer-menus);
+	z-index: var(--tl-layer-menus);
 	height: fit-content;
 	width: fit-content;
-	border-radius: var(--radius-3);
+	border-radius: var(--tl-radius-3);
 	pointer-events: all;
 	touch-action: auto;
 	overflow-y: auto;
 	overscroll-behavior: none;
-	background-color: var(--color-panel);
-	box-shadow: var(--shadow-3);
+	background-color: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-3);
 }
 
 .tlui-menu::-webkit-scrollbar {
@@ -573,7 +573,7 @@
 }
 
 .tlui-menu__group {
-	border-bottom: 1px solid var(--color-divider);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 .tlui-menu__group:nth-last-of-type(1) {
 	border-bottom: none;
@@ -583,23 +583,23 @@
 
 .tlui-menu__submenu__trigger[data-state='open']::after {
 	opacity: 1;
-	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 }
 
 .tlui-menu__submenu__trigger[data-direction='left'][data-state='open']::after {
 	opacity: 1;
-	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 }
 
 @media (hover: hover) {
 	.tlui-menu__submenu__trigger[data-state='open']:not(:hover)::after {
 		opacity: 1;
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	}
 
 	.tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
 		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	}
 }
 
@@ -624,7 +624,7 @@
 .tlui-menu-click-capture {
 	position: fixed;
 	inset: 0;
-	z-index: var(--layer-menu-click-capture);
+	z-index: var(--tl-layer-menu-click-capture);
 }
 
 /* --------------------- Popover -------------------- */
@@ -640,10 +640,10 @@
 	max-height: calc(var(--radix-popover-content-available-height) - 8px);
 	margin: 0px;
 	border: none;
-	border-radius: var(--radius-3);
-	background-color: var(--color-panel);
-	box-shadow: var(--shadow-3);
-	z-index: var(--layer-menus);
+	border-radius: var(--tl-radius-3);
+	background-color: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-3);
+	z-index: var(--tl-layer-menus);
 	overflow: hidden;
 	overflow-y: auto;
 	touch-action: auto;
@@ -656,22 +656,22 @@
 
 .tlui-menu-zone {
 	position: relative;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	width: fit-content;
-	border-right: 2px solid var(--color-background);
-	border-bottom: 2px solid var(--color-background);
-	border-bottom-right-radius: var(--radius-4);
-	background-color: var(--color-low);
+	border-right: 2px solid var(--tl-color-background);
+	border-bottom: 2px solid var(--tl-color-background);
+	border-bottom-right-radius: var(--tl-radius-4);
+	background-color: var(--tl-color-low);
 }
 
 .tlui-menu-zone *[data-state='open']::after {
-	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	opacity: 1;
 }
 
 @media (hover: hover) {
 	.tlui-menu-zone *[data-state='open']:not(:hover)::after {
-		background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(180deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 		opacity: 1;
 	}
 }
@@ -697,8 +697,8 @@
 	align-items: center;
 	width: 100%;
 	height: 40px;
-	padding-left: var(--space-4);
-	border-bottom: 1px solid var(--color-divider);
+	padding-left: var(--tl-space-4);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 
 .tlui-page-menu__header > .tlui-button:nth-of-type(1) {
@@ -706,7 +706,7 @@
 }
 
 .tlui-page-menu__header__title {
-	color: var(--color-text);
+	color: var(--tl-color-text);
 	font-size: 12px;
 	flex-grow: 2;
 }
@@ -791,7 +791,7 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 }
 
 .tlui-page_menu__item__sortable {
@@ -804,7 +804,7 @@
 	flex-direction: row;
 	align-items: center;
 	overflow: hidden;
-	z-index: var(--layer-above);
+	z-index: var(--tl-layer-above);
 }
 
 .tlui-page_menu__item__sortable__title {
@@ -816,7 +816,7 @@
 }
 
 .tlui-page_menu__item__sortable:focus-visible {
-	z-index: var(--layer-focused-input);
+	z-index: var(--tl-layer-focused-input);
 }
 
 .tlui-page_menu__item__sortable__handle {
@@ -825,7 +825,7 @@
 	min-width: 0px;
 	height: 40px;
 	cursor: grab;
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	flex-shrink: 0;
 	margin-right: -9px;
 }
@@ -867,13 +867,13 @@
 }
 
 .tlui-page_menu__item__submenu > .tlui-button[data-state='open']::after {
-	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	opacity: 1;
 }
 
 @media (hover: hover) {
 	.tlui-page_menu__item__submenu > .tlui-button[data-state='open']:not(:hover)::after {
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 		opacity: 1;
 	}
 }
@@ -909,7 +909,7 @@
 	top: 48px;
 	left: -9999px;
 	padding: 8px 16px;
-	z-index: var(--layer-toasts);
+	z-index: var(--tl-layer-toasts);
 }
 
 .tl-skip-to-main-content:focus {
@@ -921,11 +921,11 @@
 .tlui-offline-indicator {
 	display: flex;
 	flex-direction: row;
-	gap: var(--space-3);
-	color: var(--color-text);
-	background-color: var(--color-low);
-	border: 3px solid var(--color-background);
-	padding: 0px var(--space-5);
+	gap: var(--tl-space-3);
+	color: var(--tl-color-text);
+	background-color: var(--tl-color-low);
+	border: 3px solid var(--tl-color-background);
+	padding: 0px var(--tl-space-5);
 	height: 42px;
 	align-items: center;
 	justify-content: center;
@@ -940,10 +940,10 @@
 /* ------------------- Style panel ------------------ */
 
 .tlui-style-panel__wrapper {
-	box-shadow: var(--shadow-2);
-	border-radius: var(--radius-3);
+	box-shadow: var(--tl-shadow-2);
+	border-radius: var(--tl-radius-3);
 	pointer-events: all;
-	background-color: var(--color-panel);
+	background-color: var(--tl-color-panel);
 	height: fit-content;
 	max-height: 100%;
 	margin: 8px;
@@ -952,7 +952,7 @@
 	overscroll-behavior: none;
 	overflow-y: auto;
 	overflow-x: hidden;
-	color: var(--color-text);
+	color: var(--tl-color-text);
 }
 /* if the style panel is the only child (ie no share menu), increase the margin */
 .tlui-style-panel__wrapper:only-child {
@@ -961,7 +961,7 @@
 
 .tlui-style-panel {
 	position: relative;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	pointer-events: all;
 	width: 148px;
 	max-width: 148px;
@@ -969,7 +969,7 @@
 
 .tlui-style-panel[data-show-ui-labels='true'] .tlui-button[data-isactive='true'] {
 	border-radius: 10px;
-	outline: 2px solid var(--color-text);
+	outline: 2px solid var(--tl-color-text);
 	outline-offset: -5px;
 }
 
@@ -988,7 +988,7 @@
 }
 
 .tlui-style-panel__section:nth-of-type(n + 2):not(:last-child) {
-	border-bottom: 1px solid var(--color-divider);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 
 .tlui-style-panel__section:empty {
@@ -997,7 +997,7 @@
 
 .tlui-style-panel__section__common:not(:only-child) {
 	margin-bottom: 7px;
-	border-bottom: 1px solid var(--color-divider);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 
 .tlui-style-panel__dropdown-picker:only-child {
@@ -1008,8 +1008,8 @@
 	display: flex;
 	grid-template-columns: 1fr auto;
 	align-items: center;
-	padding-left: var(--space-4);
-	color: var(--color-text-1);
+	padding-left: var(--tl-space-4);
+	color: var(--tl-color-text-1);
 	font-size: 12px;
 }
 
@@ -1023,13 +1023,13 @@
 
 .tlui-style-panel .tlui-button[data-state='open']::after {
 	opacity: 1;
-	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 }
 
 @media (hover: hover) {
 	.tlui-style-panel .tlui-button[data-state='open']:not(:hover)::after {
 		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	}
 }
 
@@ -1039,14 +1039,14 @@
 .tlui-style-panel__section__common .tlui-style-panel__subheading,
 .tlui-style-panel__subheading + .tlui-slider__container {
 	margin: 0;
-	padding: var(--space-2) var(--space-3) 0px var(--space-4);
+	padding: var(--tl-space-2) var(--tl-space-3) 0px var(--tl-space-4);
 	font-size: 12px;
 	font-weight: inherit;
 	line-height: inherit;
 }
 
 .tlui-style-panel .tlui-style-panel__subheading:nth-of-type(1) {
-	padding-top: var(--space-3);
+	padding-top: var(--tl-space-3);
 }
 
 .tlui-style-panel__subheading + .tlui-slider__container {
@@ -1073,7 +1073,7 @@
 	display: flex;
 	width: min-content;
 	flex-direction: column;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	pointer-events: all;
 	position: absolute;
 	left: 0px;
@@ -1087,10 +1087,10 @@
 	z-index: -1;
 	inset: -2px -2px 0px 0px;
 	border-radius: 0;
-	border-top: 2px solid var(--color-background);
-	border-right: 2px solid var(--color-background);
-	border-top-right-radius: var(--radius-4);
-	background-color: var(--color-low);
+	border-top: 2px solid var(--tl-color-background);
+	border-right: 2px solid var(--tl-color-background);
+	border-top-right-radius: var(--tl-radius-4);
+	background-color: var(--tl-color-low);
 }
 
 .tlui-navigation-panel[data-a11y='true']::before {
@@ -1104,7 +1104,7 @@
 	height: 96px;
 	min-height: 96px;
 	overflow: hidden;
-	padding: var(--space-3);
+	padding: var(--tl-space-3);
 	padding-top: 0px;
 }
 
@@ -1124,7 +1124,7 @@
 	align-items: center;
 	justify-content: center;
 	flex-grow: 2;
-	padding-bottom: calc(var(--space-3) + var(--sab));
+	padding-bottom: calc(var(--tl-space-3) + var(--tl-sab));
 }
 
 /* Centered Content */
@@ -1132,7 +1132,7 @@
 	position: relative;
 	width: fit-content;
 	display: flex;
-	gap: var(--space-3);
+	gap: var(--tl-space-3);
 	align-items: flex-end;
 }
 
@@ -1143,7 +1143,7 @@
 /* Row of controls + lock button */
 .tlui-main-toolbar__extras {
 	position: relative;
-	z-index: var(--layer-above);
+	z-index: var(--tl-layer-above);
 	width: 100%;
 	pointer-events: none;
 	top: 6px;
@@ -1158,11 +1158,11 @@
 	display: flex;
 	position: relative;
 	flex-direction: row;
-	z-index: var(--layer-above);
-	background-color: var(--color-low);
-	border-top-left-radius: var(--radius-4);
-	border-top-right-radius: var(--radius-4);
-	border: 2px solid var(--color-background);
+	z-index: var(--tl-layer-above);
+	background-color: var(--tl-color-low);
+	border-top-left-radius: var(--tl-radius-4);
+	border-top-right-radius: var(--tl-radius-4);
+	border: 2px solid var(--tl-color-background);
 	margin-left: 8px;
 	margin-right: 0px;
 	pointer-events: all;
@@ -1173,12 +1173,12 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	border-radius: var(--radius-4);
-	z-index: var(--layer-panels);
+	border-radius: var(--tl-radius-4);
+	z-index: var(--tl-layer-panels);
 	pointer-events: all;
 	position: relative;
-	background: var(--color-panel);
-	box-shadow: var(--shadow-2);
+	background: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-2);
 }
 
 .tlui-main-toolbar__overflow {
@@ -1192,13 +1192,13 @@
 }
 
 .tlui-main-toolbar *[data-state='open']::after {
-	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+	background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 	opacity: 1;
 }
 
 @media (hover: hover) {
 	.tlui-main-toolbar *[data-state='open']:not(:hover)::after {
-		background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--color-muted-2) 100%);
+		background: linear-gradient(0deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
 		opacity: 1;
 	}
 }
@@ -1209,9 +1209,9 @@
 	font-size: 12px;
 	padding: 2px 8px;
 	border-radius: 4px;
-	background-color: var(--color-tooltip);
+	background-color: var(--tl-color-tooltip);
 	box-shadow: none;
-	color: var(--color-text-shadow);
+	color: var(--tl-color-text-shadow);
 	max-width: 400px;
 	width: fit-content;
 	text-align: center;
@@ -1221,12 +1221,12 @@
 }
 
 .tlui-tooltip__arrow {
-	fill: var(--color-tooltip);
+	fill: var(--tl-color-tooltip);
 	will-change: opacity;
 }
 
 [data-radix-popper-content-wrapper]:has(.tlui-tooltip) {
-	z-index: var(--layer-toasts) !important;
+	z-index: var(--tl-layer-toasts) !important;
 }
 
 [data-radix-popper-content-wrapper]:has(.tlui-tooltip[data-should-animate='true']) {
@@ -1236,17 +1236,17 @@
 /* ------------------- Debug panel ------------------ */
 
 .tlui-debug-panel {
-	background-color: var(--color-low);
+	background-color: var(--tl-color-low);
 	width: 100%;
 	display: grid;
 	align-items: center;
 	grid-template-columns: 1fr auto auto auto;
 	justify-content: space-between;
-	padding-left: var(--space-4);
-	border-top: 1px solid var(--color-background);
+	padding-left: var(--tl-space-4);
+	border-top: 1px solid var(--tl-color-background);
 	font-size: 12px;
-	color: var(--color-text-1);
-	z-index: var(--layer-panels);
+	color: var(--tl-color-text-1);
+	z-index: var(--tl-layer-panels);
 	pointer-events: all;
 }
 
@@ -1262,7 +1262,7 @@
 
 .tlui-debug-panel__fps__slow {
 	font-weight: bold;
-	color: var(--color-danger);
+	color: var(--tl-color-danger);
 }
 
 .tlui-a11y-audit {
@@ -1272,7 +1272,7 @@
 .tlui-a11y-audit th,
 .tlui-a11y-audit td {
 	padding: 8px;
-	border: 1px solid var(--color-low-border);
+	border: 1px solid var(--tl-color-low-border);
 }
 
 /* --------------------- Toasts --------------------- */
@@ -1285,10 +1285,10 @@
 	align-items: flex-end;
 	justify-content: flex-end;
 	flex-direction: column;
-	gap: var(--space-3);
+	gap: var(--tl-space-3);
 	pointer-events: none;
-	padding: 0px var(--space-3) 64px 0px;
-	z-index: var(--layer-toasts);
+	padding: 0px var(--tl-space-3) 64px 0px;
+	z-index: var(--tl-layer-toasts);
 }
 
 .tlui-toast__viewport > * {
@@ -1297,34 +1297,34 @@
 
 .tlui-toast__icon {
 	padding-top: 11px;
-	padding-left: var(--space-4);
-	color: var(--color-text-1);
+	padding-left: var(--tl-space-4);
+	color: var(--tl-color-text-1);
 }
 
 .tlui-toast__container {
 	min-width: 200px;
 	display: flex;
 	flex-direction: row;
-	background-color: var(--color-panel);
-	box-shadow: var(--shadow-2);
-	border-radius: var(--radius-3);
+	background-color: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-2);
+	border-radius: var(--tl-radius-3);
 	font-size: 12px;
 }
 
 .tlui-toast__container[data-severity='success'] .tlui-icon {
-	color: var(--color-success);
+	color: var(--tl-color-success);
 }
 
 .tlui-toast__container[data-severity='info'] .tlui-icon {
-	color: var(--color-info);
+	color: var(--tl-color-info);
 }
 
 .tlui-toast__container[data-severity='warning'] .tlui-icon {
-	color: var(--color-warning);
+	color: var(--tl-color-warning);
 }
 
 .tlui-toast__container[data-severity='error'] .tlui-icon {
-	color: var(--color-danger);
+	color: var(--tl-color-danger);
 }
 
 .tlui-toast__main {
@@ -1333,27 +1333,27 @@
 }
 
 .tlui-toast__content {
-	padding: var(--space-4);
+	padding: var(--tl-space-4);
 	display: flex;
 	line-height: 1.4;
 	flex-direction: column;
-	gap: var(--space-3);
+	gap: var(--tl-space-3);
 }
 
 .tlui-toast__main[data-actions='true'] .tlui-toast__content {
-	padding-bottom: var(--space-2);
+	padding-bottom: var(--tl-space-2);
 }
 
 .tlui-toast__title {
 	font-weight: bold;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	/* this makes the default toast look better */
 	line-height: 16px;
 }
 
 .tlui-toast__description {
-	color: var(--color-text-1);
-	padding: var(--space-3);
+	color: var(--tl-color-text-1);
+	padding: var(--tl-space-3);
 	margin: 0px;
 	padding: 0px;
 }
@@ -1405,14 +1405,14 @@
 	left: 0px;
 	width: 100%;
 	height: 100%;
-	z-index: var(--layer-canvas-overlays);
-	background-color: var(--color-overlay);
+	z-index: var(--tl-layer-canvas-overlays);
+	background-color: var(--tl-color-overlay);
 	pointer-events: all;
 	animation: tl-fade-in 0.12s ease-out;
 	display: grid;
 	place-items: center;
 	overflow-y: auto;
-	padding: 0px var(--space-3);
+	padding: 0px var(--tl-space-3);
 }
 
 .tlui-dialog__content {
@@ -1420,9 +1420,9 @@
 	flex-direction: column;
 	position: relative;
 	cursor: default;
-	background-color: var(--color-panel);
-	box-shadow: var(--shadow-3);
-	border-radius: var(--radius-3);
+	background-color: var(--tl-color-panel);
+	box-shadow: var(--tl-shadow-3);
+	border-radius: var(--tl-radius-3);
 	font-size: 12px;
 	overflow: hidden;
 	min-width: 300px;
@@ -1435,9 +1435,9 @@
 	display: flex;
 	align-items: center;
 	flex: 0;
-	z-index: var(--layer-header-footer);
-	padding-left: var(--space-4);
-	color: var(--color-text);
+	z-index: var(--tl-layer-header-footer);
+	padding-left: var(--tl-space-4);
+	color: var(--tl-color-text);
 	height: 40px;
 }
 
@@ -1446,7 +1446,7 @@
 	font-weight: inherit;
 	font-size: 12px;
 	margin: 0px;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 }
 
 .tlui-dialog__header__close {
@@ -1454,16 +1454,16 @@
 }
 
 .tlui-dialog__body {
-	padding: var(--space-4) var(--space-4);
+	padding: var(--tl-space-4) var(--tl-space-4);
 	flex: 0 1;
 	overflow-y: auto;
 	overflow-x: hidden;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	user-select: all;
 	-webkit-user-select: text;
 }
 .tlui-dialog__body a {
-	color: var(--color-selected);
+	color: var(--tl-color-selected);
 }
 
 .tlui-dialog__body ul,
@@ -1471,13 +1471,13 @@
 	padding-left: 16px;
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-2);
+	gap: var(--tl-space-2);
 }
 
 .tlui-dialog__footer {
 	position: relative;
 	min-height: 12px;
-	z-index: var(--layer-header-footer);
+	z-index: var(--tl-layer-header-footer);
 }
 
 .tlui-dialog__footer__actions {
@@ -1497,15 +1497,15 @@
 .tlui-edit-link-dialog {
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-4);
-	color: var(--color-text);
+	gap: var(--tl-space-4);
+	color: var(--tl-color-text);
 }
 
 .tlui-edit-link-dialog__input {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	flex-grow: 2;
-	border-radius: var(--radius-2);
-	padding: 0px var(--space-4);
+	border-radius: var(--tl-radius-2);
+	padding: 0px var(--tl-space-4);
 }
 
 /* Embed Dialog */
@@ -1513,15 +1513,15 @@
 .tlui-embed__spacer {
 	flex-grow: 2;
 	min-height: 0px;
-	margin-left: calc(-1 * var(--space-4));
-	margin-top: calc(-1 * var(--space-4));
+	margin-left: calc(-1 * var(--tl-space-4));
+	margin-top: calc(-1 * var(--tl-space-4));
 	pointer-events: none;
 }
 
 .tlui-embed-dialog__list {
 	display: flex;
 	flex-direction: column;
-	padding: 0px var(--space-3) var(--space-4) var(--space-3);
+	padding: 0px var(--tl-space-3) var(--tl-space-4) var(--tl-space-3);
 }
 
 .tlui-embed-dialog__item__image {
@@ -1533,49 +1533,49 @@
 	background-size: contain;
 	background-repeat: no-repeat;
 	background-position: center center;
-	background-color: var(--color-selected-contrast);
-	border-radius: var(--radius-1);
+	background-color: var(--tl-color-selected-contrast);
+	border-radius: var(--tl-radius-1);
 }
 
 .tlui-embed-dialog__enter {
 	display: flex;
 	flex-direction: column;
-	gap: var(--space-4);
-	color: var(--color-text-1);
+	gap: var(--tl-space-4);
+	color: var(--tl-color-text-1);
 }
 
 .tlui-embed-dialog__input {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	flex-grow: 2;
-	border-radius: var(--radius-2);
-	padding: 0px var(--space-4);
+	border-radius: var(--tl-radius-2);
+	padding: 0px var(--tl-space-4);
 }
 
 .tlui-embed-dialog__warning {
-	color: var(--color-danger);
+	color: var(--tl-color-danger);
 	text-shadow: none;
 }
 
 .tlui-embed-dialog__instruction__link {
 	display: flex;
-	gap: var(--space-1);
-	margin-top: var(--space-4);
+	gap: var(--tl-space-1);
+	margin-top: var(--tl-space-4);
 }
 
 .tlui-embed-dialog__enter a {
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 }
 
 /* --------------- Keyboard shortcuts --------------- */
 
 .tlui-shortcuts-dialog__header {
-	border-bottom: 1px solid var(--color-divider);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 
 .tlui-shortcuts-dialog__body {
 	position: relative;
 	columns: 3;
-	column-gap: var(--space-9);
+	column-gap: var(--tl-space-9);
 	pointer-events: all;
 	touch-action: auto;
 
@@ -1593,14 +1593,14 @@
 
 .tlui-shortcuts-dialog__group {
 	break-inside: avoid-column;
-	padding-bottom: var(--space-6);
+	padding-bottom: var(--tl-space-6);
 }
 
 .tlui-shortcuts-dialog__group__title {
 	font-size: inherit;
 	font-weight: inherit;
 	margin: 0px;
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	height: 32px;
 	display: flex;
 	align-items: center;
@@ -1609,12 +1609,12 @@
 .tlui-shortcuts-dialog__group__content {
 	display: flex;
 	flex-direction: column;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 }
 
 .tlui-shortcuts-dialog__key-pair {
 	display: flex;
-	gap: var(--space-4);
+	gap: var(--tl-space-4);
 	align-items: center;
 	justify-content: space-between;
 	height: 32px;
@@ -1641,12 +1641,12 @@
 	height: 24px;
 	background: linear-gradient(
 		to bottom,
-		var(--color-panel-transparent) 0%,
-		var(--color-panel) 90%,
-		var(--color-panel) 100%
+		var(--tl-color-panel-transparent) 0%,
+		var(--tl-color-panel) 90%,
+		var(--tl-color-panel) 100%
 	);
-	border-bottom-left-radius: var(--radius-3);
-	border-bottom-right-radius: var(--radius-3);
+	border-bottom-left-radius: var(--tl-radius-3);
+	border-bottom-right-radius: var(--tl-radius-3);
 	pointer-events: none;
 }
 
@@ -1661,10 +1661,10 @@
 .tlui-help-menu {
 	pointer-events: all;
 	position: absolute;
-	bottom: var(--space-2);
-	right: var(--space-2);
-	z-index: var(--layer-panels);
-	border: 2px solid var(--color-background);
+	bottom: var(--tl-space-2);
+	right: var(--tl-space-2);
+	z-index: var(--tl-layer-panels);
+	border: 2px solid var(--tl-color-background);
 	border-radius: 100%;
 }
 
@@ -1675,7 +1675,7 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-end;
-	z-index: var(--layer-panels);
+	z-index: var(--tl-layer-panels);
 	align-items: center;
 	padding-top: 2px;
 	padding-right: 4px;
@@ -1691,7 +1691,7 @@
 	border: none;
 	cursor: pointer;
 	pointer-events: all;
-	border-radius: var(--radius-1);
+	border-radius: var(--tl-radius-1);
 	padding-right: 1px;
 	height: 100%;
 }
@@ -1704,8 +1704,8 @@
 .tlui-people-menu__avatar {
 	height: 24px;
 	width: 24px;
-	border: 2px solid var(--color-background);
-	background-color: var(--color-low);
+	border: 2px solid var(--tl-color-background);
+	background-color: var(--tl-color-low);
 	border-radius: 100%;
 	display: flex;
 	align-items: center;
@@ -1714,7 +1714,7 @@
 	font-size: 10px;
 	font-weight: bold;
 	text-align: center;
-	color: var(--color-selected-contrast);
+	color: var(--tl-color-selected-contrast);
 	z-index: 2;
 }
 
@@ -1728,7 +1728,7 @@
 
 @media (hover: hover) {
 	.tlui-people-menu__avatars-button:hover .tlui-people-menu__avatar {
-		border-color: var(--color-low);
+		border-color: var(--tl-color-low);
 	}
 }
 
@@ -1736,12 +1736,12 @@
 	min-width: 0px;
 	font-size: 11px;
 	font-weight: 600;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	font-family: inherit;
 	padding: 0px 4px;
 }
 .tlui-people-menu__more::after {
-	border-radius: var(--radius-2);
+	border-radius: var(--tl-radius-2);
 	inset: 0px;
 }
 
@@ -1770,7 +1770,7 @@
 }
 
 .tlui-people-menu__section:not(:last-child) {
-	border-bottom: 1px solid var(--color-divider);
+	border-bottom: 1px solid var(--tl-color-divider);
 }
 
 .tlui-people-menu__user {
@@ -1789,7 +1789,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-size: 12px;
-	color: var(--color-text-1);
+	color: var(--tl-color-text-1);
 	max-width: 100%;
 	flex-grow: 1;
 	flex-shrink: 100;
@@ -1801,7 +1801,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-size: 12px;
-	color: var(--color-text-3);
+	color: var(--tl-color-text-3);
 	flex-grow: 100;
 	flex-shrink: 0;
 	margin-left: 4px;
@@ -1892,7 +1892,7 @@
 	inset: 0px;
 	border-width: 2px;
 	border-style: solid;
-	z-index: var(--layer-following-indicator);
+	z-index: var(--tl-layer-following-indicator);
 	pointer-events: none;
 }
 
@@ -1911,7 +1911,7 @@
 }
 
 .tlui-contextual-toolbar [data-isactive='true']::after {
-	background-color: var(--color-muted-2);
+	background-color: var(--tl-color-muted-2);
 	opacity: 1;
 }
 
@@ -1927,7 +1927,7 @@
 
 .tlui-contextual-toolbar[data-visible='true'] {
 	opacity: 1;
-	z-index: var(--layer-menus);
+	z-index: var(--tl-layer-menus);
 }
 
 .tlui-contextual-toolbar[data-interactive='true'],
@@ -1986,7 +1986,7 @@
 
 @keyframes tlui-slide-in {
 	from {
-		transform: translateX(calc(100% + var(--space-3)));
+		transform: translateX(calc(100% + var(--tl-space-3)));
 	}
 	to {
 		transform: translateX(0px);
@@ -1998,6 +1998,6 @@
 		transform: translateX(var(--radix-toast-swipe-end-x));
 	}
 	to {
-		transform: translateX(calc(100% + var(--space-3)));
+		transform: translateX(calc(100% + var(--tl-space-3)));
 	}
 }

--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -46,10 +46,10 @@ export class MinimapManager {
 		const style = getComputedStyle(this.editor.getContainer())
 
 		return {
-			shapeFill: getRgba(style.getPropertyValue('--color-text-3').trim()),
-			selectFill: getRgba(style.getPropertyValue('--color-selected').trim()),
-			viewportFill: getRgba(style.getPropertyValue('--color-muted-1').trim()),
-			background: getRgba(style.getPropertyValue('--color-low').trim()),
+			shapeFill: getRgba(style.getPropertyValue('--tl-color-text-3').trim()),
+			selectFill: getRgba(style.getPropertyValue('--tl-color-selected').trim()),
+			viewportFill: getRgba(style.getPropertyValue('--tl-color-muted-1').trim()),
+			background: getRgba(style.getPropertyValue('--tl-color-low').trim()),
 		}
 	}
 

--- a/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/MobileStylePanel.tsx
@@ -56,7 +56,7 @@ export function MobileStylePanel() {
 					type="tool"
 					data-testid="mobile-styles.button"
 					style={{
-						color: disableStylePanel ? 'var(--color-muted-1)' : currentColor,
+						color: disableStylePanel ? 'var(--tl-color-muted-1)' : currentColor,
 					}}
 					title={msg('style-panel.title')}
 					disabled={disableStylePanel}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -272,7 +272,7 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 					type="icon"
 					onClick={onManipulatingEnd}
 					data-testid="tool.image-confirm"
-					style={{ borderLeft: '1px solid var(--color-divider)', marginLeft: '2px' }}
+					style={{ borderLeft: '1px solid var(--tl-color-divider)', marginLeft: '2px' }}
 				>
 					<TldrawUiButtonIcon small icon="check" />
 				</TldrawUiButton>


### PR DESCRIPTION
css variables cascade down through the tree. we've had reports in the past of people having issues because our css variable names, which are fairly generic (`--space-3`, `--color-warning`) clash with those from customers design systems.

this diff takes advantage of the coming 4.0 to rename all our variables to namespace them with `--tl-`, like we do with our classnames.

### Change type

- [x] `api`

### Release notes

- **BREAKING:** all of tldraw's css variables now start with `--tl`. e.g. `--color-background` is now `--tl-color-background`, `--space-4` is now `--tl-space-4`, etc. Names which already started with `--tl-` remain the same.