### PR TITLE
Track which url was opened.

### DIFF
--- a/apps/dotcom/client/src/hooks/useOpenUrlAndTrack.ts
+++ b/apps/dotcom/client/src/hooks/useOpenUrlAndTrack.ts
@@ -4,7 +4,7 @@ import { openUrl } from '../utils/url'
 export function useOpenUrlAndTrack(source: TLUiEventSource) {
 	const trackEvent = useUiEvents()
 	return (url: string) => {
-		trackEvent('open-url', { source, url })
+		trackEvent('open-url', { source, destinationUrl: url })
 		openUrl(url)
 	}
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -76,7 +76,9 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 				<F defaultMessage="Share this file" />
 			</TlaMenuControlLabel>
 			<TlaMenuControlInfoTooltip
-				onClick={() => trackEvent('open-url', { url: learnMoreUrl, source: 'file-share-menu' })}
+				onClick={() =>
+					trackEvent('open-url', { destinationUrl: learnMoreUrl, source: 'file-share-menu' })
+				}
 				href={learnMoreUrl}
 			>
 				<F defaultMessage="Learn more about sharing." />

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
@@ -82,7 +82,10 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip
 								onClick={() =>
-									trackEvent('open-url', { url: learnMoreUrl, source: 'file-share-menu' })
+									trackEvent('open-url', {
+										destinationUrl: learnMoreUrl,
+										source: 'file-share-menu',
+									})
 								}
 								href={learnMoreUrl}
 							>

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -51,7 +51,7 @@ export interface TLAppUiEventMap {
 		background: TlaUser['exportBackground']
 	}
 	'set-shared-link-type': { type: TlaFile['sharedLinkType'] | 'no-access' }
-	'open-url': { url: string }
+	'open-url': { destinationUrl: string }
 	'publish-file': null
 	'unpublish-file': null
 	'copy-publish-link': null

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3867,7 +3867,7 @@ export interface TLUiEventMap {
     };
     // (undocumented)
     'open-url': {
-        url: string;
+        destinationUrl: string;
     };
     // (undocumented)
     'pack-shapes': null;

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -123,7 +123,7 @@ export interface TLUiEventMap {
 	'shrink-shapes': null
 	'flatten-to-image': null
 	'a11y-repeat-shape-announce': null
-	'open-url': { url: string }
+	'open-url': { destinationUrl: string }
 	'open-context-menu': null
 	'adjust-shape-styles': null
 	'copy-link': null


### PR DESCRIPTION
Looks like `url` is getting shadowed by a built in URL property in posthog ([example insight](https://eu.posthog.com/project/45972/insights/CCvinhWr/edit)).

<img width="602" height="579" alt="image" src="https://github.com/user-attachments/assets/4bbca009-2fc2-41d7-858e-8de4b477d587" />

It's getting redacted, so we can't see exact destination of this. This change the name of the property so that we stop shadowing the existing one.

### Change type

- [x] `bugfix`

### Release notes
* Breaking change: `url` param of the `open-url` event was renamed to `destinationUrl`.

### API changes
* Change the `open-url` event data - rename it from `url` to `destinationUrl` as `url` might shadow some automatically sent properties by analytics tools.

