### PR TITLE
docs: address feedback and rearrange sidebar

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -73,10 +73,10 @@ export default async function Page(props: { params: Promise<{ slug: string | str
 				<main className="relative w-full px-5 pt-12 shrink md:pt-0 min-w-[1px]">
 					<DocsHeader article={content.article} />
 					<Content mdx={content.article.content ?? ''} type={content.article.sectionId} />
-					<div className="mx-auto w-full max-w-sm">
-						<DocsFeedbackWidget className="mb-12" />
-					</div>
 					<DocsFooter article={content.article} />
+					<div className="mx-auto w-full max-w-sm mt-8 mb-16">
+						<DocsFeedbackWidget />
+					</div>
 				</main>
 			) : (
 				<>

--- a/apps/docs/components/docs/docs-category-menu.tsx
+++ b/apps/docs/components/docs/docs-category-menu.tsx
@@ -14,12 +14,6 @@ const categoryLinks = [
 			['/quick-start', '/installation', '/releases'].some((e) => pathname.startsWith(e)),
 	},
 	{
-		caption: 'Starter Kits',
-		icon: CubeIcon,
-		href: '/starter-kits/overview',
-		active: (pathname: string) => ['/starter-kits'].some((e) => pathname.startsWith(e)),
-	},
-	{
 		caption: 'Guides',
 		icon: AcademicCapIcon,
 		href: '/docs/editor',
@@ -36,6 +30,12 @@ const categoryLinks = [
 		icon: PlayIcon,
 		href: '/examples',
 		active: (pathname: string) => pathname.startsWith('/examples'),
+	},
+	{
+		caption: 'Starter Kits',
+		icon: CubeIcon,
+		href: '/starter-kits/overview',
+		active: (pathname: string) => ['/starter-kits'].some((e) => pathname.startsWith(e)),
 	},
 ]
 

--- a/apps/docs/content/sections.json
+++ b/apps/docs/content/sections.json
@@ -7,13 +7,6 @@
 		"sidebar_behavior": "show-links"
 	},
 	{
-		"id": "starter-kits",
-		"title": "Starter Kits",
-		"description": "Ready-to-use templates to jumpstart your tldraw projects.",
-		"categories": [],
-		"sidebar_behavior": "show-links"
-	},
-	{
 		"id": "releases",
 		"title": "Releases",
 		"description": "Introduction articles for tldraw.",
@@ -74,6 +67,13 @@
 		"id": "docs",
 		"title": "Learn tldraw",
 		"description": "Learn to use the tldraw SDK.",
+		"categories": [],
+		"sidebar_behavior": "show-links"
+	},
+	{
+		"id": "starter-kits",
+		"title": "Starter Kits",
+		"description": "Ready-to-use templates to jumpstart your tldraw projects.",
 		"categories": [],
 		"sidebar_behavior": "show-links"
 	},


### PR DESCRIPTION
This PR addresses documentation feedback by adding spacing before the feedback form and rearranging the sidebar.

### Change type

- [x] `other`

### Test plan

1. Navigate to the documentation site
2. Verify spacing before the feedback form
3. Verify the new sidebar order

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved documentation layout and sidebar organization