### PR TITLE
Fix dotcom e2e tests

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/HomePage.ts
+++ b/apps/dotcom/client/e2e/fixtures/HomePage.ts
@@ -31,12 +31,7 @@ export class HomePage {
 		await this.page.getByLabel('Email address').fill(email)
 		await this.page.getByRole('button', { name: 'Continue', exact: true }).click()
 		await this.page.waitForTimeout(1000)
-		await this.page.getByRole('textbox', { name: 'Digit 1' }).fill('4')
-		await this.page.getByRole('textbox', { name: 'Digit 2' }).fill('2')
-		await this.page.getByRole('textbox', { name: 'Digit 3' }).fill('4')
-		await this.page.getByRole('textbox', { name: 'Digit 4' }).fill('2')
-		await this.page.getByRole('textbox', { name: 'Digit 5' }).fill('4')
-		await this.page.getByRole('textbox', { name: 'Digit 6' }).fill('2')
+		await this.page.getByRole('textbox', { name: 'Enter verification code' }).fill('424242')
 		await expect(async () => {
 			await expect(this.page.getByTestId('tla-sidebar-toggle')).toBeVisible()
 		}).toPass()


### PR DESCRIPTION
Tests are failing for the open PRs. Looks like they changed it again?

Basically a revert of https://github.com/tldraw/tldraw/pull/6420

### Change type

- [x] `bugfix`
