### PR TITLE
[Agent template] Fix overscroll navback and webkit scorllbar css

### DIFF
--- a/templates/agent/client/index.css
+++ b/templates/agent/client/index.css
@@ -3,11 +3,11 @@
 
 * {
 	box-sizing: border-box;
+	overscroll-behavior: none;
 }
 
 body {
 	font-family: 'Inter', sans-serif;
-	overscroll-behavior: none;
 }
 
 .tldraw-agent-container {
@@ -64,6 +64,7 @@ body {
 
 .chat-panel {
 	position: relative;
+	
 }
 
 .chat-panel * {

--- a/templates/agent/client/index.css
+++ b/templates/agent/client/index.css
@@ -64,7 +64,6 @@ body {
 
 .chat-panel {
 	position: relative;
-	
 }
 
 .chat-panel * {
@@ -175,11 +174,17 @@ body {
 }
 
 .chat-input textarea::-webkit-scrollbar {
+	width: 8px;
+	background: transparent;
+}
+
+.chat-input textarea::-webkit-scrollbar-track {
 	background: transparent;
 }
 
 .chat-input textarea::-webkit-scrollbar-thumb {
 	background: var(--tl-color-text-3);
+	border-radius: 4px;
 }
 
 .chat-input-submit {
@@ -324,6 +329,19 @@ body {
 	width: 100%;
 	scrollbar-width: 8px;
 	scrollbar-color: var(--tl-color-muted-1) transparent;
+}
+
+.chat-history::-webkit-scrollbar {
+	width: 8px;
+}
+
+.chat-history::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.chat-history::-webkit-scrollbar-thumb {
+	background: var(--tl-color-muted-1);
+	border-radius: 4px;
 }
 
 .chat-history-section {


### PR DESCRIPTION
2 finger scrolling on chat panel on safari doesn't navback anymore, and webkit css on chat panel and chat input scrollbars now matches chromium

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`