### PR TITLE
fix: always render hidden dialog title in dialog to satisfy radix and a11y

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/components/Dialogs.tsx
@@ -1,5 +1,5 @@
 import { useContainer, useValue } from '@tldraw/editor'
-import { Dialog as _Dialog } from 'radix-ui'
+import { Dialog as _Dialog, VisuallyHidden } from 'radix-ui'
 import { memo, useCallback, useRef } from 'react'
 import { TLUiDialog, useDialogs } from '../context/dialogs'
 
@@ -49,6 +49,7 @@ const TldrawUiDialog = ({
 						dir="ltr"
 						className="tlui-dialog__content"
 						aria-describedby={undefined}
+						aria-label="Dialog"
 						onMouseDown={() => (mouseDownInsideContentRef.current = true)}
 						onMouseUp={() => (mouseDownInsideContentRef.current = false)}
 						onInteractOutside={(e) => {
@@ -58,6 +59,9 @@ const TldrawUiDialog = ({
 							}
 						}}
 					>
+						<VisuallyHidden.Root>
+							<_Dialog.Title aria-hidden>Dialog</_Dialog.Title>
+						</VisuallyHidden.Root>
 						<ModalContent
 							onClose={() => {
 								mouseDownInsideContentRef.current = false


### PR DESCRIPTION
Fixes #6518

### Problem
- In the simple dialog example on the docs site ([toasts-and-dialogs](https://tldraw.dev/examples/toasts-and-dialogs))
- Radix UI Dialog expects a `<Dialog.Title>` to exist in the subtree

<img width="508" height="116" alt="image" src="https://github.com/user-attachments/assets/d19601ca-1312-40db-814c-e403e4596c0c" />

### Changes
- `packages/tldraw/src/lib/ui/components/Dialogs.tsx`
- Add `aria-label` attribute to `<_Dialog.Content>`.
- Always render a hidden `<_Dialog.Title>` wrapped in `<VisuallyHidden.Root>` with `aria-hidden`, inside `<_Dialog.Content>`.

### Impact
- No API changes. No breaking changes.
- Removes Radix warnings in simple cases while preserving accessibility defaults.
- Improves DX by making dialogs safe-by-default even when users don’t render a visible title.

1) When users pass a component without a visible title (e.g., the “Simple dialog” example), Radix’s rule fails because there’s no `<Dialog.Title>` in the subtree. The hidden title ensures Radix’s requirement is satisfied; `aria-label` provides a fallback accessible name.
2) When users provide `<TldrawUiDialogTitle>`, Radix will use that as the accessible name. The hidden title does not affect rendering (`VisuallyHidden`) and does not interfere with a11y (`aria-hidden`).

### Change type

- [x] `bugfix`