### PR TITLE
docs: remove mobile menu links

### DIFF
--- a/apps/docs/components/common/theme-switch.tsx
+++ b/apps/docs/components/common/theme-switch.tsx
@@ -28,8 +28,8 @@ export function ThemeSwitch() {
 	}
 
 	return (
-		<div className="flex flex-col items-end sm:flex-row sm:items-center gap-4 mt-4 sm:mt-0">
-			<div className="h-px sm:h-5 w-full sm:w-px bg-zinc-100 sm:bg-zinc-200 dark:bg-zinc-800 dark:sm:bg-zinc-700" />
+		<div className="flex flex-col items-end sm:flex-row sm:items-center gap-4 ml-2 md:ml-0">
+			<div className="hidden md:block h-px sm:h-5 w-full sm:w-px bg-zinc-100 sm:bg-zinc-200 dark:bg-zinc-800 dark:sm:bg-zinc-700" />
 			<button
 				onClick={() => setThemeAndPersist()}
 				className="hover:text-zinc-600 dark:hover:text-zinc-100"

--- a/apps/docs/components/navigation/header.tsx
+++ b/apps/docs/components/navigation/header.tsx
@@ -2,43 +2,12 @@
 
 import { type IconName } from '@/components/common/icon'
 import { Logo } from '@/components/common/logo'
-import { MobileMenu } from '@/components/navigation/mobile-menu'
 import { SocialLink } from '@/components/navigation/social-link'
 import { SearchButton } from '@/components/search/SearchButton'
 import { motion, useScroll, useTransform } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Suspense } from 'react'
 import { ThemeSwitch } from '../common/theme-switch'
-
-const mainLinks = [
-	// { caption: 'Features', active: () => false, href: '/#features' },
-	{
-		caption: 'Docs',
-		href: '/quick-start',
-		active: (pathname: string) =>
-			[
-				'/quick-start',
-				'/installation',
-				'/releases',
-				'/docs',
-				'/community',
-				'/reference',
-				'/search',
-			].some((e) => pathname.startsWith(e)) && !pathname.startsWith('/search/blog'),
-	},
-	{
-		caption: 'Examples',
-		href: '/examples',
-		active: (pathname: string) => ['/examples'].some((e) => pathname.startsWith(e)),
-	},
-	{ caption: 'Pricing', active: () => false, href: '/#pricing' },
-	{
-		caption: 'Blog',
-		href: '/blog',
-		active: (pathname: string) => ['/blog', '/search/blog'].some((e) => pathname.startsWith(e)),
-	},
-]
 
 const socialLinks = [
 	{
@@ -85,9 +54,7 @@ export function Header() {
 					{!pathname?.startsWith('/search') && (
 						<SearchButton type={pathname?.startsWith('/blog') ? 'blog' : 'docs'} layout="mobile" />
 					)}
-					<Suspense>
-						<MobileMenu main={mainLinks} social={socialLinks} />
-					</Suspense>
+					<ThemeSwitch />
 				</div>
 			</nav>
 		</header>


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/6754

### Change type

- [x] `other`

### Test plan

1. Open documentation on a mobile device or resize browser to mobile width
2. Verify the menu links are no longer present

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Removed unnecessary mobile menu links from documentation site