### PR TITLE
Dynamically sized shape example

### DIFF
--- a/apps/examples/src/examples/size-from-dom/README.md
+++ b/apps/examples/src/examples/size-from-dom/README.md
@@ -1,0 +1,11 @@
+---
+title: DOM-based shape size
+component: ./SizeFromDomExample.tsx
+category: shapes/tools
+priority: 10
+keywords: [dom, size, custom, dynamic, shape]
+---
+
+A custom shape who's size is derived from it's rendered DOM.
+
+---

--- a/apps/examples/src/examples/size-from-dom/SizeFromDomExample.tsx
+++ b/apps/examples/src/examples/size-from-dom/SizeFromDomExample.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+	AtomMap,
+	EditorAtom,
+	RecordProps,
+	Rectangle2d,
+	ShapeUtil,
+	T,
+	TLBaseShape,
+	Tldraw,
+	TLShapeId,
+	useEditor,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { contents } from './contents'
+
+const SHAPE_WIDTH_PX = 150
+
+type DynamicSizeShape = TLBaseShape<'dynamic-size', { contents: string[] }>
+
+const ShapeSizes = new EditorAtom('shape sizes', (editor) => {
+	const map = new AtomMap<TLShapeId, { width: number; height: number }>('shape sizes')
+
+	editor.sideEffects.registerAfterDeleteHandler('shape', (shape) => {
+		map.delete(shape.id)
+	})
+
+	return map
+})
+
+function useDynamicShapeSize(shape: DynamicSizeShape) {
+	const ref = useRef<HTMLDivElement>(null)
+	const editor = useEditor()
+
+	const updateShapeSize = useCallback(() => {
+		if (!ref.current) return
+
+		const width = ref.current.offsetWidth
+		const height = ref.current.offsetHeight
+
+		ShapeSizes.update(editor, (map) => {
+			const existing = map.get(shape.id)
+			if (existing && existing.width === width && existing.height === height) return map
+			return map.set(shape.id, { width, height })
+		})
+	}, [editor, shape.id])
+
+	useLayoutEffect(() => {
+		updateShapeSize()
+	})
+
+	useLayoutEffect(() => {
+		if (!ref.current) return
+		const observer = new ResizeObserver(updateShapeSize)
+		observer.observe(ref.current)
+		return () => {
+			observer.disconnect()
+		}
+	}, [updateShapeSize])
+
+	return ref
+}
+
+export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
+	static override type = 'dynamic-size' as const
+	static override props: RecordProps<DynamicSizeShape> = {
+		contents: T.arrayOf(T.string),
+	}
+
+	getDefaultProps(): DynamicSizeShape['props'] {
+		return {
+			contents,
+		}
+	}
+
+	override canEdit() {
+		return false
+	}
+	override canResize() {
+		return false
+	}
+	override isAspectRatioLocked() {
+		return true
+	}
+
+	getGeometry(shape: DynamicSizeShape) {
+		const size = ShapeSizes.get(this.editor).get(shape.id)
+		return new Rectangle2d({
+			width: SHAPE_WIDTH_PX,
+			height: size?.height ?? 50,
+			isFilled: true,
+		})
+	}
+
+	component(shape: DynamicSizeShape) {
+		const ref = useDynamicShapeSize(shape)
+
+		const [contentsToShow, setContentsToShow] = useState<string>('')
+
+		useEffect(() => {
+			const animationDuration = 6000
+			const tick = (time: number) => {
+				const progress = (time % animationDuration) / animationDuration
+				const amountToShow = progress < 0.5 ? progress * 2 : 1 - (progress - 0.5) * 2
+
+				setContentsToShow(
+					shape.props.contents
+						.slice(0, Math.floor(amountToShow * shape.props.contents.length))
+						.join(' ')
+				)
+
+				frame = requestAnimationFrame(tick)
+			}
+
+			let frame = requestAnimationFrame(tick)
+
+			return () => {
+				cancelAnimationFrame(frame)
+			}
+		}, [shape.props.contents])
+
+		return (
+			<div ref={ref} style={{ width: SHAPE_WIDTH_PX }}>
+				{contentsToShow}
+			</div>
+		)
+	}
+
+	indicator(shape: DynamicSizeShape) {
+		const { width, height } = this.editor.getShapeGeometry(shape).bounds
+
+		return <rect width={width} height={height} />
+	}
+}
+
+const shapeUtils = [DynamicSizeShapeUtil]
+
+export default function BasicExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={shapeUtils}
+				onMount={(editor) => {
+					editor.selectAll()
+					editor.deleteShapes(editor.getSelectedShapeIds())
+
+					editor.createShape<DynamicSizeShape>({
+						type: 'dynamic-size',
+						x: 100,
+						y: 100,
+					})
+
+					editor.selectAll().zoomToSelection()
+				}}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/size-from-dom/SizeFromDomExample.tsx
+++ b/apps/examples/src/examples/size-from-dom/SizeFromDomExample.tsx
@@ -15,13 +15,18 @@ import {
 import 'tldraw/tldraw.css'
 import { contents } from './contents'
 
+// There's a guide at the bottom of this file!
+
 const SHAPE_WIDTH_PX = 150
 
+// [1]
 type DynamicSizeShape = TLBaseShape<'dynamic-size', { contents: string[] }>
 
+// [2]
 const ShapeSizes = new EditorAtom('shape sizes', (editor) => {
 	const map = new AtomMap<TLShapeId, { width: number; height: number }>('shape sizes')
 
+	// [a] Clean up sizes when shapes are deleted
 	editor.sideEffects.registerAfterDeleteHandler('shape', (shape) => {
 		map.delete(shape.id)
 	})
@@ -29,6 +34,7 @@ const ShapeSizes = new EditorAtom('shape sizes', (editor) => {
 	return map
 })
 
+// [3]
 function useDynamicShapeSize(shape: DynamicSizeShape) {
 	const ref = useRef<HTMLDivElement>(null)
 	const editor = useEditor()
@@ -36,9 +42,11 @@ function useDynamicShapeSize(shape: DynamicSizeShape) {
 	const updateShapeSize = useCallback(() => {
 		if (!ref.current) return
 
+		// [a] Get actual DOM dimensions
 		const width = ref.current.offsetWidth
 		const height = ref.current.offsetHeight
 
+		// [b] Update the shape size in our global atom
 		ShapeSizes.update(editor, (map) => {
 			const existing = map.get(shape.id)
 			if (existing && existing.width === width && existing.height === height) return map
@@ -46,10 +54,12 @@ function useDynamicShapeSize(shape: DynamicSizeShape) {
 		})
 	}, [editor, shape.id])
 
+	// [c] Update size immediately on render
 	useLayoutEffect(() => {
 		updateShapeSize()
 	})
 
+	// [d] Watch for DOM size changes using ResizeObserver
 	useLayoutEffect(() => {
 		if (!ref.current) return
 		const observer = new ResizeObserver(updateShapeSize)
@@ -62,18 +72,27 @@ function useDynamicShapeSize(shape: DynamicSizeShape) {
 	return ref
 }
 
+// [4]
 export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
+	// [a]
 	static override type = 'dynamic-size' as const
 	static override props: RecordProps<DynamicSizeShape> = {
 		contents: T.arrayOf(T.string),
 	}
 
+	// [b]
 	getDefaultProps(): DynamicSizeShape['props'] {
 		return {
 			contents,
 		}
 	}
 
+	// [c]
+	override canCull() {
+		return false
+	}
+
+	// [d]
 	override canEdit() {
 		return false
 	}
@@ -84,6 +103,7 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 		return true
 	}
 
+	// [e]
 	getGeometry(shape: DynamicSizeShape) {
 		const size = ShapeSizes.get(this.editor).get(shape.id)
 		return new Rectangle2d({
@@ -93,11 +113,13 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 		})
 	}
 
+	// [f]
 	component(shape: DynamicSizeShape) {
 		const ref = useDynamicShapeSize(shape)
 
 		const [contentsToShow, setContentsToShow] = useState<string>('')
 
+		// [i] Animate text content to demonstrate dynamic sizing
 		useEffect(() => {
 			const animationDuration = 6000
 			const tick = (time: number) => {
@@ -120,6 +142,7 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 			}
 		}, [shape.props.contents])
 
+		// [ii] Return DOM element that will be measured
 		return (
 			<div ref={ref} style={{ width: SHAPE_WIDTH_PX }}>
 				{contentsToShow}
@@ -127,6 +150,7 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 		)
 	}
 
+	// [g]
 	indicator(shape: DynamicSizeShape) {
 		const { width, height } = this.editor.getShapeGeometry(shape).bounds
 
@@ -134,9 +158,10 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 	}
 }
 
+// [5]
 const shapeUtils = [DynamicSizeShapeUtil]
 
-export default function BasicExample() {
+export default function SizeFromDomExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
@@ -157,3 +182,68 @@ export default function BasicExample() {
 		</div>
 	)
 }
+
+/*
+Introduction:
+
+This example demonstrates how to create a shape whose size is determined by its DOM content rather than
+shape props. It showcases two potentially reusable utilities: ShapeSizes and useDynamicShapeSize, which
+can be adapted for other shapes that need DOM-driven sizing.
+
+[1]
+Define the shape type. This shape only stores content data - its size is determined dynamically by
+measuring the DOM element that renders the content.
+
+[2] 
+ShapeSizes is a global EditorAtom that stores size information for shapes by their ID. This is the key
+piece that makes DOM-driven sizing work:
+	
+	[a] We register a cleanup handler to remove size data when shapes are deleted, preventing memory leaks.
+
+[3]
+useDynamicShapeSize is a reusable hook that measures DOM elements and updates the shape size data:
+
+	[a] We measure the actual DOM dimensions using offsetWidth/offsetHeight
+	
+	[b] We store these dimensions in our global ShapeSizes atom. The atom will trigger re-renders of
+	    components that depend on this data when the size changes.
+	
+	[c] We measure immediately on every render to ensure we have current size data
+	
+	[d] We use ResizeObserver to watch for size changes and update accordingly. This is what makes
+	    the shape truly dynamic - it will update whenever the DOM content changes size.
+
+[4]
+The shape util defines how our dynamic-size shape behaves:
+
+	[a] Standard shape type and props definition. Note we only store content, not size.
+	
+	[b] Default props with some sample content
+
+	[c] Prevent the shape from being culled when it's outside the viewport, which would break our measurements
+	
+	[d] Shape behavior: not editable, not resizable (since size comes from DOM), aspect ratio locked
+	
+	[e] getGeometry uses the size from our ShapeSizes atom. This is where the DOM-measured size gets
+	    used by the editor for hit-testing, selection bounds, etc.
+	
+	[f] The component renders the content and uses our hook to measure it:
+	
+		[i] We animate the text content to demonstrate the dynamic sizing in action
+		
+		[ii] The ref from useDynamicShapeSize is attached to the DOM element we want to measure
+	
+	[g] Standard indicator for selection outline
+
+[5]
+Standard setup - pass our custom shape util to Tldraw and create an instance on mount.
+
+Reusability:
+
+The ShapeSizes atom and useDynamicShapeSize hook are designed to be reusable. To use them with other
+shapes, you just need to:
+1. Call useDynamicShapeSize(shape) in your component and attach the returned ref
+2. Use ShapeSizes.get(editor).get(shapeId) in your getGeometry method
+3. Ensure your shape doesn't have conflicting size props (or handle the conflict appropriately)
+
+*/

--- a/apps/examples/src/examples/size-from-dom/contents.ts
+++ b/apps/examples/src/examples/size-from-dom/contents.ts
@@ -1,0 +1,18 @@
+export const contents = `
+Have five minutes? Let's try out the tldraw SDK in a React project. If you're new to React, we recommend using a Vite template as a starter. We'll assume your project is already running locally.
+
+Prefer to jump straight to some code? Try this sandbox.
+
+First, install the tldraw package from NPM:
+
+npm install tldraw
+
+Next, in your React project, import the Tldraw component and tldraw's CSS styles. Then render the Tldraw component inside a full screen container:
+
+That's pretty much it! At this point, you should have a complete working single-user canvas. You can draw and write on the canvas, add images and video, zoom and pan, copy and paste, undo and redo, and do just about everything else you'd expect to do on a canvas.
+
+You'll be starting from our default shapes, tools, and user interface, but you can customize all of these things for your project if you wish. For now, let's show off a few more features.
+`
+	.replace(/\n/g, '')
+	.replace(/\s+/g, ' ')
+	.split(' ')

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2561,6 +2561,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
     canBeLaidOut(_shape: Shape, _info: TLShapeUtilCanBeLaidOutOpts): boolean;
     canBind(_opts: TLShapeUtilCanBindOpts): boolean;
     canCrop(_shape: Shape): boolean;
+    canCull(_shape: Shape): boolean;
     canEdit(_shape: Shape): boolean;
     canEditInReadonly(_shape: Shape): boolean;
     canReceiveNewChildrenOfType(_shape: Shape, _type: TLShape['type']): boolean;

--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -7,6 +7,12 @@ function fromScratch(editor: Editor): Set<TLShapeId> {
 	const viewportPageBounds = editor.getViewportPageBounds()
 	const notVisibleShapes = new Set<TLShapeId>()
 	shapesIds.forEach((id) => {
+		const shape = editor.getShape(id)
+		if (!shape) return
+
+		const canCull = editor.getShapeUtil(shape.type).canCull(shape)
+		if (!canCull) return
+
 		// If the shape is fully outside of the viewport page bounds, add it to the set.
 		// We'll ignore masks here, since they're more expensive to compute and the overhead is not worth it.
 		const pageBounds = editor.getShapePageBounds(id)

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -284,6 +284,17 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
+	 * Whether this shape can be culled when rendering. By default, shapes are culled for
+	 * performance reasons when they are outside of the viewport. Culled shapes are still rendered
+	 * to the DOM, but have their `display` property set to `none`.
+	 *
+	 * @param shape - The shape.
+	 */
+	canCull(_shape: Shape): boolean {
+		return true
+	}
+
+	/**
 	 * Does this shape provide a background for its children? If this is true,
 	 * then any children with a `renderBackground` method will have their
 	 * backgrounds rendered _above_ this shape. Otherwise, the children's

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -284,7 +284,7 @@ export abstract class ShapeUtil<Shape extends TLUnknownShape = TLUnknownShape> {
 	}
 
 	/**
-	 * Whether this shape can be culled when rendering. By default, shapes are culled for
+	 * Whether this shape can be culled. By default, shapes are culled for
 	 * performance reasons when they are outside of the viewport. Culled shapes are still rendered
 	 * to the DOM, but have their `display` property set to `none`.
 	 *


### PR DESCRIPTION
An example of a shape that pulls its size from the DOM. This also adds a `canCull()` flag to shape utils, and these shapes need their dom layout at all times, not just when on screen.

### Change type

- [x] `api`

### API Changes

- Add `ShapeUtil.canCull`, which can be used to disable culling on certain shapes.