### PR TITLE
Add drag out hands to logged in

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -45,6 +45,7 @@ import { SneakyTldrawFileDropHandler } from './sneaky/SneakyFileDropHandler'
 import { SneakyLargeFileHander } from './sneaky/SneakyLargeFileHandler'
 import { SneakySetDocumentTitle } from './sneaky/SneakySetDocumentTitle'
 import { SneakyToolSwitcher } from './sneaky/SneakyToolSwitcher'
+import { useExtraDragIconOverrides } from './useExtraToolDragIcons'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 /** @internal */
@@ -253,6 +254,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	}, [app, fileId, store.status])
 
 	const overrides = useFileEditorOverrides({ fileSlug })
+	const extraDragIconOverrides = useExtraDragIconOverrides()
 
 	return (
 		<TlaEditorWrapper>
@@ -267,7 +269,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				components={components}
 				options={{ actionShortcutsLocation: 'toolbar' }}
 				deepLinks={deepLinks || undefined}
-				overrides={overrides}
+				overrides={[overrides, extraDragIconOverrides]}
 				getShapeVisibility={getShapeVisibility}
 			>
 				<ThemeUpdater />


### PR DESCRIPTION
This pull request introduces an enhancement to the `TlaEditor` component by allowing multiple override sources to be passed to the editor, specifically adding extra drag icon overrides alongside existing file editor overrides. This change improves the editor's flexibility and customizability for tool drag icons.

**Editor override enhancements:**

* Imported the `useExtraDragIconOverrides` hook from `useExtraToolDragIcons` to enable additional drag icon customizations in `TlaEditor.tsx`.
* Initialized `extraDragIconOverrides` using the new hook within the `TlaEditorInner` function.
* Updated the `overrides` prop passed to the editor to accept an array containing both `overrides` and `extraDragIconOverrides`, allowing multiple override sources.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
