### PR TITLE
Fix panning perf.

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -142,12 +142,22 @@ function TooltipSingleton() {
 	const [isOpen, setIsOpen] = useState(false)
 	const triggerRef = useRef<HTMLDivElement>(null)
 	const isFirstShowRef = useRef(true)
+	const editor = useMaybeEditor()
 
 	const currentTooltip = useValue(
 		'current tooltip',
 		() => tooltipManager.getCurrentTooltipData(),
 		[]
 	)
+
+	const cameraState = useValue('camera state', () => editor?.getCameraState(), [editor])
+
+	// Hide tooltip when camera is moving (panning/zooming)
+	useEffect(() => {
+		if (cameraState === 'moving' && isOpen && currentTooltip) {
+			tooltipManager.hideTooltip(editor, currentTooltip.id, true)
+		}
+	}, [cameraState, isOpen, currentTooltip, editor])
 
 	// Update open state and trigger position
 	useEffect(() => {
@@ -235,8 +245,6 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 		const orientationCtx = useTldrawUiOrientation()
 		const sideToUse = side ?? orientationCtx.tooltipSide
 
-		const camera = useValue('camera', () => editor?.getCamera(), [])
-
 		useEffect(() => {
 			const currentTooltipId = tooltipId.current
 			return () => {
@@ -245,10 +253,6 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 				}
 			}
 		}, [editor, hasProvider])
-
-		useEffect(() => {
-			tooltipManager.hideTooltip(editor, tooltipId.current, true)
-		}, [editor, camera])
 
 		// Don't show tooltip if disabled, no content, or UI labels are disabled
 		if (disabled || !content) {


### PR DESCRIPTION
Every tooltip component tracked camera changes, causing hundreds of re-renders during panning. Moved camera tracking to `TooltipSingleton` using `getCameraState()` API.

This is what caused the perf tests to start failing. Probably worth hotfixing.
 
### Change type

- [x] `bugfix`
