### PR TITLE
a11y: many more little fixes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -89,10 +89,10 @@ function ExportPaddingToggle({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="export-padding-switch">
 				<F defaultMessage="Padding" />
 			</TlaMenuControlLabel>
-			<TlaMenuSwitch checked={value} onChange={handleChange} />
+			<TlaMenuSwitch id="export-padding-switch" checked={value} onChange={handleChange} />
 		</TlaMenuControl>
 	)
 }
@@ -117,10 +117,10 @@ function ExportBackgroundToggle({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="export-background-switch">
 				<F defaultMessage="Background" />
 			</TlaMenuControlLabel>
-			<TlaMenuSwitch checked={value} onChange={handleChange} />
+			<TlaMenuSwitch id="export-background-switch" checked={value} onChange={handleChange} />
 		</TlaMenuControl>
 	)
 }
@@ -147,10 +147,11 @@ function ExportFormatSelect({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="export-format-select">
 				<F defaultMessage="Export as" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
+				id="export-format-select"
 				value={value}
 				label={value === 'svg' ? 'SVG' : 'PNG'}
 				onChange={handleChange}
@@ -188,10 +189,11 @@ function ExportThemeSelect({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="export-theme-select">
 				<F defaultMessage="Theme" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
+				id="export-theme-select"
 				value={value}
 				label={label}
 				onChange={handleChange}

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -89,10 +89,10 @@ function ExportPaddingToggle({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="export-padding-switch">
+			<TlaMenuControlLabel htmlFor="tla-export-padding-switch">
 				<F defaultMessage="Padding" />
 			</TlaMenuControlLabel>
-			<TlaMenuSwitch id="export-padding-switch" checked={value} onChange={handleChange} />
+			<TlaMenuSwitch id="tla-export-padding-switch" checked={value} onChange={handleChange} />
 		</TlaMenuControl>
 	)
 }
@@ -117,10 +117,10 @@ function ExportBackgroundToggle({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="export-background-switch">
+			<TlaMenuControlLabel htmlFor="tla-export-background-switch">
 				<F defaultMessage="Background" />
 			</TlaMenuControlLabel>
-			<TlaMenuSwitch id="export-background-switch" checked={value} onChange={handleChange} />
+			<TlaMenuSwitch id="tla-export-background-switch" checked={value} onChange={handleChange} />
 		</TlaMenuControl>
 	)
 }
@@ -147,11 +147,11 @@ function ExportFormatSelect({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="export-format-select">
+			<TlaMenuControlLabel htmlFor="tla-export-format-select">
 				<F defaultMessage="Export as" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
-				id="export-format-select"
+				id="tla-export-format-select"
 				value={value}
 				label={value === 'svg' ? 'SVG' : 'PNG'}
 				onChange={handleChange}
@@ -189,11 +189,11 @@ function ExportThemeSelect({
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="export-theme-select">
+			<TlaMenuControlLabel htmlFor="tla-export-theme-select">
 				<F defaultMessage="Theme" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
-				id="export-theme-select"
+				id="tla-export-theme-select"
 				value={value}
 				label={label}
 				onChange={handleChange}

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -72,7 +72,7 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 	const learnMoreUrl = 'https://tldraw.notion.site/Sharing-1283e4c324c080a69618ff37eb3fc98f'
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="shared-link-shared-switch">
+			<TlaMenuControlLabel htmlFor="tla-shared-link-shared-switch">
 				<F defaultMessage="Share this file" />
 			</TlaMenuControlLabel>
 			<TlaMenuControlInfoTooltip
@@ -84,7 +84,7 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 				<F defaultMessage="Learn more about sharing." />
 			</TlaMenuControlInfoTooltip>
 			<TlaMenuSwitch
-				id="shared-link-shared-switch"
+				id="tla-shared-link-shared-switch"
 				data-testid="shared-link-shared-switch"
 				checked={!!isShared}
 				onChange={handleToggleShared}
@@ -119,11 +119,11 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel htmlFor="shared-link-type-select">
+			<TlaMenuControlLabel htmlFor="tla-shared-link-type-select">
 				<F defaultMessage="Anyone with the link" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
-				id="shared-link-type-select"
+				id="tla-shared-link-type-select"
 				data-testid="shared-link-type-select"
 				label={label}
 				value={sharedLinkType!}

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -72,7 +72,7 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 	const learnMoreUrl = 'https://tldraw.notion.site/Sharing-1283e4c324c080a69618ff37eb3fc98f'
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="shared-link-shared-switch">
 				<F defaultMessage="Share this file" />
 			</TlaMenuControlLabel>
 			<TlaMenuControlInfoTooltip
@@ -84,6 +84,7 @@ function TlaSharedToggle({ isShared, fileId }: { isShared: boolean; fileId: stri
 				<F defaultMessage="Learn more about sharing." />
 			</TlaMenuControlInfoTooltip>
 			<TlaMenuSwitch
+				id="shared-link-shared-switch"
 				data-testid="shared-link-shared-switch"
 				checked={!!isShared}
 				onChange={handleToggleShared}
@@ -118,10 +119,11 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 
 	return (
 		<TlaMenuControl>
-			<TlaMenuControlLabel>
+			<TlaMenuControlLabel htmlFor="shared-link-type-select">
 				<F defaultMessage="Anyone with the link" />
 			</TlaMenuControlLabel>
 			<TlaMenuSelect
+				id="shared-link-type-select"
 				data-testid="shared-link-type-select"
 				label={label}
 				value={sharedLinkType!}

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
@@ -77,7 +77,7 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 				<TlaMenuControlGroup>
 					{isOwner && (
 						<TlaMenuControl>
-							<TlaMenuControlLabel htmlFor="publish-this-file-switch">
+							<TlaMenuControlLabel htmlFor="tla-publish-this-file-switch">
 								<F defaultMessage="Publish this file" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip
@@ -92,7 +92,7 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 								<F defaultMessage="Learn more about publishing." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch
-								id="publish-this-file-switch"
+								id="tla-publish-this-file-switch"
 								checked={published}
 								onChange={() => (published ? unpublish() : publish(false))}
 							/>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
@@ -77,7 +77,7 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 				<TlaMenuControlGroup>
 					{isOwner && (
 						<TlaMenuControl>
-							<TlaMenuControlLabel>
+							<TlaMenuControlLabel htmlFor="publish-this-file-switch">
 								<F defaultMessage="Publish this file" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip
@@ -92,6 +92,7 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 								<F defaultMessage="Learn more about publishing." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch
+								id="publish-this-file-switch"
 								checked={published}
 								onChange={() => (published ? unpublish() : publish(false))}
 							/>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
@@ -45,23 +45,23 @@ export function TlaManageCookiesDialog() {
 					</p>
 					<TlaMenuControlGroup>
 						<TlaMenuControl>
-							<TlaMenuControlLabel htmlFor="essential-cookies-switch">
+							<TlaMenuControlLabel htmlFor="tla-essential-cookies-switch">
 								<F defaultMessage="Essential cookies" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use these cookies to save your files and settings." />
 							</TlaMenuControlInfoTooltip>
-							<TlaMenuSwitch id="essential-cookies-switch" checked={true} disabled />
+							<TlaMenuSwitch id="tla-essential-cookies-switch" checked={true} disabled />
 						</TlaMenuControl>
 						<TlaMenuControl>
-							<TlaMenuControlLabel htmlFor="analytics-switch">
+							<TlaMenuControlLabel htmlFor="tla-analytics-switch">
 								<F defaultMessage="Analytics" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use analytics cookies to make tldraw better." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch
-								id="analytics-switch"
+								id="tla-analytics-switch"
 								checked={consent === true}
 								onChange={() => updateConsent(!(consent === true))}
 							/>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
@@ -45,22 +45,23 @@ export function TlaManageCookiesDialog() {
 					</p>
 					<TlaMenuControlGroup>
 						<TlaMenuControl>
-							<TlaMenuControlLabel>
+							<TlaMenuControlLabel htmlFor="essential-cookies-switch">
 								<F defaultMessage="Essential cookies" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use these cookies to save your files and settings." />
 							</TlaMenuControlInfoTooltip>
-							<TlaMenuSwitch checked={true} disabled />
+							<TlaMenuSwitch id="essential-cookies-switch" checked={true} disabled />
 						</TlaMenuControl>
 						<TlaMenuControl>
-							<TlaMenuControlLabel>
+							<TlaMenuControlLabel htmlFor="analytics-switch">
 								<F defaultMessage="Analytics" />
 							</TlaMenuControlLabel>
 							<TlaMenuControlInfoTooltip showOnMobile>
 								<F defaultMessage="We use analytics cookies to make tldraw better." />
 							</TlaMenuControlInfoTooltip>
 							<TlaMenuSwitch
+								id="analytics-switch"
 								checked={consent === true}
 								onChange={() => updateConsent(!(consent === true))}
 							/>

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -75,8 +75,18 @@ export function TlaMenuControlInfoTooltip({
 }
 
 // A label for a control
-export function TlaMenuControlLabel({ children }: { children: ReactNode }) {
-	return <label className={classNames(styles.menuLabel, 'tla-text_ui__medium')}>{children}</label>
+export function TlaMenuControlLabel({
+	children,
+	htmlFor,
+}: {
+	children: ReactNode
+	htmlFor: string
+}) {
+	return (
+		<label className={classNames(styles.menuLabel, 'tla-text_ui__medium')} htmlFor={htmlFor}>
+			{children}
+		</label>
+	)
 }
 
 // A detail
@@ -89,6 +99,7 @@ export function TlaMenuDetail({ children }: { children: ReactNode }) {
 /* --------------------- Select --------------------- */
 
 export function TlaMenuSelect<T extends string>({
+	id,
 	label,
 	value,
 	disabled,
@@ -96,6 +107,7 @@ export function TlaMenuSelect<T extends string>({
 	options,
 	'data-testid': dataTestId,
 }: {
+	id: string
 	label: string
 	value: T
 	disabled?: boolean
@@ -141,6 +153,7 @@ export function TlaMenuSelect<T extends string>({
 				onValueChange={handleChange}
 			>
 				<_Select.Trigger
+					id={id}
 					className={styles.menuSelectTrigger}
 					disabled={disabled}
 					aria-label={label}
@@ -177,12 +190,13 @@ export function TlaMenuSelect<T extends string>({
 /* --------------------- Switch --------------------- */
 
 export interface TlaMenuSwitchProps extends Omit<HTMLAttributes<HTMLInputElement>, 'onChange'> {
+	id: string
 	checked: boolean
 	onChange?(checked: boolean): void
 	disabled?: boolean
 }
 
-export function TlaMenuSwitch({ checked, onChange, disabled, ...rest }: TlaMenuSwitchProps) {
+export function TlaMenuSwitch({ id, checked, onChange, disabled, ...rest }: TlaMenuSwitchProps) {
 	const handleChange = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {
 			onChange?.(e.currentTarget.checked)
@@ -200,6 +214,7 @@ export function TlaMenuSwitch({ checked, onChange, disabled, ...rest }: TlaMenuS
 		>
 			<div className={styles.menuSwitch} data-checked={checked} />
 			<input
+				id={id}
 				name="shared"
 				disabled={disabled}
 				role="switch"

--- a/apps/examples/e2e/tests/fixtures/menus/NavigationPanel.ts
+++ b/apps/examples/e2e/tests/fixtures/menus/NavigationPanel.ts
@@ -7,7 +7,7 @@ export class NavigationPanel {
 	readonly zoomMenuItems: { [key: string]: Locator }
 	constructor(private readonly page: Page) {
 		this.page = page
-		this.minimap = page.getByLabel('minimap')
+		this.minimap = page.getByTestId('minimap.canvas')
 		this.zoomMenuButton = page.getByTestId('minimap.zoom-menu-button')
 		this.toggleButton = page.getByTestId('minimap.toggle-button')
 		this.zoomMenuItems = {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3243,7 +3243,7 @@ export function TldrawUiMenuActionCheckboxItem({ actionId, ...rest }: TLUiMenuAc
 export function TldrawUiMenuActionItem({ actionId, ...rest }: TLUiMenuActionItemProps): JSX_2.Element | null;
 
 // @public (undocumented)
-export function TldrawUiMenuCheckboxItem<TranslationKey extends string = string, IconType extends string = string>({ id, kbd, label, readonlyOk, onSelect, toggle, disabled, checked, }: TLUiMenuCheckboxItemProps<TranslationKey, IconType>): JSX_2.Element | null;
+export function TldrawUiMenuCheckboxItem<TranslationKey extends string = string, IconType extends string = string>({ id, kbd, label, lang, readonlyOk, onSelect, toggle, disabled, checked, }: TLUiMenuCheckboxItemProps<TranslationKey, IconType>): JSX_2.Element | null;
 
 // @public (undocumented)
 export function TldrawUiMenuContextProvider({ type, sourceId, children, }: TLUiMenuContextProviderProps): JSX_2.Element;
@@ -4226,6 +4226,8 @@ export interface TLUiMenuCheckboxItemProps<TranslationKey extends string = strin
     label?: {
         [key: string]: TranslationKey;
     } | TranslationKey;
+    // (undocumented)
+    lang?: string;
     // (undocumented)
     onSelect(source: TLUiEventSource): Promise<void> | void;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -494,6 +494,10 @@
 	-webkit-user-select: auto !important;
 }
 
+.tlui-input::placeholder {
+	color: var(--tl-color-text-3);
+}
+
 .tlui-input__wrapper {
 	width: 100%;
 	height: 44px;

--- a/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/LanguageMenu.tsx
@@ -18,6 +18,7 @@ export function LanguageMenu() {
 				{LANGUAGES.map(({ locale, label }) => (
 					<TldrawUiMenuCheckboxItem
 						id={`language-${locale}`}
+						lang={locale}
 						key={locale}
 						title={locale}
 						label={label}

--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -204,6 +204,7 @@ export function DefaultMinimap() {
 			<canvas
 				role="img"
 				aria-label={msg('navigation-zone.minimap')}
+				data-testid="minimap.canvas"
 				ref={rCanvas}
 				className="tlui-minimap__canvas"
 				onDoubleClick={onDoubleClick}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
@@ -70,6 +70,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 				data-testid="media-toolbar.alt-text-input"
 				value={altText}
 				placeholder={msg('tool.media-alt-text-desc')}
+				aria-label={msg('tool.media-alt-text-desc')}
 				onValueChange={handleValueChange}
 				onComplete={handleComplete}
 				onCancel={handleAltTextCancel}

--- a/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
@@ -75,6 +75,7 @@ export function LinkEditor({ textEditor, value: initialValue, onClose }: LinkEdi
 				onComplete={handleLinkComplete}
 				onCancel={handleLinkCancel}
 				placeholder="example.com"
+				aria-label="example.com"
 			/>
 			<TldrawUiToolbarButton
 				className="tlui-rich-text__toolbar-link-visit"

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
@@ -71,6 +71,7 @@ export const TldrawUiToolbarButton = React.forwardRef<HTMLButtonElement, TLUiToo
 				draggable={false}
 				data-isactive={isActive}
 				{...props}
+				aria-label={props.title}
 				// The tooltip takes care of this.
 				title={undefined}
 				className={classnames('tlui-button', `tlui-button__${type}`, props.className)}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -171,6 +171,19 @@ function TooltipSingleton() {
 		}
 	}, [cameraState, isOpen, currentTooltip, editor])
 
+	useEffect(() => {
+		function handleKeyDown(event: KeyboardEvent) {
+			if (event.key === 'Escape' && currentTooltip) {
+				tooltipManager.hideTooltip(editor, currentTooltip.id)
+			}
+		}
+
+		document.addEventListener('keydown', handleKeyDown)
+		return () => {
+			document.removeEventListener('keydown', handleKeyDown)
+		}
+	}, [editor, currentTooltip])
+
 	// Update open state and trigger position
 	useEffect(() => {
 		let timer: ReturnType<typeof setTimeout> | null = null
@@ -266,19 +279,6 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 				}
 			}
 		}, [editor, hasProvider])
-
-		useEffect(() => {
-			function handleKeyDown(event: KeyboardEvent) {
-				if (event.key === 'Escape') {
-					tooltipManager.hideTooltip(editor, tooltipId.current)
-				}
-			}
-
-			document.addEventListener('keydown', handleKeyDown)
-			return () => {
-				document.removeEventListener('keydown', handleKeyDown)
-			}
-		}, [editor])
 
 		useLayoutEffect(() => {
 			if (hasProvider && tooltipManager.getCurrentTooltipData()?.id === tooltipId.current) {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -278,7 +278,7 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 			return () => {
 				document.removeEventListener('keydown', handleKeyDown)
 			}
-		}, [])
+		}, [editor])
 
 		useLayoutEffect(() => {
 			if (hasProvider && tooltipManager.getCurrentTooltipData()?.id === tooltipId.current) {

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -267,6 +267,19 @@ export const TldrawUiTooltip = forwardRef<HTMLButtonElement, TldrawUiTooltipProp
 			}
 		}, [editor, hasProvider])
 
+		useEffect(() => {
+			function handleKeyDown(event: KeyboardEvent) {
+				if (event.key === 'Escape') {
+					tooltipManager.hideTooltip(editor, tooltipId.current)
+				}
+			}
+
+			document.addEventListener('keydown', handleKeyDown)
+			return () => {
+				document.removeEventListener('keydown', handleKeyDown)
+			}
+		}, [])
+
 		useLayoutEffect(() => {
 			if (hasProvider && tooltipManager.getCurrentTooltipData()?.id === tooltipId.current) {
 				tooltipManager.updateCurrentTooltip(tooltipId.current, (tooltip) => ({

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
@@ -19,6 +19,7 @@ export interface TLUiMenuCheckboxItemProps<
 	kbd?: string
 	title?: string
 	label?: TranslationKey | { [key: string]: TranslationKey }
+	lang?: string
 	readonlyOk?: boolean
 	onSelect(source: TLUiEventSource): Promise<void> | void
 	toggle?: boolean
@@ -34,6 +35,7 @@ export function TldrawUiMenuCheckboxItem<
 	id,
 	kbd,
 	label,
+	lang,
 	readonlyOk,
 	onSelect,
 	toggle = false,
@@ -55,6 +57,7 @@ export function TldrawUiMenuCheckboxItem<
 			return (
 				<_DropdownMenu.CheckboxItem
 					dir="ltr"
+					lang={lang}
 					className="tlui-button tlui-button__menu tlui-button__checkbox"
 					title={labelStr}
 					onSelect={(e) => {
@@ -84,6 +87,7 @@ export function TldrawUiMenuCheckboxItem<
 					key={id}
 					className="tlui-button tlui-button__menu tlui-button__checkbox"
 					dir="ltr"
+					lang={lang}
 					title={labelStr}
 					onSelect={(e) => {
 						onSelect(sourceId)

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1584,6 +1584,19 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				onSelect: async (source) => {
 					if (!canApplySelectionAction()) return
 
+					const onlySelectedShape = editor.getOnlySelectedShape()
+					if (
+						onlySelectedShape &&
+						(editor.isShapeOfType<TLImageShape>(onlySelectedShape, 'image') ||
+							editor.isShapeOfType<TLVideoShape>(onlySelectedShape, 'video'))
+					) {
+						const firstToolbarButton = editor
+							.getContainer()
+							.querySelector('.tlui-contextual-toolbar button:first-child') as HTMLElement | null
+						firstToolbarButton?.focus()
+						return
+					}
+
 					const firstButton = editor
 						.getContainer()
 						.querySelector('.tlui-style-panel button') as HTMLElement | null


### PR DESCRIPTION
This fixes a bunch of things in our latest review:
- [x] Image toolbar being accessible, Cmd+Enter now selects the contextual toolbar when relevant
- [x] Fixing input field placeholder (for alternate text)
- [x] Regression on text labels being missing on some buttons in various toolbars
- [x] Adding accessible labels to our control labels that point to switches and selects
- [x] More contrast on our placeholder text (Safari didn't have enough contrast)
- [x] Adding `lang={locale}` to our language menu


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- a11y: many more fixes, including: accessible contextual toolbars, fixing missing labels in various places, more contrast for placeholder text, and adding `lang` for our language menu

### API changes

- adds `lang` to `TldrawUiMenuCheckboxItem`