### PR TITLE
Add non breaking space between parentheses to function names in docs

### DIFF
--- a/apps/docs/scripts/lib/getApiMarkdown.ts
+++ b/apps/docs/scripts/lib/getApiMarkdown.ts
@@ -305,7 +305,7 @@ function getItemTitle(item: ApiItem) {
 
 	const name = item.displayName
 	if (item.kind === ApiItemKind.Method || item.kind === ApiItemKind.Function) {
-		return `${name}()`
+		return `${name}(\u00A0)`
 	}
 
 	return name


### PR DESCRIPTION
Add non breaking space between parentheses to function names in docs

### Before
<img width="710" height="368" alt="image" src="https://github.com/user-attachments/assets/5f2879f6-f6da-404c-b4f2-4e09d47f92ab" />

### After
<img width="445" height="478" alt="image" src="https://github.com/user-attachments/assets/030fbda6-3822-40ae-b59a-ab9b300734c6" />

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`