### PR TITLE
Rename node definitions from 'Type' to 'Definition' suffix

### DIFF
--- a/templates/workflow/src/nodes/nodeTypes.tsx
+++ b/templates/workflow/src/nodes/nodeTypes.tsx
@@ -6,29 +6,29 @@ import {
 } from '../constants'
 import { PortId, ShapePort } from '../ports/Port'
 import { NodeShape } from './NodeShapeUtil'
-import { AddNodeType } from './types/AddNode'
-import { ConditionalNodeType } from './types/ConditionalNode'
-import { DivideNodeType } from './types/DivideNode'
-import { EarthquakeNodeType } from './types/EarthquakeNode'
-import { MultiplyNodeType } from './types/MultiplyNode'
+import { AddNodeDefinition } from './types/AddNode'
+import { ConditionalNodeDefinition } from './types/ConditionalNode'
+import { DivideNodeDefinition } from './types/DivideNode'
+import { EarthquakeNodeDefinition } from './types/EarthquakeNode'
+import { MultiplyNodeDefinition } from './types/MultiplyNode'
 import {
 	ExecutionResult,
 	InfoValues,
 	NodeDefinition,
 	NodeDefinitionConstructor,
 } from './types/shared'
-import { SliderNodeType } from './types/SliderNode'
-import { SubtractNodeType } from './types/SubtractNode'
+import { SliderNodeDefinition } from './types/SliderNode'
+import { SubtractNodeDefinition } from './types/SubtractNode'
 
 /** All our node types */
 export const NodeDefinitions = {
-	add: AddNodeType,
-	subtract: SubtractNodeType,
-	multiply: MultiplyNodeType,
-	divide: DivideNodeType,
-	conditional: ConditionalNodeType,
-	slider: SliderNodeType,
-	earthquake: EarthquakeNodeType,
+	add: AddNodeDefinition,
+	subtract: SubtractNodeDefinition,
+	multiply: MultiplyNodeDefinition,
+	divide: DivideNodeDefinition,
+	conditional: ConditionalNodeDefinition,
+	slider: SliderNodeDefinition,
+	earthquake: EarthquakeNodeDefinition,
 } satisfies Record<string, NodeDefinitionConstructor<any>>
 
 /**

--- a/templates/workflow/src/nodes/types/AddNode.tsx
+++ b/templates/workflow/src/nodes/types/AddNode.tsx
@@ -35,7 +35,7 @@ export const AddNode = T.object({
 	lastResult: T.number.nullable(),
 })
 
-export class AddNodeType extends NodeDefinition<AddNode> {
+export class AddNodeDefinition extends NodeDefinition<AddNode> {
 	static type = 'add'
 	static validator = AddNode
 	title = 'Add'

--- a/templates/workflow/src/nodes/types/ConditionalNode.tsx
+++ b/templates/workflow/src/nodes/types/ConditionalNode.tsx
@@ -75,7 +75,7 @@ export const ConditionalNode = T.object({
 	previousResult: T.literalEnum('lhs', 'rhs').nullable(),
 })
 
-export class ConditionalNodeType extends NodeDefinition<ConditionalNode> {
+export class ConditionalNodeDefinition extends NodeDefinition<ConditionalNode> {
 	static type = 'conditional'
 	static validator = ConditionalNode
 	title = 'Conditional'

--- a/templates/workflow/src/nodes/types/DivideNode.tsx
+++ b/templates/workflow/src/nodes/types/DivideNode.tsx
@@ -30,7 +30,7 @@ export const DivideNode = T.object({
 	lastResult: T.number.nullable(),
 })
 
-export class DivideNodeType extends NodeDefinition<DivideNode> {
+export class DivideNodeDefinition extends NodeDefinition<DivideNode> {
 	static type = 'divide'
 	static validator = DivideNode
 	title = 'Divide'

--- a/templates/workflow/src/nodes/types/EarthquakeNode.tsx
+++ b/templates/workflow/src/nodes/types/EarthquakeNode.tsx
@@ -41,7 +41,7 @@ interface EarthquakeApiResponse {
 	features: EarthquakeFeature[]
 }
 
-export class EarthquakeNodeType extends NodeDefinition<EarthquakeNode> {
+export class EarthquakeNodeDefinition extends NodeDefinition<EarthquakeNode> {
 	static type = 'earthquake'
 	static validator = EarthquakeNode
 	title = 'Earthquake data'

--- a/templates/workflow/src/nodes/types/MultiplyNode.tsx
+++ b/templates/workflow/src/nodes/types/MultiplyNode.tsx
@@ -30,7 +30,7 @@ export const MultiplyNode = T.object({
 	lastResult: T.number.nullable(),
 })
 
-export class MultiplyNodeType extends NodeDefinition<MultiplyNode> {
+export class MultiplyNodeDefinition extends NodeDefinition<MultiplyNode> {
 	static type = 'multiply'
 	static validator = MultiplyNode
 	title = 'Multiply'

--- a/templates/workflow/src/nodes/types/SliderNode.tsx
+++ b/templates/workflow/src/nodes/types/SliderNode.tsx
@@ -21,7 +21,7 @@ export const SliderNode = T.object({
 	value: T.number,
 })
 
-export class SliderNodeType extends NodeDefinition<SliderNode> {
+export class SliderNodeDefinition extends NodeDefinition<SliderNode> {
 	static type = 'slider'
 	static validator = SliderNode
 	title = 'Slider'

--- a/templates/workflow/src/nodes/types/SubtractNode.tsx
+++ b/templates/workflow/src/nodes/types/SubtractNode.tsx
@@ -30,7 +30,7 @@ export const SubtractNode = T.object({
 	lastResult: T.number.nullable(),
 })
 
-export class SubtractNodeType extends NodeDefinition<SubtractNode> {
+export class SubtractNodeDefinition extends NodeDefinition<SubtractNode> {
 	static type = 'subtract'
 	static validator = SubtractNode
 	title = 'Subtract'


### PR DESCRIPTION
Rename all workflow node definitions to use 'Definition' suffix instead of 'Type' for better semantic consistency.

Changes:
- AddNodeType → AddNodeDefinition
- ConditionalNodeType → ConditionalNodeDefinition
- DivideNodeType → DivideNodeDefinition
- EarthquakeNodeType → EarthquakeNodeDefinition
- MultiplyNodeType → MultiplyNodeDefinition
- SliderNodeType → SliderNodeDefinition
- SubtractNodeType → SubtractNodeDefinition

Updated all imports and references in nodeTypes.tsx accordingly.

Generated with [Claude Code](https://claude.ai/code)