### PR TITLE
Fix PdfJS worker src resolution in exam marking example

### DIFF
--- a/apps/examples/src/examples/exam-marking/pdf-editor/PdfPicker.tsx
+++ b/apps/examples/src/examples/exam-marking/pdf-editor/PdfPicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { AssetRecordType, Box, TLAssetId, TLShapeId, createShapeId } from 'tldraw'
 import examPdf from '../assets/biologyExamExample.pdf'
+import PdfJSWorkerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 
 export interface PdfPage {
 	src: string
@@ -22,10 +23,7 @@ export function PdfPicker({ onOpenPdf }: { onOpenPdf(pdf: Pdf): void }) {
 
 	async function loadPdf(name: string, source: ArrayBuffer): Promise<Pdf> {
 		const PdfJS = await import('pdfjs-dist')
-		PdfJS.GlobalWorkerOptions.workerSrc = new URL(
-			'pdfjs-dist/build/pdf.worker.min.mjs',
-			import.meta.url
-		).toString()
+		PdfJS.GlobalWorkerOptions.workerSrc = PdfJSWorkerSrc
 		const pdf = await PdfJS.getDocument(source.slice(0)).promise
 		const pages: PdfPage[] = []
 


### PR DESCRIPTION
Applies the same PdfJS worker fix from PR #6773 to the exam marking example.

Switches from `new URL()` with `import.meta.url` to importing the worker source directly using Vite's `?url` suffix for better bundling compatibility.

Generated with [Claude Code](https://claude.ai/code)