### PR TITLE
fix(ui): disable context menu on style panel buttons

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiButtonPicker.tsx
@@ -148,6 +148,9 @@ export const TldrawUiButtonPicker = memo(function TldrawUiButtonPicker<T extends
 							onPointerDown={handleButtonPointerDown}
 							onPointerUp={handleButtonPointerUp}
 							onClick={handleButtonClick}
+							onContextMenu={(e) => {
+								e.preventDefault()
+							}}
 						>
 							<TldrawUiButtonIcon icon={item.icon} />
 						</TldrawUiToolbarToggleItem>


### PR DESCRIPTION
This PR disables the context menu when you right click buttons in the style panel.

Previously, opening the context menu in this way would get your pointer stuck 'down'. And it felt broken because it showed the native context menu instead of our own. Let's disable it instead!

Any a11y considerations here, Mime? Would be good to get your thoughts on this when you're back. If this is the way to go, we could do it for other menus too (eg: toolbar).

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Right click on a button in the style panel
2. Make sure it doesn't show a context menu, but instead selects that style.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- We no longer show the native context menu when you right click a style in the style panel. 