### PR TITLE
new extract draft changelog script

### DIFF
--- a/.github/workflows/get-changelog.yml
+++ b/.github/workflows/get-changelog.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       from:
-        description: 'From tag or ref'
+        description: 'From tag or ref. Usually the previous release tag.'
         required: true
         type: string
       to:
@@ -18,8 +18,8 @@ defaults:
     shell: bash
 
 jobs:
-  get_changelog:
-    name: 'Extract draft changelog'
+  deploy:
+    name: 'Get draft changlog'
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/get-changelog.yml
+++ b/.github/workflows/get-changelog.yml
@@ -3,39 +3,37 @@ name: Get draft changelog
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: The branch to get the changelog for
+      from:
+        description: 'From tag or ref'
         required: true
-        default: production
+        type: string
+      to:
+        description: 'To tag or ref (default: HEAD)'
+        required: false
+        type: string
+        default: 'HEAD'
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  deploy:
-    name: 'Get draft changlog'
-    environment: npm deploy
+  get_changelog:
+    name: 'Extract draft changelog'
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Prepare repository
-        # Fetch full git history and tags for auto
-        run: git fetch --unshallow --tags
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run our setup
         uses: ./.github/actions/setup
 
-      - name: Generate changelog
-        run: |
-          yarn auto changelog --dry-run --base-branch ${{ inputs.version }}
-          yarn auto changelog --dry-run --base-branch ${{ inputs.version }} > changelog.md
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Extract changelog
+        run: yarn extract-draft-changelog ${{ inputs.from }} ${{ inputs.to }}
 
       - name: Upload changelog.md to artifacts
         uses: actions/upload-artifact@v4

