### PR TITLE
Update earthquake node label to 'Earthquake data'

### DIFF
--- a/templates/workflow/src/nodes/types/EarthquakeNode.tsx
+++ b/templates/workflow/src/nodes/types/EarthquakeNode.tsx
@@ -44,7 +44,7 @@ interface EarthquakeApiResponse {
 export class EarthquakeNodeType extends NodeDefinition<EarthquakeNode> {
 	static type = 'earthquake'
 	static validator = EarthquakeNode
-	title = 'Earthquake'
+	title = 'Earthquake data'
 	heading = 'USGS Data'
 	icon = (<EarthquakeIcon />)
 


### PR DESCRIPTION
Updates the earthquake node tooltip label from "earthquake" to "earthquake data" as requested.

This changes the title property in the EarthquakeNodeType class, which is used for the tooltip text in the workflow toolbar.

🤖 Generated with [Claude Code](https://claude.ai/code)