### PR TITLE
fix(editor): allow passthrough wheel events when not focused

### DIFF
--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -11,6 +11,7 @@ export function usePassThroughWheelEvents(ref: RefObject<HTMLElement>) {
 
 	useEffect(() => {
 		function onWheel(e: WheelEvent) {
+			// Only pass through wheel events if the editor is focused
 			if (!editor?.getInstanceState().isFocused) return
 
 			if ((e as any).isSpecialRedispatchedEvent) return


### PR DESCRIPTION
This pull request updates the `usePassThroughWheelEvents` hook to improve its handling of wheel events in the editor. The main change is that wheel events are now only passed through when the editor is focused, preventing unintended behavior when the editor is not active.

Wheel event handling improvements:

* Added a check in `usePassThroughWheelEvents` to ensure wheel events are only passed through if the editor is focused, using `editor?.getInstanceState().isFocused`.
* Updated the hook's effect dependencies to include `editor`, ensuring the event handler responds to editor focus changes.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Items marked with `usePassThroughWheelEvents` no longer block wheel events when the editor is not focused.