### PR TITLE
fix(utils): parse PNG pHYs unit field correctly

### DIFF
--- a/packages/utils/src/lib/media/media.ts
+++ b/packages/utils/src/lib/media/media.ts
@@ -188,7 +188,7 @@ export class MediaHelpers {
 					const physChunk = PngHelpers.findChunk(view, 'pHYs')
 					if (physChunk) {
 						const physData = PngHelpers.parsePhys(view, physChunk.dataOffset)
-						if (physData.unit === 0 && physData.ppux === physData.ppuy) {
+						if (physData.unit === 1 && physData.ppux === physData.ppuy) {
 							// Calculate pixels per meter:
 							// - 1 inch = 0.0254 meters
 							// - 72 DPI is 72 dots per inch

--- a/packages/utils/src/lib/media/png.ts
+++ b/packages/utils/src/lib/media/png.ts
@@ -160,10 +160,10 @@ export class PngHelpers {
 		pHYsDataView.setUint8(6, 'Y'.charCodeAt(0))
 		pHYsDataView.setUint8(7, 's'.charCodeAt(0))
 
-		const DPI_96 = 2835.5
+		const DPI_72 = 2835.5
 
-		pHYsDataView.setInt32(8, DPI_96 * dpr)
-		pHYsDataView.setInt32(12, DPI_96 * dpr)
+		pHYsDataView.setInt32(8, DPI_72 * dpr)
+		pHYsDataView.setInt32(12, DPI_72 * dpr)
 		pHYsDataView.setInt8(16, 1)
 
 		const crcBit = new Uint8Array(pHYsData.slice(4, 17))


### PR DESCRIPTION
This PR fixes an inconsistency in how PNG `pHYs` unit fields are parsed, ensuring alignment with the W3C specification.

### Change type

- [x] `bugfix` 

### Test plan

1. Upload PNG files with physical dimension chunks and verify metadata parsing.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where our parsing of the `pHYs`'s unit field was inconsistent with the [png specification](https://www.w3.org/TR/PNG-Chunks.html)
<img width="815" height="383" alt="Screenshot 2025-09-12 at 16 43 30" src="https://github.com/user-attachments/assets/196d4c54-bd86-4a32-a83e-8d408233051d" />