### PR TITLE
prioritised topological sort for migrations

### DIFF
--- a/packages/store/src/lib/migrate.ts
+++ b/packages/store/src/lib/migrate.ts
@@ -160,38 +160,127 @@ export interface MigrationSequence {
 	sequence: Migration[]
 }
 
+/**
+ * Sorts migrations using a distance-minimizing topological sort.
+ *
+ * This function respects two types of dependencies:
+ * 1. Implicit sequence dependencies (foo/1 must come before foo/2)
+ * 2. Explicit dependencies via `dependsOn` property
+ *
+ * The algorithm minimizes the total distance between migrations and their explicit
+ * dependencies in the final ordering, while maintaining topological correctness.
+ * This means when migration A depends on migration B, A will be scheduled as close
+ * as possible to B (while respecting all constraints).
+ *
+ * Implementation uses Kahn's algorithm with priority scoring:
+ * - Builds dependency graph and calculates in-degrees
+ * - Uses priority queue that prioritizes migrations which unblock explicit dependencies
+ * - Processes migrations in urgency order while maintaining topological constraints
+ * - Detects cycles by ensuring all migrations are processed
+ *
+ * @param migrations - Array of migrations to sort
+ * @returns Sorted array of migrations in execution order
+ */
 export function sortMigrations(migrations: Migration[]): Migration[] {
-	// we do a topological sort using dependsOn and implicit dependencies between migrations in the same sequence
+	if (migrations.length === 0) return []
+
+	// Build dependency graph and calculate in-degrees
 	const byId = new Map(migrations.map((m) => [m.id, m]))
-	const isProcessing = new Set<MigrationId>()
+	const dependents = new Map<MigrationId, Set<MigrationId>>() // who depends on this
+	const inDegree = new Map<MigrationId, number>()
+	const explicitDeps = new Map<MigrationId, Set<MigrationId>>() // explicit dependsOn relationships
 
-	const result: Migration[] = []
+	// Initialize
+	for (const m of migrations) {
+		inDegree.set(m.id, 0)
+		dependents.set(m.id, new Set())
+		explicitDeps.set(m.id, new Set())
+	}
 
-	function process(m: Migration) {
-		assert(!isProcessing.has(m.id), `Circular dependency in migrations: ${m.id}`)
-		isProcessing.add(m.id)
-
+	// Add implicit sequence dependencies and explicit dependencies
+	for (const m of migrations) {
 		const { version, sequenceId } = parseMigrationId(m.id)
-		const parent = byId.get(`${sequenceId}/${version - 1}`)
-		if (parent) {
-			process(parent)
+
+		// Implicit dependency on previous in sequence
+		const prevId = `${sequenceId}/${version - 1}` as MigrationId
+		if (byId.has(prevId)) {
+			dependents.get(prevId)!.add(m.id)
+			inDegree.set(m.id, inDegree.get(m.id)! + 1)
 		}
 
+		// Explicit dependencies
 		if (m.dependsOn) {
-			for (const dep of m.dependsOn) {
-				const depMigration = byId.get(dep)
-				if (depMigration) {
-					process(depMigration)
+			for (const depId of m.dependsOn) {
+				if (byId.has(depId)) {
+					dependents.get(depId)!.add(m.id)
+					explicitDeps.get(m.id)!.add(depId)
+					inDegree.set(m.id, inDegree.get(m.id)! + 1)
 				}
 			}
 		}
-
-		byId.delete(m.id)
-		result.push(m)
 	}
 
-	for (const m of byId.values()) {
-		process(m)
+	// Priority queue: migrations ready to process (in-degree 0)
+	const ready = migrations.filter((m) => inDegree.get(m.id) === 0)
+	const result: Migration[] = []
+	const processed = new Set<MigrationId>()
+
+	while (ready.length > 0) {
+		// Calculate urgency scores for ready migrations
+		const scored = ready.map((m) => {
+			let urgencyScore = 0
+
+			// Priority 1: If this migration is explicitly depended on by others, boost priority
+			for (const depId of dependents.get(m.id) || []) {
+				if (!processed.has(depId) && explicitDeps.get(depId)!.has(m.id)) {
+					urgencyScore += 100 // High priority for explicit dependencies
+				}
+			}
+
+			// Priority 2: Count all unprocessed dependents (to break ties)
+			for (const depId of dependents.get(m.id) || []) {
+				if (!processed.has(depId)) {
+					urgencyScore += 1
+				}
+			}
+
+			return { migration: m, urgencyScore }
+		})
+
+		// Sort by urgency (higher = more urgent), then by sequence/version as tiebreaker
+		scored.sort((a, b) => {
+			if (a.urgencyScore !== b.urgencyScore) {
+				return b.urgencyScore - a.urgencyScore
+			}
+			// Tiebreaker: prefer lower sequence/version
+			return a.migration.id.localeCompare(b.migration.id)
+		})
+
+		const nextMigration = scored[0].migration
+		ready.splice(ready.indexOf(nextMigration), 1)
+
+		// Cycle detection - if we have processed everything and still have items left, there's a cycle
+		// This is handled by Kahn's algorithm naturally - if we finish with items unprocessed, there's a cycle
+
+		// Process this migration
+		result.push(nextMigration)
+		processed.add(nextMigration.id)
+
+		// Update in-degrees and add newly ready migrations
+		for (const depId of dependents.get(nextMigration.id) || []) {
+			if (!processed.has(depId)) {
+				inDegree.set(depId, inDegree.get(depId)! - 1)
+				if (inDegree.get(depId) === 0) {
+					ready.push(byId.get(depId)!)
+				}
+			}
+		}
+	}
+
+	// Check for cycles - if we didn't process all migrations, there's a cycle
+	if (result.length !== migrations.length) {
+		const unprocessed = migrations.filter((m) => !processed.has(m.id))
+		assert(false, `Circular dependency in migrations: ${unprocessed[0].id}`)
 	}
 
 	return result

--- a/packages/store/src/lib/test/sortMigrations.test.ts
+++ b/packages/store/src/lib/test/sortMigrations.test.ts
@@ -31,6 +31,38 @@ describe(sortMigrations, () => {
 		).toEqual(['bar/1', 'bar/2', 'foo/1', 'foo/2'])
 	})
 
+	it('should minimize distance between dependencies and dependents', () => {
+		// bar/3 depends on foo/1 - should process bar sequence immediately after foo/1
+		expect(
+			sort([m('foo/2'), m('bar/3', { dependsOn: ['foo/1'] }), m('foo/1'), m('bar/1'), m('bar/2')])
+		).toEqual(['foo/1', 'bar/1', 'bar/2', 'bar/3', 'foo/2'])
+	})
+
+	it('should minimize total distance for multiple explicit dependencies', () => {
+		// Both bar/2 and baz/1 depend on foo/1 - minimize total distance
+		expect(
+			sort([
+				m('foo/2'),
+				m('bar/2', { dependsOn: ['foo/1'] }),
+				m('foo/1'),
+				m('bar/1'),
+				m('baz/1', { dependsOn: ['foo/1'] }),
+			])
+		).toEqual(['foo/1', 'bar/1', 'bar/2', 'baz/1', 'foo/2'])
+	})
+
+	it('should handle chain of explicit dependencies optimally', () => {
+		// foo/1 -> bar/1 -> baz/1 chain should be consecutive
+		expect(
+			sort([
+				m('foo/2'),
+				m('bar/1', { dependsOn: ['foo/1'] }),
+				m('foo/1'),
+				m('baz/1', { dependsOn: ['bar/1'] }),
+			])
+		).toEqual(['foo/1', 'bar/1', 'baz/1', 'foo/2'])
+	})
+
 	it('should fail if a cycle is created', () => {
 		expect(() => {
 			sort([m('foo/1', { dependsOn: ['foo/1'] })])


### PR DESCRIPTION
Replace basic topological sort with priority-based Kahn's algorithm that minimizes the total distance between migrations and their explicit dependencies. The new algorithm respects both implicit sequence dependencies (`foo/1` → `foo/2`) and explicit dependsOn relationships while scheduling dependent migrations as close as possible to their dependencies.

This is to make `dependsOn` migrations more predictable. If `foo/1` and `foo/2` both make changes to `foo` records, and `store/1` depends on `foo/1`, it's better that `store/1` runs before `foo/2` in case `foo/2` makes changes that affect `store/1`.

Key changes:
- Use Kahn's algorithm with urgency scoring to prioritize migrations that unblock explicit dependencies
- Add comprehensive test coverage for distance minimization scenarios
- Maintain all existing behavior including cycle detection
- Add detailed documentation explaining the algorithm and its benefits

🤖 Generated with [Claude Code](https://claude.ai/code)

### Change type

- [x] `improvement`

### Release notes

- Migrations with explicit `dependsOn` constraints will now be scheduled as close as possible to the things they depend on