### PR TITLE
Eslint improvements

### DIFF
--- a/.eslintplugin.js
+++ b/.eslintplugin.js
@@ -1,2 +1,0 @@
-require('ts-node/register')
-module.exports = require('./internal/scripts/lib/eslint-plugin.ts')

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/.prettierignore
+++ b/.prettierignore
@@ -36,3 +36,5 @@ apps/dotcom/client/public/**/*.*
 apps/dotcom/zero-cache/docker/docker-compose.yml
 
 lerna.json
+
+internal/scripts/eslint/eslint-plugin.mjs

--- a/MARKETING_STYLE_GUIDE.md
+++ b/MARKETING_STYLE_GUIDE.md
@@ -5,11 +5,13 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Target Audience & Product Focus
 
 ### Primary Audience: Technical Decision Makers
+
 - **Senior Frontend/Fullstack Developers** evaluating tools for canvas applications
 - **Technical Leads** assessing SDK capabilities and extensibility
 - **Product Managers** understanding what's possible to build
 
 ### Product Positioning
+
 - Marketing the SDK, not the dotcom - Focus on what developers get to build with, not end-user design tool features
 - TypeScript/React SDK for building canvas applications, providing "undifferentiated heavy-lifting"
 - Technical product with friendly but professional tone - Accessible to developers but not overly technical
@@ -18,12 +20,14 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Language & Word Choice
 
 ### Voice and Tone
+
 - **Confident but not arrogant** - Know your stuff, don't oversell
 - **Helpful but not condescending** - Respect developer expertise
 - **Direct and practical** - Focus on what developers can accomplish
 - **Professional but approachable** - Like a knowledgeable colleague, not a salesperson
 
 ### Words to Avoid/Use Sparingly
+
 - Avoid overused words: "seamless," "sophisticated"
 - Use sparingly (max once per article): "harness", "accelerate", "unleash", "enables," "allows," "ensures", "enhances", "robust", "powerful"
 - Instead of "enables" → use "supports," "provides," "includes"
@@ -32,12 +36,14 @@ The overall goal is confident, clear technical marketing that shows both immedia
 - Instead of "powerful" → use "flexible," "capable," "full-featured"
 
 ### Technical Jargon Guidelines
+
 - **Define on first use** for canvas/graphics terms (viewport, geometry, binding, etc.)
 - **Assume familiarity** with React/TypeScript concepts (hooks, props, components)
 - **Briefly explain** tldraw-specific concepts: "binding system (automatic relationship management)"
 - **Use parenthetical definitions**: "shape utilities (the classes that define shape behavior)"
 
 ### Writing Mechanics
+
 - Avoid complex clauses, especially "while" clauses
 - Prefer active, direct language over passive constructions
 - Always keep tldraw lowercase (avoid at sentence beginnings)
@@ -58,20 +64,24 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Content Strategy & Value Props
 
 ### Dual Value Proposition Framework
+
 1. **Out-of-the-box excellence**: "Look at this precision-engineered UX your users get immediately"
 2. **Extensibility foundation**: "Built on the same APIs you can use to create custom solutions"
 
 ### Content Categorization
+
 - **"Out of the box whiteboard"**: Ready-to-use features that work immediately (embeds, arrows, tools)
 - **"Composable primitives"**: Foundational systems developers can extend (geometry, snapping, bindings)
 
 ### Developer-Focused Benefits
+
 - Lead with **what developers can build**, not just what the SDK does
 - Address **common canvas application challenges** (performance, collaboration, precision)
 - Show **time-to-value**: "Get X working in minutes, customize Y when needed"
 - Use **concrete examples**: "Build a flowchart editor," "Create a design tool," "Add annotations"
 
 ### Competitive Positioning (Subtle)
+
 - Focus on **unique capabilities** rather than direct comparisons
 - Emphasize **depth of implementation** without claiming superiority
 - Let **technical details** demonstrate quality rather than adjectives
@@ -79,12 +89,14 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Technical Accuracy
 
 ### Verification Process
+
 1. **Search codebase** for claimed features using relevant keywords
 2. **Check API exports** - verify methods/classes mentioned are actually exported
 3. **Review examples** - ensure described use cases have working implementations
 4. **Test extensibility claims** - confirm developers can actually build described customizations
 
 ### Accuracy Standards
