### PR TITLE
bring back focus mode

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1345,6 +1345,28 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				},
 			},
 			{
+				id: 'toggle-focus-mode',
+				label: {
+					default: 'action.toggle-focus-mode',
+					menu: 'action.toggle-focus-mode.menu',
+				},
+				readonlyOk: true,
+				kbd: 'cmd+.,ctrl+.',
+				checkbox: true,
+				onSelect(source) {
+					// this needs to be deferred because it causes the menu
+					// UI to unmount which puts us in a dodgy state
+					editor.timers.requestAnimationFrame(() => {
+						editor.run(() => {
+							trackEvent('toggle-focus-mode', { source })
+							helpers.clearDialogs()
+							helpers.clearToasts()
+							editor.updateInstanceState({ isFocusMode: !editor.getInstanceState().isFocusMode })
+						})
+					})
+				},
+			},
+			{
 				id: 'toggle-grid',
 				label: {
 					default: 'action.toggle-grid',


### PR DESCRIPTION
The focus mode action was accidentally deleted in https://github.com/tldraw/tldraw/pull/6755 This PR brings it back

### Change type

- [x] `bugfix`

### Release notes

- Reinstate the focus mode action which was deleted by accident.