### PR TITLE
make sure arrow labels aren't cut off in exports

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1686,7 +1686,7 @@ export abstract class Geometry2d {
     // (undocumented)
     getArea(): number;
     // (undocumented)
-    getBounds(): Box;
+    getBounds(filters?: Geometry2dFilters): Box;
     // (undocumented)
     getLength(_filters?: Geometry2dFilters): number;
     // (undocumented)

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -35,7 +35,7 @@ import { useEvent } from '../hooks/useEvent'
 import { suffixSafeId, useUniqueSafeId } from '../hooks/useSafeId'
 import { Box } from '../primitives/Box'
 import { Mat } from '../primitives/Mat'
-import { Vec } from '../primitives/Vec'
+import { Vec, VecLike } from '../primitives/Vec'
 import { intersectPolygonPolygon } from '../primitives/intersect'
 import { ExportDelay } from './ExportDelay'
 
@@ -128,7 +128,7 @@ function getExportDefaultBounds(editor: Editor, renderingShapes: TLRenderingShap
 
 		const pageMask = editor.getShapeMask(id)
 		let maskedPageBounds
-		if (pageMask && !pageBounds.corners.every((p, i) => p && Vec.Equals(p, pageMask[i]))) {
+		if (pageMask && !polygonMatchesBounds(pageMask, pageBounds)) {
 			const intersection = intersectPolygonPolygon(pageMask, pageBounds.corners)
 			if (!intersection) continue
 			maskedPageBounds = Box.FromPoints(intersection)
@@ -143,6 +143,10 @@ function getExportDefaultBounds(editor: Editor, renderingShapes: TLRenderingShap
 		}
 	}
 	return bbox
+}
+
+function polygonMatchesBounds(polygon: VecLike[], bounds: Box) {
+	return polygon.length === 4 && polygon.every((p, i) => p && Vec.Equals(p, bounds.corners[i]))
 }
 
 function SvgExport({

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -271,8 +271,8 @@ export abstract class Geometry2d {
 		return this._vertices
 	}
 
-	getBounds() {
-		return Box.FromPoints(this.vertices)
+	getBounds(filters?: Geometry2dFilters) {
+		return Box.FromPoints(filters ? this.getVertices(filters) : this.vertices)
 	}
 
 	private _bounds: Box | undefined


### PR DESCRIPTION
<img width="1382" height="1114" alt="image" src="https://github.com/user-attachments/assets/808d0398-d08f-46a5-874b-529caa02b52f" />

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Arrow labels are no longer sometimes cut off in exports

### API changes

- `Geometry2d.getBounds` now accepts `filters`