### PR TITLE
fix: use correct translation key for too many files

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -382,7 +382,7 @@ export async function defaultHandleExternalFileContent(
 ) {
 	const { acceptedImageMimeTypes = DEFAULT_SUPPORTED_IMAGE_TYPES, toasts, msg } = options
 	if (files.length > editor.options.maxFilesAtOnce) {
-		toasts.addToast({ title: msg('assets.files.amount-too-big'), severity: 'error' })
+		toasts.addToast({ title: msg('assets.files.amount-too-many'), severity: 'error' })
 		return
 	}
 


### PR DESCRIPTION
Looks like we were using the incorrect label. Not sure why our type system didn't catch this?

### Change type

- [x] `bugfix` 

### Test plan

1. Attempt to upload more than the allowed number of files.
2. Verify the error message displays correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a translation error when uploading too many files.