### PR TITLE
Tooltip fixes

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4101,7 +4101,7 @@ export interface TLUiMenuContextProviderProps {
 }
 
 // @public (undocumented)
-export type TLUiMenuContextType = 'context-menu' | 'helper-buttons' | 'icons' | 'keyboard-shortcuts' | 'menu' | 'panel' | 'small-icons' | 'toolbar-overflow' | 'toolbar';
+export type TLUiMenuContextType = 'context-menu' | 'helper-buttons' | 'icons' | 'keyboard-shortcuts' | 'menu' | 'small-icons' | 'toolbar-overflow' | 'toolbar';
 
 // @public (undocumented)
 export interface TLUiMenuGroupProps<TranslationKey extends string = string> {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1318,7 +1318,6 @@
 	max-width: 400px;
 	width: fit-content;
 	text-align: center;
-	pointer-events: none;
 	will-change: transform, opacity;
 	z-index: 2;
 }
@@ -1330,6 +1329,7 @@
 
 [data-radix-popper-content-wrapper]:has(.tlui-tooltip) {
 	z-index: var(--tl-layer-toasts) !important;
+	pointer-events: none;
 }
 
 /* ------------------- Debug panel ------------------ */

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1078,7 +1078,6 @@
 .tlui-layout__bottom {
 	grid-row: 2;
 	width: 100%;
-	overflow: hidden;
 }
 
 .tlui-layout__bottom__main {
@@ -1331,10 +1330,6 @@
 
 [data-radix-popper-content-wrapper]:has(.tlui-tooltip) {
 	z-index: var(--tl-layer-toasts) !important;
-}
-
-[data-radix-popper-content-wrapper]:has(.tlui-tooltip[data-should-animate='true']) {
-	transition: all 0.1s ease-out;
 }
 
 /* ------------------- Debug panel ------------------ */

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -270,7 +270,7 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 
 		const handleMouseLeave = (event: React.MouseEvent<HTMLElement>) => {
 			child.props.onMouseLeave?.(event)
-			tooltipManager.hideTooltip(editor, tooltipId.current)
+			// tooltipManager.hideTooltip(editor, tooltipId.current)
 		}
 
 		const handleFocus = (event: React.FocusEvent<HTMLElement>) => {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -270,7 +270,7 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 
 		const handleMouseLeave = (event: React.MouseEvent<HTMLElement>) => {
 			child.props.onMouseLeave?.(event)
-			// tooltipManager.hideTooltip(editor, tooltipId.current)
+			tooltipManager.hideTooltip(editor, tooltipId.current)
 		}
 
 		const handleFocus = (event: React.FocusEvent<HTMLElement>) => {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -1,7 +1,14 @@
-import { assert, Editor, uniqueId, useMaybeEditor, Vec } from '@tldraw/editor'
+import { assert, Atom, atom, Editor, uniqueId, useMaybeEditor, useValue } from '@tldraw/editor'
 import { Tooltip as _Tooltip } from 'radix-ui'
-import React, { createContext, forwardRef, useContext, useEffect, useRef, useState } from 'react'
-import { usePrefersReducedMotion } from '../../../shapes/shared/usePrefersReducedMotion'
+import React, {
+	createContext,
+	forwardRef,
+	ReactNode,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from 'react'
 import { useTldrawUiOrientation } from './layout'
 
 const DEFAULT_TOOLTIP_DELAY_MS = 700
@@ -18,14 +25,15 @@ export interface TldrawUiTooltipProps {
 // Singleton tooltip manager
 class TooltipManager {
 	private static instance: TooltipManager | null = null
-	private currentTooltipId: string | null = null
-	private currentContent: string | React.ReactNode = ''
-	private currentSide: 'top' | 'right' | 'bottom' | 'left' = 'bottom'
-	private currentSideOffset: number = 5
+	private currentTooltip = atom<{
+		id: string
+		content: ReactNode
+		side: 'top' | 'right' | 'bottom' | 'left'
+		sideOffset: number
+		targetElement: HTMLElement
+	} | null>('current tooltip', null)
 	private destroyTimeoutId: number | null = null
 	private subscribers: Set<() => void> = new Set()
-	private activeElement: HTMLElement | null = null
-	private editor: Editor | null = null
 
 	static getInstance(): TooltipManager {
 		if (!TooltipManager.instance) {
@@ -34,23 +42,10 @@ class TooltipManager {
 		return TooltipManager.instance
 	}
 
-	setEditor(editor: Editor | null) {
-		this.editor = editor
-	}
-
-	subscribe(callback: () => void): () => void {
-		this.subscribers.add(callback)
-		return () => this.subscribers.delete(callback)
-	}
-
-	private notify() {
-		this.subscribers.forEach((callback) => callback())
-	}
-
 	showTooltip(
 		tooltipId: string,
 		content: string | React.ReactNode,
-		element: HTMLElement,
+		targetElement: HTMLElement,
 		side: 'top' | 'right' | 'bottom' | 'left' = 'bottom',
 		sideOffset: number = 5
 	) {
@@ -61,51 +56,53 @@ class TooltipManager {
 		}
 
 		// Update current tooltip
-		this.currentTooltipId = tooltipId
-		this.currentContent = content
-		this.currentSide = side
-		this.currentSideOffset = sideOffset
-		this.activeElement = element
-
-		this.notify()
+		this.currentTooltip.set({
+			id: tooltipId,
+			content,
+			side,
+			sideOffset,
+			targetElement,
+		})
 	}
 
-	hideTooltip(tooltipId: string, instant: boolean = false) {
+	hideTooltip(editor: Editor | null, tooltipId: string, instant: boolean = false) {
 		const hide = () => {
 			// Only hide if this is the current tooltip
-			if (this.currentTooltipId === tooltipId) {
-				this.currentTooltipId = null
-				this.currentContent = ''
-				this.activeElement = null
+			if (this.currentTooltip.get()?.id === tooltipId) {
+				this.currentTooltip.set(null)
 				this.destroyTimeoutId = null
-				this.notify()
 			}
 		}
 
-		if (instant) {
-			hide()
-		} else if (this.editor) {
+		if (editor && !instant) {
 			// Start destroy timeout (1 second)
-			this.destroyTimeoutId = this.editor.timers.setTimeout(hide, 300)
+			this.destroyTimeoutId = editor.timers.setTimeout(hide, 300)
+		} else {
+			hide()
 		}
 	}
 
 	hideAllTooltips() {
-		this.currentTooltipId = null
-		this.currentContent = ''
-		this.activeElement = null
+		this.currentTooltip.set(null)
 		this.destroyTimeoutId = null
-		this.notify()
 	}
 
 	getCurrentTooltipData() {
-		return {
-			id: this.currentTooltipId,
-			content: this.currentContent,
-			side: this.currentSide,
-			sideOffset: this.currentSideOffset,
-			element: this.activeElement,
+		if (!this.supportsHover()) return null
+		return this.currentTooltip.get()
+	}
+
+	private supportsHoverAtom: Atom<boolean> | null = null
+	supportsHover() {
+		if (!this.supportsHoverAtom) {
+			const mediaQuery = window.matchMedia('(hover: hover)')
+			const supportsHover = atom('has hover', mediaQuery.matches)
+			this.supportsHoverAtom = supportsHover
+			mediaQuery.addEventListener('change', (e) => {
+				supportsHover.set(e.matches)
+			})
 		}
+		return this.supportsHoverAtom.get()
 	}
 }
 
@@ -134,64 +131,29 @@ export function TldrawUiTooltipProvider({ children }: TldrawUiTooltipProviderPro
 // The singleton tooltip component that renders once
 function TooltipSingleton() {
 	const editor = useMaybeEditor()
-	const [, forceUpdate] = useState({})
 	const [isOpen, setIsOpen] = useState(false)
 	const triggerRef = useRef<HTMLDivElement>(null)
-	const previousPositionRef = useRef<{ x: number; y: number } | null>(null)
-	const prefersReducedMotion = usePrefersReducedMotion()
-	const [shouldAnimate, setShouldAnimate] = useState(false)
 	const isFirstShowRef = useRef(true)
 	const showTimeoutRef = useRef<number | null>(null)
 
-	// Set editor in tooltip manager
-	useEffect(() => {
-		tooltipManager.setEditor(editor)
-	}, [editor])
-
-	// Subscribe to tooltip manager updates
-	useEffect(() => {
-		const unsubscribe = tooltipManager.subscribe(() => {
-			forceUpdate({})
-		})
-		return unsubscribe
-	}, [])
-
-	const tooltipData = tooltipManager.getCurrentTooltipData()
+	const currentTooltip = useValue(
+		'current tooltip',
+		() => tooltipManager.getCurrentTooltipData(),
+		[]
+	)
 
 	// Update open state and trigger position
 	useEffect(() => {
-		const shouldBeOpen = Boolean(tooltipData.id && tooltipData.element)
-
 		// Clear any existing show timeout
 		if (showTimeoutRef.current) {
 			clearTimeout(showTimeoutRef.current)
 			showTimeoutRef.current = null
 		}
 
-		if (shouldBeOpen && tooltipData.element && triggerRef.current) {
+		if (currentTooltip && triggerRef.current) {
 			// Position the invisible trigger element over the active element
-			const activeRect = tooltipData.element.getBoundingClientRect()
+			const activeRect = currentTooltip.targetElement.getBoundingClientRect()
 			const trigger = triggerRef.current
-
-			const newPosition = {
-				x: activeRect.left + activeRect.width / 2,
-				y: activeRect.top + activeRect.height / 2,
-			}
-
-			// Determine if we should animate
-			let shouldAnimateCheck = false
-			if (previousPositionRef.current) {
-				const isNearPrevious = Vec.DistMin(previousPositionRef.current, newPosition, 200)
-				// Only animate if the distance is less than 200px (nearby tooltips)
-				shouldAnimateCheck =
-					!prefersReducedMotion &&
-					isNearPrevious &&
-					Math.abs(newPosition.y - previousPositionRef.current.y) < 50
-			}
-			// Don't animate on initial show (previousPositionRef.current is null)
-
-			setShouldAnimate(isFirstShowRef.current ? false : shouldAnimateCheck)
-			previousPositionRef.current = newPosition
 
 			trigger.style.position = 'fixed'
 			trigger.style.left = `${activeRect.left}px`
@@ -211,18 +173,15 @@ function TooltipSingleton() {
 				// Subsequent tooltips show immediately
 				setIsOpen(true)
 			}
-		} else if (!shouldBeOpen) {
+		} else {
 			// Hide tooltip immediately
 			setIsOpen(false)
-			// Reset position tracking when tooltip closes
-			previousPositionRef.current = null
-			setShouldAnimate(false)
 			// Reset first show state after tooltip is hidden
 			isFirstShowRef.current = true
 		}
-	}, [tooltipData.id, tooltipData.element, editor, prefersReducedMotion])
+	}, [editor, currentTooltip])
 
-	if (!tooltipData.id) {
+	if (!currentTooltip) {
 		return null
 	}
 
@@ -233,14 +192,13 @@ function TooltipSingleton() {
 			</_Tooltip.Trigger>
 			<_Tooltip.Content
 				className="tlui-tooltip"
-				data-should-animate={shouldAnimate}
-				side={tooltipData.side}
-				sideOffset={tooltipData.sideOffset}
+				side={currentTooltip.side}
+				sideOffset={currentTooltip.sideOffset}
 				avoidCollisions
 				collisionPadding={8}
 				dir="ltr"
 			>
-				{tooltipData.content}
+				{currentTooltip.content}
 				<_Tooltip.Arrow className="tlui-tooltip__arrow" />
 			</_Tooltip.Content>
 		</_Tooltip.Root>
@@ -261,10 +219,10 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 			const currentTooltipId = tooltipId.current
 			return () => {
 				if (hasProvider) {
-					tooltipManager.hideTooltip(currentTooltipId, true)
+					tooltipManager.hideTooltip(editor, currentTooltipId, true)
 				}
 			}
-		}, [hasProvider])
+		}, [editor, hasProvider])
 
 		// Don't show tooltip if disabled, no content, or UI labels are disabled
 		if (disabled || !content) {
@@ -312,7 +270,7 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 
 		const handleMouseLeave = (event: React.MouseEvent<HTMLElement>) => {
 			child.props.onMouseLeave?.(event)
-			tooltipManager.hideTooltip(tooltipId.current)
+			tooltipManager.hideTooltip(editor, tooltipId.current)
 		}
 
 		const handleFocus = (event: React.FocusEvent<HTMLElement>) => {
@@ -328,7 +286,7 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 
 		const handleBlur = (event: React.FocusEvent<HTMLElement>) => {
 			child.props.onBlur?.(event)
-			tooltipManager.hideTooltip(tooltipId.current)
+			tooltipManager.hideTooltip(editor, tooltipId.current)
 		}
 
 		const childrenWithHandlers = React.cloneElement(children as React.ReactElement, {

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuContext.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuContext.tsx
@@ -3,7 +3,6 @@ import { TLUiEventSource } from '../../../context/events'
 
 /** @public */
 export type TLUiMenuContextType =
-	| 'panel'
 	| 'menu'
 	| 'small-icons'
 	| 'context-menu'

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuGroup.tsx
@@ -27,16 +27,6 @@ export function TldrawUiMenuGroup({ id, label, className, children }: TLUiMenuGr
 	const labelStr = labelToUse ? msg(labelToUse as TLUiTranslationKey) : undefined
 
 	switch (menu.type) {
-		case 'panel': {
-			return (
-				<div
-					className={classNames('tlui-menu__group', className)}
-					data-testid={`${menu.sourceId}-group.${id}`}
-				>
-					{children}
-				</div>
-			)
-		}
 		case 'menu': {
 			return (
 				<TldrawUiDropdownMenuGroup

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -120,7 +120,6 @@ export function TldrawUiMenuItem<
 						type="menu"
 						data-testid={`${sourceId}.${id}`}
 						disabled={disabled}
-						title={titleStr}
 						onClick={(e) => {
 							if (noClose) {
 								preventDefault(e)
@@ -146,7 +145,6 @@ export function TldrawUiMenuItem<
 			return (
 				<_ContextMenu.Item
 					dir="ltr"
-					title={titleStr}
 					draggable={false}
 					className="tlui-button tlui-button__menu"
 					data-testid={`${sourceId}.${id}`}
@@ -166,20 +164,6 @@ export function TldrawUiMenuItem<
 					{kbd && <TldrawUiKbd>{kbd}</TldrawUiKbd>}
 					{spinner && <Spinner />}
 				</_ContextMenu.Item>
-			)
-		}
-		case 'panel': {
-			return (
-				<TldrawUiButton
-					data-testid={`${sourceId}.${id}`}
-					type="menu"
-					title={titleStr}
-					disabled={disabled}
-					onClick={() => onSelect(sourceId)}
-				>
-					<TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>
-					{spinner ? <Spinner /> : icon && <TldrawUiButtonIcon icon={icon} />}
-				</TldrawUiButton>
 			)
 		}
 		case 'small-icons':


### PR DESCRIPTION
- Remove the animation (fixes INT-2151)
- Remove the title attribute from dropdown menus (fixes INT-2149)
- Prevent tooltips showing on devices that don't support hover (fixes INT-2137)
- Make sure `pointer-events: none` is correctly set on tooltips (fixes INT-2134)

### API Changes

Removes "panel" from `TLUiMenuContextType`, which was unused.