### PR TITLE
Allow custom per-shape padding in exports

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -228,7 +228,7 @@ function ExportImageButton() {
 		}
 
 		const opts = {
-			padding: exportPadding ? editor.options.defaultSvgPadding : 0,
+			padding: exportPadding ? editor.options.defaultExportPadding : 0,
 			background: exportBackground,
 			darkMode: exportTheme === 'auto' ? undefined : exportTheme === 'dark',
 			format: exportFormat as TLExportType,
@@ -344,7 +344,7 @@ async function getEditorImage(
 	const result = await editor.toImage(shapes, {
 		scale,
 		format: 'png',
-		padding: exportPadding ? editor.options.defaultSvgPadding : 0,
+		padding: exportPadding ? editor.options.defaultExportPadding : 0,
 		background: exportBackground,
 		darkMode: exportTheme === 'auto' ? undefined : exportTheme === 'dark',
 	})

--- a/apps/examples/src/examples/export-canvas-settings/ExportCanvasImageSettingsExample.tsx
+++ b/apps/examples/src/examples/export-canvas-settings/ExportCanvasImageSettingsExample.tsx
@@ -21,7 +21,7 @@ function ExportCanvasButton() {
 	const [opts, setOpts] = useState<TLImageExportOptions>({
 		scale: 1,
 		background: false,
-		padding: editor.options.defaultSvgPadding,
+		padding: 32,
 	})
 
 	// [2]
@@ -69,7 +69,7 @@ function ExportCanvasButton() {
 				<Control
 					type="number"
 					name="padding"
-					value={opts.padding}
+					value={opts.padding as number}
 					onChange={(e) => {
 						setOpts({ ...opts, padding: Math.ceil(Number(e.target.value)) })
 					}}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -672,7 +672,7 @@ export const defaultTldrawOptions: {
     readonly collaboratorIdleTimeoutMs: 3000;
     readonly collaboratorInactiveTimeoutMs: 60000;
     readonly createTextOnCanvasDoubleClick: true;
-    readonly defaultSvgPadding: 32;
+    readonly defaultExportPadding: (shape: TLShape) => 0 | 32;
     readonly doubleClickDurationMs: 450;
     readonly dragDistanceSquared: 16;
     readonly edgeScrollDelay: 200;
@@ -3263,8 +3263,7 @@ export interface TldrawOptions {
     readonly collaboratorInactiveTimeoutMs: number;
     // (undocumented)
     readonly createTextOnCanvasDoubleClick: boolean;
-    // (undocumented)
-    readonly defaultSvgPadding: number;
+    readonly defaultExportPadding: ((shape: TLShape, editor: Editor) => number) | number;
     // (undocumented)
     readonly doubleClickDurationMs: number;
     // (undocumented)
@@ -4213,7 +4212,7 @@ export interface TLSvgExportOptions {
     background?: boolean;
     bounds?: Box;
     darkMode?: boolean;
-    padding?: number;
+    padding?: ((shape: TLShape, editor: Editor) => number) | number;
     pixelRatio?: number;
     preserveAspectRatio?: React.SVGAttributes<SVGSVGElement>['preserveAspectRatio'];
     scale?: number;

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -1,6 +1,7 @@
 import { BoxModel, TLShape } from '@tldraw/tlschema'
 import { Box } from '../../primitives/Box'
 import { VecLike } from '../../primitives/Vec'
+import { Editor } from '../Editor'
 
 /** @public */
 export type RequiredKeys<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>
@@ -40,9 +41,13 @@ export interface TLSvgExportOptions {
 	background?: boolean
 
 	/**
-	 * How much padding to include around the bounds of exports? Defaults to 32px.
+	 * How much padding should be added to the exported image? This can be a number to add a fixed
+	 * number of pixels, or a function that takes a shape and returns a number to add a variable
+	 * amount of padding for each shape in the export.
+	 *
+	 * This defaults to `options.defaultExportPadding`: 32px, or 0 for image shapes.
 	 */
-	padding?: number
+	padding?: number | ((shape: TLShape, editor: Editor) => number)
 
 	/**
 	 * Should the export be rendered in dark mode (true) or light mode (false)? Defaults to the

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -87,10 +87,7 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 	if (singleFrameShapeId && !opts.bounds) {
 		// when exporting a single frame without custom bounds, use the frame's bounds directly
 		// (this avoids including content that extends outside the frame)
-		const frameBounds = editor.getShapeMaskedPageBounds(singleFrameShapeId)!
-		const frameShape = editor.getShape(singleFrameShapeId)!
-		const paddingForFrame = typeof padding === 'function' ? padding(frameShape, editor) : padding
-		bbox = paddingForFrame === 0 ? frameBounds : frameBounds.clone().expandBy(paddingForFrame)
+		bbox = editor.getShapeMaskedPageBounds(singleFrameShapeId)!
 	}
 
 	// We want the svg image to be BIGGER THAN USUAL to account for image quality

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -84,9 +84,13 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 		ids.length === 1 && editor.isShapeOfType<TLFrameShape>(editor.getShape(ids[0])!, 'frame')
 			? ids[0]
 			: null
-	if (singleFrameShapeId) {
-		// when exporting a single frame, we want to use the frame's bounds, not the shapes inside it
-		bbox = editor.getShapeMaskedPageBounds(singleFrameShapeId)!
+	if (singleFrameShapeId && !opts.bounds) {
+		// when exporting a single frame without custom bounds, use the frame's bounds directly
+		// (this avoids including content that extends outside the frame)
+		const frameBounds = editor.getShapeMaskedPageBounds(singleFrameShapeId)!
+		const frameShape = editor.getShape(singleFrameShapeId)!
+		const paddingForFrame = typeof padding === 'function' ? padding(frameShape, editor) : padding
+		bbox = paddingForFrame === 0 ? frameBounds : frameBounds.clone().expandBy(paddingForFrame)
 	}
 
 	// We want the svg image to be BIGGER THAN USUAL to account for image quality

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -1,4 +1,6 @@
+import { TLShape } from '@tldraw/tlschema'
 import { ComponentType, Fragment } from 'react'
+import { Editor } from './editor/Editor'
 
 /**
  * Options for configuring tldraw. For defaults, see {@link defaultTldrawOptions}.
@@ -29,7 +31,14 @@ export interface TldrawOptions {
 	readonly dragDistanceSquared: number
 	readonly uiDragDistanceSquared: number
 	readonly uiCoarseDragDistanceSquared: number
-	readonly defaultSvgPadding: number
+	/**
+	 * How much padding should be added to an exported image by default? This can be a number to add
+	 * a fixed number of pixels, or a function that takes a shape and returns a number to add a
+	 * variable amount of padding for each shape in the export.
+	 *
+	 * Defaults to 32px, or 0 for image shapes.
+	 */
+	readonly defaultExportPadding: number | ((shape: TLShape, editor: Editor) => number)
 	readonly cameraSlideFriction: number
 	readonly gridSteps: readonly {
 		readonly min: number
@@ -104,7 +113,7 @@ export const defaultTldrawOptions = {
 	// it's really easy to accidentally drag from the toolbar on mobile, so we use a much larger
 	// threshold than usual here to try and prevent accidental drags.
 	uiCoarseDragDistanceSquared: 625, // 25 squared
-	defaultSvgPadding: 32,
+	defaultExportPadding: (shape) => (shape.type === 'image' ? 0 : 32),
 	cameraSlideFriction: 0.09,
 	gridSteps: [
 		{ min: -1, mid: 0.15, step: 64 },

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -79,7 +79,7 @@ it('Gets the bounding box at the correct size', async () => {
 	const svg = await editor.getSvgString(editor.getSelectedShapeIds())
 	const parsed = parseSvg(svg!)
 	const bbox = editor.getSelectionRotatedPageBounds()!
-	const expanded = bbox.expandBy(editor.options.defaultSvgPadding) // adds 32px padding
+	const expanded = bbox.expandBy(32) // adds 32px padding
 
 	expect(parsed.getAttribute('width')).toMatch(expanded.width + '')
 	expect(parsed.getAttribute('height')).toMatch(expanded.height + '')


### PR DESCRIPTION
When working with images, it's often really annoying that tldraw adds padding when exporting back to an image - it's not needed if it'm using tldraw to make some annotations on top of an image, or composing some images together. This diff makes the export padding option accept a function as well as a number that can return a different amount of padding for different shapes. By default, we return 32 (the previous default), or 0 for image shapes.

Also taking the opportunity of 4.0 to rename this to something more consistent with other export related options.

Pulled out of #6619. Closes ENG-3651.

### Change type

- [x] `improvement`

### Release notes

- Image exports of images no longer add unneeded padding

### API Changes

- You can now pass a function to the export `padding` option to add different padding to different shapes in the export
- **BREAKING:** `TldrawOptions.defaultSvgPadding` has been renamed to `TldrawOptions.defaultExportPadding`