### PR TITLE
fix extra dropdown slot and bad gradient in style panel

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1047,6 +1047,9 @@
 }
 
 @media (hover: hover) {
+	.tlui-style-panel .tlui-button[aria-expanded='true'] {
+		background: none;
+	}
 	.tlui-style-panel .tlui-button[data-state='open']:not(:hover)::after {
 		opacity: 1;
 		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DropdownPicker.tsx
@@ -74,7 +74,7 @@ function DropdownPickerInner<T extends string>({
 				</TldrawUiToolbarButton>
 			</TldrawUiPopoverTrigger>
 			<TldrawUiPopoverContent side="left" align="center">
-				<TldrawUiToolbar orientation="grid" label={labelStr}>
+				<TldrawUiToolbar orientation={items.length > 4 ? 'grid' : 'horizontal'} label={labelStr}>
 					<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
 						{items.map((item) => {
 							return (


### PR DESCRIPTION
Before: 
<img width="223" height="77" alt="Screenshot 2025-08-20 at 10 43 14" src="https://github.com/user-attachments/assets/fd15f5e4-e1f3-461b-9dfc-7ee7ca093577" />

After: 
<img width="240" height="87" alt="Screenshot 2025-08-20 at 10 43 31" src="https://github.com/user-attachments/assets/5816fdbe-3e5a-49d8-9362-65ca4150d715" />

Fixes INT-2225

### Change type

- [x] `other`

