### PR TITLE
chat template: add uploads, temporarily disable image output

### DIFF
--- a/templates/chat/package.json
+++ b/templates/chat/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@ai-sdk/google": "^2.0.11",
 		"@ai-sdk/react": "^2.0.15",
+		"@google/genai": "^1.17.0",
 		"@types/node": "^22.15.31",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",

--- a/templates/chat/src/app/api/chat/route.ts
+++ b/templates/chat/src/app/api/chat/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
 	const { messages }: { messages: UIMessage[] } = await req.json()
 
 	const result = streamText({
-		model: google('gemini-2.5-flash-image-preview'),
+		model: google('gemini-2.5-flash'),
 		system: [
 			"You're a friendly AI chatbot.",
 			'The user can send you images, sketches and diagrams using your built-in tldraw whiteboard.',

--- a/templates/chat/src/app/api/upload/route.ts
+++ b/templates/chat/src/app/api/upload/route.ts
@@ -1,0 +1,30 @@
+import { GoogleGenAI } from '@google/genai'
+
+export async function POST(req: Request) {
+	const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY
+	if (!apiKey) {
+		return new Response('GOOGLE_GENERATIVE_AI_API_KEY is not set', { status: 500 })
+	}
+
+	const contentType = req.headers.get('content-type')
+	if (!contentType) {
+		return new Response('content-type is not set', { status: 400 })
+	}
+
+	const displayName = req.headers.get('x-file-name')
+	if (!displayName) {
+		return new Response('x-file-name is not set', { status: 400 })
+	}
+
+	const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY })
+
+	const file = await ai.files.upload({
+		file: await req.blob(),
+		config: {
+			mimeType: contentType,
+			displayName,
+		},
+	})
+
+	return Response.json({ uploadedUrl: file.uri, expiresAt: file.expirationTime })
+}

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useChatMessageStorage } from '@/hooks/useChatMessageStorage'
+import { uploadMessageContents } from '@/utils/uploadMessageContents'
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport, FileUIPart, TextUIPart, UIMessage } from 'ai'
 import { useCallback, useEffect } from 'react'
