### PR TITLE
fix resize/rotate cursors with tailwindcss

### DIFF
--- a/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
+++ b/packages/tldraw/src/lib/canvas/TldrawSelectionForeground.tsx
@@ -459,7 +459,7 @@ export const ResizeHandle = function ResizeHandle({
 			y={y}
 			width={width}
 			height={height}
-			cursor={cursor}
+			style={{ cursor }}
 			{...events}
 		/>
 	)
@@ -497,7 +497,7 @@ export const RotateCornerHandle = function RotateCornerHandle({
 			y={toDomPrecision(cy - targetSize * 3)}
 			width={toDomPrecision(Math.max(1, targetSize * 3))}
 			height={toDomPrecision(Math.max(1, targetSize * 3))}
-			cursor={cursor}
+			style={{ cursor }}
 			{...events}
 		/>
 	)


### PR DESCRIPTION
tailwind's preflight includes [a rule](https://github.com/tailwindlabs/tailwindcss/blob/40f506f31765b004df6b3b6eb9e965f8cfc7cd2d/src/css/preflight.css#L339-L346) that sets `cursor: pointer` on anything with `role="button"`. Properties set with CSS always have higher precedence that ones set with attributes. So the `cursor` attributes we set get overridden by the default tailwind ones. 

This diff switches `cursor` attributes to use style attributes instead.

### Change type

- [x] `bugfix`


### Release notes

- Make sure the correct cursors show for resizing and rotating on pages that use tailwindcss.