### PR TITLE
Adjust cookie dialog spacing and positioning

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -37,7 +37,8 @@
 	padding: 6px;
 	max-width: 240px;
 	box-shadow: var(--tla-shadow-3);
-	margin-bottom: 12px;
+	margin-bottom: 4px;
+	margin-right: 4px;
 }
 
 .cookieText {
@@ -95,7 +96,7 @@
 .cookieConsentWrapper {
 	position: fixed;
 	bottom: 0;
-	right: var(--tl-space-4);
+	right: 0;
 	z-index: var(--tl-layer-menus);
 	width: fit-content;
 }


### PR DESCRIPTION
Reduced margin-bottom and added margin-right for the cookie dialog. Updated cookieConsentWrapper to align to the right edge instead of using a variable offset.

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
