### PR TITLE
Fix over-measuring arrow labels

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
@@ -10,8 +10,8 @@ export function getArrowBodyPath(shape: TLArrowShape, info: TLArrowInfo, opts: P
 				.moveTo(info.start.point.x, info.start.point.y, { offset: 0, roundness: 0 })
 				.lineTo(info.end.point.x, info.end.point.y, { offset: 0, roundness: 0 })
 				.toSvg(opts)
-		case 'arc': {
-			const path = new PathBuilder()
+		case 'arc':
+			return new PathBuilder()
 				.moveTo(info.start.point.x, info.start.point.y, { offset: 0, roundness: 0 })
 				.circularArcTo(
 					info.bodyArc.radius,
@@ -22,8 +22,6 @@ export function getArrowBodyPath(shape: TLArrowShape, info: TLArrowInfo, opts: P
 					{ offset: 0, roundness: 0 }
 				)
 				.toSvg(opts)
-			return path
-		}
 		case 'elbow': {
 			const path = new PathBuilder()
 			path.moveTo(info.start.point.x, info.start.point.y, {

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
@@ -10,8 +10,8 @@ export function getArrowBodyPath(shape: TLArrowShape, info: TLArrowInfo, opts: P
 				.moveTo(info.start.point.x, info.start.point.y, { offset: 0, roundness: 0 })
 				.lineTo(info.end.point.x, info.end.point.y, { offset: 0, roundness: 0 })
 				.toSvg(opts)
-		case 'arc':
-			return new PathBuilder()
+		case 'arc': {
+			const path = new PathBuilder()
 				.moveTo(info.start.point.x, info.start.point.y, { offset: 0, roundness: 0 })
 				.circularArcTo(
 					info.bodyArc.radius,
@@ -22,6 +22,8 @@ export function getArrowBodyPath(shape: TLArrowShape, info: TLArrowInfo, opts: P
 					{ offset: 0, roundness: 0 }
 				)
 				.toSvg(opts)
+			return path
+		}
 		case 'elbow': {
 			const path = new PathBuilder()
 			path.moveTo(info.start.point.x, info.start.point.y, {

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -17,7 +17,6 @@ import {
 	exhaustiveSwitchError,
 	getChangedKeys,
 	pointInPolygon,
-	toRichText,
 } from '@tldraw/editor'
 import { isEmptyRichText, renderHtmlFromRichTextForMeasurement } from '../../utils/text/richText'
 import {
@@ -64,10 +63,11 @@ const labelSizeCache = createComputedCache(
 		const bodyGeom = getArrowBodyGeometry(editor, shape)
 		// We use 'i' as a default label to measure against as a minimum width.
 		const isEmpty = isEmptyRichText(shape.props.richText)
-		const html = renderHtmlFromRichTextForMeasurement(
-			editor,
-			isEmpty ? toRichText('i') : shape.props.richText
-		)
+		if (isEmpty) {
+			return new Vec(1, 1)
+		}
+
+		const html = renderHtmlFromRichTextForMeasurement(editor, shape.props.richText)
 
 		const bodyBounds = bodyGeom.bounds
 

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -17,6 +17,7 @@ import {
 	exhaustiveSwitchError,
 	getChangedKeys,
 	pointInPolygon,
+	toRichText,
 } from '@tldraw/editor'
 import { isEmptyRichText, renderHtmlFromRichTextForMeasurement } from '../../utils/text/richText'
 import {
@@ -53,6 +54,8 @@ export function getArrowBodyGeometry(editor: Editor, shape: TLArrowShape) {
 	}
 }
 
+const SIZES: Record<string, Vec> = {}
+
 const labelSizeCache = createComputedCache(
 	'arrow label size',
 	(editor: Editor, shape: TLArrowShape) => {
@@ -63,11 +66,19 @@ const labelSizeCache = createComputedCache(
 		const bodyGeom = getArrowBodyGeometry(editor, shape)
 		// We use 'i' as a default label to measure against as a minimum width.
 		const isEmpty = isEmptyRichText(shape.props.richText)
+
 		if (isEmpty) {
-			return new Vec(1, 1)
+			if (SIZES[shape.props.size]) {
+				return SIZES[shape.props.size]
+					.clone()
+					.addScalar(ARROW_LABEL_PADDING * 2 * shape.props.scale)
+			}
 		}
 
-		const html = renderHtmlFromRichTextForMeasurement(editor, shape.props.richText)
+		const html = renderHtmlFromRichTextForMeasurement(
+			editor,
+			isEmpty ? toRichText('i') : shape.props.richText
+		)
 
 		const bodyBounds = bodyGeom.bounds
 
@@ -80,6 +91,10 @@ const labelSizeCache = createComputedCache(
 			fontSize,
 			maxWidth: null,
 		})
+
+		if (isEmpty) {
+			SIZES[shape.props.size] = new Vec(w, h)
+		}
 
 		width = w
 		height = h


### PR DESCRIPTION
This PR fixes a performance issue on arrows with empty labels. Previously we would measure the size of the letter "i" every time an arrow without a label rendered. We would only ever have to do this when the shape is editing, so that the empty state still has the correct bounds... but we can also just stash those "i" sizes somewhere so that we don't have to go down the slow prosemirror flatten + dom measurement process.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Improved arrow performance