### PR TITLE
Fix internal license logic.

### DIFF
--- a/apps/examples/e2e/tests/test-licensing.spec.ts
+++ b/apps/examples/e2e/tests/test-licensing.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test'
+import test from './fixtures/fixtures'
+
+// Helper function to set up license testing
+async function setupLicenseTest(page: any, licenseKey: string) {
+	await page.addInitScript(`
+			window.__TLDRAW_LICENSE_KEY__ = "${licenseKey}";
+		`)
+	await page.goto('http://localhost:5420/end-to-end')
+	await page.waitForTimeout(2000) // Wait for license processing
+}
+
+test.describe('Internal License', () => {
+	test('does not render editor for expired internal license', async ({ page }) => {
+		const expiredInternalLicenseKey =
+			'tldraw-/WyJ0ZXN0LWludGVybmFsLWV4cGlyZWQiLFsibG9jYWxob3N0Il0sNSwiMjAyNS0wOC0xOFQxMDozOTozOC4xMzRaIl0=.oKdLpnwcnSxmI76ZLowRg6chGUWEyeGYLRbIU1pqtVPS4hmfxSzsCtgvVHxgOslNxz9FkN58Quo7npxhIs7LMA=='
+
+		const consoleMessages: string[] = []
+		page.on('console', (msg) => {
+			consoleMessages.push(msg.text())
+		})
+
+		await setupLicenseTest(page, expiredInternalLicenseKey)
+
+		await expect(page.getByTestId('license-expired')).toBeAttached()
+
+		// The actual editor canvas should not be rendered
+		await expect(page.locator('.tl-canvas')).not.toBeVisible()
+
+		// Check that console contains license expiry message
+		const hasExpiredMessage = consoleMessages.some((msg) =>
+			msg.includes('Your tldraw license has expired!')
+		)
+		expect(hasExpiredMessage).toBe(true)
+	})
+})

--- a/apps/examples/e2e/tests/test-licensing.spec.ts
+++ b/apps/examples/e2e/tests/test-licensing.spec.ts
@@ -22,7 +22,7 @@ test.describe('Internal License', () => {
 
 		await setupLicenseTest(page, expiredInternalLicenseKey)
 
-		await expect(page.getByTestId('license-expired')).toBeAttached()
+		await expect(page.getByTestId('tl-license-expired')).toBeAttached()
 
 		// The actual editor canvas should not be rendered
 		await expect(page.locator('.tl-canvas')).not.toBeVisible()

--- a/apps/examples/e2e/tests/test-licensing.spec.ts
+++ b/apps/examples/e2e/tests/test-licensing.spec.ts
@@ -34,3 +34,17 @@ test.describe('Internal License', () => {
 		expect(hasExpiredMessage).toBe(true)
 	})
 })
