### PR TITLE
docs(chat): correct .env example for chat template

### DIFF
--- a/templates/chat/README.md
+++ b/templates/chat/README.md
@@ -35,7 +35,7 @@ Key interactions include:
 Create a `.env.local` file in the root directory and add your Google Generative API key:
 
 ```
-OPENAI_API_KEY=your_openai_api_key_here
+GOOGLE_GENERATIVE_AI_API_KEY=your_gemini_api_key_here
 ```
 
 Get your API key from [Google AI Studio](https://aistudio.google.com/apikey).


### PR DESCRIPTION
Correct the .env example in the chat template README to ensure users have the right configuration instructions.

### Change type

- [x] `other` 

### Test plan

1. Verify the README content in the chat template directory.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Corrected .env example in the chat template documentation.