### PR TITLE
fix: prevent opening a new window for empty href

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -109,7 +109,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			// We don't get the mouseup event later because we preventDefault
 			// so we have to do it manually.
 			const handlePointerUp = (e: TLEventInfo) => {
-				if (e.name !== 'pointer_up') return
+				if (e.name !== 'pointer_up' || !link) return
 
 				if (!isDragging.current) {
 					window.open(link, '_blank', 'noopener, noreferrer')


### PR DESCRIPTION
On clicking a `Link` in rich text `Shape` without href, It will not open a empty window. In my case, I had to remove href from the `a` tag, and provided a visual way to click on the link after its clearly visible. The default  a tag tooltip is not clear.

### Change type

- [x] `bugfix`

### Test plan

1. Create a Text shape
2. Configure LINK Extension to not to have an href

```
      Link.extend({
        inclusive: false,
        renderHTML({ HTMLAttributes }) {
          const href = HTMLAttributes.href ?? ""
          delete HTMLAttributes.href
          return [
            "a",
            {
              ...HTMLAttributes,
              class: "tiptap-link-with-tooltip",
              "data-tooltip": href,
              style: "pointer-events: auto; cursor: text;",
            },
            0,
          ]
        },
      }).configure({
        openOnClick: false,
        autolink: true,
        defaultProtocol: "https",
      }),
```

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix a bug that allow opening a empty window on `a` tag click