### PR TITLE
license: have NATIVE_LICENSE use a regex

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -266,7 +266,7 @@ describe('LicenseManager', () => {
 			delete window.location
 			// @ts-ignore
 			window.location = new URL(
-				'vscode-webview:vscode-webview://1ipd8pun8ud7nd7hv9d112g7evi7m10vak9vviuvia66ou6aibp3/index.html?id=6ec2dc7a-afe9-45d9-bd71-1749f9568d28&origin=955b256f-37e1-4a72-a2f4-ad633e88239c&swVersion=4&extensionId=tldraw-org.tldraw-vscode&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app'
+				'vscode-webview://1ipd8pun8ud7nd7hv9d112g7evi7m10vak9vviuvia66ou6aibp3/index.html?id=6ec2dc7a-afe9-45d9-bd71-1749f9568d28&origin=955b256f-37e1-4a72-a2f4-ad633e88239c&swVersion=4&extensionId=tldraw-org.tldraw-vscode&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app'
 			)
 
 			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
@@ -286,7 +286,7 @@ describe('LicenseManager', () => {
 			delete window.location
 			// @ts-ignore
 			window.location = new URL(
-				'vscode-webview:vscode-webview://1ipd8pun8ud7nd7hv9d112g7evi7m10vak9vviuvia66ou6aibp3/index.html?id=6ec2dc7a-afe9-45d9-bd71-1749f9568d28&origin=955b256f-37e1-4a72-a2f4-ad633e88239c&swVersion=4&extensionId=tldraw-org.tldraw-vscode&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app'
+				'vscode-webview://1ipd8pun8ud7nd7hv9d112g7evi7m10vak9vviuvia66ou6aibp3/index.html?id=6ec2dc7a-afe9-45d9-bd71-1749f9568d28&origin=955b256f-37e1-4a72-a2f4-ad633e88239c&swVersion=4&extensionId=tldraw-org.tldraw-vscode&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app'
 			)
 
 			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
@@ -310,6 +310,38 @@ describe('LicenseManager', () => {
 			const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
 			nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
 			nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
+			const nativeLicenseKey = await generateLicenseKey(JSON.stringify(nativeLicenseInfo), keyPair)
+			const result = (await licenseManager.getLicenseFromKey(
+				nativeLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(true)
+		})
+
+		it('Succeeds if it is a native app with a wildcard', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('app-bundle://unique-id-123/index.html')
+
+			const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+			nativeLicenseInfo[PROPERTIES.HOSTS] = ['^app-bundle://unique-id-123.*']
+			const nativeLicenseKey = await generateLicenseKey(JSON.stringify(nativeLicenseInfo), keyPair)
+			const result = (await licenseManager.getLicenseFromKey(
+				nativeLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(true)
+		})
+
+		it('Succeeds if it is a native app with a wildcard and search param', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('app-bundle://app/index.html?unique-id-123')
+
+			const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+			nativeLicenseInfo[PROPERTIES.HOSTS] = ['^app-bundle://app.*unique-id-123.*']
 			const nativeLicenseKey = await generateLicenseKey(JSON.stringify(nativeLicenseInfo), keyPair)
 			const result = (await licenseManager.getLicenseFromKey(
 				nativeLicenseKey

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -323,11 +323,8 @@ export class LicenseManager {
 
 			// Native license support
 			// In this case, `normalizedHost` is actually a protocol, e.g. `app-bundle:`
-			if (
-				this.isNativeLicense(licenseInfo) &&
-				new RegExp(normalizedHostOrUrlRegex).test(window.location.href)
-			) {
-				return true
+			if (this.isNativeLicense(licenseInfo)) {
+				return new RegExp(normalizedHostOrUrlRegex).test(window.location.href)
 			}
 
 			// Glob testing, we only support '*.somedomain.com' right now.

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -304,14 +304,13 @@ export class LicenseManager {
 		const currentHostname = window.location.hostname.toLowerCase()
 
 		return licenseInfo.hosts.some((host) => {
-			const normalizedHost = host.toLowerCase().trim()
-			const maybeProtocol = normalizedHost.endsWith(':') ? normalizedHost : undefined
+			const normalizedHostOrUrlRegex = host.toLowerCase().trim()
 
 			// Allow the domain if listed and www variations, 'example.com' allows 'example.com' and 'www.example.com'
 			if (
-				normalizedHost === currentHostname ||
-				`www.${normalizedHost}` === currentHostname ||
-				normalizedHost === `www.${currentHostname}`
+				normalizedHostOrUrlRegex === currentHostname ||
+				`www.${normalizedHostOrUrlRegex}` === currentHostname ||
+				normalizedHostOrUrlRegex === `www.${currentHostname}`
 			) {
 				return true
 			}
@@ -319,6 +318,15 @@ export class LicenseManager {
 			// If host is '*', we allow all domains.
 			if (host === '*') {
 				// All domains allowed.
+				return true
+			}
+
+			// Native license support
+			// In this case, `normalizedHost` is actually a protocol, e.g. `app-bundle:`
+			if (
+				this.isNativeLicense(licenseInfo) &&
+				new RegExp(normalizedHostOrUrlRegex).test(window.location.href)
+			) {
 				return true
 			}
 
@@ -332,15 +340,9 @@ export class LicenseManager {
 			if (window.location.protocol === 'vscode-webview:') {
 				const currentUrl = new URL(window.location.href)
 				const extensionId = currentUrl.searchParams.get('extensionId')
-				if (normalizedHost === extensionId) {
+				if (normalizedHostOrUrlRegex === extensionId) {
 					return true
 				}
-			}
-
-			// Native license support
-			// In this case, `normalizedHost` is actually a protocol, e.g. `app-bundle:`
-			if (this.isNativeLicense(licenseInfo) && window.location.protocol === maybeProtocol) {
-				return true
 			}
 
 			return false


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/6726

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- license: have NATIVE_LICENSE use a regex