--- a/internal/scripts/extract-draft-changelog.tsx
+++ b/internal/scripts/extract-draft-changelog.tsx
@@ -1,0 +1,176 @@
+import { join } from 'path'
+import { exec } from './lib/exec'
+import { REPO_ROOT, writeStringFile } from './lib/file'
+import { nicelog } from './lib/nicelog'
+
+async function main() {
+	const args = process.argv.slice(2)
+
+	if (args.length < 1 || args.length > 2) {
+		console.error('Usage: yarn extract-draft-changelog <start-ref> [end-ref]')
+		console.error('Example: yarn extract-draft-changelog v2.0.0 HEAD')
+		console.error('Example: yarn extract-draft-changelog v2.0.0  # uses current HEAD')
+		process.exit(1)
+	}
+
+	const startRef = args[0]
+	const endRef = args[1] || 'HEAD'
+
+	nicelog(`Extracting changelog from ${startRef} to ${endRef}`)
+
+	try {
+		// Get list of commits between the two refs
+		const gitLogOutput = await exec(
+			'git',
+			['log', '--oneline', '--no-merges', `${startRef}..${endRef}`],
+			{
+				processStdoutLine: () => {}, // Suppress output
+				processStderrLine: () => {},
+			}
+		)
+
+		if (!gitLogOutput.trim()) {
+			nicelog('No commits found in the specified range')
+			process.exit(0)
+		}
+
+		const commitHashes = gitLogOutput
+			.split('\n')
+			.filter((line) => line.trim())
+			.map((line) => line.split(' ')[0])
+
+		nicelog(`Found ${commitHashes.length} commits`)
+
+		// Extract full commit messages for each commit
+		const entries: Array<{
+			firstLine: string
+			restOfMessage: string
+			changeType: string
+			changedFolders: string[]
+		}> = []
+
+		for (const hash of commitHashes) {
+			const fullMessage = await exec('git', ['log', '-1', '--pretty=format:%B', hash], {
+				processStdoutLine: () => {}, // Suppress output
+				processStderrLine: () => {},
+			})
+
+			// Get changed files for this commit
+			const changedFiles = await exec('git', ['show', '--name-only', '--pretty=format:', hash], {
+				processStdoutLine: () => {}, // Suppress output
+				processStderrLine: () => {},
+			})
+
+			// Extract unique folders (max 2 levels deep) from changed files
+			const folders = new Set<string>()
+			changedFiles
+				.split('\n')
+				.filter((file) => file.trim())
+				.forEach((file) => {
+					const parts = file.split('/')
+					if (parts.length >= 2) {
+						folders.add(`${parts[0]}/${parts[1]}`)
+					} else if (parts.length === 1) {
+						folders.add(parts[0])
+					}
+				})
+
+			const lines = fullMessage.trim().split('\n')
+			const firstLine = lines[0] || hash
+			let restOfMessage = lines.slice(1).join('\n').trim()
+
+			// Extract change type from checkboxes
+			let changeType = 'other'
+			const changeTypes = ['bugfix', 'improvement', 'feature', 'api', 'other']
+
+			for (const type of changeTypes) {
+				if (restOfMessage.includes(`- [x] \`${type}\``)) {
+					changeType = type
+					break
+				}
+			}
+
+			// Remove the Change type section and all checkboxes
+			restOfMessage = restOfMessage
+				// remove Change type section
+				.replace(/### Change type[\s\n]*/g, '')
+				// remove checkboxes
+				.replace(/- \[[ x]\] `(bugfix|improvement|feature|api|other)`[\s\n]*/g, '')
+				// remove co-authored-by lines
+				.replace(/^co-authored-by: .*$/gim, '')
+				// Clean up excessive newlines
+				.replace(/\n{3,}/g, '\n\n')
+				// remove trailing horizontal rule
+				.trim()
+				.replace(/-{3,}$/, '')
+				.trim()
+
+			// Only include entries that touch packages/ folder
+			const touchesPackages = Array.from(folders).some((folder) => folder.startsWith('packages/'))
+			if (touchesPackages) {
+				entries.push({
+					firstLine,
+					restOfMessage: restOfMessage || '_no content_',
+					changeType,
+					changedFolders: Array.from(folders).sort(),
+				})
+			}
+		}
+
+		// Group entries by change type
+		const groupedEntries: Record<string, typeof entries> = {
+			bugfix: [],
+			improvement: [],
+			feature: [],
+			api: [],
+			other: [],
+		}
+
+		for (const entry of entries) {
+			groupedEntries[entry.changeType].push(entry)
+		}
+
+		// Generate output.md content
+		let output = `Generated from commits between \`${startRef}\` and \`${endRef}\`\n\n`
+
+		// Output each change type section
+		const changeTypeLabels = {
+			bugfix: 'Bug Fixes',
+			improvement: 'Improvements',
+			feature: 'Features',
+			api: 'API Changes',
+			other: 'Other Changes',
+		}
+
+		for (const [changeType, label] of Object.entries(changeTypeLabels)) {
+			const entriesForType = groupedEntries[changeType]
+			if (entriesForType.length === 0) continue
+
+			output += `# ${label}\n\n`
+
+			for (const entry of entriesForType) {
+				output += `## ${entry.firstLine}\n\n`
+
+				if (entry.restOfMessage) {
+					output += `${entry.restOfMessage}\n\n`
+				}
+
+				output += `---\n\n`
+			}
+		}
+
+		// Write to changelog.md in the repo root
+		const outputPath = join(REPO_ROOT, 'changelog.md')
+		await writeStringFile(outputPath, output)
+
+		nicelog(`Draft changelog written to changelog.md (${entries.length} entries)`)
+	} catch (error) {
+		console.error('Error extracting changelog:', error)
+		process.exit(1)
+	}
+}
+
+main().catch((error) => {
+	console.error('Unhandled error:', error)
+	process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"aws-login": "aws sso login --sso-session=tldraw",
 		"clean": "internal/scripts/clean.sh",
 		"context": "tsx internal/scripts/context.ts",
+		"extract-draft-changelog": "tsx internal/scripts/extract-draft-changelog.tsx",
 		"postinstall": "husky install && yarn refresh-assets",
 		"refresh-assets": "lazy refresh-assets",
 		"refresh-context": "tsx internal/scripts/refresh-context.ts",


### PR DESCRIPTION
Adds a new script for extracting draft changelogs. This is based entirely on my personal workflow for writing changelogs, which usually involves checking each PR anyway. So this script includes almost the entire commit message, just cleaning it up a little by removing sections and commits we don't need.

### Change type

- [x] `other`
