### PR TITLE
Allow custom shapes to clip their children

### DIFF
--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -282,6 +282,10 @@ export default function RichTextCustomExtensionExample() {
 
 Check out our [rich text examples](/examples/rich-text-custom-extension) to see how to add custom extensions or UI to tailor the rich text.
 
+### Clipping
+
+Custom shapes can clip their children using the `getClipPath` and `shouldClipChild` methods. See our [custom clipping shape example](/examples/editor-api/custom-clipping-shape) for details.
+
 ### Migrations
 
 You can add migrations for your shape props by adding a `migrations` property to your shape's util class. See [the persistence docs](/docs/persistence#Shape-props-migrations) for more information.

--- a/apps/examples/src/examples/custom-clipping-shape/CircleClipShapeTool.tsx
+++ b/apps/examples/src/examples/custom-clipping-shape/CircleClipShapeTool.tsx
@@ -1,0 +1,26 @@
+import { StateNode, TLEventHandlers } from 'tldraw'
+import { CircleClipShape } from './CircleClipShapeUtil'
+
+export class CircleClipShapeTool extends StateNode {
+	static override id = 'circle-clip'
+
+	override onEnter(): void {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown(info: Parameters<TLEventHandlers['onPointerDown']>[0]) {
+		if (info.target === 'canvas') {
+			const { originPagePoint } = this.editor.inputs
+
+			this.editor.createShape<CircleClipShape>({
+				type: 'circle-clip',
+				x: originPagePoint.x - 100,
+				y: originPagePoint.y - 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+		}
+	}
+}

--- a/apps/examples/src/examples/custom-clipping-shape/CircleClipShapeUtil.tsx
+++ b/apps/examples/src/examples/custom-clipping-shape/CircleClipShapeUtil.tsx
@@ -1,0 +1,135 @@
+import {
+	BaseBoxShapeUtil,
+	Circle2d,
+	Geometry2d,
+	RecordProps,
+	SVGContainer,
+	T,
+	TLBaseShape,
+	TLResizeInfo,
+	TLShape,
+	Vec,
+	atom,
+	resizeBox,
+	toDomPrecision,
+} from 'tldraw'
+
+export type CircleClipShape = TLBaseShape<
+	'circle-clip',
+	{
+		w: number
+		h: number
+	}
+>
+
+export const isClippingEnabled$ = atom('isClippingEnabled', true)
+
+export class CircleClipShapeUtil extends BaseBoxShapeUtil<CircleClipShape> {
+	static override type = 'circle-clip' as const
+	static override props: RecordProps<CircleClipShape> = {
+		w: T.number,
+		h: T.number,
+	}
+
+	override canBind() {
+		return false
+	}
+
+	override canReceiveNewChildrenOfType(shape: TLShape) {
+		return !shape.isLocked
+	}
+
+	override providesBackgroundForChildren(): boolean {
+		return true
+	}
+
+	override getDefaultProps(): CircleClipShape['props'] {
+		return {
+			w: 200,
+			h: 200,
+		}
+	}
+
+	override getGeometry(shape: CircleClipShape): Geometry2d {
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		return new Circle2d({
+			radius,
+			x: shape.props.w / 2 - radius,
+			y: shape.props.h / 2 - radius,
+			isFilled: true,
+		})
+	}
+
+	override getClipPath(shape: CircleClipShape): Vec[] | undefined {
+		// Generate a polygon approximation of the circle
+		const centerX = shape.props.w / 2
+		const centerY = shape.props.h / 2
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		const segments = 48 // More segments = smoother circle
+
+		const points: Vec[] = []
+		for (let i = 0; i < segments; i++) {
+			const angle = (i / segments) * Math.PI * 2
+			const x = centerX + Math.cos(angle) * radius
+			const y = centerY + Math.sin(angle) * radius
+			points.push(new Vec(x, y))
+		}
+
+		return points
+	}
+
+	override shouldClipChild(_child: TLShape): boolean {
+		// For now, clip all children - we removed the onlyClipText feature for simplicity
+		return isClippingEnabled$.get()
+	}
+
+	override component(shape: CircleClipShape) {
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		const centerX = shape.props.w / 2
+		const centerY = shape.props.h / 2
+
+		const clippingEnabled = isClippingEnabled$.get()
+
+		return (
+			<SVGContainer>
+				<circle
+					cx={toDomPrecision(centerX)}
+					cy={toDomPrecision(centerY)}
+					r={toDomPrecision(radius)}
+					fill={clippingEnabled ? 'rgba(100, 150, 255, 0.1)' : 'rgba(150, 150, 150, 0.1)'}
+					stroke={clippingEnabled ? '#4285f4' : '#999'}
+					strokeWidth={2}
+					strokeDasharray={clippingEnabled ? 'none' : '5,5'}
+				/>
+				{/* Visual indicator */}
+				<text
+					x={centerX}
+					y={centerY + 4}
+					textAnchor="middle"
+					fontSize="12"
+					fill={clippingEnabled ? '#4285f4' : '#999'}
+				>
+					{clippingEnabled ? '✂️' : '○'}
+				</text>
+			</SVGContainer>
+		)
+	}
+
+	override indicator(shape: CircleClipShape) {
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		const centerX = shape.props.w / 2
+		const centerY = shape.props.h / 2
+
+		return (
+			<circle
+				cx={toDomPrecision(centerX)}
+				cy={toDomPrecision(centerY)}
+				r={toDomPrecision(radius)}
+			/>
+		)
+	}
+
+	override onResize(shape: CircleClipShape, info: TLResizeInfo<CircleClipShape>) {
+		return resizeBox(shape, info)
+	}
+}

--- a/apps/examples/src/examples/custom-clipping-shape/CustomClipping.css
+++ b/apps/examples/src/examples/custom-clipping-shape/CustomClipping.css
@@ -1,0 +1,26 @@
+.CustomClipping-toggleButton {
+	position: absolute;
+	top: 64px;
+	left: 12px;
+	pointer-events: all;
+	z-index: 1000;
+}
+
+.CustomClipping-button {
+	padding: 8px 16px;
+	color: white;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 14px;
+	font-weight: 500;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.CustomClipping-button--enabled {
+	background-color: #ea4335;
+}
+
+.CustomClipping-button--disabled {
+	background-color: #34a853;
+}

--- a/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
+++ b/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
@@ -19,10 +19,13 @@ import { CircleClipShapeTool } from './CircleClipShapeTool'
 import { CircleClipShape, CircleClipShapeUtil, isClippingEnabled$ } from './CircleClipShapeUtil'
 import './CustomClipping.css'
 
+// There's a guide at the bottom of this file!
+
+// [1]
 const shapeUtils = [CircleClipShapeUtil]
 const tools = [CircleClipShapeTool]
 
-// Add the circle clip tool to the UI
+// [2]
 const customUiOverrides: TLUiOverrides = {
 	tools: (editor: any, tools: any) => {
 		return {
@@ -30,7 +33,7 @@ const customUiOverrides: TLUiOverrides = {
 			'circle-clip': {
 				id: 'circle-clip',
 				label: 'Circle Clip',
-				icon: 'geo-circle',
+				icon: 'color',
 				kbd: 'c',
 				onSelect() {
 					editor.setCurrentTool('circle-clip')
@@ -40,6 +43,7 @@ const customUiOverrides: TLUiOverrides = {
 	},
 }
 
+// [3]
 function ToggleClippingButton() {
 	const editor = useEditor()
 
@@ -61,6 +65,7 @@ function ToggleClippingButton() {
 	)
 }
 
+// [4]
 function CustomToolbar() {
 	const tools = useTools()
 	const isCircleClipSelected = useIsToolSelected(tools['circle-clip'])
@@ -73,11 +78,13 @@ function CustomToolbar() {
 	)
 }
 
+// [5]
 const components: TLComponents = {
 	Toolbar: CustomToolbar,
 	InFrontOfTheCanvas: ToggleClippingButton,
 }
 
+// [6]
 export default function CustomClippingExample() {
 	return (
 		<div className="tldraw__editor">
@@ -87,10 +94,8 @@ export default function CustomClippingExample() {
 				components={components}
 				overrides={customUiOverrides}
 				onMount={(editor) => {
-					// Set default tool
 					editor.setCurrentTool('select')
 
-					// Create initial demo content with clipping
 					const clipShapeId = createShapeId()
 					editor.createShape<CircleClipShape>({
 						id: clipShapeId,
@@ -103,7 +108,6 @@ export default function CustomClippingExample() {
 						},
 					})
 
-					// Add content that will be clipped
 					editor.createShape({
 						type: 'text',
 						x: 0,
@@ -131,10 +135,44 @@ export default function CustomClippingExample() {
 						} satisfies Partial<TLGeoShapeProps>,
 					})
 
-					// Zoom to fit the content
 					editor.zoomToFit()
 				}}
 			/>
 		</div>
 	)
 }
+
+/*
+Introduction:
+
+This example demonstrates the extensible clipping system in tldraw, showing how to create custom shapes 
+that can clip their children with any polygon geometry. The clipping system uses two key methods: 
+`getClipPath` to define the clip boundary and `shouldClipChild` to control which children get clipped.
+
+[1] 
+We define arrays to hold our custom shape util and tool. It's important to do this outside of any React 
+component so that these arrays don't get redefined on every render.
+
+[2]
+Here we define UI overrides to add our custom circle clip tool to the toolbar. The `tools` override 
+allows us to add new tools with custom icons, labels, and keyboard shortcuts.
+
+[3]
+The ToggleClippingButton component demonstrates how to create global state management for clipping. 
+It uses the `isClippingEnabled$` atom to toggle clipping on/off for all circle clip shapes.
+
+[4]
+The CustomToolbar component shows how to integrate custom tools into the main toolbar. We use 
+`useIsToolSelected` to highlight the active tool and `TldrawUiMenuItem` to render the tool button.
+
+[5]
+We define custom components to override the default toolbar and add our toggle button in front of 
+the canvas. The `components` prop allows us to customize various parts of the tldraw UI.
+
+[6]
+This is where we render the Tldraw component with our custom shape utils, tools, components, and 
+overrides. The onMount callback sets up the initial demo content.
+
+For more details on the clipping implementation, see CircleClipShapeUtil.tsx and CircleClipShapeTool.tsx.
+
+*/

--- a/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
+++ b/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
@@ -1,0 +1,140 @@
+import {
+	createShapeId,
+	DefaultToolbar,
+	DefaultToolbarContent,
+	TLComponents,
+	Tldraw,
+	TldrawUiMenuItem,
+	TLGeoShapeProps,
+	TLTextShapeProps,
+	TLUiOverrides,
+	toRichText,
+	useEditor,
+	useIsToolSelected,
+	useTools,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { CircleClipShapeTool } from './CircleClipShapeTool'
+import { CircleClipShape, CircleClipShapeUtil, isClippingEnabled$ } from './CircleClipShapeUtil'
+import './CustomClipping.css'
+
+const shapeUtils = [CircleClipShapeUtil]
+const tools = [CircleClipShapeTool]
+
+// Add the circle clip tool to the UI
+const customUiOverrides: TLUiOverrides = {
+	tools: (editor: any, tools: any) => {
+		return {
+			...tools,
+			'circle-clip': {
+				id: 'circle-clip',
+				label: 'Circle Clip',
+				icon: 'geo-circle',
+				kbd: 'c',
+				onSelect() {
+					editor.setCurrentTool('circle-clip')
+				},
+			},
+		}
+	},
+}
+
+function ToggleClippingButton() {
+	const editor = useEditor()
+
+	const clippingEnabled = useValue('isClippingEnabled', () => isClippingEnabled$.get(), [editor])
+
+	return (
+		<div className="CustomClipping-toggleButton">
+			<button
+				className={`CustomClipping-button ${
+					clippingEnabled ? 'CustomClipping-button--enabled' : 'CustomClipping-button--disabled'
+				}`}
+				onClick={() => {
+					isClippingEnabled$.update((prev) => !prev)
+				}}
+			>
+				{clippingEnabled ? '✂️ Disable Clipping' : '○ Enable Clipping'}
+			</button>
+		</div>
+	)
+}
+
+function CustomToolbar() {
+	const tools = useTools()
+	const isCircleClipSelected = useIsToolSelected(tools['circle-clip'])
+
+	return (
+		<DefaultToolbar>
+			<TldrawUiMenuItem {...tools['circle-clip']} isSelected={isCircleClipSelected} />
+			<DefaultToolbarContent />
+		</DefaultToolbar>
+	)
+}
+
+const components: TLComponents = {
+	Toolbar: CustomToolbar,
+	InFrontOfTheCanvas: ToggleClippingButton,
+}
+
+export default function CustomClippingExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={shapeUtils}
+				tools={tools}
+				components={components}
+				overrides={customUiOverrides}
+				onMount={(editor) => {
+					// Set default tool
+					editor.setCurrentTool('select')
+
+					// Create initial demo content with clipping
+					const clipShapeId = createShapeId()
+					editor.createShape<CircleClipShape>({
+						id: clipShapeId,
+						type: 'circle-clip',
+						x: 200,
+						y: 200,
+						props: {
+							w: 300,
+							h: 300,
+						},
+					})
+
+					// Add content that will be clipped
+					editor.createShape({
+						type: 'text',
+						x: 0,
+						y: 100,
+						parentId: clipShapeId,
+						props: {
+							size: 'l',
+							textAlign: 'middle',
+							richText: toRichText('This text is clipped to the circle! ✂️'),
+						} satisfies Partial<TLTextShapeProps>,
+					})
+
+					editor.createShape({
+						type: 'geo',
+						x: 100,
+						y: 290,
+						parentId: clipShapeId,
+						props: {
+							geo: 'rectangle',
+							w: 200,
+							h: 100,
+							fill: 'solid',
+							color: 'blue',
+							richText: toRichText('Oops you found me!'),
+						} satisfies Partial<TLGeoShapeProps>,
+					})
+
+					// Zoom to fit the content
+					editor.zoomToFit()
+				}}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/custom-clipping-shape/README.md
+++ b/apps/examples/src/examples/custom-clipping-shape/README.md
@@ -1,0 +1,67 @@
+---
+title: Custom Clipping Shape
+component: ./CustomClippingExample.tsx
+category: editor-api
+priority: 1
+keywords: [clipping, shape]
+---
+
+# Custom Clipping Shape Example
+
+This example demonstrates the extensible clipping system in tldraw, showing how to create custom shapes that can clip their children with any polygon geometry.
+
+## Features
+
+- **Circle Clipping Shape**: A custom shape that clips its children to a circular boundary
+- **Toggle Clipping**: Enable/disable clipping on individual shapes
+- **Selective Clipping**: Option to only clip specific shape types (e.g., text-only mode)
+- **Visual Feedback**: Different visual styles to indicate clipping state
+
+## Key Implementation Details
+
+### ShapeUtil Methods
+
+The clipping system uses two methods in the `ShapeUtil` base class:
+
+```typescript
+// Returns the clip path polygon in local coordinates
+getClipPath(shape: Shape): Vec[] | undefined
+
+// Determines which children should be clipped
+shouldClipChild(child: TLShape): boolean
+```
+
+### Circle Clip Shape
+
+The `CircleClipShapeUtil` demonstrates:
+
+- **Custom Geometry**: Uses a polygon approximation of a circle for clipping
+- **Conditional Clipping**: Can be enabled/disabled via shape properties
+- **Selective Clipping**: Optional "text-only" mode that only clips text shapes
+- **Visual Indicators**: Different appearance based on clipping state
+
+### Advanced Features
+
+- **Dynamic Clipping**: Clip path can change based on shape properties
+- **Smart Child Filtering**: `shouldClipChild()` can inspect child properties
+- **Smooth Circular Clipping**: Uses 32-segment polygon for smooth circular boundaries
+
+## Usage
+
+1. Use the **Circle Clip Tool** (circle icon) in the toolbar to create circular clipping shapes
+2. Click the **"✂️ Toggle Clipping"** button in the top-left to enable/disable clipping for all circle shapes globally
+3. The example starts with demo content already clipped by a circular shape
+
+## Key Features
+
+- **Toolbar Integration**: Circle clip tool appears in the main tldraw toolbar
+- **Global Toggle**: One button controls clipping for all circle shapes at once
+- **Visual Feedback**: Circle shapes change appearance when clipping is enabled/disabled
+- **Auto Demo Content**: Example starts with clipped content to demonstrate the feature
+
+## Technical Notes
+
+- Clip paths are defined in the shape's local coordinate system
+- The Editor automatically transforms them to page space for rendering
+- Multiple clipping ancestors are supported (intersected together)
+- Performance is optimized through computed caching

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2603,6 +2603,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     getAriaDescriptor(_shape: Shape): string | undefined;
     getBoundsSnapGeometry(_shape: Shape): BoundsSnapGeometry;
     getCanvasSvgDefs(): TLShapeUtilCanvasSvgDef[];
+    getClipPath?(shape: Shape): undefined | Vec[];
     abstract getDefaultProps(): Shape['props'];
     getFontFaces(shape: Shape): TLFontFace[];
     abstract getGeometry(shape: Shape, opts?: TLGeometryOpts): Geometry2d;
@@ -2655,6 +2656,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     static props?: RecordProps<TLUnknownShape>;
     // @internal
     providesBackgroundForChildren(_shape: Shape): boolean;
+    shouldClipChild?(child: TLShape): boolean;
     toBackgroundSvg?(shape: Shape, ctx: SvgExportContext): null | Promise<null | ReactElement> | ReactElement;
     toSvg?(shape: Shape, ctx: SvgExportContext): null | Promise<null | ReactElement> | ReactElement;
     static type: string;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -297,6 +297,27 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
+	 * Get the clip path to apply to this shape's children.
+	 *
+	 * @param shape - The shape to get the clip path for
+	 * @returns Array of points defining the clipping polygon in local coordinates, or undefined if no clipping
+	 * @public
+	 */
+	getClipPath?(shape: Shape): Vec[] | undefined
+
+	/**
+	 * Whether a specific child shape should be clipped by this shape.
+	 * Only called if getClipPath returns a valid polygon.
+	 *
+	 * If not defined, the default behavior is to clip all children.
+	 *
+	 * @param child - The child shape to check
+	 * @returns boolean indicating if this child should be clipped
+	 * @public
+	 */
+	shouldClipChild?(child: TLShape): boolean
+
+	/**
 	 * Whether the shape should hide its resize handles when selected.
 	 *
 	 * @public

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1484,6 +1484,8 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     getAriaDescriptor(shape: TLFrameShape): string;
     // (undocumented)
+    getClipPath(shape: TLFrameShape): Vec[];
+    // (undocumented)
     getDefaultProps(): TLFrameShape['props'];
     // (undocumented)
     getGeometry(shape: TLFrameShape): Geometry2d;

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -335,6 +335,10 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return true
 	}
 
+	override getClipPath(shape: TLFrameShape) {
+		return this.editor.getShapeGeometry(shape.id).vertices
+	}
+
 	override canReceiveNewChildrenOfType(shape: TLShape) {
 		return !shape.isLocked
 	}

--- a/packages/tldraw/src/test/custom-clipping.test.ts
+++ b/packages/tldraw/src/test/custom-clipping.test.ts
@@ -1,0 +1,436 @@
+import {
+	atom,
+	BaseBoxShapeUtil,
+	Circle2d,
+	createShapeId,
+	Geometry2d,
+	RecordProps,
+	resizeBox,
+	StateNode,
+	T,
+	TLBaseShape,
+	TLEventHandlers,
+	TLGeoShape,
+	TLResizeInfo,
+	TLShape,
+	TLTextShape,
+	toRichText,
+	Vec,
+} from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+// Custom Circle Clip Shape Definition
+export type CircleClipShape = TLBaseShape<
+	'circle-clip',
+	{
+		w: number
+		h: number
+	}
+>
+
+export const isClippingEnabled$ = atom('isClippingEnabled', true)
+
+export class CircleClipShapeUtil extends BaseBoxShapeUtil<CircleClipShape> {
+	static override type = 'circle-clip' as const
+	static override props: RecordProps<CircleClipShape> = {
+		w: T.number,
+		h: T.number,
+	}
+
+	override canBind() {
+		return false
+	}
+
+	override canReceiveNewChildrenOfType(shape: TLShape) {
+		return !shape.isLocked
+	}
+
+	override getDefaultProps(): CircleClipShape['props'] {
+		return {
+			w: 200,
+			h: 200,
+		}
+	}
+
+	override getGeometry(shape: CircleClipShape): Geometry2d {
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		return new Circle2d({
+			radius,
+			x: shape.props.w / 2 - radius,
+			y: shape.props.h / 2 - radius,
+			isFilled: true,
+		})
+	}
+
+	override getClipPath(shape: CircleClipShape): Vec[] | undefined {
+		// Generate a polygon approximation of the circle
+		const centerX = shape.props.w / 2
+		const centerY = shape.props.h / 2
+		const radius = Math.min(shape.props.w, shape.props.h) / 2
+		const segments = 48 // More segments = smoother circle
+
+		const points: Vec[] = []
+		for (let i = 0; i < segments; i++) {
+			const angle = (i / segments) * Math.PI * 2
+			const x = centerX + Math.cos(angle) * radius
+			const y = centerY + Math.sin(angle) * radius
+			points.push(new Vec(x, y))
+		}
+
+		return points
+	}
+
+	override shouldClipChild(_child: TLShape): boolean {
+		// For now, clip all children - we removed the onlyClipText feature for simplicity
+		return isClippingEnabled$.get()
+	}
+
+	override component(_shape: CircleClipShape) {
+		// For testing purposes, we'll just return null
+		// In a real implementation, this would return JSX
+		return null as any
+	}
+
+	override indicator(_shape: CircleClipShape) {
+		// For testing purposes, we'll just return null
+		// In a real implementation, this would return JSX
+		return null as any
+	}
+
+	override onResize(shape: CircleClipShape, info: TLResizeInfo<CircleClipShape>) {
+		return resizeBox(shape, info)
+	}
+}
+
+export class CircleClipShapeTool extends StateNode {
+	static override id = 'circle-clip'
+
+	override onEnter(): void {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown(info: Parameters<TLEventHandlers['onPointerDown']>[0]) {
+		if (info.target === 'canvas') {
+			const { originPagePoint } = this.editor.inputs
+
+			this.editor.createShape<CircleClipShape>({
+				type: 'circle-clip',
+				x: originPagePoint.x - 100,
+				y: originPagePoint.y - 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+		}
+	}
+}
+
+let editor: TestEditor
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+const ids = {
+	circleClip1: createShapeId('circleClip1'),
+	circleClip2: createShapeId('circleClip2'),
+	text1: createShapeId('text1'),
+	geo1: createShapeId('geo1'),
+	geo2: createShapeId('geo2'),
+}
+
+beforeEach(() => {
+	editor = new TestEditor({
+		shapeUtils: [CircleClipShapeUtil],
+		tools: [CircleClipShapeTool],
+	})
+
+	// Reset clipping state
+	isClippingEnabled$.set(true)
+})
+
+describe('CircleClipShapeUtil', () => {
+	describe('shape creation and properties', () => {
+		it('should create a circle clip shape with default properties', () => {
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+
+			const shape = editor.getShape<CircleClipShape>(ids.circleClip1)
+			expect(shape).toBeDefined()
+			expect(shape!.type).toBe('circle-clip')
+			expect(shape!.props.w).toBe(200)
+			expect(shape!.props.h).toBe(200)
+		})
+
+		it('should use default props when not specified', () => {
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {},
+			})
+
+			const shape = editor.getShape<CircleClipShape>(ids.circleClip1)
+			expect(shape!.props.w).toBe(200) // default from getDefaultProps
+			expect(shape!.props.h).toBe(200) // default from getDefaultProps
+		})
+	})
+
+	describe('geometry and clipping', () => {
+		it('should generate correct circle geometry', () => {
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+
+			const shape = editor.getShape<CircleClipShape>(ids.circleClip1)
+			const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+			const geometry = util.getGeometry(shape!)
+
+			expect(geometry).toBeDefined()
+			expect(geometry.bounds).toBeDefined()
+			expect(geometry.bounds.width).toBe(200)
+			expect(geometry.bounds.height).toBe(200)
+		})
+
+		it('should generate clip path for circle', () => {
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+
+			const shape = editor.getShape<CircleClipShape>(ids.circleClip1)
+			const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+			const clipPath = util.getClipPath?.(shape!)
+			if (!clipPath) throw new Error('Clip path is undefined')
+
+			expect(clipPath).toBeDefined()
+			expect(Array.isArray(clipPath)).toBe(true)
+			expect(clipPath.length).toBeGreaterThan(0)
+
+			// Should be a polygon approximation of a circle
+			// Check that points are roughly in a circle pattern
+			const centerX = 100 // shape.x
+			const centerY = 100 // shape.y
+			const radius = 100 // min(w, h) / 2
+
+			clipPath.forEach((point) => {
+				const distance = Math.sqrt(Math.pow(point.x - centerX, 2) + Math.pow(point.y - centerY, 2))
+				expect(distance).toBeCloseTo(radius, 0)
+			})
+		})
+	})
+
+	describe('child clipping behavior', () => {
+		it('should clip children when clipping is enabled', () => {
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+
+			editor.createShape<TLTextShape>({
+				id: ids.text1,
+				type: 'text',
+				x: 0,
+				y: 0,
+				parentId: ids.circleClip1,
+				props: {
+					richText: toRichText('Test text'),
+				},
+			})
+
+			const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+			const textShape = editor.getShape<TLTextShape>(ids.text1)
+
+			// Clipping should be enabled by default
+			expect(isClippingEnabled$.get()).toBe(true)
+			expect(util.shouldClipChild?.(textShape!)).toBe(true)
+			expect(editor.getShapeClipPath(ids.text1)).toBeDefined()
+		})
+
+		it('should not clip children when clipping is disabled', () => {
+			isClippingEnabled$.set(false)
+
+			editor.createShape<CircleClipShape>({
+				id: ids.circleClip1,
+				type: 'circle-clip',
+				x: 100,
+				y: 100,
+				props: {
+					w: 200,
+					h: 200,
+				},
+			})
+
+			editor.createShape<TLTextShape>({
+				id: ids.text1,
+				type: 'text',
+				x: 0,
+				y: 0,
+				parentId: ids.circleClip1,
+				props: {
+					richText: toRichText('Test text'),
+				},
+			})
+
+			const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+			const textShape = editor.getShape<TLTextShape>(ids.text1)
+
+			expect(isClippingEnabled$.get()).toBe(false)
+			expect(util.shouldClipChild?.(textShape!)).toBe(false)
+			expect(editor.getShapeClipPath(ids.text1)).toBeUndefined()
+		})
+	})
+})
+
+describe('Integration tests', () => {
+	it('should create and manage circle clip shapes with children', () => {
+		// Create circle clip shape
+		editor.createShape<CircleClipShape>({
+			id: ids.circleClip1,
+			type: 'circle-clip',
+			x: 100,
+			y: 100,
+			props: {
+				w: 200,
+				h: 200,
+			},
+		})
+
+		// Add text child
+		editor.createShape<TLTextShape>({
+			id: ids.text1,
+			type: 'text',
+			x: 50,
+			y: 50,
+			parentId: ids.circleClip1,
+			props: {
+				richText: toRichText('Clipped text'),
+			},
+		})
+
+		// Add geo child
+		editor.createShape<TLGeoShape>({
+			id: ids.geo1,
+			type: 'geo',
+			x: 150,
+			y: 150,
+			parentId: ids.circleClip1,
+			props: {
+				w: 50,
+				h: 50,
+			},
+		})
+
+		const circleClipShape = editor.getShape<CircleClipShape>(ids.circleClip1)
+		const textShape = editor.getShape<TLTextShape>(ids.text1)
+		const geoShape = editor.getShape<TLGeoShape>(ids.geo1)
+
+		expect(circleClipShape).toBeDefined()
+		expect(textShape!.parentId).toBe(ids.circleClip1)
+		expect(geoShape!.parentId).toBe(ids.circleClip1)
+
+		// Verify clipping behavior
+		const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+		expect(util.shouldClipChild?.(textShape!)).toBe(true)
+		expect(util.shouldClipChild?.(geoShape!)).toBe(true)
+		expect(editor.getShapeClipPath(ids.text1)).toBeDefined()
+		expect(editor.getShapeClipPath(ids.geo1)).toBeDefined()
+
+		// Test clipping toggle
+		isClippingEnabled$.set(false)
+		expect(util.shouldClipChild?.(textShape!)).toBe(false)
+		expect(util.shouldClipChild?.(geoShape!)).toBe(false)
+		expect(editor.getShapeClipPath(ids.text1)).toBeUndefined()
+		expect(editor.getShapeClipPath(ids.geo1)).toBeUndefined()
+	})
+
+	it('should handle multiple circle clip shapes independently', () => {
+		// Create two circle clip shapes
+		editor.createShape<CircleClipShape>({
+			id: ids.circleClip1,
+			type: 'circle-clip',
+			x: 100,
+			y: 100,
+			props: {
+				w: 200,
+				h: 200,
+			},
+		})
+
+		editor.createShape<CircleClipShape>({
+			id: ids.circleClip2,
+			type: 'circle-clip',
+			x: 400,
+			y: 100,
+			props: {
+				w: 150,
+				h: 150,
+			},
+		})
+
+		// Add children to both
+		editor.createShape<TLTextShape>({
+			id: ids.text1,
+			type: 'text',
+			x: 0,
+			y: 0,
+			parentId: ids.circleClip1,
+			props: {
+				richText: toRichText('First clip'),
+			},
+		})
+
+		editor.createShape<TLTextShape>({
+			id: ids.geo1,
+			type: 'text',
+			x: 0,
+			y: 0,
+			parentId: ids.circleClip2,
+			props: {
+				richText: toRichText('Second clip'),
+			},
+		})
+
+		const util = editor.getShapeUtil<CircleClipShape>('circle-clip')
+		const text1 = editor.getShape<TLTextShape>(ids.text1)
+		const text2 = editor.getShape<TLTextShape>(ids.geo1)
+
+		// Both should be clipped when enabled
+		expect(util.shouldClipChild?.(text1!)).toBe(true)
+		expect(util.shouldClipChild?.(text2!)).toBe(true)
+
+		// Both should not be clipped when disabled
+		isClippingEnabled$.set(false)
+		expect(util.shouldClipChild?.(text1!)).toBe(false)
+		expect(util.shouldClipChild?.(text2!)).toBe(false)
+	})
+})


### PR DESCRIPTION
Fixes #3455 

The `'frame'` shape has enjoyed its privilege for too long. Other shapes demand inclusion. Other shapes demand equity. They shall have it.

### Change type

- [x] `api`

### Release notes

- Add the ability for custom shapes to clip their children just like the frame shape.