+
 - **No aspirational features** - Only describe what actually exists and works today
 - **Verify specific numbers** - "Nine arrowhead types" must be exactly nine, not "about nine"
 - **Check API availability** - Don't mention internal-only functionality
@@ -101,18 +113,21 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Common Pitfalls to Avoid
 
 ### Technical Marketing Mistakes
+
 - **Over-promising capabilities** - Don't describe ideal future state as current reality
 - **Generic benefit language** - Avoid "increase productivity" without specific context
 - **Feature laundry lists** - Focus on outcomes, not just capabilities
 - **Internal jargon** - Don't use tldraw team terminology unfamiliar to developers
 
 ### SDK-Specific Pitfalls
+
 - **Confusing SDK with product** - Don't describe end-user experiences as developer benefits
 - **Underestimating integration complexity** - Be realistic about implementation effort
 - **Ignoring developer context** - Remember readers are evaluating tools, not learning to use them
 - **Missing the "why"** - Always connect features to developer problems they solve
 
 ### Language and Style Errors
+
 - **Passive voice overuse** - "Can be extended" vs "You can extend"
 - **Vague quantifiers** - "Many options" vs "Nine arrowhead types"
 - **Buzzword inflation** - "Revolutionary" vs specific technical advantages
@@ -121,6 +136,7 @@ The overall goal is confident, clear technical marketing that shows both immedia
 ## Quality Gates Checklist
 
 ### Before Submitting Content
+
 - [ ] **Audience check**: Would a senior React developer find this useful and credible?
 - [ ] **Fact verification**: Have all technical claims been checked against the codebase?
 - [ ] **Voice consistency**: Does this sound like a knowledgeable colleague, not a salesperson?

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import localRules from './.eslintplugin.js'
+import localRules from './internal/scripts/eslint/eslint-plugin.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -58,6 +58,7 @@ export default [
 			'apps/docs/postcss.config.js',
 			'apps/docs/tailwind.config.js',
 			'apps/dotcom/client/public/sw.js',
+			'apps/analytics/public/*',
 			'**/.clasp.json',
 			'**/*.mjs',
 			'**/.*.js',

