### PR TITLE
revert: update year from 2024 to 2025 on licenses and readmes

### DIFF
--- a/apps/docs/LICENSE.md
+++ b/apps/docs/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/apps/examples/LICENSE.md
+++ b/apps/examples/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/apps/vscode/editor/LICENSE.md
+++ b/apps/vscode/editor/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/apps/vscode/extension/LICENSE.md
+++ b/apps/vscode/extension/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/state-react/LICENSE.md
+++ b/packages/state-react/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/state/LICENSE.md
+++ b/packages/state/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/store/LICENSE.md
+++ b/packages/store/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/tlschema/LICENSE.md
+++ b/packages/tlschema/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/utils/LICENSE.md
+++ b/packages/utils/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/validate/LICENSE.md
+++ b/packages/validate/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/ai/LICENSE.md
+++ b/templates/ai/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/chat/LICENSE.md
+++ b/templates/chat/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/nextjs/LICENSE.md
+++ b/templates/nextjs/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/sync-cloudflare/LICENSE.md
+++ b/templates/sync-cloudflare/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/vite/LICENSE.md
+++ b/templates/vite/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/vue/LICENSE.md
+++ b/templates/vue/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/workflow/LICENSE.md
+++ b/templates/workflow/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 tldraw Inc.
+Copyright (c) 2024 tldraw Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Reverts tldraw/tldraw#6700

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reverted license year update.