+
+test.describe('License with watermark', () => {
+	test('shows the watermark', async ({ page }) => {
+		// Don't set any license key - this should use our default license that shows the watermark
+		await page.goto('http://localhost:5420/end-to-end')
+		await page.waitForTimeout(2000)
+
+		// The editor should render normally
+		await expect(page.locator('.tl-canvas')).toBeVisible()
+
+		// The watermark should be visible
+		await expect(page.locator('.tl-watermark_SEE-LICENSE')).toBeVisible()
+	})
+})

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -51,6 +51,9 @@ function HtmlCssShapeComponent({ shape }: { shape: HtmlCssShape }) {
 }
 
 export default function EndToEnd() {
+	// Use test license key if available, otherwise use the default
+	const licenseKey = (window as any).__TLDRAW_LICENSE_KEY__ || getLicenseKey()
+
 	useLayoutEffect(() => {
 		if (customElements.get('custom-element')) return
 
@@ -97,7 +100,7 @@ export default function EndToEnd() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				licenseKey={getLicenseKey()}
+				licenseKey={licenseKey}
 				onMount={(editor) => {
 					;(window as any).app = editor
 					;(window as any).editor = editor

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2100,10 +2100,13 @@ export class LicenseManager {
     // (undocumented)
     isTest: boolean;
     // (undocumented)
-    state: Atom<"internal-expired" | "licensed-with-watermark" | "licensed" | "pending" | "unlicensed", unknown>;
+    state: Atom<LicenseState, unknown>;
     // (undocumented)
     verbose: boolean;
 }
+
+// @internal (undocumented)
+export type LicenseState = 'internal-expired' | 'licensed-with-watermark' | 'licensed' | 'pending' | 'unlicensed';
 
 // @public (undocumented)
 export function linesIntersect(A: VecLike, B: VecLike, C: VecLike, D: VecLike): boolean;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2100,7 +2100,7 @@ export class LicenseManager {
     // (undocumented)
     isTest: boolean;
     // (undocumented)
-    state: Atom<"licensed-with-watermark" | "licensed" | "pending" | "unlicensed", unknown>;
+    state: Atom<"internal-expired" | "licensed-with-watermark" | "licensed" | "pending" | "unlicensed", unknown>;
     // (undocumented)
     verbose: boolean;
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -331,6 +331,7 @@ export {
 	type InvalidLicenseReason,
 	type LicenseFromKeyResult,
 	type LicenseInfo,
+	type LicenseState,
 	type TestEnvironment,
 	type ValidLicenseKeyResult,
 } from './lib/license/LicenseManager'

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -576,9 +576,12 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicense: true,
 			isAnnualLicenseExpired: true,
 			isInternalLicense: true,
+			isDomainValid: true,
 			expiryDate,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		const result = isEditorUnlicensed(licenseResult)
+		expect(result.unlicensed).toBe(true)
+		expect(result.internalExpired).toBe(true)
 	})
 
 	it('returns true when an internal perpetual license has expired', () => {
@@ -587,9 +590,12 @@ describe(isEditorUnlicensed, () => {
 			isPerpetualLicense: true,
 			isPerpetualLicenseExpired: true,
 			isInternalLicense: true,
+			isDomainValid: true,
 			expiryDate,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		const result = isEditorUnlicensed(licenseResult)
+		expect(result.unlicensed).toBe(true)
+		expect(result.internalExpired).toBe(true)
 	})
 
 	it('shows watermark when license has that flag specified', () => {
@@ -597,20 +603,6 @@ describe(isEditorUnlicensed, () => {
 			isLicensedWithWatermark: true,
 		})
 		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
-	})
-
-	it('returns internalExpired=true for expired internal annual license', () => {
-		const expiryDate = new Date(2023, 1, 1)
-		const licenseResult = getDefaultLicenseResult({
-			isAnnualLicense: true,
-			isAnnualLicenseExpired: true,
-			isInternalLicense: true,
-			isDomainValid: true,
-			expiryDate,
-		})
-		const result = isEditorUnlicensed(licenseResult)
-		expect(result.unlicensed).toBe(true)
-		expect(result.internalExpired).toBe(true)
 	})
 
 	it('returns internalExpired=false for expired internal license with invalid domain', () => {

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -4,6 +4,7 @@ import { publishDates } from '../../version'
 import { str2ab } from '../utils/licensing'
 import {
 	FLAGS,
+	getLicenseState,
 	isEditorUnlicensed,
 	LicenseManager,
 	PROPERTIES,
@@ -617,5 +618,54 @@ describe(isEditorUnlicensed, () => {
 		const result = isEditorUnlicensed(licenseResult)
 		expect(result.isUnlicensed).toBe(true)
 		expect(result.internalExpired).toBe(false)
+	})
+
+	describe('getLicenseState', () => {
+		it('returns "unlicensed" for unparseable license', () => {
+			const licenseResult = getDefaultLicenseResult({
+				// @ts-ignore
+				isLicenseParseable: false,
+			})
+			expect(getLicenseState(licenseResult)).toBe('unlicensed')
+		})
+
+		it('returns "unlicensed" for invalid domain', () => {
+			const licenseResult = getDefaultLicenseResult({
+				isDomainValid: false,
+				isDevelopment: false,
+			})
+			expect(getLicenseState(licenseResult)).toBe('unlicensed')
+		})
+
+		it('returns "internal-expired" for expired internal license with valid domain', () => {
+			const licenseResult = getDefaultLicenseResult({
+				isAnnualLicense: true,
+				isAnnualLicenseExpired: true,
+				isInternalLicense: true,
+				isDomainValid: true,
+			})
+			expect(getLicenseState(licenseResult)).toBe('internal-expired')
+		})
+
+		it('returns "unlicensed" for expired non-internal license', () => {
+			const licenseResult = getDefaultLicenseResult({
+				isAnnualLicense: true,
+				isAnnualLicenseExpired: true,
+				isInternalLicense: false,
+			})
+			expect(getLicenseState(licenseResult)).toBe('unlicensed')
+		})
+
+		it('returns "licensed-with-watermark" for watermarked license', () => {
+			const licenseResult = getDefaultLicenseResult({
+				isLicensedWithWatermark: true,
+			})
+			expect(getLicenseState(licenseResult)).toBe('licensed-with-watermark')
+		})
+
+		it('returns "licensed" for valid license without watermark', () => {
+			const licenseResult = getDefaultLicenseResult({})
+			expect(getLicenseState(licenseResult)).toBe('licensed')
+		})
 	})
 })

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -570,7 +570,7 @@ describe(isEditorUnlicensed, () => {
 		expect(isEditorUnlicensed(licenseResult)).toBe(false)
 	})
 
-	it('throws when an internal annual license has expired', () => {
+	it('returns true when an internal annual license has expired', () => {
 		const expiryDate = new Date(2023, 1, 1)
 		const licenseResult = getDefaultLicenseResult({
 			isAnnualLicense: true,
@@ -578,10 +578,10 @@ describe(isEditorUnlicensed, () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(() => isEditorUnlicensed(licenseResult)).toThrow(/License: Internal license expired/)
+		expect(isEditorUnlicensed(licenseResult)).toBe(true)
 	})
 
-	it('throws when an internal perpetual license has expired', () => {
+	it('returns true when an internal perpetual license has expired', () => {
 		const expiryDate = new Date(2023, 1, 1)
 		const licenseResult = getDefaultLicenseResult({
 			isPerpetualLicense: true,
@@ -589,7 +589,7 @@ describe(isEditorUnlicensed, () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(() => isEditorUnlicensed(licenseResult)).toThrow(/License: Internal license expired/)
+		expect(isEditorUnlicensed(licenseResult)).toBe(true)
 	})
 
 	it('shows watermark when license has that flag specified', () => {

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -493,14 +493,14 @@ describe(isEditorUnlicensed, () => {
 			// @ts-ignore
 			isLicenseParseable: false,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('shows watermark when domain is not valid', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isDomainValid: false,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('shows watermark when annual license has expired', () => {
@@ -508,7 +508,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicense: true,
 			isAnnualLicenseExpired: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('shows watermark when annual license has expired, even if dev mode', () => {
@@ -517,7 +517,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicenseExpired: true,
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('shows watermark when perpetual license has expired', () => {
@@ -525,7 +525,7 @@ describe(isEditorUnlicensed, () => {
 			isPerpetualLicense: true,
 			isPerpetualLicenseExpired: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('does not show watermark when license is valid and not expired', () => {
@@ -534,7 +534,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicenseExpired: false,
 			isInternalLicense: false,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
 	})
 
 	it('does not show watermark when perpetual license is valid and not expired', () => {
@@ -543,14 +543,14 @@ describe(isEditorUnlicensed, () => {
 			isPerpetualLicenseExpired: false,
 			isInternalLicense: false,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
 	})
 
 	it('does not show watermark when in development mode', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
 	})
 
 	it('does not show watermark when license is parseable and domain is valid', () => {
@@ -558,7 +558,7 @@ describe(isEditorUnlicensed, () => {
 			isLicenseParseable: true,
 			isDomainValid: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
 	})
 
 	it('does not show watermark when license is parseable and domain is not valid and dev mode', () => {
@@ -567,7 +567,7 @@ describe(isEditorUnlicensed, () => {
 			isDomainValid: false,
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
 	})
 
 	it('returns true when an internal annual license has expired', () => {
@@ -578,7 +578,7 @@ describe(isEditorUnlicensed, () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('returns true when an internal perpetual license has expired', () => {
@@ -589,13 +589,41 @@ describe(isEditorUnlicensed, () => {
 			isInternalLicense: true,
 			expiryDate,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
 	})
 
 	it('shows watermark when license has that flag specified', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isLicensedWithWatermark: true,
 		})
-		expect(isEditorUnlicensed(licenseResult)).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+	})
+
+	it('returns internalExpired=true for expired internal annual license', () => {
+		const expiryDate = new Date(2023, 1, 1)
+		const licenseResult = getDefaultLicenseResult({
+			isAnnualLicense: true,
+			isAnnualLicenseExpired: true,
+			isInternalLicense: true,
+			isDomainValid: true,
+			expiryDate,
+		})
+		const result = isEditorUnlicensed(licenseResult)
+		expect(result.unlicensed).toBe(true)
+		expect(result.internalExpired).toBe(true)
+	})
+
+	it('returns internalExpired=false for expired internal license with invalid domain', () => {
+		const expiryDate = new Date(2023, 1, 1)
+		const licenseResult = getDefaultLicenseResult({
+			isAnnualLicense: true,
+			isAnnualLicenseExpired: true,
+			isInternalLicense: true,
+			isDomainValid: false,
+			expiryDate,
+		})
+		const result = isEditorUnlicensed(licenseResult)
+		expect(result.unlicensed).toBe(true)
+		expect(result.internalExpired).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -493,14 +493,14 @@ describe(isEditorUnlicensed, () => {
 			// @ts-ignore
 			isLicenseParseable: false,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(true)
 	})
 
 	it('shows watermark when domain is not valid', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isDomainValid: false,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(true)
 	})
 
 	it('shows watermark when annual license has expired', () => {
@@ -508,7 +508,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicense: true,
 			isAnnualLicenseExpired: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(true)
 	})
 
 	it('shows watermark when annual license has expired, even if dev mode', () => {
@@ -517,7 +517,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicenseExpired: true,
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(true)
 	})
 
 	it('shows watermark when perpetual license has expired', () => {
@@ -525,7 +525,7 @@ describe(isEditorUnlicensed, () => {
 			isPerpetualLicense: true,
 			isPerpetualLicenseExpired: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(true)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(true)
 	})
 
 	it('does not show watermark when license is valid and not expired', () => {
@@ -534,7 +534,7 @@ describe(isEditorUnlicensed, () => {
 			isAnnualLicenseExpired: false,
 			isInternalLicense: false,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('does not show watermark when perpetual license is valid and not expired', () => {
@@ -543,14 +543,14 @@ describe(isEditorUnlicensed, () => {
 			isPerpetualLicenseExpired: false,
 			isInternalLicense: false,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('does not show watermark when in development mode', () => {
 		const licenseResult = getDefaultLicenseResult({
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('does not show watermark when license is parseable and domain is valid', () => {
@@ -558,7 +558,7 @@ describe(isEditorUnlicensed, () => {
 			isLicenseParseable: true,
 			isDomainValid: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('does not show watermark when license is parseable and domain is not valid and dev mode', () => {
@@ -567,7 +567,7 @@ describe(isEditorUnlicensed, () => {
 			isDomainValid: false,
 			isDevelopment: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('returns true when an internal annual license has expired', () => {
@@ -580,7 +580,7 @@ describe(isEditorUnlicensed, () => {
 			expiryDate,
 		})
 		const result = isEditorUnlicensed(licenseResult)
-		expect(result.unlicensed).toBe(true)
+		expect(result.isUnlicensed).toBe(true)
 		expect(result.internalExpired).toBe(true)
 	})
 
@@ -594,7 +594,7 @@ describe(isEditorUnlicensed, () => {
 			expiryDate,
 		})
 		const result = isEditorUnlicensed(licenseResult)
-		expect(result.unlicensed).toBe(true)
+		expect(result.isUnlicensed).toBe(true)
 		expect(result.internalExpired).toBe(true)
 	})
 
@@ -602,7 +602,7 @@ describe(isEditorUnlicensed, () => {
 		const licenseResult = getDefaultLicenseResult({
 			isLicensedWithWatermark: true,
 		})
-		expect(isEditorUnlicensed(licenseResult).unlicensed).toBe(false)
+		expect(isEditorUnlicensed(licenseResult).isUnlicensed).toBe(false)
 	})
 
 	it('returns internalExpired=false for expired internal license with invalid domain', () => {
@@ -615,7 +615,7 @@ describe(isEditorUnlicensed, () => {
 			expiryDate,
 		})
 		const result = isEditorUnlicensed(licenseResult)
-		expect(result.unlicensed).toBe(true)
+		expect(result.isUnlicensed).toBe(true)
 		expect(result.internalExpired).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -90,13 +90,13 @@ export class LicenseManager {
 
 		this.getLicenseFromKey(licenseKey)
 			.then((result) => {
-				const { unlicensed, internalExpired } = isEditorUnlicensed(result)
+				const { isUnlicensed, internalExpired } = isEditorUnlicensed(result)
 
-				if (!this.isDevelopment && unlicensed) {
+				if (!this.isDevelopment && isUnlicensed) {
 					fetch(WATERMARK_TRACK_SRC)
 				}
 
-				if (unlicensed) {
+				if (isUnlicensed) {
 					if (internalExpired) {
 						this.state.set('internal-expired')
 					} else {
@@ -376,17 +376,17 @@ export class LicenseManager {
 }
 
 export function isEditorUnlicensed(result: LicenseFromKeyResult): {
-	unlicensed: boolean
+	isUnlicensed: boolean
 	internalExpired: boolean
 } {
-	if (!result.isLicenseParseable) return { unlicensed: true, internalExpired: false }
+	if (!result.isLicenseParseable) return { isUnlicensed: true, internalExpired: false }
 	if (!result.isDomainValid && !result.isDevelopment)
-		return { unlicensed: true, internalExpired: false }
+		return { isUnlicensed: true, internalExpired: false }
 	if (result.isPerpetualLicenseExpired || result.isAnnualLicenseExpired) {
 		// Check if it's an expired internal license
 		const internalExpired = result.isInternalLicense && result.isDomainValid
-		return { unlicensed: true, internalExpired }
+		return { isUnlicensed: true, internalExpired }
 	}
 
-	return { unlicensed: false, internalExpired: false }
+	return { isUnlicensed: false, internalExpired: false }
 }

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -381,25 +381,9 @@ export function getLicenseState(result: LicenseFromKeyResult): LicenseState {
 	}
 
 	// License is valid, determine if it has watermark
-	if ((result as ValidLicenseKeyResult).isLicensedWithWatermark) {
+	if (result.isLicensedWithWatermark) {
 		return 'licensed-with-watermark'
 	}
 
 	return 'licensed'
-}
-
-export function isEditorUnlicensed(result: LicenseFromKeyResult): {
-	isUnlicensed: boolean
-	internalExpired: boolean
-} {
-	if (!result.isLicenseParseable) return { isUnlicensed: true, internalExpired: false }
-	if (!result.isDomainValid && !result.isDevelopment)
-		return { isUnlicensed: true, internalExpired: false }
-	if (result.isPerpetualLicenseExpired || result.isAnnualLicenseExpired) {
-		// Check if it's an expired internal license
-		const internalExpired = result.isInternalLicense && result.isDomainValid
-		return { isUnlicensed: true, internalExpired }
-	}
-
-	return { isUnlicensed: false, internalExpired: false }
 }

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -98,7 +98,7 @@ export class LicenseManager {
 			.then((result) => {
 				const licenseState = getLicenseState(result)
 
-				if (!this.isDevelopment && ['unlicensed', 'internal-expired'].includes(licenseState)) {
+				if (!this.isDevelopment && licenseState === 'unlicensed') {
 					fetch(WATERMARK_TRACK_SRC)
 				}
 

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -97,7 +97,12 @@ export class LicenseManager {
 				}
 
 				if (isUnlicensed) {
-					if (result.isLicenseParseable && result.isInternalLicense) {
+					if (
+						result.isLicenseParseable &&
+						result.isInternalLicense &&
+						result.isDomainValid &&
+						(result.isAnnualLicenseExpired || result.isPerpetualLicenseExpired)
+					) {
 						this.state.set('internal-expired')
 					} else {
 						this.state.set('unlicensed')

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -21,7 +21,7 @@ export function LicenseProvider({
 
 	// If internal license has expired, don't render the editor at all
 	if (licenseState === 'internal-expired') {
-		return <div data-testid="license-expired" style={{ display: 'none' }} />
+		return <div data-testid="tl-license-expired" style={{ display: 'none' }} />
 	}
 
 	return <LicenseContext.Provider value={licenseManager}>{children}</LicenseContext.Provider>

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,3 +1,4 @@
+import { useValue } from '@tldraw/state-react'
 import { createContext, ReactNode, useContext, useState } from 'react'
 import { LicenseManager } from './LicenseManager'
 
@@ -16,5 +17,12 @@ export function LicenseProvider({
 	children: ReactNode
 }) {
 	const [licenseManager] = useState(() => new LicenseManager(licenseKey))
+	const licenseState = useValue(licenseManager.state)
+
+	// If internal license has expired, don't render the editor at all
+	if (licenseState === 'internal-expired') {
+		return null
+	}
+
 	return <LicenseContext.Provider value={licenseManager}>{children}</LicenseContext.Provider>
 }

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -21,7 +21,7 @@ export function LicenseProvider({
 
 	// If internal license has expired, don't render the editor at all
 	if (licenseState === 'internal-expired') {
-		return null
+		return <div data-testid="license-expired" style={{ display: 'none' }} />
 	}
 
 	return <LicenseContext.Provider value={licenseManager}>{children}</LicenseContext.Provider>

--- a/packages/editor/src/lib/license/useLicenseManagerState.ts
+++ b/packages/editor/src/lib/license/useLicenseManagerState.ts
@@ -1,7 +1,7 @@
 import { useValue } from '@tldraw/state-react'
-import { LicenseManager } from './LicenseManager'
+import { LicenseManager, LicenseState } from './LicenseManager'
 
 /** @internal */
-export function useLicenseManagerState(licenseManager: LicenseManager) {
+export function useLicenseManagerState(licenseManager: LicenseManager): LicenseState {
 	return useValue('watermarkState', () => licenseManager.state.get(), [licenseManager])
 }


### PR DESCRIPTION
Looks like we never properly errored out on a expired internal license. 

We should probably hotfix this so it goes out in the 3.x branch?

### Change type

- [x] `bugfix`


### Release notes

- Fix a bug with expired internal license check.

### API changes

* Add an `internal-expired` state to the license manager.