### PR TITLE
revert: "a11y: add tooltip for opacity slider"

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -2,7 +2,6 @@ import { Slider as _Slider } from 'radix-ui'
 import React, { useCallback, useEffect, useState } from 'react'
 import { TLUiTranslationKey } from '../../hooks/useTranslation/TLUiTranslationKey'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
-import { TldrawUiTooltip, tooltipManager } from './TldrawUiTooltip'
 
 /** @public */
 export interface TLUiSliderProps {
@@ -50,7 +49,6 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 	)
 
 	const handlePointerDown = useCallback(() => {
-		tooltipManager.hideAllTooltips()
 		onHistoryMark('click slider')
 	}, [onHistoryMark])
 
@@ -64,41 +62,38 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 		}
 	}, [])
 
-	const titleAndLabel = title + ' — ' + msg(label as TLUiTranslationKey)
-
 	return (
 		<div className="tlui-slider__container">
-			<TldrawUiTooltip content={titleAndLabel}>
-				<_Slider.Root
-					data-testid={testId}
-					className="tlui-slider"
-					dir="ltr"
-					min={min ?? 0}
-					max={steps}
-					step={1}
-					value={value !== null ? [value] : undefined}
-					onPointerDown={handlePointerDown}
-					onValueChange={handleValueChange}
-					onKeyDownCapture={handleKeyEvent}
-					onKeyUpCapture={handleKeyEvent}
-				>
-					<_Slider.Track className="tlui-slider__track" dir="ltr">
-						{value !== null && <_Slider.Range className="tlui-slider__range" dir="ltr" />}
-					</_Slider.Track>
-					{value !== null && (
-						<_Slider.Thumb
-							aria-valuemin={(min ?? 0) * ariaValueModifier}
-							aria-valuenow={value * ariaValueModifier}
-							aria-valuemax={steps * ariaValueModifier}
-							aria-label={titleAndLabel}
-							className="tlui-slider__thumb"
-							dir="ltr"
-							ref={ref}
-							tabIndex={tabIndex}
-						/>
-					)}
-				</_Slider.Root>
-			</TldrawUiTooltip>
+			<_Slider.Root
+				data-testid={testId}
+				className="tlui-slider"
+				dir="ltr"
+				min={min ?? 0}
+				max={steps}
+				step={1}
+				value={value !== null ? [value] : undefined}
+				onPointerDown={handlePointerDown}
+				onValueChange={handleValueChange}
+				onKeyDownCapture={handleKeyEvent}
+				onKeyUpCapture={handleKeyEvent}
+				title={title + ' — ' + msg(label as TLUiTranslationKey)}
+			>
+				<_Slider.Track className="tlui-slider__track" dir="ltr">
+					{value !== null && <_Slider.Range className="tlui-slider__range" dir="ltr" />}
+				</_Slider.Track>
+				{value !== null && (
+					<_Slider.Thumb
+						aria-valuemin={(min ?? 0) * ariaValueModifier}
+						aria-valuenow={value * ariaValueModifier}
+						aria-valuemax={steps * ariaValueModifier}
+						aria-label={title + ' — ' + msg(label as TLUiTranslationKey)}
+						className="tlui-slider__thumb"
+						dir="ltr"
+						ref={ref}
+						tabIndex={tabIndex}
+					/>
+				)}
+			</_Slider.Root>
 		</div>
 	)
 })


### PR DESCRIPTION
Reverts tldraw/tldraw#6647

This causes the tooltip on the cropping indicator to appear when it shouldn't when entering cropping mode. Also, tooltips on on-canvas controls don't correctly follow their target's positions: 
![Kapture 2025-08-27 at 14 19 56](https://github.com/user-attachments/assets/10e06dd5-cd9c-4444-87af-e38186e12beb)

### Change type

- [x] `bugfix` 

### Test plan

1. Enter cropping mode and verify the tooltip does not appear incorrectly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where tooltips would incorrectly appear when entering cropping mode.