### PR TITLE
automatically pull license from env var

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -1,6 +1,7 @@
 import { MigrationSequence, Store } from '@tldraw/store'
 import { TLShape, TLStore, TLStoreSnapshot } from '@tldraw/tlschema'
 import { annotateError, Required } from '@tldraw/utils'
+import classNames from 'classnames'
 import React, {
 	memo,
 	ReactNode,
@@ -12,8 +13,6 @@ import React, {
 	useState,
 	useSyncExternalStore,
 } from 'react'
-
-import classNames from 'classnames'
 import { version } from '../version'
 import { DefaultErrorFallback } from './components/default-components/DefaultErrorFallback'
 import { OptionalErrorBoundary } from './components/ErrorBoundary'

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -15,6 +15,8 @@ function shouldHideEditorAfterDelay(licenseState: string): boolean {
 /** @internal */
 export const LICENSE_TIMEOUT = 5000
 
+const LICENSE_KEY_FROM_ENV = getLicenseKeyFromEnv()
+
 /** @internal */
 export function LicenseProvider({
 	licenseKey,
@@ -50,4 +52,36 @@ export function LicenseProvider({
 // Renders as a hidden div that can be detected by tests
 function LicenseGate() {
 	return <div data-testid="tl-license-expired" style={{ display: 'none' }} />
+}
+
+function getLicenseKeyFromEnv() {
+	// framework-specific prefixes borrowed from the ones vercel uses, but trimmed down to just the
+	// react-y ones: https://vercel.com/docs/environment-variables/framework-environment-variables
+	// it's important here that we write out the full process.env.WHATEVER expression instead of
+	// doing something like process.env[someVariable]. This is because most bundlers do something
+	// like a find-replace inject environment variables, and so won't pick up on dynamic ones. It
+	// also means we can't do checks like `process.env && process.env.WHATEVER`, which is why we use
+	// the `getEnv` try/catch approach.
+	return (
+		getEnv(() => process.env.TLDRAW_LICENSE_KEY) ||
+		getEnv(() => process.env.NEXT_PUBLIC_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => process.env.REACT_APP_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => process.env.GATSBY_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => process.env.VITE_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => process.env.PUBLIC_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.NEXT_PUBLIC_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.REACT_APP_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.GATSBY_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.VITE_TLDRAW_LICENSE_KEY) ||
+		getEnv(() => (import.meta as any).env.PUBLIC_TLDRAW_LICENSE_KEY)
+	)
+}
+
+function getEnv(cb: () => string | undefined) {
+	try {
+		return cb()
+	} catch {
+		return undefined
+	}
 }

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -19,7 +19,7 @@ const LICENSE_KEY_FROM_ENV = getLicenseKeyFromEnv()
 
 /** @internal */
 export function LicenseProvider({
-	licenseKey,
+	licenseKey = LICENSE_KEY_FROM_ENV,
 	children,
 }: {
 	licenseKey?: string
@@ -55,13 +55,14 @@ function LicenseGate() {
 }
 
 function getLicenseKeyFromEnv() {
-	// framework-specific prefixes borrowed from the ones vercel uses, but trimmed down to just the
-	// react-y ones: https://vercel.com/docs/environment-variables/framework-environment-variables
 	// it's important here that we write out the full process.env.WHATEVER expression instead of
 	// doing something like process.env[someVariable]. This is because most bundlers do something
 	// like a find-replace inject environment variables, and so won't pick up on dynamic ones. It
 	// also means we can't do checks like `process.env && process.env.WHATEVER`, which is why we use
 	// the `getEnv` try/catch approach.
+
+	// framework-specific prefixes borrowed from the ones vercel uses, but trimmed down to just the
+	// react-y ones: https://vercel.com/docs/environment-variables/framework-environment-variables
 	return (
 		getEnv(() => process.env.TLDRAW_LICENSE_KEY) ||
 		getEnv(() => process.env.NEXT_PUBLIC_TLDRAW_LICENSE_KEY) ||


### PR DESCRIPTION
tldraw will automatically pull your license key from a `TLDRAW_LICENSE_KEY`, `NEXT_PUBLIC_TLDRAW_LICENSE_KEY`, `REACT_APP_TLDRAW_LICENSE_KEY`, `GATSBY_TLDRAW_LICENSE_KEY`, `VITE_TLDRAW_LICENSE_KEY`, or `PUBLIC_TLDRAW_LICENSE_KEY` if it's set.

### Change type

- [x] `improvement`


### Release notes

- tldraw will automatically find your license key in an environment variable if it's passed through by your bundler. We check `TLDRAW_LICENSE_KEY`, `NEXT_PUBLIC_TLDRAW_LICENSE_KEY`, `REACT_APP_TLDRAW_LICENSE_KEY`, `GATSBY_TLDRAW_LICENSE_KEY`, `VITE_TLDRAW_LICENSE_KEY`, and `PUBLIC_TLDRAW_LICENSE_KEY`.