### PR TITLE
a11y: make menus scrollable when zoomed in

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -578,6 +578,12 @@
 	box-shadow: var(--tl-shadow-3);
 }
 
+@media (max-height: 600px) {
+	.tlui-menu {
+		max-height: 70vh;
+	}
+}
+
 .tlui-menu::-webkit-scrollbar {
 	display: none;
 }


### PR DESCRIPTION
Fixes this a11y issue: https://linear.app/tldraw/issue/ACC-88/when-zoomed-in-to-200percent-and-400percent-the-menu-can-not-be-used

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: make menus scrollable when zoomed in