### PR TITLE
make z-index of camera options smaller to allow for user preferences to toggle above it

### DIFF
--- a/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
+++ b/apps/examples/src/examples/camera-options/CameraOptionsExample.tsx
@@ -186,7 +186,7 @@ const CameraOptionsControlPanel = track(() => {
 				left: 0,
 				padding: 4,
 				background: 'white',
-				zIndex: 1000000,
+				zIndex: 100,
 			}}
 		>
 			<div


### PR DESCRIPTION
Allow the user preferences to toggle above the camera options panel in the Camera Options example.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
