### PR TITLE
docs: clarify third-party backend documentation

### DIFF
--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -81,7 +81,7 @@ To use tldraw sync in production, you will need to self-host the tldraw sync ser
 
 ## Using other collaboration backends
 
-While [tldraw sync](/docs/sync) is our recommended and best-supported backend for tldraw, we designed the tldraw SDK to work with any data solution. For example, Liveblocks offers a [tldraw starter](https://liveblocks.io/examples/tldraw-whiteboard), and many product teams have plugged tldraw into their own real-time data solutions. 
+While [tldraw sync](/docs/sync) is our recommended and best-supported backend for tldraw, we designed the tldraw SDK to work with any data solution. For example, Liveblocks offers a [tldraw starter](https://liveblocks.io/examples/tldraw-whiteboard), and many product teams have plugged tldraw into their own real-time data solutions.
 
 ### Manual setup
 


### PR DESCRIPTION
This PR clarifies the phrasing around third-party backends.

NOTE: The paragraph includes a little bit of repetition in reference to the preceding paragraph. This is in case someone lands on this header through a search (see the second screenshot).

<figure>
<img width="1262" height="525" alt="Full section screenshot" src="https://github.com/user-attachments/assets/6dbe9be6-0970-4f58-b5f3-4528e1ecf733" />
  <figcaption><i>Full section</i></figcaption>
</figure>

<figure>
<img width="1262" height="525" alt="Only third-party backends subsection" src="https://github.com/user-attachments/assets/5691434c-dc0a-4ea4-96f1-000480eb320c" />
  <figcaption><i>Only third-party backends subsection</i></figcaption>
</figure>

### Change type

- [ ] `bugfix` 
- [ ] `improvement` 
- [ ] `feature` 
- [ ] `api` 
- [x] `other` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Clarified documentation regarding third-party backends.