### PR TITLE
Fix arrow shape when dragged out of toolbar

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -176,7 +176,7 @@ export function ToolsProvider({ overrides, children }: TLUiToolsProviderProps) {
 							editor.createShape({
 								id,
 								type: 'arrow',
-								props: { start: { x: 0, y: 0 }, end: { x: 200, y: 0 } },
+								props: { start: { x: 0, y: 200 }, end: { x: 200, y: 0 } },
 							}),
 					})
 					trackEvent('drag-tool', { source, id: 'arrow' })


### PR DESCRIPTION
This pull request makes a small adjustment to the default position of the arrow shape when created with the drag tool.

* The starting point of the arrow (`start.x`, `start.y`) has been changed from `{ x: 0, y: 0 }` to `{ x: 0, y: 200 }` in the `ToolsProvider` component, which affects how arrows are drawn by default.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed shape of arrow when dragging out of toolbar