### PR TITLE
Only deploy dotcom previews with a label?

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -2,6 +2,7 @@ name: Deploy .com
 
 on:
   pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
   push:
     branches:
       - main
@@ -27,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest-16-cores-open
     environment: ${{ github.ref == 'refs/heads/production' && 'deploy-production' || 'deploy-staging' }}
     concurrency: dotcom-${{ github.ref == 'refs/heads/production' && 'deploy-production' || github.ref }}
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dotcom-preview-please'))
 
     steps:
       # - name: Notify initial start


### PR DESCRIPTION
How do people feel about not having dotcom preview deploys unless you explicitly opt in? It feels like they're only needed on <5% of PRs right now. If this becomes annoying we can always revert, or maybe set up a thing where it checks whether files inside dotcom or dotcom-shared have been edited? 

This might lead to situations where PRs get merged that break dotcom deployment to staging, but we get discord messages about that and it's not too hard to debug. Also I can't remember the dotcom deployment ever breaking for reasons other than Vercel/cloudflare api flake.

### Change type

- [x] `other`
