### PR TITLE
fix: wheel and pinch canvas events

### DIFF
--- a/apps/examples/src/examples/canvas-events/CanvasEventsExample.tsx
+++ b/apps/examples/src/examples/canvas-events/CanvasEventsExample.tsx
@@ -3,54 +3,55 @@ import { TLEventInfo, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file!
+type TimedEvent = TLEventInfo & { lastUpdated: number }
 
 export default function CanvasEventsExample() {
-	const [events, setEvents] = useState<any[]>([])
+	const [events, setEvents] = useState<Record<string, TimedEvent>>({})
 
 	const handleEvent = useCallback((data: TLEventInfo) => {
-		setEvents((events) => {
-			const newEvents = events.slice(0, 100)
-			if (
-				newEvents[newEvents.length - 1] &&
-				newEvents[newEvents.length - 1].type === 'pointer' &&
-				data.type === 'pointer' &&
-				data.target === 'canvas'
-			) {
-				newEvents[newEvents.length - 1] = data
-			} else {
-				newEvents.unshift(data)
-			}
-			return newEvents
-		})
+		// Update the event entry for this event type with new data
+		// This replaces previous event data of this type completely, keeping one per type
+		setEvents((prevEvents) => ({
+			...prevEvents,
+			[data.type]: {
+			...data,
+			lastUpdated: Date.now(),
+			},
+		}))
 	}, [])
+
+	// Convert events to array and sort by lastUpdated descending (most recent first)
+	const eventsArray = Object.values(events).sort(
+		(a, b) => a.lastUpdated - b.lastUpdated
+	)
 
 	return (
 		<div style={{ display: 'flex' }}>
 			<div style={{ width: '50%', height: '100vh' }}>
 				<Tldraw
-					onMount={(editor) => {
-						editor.on('event', (event) => handleEvent(event))
-					}}
+				onMount={(editor) => {
+					editor.on('event', (event) => handleEvent(event))
+				}}
 				/>
 			</div>
 			<div
 				style={{
-					width: '50%',
-					height: '100vh',
-					padding: 8,
-					background: '#eee',
-					border: 'none',
-					fontFamily: 'monospace',
-					fontSize: 12,
-					borderLeft: 'solid 2px #333',
-					display: 'flex',
-					flexDirection: 'column-reverse',
-					overflow: 'auto',
-					whiteSpace: 'pre-wrap',
+				width: '50%',
+				height: '100vh',
+				padding: 8,
+				background: '#eee',
+				border: 'none',
+				fontFamily: 'monospace',
+				fontSize: 12,
+				borderLeft: 'solid 2px #333',
+				display: 'flex',
+				flexDirection: 'column-reverse',
+				overflow: 'auto',
+				whiteSpace: 'pre-wrap',
 				}}
 				onCopy={(event) => event.stopPropagation()}
 			>
-				<div>{JSON.stringify(events, undefined, 2)}</div>
+				<pre>{JSON.stringify(eventsArray, undefined, 2)}</pre>
 			</div>
 		</div>
 	)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10265,7 +10265,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.interrupt()
 						}
 
-						return // Stop here!
+						break // Stop here!
 					}
 					case 'pinch': {
 						if (!inputs.isPinching) return
@@ -10299,7 +10299,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							{ immediate: true }
 						)
 
-						return // Stop here!
+						break // Stop here!
 					}
 					case 'pinch_end': {
 						if (!inputs.isPinching) return this
@@ -10325,9 +10325,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 							}
 						}
 
-						return // Stop here!
+						break // Stop here!
 					}
 				}
+				break
 			}
 			case 'wheel': {
 				if (cameraOptions.isLocked) return
@@ -10380,7 +10381,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								immediate: true,
 							})
 							this.maybeTrackPerformance('Zooming')
-							return
+							break
 						}
 						case 'pan': {
 							// Pan the camera based on the wheel delta
@@ -10388,7 +10389,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								immediate: true,
 							})
 							this.maybeTrackPerformance('Panning')
-							return
+							break
 						}
 					}
 				}
@@ -10661,7 +10662,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// Send the event to the statechart. It will be handled by all
 		// active states, starting at the root.
-		this.root.handleEvent(info)
+		if (info.type !== 'pinch') {
+			this.root.handleEvent(info)
+		}
 		this.emit('event', info)
 
 		// close open menus at the very end on pointer down! after everything else! συντελείας τοῦ κώδικα!!


### PR DESCRIPTION
### Change type

- [x] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open canvas-events page.
2. Scroll up and down -> see scroll events in the info panel
3. Pinch -> see pinch events in the info panel

### Release notes

1. Addresses https://github.com/tldraw/tldraw/issues/5439. Unlike reported click events already work (double click to test).
Returns instead of break in switch statements prevented the emitting of these events.

2. Improves the "Canvas events" example page by only showing the last event of each event-type. Previously this was done just for pointer events.