### PR TITLE
improvement(tldraw): allow embeds to opt-out of paste-to-embed behavior

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -619,6 +619,7 @@ export function DebugFlags(): JSX_2.Element | null;
 // @public (undocumented)
 export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly doesResize: true;
+    readonly embedOnPaste: false;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["beta.tldraw.com", "tldraw.com", "localhost:3000"];
@@ -627,13 +628,13 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly overridePermissions: {
         readonly 'allow-top-navigation': true;
     };
-    readonly skipOnPaste: true;
     readonly title: "tldraw";
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly type: "tldraw";
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["figma.com"];
@@ -643,6 +644,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["google.*"];
@@ -655,6 +657,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["val.town"];
@@ -666,6 +669,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["codesandbox.io"];
@@ -677,6 +681,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 400;
     readonly hostnames: readonly ["codepen.io"];
@@ -688,6 +693,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 520;
 }, {
     readonly doesResize: false;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 400;
     readonly hostnames: readonly ["scratch.mit.edu"];
@@ -697,6 +703,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 520;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 450;
     readonly hostnames: readonly ["*.youtube.com", "youtube.com", "youtu.be"];
@@ -711,6 +718,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 800;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["calendar.google.*"];
@@ -726,6 +734,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["docs.google.*"];
@@ -740,6 +749,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["gist.github.com"];
@@ -749,6 +759,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["replit.com"];
@@ -758,6 +769,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["felt.com"];
@@ -767,6 +779,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["open.spotify.com"];
@@ -778,6 +791,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 360;
     readonly hostnames: readonly ["vimeo.com", "player.vimeo.com"];
@@ -788,6 +802,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 640;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["excalidraw.com"];
@@ -799,6 +814,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
 }, {
     readonly backgroundColor: "#fff";
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 500;
     readonly hostnames: readonly ["observablehq.com"];
@@ -809,6 +825,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly width: 720;
 }, {
     readonly doesResize: true;
+    readonly embedOnPaste: true;
     readonly fromEmbedUrl: (url: string) => string | undefined;
     readonly height: 450;
     readonly hostnames: readonly ["desmos.com"];
@@ -1308,6 +1325,8 @@ export interface EmbedDefinition {
     // (undocumented)
     readonly doesResize: boolean;
     // (undocumented)
+    readonly embedOnPaste?: boolean;
+    // (undocumented)
     readonly fromEmbedUrl: (url: string) => string | undefined;
     // (undocumented)
     readonly height: number;
@@ -1325,8 +1344,6 @@ export interface EmbedDefinition {
     readonly overrideOutlineRadius?: number;
     // (undocumented)
     readonly overridePermissions?: TLEmbedShapePermissions;
-    // (undocumented)
-    readonly skipOnPaste?: boolean;
     // (undocumented)
     readonly title: string;
     // (undocumented)

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -35,7 +35,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
-		skipOnPaste: true,
+		embedOnPaste: false,
 	},
 	{
 		type: 'figma',
@@ -66,6 +66,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
+		embedOnPaste: true,
 	},
 	{
 		type: 'google_maps',
@@ -117,6 +118,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
+		embedOnPaste: true,
 	},
 	{
 		type: 'val_town',
@@ -145,6 +147,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
+		embedOnPaste: true,
 	},
 	{
 		type: 'codesandbox',
@@ -171,6 +174,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
+		embedOnPaste: true,
 	},
 	{
 		type: 'codepen',
@@ -199,6 +203,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			}
 			return
 		},
+		embedOnPaste: true,
 	},
 	{
 		type: 'scratch',
@@ -207,6 +212,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 520,
 		height: 400,
 		doesResize: false,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const SCRATCH_URL_REGEXP = /https?:\/\/scratch.mit.edu\/projects\/([^/]+)/
 			const matches = url.match(SCRATCH_URL_REGEXP)
@@ -238,6 +244,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			'allow-popups-to-escape-sandbox': true,
 		},
 		isAspectRatioLocked: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (!urlObj) return
@@ -304,6 +311,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		overridePermissions: {
 			'allow-popups-to-escape-sandbox': true,
 		},
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			const cidQs = urlObj?.searchParams.get('cid')
@@ -348,6 +356,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		overridePermissions: {
 			'allow-popups-to-escape-sandbox': true,
 		},
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 
@@ -382,6 +391,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		embedOnPaste: true,
 		// Security warning:
 		// Gists allow adding .json extensions to the URL which return JSONP.
 		// Furthermore, the JSONP can include callbacks that execute arbitrary JavaScript.
@@ -414,6 +424,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/\/@([^/]+)\/([^/]+)/)) {
@@ -441,6 +452,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 720,
 		height: 500,
 		doesResize: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/^\/map\//)) {
@@ -466,6 +478,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		minHeight: 500,
 		overrideOutlineRadius: 12,
 		doesResize: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/^\/(artist|album)\//)) {
@@ -489,6 +502,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		height: 360,
 		doesResize: true,
 		isAspectRatioLocked: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.hostname === 'vimeo.com') {
@@ -519,6 +533,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		height: 500,
 		doesResize: true,
 		isAspectRatioLocked: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.hash.match(/#room=/)) {
@@ -543,6 +558,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		doesResize: true,
 		isAspectRatioLocked: false,
 		backgroundColor: '#fff',
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/^\/@([^/]+)\/([^/]+)\/?$/)) {
@@ -574,6 +590,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		width: 700,
 		height: 450,
 		doesResize: true,
+		embedOnPaste: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (
@@ -674,7 +691,7 @@ export interface EmbedDefinition {
 	readonly overridePermissions?: TLEmbedShapePermissions
 	readonly instructionLink?: string
 	readonly backgroundColor?: string
-	readonly skipOnPaste?: boolean
+	readonly embedOnPaste?: boolean
 	// TODO: FIXME this is ugly be required because some embeds have their own border radius for example spotify embeds
 	readonly overrideOutlineRadius?: number
 	// eslint-disable-next-line @typescript-eslint/method-signature-style

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -557,7 +557,7 @@ export async function defaultHandleExternalUrlContent(
 	const embedUtil = editor.getShapeUtil('embed') as EmbedShapeUtil | undefined
 	const embedInfo = embedUtil?.getEmbedDefinition(url)
 
-	if (embedInfo && !embedInfo.definition.skipOnPaste) {
+	if (embedInfo && embedInfo.definition.embedOnPaste) {
 		return editor.putExternalContent({
 			type: 'embed',
 			url: embedInfo.url,


### PR DESCRIPTION
We should make the default for pasted tldraw links bookmarks instead of an embedded iframe. This change adds a parameter to `EmbedDefinition` called `skipOnPaste` in which we can control this behaviour. 

### Change type

- [x] `improvement`

### Test plan

1. Copy a tldraw URL.
2. Paste it into the editor.
3. Verify it creates a bookmark instead of an embed.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Tldraw links default to pasting as bookmarks rather than embeds