### PR TITLE
fix(ui): prevent context menu submenu flickering on hover

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -609,35 +609,31 @@
 
 /* Submenu triggers */
 
+.tlui-menu__submenu__trigger {
+	--gradient-angle: 90deg;
+}
+
+.tlui-menu__submenu__trigger[data-direction='left'] {
+	--gradient-angle: 270deg;
+}
+
 .tlui-menu__submenu__trigger[data-state='open']::after {
 	opacity: 1;
-	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
+	background: linear-gradient(
+		var(--gradient-angle),
+		rgba(144, 144, 144, 0) 0%,
+		var(--tl-color-muted-2) 100%
+	);
 }
 
-.tlui-menu__submenu__trigger[data-direction='left'][data-state='open']::after {
-	opacity: 1;
-	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-}
-
-@media (hover: hover) {	
-	.tlui-menu__submenu__trigger:hover::after {
+@media (hover: hover) {
+	.tlui-menu__submenu__trigger:is(:hover, [data-state='open'])::after {
 		opacity: 1;
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-	
-	.tlui-menu__submenu__trigger[data-direction='left']:hover::after {
-		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-
-	.tlui-menu__submenu__trigger[data-state='open']:not(:hover)::after {
-		opacity: 1;
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-
-	.tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
-		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
+		background: linear-gradient(
+			var(--gradient-angle),
+			rgba(144, 144, 144, 0) 0%,
+			var(--tl-color-muted-2) 100%
+		);
 	}
 }
 


### PR DESCRIPTION
Context menu items with submenus would previously flicker because they would only set their gradient style once the submenu was open and set the data-state of the menu to 'open'. We can stop the flickering by applying the style on hover.

To simplify the CSS and eliminate duplication, this PR consolidates the submenu trigger gradient styling using CSS custom properties and `:is()` selector.

**Changes:**
- Introduced `--gradient-angle` CSS variable to avoid repeating gradient angles across rules
- Used `:is(:hover, [data-state='open'])` to combine hover and open states
- Reduced from 4 separate rules to 2 cleaner rules while maintaining identical functionality

### Change type

- [x] `bugfix` 

### Preview

## Before
https://github.com/user-attachments/assets/8a7a96cd-dea3-4caa-aab7-b81f67298d21

## Now
https://github.com/user-attachments/assets/b656bbef-5064-43cb-b3b0-58c5b54734fe

### Test plan

1. Open the context menu.
2. Hover over items with a submenu

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes flickering when hovering over context-menu item with submenu - resolves https://github.com/tldraw/tldraw/issues/6609#issuecomment-3209797721


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates flicker on context-menu submenu items by adjusting CSS to show the gradient during hover and open states.
> 
> - Refactors `packages/tldraw/src/lib/ui.css` submenu trigger styles to use `--gradient-angle` and `linear-gradient(var(--gradient-angle), ...)` for both directions
> - Applies gradient via `.tlui-menu__submenu__trigger:is(:hover, [data-state='open'])::after` to render before open, preventing flicker
> - Simplifies left alignment with `[data-direction='left']` setting `--gradient-angle: 270deg` (default 90deg)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb9840c40a4207f162a69c8405879d80f175b10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->