### PR TITLE
fix(a11y): resolve focus and tooltip issues

### DIFF
--- a/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
@@ -58,8 +58,12 @@ export class FocusManager {
 
 	private handleKeyDown(keyEvent: KeyboardEvent) {
 		const container = this.editor.getContainer()
-		if (this.editor.isIn('select.editing_shape')) return
-		if (document.activeElement === container && this.editor.getSelectedShapeIds().length > 0) return
+		const activeEl = document.activeElement
+		// Edit mode should remove the focus ring, however if the active element's
+		// parent is the contextual toolbar, then allow it.
+		if (this.editor.isIn('select.editing_shape') && !activeEl?.closest('.tlui-contextual-toolbar'))
+			return
+		if (activeEl === container && this.editor.getSelectedShapeIds().length > 0) return
 		if (['Tab', 'ArrowUp', 'ArrowDown'].includes(keyEvent.key)) {
 			container.classList.remove('tl-container__no-focus-ring')
 		}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4133,6 +4133,8 @@ export interface TLUiImageToolbarProps {
 // @public (undocumented)
 export interface TLUiInputProps {
     // (undocumented)
+    'aria-label'?: string;
+    // (undocumented)
     'data-testid'?: string;
     // (undocumented)
     autoFocus?: boolean;

--- a/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
@@ -2,9 +2,9 @@ import { preventDefault, TLShape, TLShapeId, useEditor } from '@tldraw/editor'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
+import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import { TldrawUiInput } from '../primitives/TldrawUiInput'
-import { TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
 
 /** @public */
 export interface AltTextEditorProps {
@@ -77,7 +77,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 				disabled={isReadonly}
 			/>
 			{!isReadonly && (
-				<TldrawUiToolbarButton
+				<TldrawUiButton
 					title={msg('tool.media-alt-text-confirm')}
 					data-testid="tool.media-alt-text-confirm"
 					type="icon"
@@ -85,7 +85,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 					onClick={handleConfirm}
 				>
 					<TldrawUiButtonIcon small icon="check" />
-				</TldrawUiToolbarButton>
+				</TldrawUiButton>
 			)}
 		</>
 	)

--- a/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/LinkEditor.tsx
@@ -2,9 +2,9 @@ import { preventDefault, TiptapEditor, useEditor } from '@tldraw/editor'
 import { useEffect, useRef, useState } from 'react'
 import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
+import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import { TldrawUiInput } from '../primitives/TldrawUiInput'
-import { TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
 
 /** @public */
 export interface LinkEditorProps {
@@ -77,7 +77,7 @@ export function LinkEditor({ textEditor, value: initialValue, onClose }: LinkEdi
 				placeholder="example.com"
 				aria-label="example.com"
 			/>
-			<TldrawUiToolbarButton
+			<TldrawUiButton
 				className="tlui-rich-text__toolbar-link-visit"
 				title={msg('tool.rich-text-link-visit')}
 				type="icon"
@@ -86,8 +86,8 @@ export function LinkEditor({ textEditor, value: initialValue, onClose }: LinkEdi
 				disabled={!value}
 			>
 				<TldrawUiButtonIcon small icon="external-link" />
-			</TldrawUiToolbarButton>
-			<TldrawUiToolbarButton
+			</TldrawUiButton>
+			<TldrawUiButton
 				className="tlui-rich-text__toolbar-link-remove"
 				title={msg('tool.rich-text-link-remove')}
 				data-testid="rich-text.link-remove"
@@ -96,7 +96,7 @@ export function LinkEditor({ textEditor, value: initialValue, onClose }: LinkEdi
 				onClick={handleRemoveLink}
 			>
 				<TldrawUiButtonIcon small icon="trash" />
-			</TldrawUiToolbarButton>
+			</TldrawUiButton>
 		</>
 	)
 }

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiInput.tsx
@@ -35,6 +35,7 @@ export interface TLUiInputProps {
 	shouldManuallyMaintainScrollPositionWhenFocused?: boolean
 	value?: string
 	'data-testid'?: string
+	'aria-label'?: string
 }
 
 /** @public @react */
@@ -60,6 +61,7 @@ export const TldrawUiInput = React.forwardRef<HTMLInputElement, TLUiInputProps>(
 			value,
 			'data-testid': dataTestId,
 			disabled,
+			'aria-label': ariaLabel,
 		},
 		ref
 	) {
@@ -198,6 +200,7 @@ export const TldrawUiInput = React.forwardRef<HTMLInputElement, TLUiInputProps>(
 					onCompositionStart={handleCompositionStart}
 					onCompositionEnd={handleCompositionEnd}
 					autoFocus={autoFocus}
+					aria-label={ariaLabel}
 					placeholder={placeholder}
 					value={value}
 					data-testid={dataTestId}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -173,16 +173,17 @@ function TooltipSingleton() {
 
 	useEffect(() => {
 		function handleKeyDown(event: KeyboardEvent) {
-			if (event.key === 'Escape' && currentTooltip) {
+			if (event.key === 'Escape' && currentTooltip && isOpen) {
 				tooltipManager.hideTooltip(editor, currentTooltip.id)
+				event.stopPropagation()
 			}
 		}
 
-		document.addEventListener('keydown', handleKeyDown)
+		document.addEventListener('keydown', handleKeyDown, { capture: true })
 		return () => {
-			document.removeEventListener('keydown', handleKeyDown)
+			document.removeEventListener('keydown', handleKeyDown, { capture: true })
 		}
-	}, [editor, currentTooltip])
+	}, [editor, currentTooltip, isOpen])
 
 	// Update open state and trigger position
 	useEffect(() => {


### PR DESCRIPTION
followup tweaks to https://github.com/tldraw/tldraw/pull/6750

- [x] hitting Escape when a tooltip is open, just hides the tooltip and doesn't lose focus. 
- [x] shows focus ring on rich text toolbar when appropriate, followup tweak to https://github.com/tldraw/tldraw/pull/6125
- [x] allows Confirm button for AltTextEditor to be tabbable, along with buttons for the LinkEditor

### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Open a tooltip and press Escape: verify tooltip closes but focus remains.
2. Verify focus ring appears on rich text toolbar.
3. Verify Confirm button in AltTextEditor and LinkEditor buttons are tabbable.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Improved accessibility for tooltips, focus rings, and editor buttons.

### API changes

- adds `aria-label` to `TLUiInput`