### PR TITLE
fix(ui): wrap style panel labels for long translations

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1039,6 +1039,11 @@ tldraw? probably.
 	display: none;
 }
 
+/*
+ * This is used in a couple places, like Align and Vertical Align.
+ * It's because we have a toolbar with a Toggle Group but then an adjacent button
+ * next to it that opens a popup.
+ */
 .tlui-style-panel__section .tlui-toolbar:has(.tlui-toolbar) {
 	flex-wrap: wrap;
 }


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/6783
we just need to have this wrap in general, it barely works in English as it is, let alone other languages.

before:
<img width="348" height="246" alt="Screenshot 2025-09-18 at 10 35 35" src="https://github.com/user-attachments/assets/1e166e6c-2292-4927-8487-e5884091f841" />

after:
<img width="322" height="228" alt="Screenshot 2025-09-18 at 10 41 47" src="https://github.com/user-attachments/assets/a8a240a2-63a9-459d-8156-7895337b253d" />

also, drive-by fix for buttons losing their margin when the tooltip is hovered
<img width="348" height="112" alt="Screenshot 2025-09-18 at 10 41 52" src="https://github.com/user-attachments/assets/28357c46-1725-400a-a3b8-ae711bac1a0c" />

### Change type

- [x] `bugfix`

### Test plan

1. Open the style panel.
2. Verify that labels wrap correctly (especially in non-English languages).
3. Verify that buttons maintain their margin when tooltips are hovered.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where style panel labels would not wrap for long translations.