### PR TITLE
docs: fix analytics switch styling

### DIFF
--- a/apps/analytics/src/styles.css
+++ b/apps/analytics/src/styles.css
@@ -190,6 +190,8 @@
 	border-radius: 9999px;
 	position: relative;
 	cursor: pointer;
+	border: 0;
+	padding: 0;
 }
 
 .tl-analytics-checkbox[data-state='checked'] {


### PR DESCRIPTION
Fixes the styling for the analytics switch on the new documentation site.

### Change type

- [x] `other`

### Test plan

1. Verify the analytics switch styling in the docs site matches the design.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed analytics switch styling on the documentation site.