### PR TITLE
feat(agent): add Claude 4.5 Sonnet and set as default

### DIFF
--- a/templates/agent/worker/models.ts
+++ b/templates/agent/worker/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MODEL_NAME = 'claude-4-sonnet'
+export const DEFAULT_MODEL_NAME = 'claude-4.5-sonnet'
 
 export type AgentModelName = keyof typeof AGENT_MODEL_DEFINITIONS
 export type AgentModelProvider = 'openai' | 'anthropic' | 'google'
@@ -27,6 +27,13 @@ export function getAgentModelDefinition(modelName: AgentModelName): AgentModelDe
 
 export const AGENT_MODEL_DEFINITIONS = {
 	// Strongly recommended
+	'claude-4.5-sonnet': {
+		name: 'claude-4.5-sonnet',
+		id: 'claude-sonnet-4-5',
+		provider: 'anthropic',
+	},
+
+	// Recommended
 	'claude-4-sonnet': {
 		name: 'claude-4-sonnet',
 		id: 'claude-sonnet-4-0',


### PR DESCRIPTION
Add [Clause 4.5 Sonnet](https://www.anthropic.com/news/claude-sonnet-4-5) to agent starter and make it the default model

### Change type

- [x] `improvement`

### Test plan

1. Verify the agent worker uses Claude 4.5 Sonnet by default.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated the agent starter to use Claude 4.5 Sonnet as the default model.