### PR TITLE
fix(dotcom): prevent cookie dialog from showing before canvas

### DIFF
--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -135,7 +135,7 @@ function InsideOfContainerContext({ children }: { children: ReactNode }) {
 					<DefaultToasts />
 					<DefaultA11yAnnouncer />
 					<PutToastsInApp />
-					<TlaCookieConsent />
+					{currentEditor && <TlaCookieConsent />}
 				</TldrawUiContextProvider>
 			</TldrawUiA11yProvider>
 		</EditorContext.Provider>


### PR DESCRIPTION
came up in our bug bash today, the cookie banner just hangs out for a couple seconds while the page loads, all by its lonesome

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other` 

### Test plan

1. Open the site and verify the cookie banner does not appear before the canvas loads.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Prevented the cookie banner from appearing before the canvas has loaded.