### PR TITLE
fix(ui): select all text when dragging out of toolbar

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -219,8 +219,8 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 						createShape: (id) =>
 							editor.createShape({ id, type: 'text', props: { richText: toRichText('Text') } }),
 						onDragEnd: (id) => {
-							editor.emit('select-all-text', { shapeId: id })
 							editor.setEditingShape(id)
+							editor.emit('select-all-text', { shapeId: id })
 						},
 					})
 					trackEvent('drag-tool', { source, id: 'text' })
@@ -249,8 +249,8 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 					onDragFromToolbarToCreateShape(editor, info, {
 						createShape: (id) => editor.createShape({ id, type: 'note' }),
 						onDragEnd: (id) => {
-							editor.emit('select-all-text', { shapeId: id })
 							editor.setEditingShape(id)
+							editor.emit('select-all-text', { shapeId: id })
 						},
 					})
 					trackEvent('drag-tool', { source, id: 'note' })


### PR DESCRIPTION
This pull request makes a minor adjustment to the order of function calls when handling the drag-and-drop creation of text and note shapes in the `useTools.tsx` file. The change ensures that the shape enters editing mode before emitting the `select-all-text` event, which may improve user experience and reliability.

Most important changes:

**Drag-and-drop shape creation behavior:**

* In the `onDragEnd` handler for both text and note shapes, the call to `editor.setEditingShape(id)` now occurs before emitting the `select-all-text` event, rather than after. 

### Change type

- [x] `bugfix` 

### Test plan

1. Drag a text or note tool from the toolbar onto the canvas.
2. Verify that the text is automatically selected for editing upon creation.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where text might not be automatically selected when dragging a text or note tool from the toolbar.