### PR TITLE
chore(ci): delete previous Claude reviews in workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Please review this pull request and provide feedback on:
+            FIRST: Delete any previous Claude Code reviews on this PR by running:
+            `gh pr view --json comments --jq '.comments[] | select(.body | contains("🤖 Claude Code Review")) | .id' | xargs -I {} gh api --method DELETE repos/:owner/:repo/issues/comments/{} 2>/dev/null || true`
+
+            THEN: Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
@@ -48,7 +51,7 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-            For any earlier pull request reviews by you, place all of the contents of the review into a toggle list so that it does not crowd the comments.
+            IMPORTANT: Start your review comment with "🤖 Claude Code Review" so it can be identified and deleted in future runs.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options


### PR DESCRIPTION
## Summary

This PR improves the Claude Code Review GitHub Actions workflow to automatically clean up previous Claude reviews before posting new ones, preventing comment clutter on pull requests.

## Changes

- Modified `.github/workflows/claude-code-review.yml` to include a cleanup step that deletes previous Claude reviews
- Added a unique identifier "🤖 Claude Code Review" that Claude must use to start its review comments
- The cleanup command specifically targets only comments containing this identifier, ensuring other bot comments and human comments are preserved
- Added error handling (`2>/dev/null || true`) to gracefully handle cases where no previous reviews exist

### Change type

- [x] `other`

### Test plan

1. Create a test PR and verify Claude posts a review with the identifier
2. Trigger the workflow again on the same PR and verify the previous review is deleted
3. Verify that other comments (human, other bots) are not affected

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved CI workflow to clean up previous AI code reviews