@@ -36,6 +37,20 @@ function ChatInner({
 	const chat = useChat({
 		transport: new DefaultChatTransport({
 			api: '/api/chat',
+			prepareSendMessagesRequest: async (options) => {
+				const { messagesToSend, messagesToSave } = await uploadMessageContents(options.messages)
+				console.log({ messagesToSend, messagesToSave })
+				chat.setMessages(messagesToSave)
+				return {
+					body: {
+						...options.body,
+						id: options.id,
+						messages: messagesToSend,
+						trigger: options.trigger,
+						messageId: options.messageId,
+					},
+				}
+			},
 		}),
 		messages: initialMessages,
 	})

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -39,7 +39,6 @@ function ChatInner({
 			api: '/api/chat',
 			prepareSendMessagesRequest: async (options) => {
 				const { messagesToSend, messagesToSave } = await uploadMessageContents(options.messages)
-				console.log({ messagesToSend, messagesToSave })
 				chat.setMessages(messagesToSave)
 				return {
 					body: {

--- a/templates/chat/src/utils/uploadMessageContents.ts
+++ b/templates/chat/src/utils/uploadMessageContents.ts
@@ -1,0 +1,88 @@
+import { FileUIPart, UIMessage } from 'ai'
+import { FileHelpers } from 'tldraw'
+
+interface UploadedMetadata {
+	uploadedUrl: string
+	expiresAt: string
+}
+
+const UPLOAD_METADATA_KEY = 'tldraw_uploaded'
+
+/**
+ * Vercel limits us to 4.5mb uploads. We upload files to Google GenAI to avoid this limitation.
+ * There's two problems with that we need to work around though:
+ * 1. Google will only store files for 24 hours.
+ * 2. Google will host files privately - so we can't use them to display them in the UI.
+ *
+ * To work around these, we process the messages into two versions:
+ * 1. The messages to send to the server - these have the file data URLs replaced with uploaded versions.
+ * 2. The messages we use locally - these store the upload for re-use in `providerMetadata`, but keep the originals for display or when the uploads expire.
+ */
+export async function uploadMessageContents(messages: UIMessage[]) {
+	const now = new Date().toISOString()
+	const messagesToSend = []
+	const messagesToSave = []
+	const promises = []
+
+	for (const message of messages) {
+		const partsToSend = []
+		const partsToSave = []
+
+		for (const part of message.parts) {
+			if (part.type === 'file' && part.url.startsWith('data:')) {
+				const metadata = getUploadedMetadata(part)
+				if (metadata && metadata.expiresAt > now) {
+					partsToSend.push({
+						...part,
+						url: metadata.uploadedUrl,
+					})
+					partsToSave.push(part)
+				} else {
+					const partToSend = { ...part }
+					const partToSave = { ...part }
+
+					const promise = (async () => {
+						const response = await fetch('/api/upload', {
+							method: 'POST',
+							body: await FileHelpers.urlToBlob(part.url),
+							headers: {
+								'Content-Type': part.mediaType,
+								'x-file-name': part.filename || 'image.png',
+							},
+						})
+
+						const data: UploadedMetadata = await response.json()
+
+						partToSend.url = data.uploadedUrl
+						partToSave.providerMetadata ??= {}
+						partToSave.providerMetadata[UPLOAD_METADATA_KEY] = data as any
+					})()
+
+					promises.push(promise)
+					partsToSend.push(partToSend)
+					partsToSave.push(partToSave)
+				}
+			} else {
+				partsToSend.push(part)
+				partsToSave.push(part)
+			}
+		}
+
+		messagesToSend.push({
+			...message,
+			parts: partsToSend,
+		})
+		messagesToSave.push({
+			...message,
+			parts: partsToSave,
+		})
+	}
+
+	await Promise.all(promises)
+
+	return { messagesToSend, messagesToSave }
+}
+
+function getUploadedMetadata(part: FileUIPart): UploadedMetadata | undefined {
+	return part.providerMetadata?.[UPLOAD_METADATA_KEY] as UploadedMetadata | undefined
+}

--- a/templates/chat/src/utils/uploadMessageContents.ts
+++ b/templates/chat/src/utils/uploadMessageContents.ts
@@ -54,8 +54,12 @@ export async function uploadMessageContents(messages: UIMessage[]) {
 						const data: UploadedMetadata = await response.json()
 
 						partToSend.url = data.uploadedUrl
+						if (partToSend.providerMetadata) {
+							delete partToSend.providerMetadata.tldraw_uploaded
+							delete partToSend.providerMetadata.tldraw
+						}
 						partToSave.providerMetadata ??= {}
-						partToSave.providerMetadata[UPLOAD_METADATA_KEY] = data as any
+						partToSave.providerMetadata.tldraw_uploaded = data as any
 					})()
 
 					promises.push(promise)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,6 +3457,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google/genai@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "@google/genai@npm:1.17.0"
+  dependencies:
+    google-auth-library: "npm:^9.14.2"
+    ws: "npm:^8.18.0"
+  peerDependencies:
+    "@modelcontextprotocol/sdk": ^1.11.4
+  peerDependenciesMeta:
+    "@modelcontextprotocol/sdk":
+      optional: true
+  checksum: 10/b46b6bf35bebce515ebbd554c1db2af385012740aac476158c37b169192760db615bd77418f49443fffbf6980f1616f3d10ec6b630f5b8d41e702bd685376b41
+  languageName: node
+  linkType: hard
+
 "@google/generative-ai@npm:^0.24.1":
   version: 0.24.1
   resolution: "@google/generative-ai@npm:0.24.1"
@@ -17498,7 +17513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^9.15.1":
+"google-auth-library@npm:^9.14.2, google-auth-library@npm:^9.15.1":
   version: 9.15.1
   resolution: "google-auth-library@npm:9.15.1"
   dependencies:
@@ -27654,6 +27669,7 @@ __metadata:
   dependencies:
     "@ai-sdk/google": "npm:^2.0.11"
     "@ai-sdk/react": "npm:^2.0.15"
+    "@google/genai": "npm:^1.17.0"
     "@types/node": "npm:^22.15.31"
     "@types/react": "npm:^18.3.18"
     "@types/react-dom": "npm:^18.3.5"


### PR DESCRIPTION
Vercel has a limit of 4.5mb on requests. the images that gemini creates are pretty large - we reach that _very_ quickly. to work around this, we now upload images to gemini's file hosting service instead of sending them with every request. for some reason though, we're not allowed to do that with messages from the assistant - they have to be `data:` urls. so for now, we need to disable image output :(

### Change type

- [x] `other`
