### PR TITLE
feat(editor): track license id

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -178,6 +178,9 @@ export class LicenseManager {
 		const url = new URL(WATERMARK_TRACK_SRC)
 		url.searchParams.set('version', version)
 		url.searchParams.set('license_type', trackType)
+		if ('license' in result) {
+			url.searchParams.set('license_id', result.license.id)
+		}
 
 		// eslint-disable-next-line no-restricted-globals
 		fetch(url.toString())


### PR DESCRIPTION
Track the license ID within the LicenseManager to improve license management and validation.

### Change type

- [x] `feature`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added tracking for license IDs in the editor.