### PR TITLE
feat: Add option 'preciseToExact' which overrides precise movements to exact

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -229,6 +229,7 @@ export interface ArrowShapeOptions {
     readonly minElbowHandleDistance: number;
     readonly minElbowLegLength: Record<TLDefaultSizeStyle, number>;
     readonly pointingPreciseTimeout: number;
+    readonly preciseToExact: boolean;
     readonly shouldBeExact: (editor: Editor) => boolean;
     readonly shouldIgnoreTargets: (editor: Editor) => boolean;
 }

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -117,6 +117,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		hoverPreciseTimeout: 600,
 		pointingPreciseTimeout: 320,
+		preciseToExact: false,
 
 		shouldBeExact: (editor: Editor) => editor.inputs.altKey,
 		shouldIgnoreTargets: (editor: Editor) => editor.inputs.ctrlKey,

--- a/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
@@ -92,6 +92,12 @@ export interface ArrowShapeOptions {
 	 */
 	// eslint-disable-next-line @typescript-eslint/method-signature-style
 	readonly shouldBeExact: (editor: Editor) => boolean
+
+	/**
+	 * Override to use exact instead of precise in arrow target state
+	 */
+	readonly preciseToExact: boolean
+
 	/**
 	 * When creating an arrow, should it bind to the target shape.
 	 */

--- a/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
@@ -87,7 +87,7 @@ export function updateArrowTargetState({
 		return null
 	}
 
-	const isExact = util.options.shouldBeExact(editor)
+	const isExact = util.options.shouldBeExact(editor) || (isPrecise && util.options.preciseToExact)
 
 	const arrowKind = arrow ? arrow.props.kind : editor.getStyleForNextShape(ArrowShapeKindStyle)
 


### PR DESCRIPTION
- Suggestion implementation of https://github.com/tldraw/tldraw/issues/6764

> When using the arrow tool, you can hover above the target for short while to trigger isPrecise behaviour. This get you into a state where you can precisely place your endpoints...

> ...It would be great to have an option to configure ArrowShapeUtil e.g where the timeout's already in place could make the arrow endpoints use isExact snapping instead of isPrecise.

This PR introduces a boolean option `preciseToExact` that makes the arrows have exact behaviour instead of precise after the hover-timeout:

https://github.com/user-attachments/assets/c84a5eb8-0445-4ba9-96cc-84d23aaf84e5

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. Configure the arrow util: `ArrowShapeUtil.configure({ preciseToExact: true })`
2. Create any shape
3. Create an arrow targeting the shape, observe that the arrow uses exact instead of precise arrows on hover
4. Create an arrow originating from the shape, observe that when hovering, the origin uses exact arrows instead of precise arrows

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Support configuring if arrows should be exact on hover instead of precise

### API changes
- Added option `preciseToExact` in ArrowShapeUtil