### PR TITLE
style panel: fix certain labels on mobile

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1039,6 +1039,10 @@ tldraw? probably.
 	display: none;
 }
 
+.tlui-style-panel[data-ismobile='true'] .tlui-style-panel__section .tlui-row.tlui-toolbar {
+	flex-wrap: wrap;
+}
+
 .tlui-style-panel__section__common:not(:only-child) {
 	margin-bottom: 7px;
 	border-bottom: 1px solid var(--tl-color-divider);


### PR DESCRIPTION
before:
<img width="320" height="256" alt="Screenshot 2025-09-17 at 23 27 51" src="https://github.com/user-attachments/assets/2ee23f4a-b79b-43f4-8bae-af1eb3f1f7c6" />

after:
<img width="392" height="316" alt="Screenshot 2025-09-17 at 23 28 06" src="https://github.com/user-attachments/assets/01fa3fac-4031-4d74-b736-6fc49cbaefbe" />


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- style panel: fix certain labels on mobile