### PR TITLE
events: allow passthrough mouse events only when focused

### DIFF
--- a/packages/editor/src/lib/hooks/usePassThroughMouseOverEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughMouseOverEvents.ts
@@ -1,14 +1,17 @@
 import { RefObject, useEffect } from 'react'
 import { preventDefault } from '../utils/dom'
 import { useContainer } from './useContainer'
+import { useMaybeEditor } from './useEditor'
 
 /** @public */
 export function usePassThroughMouseOverEvents(ref: RefObject<HTMLElement>) {
 	if (!ref) throw Error('usePassThroughWheelEvents must be passed a ref')
 	const container = useContainer()
+	const editor = useMaybeEditor()
 
 	useEffect(() => {
 		function onMouseOver(e: MouseEvent) {
+			if (!editor?.getInstanceState().isFocused) return
 			if ((e as any).isSpecialRedispatchedEvent) return
 			preventDefault(e)
 			const cvs = container.querySelector('.tl-canvas')
@@ -25,5 +28,5 @@ export function usePassThroughMouseOverEvents(ref: RefObject<HTMLElement>) {
 		return () => {
 			elm.removeEventListener('mouseover', onMouseOver)
 		}
-	}, [container, ref])
+	}, [container, editor, ref])
 }


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/6640

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- events: allow passthrough mouse events only when focused