### PR TITLE
no frame color

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -284,8 +284,12 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		const colorToUse = showFrameColors ? shape.props.color : 'black'
 		const frameFill = getColorValue(theme, colorToUse, 'frameFill')
 		const frameStroke = getColorValue(theme, colorToUse, 'frameStroke')
-		const frameHeadingStroke = getColorValue(theme, colorToUse, 'frameHeadingStroke')
-		const frameHeadingFill = getColorValue(theme, colorToUse, 'frameHeadingFill')
+		const frameHeadingStroke = showFrameColors
+			? getColorValue(theme, colorToUse, 'frameHeadingStroke')
+			: theme.background
+		const frameHeadingFill = showFrameColors
+			? getColorValue(theme, colorToUse, 'frameHeadingFill')
+			: theme.background
 		const frameHeadingText = getColorValue(theme, colorToUse, 'frameText')
 
 		return (

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -224,8 +224,12 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		const colorToUse = showFrameColors ? shape.props.color : 'black'
 		const frameFill = getColorValue(theme, colorToUse, 'frameFill')
 		const frameStroke = getColorValue(theme, colorToUse, 'frameStroke')
-		const frameHeadingStroke = getColorValue(theme, colorToUse, 'frameHeadingStroke')
-		const frameHeadingFill = getColorValue(theme, colorToUse, 'frameHeadingFill')
+		const frameHeadingStroke = showFrameColors
+			? getColorValue(theme, colorToUse, 'frameHeadingStroke')
+			: theme.background
+		const frameHeadingFill = showFrameColors
+			? getColorValue(theme, colorToUse, 'frameHeadingFill')
+			: theme.background
 		const frameHeadingText = getColorValue(theme, colorToUse, 'frameText')
 
 		return (


### PR DESCRIPTION
don't show the `black` frame label colors when frame colors are disabled. Fixes INT-2135

### Change type

- [x] `other`
