### PR TITLE
Remove starter kits from sidebar list

### DIFF
--- a/apps/docs/components/docs/docs-sidebar.tsx
+++ b/apps/docs/components/docs/docs-sidebar.tsx
@@ -13,7 +13,7 @@ export async function DocsSidebar({
 	articleId?: string
 }) {
 	const sidebar = await db.getSidebarContentList({ sectionId, categoryId, articleId })
-	const skipFirstLevel = ['reference', 'examples'].includes(sectionId ?? '')
+	const skipFirstLevel = ['reference', 'examples', 'starter-kits'].includes(sectionId ?? '')
 	// @ts-ignore
 	const elements = skipFirstLevel ? sidebar.links[0].children : sidebar.links
 

--- a/apps/docs/content/sections.json
+++ b/apps/docs/content/sections.json
@@ -72,7 +72,7 @@
 	},
 	{
 		"id": "starter-kits",
-		"title": "Starter Kits",
+		"title": "Starter kits",
 		"description": "Ready-to-use templates to jumpstart your tldraw projects.",
 		"categories": [],
 		"sidebar_behavior": "show-links"


### PR DESCRIPTION
## Summary
• Updated docs sidebar to skip first level for starter-kits section
• Fixed capitalization of "Starter kits" in sections.json

## Test plan
- [ ] Verify starter kits section displays correctly in docs
- [ ] Check that sidebar navigation works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)