--- a/internal/scripts/eslint/eslint-plugin.mjs
+++ b/internal/scripts/eslint/eslint-plugin.mjs
@@ -1,0 +1,567 @@
+/* eslint-disable local/no-whilst */
+import { TSDocParser } from '@microsoft/tsdoc';
+import * as utils from '@typescript-eslint/utils';
+import { isReassignmentTarget } from 'tsutils';
+import ts from 'typescript';
+const { AST_NODE_TYPES, ESLintUtils } = utils;
+const rules = {
+    // Rule to enforce using "while" instead of "whilst"
+    'no-whilst': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            // If we're in the ESLint plugin file, don't apply the rule to avoid
+            // self-reference issues
+            if (context.filename.includes('eslint-plugin.mjs')) {
+                return {};
+            }
+            return {
+                Literal(node) {
+                    if (typeof node.value === 'string' && node.value.includes('whilst')) {
+                        context.report({
+                            messageId: 'noWhilst',
+                            node,
+                            fix: (fixer) => {
+                                return fixer.replaceText(node, node.raw.replace(/whilst/g, 'while'));
+                            },
+                        });
+                    }
+                },
+                JSXText(node) {
+                    if (node.value.includes('whilst')) {
+                        context.report({
+                            messageId: 'noWhilst',
+                            node,
+                            fix: (fixer) => {
+                                return fixer.replaceText(node, node.value.replace(/whilst/g, 'while'));
+                            },
+                        });
+                    }
+                },
+                TemplateElement(node) {
+                    if (node.value.raw.includes('whilst')) {
+                        context.report({
+                            messageId: 'noWhilst',
+                            node,
+                            fix: (fixer) => {
+                                return fixer.replaceText(node, node.value.raw.replace(/whilst/g, 'while'));
+                            },
+                        });
+                    }
+                },
+            };
+        },
+        meta: {
+            messages: {
+                noWhilst: 'Use "while" instead of "whilst" to maintain American English style, sorry.',
+            },
+            type: 'problem',
+            schema: [],
+            fixable: 'code',
+        },
+        defaultOptions: [],
+    }),
+    'no-export-star': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            return {
+                ExportAllDeclaration(node) {
+                    if (node.exported !== null) {
+                        // we're exporting a specific name, so that's OK!
+                        return;
+                    }
+                    // 1. Grab the TypeScript program from parser services
+                    const parserServices = ESLintUtils.getParserServices(context);
+                    const checker = parserServices.program.getTypeChecker();
+                    // 2. Find the backing TS node for the ES node, then the symbol for the imported file
+                    const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+                    const importedFileSymbol = checker.getSymbolAtLocation(originalNode.moduleSpecifier);
+                    // 3. Find all the imported names from the file
+                    const importedNames = checker.getExportsOfModule(importedFileSymbol).map((imported) => ({
+                        name: imported.getEscapedName(),
+                        isType: !(imported.flags & ts.SymbolFlags.Value),
+                    }));
+                    // report the error and offer a fix (listing imported names)
+                    context.report({
+                        messageId: 'named',
+                        node,
+                        fix: (fixer) => {
+                            return fixer.replaceText(node, [
+                                'export {',
+                                ...importedNames.map((imported) => `  ${imported.isType ? 'type ' : ''}${imported.name},`),
+                                `} from ${JSON.stringify(node.source.value)};`,
+                            ].join('\n'));
+                        },
+                    });
+                },
+            };
+        },
+        meta: {
+            messages: {
+                named: 'Use specific named exports instead of export *',
+            },
+            type: 'suggestion',
+            schema: [],
+            fixable: 'code',
+        },
+        defaultOptions: [],
+    }),
+    'no-internal-imports': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            return {
+                ImportDeclaration(node) {
+                    const path = node.source.value;
+                    const parts = path.split('/');
+                    switch (parts[0]) {
+                        case 'tldraw':
+                            // 'tldraw'
+                            if (parts.length === 1)
+                                return;
+                            // 'tldraw/**/*.css'
+                            if (path.endsWith('.css'))
+                                return;
+                            break;
+                        case '@tldraw':
+                            // '@tldraw/*'
+                            if (parts.length === 2)
+                                return;
+                            // '@tldraw/**/*.css'
+                            if (path.endsWith('.css'))
+                                return;
+                            // '@tldraw/assets/*'
+                            if (parts[1] === 'assets' && parts.length === 3)
+                                return;
+                            break;
+                        default:
+                            return;
+                    }
+                    context.report({
+                        messageId: 'internal',
+                        node: node.source,
+                        data: { path },
+                    });
+                },
+            };
+        },
+        meta: {
+            messages: {
+                internal: "Don't import from internal tldraw source ({{path}})",
+            },
+            type: 'problem',
+            schema: [],
+        },
+        defaultOptions: [],
+    }),
+    'no-at-internal': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            // adapted from https://github.com/gund/eslint-plugin-deprecation
+            function identifierRule(id) {
+                const services = ESLintUtils.getParserServices(context);
+                // Don't consider deprecations in certain cases:
+                // - On JSX closing elements (only flag the opening element)
+                const isClosingElement = id.type === 'JSXIdentifier' && id.parent?.type === 'JSXClosingElement';
+                if (isClosingElement) {
+                    return;
+                }
+                // - Inside an import
+                const isInsideImport = context.sourceCode
+                    .getAncestors(id)
+                    .some((anc) => anc.type.includes('Import'));
+                if (isInsideImport) {
+                    return;
+                }
+                const internalMarker = getInternalMarker(id, services);
+                if (internalMarker) {
+                    context.report({
+                        node: id,
+                        messageId: 'internal',
+                        data: {
+                            name: id.name,
+                        },
+                    });
+                }
+            }
+            function getInternalMarker(id, services) {
+                const tc = services.program?.getTypeChecker();
+                if (!tc)
+                    return undefined;
+                const callExpression = getCallExpression(id);
+                if (callExpression) {
+                    const tsCallExpression = services.esTreeNodeToTSNodeMap.get(callExpression);
+                    const signature = tc.getResolvedSignature(tsCallExpression);
+                    if (signature) {
+                        const deprecation = getJsDocInternal(signature.getJsDocTags());
+                        if (deprecation) {
+                            return deprecation;
+                        }
+                    }
+                }
+                const symbol = getSymbol(id, services, tc);
+                if (!symbol) {
+                    return undefined;
+                }
+                if (callExpression && isFunction(symbol)) {
+                    return undefined;
+                }
+                return getJsDocInternal(symbol.getJsDocTags());
+            }
+            function isFunction(symbol) {
+                const { declarations } = symbol;
+                if (declarations === undefined || declarations.length === 0) {
+                    return false;
+                }
+                switch (declarations[0].kind) {
+                    case ts.SyntaxKind.MethodDeclaration:
+                    case ts.SyntaxKind.FunctionDeclaration:
+                    case ts.SyntaxKind.FunctionExpression:
+                    case ts.SyntaxKind.MethodSignature:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+            function getCallExpression(id) {
+                const ancestors = context.sourceCode.getAncestors(id);
+                let callee = id;
+                let parent = ancestors.length > 0 ? ancestors[ancestors.length - 1] : undefined;
+                if (parent && parent.type === 'MemberExpression' && parent.property === id) {
+                    callee = parent;
+                    parent = ancestors.length > 1 ? ancestors[ancestors.length - 2] : undefined;
+                }
+                if (isCallExpression(parent, callee)) {
+                    return parent;
+                }
+                return undefined;
+            }
+            function isCallExpression(node, callee) {
+                if (node) {
+                    if (node.type === 'NewExpression' || node.type === 'CallExpression') {
+                        return node.callee === callee;
+                    }
+                    else if (node.type === 'TaggedTemplateExpression') {
+                        return node.tag === callee;
+                    }
+                    else if (node.type === 'JSXOpeningElement') {
+                        return node.name === callee;
+                    }
+                }
+                return false;
+            }
+            function getJsDocInternal(tags) {
+                for (const tag of tags) {
+                    if (tag.name === 'internal') {
+                        return { reason: ts.displayPartsToString(tag.text) };
+                    }
+                }
+                return undefined;
+            }
+            function getSymbol(id, services, tc) {
+                let symbol;
+                const tsId = services.esTreeNodeToTSNodeMap.get(id);
+                const parent = tsId.parent;
+                if (parent.kind === ts.SyntaxKind.BindingElement) {
+                    symbol = tc.getTypeAtLocation(parent.parent).getProperty(tsId.text);
+                }
+                else if ((isPropertyAssignment(parent) && parent.name === tsId) ||
+                    (isShorthandPropertyAssignment(parent) &&
+                        parent.name === tsId &&
+                        isReassignmentTarget(tsId))) {
+                    try {
+                        symbol = tc.getPropertySymbolOfDestructuringAssignment(tsId);
+                    }
+                    catch {
+                        // we are in object literal, not destructuring
+                        // no obvious easy way to check that in advance
+                        symbol = tc.getSymbolAtLocation(tsId);
+                    }
+                }
+                else {
+                    symbol = tc.getSymbolAtLocation(tsId);
+                }
+                if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+                    symbol = tc.getAliasedSymbol(symbol);
+                }
+                return symbol;
+            }
+            function isPropertyAssignment(node) {
+                return node.kind === ts.SyntaxKind.PropertyAssignment;
+            }
+            function isShorthandPropertyAssignment(node) {
+                return node.kind === ts.SyntaxKind.ShorthandPropertyAssignment;
+            }
+            return {
+                Identifier: identifierRule,
+                JSXIdentifier: identifierRule,
+            };
+        },
+        meta: {
+            messages: {
+                internal: '"{{name}}" is internal and can\'t be used publicly.',
+            },
+            type: 'problem',
+            schema: [],
+        },
+        defaultOptions: [],
+    }),
+    'tagged-components': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            function isComponentName(node) {
+                return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+            }
+            function checkComponentDeclaration(services, node, propsType) {
+                const declaration = findTopLevelParent(node);
+                const comments = context.sourceCode.getCommentsBefore(declaration);
+                // we only care about components tagged as public
+                const publicComment = comments.find((comment) => comment.value.includes('@public'));
+                if (!publicComment)
+                    return;
+                // if it's not tagged as a react component, it should be:
+                if (!publicComment.value.includes('@react')) {
+                    context.report({
+                        messageId: 'untagged',
+                        node: publicComment,
+                        fix: (fixer) => {
+                            const hasLines = publicComment.value.includes('\n');
+                            let replacement;
+                            if (hasLines) {
+                                const lines = publicComment.value.split('\n');
+                                const publicLineIdx = lines.findIndex((line) => line.includes('@public'));
+                                if (!publicLineIdx)
+                                    throw new Error('Could not find @public line');
+                                const indent = lines[publicLineIdx].match(/^\s*/)[0];
+                                lines.splice(publicLineIdx + 1, 0, `${indent}* @react`);
+                                replacement = lines.join('\n');
+                            }
+                            else {
+                                replacement = publicComment.value.replace('@public', '@public @react');
+                            }
+                            return fixer.replaceText(publicComment, `/*${replacement}*/`);
+                        },
+                    });
+                    return;
+                }
+                // if it is tagged as a react component, the props should be a named export:
+                if (!propsType)
+                    return;
+                if (propsType.kind !== ts.SyntaxKind.TypeReference) {
+                    context.report({
+                        messageId: 'nonNamedProps',
+                        node: services.tsNodeToESTreeNodeMap.get(propsType),
+                    });
+                }
+            }
+            function findTopLevelParent(node) {
+                let current = node;
+                while (current.parent && current.parent.type !== 'Program') {
+                    current = current.parent;
+                }
+                return current;
+            }
+            function checkFunctionExpression(node) {
+                const services = ESLintUtils.getParserServices(context);
+                const parent = node.parent;
+                if (parent.type === AST_NODE_TYPES.VariableDeclarator && isComponentName(parent.id)) {
+                    const propsType = services.esTreeNodeToTSNodeMap.get(node).parameters[0]?.type;
+                    checkComponentDeclaration(services, parent, propsType);
+                }
+                if (parent.type === AST_NODE_TYPES.CallExpression) {
+                    const callee = parent.callee;
+                    const grandparent = parent.parent;
+                    const isMemoFn = (callee.type === AST_NODE_TYPES.Identifier && callee.name === 'memo') ||
+                        (callee.type === AST_NODE_TYPES.MemberExpression &&
+                            callee.property.type === AST_NODE_TYPES.Identifier &&
+                            callee.property.name === 'memo');
+                    const isForwardRefFn = (callee.type === AST_NODE_TYPES.Identifier && callee.name === 'forwardRef') ||
+                        (callee.type === AST_NODE_TYPES.MemberExpression &&
+                            callee.property.type === AST_NODE_TYPES.Identifier &&
+                            callee.property.name === 'forwardRef');
+                    const isComponenty = grandparent.type === AST_NODE_TYPES.VariableDeclarator &&
+                        isComponentName(grandparent.id);
+                    if (isMemoFn && isComponenty) {
+                        const propsType = services.esTreeNodeToTSNodeMap.get(node).parameters[0]?.type;
+                        checkComponentDeclaration(services, grandparent, propsType);
+                    }
+                    if (isForwardRefFn && isComponenty) {
+                        const propsType = services.esTreeNodeToTSNodeMap.get(node).parameters[1]?.type ||
+                            services.esTreeNodeToTSNodeMap.get(parent).typeArguments?.[1];
+                        checkComponentDeclaration(services, grandparent, propsType);
+                    }
+                }
+            }
+            return {
+                FunctionDeclaration(node) {
+                    if (node.id && isComponentName(node.id)) {
+                        const services = ESLintUtils.getParserServices(context);
+                        const propsType = services.esTreeNodeToTSNodeMap.get(node).parameters[0]?.type;
+                        checkComponentDeclaration(services, node, propsType);
+                    }
+                },
+                FunctionExpression(node) {
+                    checkFunctionExpression(node);
+                },
+                ArrowFunctionExpression(node) {
+                    checkFunctionExpression(node);
+                },
+            };
+        },
+        meta: {
+            messages: {
+                untagged: 'This react component should be tagged with @react',
+                nonNamedProps: 'Props should be a separate named & public exported type/interface.',
+            },
+            type: 'problem',
+            schema: [],
+            fixable: 'code',
+        },
+        defaultOptions: [],
+    }),
+    'prefer-class-methods': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            return {
+                ClassBody(node) {
+                    node.body.forEach((member) => {
+                        if (member.type === 'PropertyDefinition' &&
+                            member.value &&
+                            member.value.type === 'ArrowFunctionExpression') {
+                            const arrowFunction = member.value;
+                            const hasBlockBody = arrowFunction.body.type === 'BlockStatement';
+                            context.report({
+                                node: member,
+                                messageId: 'preferMethod',
+                                fix(fixer) {
+                                    const sourceCode = context.sourceCode;
+                                    const propertyName = sourceCode.getText(member.key);
+                                    const params = arrowFunction.params.map((p) => sourceCode.getText(p)).join(', ');
+                                    const asyncModifier = arrowFunction.async ? 'async ' : '';
+                                    const typeAnnotation = member.typeAnnotation
+                                        ? sourceCode.getText(member.typeAnnotation)
+                                        : '';
+                                    let methodBody;
+                                    if (hasBlockBody) {
+                                        // For arrow functions with block body: () => { return true }
+                                        methodBody = sourceCode.getText(arrowFunction.body);
+                                    }
+                                    else {
+                                        // For arrow functions with concise body: () => true
+                                        const bodyText = sourceCode.getText(arrowFunction.body);
+                                        methodBody = `{ return ${bodyText} }`;
+                                    }
+                                    const fixedMethod = `${asyncModifier}${propertyName}(${params})${typeAnnotation} ${methodBody}`;
+                                    return fixer.replaceText(member, fixedMethod);
+                                },
+                            });
+                        }
+                    });
+                },
+            };
+        },
+        meta: {
+            messages: {
+                preferMethod: 'Prefer using a method instead of an arrow function property.',
+            },
+            type: 'problem',
+            schema: [],
+            fixable: 'code',
+        },
+        defaultOptions: [],
+    }),
+    'tsdoc-param-matching': ESLintUtils.RuleCreator.withoutDocs({
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Ensure TSDoc @param tags match function parameters',
+            },
+            schema: [],
+            messages: {
+                paramMismatch: "Parameter '{{ paramName }}' is documented but not present in function definition (in {{ name }}).",
+                paramMissing: "Parameter '{{ paramName }}' is defined but missing from TSDoc @param (in {{ name }}).",
+            },
+        },
+        defaultOptions: [],
+        create(context) {
+            return {
+                FunctionDeclaration(node) {
+                    checkParams(context, node, node.params, node.id?.name || 'anonymous function');
+                },
+                MethodDefinition(node) {
+                    if (node.value.type === AST_NODE_TYPES.FunctionExpression) {
+                        checkParams(context, node, node.value.params, node.key.type === 'Identifier' ? node.key.name : 'anonymous method');
+                    }
+                },
+                TSAbstractMethodDefinition(node) {
+                    checkParams(context, node, node.value.params, node.key.type === 'Identifier' ? node.key.name : 'anonymous method');
+                },
+                Property(node) {
+                    if ((node.value.type === 'FunctionExpression' ||
+                        node.value.type === 'ArrowFunctionExpression') &&
+                        node.key.type === 'Identifier') {
+                        checkParams(context, node, node.value.params, node.key.name);
+                    }
+                },
+            };
+        },
+    }),
+};
+export default { rules };
+function checkParams(context, node, params, name) {
+    const tsDocComment = getTSDocComment(context, node);
+    if (tsDocComment) {
+        const docParams = getTSDocParams(tsDocComment);
+        if (docParams.length === 0)
+            return;
+        const funcParams = params.map((param) => getParamName(param)).filter(Boolean);
+        docParams.forEach((param) => {
+            // We have to check if the function is using the parameter name with or without the _
+            if (!funcParams.includes(param) && !funcParams.includes(`_${param}`)) {
+                context.report({
+                    node,
+                    messageId: 'paramMismatch',
+                    data: { paramName: param, name },
+                });
+            }
+        });
+        // Some abstract methods use _param names, so we need to adjust the doc params to match
+        const adjustedDocsParams = new Set(docParams.flatMap((param) => [param, `_${param}`]));
+        funcParams.forEach((param) => {
+            if (!adjustedDocsParams.has(param)) {
+                context.report({
+                    node,
+                    messageId: 'paramMissing',
+                    data: { paramName: param, name },
+                });
+            }
+        });
+    }
+}
+function getTSDocComment(context, node) {
+    const leadingComments = context.sourceCode.getCommentsBefore(node);
+    for (let i = leadingComments.length - 1; i >= 0; i--) {
+        const comment = leadingComments[i];
+        const isBlockComment = comment.type === 'Block' && comment.value.includes('* @param');
+        const isDirectlyBeforeNode = comment.loc.end.line === node.loc.start.line - 1;
+        if (isBlockComment && isDirectlyBeforeNode) {
+            return '/*' + comment.value + '*/';
+        }
+    }
+    return null;
+}
+function getTSDocParams(tsDocComment) {
+    const parser = new TSDocParser();
+    const docComment = parser.parseString(tsDocComment);
+    return docComment.docComment.params.blocks.map((paramBlock) => paramBlock.parameterName);
+}
+function getParamName(param) {
+    switch (param.type) {
+        case 'Identifier':
+            return param.name;
+        case 'AssignmentPattern':
+            if (param.left.type === 'Identifier') {
+                return param.left.name;
+            }
+            return getParamName(param.left);
+        case 'RestElement':
+            if (param.argument.type === 'Identifier') {
+                return param.argument.name;
+            }
+            return null;
+        default:
+            return null;
+    }
+}

