### PR TITLE
Revert "Fix dragging within multiple editors"

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -151,6 +151,9 @@ export function useCanvasEvents() {
 		let lastX: number, lastY: number
 
 		function onPointerMove(e: PointerEvent) {
+			if ((e as any).isKilled) return
+			;(e as any).isKilled = true
+
 			if (e.clientX === lastX && e.clientY === lastY) return
 			lastX = e.clientX
 			lastY = e.clientY


### PR DESCRIPTION
Reverts tldraw/tldraw#6543

This was causing events to get dispatched multiple times (maybe 3???), resulting in v janky drawing:

<img width="1731" height="739" alt="image" src="https://github.com/user-attachments/assets/16e56cb9-f42f-4ec8-b9ee-f3abd971892d" />
