### PR TITLE
fix mobile cookie tooltip

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
@@ -48,7 +48,7 @@ export function TlaManageCookiesDialog() {
 							<TlaMenuControlLabel>
 								<F defaultMessage="Essential cookies" />
 							</TlaMenuControlLabel>
-							<TlaMenuControlInfoTooltip>
+							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use these cookies to save your files and settings." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch checked={true} disabled />
@@ -57,7 +57,7 @@ export function TlaManageCookiesDialog() {
 							<TlaMenuControlLabel>
 								<F defaultMessage="Analytics" />
 							</TlaMenuControlLabel>
-							<TlaMenuControlInfoTooltip>
+							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use analytics cookies to make tldraw better." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -43,16 +43,18 @@ export function TlaMenuControlInfoTooltip({
 	href,
 	children,
 	onClick,
+	showOnMobile,
 }: {
 	href?: string
 	onClick?(): void
 	children: ReactNode
+	showOnMobile?: boolean
 }) {
 	const helpMsg = useMsg(messages.help)
 
 	return (
 		<div className={styles.menuInfoTriggerContainer}>
-			<TldrawUiTooltip content={children}>
+			<TldrawUiTooltip content={children} showOnMobile={showOnMobile}>
 				{href ? (
 					<a
 						onClick={onClick}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3172,6 +3172,8 @@ export interface TldrawUiTooltipProps {
     // (undocumented)
     disabled?: boolean;
     // (undocumented)
+    showOnMobile?: boolean;
+    // (undocumented)
     side?: 'bottom' | 'left' | 'right' | 'top';
     // (undocumented)
     sideOffset?: number;


### PR DESCRIPTION
Lu pointed out an issue in #6582 

### Change type

- [x] `other`

### API Changes

- add `showOnMobile` prop to `TldrawUiTooltip`, which defaults to false.
