### PR TITLE
Consolidate preferences menu groups

### DIFF
--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
@@ -165,13 +165,9 @@ export function PreferencesGroup() {
 					<TogglePasteAtCursorItem />
 					<ToggleDebugModeItem />
 				</TldrawUiMenuGroup>
-				<TldrawUiMenuGroup id="input-mode">
+				<TldrawUiMenuGroup id="user-interface-submenus">
 					<InputModeMenu />
-				</TldrawUiMenuGroup>
-				<TldrawUiMenuGroup id="color-scheme">
 					<ColorSchemeMenu />
-				</TldrawUiMenuGroup>
-				<TldrawUiMenuGroup id="accessibility-menu">
 					<AccessibilityMenu />
 				</TldrawUiMenuGroup>
 			</TldrawUiMenuSubmenu>


### PR DESCRIPTION
## Summary
- Combines three separate menu groups (input-mode, color-scheme, accessibility-menu) into a single user-interface-submenus group in the preferences menu
- Reduces visual separation and creates a cleaner, more cohesive menu structure

## Test plan
- [ ] Verify preferences menu still displays all three submenus (Input Mode, Color Scheme, Accessibility)  
- [ ] Confirm menus function correctly without visual separation lines between them
- [ ] Test menu accessibility and navigation flow

- [x] Internal

🤖 Generated with [Claude Code](https://claude.ai/code)