### PR TITLE
perf(editor): skip font loading when maxFontsToLoadBeforeRender is 0

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -586,8 +586,13 @@ function TldrawEditorWithReadyStore({
 	if (editor !== fontLoadingState?.editor) {
 		fontLoadingState = null
 	}
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (!editor) return
+		if (editor.options.maxFontsToLoadBeforeRender === 0) {
+			setFontLoadingState({ editor, isLoaded: true })
+			return
+		}
+
 		let isCancelled = false
 
 		setFontLoadingState({ editor, isLoaded: false })


### PR DESCRIPTION
Previously, there would be a noticeable delay waiting for fonts to load which looked bad in some usecases. Extracted from #6619. Closes ENG-3655.

### Change type

- [x] `improvement`

### Test plan

1. Set `maxFontsToLoadBeforeRender` to 0
2. Verify that the editor renders immediately without waiting for fonts

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Tldraw now completely skips font loading when `maxFontsToLoadBeforeRender` is 0