### PR TITLE
Custom people menu example

### DIFF
--- a/apps/examples/src/examples/sync-custom-people-menu/README.md
+++ b/apps/examples/src/examples/sync-custom-people-menu/README.md
@@ -1,0 +1,20 @@
+---
+title: Multiplayer sync with custom people menu
+component: ./SyncCustomPeopleMenuExample.tsx
+category: collaboration
+priority: 3
+keywords: [multiplayer, sync, collaboration, custom shape, presence, people, ui, facepile]
+multiplayer: true
+---
+
+A custom multiplay people menu / facepile that displays connected collaborators.
+
+---
+
+This example demonstrates how to build a custom people menu (also known as a facepile) that shows information about all connected users in a multiplayer session. The custom component replaces the default SharePanel and displays:
+
+- Your own user information with color indicator
+- A list of other connected users with their names, colors, and cursor positions
+- Real-time updates as users join and leave the session
+
+This is useful when you want to create a more detailed or custom-styled presence indicator than the default tldraw UI provides. The example shows how to access user presence data, track peer connections, and build a reactive UI that updates as the collaboration state changes.

--- a/apps/examples/src/examples/sync-custom-people-menu/README.md
+++ b/apps/examples/src/examples/sync-custom-people-menu/README.md
@@ -7,14 +7,10 @@ keywords: [multiplayer, sync, collaboration, custom shape, presence, people, ui,
 multiplayer: true
 ---
 
-A custom multiplay people menu / facepile that displays connected collaborators.
+A custom multiplayer people menu / facepile that displays connected collaborators.
 
 ---
 
-This example demonstrates how to build a custom people menu (also known as a facepile) that shows information about all connected users in a multiplayer session. The custom component replaces the default SharePanel and displays:
+This example demonstrates how to build a custom people menu (or facepile) that shows information about all users in a multiplayer session.
 
-- Your own user information with color indicator
-- A list of other connected users with their names, colors, and cursor positions
-- Real-time updates as users join and leave the session
-
-This is useful when you want to create a more detailed or custom-styled presence indicator than the default tldraw UI provides. The example shows how to access user presence data, track peer connections, and build a reactive UI that updates as the collaboration state changes.
+This is useful when you want to create a more detailed or custom-styled presence indicator than the default tldraw provides. This example shows user's names, ids, colors, and cursor postition, all information provided in 

--- a/apps/examples/src/examples/sync-custom-people-menu/SyncCustomPeopleMenuExample.tsx
+++ b/apps/examples/src/examples/sync-custom-people-menu/SyncCustomPeopleMenuExample.tsx
@@ -1,0 +1,141 @@
+import { useSyncDemo } from '@tldraw/sync'
+import { useMemo } from 'react'
+import { Tldraw, useEditor, usePeerIds, useValue } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// [1]
+const components = {
+	SharePanel: () => (
+		<div className="tlui-share-zone" draggable={false}>
+			<CustomPeopleMenu />
+		</div>
+	),
+}
+
+// [2]
+export default function SyncCustomPeopleMenuExample({ roomId }: { roomId: string }) {
+	const store = useSyncDemo({ roomId })
+	return (
+		<div className="tldraw__editor">
+			<Tldraw store={store} deepLinks components={components} />
+		</div>
+	)
+}
+
+// [3]
+function CustomPeopleMenu() {
+	const editor = useEditor()
+
+	// [a]
+	const myUserColor = useValue('user', () => editor.user.getColor(), [editor])
+	const myUserName = useValue('user', () => editor.user.getName(), [editor]) || 'Huppy'
+	const myUserId = useValue('user', () => editor.user.getId(), [editor])
+
+	// [b]
+	const otherUserIds = usePeerIds()
+	const allPresences = useValue('presences', () => editor.getCollaborators(), [editor])
+	const otherUserInfo = useMemo(() => {
+		return allPresences.filter((presence) => otherUserIds.includes(presence.userId))
+	}, [allPresences, otherUserIds])
+
+	if (!otherUserInfo.length && !myUserName) return null
+
+	return (
+		<div
+			style={{
+				background: '#f5f5f5',
+				padding: 4,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 12,
+				width: 320,
+			}}
+		>
+			{/* [c] */}
+			<div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+				<h4 style={{ margin: 0 }}>Me</h4>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						padding: '8px 12px',
+						gap: 8,
+					}}
+				>
+					<div
+						style={{
+							width: 16,
+							height: 16,
+							borderRadius: '50%',
+							background: myUserColor,
+							marginRight: 8,
+						}}
+					/>
+					<span style={{ color: myUserColor }}>
+						{myUserName}, ID: {myUserId}
+					</span>
+				</div>
+			</div>
+
+			{/* [d] */}
+			{otherUserInfo.length > 0 && (
+				<div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+					<h4 style={{ margin: 0 }}>Other connected users:</h4>
+					<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+						{otherUserInfo.map(({ userId, userName, color, cursor }) => (
+							<div
+								key={userId}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									padding: '6px 12px',
+									gap: 8,
+								}}
+							>
+								<div
+									style={{
+										width: 16,
+										height: 16,
+										borderRadius: '50%',
+										background: color,
+										marginRight: 8,
+									}}
+								/>
+								<span style={{ wordBreak: 'break-word', width: 170, color: color }}>
+									{userName || `ID: ${userId}`}
+								</span>
+								<span style={{ width: 80, color: '#aaa', fontSize: 12, marginLeft: 8 }}>
+									Cursor
+									<br />({Math.round(cursor?.x ?? NaN)}, {Math.round(cursor?.y ?? NaN)})
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+
+/*
+[1]
+We define custom components to override tldraw's default UI. Here we're replacing the SharePanel with our own CustomPeopleMenu component.
+
+[2]
+This is the main component that sets up a synced tldraw editor. It uses the useSyncDemo hook to create a multiplayer store and passes our custom components to replace the default UI elements.
+
+[3]
+The CustomPeopleMenu component displays information about all connected users. It uses tldraw's collaboration hooks to access real-time presence data. You can do whatever you like in here, see the TLInstancePresence interface to see what informatino you have access to.
+
+	[a]
+	We use the useValue hook to reactively get the current user's information (color, name, and ID). These values will automatically update if the user changes their name or the system assigns a new color (note: the examlpe doesn't allow for name changing).
+
+	[b]
+	We get the list of other connected users using usePeerIds() and getCollaborators(). The usePeerIds hook gives us just the user IDs, while getCollaborators() gives us full presence information including names, colors, and cursor positions. We need to call getCollaborators() in a useValue hook in order for the presence info to be reactive.
+
+	[c]
+	Display the current user's information with their color indicator and name. We show both the display name and the internal user ID for debugging purposes.
+
+	[d]
+	For each connected collaborator, we display their name (or ID if no name is set), their color indicator, and their current cursor position.
+*/

--- a/apps/examples/src/examples/sync-custom-people-menu/SyncCustomPeopleMenuExample.tsx
+++ b/apps/examples/src/examples/sync-custom-people-menu/SyncCustomPeopleMenuExample.tsx
@@ -1,6 +1,5 @@
 import { useSyncDemo } from '@tldraw/sync'
-import { useMemo } from 'react'
-import { Tldraw, useEditor, usePeerIds, useValue } from 'tldraw'
+import { Tldraw, useEditor, useValue } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // [1]
@@ -32,13 +31,9 @@ function CustomPeopleMenu() {
 	const myUserId = useValue('user', () => editor.user.getId(), [editor])
 
 	// [b]
-	const otherUserIds = usePeerIds()
-	const allPresences = useValue('presences', () => editor.getCollaborators(), [editor])
-	const otherUserInfo = useMemo(() => {
-		return allPresences.filter((presence) => otherUserIds.includes(presence.userId))
-	}, [allPresences, otherUserIds])
+	const allOtherPresences = useValue('presences', () => editor.getCollaborators(), [editor])
 
-	if (!otherUserInfo.length && !myUserName) return null
+	if (!allOtherPresences.length && !myUserName) return null
 
 	return (
 		<div
@@ -78,11 +73,11 @@ function CustomPeopleMenu() {
 			</div>
 
 			{/* [d] */}
-			{otherUserInfo.length > 0 && (
+			{allOtherPresences.length > 0 && (
 				<div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
 					<h4 style={{ margin: 0 }}>Other connected users:</h4>
 					<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-						{otherUserInfo.map(({ userId, userName, color, cursor }) => (
+						{allOtherPresences.map(({ userId, userName, color, cursor }) => (
 							<div
 								key={userId}
 								style={{
@@ -131,7 +126,7 @@ The CustomPeopleMenu component displays information about all connected users. I
 	We use the useValue hook to reactively get the current user's information (color, name, and ID). These values will automatically update if the user changes their name or the system assigns a new color (note: the examlpe doesn't allow for name changing).
 
 	[b]
-	We get the list of other connected users using usePeerIds() and getCollaborators(). The usePeerIds hook gives us just the user IDs, while getCollaborators() gives us full presence information including names, colors, and cursor positions. We need to call getCollaborators() in a useValue hook in order for the presence info to be reactive.
+	We get the live presence of all other users information using the editor's getCollaborators() method. We need to call getCollaborators() in a useValue hook in order for the presence info to be reactive.
 
 	[c]
 	Display the current user's information with their color indicator and name. We show both the display name and the internal user ID for debugging purposes.


### PR DESCRIPTION
Adds an example that shows how to implement a custom people menu.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`