### PR TITLE
fix(examples): resolve PdfJS worker src resolution

### DIFF
--- a/apps/examples/src/examples/pdf-editor/PdfPicker.tsx
+++ b/apps/examples/src/examples/pdf-editor/PdfPicker.tsx
@@ -1,3 +1,5 @@
+import PdfJSWorkerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
+
 import { useState } from 'react'
 import { AssetRecordType, Box, TLAssetId, TLShapeId, createShapeId } from 'tldraw'
 import tldrawPdf from './assets/tldraw.pdf'
@@ -22,10 +24,8 @@ export function PdfPicker({ onOpenPdf }: { onOpenPdf(pdf: Pdf): void }) {
 
 	async function loadPdf(name: string, source: ArrayBuffer): Promise<Pdf> {
 		const PdfJS = await import('pdfjs-dist')
-		PdfJS.GlobalWorkerOptions.workerSrc = new URL(
-			'pdfjs-dist/build/pdf.worker.min.mjs',
-			import.meta.url
-		).toString()
+		PdfJS.GlobalWorkerOptions.workerSrc = PdfJSWorkerSrc
+
 		const pdf = await PdfJS.getDocument(source.slice(0)).promise
 		const pages: PdfPage[] = []
 


### PR DESCRIPTION
I think this is a more robust way to do it. Seemed like vite was struggling with the `new URL` situation

### Change type

- [x] `bugfix` 

### Test plan

1. Open the PDF editor example and verify PDFs load correctly.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where PDF worker source resolution failed in some environments.