### PR TITLE
Fix mobile touch handling inside editing shape

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -79,15 +79,16 @@ export function useCanvasEvents() {
 				// check that e.target is an HTMLElement
 				if (!(e.target instanceof HTMLElement)) return
 
+				const editingShapeId = editor.getEditingShape()?.id
 				if (
+					// if the target is not inside the editing shape
+					!(editingShapeId && e.target.closest(`[data-shape-id="${editingShapeId}"]`)) &&
+					// and the target is not an clickable element
+					e.target.tagName !== 'BUTTON' &&
 					e.target.tagName !== 'A' &&
+					// or a text input ??
 					e.target.tagName !== 'TEXTAREA' &&
-					!e.target.isContentEditable &&
-					// When in EditingShape state, we are actually clicking on a 'DIV'
-					// not A/TEXTAREA/contenteditable element yet. So, to preserve cursor position
-					// for edit mode on mobile we need to not preventDefault.
-					// TODO: Find out if we still need this preventDefault in general though.
-					!(editor.getEditingShape() && e.target.className.includes('tl-text-content'))
+					!e.target.isContentEditable
 				) {
 					preventDefault(e)
 				}


### PR DESCRIPTION
Fixes #6617 

Touch events (specifically touchend), on anything other than anchors or text inputs, were being suppressed inside of editable shapes on mobile.

I think this fix preserves the previous callout for '.tl-text-content' by just allowing any pointer events on the children of an editable shape's wrapper div. @mimecuvalo you added this I think, is there a situation where we'd want to allow pointer events on a .tl-text-content but the shape itself isn't in the 'editing' state?

### Change type

- [x] `bugfix`

### Release notes

- Fixed a bug that prevented certain pointer events from firing in editable shapes on mobile.