### PR TITLE
Export `doesGeometryOverlapPolygon`

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1895,6 +1895,8 @@ export class Group2d extends Geometry2d {
     // (undocumented)
     nearestPoint(point: VecLike, filters?: Geometry2dFilters): Vec;
     // (undocumented)
+    overlapsPolygon(polygon: VecLike[]): boolean;
+    // (undocumented)
     toSimpleSvgPath(): string;
     // (undocumented)
     transform(transform: Mat): Geometry2d;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -743,9 +743,6 @@ export const defaultUserPreferences: Readonly<{
 export function degreesToRadians(d: number): number;
 
 // @public (undocumented)
-export function doesGeometryOverlapPolygon(geometry: Geometry2d, parentCornersInShapeSpace: Vec[]): boolean;
-
-// @public (undocumented)
 export const EASINGS: {
     readonly easeInCubic: (t: number) => number;
     readonly easeInExpo: (t: number) => number;
@@ -1733,6 +1730,8 @@ export abstract class Geometry2d {
     abstract nearestPoint(point: VecLike, _filters?: Geometry2dFilters): Vec;
     // @deprecated (undocumented)
     nearestPointOnLineSegment(A: VecLike, B: VecLike): Vec;
+    // (undocumented)
+    overlapsPolygon(_polygon: VecLike[]): boolean;
     // (undocumented)
     toSimpleSvgPath(): string;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -743,6 +743,9 @@ export const defaultUserPreferences: Readonly<{
 export function degreesToRadians(d: number): number;
 
 // @public (undocumented)
+export function doesGeometryOverlapPolygon(geometry: Geometry2d, parentCornersInShapeSpace: Vec[]): boolean;
+
+// @public (undocumented)
 export const EASINGS: {
     readonly easeInCubic: (t: number) => number;
     readonly easeInExpo: (t: number) => number;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -460,11 +460,7 @@ export { hardResetEditor } from './lib/utils/hardResetEditor'
 export { isAccelKey } from './lib/utils/keyboard'
 export { normalizeWheel } from './lib/utils/normalizeWheel'
 export { refreshPage } from './lib/utils/refreshPage'
-export {
-	doesGeometryOverlapPolygon,
-	getDroppedShapesToNewParents,
-	kickoutOccludedShapes,
-} from './lib/utils/reparenting'
+export { getDroppedShapesToNewParents, kickoutOccludedShapes } from './lib/utils/reparenting'
 export {
 	getFontsFromRichText,
 	type RichTextFontVisitor,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -460,7 +460,11 @@ export { hardResetEditor } from './lib/utils/hardResetEditor'
 export { isAccelKey } from './lib/utils/keyboard'
 export { normalizeWheel } from './lib/utils/normalizeWheel'
 export { refreshPage } from './lib/utils/refreshPage'
-export { getDroppedShapesToNewParents, kickoutOccludedShapes } from './lib/utils/reparenting'
+export {
+	doesGeometryOverlapPolygon,
+	getDroppedShapesToNewParents,
+	kickoutOccludedShapes,
+} from './lib/utils/reparenting'
 export {
 	getFontsFromRichText,
 	type RichTextFontVisitor,

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -13,7 +13,6 @@ import {
 	polygonsIntersect,
 } from '../intersect'
 import { approximately, pointInPolygon } from '../utils'
-import { Group2d } from './Group2d'
 
 /**
  * Filter geometry within a group.
@@ -261,11 +260,6 @@ export abstract class Geometry2d {
 
 	overlapsPolygon(_polygon: VecLike[]): boolean {
 		const polygon = _polygon.map((v) => Vec.From(v))
-
-		// If the geometry is a group, check if any of its children overlap the polygon
-		if (this instanceof Group2d) {
-			return this.children.some((childGeometry) => childGeometry.overlapsPolygon(polygon))
-		}
 
 		// Otherwise, check if the geometry itself overlaps the polygon
 		const { vertices, center, isFilled, isEmptyLabel, isClosed } = this

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -9,8 +9,11 @@ import {
 	intersectLineSegmentPolyline,
 	intersectPolys,
 	linesIntersect,
+	polygonIntersectsPolyline,
+	polygonsIntersect,
 } from '../intersect'
 import { approximately, pointInPolygon } from '../utils'
+import { Group2d } from './Group2d'
 
 /**
  * Filter geometry within a group.
@@ -254,6 +257,58 @@ export abstract class Geometry2d {
 			point.x > bounds.maxX + margin ||
 			point.y > bounds.maxY + margin
 		)
+	}
+
+	overlapsPolygon(_polygon: VecLike[]): boolean {
+		const polygon = _polygon.map((v) => Vec.From(v))
+
+		// If the geometry is a group, check if any of its children overlap the polygon
+		if (this instanceof Group2d) {
+			return this.children.some((childGeometry) => childGeometry.overlapsPolygon(polygon))
+		}
+
+		// Otherwise, check if the geometry itself overlaps the polygon
+		const { vertices, center, isFilled, isEmptyLabel, isClosed } = this
+
+		// We'll do things in order of cheapest to most expensive checks
+
+		// Skip empty labels
+		if (isEmptyLabel) return false
+
+		// If any of the geometry's vertices are inside the polygon, it's inside
+		if (vertices.some((v) => pointInPolygon(v, polygon))) {
+			return true
+		}
+
+		// If the geometry is filled and closed and its center is inside the polygon, it's inside
+		if (isClosed) {
+			if (isFilled) {
+				// If closed and filled, check if the center is inside the polygon
+				if (pointInPolygon(center, polygon)) {
+					return true
+				}
+
+				// ..then, slightly more expensive check, see the geometry covers the entire polygon but not its center
+				if (polygon.every((v) => pointInPolygon(v, vertices))) {
+					return true
+				}
+			}
+
+			// If any the geometry's vertices intersect the edge of the polygon, it's inside.
+			// for example when a rotated rectangle is moved over the corner of a parent rectangle
+			// If the geometry is closed, intersect as a polygon
+			if (polygonsIntersect(polygon, vertices)) {
+				return true
+			}
+		} else {
+			// If the geometry is not closed, intersect as a polyline
+			if (polygonIntersectsPolyline(polygon, vertices)) {
+				return true
+			}
+		}
+
+		// If none of the above checks passed, the geometry is outside the polygon
+		return false
 	}
 
 	transform(transform: MatModel, opts?: TransformedGeometry2dOptions): Geometry2d {

--- a/packages/editor/src/lib/primitives/geometry/Group2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.ts
@@ -236,4 +236,8 @@ export class Group2d extends Geometry2d {
 	getSvgPathData(): string {
 		return this.children.map((c, i) => (c.isLabel ? '' : c.getSvgPathData(i === 0))).join(' ')
 	}
+
+	overlapsPolygon(polygon: VecLike[]): boolean {
+		return this.children.some((child) => child.overlapsPolygon(polygon))
+	}
 }


### PR DESCRIPTION
This PR exports `doesGeometryOverlapPolygon` publicly. The agent starter makes use of it.

In the end, this is the only change to the SDK needed by the agent starter as we removed the dependency on the AI module. We'll still need to fix canvas pointer events when multiple editors are open on the same page, but that's an SDK fix, not a feature.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Release notes

- Added the `overlapsPolygon` method to the `Geometry2D` class.

### API Changes

- Added the `overlapsPolygon` method to the `Geometry2D` class.