### PR TITLE
fix(analytics): remove redundant initial page view tracking

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -81,8 +81,6 @@ export default function Analytics() {
 				if (window.TL_GOOGLE_ADS_ID) {
 					ReactGA.gtag('config', window.TL_GOOGLE_ADS_ID)
 				}
-
-				ReactGA.send('pageview')
 			}
 
 			isConfigured = true


### PR DESCRIPTION
GA automatically tracks page views, so we don't need to send this initial one

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved analytics tracking by removing redundant page view events