### PR TITLE
Save and reinstate documentClock properly

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -193,6 +193,8 @@ export interface RoomSnapshot {
     // (undocumented)
     clock: number;
     // (undocumented)
+    documentClock?: number;
+    // (undocumented)
     documents: Array<{
         lastChangedClock: number;
         state: UnknownRecord;

--- a/packages/sync-core/src/test/TLSocketRoom.test.ts
+++ b/packages/sync-core/src/test/TLSocketRoom.test.ts
@@ -293,4 +293,118 @@ describe(TLSocketRoom, () => {
 		room.sendCustomMessage(sessionId, 'hello world')
 		expect(send.mock.lastCall).toEqual([json({ type: 'custom', data: 'hello world' })])
 	})
+
+	describe('Room state resetting behavior', () => {
+		it('sets documentClock to oldRoom.clock + 1 when resetting room state', () => {
+			const store = getStore()
+			store.ensureStoreIsUsable()
+			const room = new TLSocketRoom({
+				initialSnapshot: store.getStoreSnapshot(),
+			})
+
+			// Load a snapshot to increment the clock
+			const snapshot = store.getStoreSnapshot()
+			room.loadSnapshot(snapshot)
+
+			const oldClock = room.getCurrentSnapshot().clock
+			expect(oldClock).toBe(1)
+
+			// Reset with a new snapshot
+			const newSnapshot = store.getStoreSnapshot()
+			room.loadSnapshot(newSnapshot)
+
+			const newSnapshotResult = room.getCurrentSnapshot()
+			expect(newSnapshotResult.documentClock).toBe(oldClock + 1)
+			expect(newSnapshotResult.clock).toBe(oldClock + 1)
+		})
+
+		it('updates all documents lastChangedClock when resetting', () => {
+			const store = getStore()
+			store.ensureStoreIsUsable()
+			const room = new TLSocketRoom({
+				initialSnapshot: store.getStoreSnapshot(),
+			})
+
+			// Get initial clock
+			const initialClock = room.getCurrentSnapshot().clock
+
+			// Reset with a new snapshot
+			const newSnapshot = store.getStoreSnapshot()
+			room.loadSnapshot(newSnapshot)
+
+			const result = room.getCurrentSnapshot()
+			expect(result.clock).toBe(initialClock + 1)
+
+			// All documents should have updated lastChangedClock
+			for (const doc of result.documents) {
+				expect(doc.lastChangedClock).toBe(initialClock + 1)
+			}
+		})
+
+		it('preserves existing tombstones with original clock values', async () => {
+			// Create a room with initial state
+			const store = getStore()
+			store.ensureStoreIsUsable()
+			const testPageId = PageRecordType.createId('test_page')
+			store.put([
+				PageRecordType.create({ id: testPageId, name: 'Test Page', index: ZERO_INDEX_KEY }),
+			])
+			const room = new TLSocketRoom({
+				initialSnapshot: store.getStoreSnapshot(),
+			})
+
+			await room.updateStore((store) => {
+				store.delete(testPageId)
+			})
+
+			const deletionClock = room.getCurrentDocumentClock()
+			expect(room.getCurrentSnapshot().tombstones).toEqual({
+				[testPageId]: deletionClock,
+			})
+
+			room.loadSnapshot(room.getCurrentSnapshot())
+
+			expect(room.getCurrentSnapshot().tombstones).toEqual({
+				[testPageId]: deletionClock,
+			})
+
+			expect(room.getCurrentSnapshot().documentClock).toBe(deletionClock + 1)
+		})
+
+		it('handles empty snapshot reset correctly', () => {
+			const store = getStore()
+			// Don't call ensureStoreIsUsable to get an empty snapshot
+			const room = new TLSocketRoom({
+				initialSnapshot: store.getStoreSnapshot(),
+			})
+
+			const oldClock = room.getCurrentSnapshot().clock
+
+			// Reset with empty snapshot
+			const emptySnapshot = store.getStoreSnapshot()
+			room.loadSnapshot(emptySnapshot)
+
+			const result = room.getCurrentSnapshot()
+			expect(result.documentClock).toBe(oldClock + 1)
+			expect(result.clock).toBe(oldClock + 1)
+			expect(result.documents).toHaveLength(0)
+		})
+
+		it('preserves schema when resetting room state', () => {
+			const store = getStore()
+			store.ensureStoreIsUsable()
+			const room = new TLSocketRoom({
+				initialSnapshot: store.getStoreSnapshot(),
+			})
+
+			const originalSchema = room.getCurrentSnapshot().schema
+
+			// Reset with a new snapshot
+			const newSnapshot = store.getStoreSnapshot()
+			room.loadSnapshot(newSnapshot)
+
+			const result = room.getCurrentSnapshot()
+			expect(result.schema).toEqual(originalSchema)
+		})
+	})
 })


### PR DESCRIPTION
Fixes #6659 

### Change type

- [x] `bugfix`

### Release notes

- Fixes a bug where the documentClock would advance even if no document changes had occurred when loading a new snapshot.

### API changes
- Adds a separate `documentClock` field to the `RoomSnapshot` type