### PR TITLE
Fix spelling typos in documentation

### DIFF
--- a/apps/dotcom/image-resize-worker/README.md
+++ b/apps/dotcom/image-resize-worker/README.md
@@ -1,6 +1,6 @@
 # Images
 
-Helpers for images on tldraw.com. Specifically, it's currently used to dynamically resize and optimize images on-the-fly via Cloudflare's image transform serivce.
+Helpers for images on tldraw.com. Specifically, it's currently used to dynamically resize and optimize images on-the-fly via Cloudflare's image transform service.
 
 ## License
 

--- a/apps/examples/src/examples/sync-custom-people-menu/README.md
+++ b/apps/examples/src/examples/sync-custom-people-menu/README.md
@@ -13,4 +13,4 @@ A custom multiplayer people menu / facepile that displays connected collaborator
 
 This example demonstrates how to build a custom people menu (or facepile) that shows information about all users in a multiplayer session.
 
-This is useful when you want to create a more detailed or custom-styled presence indicator than the default tldraw provides. This example shows user's names, ids, colors, and cursor postition, all information provided in the `TLInstancePresence` returned by `editor.getCollaborators()`.
+This is useful when you want to create a more detailed or custom-styled presence indicator than the default tldraw provides. This example shows user's names, ids, colors, and cursor position, all information provided in the `TLInstancePresence` returned by `editor.getCollaborators()`.

--- a/apps/examples/writing-examples.md
+++ b/apps/examples/writing-examples.md
@@ -136,7 +136,7 @@ Pass your components overrides to the `components` prop.
 
 ## Tight examples and use-case examples
 
-There are two types of examples: **tight** examples that show a specific use of the tldraw SDK, and **use-case** examples that shown some sliver of a user experience that involves the SDK. For example, a tight example might show how to toggle dark mode on and off programatically, while a use-case example may show how to edit a PDF.
+There are two types of examples: **tight** examples that show a specific use of the tldraw SDK, and **use-case** examples that show some sliver of a user experience that involves the SDK. For example, a tight example might show how to toggle dark mode on and off programmatically, while a use-case example may show how to edit a PDF.
 
 When writing a **tight** example, you should narrow the focus of the example as much as possible. Avoid styling unless absolutely necessary. These examples are meant to be _read_ rather than actually used. Any extraneous code may be mistaken for necessary code and so should either be removed or minimized.
 

--- a/apps/vscode/extension/CHANGELOG.md
+++ b/apps/vscode/extension/CHANGELOG.md
@@ -168,8 +168,8 @@
 
 - New laser tool!
 - New checkbox shape!
-- Add veritcal alignment options to Notes and Geo shapes.
-- Change how horizontal alignemnt works.
+- Add vertical alignment options to Notes and Geo shapes.
+- Change how horizontal alignment works.
 - Improve exporting and saving to svgs.
 
 ## 2.0.6

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -10,7 +10,7 @@ This is a production-ready backend for [tldraw sync](https://tldraw.dev/docs/syn
   Durable Object](https://developers.cloudflare.com/durable-objects/).
 - Whiteboards and any uploaded images/videos are stored in a [Cloudflare
   R2](https://developers.cloudflare.com/r2/) bucket.
-- Although unreliated to tldraw sync, this server also includes a component to fetch link previews
+- Although unrelated to tldraw sync, this server also includes a component to fetch link previews
   for URLs added to the canvas.
   This is a minimal setup of the same system that powers multiplayer collaboration for hundreds of
   thousands of rooms & users on www.tldraw.com. Because durable objects effectively create a mini


### PR DESCRIPTION
## Summary
- Fixed multiple spelling typos across documentation files
- Corrected: serivce → service, veritcal → vertical, alignemnt → alignment
- Corrected: programatically → programmatically, postition → position
- Corrected: shown some → show some, unreliated → unrelated

## Files Changed
- `apps/dotcom/image-resize-worker/README.md`
- `apps/vscode/extension/CHANGELOG.md`
- `apps/examples/writing-examples.md`
- `apps/examples/src/examples/sync-custom-people-menu/README.md`
- `templates/sync-cloudflare/README.md`

## Test plan
- [x] Reviewed all spelling corrections for accuracy
- [x] No functional code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)