--- a/internal/scripts/eslint/eslint-plugin.mts
+++ b/internal/scripts/eslint/eslint-plugin.mts
@@ -1,24 +1,20 @@
-// eslint plugins can't use esm
-
-// @ts-ignore - no import/require
-import ts = require('typescript')
-// @ts-ignore - no import/require
-import utils = require('@typescript-eslint/utils')
+/* eslint-disable local/no-whilst */
 import { TSDocParser } from '@microsoft/tsdoc'
+import * as utils from '@typescript-eslint/utils'
 import { RuleContext } from '@typescript-eslint/utils/dist/ts-eslint'
+import { isReassignmentTarget } from 'tsutils'
+import ts from 'typescript'
 
-const { isReassignmentTarget } = require('tsutils') as typeof import('tsutils')
-
-const { ESLintUtils } = utils
+const { AST_NODE_TYPES, ESLintUtils } = utils
 import TSESTree = utils.TSESTree
 
-exports.rules = {
+const rules = {
 	// Rule to enforce using "while" instead of "whilst"
 	'no-whilst': ESLintUtils.RuleCreator.withoutDocs({
 		create(context) {
 			// If we're in the ESLint plugin file, don't apply the rule to avoid
 			// self-reference issues
-			if (context.filename.includes('eslint-plugin.ts')) {
+			if (context.filename.includes('eslint-plugin.mjs')) {
 				return {}
 			}
 
@@ -420,29 +416,29 @@ exports.rules = {
 				const services = ESLintUtils.getParserServices(context)
 
 				const parent = node.parent!
-				if (parent.type === utils.AST_NODE_TYPES.VariableDeclarator && isComponentName(parent.id)) {
+				if (parent.type === AST_NODE_TYPES.VariableDeclarator && isComponentName(parent.id)) {
 					const propsType = services.esTreeNodeToTSNodeMap.get(node).parameters[0]?.type
 					checkComponentDeclaration(services, parent, propsType)
 				}
 
-				if (parent.type === utils.AST_NODE_TYPES.CallExpression) {
+				if (parent.type === AST_NODE_TYPES.CallExpression) {
 					const callee = parent.callee
 					const grandparent = parent.parent!
 
 					const isMemoFn =
-						(callee.type === utils.AST_NODE_TYPES.Identifier && callee.name === 'memo') ||
-						(callee.type === utils.AST_NODE_TYPES.MemberExpression &&
-							callee.property.type === utils.AST_NODE_TYPES.Identifier &&
+						(callee.type === AST_NODE_TYPES.Identifier && callee.name === 'memo') ||
+						(callee.type === AST_NODE_TYPES.MemberExpression &&
+							callee.property.type === AST_NODE_TYPES.Identifier &&
 							callee.property.name === 'memo')
 
 					const isForwardRefFn =
-						(callee.type === utils.AST_NODE_TYPES.Identifier && callee.name === 'forwardRef') ||
-						(callee.type === utils.AST_NODE_TYPES.MemberExpression &&
-							callee.property.type === utils.AST_NODE_TYPES.Identifier &&
+						(callee.type === AST_NODE_TYPES.Identifier && callee.name === 'forwardRef') ||
+						(callee.type === AST_NODE_TYPES.MemberExpression &&
+							callee.property.type === AST_NODE_TYPES.Identifier &&
 							callee.property.name === 'forwardRef')
 
 					const isComponenty =
-						grandparent.type === utils.AST_NODE_TYPES.VariableDeclarator &&
+						grandparent.type === AST_NODE_TYPES.VariableDeclarator &&
 						isComponentName(grandparent.id)
 
 					if (isMemoFn && isComponenty) {
@@ -561,7 +557,7 @@ exports.rules = {
 					checkParams(context, node, node.params, node.id?.name || 'anonymous function')
 				},
 				MethodDefinition(node: TSESTree.MethodDefinition) {
-					if (node.value.type === utils.AST_NODE_TYPES.FunctionExpression) {
+					if (node.value.type === AST_NODE_TYPES.FunctionExpression) {
 						checkParams(
 							context,
 							node,
@@ -591,6 +587,8 @@ exports.rules = {
 		},
 	}),
 }
+
+export default { rules }
 
 function checkParams(
 	context: RuleContext<'paramMismatch' | 'paramMissing', []>,

--- a/internal/scripts/eslint/tsconfig.json
+++ b/internal/scripts/eslint/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": false
+	},
+	"include": ["eslint-plugin.mts"]
+}

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -21,7 +21,12 @@ const config = {
 	scripts: {
 		build: {
 			baseCommand: 'exit 0',
-			runsAfter: { prebuild: {}, 'refresh-assets': {}, 'build-i18n': {} },
+			runsAfter: {
+				prebuild: {},
+				'refresh-assets': {},
+				'build-eslint-plugin': {},
+				'build-i18n': {},
+			},
 			workspaceOverrides: {
 				'apps/vscode/*': { runsAfter: { 'refresh-assets': {} } },
 				'packages/*': {
@@ -49,7 +54,7 @@ const config = {
 		},
 		dev: {
 			execution: 'independent',
-			runsAfter: { predev: {}, 'refresh-assets': {}, 'build-i18n': {} },
+			runsAfter: { predev: {}, 'refresh-assets': {}, 'build-eslint-plugin': {}, 'build-i18n': {} },
 			cache: 'none',
 			workspaceOverrides: {
 				'apps/vscode/*': { runsAfter: { build: { in: 'self-only' } } },
@@ -60,6 +65,16 @@ const config = {
 		},
 		'e2e-x10': {
 			cache: 'none',
+		},
+		'build-eslint-plugin': {
+			execution: 'top-level',
+			baseCommand: 'cd internal/scripts/eslint && tsc -p tsconfig.json',
+			cache: {
+				inputs: [
+					'<rootDir>/internal/scripts/eslint/eslint-plugin.mts',
+					'<rootDir>/internal/scripts/eslint/tsconfig.json',
+				],
+			},
 		},
 		lint: {
 			execution: 'independent',
@@ -102,6 +117,7 @@ const config = {
 			},
 			runsAfter: {
 				'refresh-assets': {},
+				'build-eslint-plugin': {},
 				'maybe-clean-tsbuildinfo': {},
 			},
 		},


### PR DESCRIPTION
I started getting weird editor (neovim) errors while editing files: `Request textDocument/diagnostic failed with message: require is not defined in ES module scope, you can use import instead`. Looks like the problem was that were are mixing CommonJS and ESM modules (eslint config is using ESM, while the plugins are defined in CommonJS).

This converts eslint plugin from CommonJS to TypeScript ESM to resolve module system conflicts. Adds build step that compiles .mts source of our custom plugins to compile them to .mjs. Decided for the compile step to keep the types.

  Changes:
  - Move ESLint plugin to internal/scripts/eslint/ directory
  - Convert from .js (CommonJS) to .mts (TypeScript ESM)
  - Add TypeScript compilation step in lazy build system
  - Update import paths in eslint.config.mjs
  - Flyby linting fixes that were broken.
 
### Change type

- [x] `improvement`
