### PR TITLE
Stop tracking app events in GA, manually track page views.

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -179,12 +179,10 @@ function getGA4() {
 export function trackEvent(name: string, data?: { [key: string]: any }) {
 	getPosthog()?.capture(name, data)
 
-	// For GA4, rename 'source' to 'event_source' to avoid session attribution
-	if (data) {
-		const { source, ...rest } = data
-		data = source !== undefined ? { ...rest, event_source: source } : rest
+	// Send pageviews to both platforms, but other app-specific events only to PostHog
+	if (name === '$pageview') {
+		getGA4()?.event('page_view', data)
 	}
-	getGA4()?.event(name, data)
 }
 
 export function useHandleUiEvents() {

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -184,7 +184,7 @@ export function trackEvent(name: string, data?: { [key: string]: any }) {
 
 	// Send pageviews to both platforms, but other app-specific events only to PostHog
 	if (name === '$pageview') {
-		getGA4()?.event('$pageview', data)
+		getGA4()?.event('page_view', data)
 	}
 }
 

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -121,8 +121,11 @@ function configureGA4(options: AnalyticsOptions) {
 			wait_for_update: 500,
 		})
 
-		ReactGA.initialize(GA4_MEASUREMENT_ID)
-		ReactGA.send('pageview')
+		ReactGA.initialize(GA4_MEASUREMENT_ID, {
+			gtagOptions: {
+				send_page_view: false,
+			},
+		})
 	}
 
 	if (options.optedIn) {
@@ -181,7 +184,7 @@ export function trackEvent(name: string, data?: { [key: string]: any }) {
 
 	// Send pageviews to both platforms, but other app-specific events only to PostHog
 	if (name === '$pageview') {
-		getGA4()?.event('page_view', data)
+		getGA4()?.event('$pageview', data)
 	}
 }
 


### PR DESCRIPTION
We already track app events in posthog, we don't want to it add additional noise to GA. Also make sure we don't send different page view events. We disable the built in page view tracking and use our manual tracking.

### Change type

- [x] `improvement`
