### PR TITLE
fix(examples): custom clipping shape button click handling

### DIFF
--- a/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
+++ b/apps/examples/src/examples/custom-clipping-shape/CustomClippingExample.tsx
@@ -2,6 +2,7 @@ import {
 	createShapeId,
 	DefaultToolbar,
 	DefaultToolbarContent,
+	stopEventPropagation,
 	TLComponents,
 	Tldraw,
 	TldrawUiMenuItem,
@@ -58,6 +59,8 @@ function ToggleClippingButton() {
 				onClick={() => {
 					isClippingEnabled$.update((prev) => !prev)
 				}}
+				onPointerDown={stopEventPropagation}
+				onPointerUp={stopEventPropagation}
 			>
 				{clippingEnabled ? '✂️ Disable Clipping' : '○ Enable Clipping'}
 			</button>


### PR DESCRIPTION
The custom clipping shape example's toggle button was not working correctly. When clicking the button, the click events were being propagated to the tldraw editor, which interfered with the button's functionality.

### Change type

- [x] `bugfix` 

### Test plan

1. Open the custom clipping shape example.
2. Click the toggle button.
3. Verify the clipping state toggles correctly without editor interference.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes button click handling in the custom clipping shape example.