### PR TITLE
feat(sync-core): expose internal types as public and add template

### DIFF
--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -50,7 +50,7 @@ Make sure you also read the section below about [deployment concerns](#deploymen
 
 We recommend using Cloudflare, but the `@tldraw/sync-core` library can be used to integrate tldraw sync into any JavaScript server environment that supports WebSockets.
 
-We have a [simple server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
+We have a [custom Socket.IO server example](https://github.com/tldraw/tldraw/tree/main/templates/custom-server-example) that shows how to integrate tldraw sync with Socket.IO instead of standard WebSockets. We also have a [simple server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
 
 ## What does a tldraw sync backend do?
 
@@ -119,6 +119,406 @@ The `@tldraw/sync-core` package exports a class called [`TLSocketRoom`](?) that 
 </Callout>
 
 Read the reference docs for [`TLSocketRoom`](?), and see an example of how to use it in the [simple server example](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/server/rooms.ts).
+
+### Sync client
+
+On the client side, the `@tldraw/sync-core` package exports a class called [`TLSyncClient`](?) that handles the connection and synchronization with the server.
+
+<Callout type="warning">
+	**Advanced usage only:** Most applications should use the [`useSync`](?) hook from the
+	`@tldraw/sync` package instead of creating `TLSyncClient` directly. The `useSync` hook handles all
+	the complexity of setting up the sync client, managing presence, and integrating with React
+	components.
+</Callout>
+
+`TLSyncClient` is used to:
+
+- Establish and maintain a WebSocket connection to the server
+- Send local changes to the server and apply remote changes from other clients
+- Handle network interruptions and reconnections automatically
+- Manage optimistic updates and conflict resolution
+- Synchronize user presence information (cursors, selections, etc.)
+
+#### When to use TLSyncClient directly
+
+You might need to create `TLSyncClient` directly if you're:
+
+- Building a non-React application
+- Implementing custom connection logic or error handling
+- Need fine-grained control over the sync lifecycle
+- Building a custom integration with a different UI framework
+
+#### Direct usage example
+
+Here's a complete advanced usage example that mirrors how `useSync` works internally:
+
+```tsx
+import {
+	TLSyncClient,
+	TLSyncErrorCloseEventReason,
+	type TLPresenceMode,
+	type TLPersistentClientSocket,
+} from '@tldraw/sync-core'
+import {
+	createTLStore,
+	InstancePresenceRecordType,
+	getDefaultUserPresence,
+	getUserPreferences,
+	defaultUserPreferences,
+	TAB_ID,
+	uniqueId,
+} from 'tldraw'
+import { atom, computed, transact } from '@tldraw/state'
+import { io, type Socket } from 'socket.io-client'
+
+// Generate unique identifiers
+const storeId = uniqueId()
+const roomId = 'my-room-123'
+
+// User preferences (in real app, this would come from your auth system)
+const userPreferences = {
+	id: 'user-' + uniqueId(),
+	name: 'John Doe',
+	color: '#ff0000',
+}
+
+// Manual Socket.IO implementation
+import { io, type Socket } from 'socket.io-client'
+
+// Create Socket.IO connection
+const ioSocket = io('wss://my-server.com', {
+	query: {
+		sessionId: TAB_ID,
+		storeId: storeId,
+		roomId: roomId,
+	},
+})
+
+// Implement TLPersistentClientSocket manually
+const socket: TLPersistentClientSocket = {
+	connectionStatus: 'offline',
+
+	sendMessage: (message) => {
+		console.log('📤 Sending:', message)
+		// Send tldraw sync protocol messages via Socket.IO
+		ioSocket.emit('tldraw-message', message)
+	},
+
+	onReceiveMessage: (callback) => {
+		// Listen for tldraw sync protocol messages
+		const handler = (message: any) => {
+			console.log('📥 Received:', message)
+			callback(message)
+		}
+
+		ioSocket.on('tldraw-message', handler)
+
+		// Return cleanup function
+		return () => {
+			ioSocket.off('tldraw-message', handler)
+		}
+	},
+
+	onStatusChange: (callback) => {
+		// Map Socket.IO events to TLPersistentClientSocket status
+		const connectHandler = () => {
+			;(socket as any).connectionStatus = 'online'
+			callback({ status: 'online' })
+		}
+
+		const disconnectHandler = () => {
+			;(socket as any).connectionStatus = 'offline'
+			callback({ status: 'offline' })
+		}
+
+		const errorHandler = (error: any) => {
+			;(socket as any).connectionStatus = 'error'
+			callback({
+				status: 'error',
+				reason: error.message || 'Connection error',
+			})
+		}
+
+		ioSocket.on('connect', connectHandler)
+		ioSocket.on('disconnect', disconnectHandler)
+		ioSocket.on('connect_error', errorHandler)
+
+		// Set initial status
+		if (ioSocket.connected) {
+			;(socket as any).connectionStatus = 'online'
+			setTimeout(() => callback({ status: 'online' }), 0)
+		}
+
+		// Return cleanup function
+		return () => {
+			ioSocket.off('connect', connectHandler)
+			ioSocket.off('disconnect', disconnectHandler)
+			ioSocket.off('connect_error', errorHandler)
+		}
+	},
+
+	restart: () => {
+		console.log('🔄 Restarting Socket.IO connection...')
+		ioSocket.disconnect()
+		ioSocket.connect()
+	},
+}
+
+// Track connection status for collaboration UX
+const collaborationStatus = computed('collaboration status', () =>
+	socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
+)
+
+// Track read/write mode
+const syncMode = atom('sync mode', 'readwrite' as 'readonly' | 'readwrite')
+
+// Create the store with collaboration status
+const store = createTLStore({
+	id: storeId,
+	// Pass your schema, assets, etc. here
+	collaboration: {
+		status: collaborationStatus,
+		mode: syncMode,
+	},
+})
+
+// Create presence signal using tldraw's built-in logic
+const presence = computed('instancePresence', () => {
+	const presenceState = getDefaultUserPresence(store, userPreferences)
+	if (!presenceState) return null
+
+	return InstancePresenceRecordType.create({
+		...presenceState,
+		id: InstancePresenceRecordType.createId(store.id),
+	})
+})
+
+// Track other users for presence mode
+const otherUserPresences = store.query.ids('instance_presence', () => ({
+	userId: { neq: userPreferences.id },
+}))
+
+const presenceMode = computed<TLPresenceMode>('presenceMode', () => {
+	if (otherUserPresences.get().size === 0) return 'solo'
+	return 'full'
+})
+
+// Track cancellation state
+let didCancel = false
+
+// Create the sync client (mirrors useSync implementation)
+const client = new TLSyncClient({
+	store,
+	socket,
+	presence,
+	presenceMode,
+	didCancel: () => didCancel,
+
+	onLoad: (client) => {
+		console.log('✅ Sync client loaded and ready')
+		// At this point, the store is synchronized and ready to use
+		// You can now render your UI or perform other initialization
+	},
+
+	onSyncError: (reason) => {
+		console.error('❌ Sync error:', reason)
+
+		// Handle specific error types
+		switch (reason) {
+			case TLSyncErrorCloseEventReason.NOT_FOUND:
+				console.error('Room not found')
+				break
+			case TLSyncErrorCloseEventReason.FORBIDDEN:
+				console.error('Access forbidden')
+				break
+			case TLSyncErrorCloseEventReason.NOT_AUTHENTICATED:
+				console.error('Authentication required')
+				break
+			case TLSyncErrorCloseEventReason.RATE_LIMITED:
+				console.error('Rate limited - too many requests')
+				break
+			case TLSyncErrorCloseEventReason.ROOM_FULL:
+				console.error('Room is full')
+				break
+			default:
+				console.error('Unknown sync error:', reason)
+		}
+
+		// Clean up on error
+		socket.close()
+	},
+
+	onAfterConnect: (client, { isReadonly }) => {
+		console.log('🔄 Connected to room', { isReadonly })
+
+		// Update sync mode and ensure store is usable
+		transact(() => {
+			syncMode.set(isReadonly ? 'readonly' : 'readwrite')
+			store.ensureStoreIsUsable()
+		})
+	},
+
+	// Optional: Handle custom messages
+	onCustomMessageReceived: (message) => {
+		console.log('📨 Custom message:', message)
+		// Process your custom server messages here
+	},
+})
+
+// Example: Send custom messages to server
+function sendCustomMessage(type: string, data: any) {
+	if (socket.connectionStatus === 'online') {
+		socket.sendMessage({
+			type: 'custom' as any, // Extend the protocol
+			customType: type,
+			data,
+		})
+	}
+}
+
+// Example: Update user presence manually
+function updateUserCursor(x: number, y: number) {
+	const current = presence.get()
+	if (current) {
+		// The presence signal will automatically sync to other users
+		// This is handled by TLSyncClient's internal reactivity
+		store.put([
+			{
+				...current,
+				cursor: { x, y, type: 'default', rotation: 0 },
+			},
+		])
+	}
+}
+
+// Cleanup function
+function cleanup() {
+	didCancel = true
+	client.close()
+	socket.close()
+}
+
+// The store is now ready to use with tldraw:
+// <Tldraw store={store} />
+```
+
+#### Alternative transport implementations
+
+Here are examples of implementing `TLPersistentClientSocket` with other transport layers:
+
+**Raw WebSocket:**
+
+```tsx
+const ws = new WebSocket('wss://my-server.com/sync')
+
+const socket: TLPersistentClientSocket = {
+	connectionStatus: 'offline',
+
+	sendMessage: (message) => {
+		if (ws.readyState === WebSocket.OPEN) {
+			ws.send(JSON.stringify(message))
+		}
+	},
+
+	onReceiveMessage: (callback) => {
+		const handler = (event: MessageEvent) => {
+			callback(JSON.parse(event.data))
+		}
+		ws.addEventListener('message', handler)
+		return () => ws.removeEventListener('message', handler)
+	},
+
+	onStatusChange: (callback) => {
+		const openHandler = () => {
+			;(socket as any).connectionStatus = 'online'
+			callback({ status: 'online' })
+		}
+		const closeHandler = () => {
+			;(socket as any).connectionStatus = 'offline'
+			callback({ status: 'offline' })
+		}
+		const errorHandler = () => {
+			;(socket as any).connectionStatus = 'error'
+			callback({ status: 'error', reason: 'WebSocket error' })
+		}
+
+		ws.addEventListener('open', openHandler)
+		ws.addEventListener('close', closeHandler)
+		ws.addEventListener('error', errorHandler)
+
+		return () => {
+			ws.removeEventListener('open', openHandler)
+			ws.removeEventListener('close', closeHandler)
+			ws.removeEventListener('error', errorHandler)
+		}
+	},
+
+	restart: () => {
+		ws.close()
+		// You'd need to recreate the WebSocket here
+	},
+}
+```
+
+**Custom HTTP polling:**
+
+```tsx
+let pollInterval: NodeJS.Timeout
+let messageHandlers: Array<(message: any) => void> = []
+
+const socket: TLPersistentClientSocket = {
+	connectionStatus: 'offline',
+
+	sendMessage: async (message) => {
+		try {
+			await fetch('/api/sync/send', {
+				method: 'POST',
+				body: JSON.stringify({ roomId, message }),
+				headers: { 'Content-Type': 'application/json' },
+			})
+		} catch (error) {
+			console.error('Failed to send message:', error)
+		}
+	},
+
+	onReceiveMessage: (callback) => {
+		messageHandlers.push(callback)
+
+		// Start polling if not already polling
+		if (!pollInterval) {
+			pollInterval = setInterval(async () => {
+				try {
+					const response = await fetch(`/api/sync/poll?roomId=${roomId}`)
+					const messages = await response.json()
+					messages.forEach((msg: any) => {
+						messageHandlers.forEach((handler) => handler(msg))
+					})
+				} catch (error) {
+					console.error('Polling error:', error)
+				}
+			}, 1000) // Poll every second
+		}
+
+		return () => {
+			messageHandlers = messageHandlers.filter((h) => h !== callback)
+			if (messageHandlers.length === 0 && pollInterval) {
+				clearInterval(pollInterval)
+				pollInterval = null
+			}
+		}
+	},
+
+	onStatusChange: (callback) => {
+		// Simulate connection status
+		setTimeout(() => callback({ status: 'online' }), 100)
+		return () => {}
+	},
+
+	restart: () => {
+		// Restart polling logic
+	},
+}
+```
 
 ### Asset storage
 

--- a/apps/docs/scripts/lib/getApiMarkdown.ts
+++ b/apps/docs/scripts/lib/getApiMarkdown.ts
@@ -9,6 +9,7 @@ import {
 	ApiDocumentedItem,
 	ApiEnum,
 	ApiFunction,
+	ApiIndexSignature,
 	ApiInterface,
 	ApiItem,
 	ApiItemKind,
@@ -165,6 +166,7 @@ function collectMembersAndExtends(model: TldrawApiModel, item: ApiItem) {
 					case ApiItemKind.Variable:
 					case ApiItemKind.Property:
 					case ApiItemKind.PropertySignature:
+					case ApiItemKind.IndexSignature:
 						addMember(properties, member, inheritedFrom)
 						break
 					case ApiItemKind.Method:
@@ -357,6 +359,7 @@ async function addDocComment(model: TldrawApiModel, result: Result, member: ApiI
 			member instanceof ApiTypeAlias ||
 			member instanceof ApiProperty ||
 			member instanceof ApiPropertySignature ||
+			member instanceof ApiIndexSignature ||
 			member instanceof ApiClass ||
 			member instanceof ApiFunction ||
 			member instanceof ApiInterface ||

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -18,7 +18,7 @@ import { TLRecord } from '@tldraw/tlschema';
 import { TLStoreSnapshot } from '@tldraw/tlschema';
 import { UnknownRecord } from '@tldraw/store';
 
-// @internal (undocumented)
+// @public (undocumented)
 export type AppendOp = [type: typeof ValueOpType.Append, values: unknown[], offset: number];
 
 // @internal (undocumented)
@@ -27,7 +27,7 @@ export function applyObjectDiff<T extends object>(object: T, objectDiff: ObjectD
 // @internal (undocumented)
 export function chunk(msg: string, maxSafeMessageSize?: number): string[];
 
-// @internal (undocumented)
+// @public (undocumented)
 export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord> {
     constructor(getUri: () => Promise<string> | string);
     // (undocumented)
@@ -56,13 +56,13 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord
     _ws: null | WebSocket;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type DeleteOp = [type: typeof ValueOpType.Delete];
 
 // @internal (undocumented)
 export function diffRecord(prev: object, next: object): null | ObjectDiff;
 
-// @internal (undocumented)
+// @public (undocumented)
 export class DocumentState<R extends UnknownRecord> {
     // (undocumented)
     static createAndValidate<R extends UnknownRecord>(state: R, lastChangedClock: number, recordType: RecordType<R, any>): Result<DocumentState<R>, Error>;
@@ -84,13 +84,13 @@ export function getNetworkDiff<R extends UnknownRecord>(diff: RecordsDiff<R>): N
 // @internal (undocumented)
 export function getTlsyncProtocolVersion(): number;
 
-// @internal
+// @public
 export interface NetworkDiff<R extends UnknownRecord> {
     // (undocumented)
     [id: string]: RecordOp<R>;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface ObjectDiff {
     // (undocumented)
     [k: string]: ValueOp;
@@ -101,7 +101,7 @@ export type OmitVoid<T, KS extends keyof T = keyof T> = {
     [K in KS extends any ? (void extends T[KS] ? never : KS) : never]: T[K];
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type PatchOp = [type: typeof ValueOpType.Patch, diff: ObjectDiff];
 
 // @internal (undocumented)
@@ -114,10 +114,10 @@ export interface PersistedRoomSnapshotForSupabase {
     slug: string;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type PutOp = [type: typeof ValueOpType.Put, value: unknown];
 
-// @internal (undocumented)
+// @public (undocumented)
 export class ReconnectManager {
     constructor(socketAdapter: ClientWebSocketAdapter, getUri: () => Promise<string> | string);
     // (undocumented)
@@ -132,20 +132,20 @@ export class ReconnectManager {
     maybeReconnected(): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type RecordOp<R extends UnknownRecord> = [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R] | [typeof RecordOpType.Remove];
 
-// @internal (undocumented)
+// @public (undocumented)
 export const RecordOpType: {
     readonly Patch: "patch";
     readonly Put: "put";
     readonly Remove: "remove";
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType];
 
-// @internal (undocumented)
+// @public (undocumented)
 export type RoomSession<R extends UnknownRecord, Meta> = {
     cancellationTime: number;
     isReadonly: boolean;
@@ -178,14 +178,14 @@ export type RoomSession<R extends UnknownRecord, Meta> = {
     state: typeof RoomSessionState.AwaitingConnectMessage;
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export const RoomSessionState: {
     readonly AwaitingConnectMessage: "awaiting-connect-message";
     readonly AwaitingRemoval: "awaiting-removal";
     readonly Connected: "connected";
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type RoomSessionState = (typeof RoomSessionState)[keyof typeof RoomSessionState];
 
 // @public (undocumented)
@@ -219,10 +219,10 @@ export interface RoomStoreMethods<R extends UnknownRecord = UnknownRecord> {
     put(record: R): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void;
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLConnectRequest {
     // (undocumented)
     connectRequestId: string;
@@ -236,10 +236,10 @@ export interface TLConnectRequest {
     type: 'connect';
 }
 
-// @public
-export type TLCustomMessageHandler = (this: null, data: any) => void;
+// @public (undocumented)
+export type TLCustomMessageHandler = (message: any) => void;
 
-// @internal @deprecated (undocumented)
+// @public @deprecated (undocumented)
 export const TLIncompatibilityReason: {
     readonly ClientTooOld: "clientTooOld";
     readonly InvalidOperation: "invalidOperation";
@@ -247,10 +247,10 @@ export const TLIncompatibilityReason: {
     readonly ServerTooOld: "serverTooOld";
 };
 
-// @internal @deprecated (undocumented)
+// @public @deprecated (undocumented)
 export type TLIncompatibilityReason = (typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason];
 
-// @internal
+// @public
 export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> {
     connectionStatus: 'error' | 'offline' | 'online';
     onReceiveMessage: SubscribingFn<TLSocketServerSentEvent<R>>;
@@ -259,19 +259,19 @@ export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecor
     sendMessage(msg: TLSocketClientSentEvent<R>): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLPersistentClientSocketStatus = 'error' | 'offline' | 'online';
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLPingRequest {
     // (undocumented)
     type: 'ping';
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLPresenceMode = 'full' | 'solo';
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLPushRequest<R extends UnknownRecord> {
     // (undocumented)
     clientClock: number;
@@ -292,7 +292,7 @@ export class TLRemoteSyncError extends Error {
     readonly reason: string | TLSyncErrorCloseEventReason;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLRoomSocket<R extends UnknownRecord> {
     // (undocumented)
     close(code?: number, reason?: string): void;
@@ -302,7 +302,7 @@ export interface TLRoomSocket<R extends UnknownRecord> {
     sendMessage(msg: TLSocketServerSentEvent<R>): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketClientSentEvent<R extends UnknownRecord> = TLConnectRequest | TLPingRequest | TLPushRequest<R>;
 
 // @public (undocumented)
@@ -393,7 +393,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     updateStore(updater: (store: RoomStoreMethods<R>) => Promise<void> | void): Promise<void>;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketServerSentDataEvent<R extends UnknownRecord> = {
     action: 'commit' | 'discard' | {
         rebaseWithDiff: NetworkDiff<R>;
@@ -407,7 +407,7 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> = {
     type: 'patch';
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketServerSentEvent<R extends UnknownRecord> = {
     connectRequestId: string;
     diff: NetworkDiff<R>;
@@ -430,7 +430,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> = {
     type: 'pong';
 } | TLSocketServerSentDataEvent<R>;
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TlSocketStatusChangeEvent = {
     reason: string;
     status: 'error';
@@ -438,10 +438,10 @@ export type TlSocketStatusChangeEvent = {
     status: 'offline' | 'online';
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketStatusListener = (params: TlSocketStatusChangeEvent) => void;
 
-// @internal
+// @public
 export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>> {
     constructor(config: {
         didCancel?(): boolean;
@@ -508,7 +508,7 @@ export interface TLSyncLog {
     warn?(...args: any[]): void;
 }
 
-// @internal
+// @public
 export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     constructor(opts: {
         log?: TLSyncLog;
@@ -527,7 +527,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     close(): void;
     // (undocumented)
     documentClock: number;
-    // (undocumented)
     documents: AtomMap<string, DocumentState<R>>;
     // (undocumented)
     readonly documentTypes: Set<string>;
@@ -572,10 +571,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
     updateStore(updater: (store: RoomStoreMethods<R>) => Promise<void> | void): Promise<void>;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type ValueOp = AppendOp | DeleteOp | PatchOp | PutOp;
 
-// @internal (undocumented)
+// @public (undocumented)
 export const ValueOpType: {
     readonly Append: "append";
     readonly Delete: "delete";
@@ -583,7 +582,7 @@ export const ValueOpType: {
     readonly Put: "put";
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type ValueOpType = (typeof ValueOpType)[keyof typeof ValueOpType];
 
 // @public

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -41,13 +41,12 @@ function debug(...args: any[]) {
 //       they don't seem to be surfaced in browser APIs and can't be relied on. Therefore,
 //       pings need to be implemented one level up, on the application API side, which for our
 //       codebase means whatever code that uses ClientWebSocketAdapter.
-/** @internal */
+/** @public */
 export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLRecord> {
 	_ws: WebSocket | null = null
 
 	isDisposed = false
 
-	/** @internal */
 	readonly _reconnectManager: ReconnectManager
 
 	// TODO: .close should be a project-wide interface with a common contract (.close()d thing
@@ -252,7 +251,7 @@ export const DELAY_EXPONENT = 1.5
 // not needlessly reconnecting if the connection is just slow to establish
 export const ATTEMPT_TIMEOUT = 1000
 
-/** @internal */
+/** @public */
 export class ReconnectManager {
 	private isDisposed = false
 	private disposables: (() => void)[] = [

--- a/packages/sync-core/src/lib/RoomSession.ts
+++ b/packages/sync-core/src/lib/RoomSession.ts
@@ -2,21 +2,21 @@ import { SerializedSchema, UnknownRecord } from '@tldraw/store'
 import { TLRoomSocket } from './TLSyncRoom'
 import { TLSocketServerSentDataEvent } from './protocol'
 
-/** @internal */
+/** @public */
 export const RoomSessionState = {
 	AwaitingConnectMessage: 'awaiting-connect-message',
 	AwaitingRemoval: 'awaiting-removal',
 	Connected: 'connected',
 } as const
 
-/** @internal */
+/** @public */
 export type RoomSessionState = (typeof RoomSessionState)[keyof typeof RoomSessionState]
 
 export const SESSION_START_WAIT_TIME = 10000
 export const SESSION_REMOVAL_WAIT_TIME = 5000
 export const SESSION_IDLE_TIMEOUT = 20000
 
-/** @internal */
+/** @public */
 export type RoomSession<R extends UnknownRecord, Meta> =
 	| {
 			state: typeof RoomSessionState.AwaitingConnectMessage

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -24,7 +24,7 @@ import {
 	getTlsyncProtocolVersion,
 } from './protocol'
 
-/** @internal */
+/** @public */
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void
 
 /**
@@ -70,10 +70,11 @@ export type TLSyncErrorCloseEventReason =
  * Event handler for userland socket messages
  * @public
  */
-export type TLCustomMessageHandler = (this: null, data: any) => void
+/** @public */
+export type TLCustomMessageHandler = (message: any) => void
 
 /**
- * @internal
+ * @public
  */
 export type TlSocketStatusChangeEvent =
 	| {
@@ -83,20 +84,20 @@ export type TlSocketStatusChangeEvent =
 			status: 'error'
 			reason: string
 	  }
-/** @internal */
+/** @public */
 export type TLSocketStatusListener = (params: TlSocketStatusChangeEvent) => void
 
-/** @internal */
+/** @public */
 export type TLPersistentClientSocketStatus = 'online' | 'offline' | 'error'
 
-/** @internal */
+/** @public */
 export type TLPresenceMode = 'solo' | 'full'
 /**
  * A socket that can be used to send and receive messages to the server. It should handle staying
  * open and reconnecting when the connection is lost. In actual client code this will be a wrapper
  * around a websocket or socket.io or something similar.
  *
- * @internal
+ * @public
  */
 export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> {
 	/** Whether there is currently an open connection to the server. */
@@ -121,7 +122,7 @@ const MAX_TIME_TO_WAIT_FOR_SERVER_INTERACTION_BEFORE_RESETTING_CONNECTION = PING
  *
  * It uses a git-style push/pull/rebase model.
  *
- * @internal
+ * @public
  */
 export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>> {
 	/** The last clock time from the most recent server update */

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -51,7 +51,7 @@ import {
 	getTlsyncProtocolVersion,
 } from './protocol'
 
-/** @internal */
+/** @public */
 export interface TLRoomSocket<R extends UnknownRecord> {
 	isOpen: boolean
 	sendMessage(msg: TLSocketServerSentEvent<R>): void
@@ -67,7 +67,7 @@ export const DATA_MESSAGE_DEBOUNCE_INTERVAL = 1000 / 60
 
 const timeSince = (time: number) => Date.now() - time
 
-/** @internal */
+/** @public */
 export class DocumentState<R extends UnknownRecord> {
 	static createWithoutValidating<R extends UnknownRecord>(
 		state: R,
@@ -140,7 +140,7 @@ function getDocumentClock(snapshot: RoomSnapshot) {
  * A room is a workspace for a group of clients. It allows clients to collaborate on documents
  * within that workspace.
  *
- * @internal
+ * @public
  */
 export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	// A table of connected clients
@@ -201,7 +201,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}>()
 
 	// Values associated with each uid (must be serializable).
-	/** @internal */
+	/**
+	 * The documents in the room
+	 * @public
+	 */
 	documents: AtomMap<string, DocumentState<R>>
 	tombstones: AtomMap<string, number>
 
@@ -526,7 +529,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		}
 	}
 
-	/** @internal */
 	private removeSession(sessionId: string, fatalReason?: string) {
 		const session = this.sessions.get(sessionId)
 		if (!session) {
@@ -643,7 +645,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * When a client connects to the room, add them to the list of clients and then merge the history
 	 * down into the snapshots.
 	 *
-	 * @internal
+	 * @public
 	 */
 	handleNewSession(opts: {
 		sessionId: string

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -1,17 +1,17 @@
 import { RecordsDiff, UnknownRecord } from '@tldraw/store'
 import { isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
 
-/** @internal */
+/** @public */
 export const RecordOpType = {
 	Put: 'put',
 	Patch: 'patch',
 	Remove: 'remove',
 } as const
 
-/** @internal */
+/** @public */
 export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType]
 
-/** @internal */
+/** @public */
 export type RecordOp<R extends UnknownRecord> =
 	| [typeof RecordOpType.Put, R]
 	| [typeof RecordOpType.Patch, ObjectDiff]
@@ -24,7 +24,7 @@ export type RecordOp<R extends UnknownRecord> =
  *
  * Each key in this object is the id of a record that has been added, updated, or removed.
  *
- * @internal
+ * @public
  */
 export interface NetworkDiff<R extends UnknownRecord> {
 	[id: string]: RecordOp<R>
@@ -61,29 +61,29 @@ export function getNetworkDiff<R extends UnknownRecord>(
 	return res
 }
 
-/** @internal */
+/** @public */
 export const ValueOpType = {
 	Put: 'put',
 	Delete: 'delete',
 	Append: 'append',
 	Patch: 'patch',
 } as const
-/** @internal */
+/** @public */
 export type ValueOpType = (typeof ValueOpType)[keyof typeof ValueOpType]
 
-/** @internal */
+/** @public */
 export type PutOp = [type: typeof ValueOpType.Put, value: unknown]
-/** @internal */
+/** @public */
 export type AppendOp = [type: typeof ValueOpType.Append, values: unknown[], offset: number]
-/** @internal */
+/** @public */
 export type PatchOp = [type: typeof ValueOpType.Patch, diff: ObjectDiff]
-/** @internal */
+/** @public */
 export type DeleteOp = [type: typeof ValueOpType.Delete]
 
-/** @internal */
+/** @public */
 export type ValueOp = PutOp | AppendOp | PatchOp | DeleteOp
 
-/** @internal */
+/** @public */
 export interface ObjectDiff {
 	[k: string]: ValueOp
 }

--- a/packages/sync-core/src/lib/protocol.ts
+++ b/packages/sync-core/src/lib/protocol.ts
@@ -9,7 +9,7 @@ export function getTlsyncProtocolVersion() {
 }
 
 /**
- * @internal
+ * @public
  * @deprecated Replaced by websocket .close status/reason
  */
 export const TLIncompatibilityReason = {
@@ -20,13 +20,13 @@ export const TLIncompatibilityReason = {
 } as const
 
 /**
- * @internal
+ * @public
  * @deprecated replaced by websocket .close status/reason
  */
 export type TLIncompatibilityReason =
 	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
-/** @internal */
+/** @public */
 export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	| {
 			type: 'connect'
@@ -50,7 +50,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	| { type: 'custom'; data: any }
 	| TLSocketServerSentDataEvent<R>
 
-/** @internal */
+/** @public */
 export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 	| {
 			type: 'patch'
@@ -64,7 +64,7 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 			action: 'discard' | 'commit' | { rebaseWithDiff: NetworkDiff<R> }
 	  }
 
-/** @internal */
+/** @public */
 export interface TLPushRequest<R extends UnknownRecord> {
 	type: 'push'
 	clientClock: number
@@ -72,7 +72,7 @@ export interface TLPushRequest<R extends UnknownRecord> {
 	presence?: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
 }
 
-/** @internal */
+/** @public */
 export interface TLConnectRequest {
 	type: 'connect'
 	connectRequestId: string
@@ -81,12 +81,12 @@ export interface TLConnectRequest {
 	schema: SerializedSchema
 }
 
-/** @internal */
+/** @public */
 export interface TLPingRequest {
 	type: 'ping'
 }
 
-/** @internal */
+/** @public */
 export type TLSocketClientSentEvent<R extends UnknownRecord> =
 	| TLPushRequest<R>
 	| TLConnectRequest

--- a/templates/custom-server-example/.gitignore
+++ b/templates/custom-server-example/.gitignore
@@ -1,0 +1,3 @@
+.rooms/
+.assets/
+.yarn

--- a/templates/custom-server-example/README.md
+++ b/templates/custom-server-example/README.md
@@ -1,0 +1,33 @@
+# tldraw sync, custom Socket.IO server example
+
+This is an example of a backend for [tldraw sync](https://tldraw.dev/docs/sync) using Socket.IO with Express server.
+
+Run `yarn dev-node` or `yarn dev-bun` in this folder to start the server + client.
+
+This example shows how to integrate tldraw sync with Socket.IO instead of the standard WebSocket implementation used in the simple-server-example.
+
+For a production-ready example specific to Cloudflare, see /templates/sync-cloudflare.
+
+## License
+
+This project is provided under the MIT license found [here](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/LICENSE.md). The tldraw SDK is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
+
+## Trademarks
+
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+
+## Distributions
+
+You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?activeTab=versions).
+
+## Contribution
+
+Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+
+## Community
+
+Have questions, comments or feedback? [Join our discord](https://discord.tldraw.com/?utm_source=github&utm_medium=readme&utm_campaign=sociallink). For the latest news and release notes, visit [tldraw.dev](https://tldraw.dev).
+
+## Contact
+
+Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw).

--- a/templates/custom-server-example/package.json
+++ b/templates/custom-server-example/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "@tldraw/custom-server-example",
+	"description": "tldraw infinite canvas SDK (example node/bun servers).",
+	"version": "0.0.0",
+	"private": true,
+	"author": {
+		"name": "tldraw GB Ltd.",
+		"email": "hello@tldraw.com"
+	},
+	"license": "MIT",
+	"main": "./src/server/server.ts",
+	"scripts": {
+		"dev": "concurrently -n server,client -c red,blue \"yarn dev-server\" \"yarn dev-client\"",
+		"dev-server": "yarn run -T tsx watch ./src/server/server.ts",
+		"dev-client": "vite dev",
+		"test-ci": "echo 'No tests yet'",
+		"test": "yarn run -T vitest run --passWithNoTests",
+		"test-coverage": "lazy inherit",
+		"lint": "yarn run -T tsx ../../internal/scripts/lint.ts"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.1.6",
+		"@types/express": "^4.17.21",
+		"@types/react": "^18.3.18",
+		"@types/react-dom": "^18.3.5",
+		"concurrently": "^9.1.2",
+		"lazyrepo": "0.0.0-alpha.27",
+		"tsx": "^4.19.2",
+		"typescript": "^5.8.3"
+	},
+	"dependencies": {
+		"@tldraw/state": "workspace:*",
+		"@tldraw/sync-core": "workspace:*",
+		"@vitejs/plugin-react-swc": "^3.10.2",
+		"express": "^4.21.1",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"react-router-dom": "^6.28.2",
+		"socket.io": "^4.8.1",
+		"socket.io-client": "^4.8.1",
+		"tldraw": "workspace:*",
+		"unfurl.js": "^6.4.0",
+		"vite": "^7.0.1"
+	}
+}

--- a/templates/custom-server-example/src/client/App.tsx
+++ b/templates/custom-server-example/src/client/App.tsx
@@ -1,0 +1,357 @@
+import { atom, computed, transact } from '@tldraw/state'
+import {
+	TLSyncClient,
+	TLSyncErrorCloseEventReason,
+	type TLPersistentClientSocket,
+	type TLPresenceMode,
+} from '@tldraw/sync-core'
+import { useEffect, useState } from 'react'
+import { io, Socket } from 'socket.io-client'
+import {
+	AssetRecordType,
+	createTLStore,
+	getDefaultUserPresence,
+	getHashForString,
+	InstancePresenceRecordType,
+	TAB_ID,
+	TLAssetStore,
+	TLBookmarkAsset,
+	Tldraw,
+	TLRecord,
+	TLStore,
+	uniqueId,
+	type TLStoreWithStatus,
+} from 'tldraw'
+import { ClientToServerMessage, ServerToClientMessage } from '../server/server'
+
+const WORKER_URL = `http://localhost:5858`
+const roomId = 'test-room'
+
+function App() {
+	const [storeWithStatus, setStoreWithStatus] = useState<TLStoreWithStatus | null>(null)
+
+	useEffect(() => {
+		// Generate unique identifiers
+		const storeId = uniqueId()
+
+		// User preferences (in real app, this would come from your auth system)
+		const userPreferences = {
+			id: 'user-' + uniqueId(),
+			name: 'User ' + Math.floor(Math.random() * 1000),
+			color: '#' + Math.floor(Math.random() * 16777215).toString(16),
+		}
+
+		const ioSocket: Socket<ServerToClientMessage, ClientToServerMessage> = io(WORKER_URL, {
+			query: {
+				sessionId: TAB_ID,
+				storeId: storeId,
+				roomId: roomId,
+			},
+		})
+
+		const socket: TLPersistentClientSocket<TLRecord> = {
+			connectionStatus: 'offline',
+
+			sendMessage: (message) => {
+				console.log('📤 Sending:', message)
+				ioSocket.emit('tldraw-message', JSON.stringify(message))
+			},
+
+			onReceiveMessage: (callback) => {
+				// Listen for tldraw sync protocol messages
+				const handler = (message: any) => {
+					console.log('📥 Received:', message)
+					callback(message)
+				}
+
+				ioSocket.on('tldraw-message', handler)
+
+				// Return cleanup function
+				return () => {
+					ioSocket.off('tldraw-message', handler)
+				}
+			},
+
+			onStatusChange: (callback) => {
+				// Map Socket.IO events to TLPersistentClientSocket status
+				const connectHandler = () => {
+					;(socket as any).connectionStatus = 'online'
+					callback({ status: 'online' })
+				}
+
+				const disconnectHandler = () => {
+					;(socket as any).connectionStatus = 'offline'
+					callback({ status: 'offline' })
+				}
+
+				const errorHandler = (error: any) => {
+					;(socket as any).connectionStatus = 'error'
+					callback({
+						status: 'error',
+						reason: error.message || 'Connection error',
+					})
+				}
+
+				ioSocket.on('connect', connectHandler)
+				ioSocket.on('disconnect', disconnectHandler)
+				ioSocket.on('connect_error', errorHandler)
+
+				// Set initial status
+				if (ioSocket.connected) {
+					;(socket as any).connectionStatus = 'online'
+					setTimeout(() => callback({ status: 'online' }), 0)
+				}
+
+				// Return cleanup function
+				return () => {
+					ioSocket.off('connect', connectHandler)
+					ioSocket.off('disconnect', disconnectHandler)
+					ioSocket.off('connect_error', errorHandler)
+				}
+			},
+
+			restart: () => {
+				console.log('🔄 Restarting Socket.IO connection...')
+				ioSocket.disconnect()
+				ioSocket.connect()
+			},
+		}
+
+		// Track connection status for collaboration UX
+		const collaborationStatus = computed('collaboration status', () =>
+			socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
+		)
+
+		// Track read/write mode
+		const syncMode = atom('sync mode', 'readwrite' as 'readonly' | 'readwrite')
+
+		// Create the store with collaboration status
+		const store = createTLStore({
+			id: storeId,
+			assets: multiplayerAssets,
+			collaboration: {
+				status: collaborationStatus,
+				mode: syncMode,
+			},
+		})
+
+		// Create presence signal using tldraw's built-in logic
+		const presence = computed('instancePresence', () => {
+			const presenceState = getDefaultUserPresence(store, userPreferences)
+			if (!presenceState) return null
+
+			return InstancePresenceRecordType.create({
+				...presenceState,
+				id: InstancePresenceRecordType.createId(store.id),
+			})
+		})
+
+		// Track other users for presence mode
+		const otherUserPresences = store.query.ids('instance_presence', () => ({
+			userId: { neq: userPreferences.id },
+		}))
+
+		const presenceMode = computed<TLPresenceMode>('presenceMode', () => {
+			if (otherUserPresences.get().size === 0) return 'solo'
+			return 'full'
+		})
+
+		// Track cancellation state
+		let didCancel = false
+
+		// Create the sync client (mirrors useSync implementation)
+		const client = new TLSyncClient<TLRecord, TLStore>({
+			store,
+			socket,
+			presence,
+			presenceMode,
+			didCancel: () => didCancel,
+
+			onLoad: (_client) => {
+				console.log('✅ Custom sync client loaded and ready')
+				// Set the store as ready
+				setStoreWithStatus({
+					store,
+					status: 'synced-remote',
+					connectionStatus: 'online',
+				})
+			},
+
+			onSyncError: (reason) => {
+				console.error('❌ Custom sync error:', reason)
+
+				// Handle specific error types
+				switch (reason) {
+					case TLSyncErrorCloseEventReason.NOT_FOUND:
+						console.error('Room not found')
+						break
+					case TLSyncErrorCloseEventReason.FORBIDDEN:
+						console.error('Access forbidden')
+						break
+					case TLSyncErrorCloseEventReason.NOT_AUTHENTICATED:
+						console.error('Authentication required')
+						break
+					case TLSyncErrorCloseEventReason.RATE_LIMITED:
+						console.error('Rate limited - too many requests')
+						break
+					case TLSyncErrorCloseEventReason.ROOM_FULL:
+						console.error('Room is full')
+						break
+					default:
+						console.error('Unknown sync error:', reason)
+				}
+
+				// Set error state
+				setStoreWithStatus({
+					status: 'error',
+					error: new Error(reason),
+				})
+			},
+
+			onAfterConnect: (_client, { isReadonly }) => {
+				console.log('🔄 Custom client connected to room', { isReadonly })
+
+				// Update sync mode and ensure store is usable
+				transact(() => {
+					syncMode.set(isReadonly ? 'readonly' : 'readwrite')
+					store.ensureStoreIsUsable()
+				})
+			},
+
+			// Optional: Handle custom messages
+			onCustomMessageReceived: (message) => {
+				console.log('📨 Custom message received:', message)
+				// Process your custom server messages here
+			},
+		})
+
+		// Cleanup function
+		const cleanup = () => {
+			console.log('🧹 Cleaning up custom sync client')
+			didCancel = true
+			client.close()
+			ioSocket.disconnect()
+		}
+
+		// Set initial loading state
+		setStoreWithStatus({
+			status: 'loading',
+		})
+
+		// Cleanup on unmount
+		return cleanup
+	}, [])
+
+	// Show loading state
+	if (!storeWithStatus) {
+		return (
+			<div
+				style={{
+					position: 'fixed',
+					inset: 0,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					fontSize: '18px',
+					color: '#666',
+				}}
+			>
+				Initializing custom sync client...
+			</div>
+		)
+	}
+
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<div
+				style={{
+					position: 'absolute',
+					top: 10,
+					left: 10,
+					zIndex: 1000,
+					background: 'rgba(0,0,0,0.8)',
+					color: 'white',
+					padding: '8px 12px',
+					borderRadius: '4px',
+					fontSize: '12px',
+					fontFamily: 'monospace',
+				}}
+			>
+				Custom TLSyncClient • Status: {storeWithStatus.status}
+				{storeWithStatus.status === 'synced-remote' &&
+					` • Connection: ${storeWithStatus.connectionStatus}`}
+			</div>
+
+			<Tldraw
+				// Pass the store created with custom TLSyncClient
+				store={storeWithStatus}
+				onMount={(editor) => {
+					// @ts-expect-error
+					window.editor = editor
+					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
+					console.log('🎨 Tldraw editor mounted with custom sync client')
+				}}
+			/>
+		</div>
+	)
+}
+
+// How does our server handle assets like images and videos?
+const multiplayerAssets: TLAssetStore = {
+	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
+	async upload(_asset, file) {
+		const id = uniqueId()
+
+		const objectName = `${id}-${file.name}`
+		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
+
+		const response = await fetch(url, {
+			method: 'PUT',
+			body: file,
+		})
+
+		if (!response.ok) {
+			throw new Error(`Failed to upload asset: ${response.statusText}`)
+		}
+
+		return { src: url }
+	},
+	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
+	// auth, or to serve optimized versions / sizes of the asset.
+	resolve(asset) {
+		return asset.props.src
+	},
+}
+
+// How does our server handle bookmark unfurling?
+async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
+	const asset: TLBookmarkAsset = {
+		id: AssetRecordType.createId(getHashForString(url)),
+		typeName: 'asset',
+		type: 'bookmark',
+		meta: {},
+		props: {
+			src: url,
+			description: '',
+			image: '',
+			favicon: '',
+			title: '',
+		},
+	}
+
+	try {
+		const response = await fetch(`${WORKER_URL}/unfurl?url=${encodeURIComponent(url)}`)
+		const data = await response.json()
+
+		asset.props.description = data?.description ?? ''
+		asset.props.image = data?.image ?? ''
+		asset.props.favicon = data?.favicon ?? ''
+		asset.props.title = data?.title ?? ''
+	} catch (e) {
+		console.error(e)
+	}
+
+	return asset
+}
+
+export default App

--- a/templates/custom-server-example/src/client/index.css
+++ b/templates/custom-server-example/src/client/index.css
@@ -1,0 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
+@import url('tldraw/tldraw.css');
+
+body {
+	font-family: 'Inter', sans-serif;
+	overscroll-behavior: none;
+}

--- a/templates/custom-server-example/src/client/index.html
+++ b/templates/custom-server-example/src/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<title>tldraw node/bun server example</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./main.tsx"></script>
+		<noscript>You need to enable JavaScript to run tldraw. ✌️</noscript>
+	</body>
+</html>

--- a/templates/custom-server-example/src/client/main.tsx
+++ b/templates/custom-server-example/src/client/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
+)

--- a/templates/custom-server-example/src/client/vite-env.d.ts
+++ b/templates/custom-server-example/src/client/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/templates/custom-server-example/src/server/assets.ts
+++ b/templates/custom-server-example/src/server/assets.ts
@@ -1,0 +1,15 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join, resolve } from 'path'
+import { Readable } from 'stream'
+
+// We are just using the filesystem to store assets
+const DIR = resolve('./.assets')
+
+export async function storeAsset(id: string, stream: Readable) {
+	await mkdir(DIR, { recursive: true })
+	await writeFile(join(DIR, id), stream)
+}
+
+export async function loadAsset(id: string) {
+	return await readFile(join(DIR, id))
+}

--- a/templates/custom-server-example/src/server/rooms.ts
+++ b/templates/custom-server-example/src/server/rooms.ts
@@ -1,0 +1,90 @@
+import { RoomSnapshot, TLSocketRoom } from '@tldraw/sync-core'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+// For this example we're just saving data to the local filesystem
+const DIR = './.rooms'
+async function readSnapshotIfExists(roomId: string) {
+	try {
+		const data = await readFile(join(DIR, roomId))
+		return JSON.parse(data.toString()) ?? undefined
+	} catch {
+		return undefined
+	}
+}
+async function saveSnapshot(roomId: string, snapshot: RoomSnapshot) {
+	await mkdir(DIR, { recursive: true })
+	await writeFile(join(DIR, roomId), JSON.stringify(snapshot))
+}
+
+// We'll keep an in-memory map of rooms and their data
+interface RoomState {
+	room: TLSocketRoom<any, void>
+	id: string
+	needsPersist: boolean
+}
+const rooms = new Map<string, RoomState>()
+
+// Very simple mutex using promise chaining, to avoid race conditions
+// when loading rooms. In production you probably want one mutex per room
+// to avoid unnecessary blocking!
+let mutex = Promise.resolve<null | Error>(null)
+
+export async function makeOrLoadRoom(roomId: string) {
+	mutex = mutex
+		.then(async () => {
+			if (rooms.has(roomId)) {
+				const roomState = await rooms.get(roomId)!
+				if (!roomState.room.isClosed()) {
+					return null // all good
+				}
+			}
+			console.log('loading room', roomId)
+			const initialSnapshot = await readSnapshotIfExists(roomId)
+
+			const roomState: RoomState = {
+				needsPersist: false,
+				id: roomId,
+				room: new TLSocketRoom({
+					initialSnapshot,
+					onSessionRemoved(room, args) {
+						console.log('client disconnected', args.sessionId, roomId)
+						if (args.numSessionsRemaining === 0) {
+							console.log('closing room', roomId)
+							room.close()
+						}
+					},
+					onDataChange() {
+						roomState.needsPersist = true
+					},
+				}),
+			}
+			rooms.set(roomId, roomState)
+			return null // all good
+		})
+		.catch((error) => {
+			// return errors as normal values to avoid stopping the mutex chain
+			return error
+		})
+
+	const err = await mutex
+	if (err) throw err
+	return rooms.get(roomId)!.room
+}
+
+// Do persistence on a regular interval.
+// In production you probably want a smarter system with throttling.
+setInterval(() => {
+	for (const roomState of rooms.values()) {
+		if (roomState.needsPersist) {
+			// persist room
+			roomState.needsPersist = false
+			console.log('saving snapshot', roomState.id)
+			saveSnapshot(roomState.id, roomState.room.getCurrentSnapshot())
+		}
+		if (roomState.room.isClosed()) {
+			console.log('deleting room', roomState.id)
+			rooms.delete(roomState.id)
+		}
+	}
+}, 2000)

--- a/templates/custom-server-example/src/server/server.ts
+++ b/templates/custom-server-example/src/server/server.ts
@@ -1,0 +1,139 @@
+import { WebSocketMinimal } from '@tldraw/sync-core'
+import express from 'express'
+import { createServer } from 'http'
+import { Server } from 'socket.io'
+import { loadAsset, storeAsset } from './assets'
+import { makeOrLoadRoom } from './rooms'
+import { unfurl } from './unfurl'
+
+const PORT = 5858
+
+// For this example we use Socket.IO with Express
+// To keep things simple we're skipping normal production concerns like rate limiting and input validation.
+// Create Express app and HTTP server for Socket.IO
+const app = express()
+const server = createServer(app)
+
+// Enable CORS and parse JSON
+app.use(express.json())
+app.use((req, res, next) => {
+	res.header('Access-Control-Allow-Origin', '*')
+	res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+	next()
+})
+
+export interface ServerToClientMessage {
+	'tldraw-message': (message: string) => void
+}
+
+export interface ClientToServerMessage {
+	'tldraw-message': (message: string) => void
+}
+
+// Create Socket.IO server
+const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
+	cors: {
+		origin: '*',
+		methods: ['GET', 'POST'],
+	},
+})
+
+// This is the main entrypoint for the multiplayer sync
+io.on('connection', async (socket) => {
+	console.log('Socket.IO client connected:', socket.id)
+
+	// The roomId and sessionId are passed from the client as query params,
+	// you need to extract them and pass them to the room.
+	const sessionId = socket.handshake.query.sessionId as string
+	const roomId = socket.handshake.query.roomId as string
+
+	if (!sessionId || !roomId) {
+		console.log('Missing required parameters, disconnecting:', socket.id)
+		socket.disconnect()
+		return
+	}
+
+	console.log('Connecting to room:', roomId, 'with session:', sessionId)
+
+	try {
+		// Here we make or get an existing instance of TLSocketRoom for the given roomId
+		const room = await makeOrLoadRoom(roomId)
+
+		// Create a socket adapter for TLSocketRoom
+		const socketAdapter: WebSocketMinimal = {
+			send: (message) => {
+				socket.emit('tldraw-message', JSON.parse(message))
+			},
+			close: () => {
+				socket.disconnect()
+			},
+			get readyState() {
+				return socket.connected ? 1 : 3 // 1 = OPEN, 3 = CLOSED
+			},
+		}
+
+		// and finally connect the socket to the room
+		room.handleSocketConnect({
+			sessionId: sessionId,
+			socket: socketAdapter,
+		})
+
+		// Handle tldraw sync messages
+		socket.on('tldraw-message', (message) => {
+			// Ensure message is a string - Socket.IO might send it as an object or buffer
+			room.handleSocketMessage(sessionId, message)
+		})
+
+		// Handle disconnect
+		socket.on('disconnect', () => {
+			console.log('Socket.IO client disconnected:', socket.id)
+		})
+	} catch (error) {
+		console.error('Error setting up room connection:', error)
+		socket.disconnect()
+	}
+})
+
+// To enable blob storage for assets, we add simple endpoints supporting PUT and GET requests
+app.put('/uploads/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+	try {
+		const id = req.params.id
+		await storeAsset(id, req.body)
+		res.json({ ok: true })
+	} catch (error) {
+		console.error('Asset upload error:', error)
+		res.status(500).json({ error: 'Upload failed' })
+	}
+})
+
+app.get('/uploads/:id', async (req, res) => {
+	try {
+		const id = req.params.id
+		const data = await loadAsset(id)
+		res.send(data)
+	} catch (error) {
+		console.error('Asset download error:', error)
+		res.status(404).json({ error: 'Asset not found' })
+	}
+})
+
+// To enable unfurling of bookmarks, we add a simple endpoint that takes a URL query param
+app.get('/unfurl', async (req, res) => {
+	try {
+		const url = req.query.url as string
+		if (!url) {
+			return res.status(400).json({ error: 'URL parameter required' })
+		}
+		const result = await unfurl(url)
+		return res.json(result)
+	} catch (error) {
+		console.error('Unfurl error:', error)
+		return res.status(500).json({ error: 'Unfurl failed' })
+	}
+})
+
+// Start server
+server.listen(PORT, () => {
+	console.log(`Server started on port ${PORT}`)
+})

--- a/templates/custom-server-example/src/server/unfurl.ts
+++ b/templates/custom-server-example/src/server/unfurl.ts
@@ -1,0 +1,14 @@
+import _unfurl from 'unfurl.js'
+
+export async function unfurl(url: string) {
+	const { title, description, open_graph, twitter_card, favicon } = await _unfurl.unfurl(url)
+
+	const image = open_graph?.images?.[0]?.url || twitter_card?.images?.[0]?.url
+
+	return {
+		title,
+		description,
+		image,
+		favicon,
+	}
+}

--- a/templates/custom-server-example/tsconfig.json
+++ b/templates/custom-server-example/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../internal/config/tsconfig.base.json",
+	"include": ["src", "scripts", "vite.config.mts"],
+	"exclude": ["node_modules", "dist", ".tsbuild*"],
+	"compilerOptions": { "noEmit": true, "emitDeclarationOnly": false, "types": ["bun", "node"] },
+	"references": [
+		{ "path": "../../packages/sync" },
+		{ "path": "../../packages/sync-core" },
+		{ "path": "../../packages/tldraw" }
+	]
+}

--- a/templates/custom-server-example/vite.config.mts
+++ b/templates/custom-server-example/vite.config.mts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react-swc'
+import path from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig(() => ({
+	plugins: [react({ tsDecorators: true })],
+	root: path.join(__dirname, 'src/client'),
+	publicDir: path.join(__dirname, 'public'),
+	server: {
+		port: 5757,
+	},
+	optimizeDeps: {
+		exclude: ['@tldraw/assets'],
+	},
+}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -8433,6 +8433,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socket.io/component-emitter@npm:~3.1.0":
+  version: 3.1.2
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
+  checksum: 10/89888f00699eb34e3070624eb7b8161fa29f064aeb1389a48f02195d55dd7c52a504e52160016859f6d6dffddd54324623cdd47fd34b3d46f9ed96c18c456edc
+  languageName: node
+  linkType: hard
+
 "@speed-highlight/core@npm:^1.2.7":
   version: 1.2.7
   resolution: "@speed-highlight/core@npm:1.2.7"
@@ -9139,6 +9146,33 @@ __metadata:
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.8.3"
     wrangler: "npm:^4.37.1"
+  languageName: unknown
+  linkType: soft
+
+"@tldraw/custom-server-example@workspace:templates/custom-server-example":
+  version: 0.0.0-use.local
+  resolution: "@tldraw/custom-server-example@workspace:templates/custom-server-example"
+  dependencies:
+    "@tldraw/state": "workspace:*"
+    "@tldraw/sync-core": "workspace:*"
+    "@types/bun": "npm:^1.1.6"
+    "@types/express": "npm:^4.17.21"
+    "@types/react": "npm:^18.3.18"
+    "@types/react-dom": "npm:^18.3.5"
+    "@vitejs/plugin-react-swc": "npm:^3.10.2"
+    concurrently: "npm:^9.1.2"
+    express: "npm:^4.21.1"
+    lazyrepo: "npm:0.0.0-alpha.27"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    react-router-dom: "npm:^6.28.2"
+    socket.io: "npm:^4.8.1"
+    socket.io-client: "npm:^4.8.1"
+    tldraw: "workspace:*"
+    tsx: "npm:^4.19.2"
+    typescript: "npm:^5.8.3"
+    unfurl.js: "npm:^6.4.0"
+    vite: "npm:^7.0.1"
   languageName: unknown
   linkType: soft
 
@@ -9889,6 +9923,15 @@ __metadata:
   version: 2.5.8
   resolution: "@types/core-js@npm:2.5.8"
   checksum: 10/58c4b86102b13b778d3631d38913c788ef7f688d99fbd741f6241a9cedc7e986e670011bdccd58b32e28e97b9c0fa6fffedef6ba0f670a005b321788a5a01a65
+  languageName: node
+  linkType: hard
+
+"@types/cors@npm:^2.8.12":
+  version: 2.8.19
+  resolution: "@types/cors@npm:2.8.19"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/9545cc532c9218754443f48a0c98c1a9ba4af1fe54a3425c95de75ff3158147bb39e666cb7c6bf98cc56a9c6dc7b4ce5b2cbdae6b55d5942e50c81b76ed6b825
   languageName: node
   linkType: hard
 
@@ -11603,6 +11646,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:~1.3.4, accepts@npm:~1.3.8":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 10/67eaaa90e2917c58418e7a9b89392002d2b1ccd69bcca4799135d0c632f3b082f23f4ae4ddeedbced5aa59bcc7bdf4699c69ebed4593696c922462b7bc5744d6
+  languageName: node
+  linkType: hard
+
 "acorn-import-attributes@npm:^1.9.5":
   version: 1.9.5
   resolution: "acorn-import-attributes@npm:1.9.5"
@@ -12136,6 +12189,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-flatten@npm:1.1.1":
+  version: 1.1.1
+  resolution: "array-flatten@npm:1.1.1"
+  checksum: 10/e13c9d247241be82f8b4ec71d035ed7204baa82fae820d4db6948d30d3c4a9f2b3905eb2eec2b937d4aa3565200bd3a1c500480114cff649fa748747d2a50feb
+  languageName: node
+  linkType: hard
+
 "array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
   version: 3.1.8
   resolution: "array-includes@npm:3.1.8"
@@ -12565,6 +12625,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64id@npm:2.0.0, base64id@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "base64id@npm:2.0.0"
+  checksum: 10/e3312328429e512b0713469c5312f80b447e71592cae0a5bddf3f1adc9c89d1b2ed94156ad7bb9f529398f310df7ff6f3dbe9550735c6a759f247c088ea67364
+  languageName: node
+  linkType: hard
+
 "basic-auth@npm:^2.0.1":
   version: 2.0.1
   resolution: "basic-auth@npm:2.0.1"
@@ -12654,6 +12721,26 @@ __metadata:
   version: 2.1.5
   resolution: "blake3-wasm@npm:2.1.5"
   checksum: 10/7138aa209ac8411755ba07df7d035974886aac1fb4bb8cf710d354732037069bacc9984c19b3bc68bf5e17cc203f454cc9cfcb7115393aaf21ce865630dbf920
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:1.20.3":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
+  dependencies:
+    bytes: "npm:3.1.2"
+    content-type: "npm:~1.0.5"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    on-finished: "npm:2.4.1"
+    qs: "npm:6.13.0"
+    raw-body: "npm:2.5.2"
+    type-is: "npm:~1.6.18"
+    unpipe: "npm:1.0.0"
+  checksum: 10/8723e3d7a672eb50854327453bed85ac48d045f4958e81e7d470c56bf111f835b97e5b73ae9f6393d0011cc9e252771f46fd281bbabc57d33d3986edf1e6aeca
   languageName: node
   linkType: hard
 
@@ -13793,6 +13880,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:0.5.4":
+  version: 0.5.4
+  resolution: "content-disposition@npm:0.5.4"
+  dependencies:
+    safe-buffer: "npm:5.2.1"
+  checksum: 10/b7f4ce176e324f19324be69b05bf6f6e411160ac94bc523b782248129eb1ef3be006f6cff431aaea5e337fe5d176ce8830b8c2a1b721626ead8933f0cbe78720
+  languageName: node
+  linkType: hard
+
 "content-disposition@npm:^1.0.0":
   version: 1.0.0
   resolution: "content-disposition@npm:1.0.0"
@@ -13809,7 +13905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:^1.0.5, content-type@npm:~1.0.4":
+"content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10/585847d98dc7fb8035c02ae2cb76c7a9bd7b25f84c447e5ed55c45c2175e83617c8813871b4ee22f368126af6b2b167df655829007b21aa10302873ea9c62662
@@ -13827,6 +13923,13 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 10/c987be3ec061348cdb3c2bfb924bec86dea1eacad10550a85ca23edb0fe3556c3a61c7399114f3331ccb3499d7fd0285ab24566e5745929412983494c3926e15
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: 10/f4e1b0a98a27a0e6e66fd7ea4e4e9d8e038f624058371bf4499cfcd8f3980be9a121486995202ba3fca74fbed93a407d6d54d43a43f96fd28d0bd7a06761591a
   languageName: node
   linkType: hard
 
@@ -13851,7 +13954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.0":
+"cookie@npm:^0.7.0, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
@@ -13881,7 +13984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:^2.8.5":
+"cors@npm:^2.8.5, cors@npm:~2.8.5":
   version: 2.8.5
   resolution: "cors@npm:2.8.5"
   dependencies:
@@ -14142,6 +14245,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:2.6.9, debug@npm:^2.2.0":
+  version: 2.6.9
+  resolution: "debug@npm:2.6.9"
+  dependencies:
+    ms: "npm:2.0.0"
+  checksum: 10/e07005f2b40e04f1bd14a3dd20520e9c4f25f60224cb006ce9d6781732c917964e9ec029fc7f1a151083cd929025ad5133814d4dc624a9aaf020effe4914ed14
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
@@ -14187,21 +14299,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^2.2.0":
-  version: 2.6.9
-  resolution: "debug@npm:2.6.9"
-  dependencies:
-    ms: "npm:2.0.0"
-  checksum: 10/e07005f2b40e04f1bd14a3dd20520e9c4f25f60224cb006ce9d6781732c917964e9ec029fc7f1a151083cd929025ad5133814d4dc624a9aaf020effe4914ed14
-  languageName: node
-  linkType: hard
-
 "debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10/d86fd7be2b85462297ea16f1934dc219335e802f629ca9a69b63ed8ed041dda492389bb2ee039217c02e5b54792b1c51aa96ae954cf28634d363a2360c7a1639
+  languageName: node
+  linkType: hard
+
+"debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/71168908b9a78227ab29d5d25fe03c5867750e31ce24bf2c44a86efc5af041758bb56569b0a3d48a9b5344c00a24a777e6f4100ed6dfd9534a42c1dde285125a
   languageName: node
   linkType: hard
 
@@ -14404,7 +14519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destroy@npm:^1.2.0":
+"destroy@npm:1.2.0, destroy@npm:^1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10/0acb300b7478a08b92d810ab229d5afe0d2f4399272045ab22affa0d99dbaf12637659411530a6fcd597a9bdac718fc94373a61a95b4651bbc7b83684a565e38
@@ -14835,6 +14950,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "encodeurl@npm:1.0.2"
+  checksum: 10/e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
+  languageName: node
+  linkType: hard
+
 "encoding-sniffer@npm:^0.2.0":
   version: 0.2.0
   resolution: "encoding-sniffer@npm:0.2.0"
@@ -14880,6 +15002,43 @@ __metadata:
     fast-json-parse: "npm:^1.0.3"
     objectorarray: "npm:^1.0.5"
   checksum: 10/c352831088fce745a39ddbd5f87a17e073ea6556e7e96e9010d945a3f3020f836b9a84657123fa01e897db9216f4b080d950b5ded9bf3a8227f14a34efaaaf7c
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.3
+  resolution: "engine.io-client@npm:6.6.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10/c5b8e7eb0f2637b21a63780214878b842306247f540cccab7a4d15606d142e42878cc79607f8f77fa29f016b6854702b7d5ad275df7ad6150f08954a1e2c332a
+  languageName: node
+  linkType: hard
+
+"engine.io-parser@npm:~5.2.1":
+  version: 5.2.3
+  resolution: "engine.io-parser@npm:5.2.3"
+  checksum: 10/eb0023fff5766e7ae9d59e52d92df53fea06d472cfd7b52e5d2c36b4c1dbf78cab5fde1052bcb3d4bb85bdb5aee10ae85d8a1c6c04676dac0c6cdf16bcba6380
+  languageName: node
+  linkType: hard
+
+"engine.io@npm:~6.6.0":
+  version: 6.6.4
+  resolution: "engine.io@npm:6.6.4"
+  dependencies:
+    "@types/cors": "npm:^2.8.12"
+    "@types/node": "npm:>=10.0.0"
+    accepts: "npm:~1.3.4"
+    base64id: "npm:2.0.0"
+    cookie: "npm:~0.7.2"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+  checksum: 10/005b43b392d5b4b9bb196d1ae2a8cc1334a7dc70af3cfb50627d257de407ca1afae725fcd8571f9621cd12ed437abaac819c64cf22f09d5ae02b954a7e7bf4f8
   languageName: node
   linkType: hard
 
@@ -16233,6 +16392,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:^4.21.1":
+  version: 4.21.2
+  resolution: "express@npm:4.21.2"
+  dependencies:
+    accepts: "npm:~1.3.8"
+    array-flatten: "npm:1.1.1"
+    body-parser: "npm:1.20.3"
+    content-disposition: "npm:0.5.4"
+    content-type: "npm:~1.0.4"
+    cookie: "npm:0.7.1"
+    cookie-signature: "npm:1.0.6"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    finalhandler: "npm:1.3.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    merge-descriptors: "npm:1.0.3"
+    methods: "npm:~1.1.2"
+    on-finished: "npm:2.4.1"
+    parseurl: "npm:~1.3.3"
+    path-to-regexp: "npm:0.1.12"
+    proxy-addr: "npm:~2.0.7"
+    qs: "npm:6.13.0"
+    range-parser: "npm:~1.2.1"
+    safe-buffer: "npm:5.2.1"
+    send: "npm:0.19.0"
+    serve-static: "npm:1.16.2"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    type-is: "npm:~1.6.18"
+    utils-merge: "npm:1.0.1"
+    vary: "npm:~1.1.2"
+  checksum: 10/34571c442fc8c9f2c4b442d2faa10ea1175cf8559237fc6a278f5ce6254a8ffdbeb9a15d99f77c1a9f2926ab183e3b7ba560e3261f1ad4149799e3412ab66bd1
+  languageName: node
+  linkType: hard
+
 "express@npm:^5.0.1":
   version: 5.0.1
   resolution: "express@npm:5.0.1"
@@ -16641,6 +16839,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:1.3.1":
+  version: 1.3.1
+  resolution: "finalhandler@npm:1.3.1"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:2.4.1"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:2.0.1"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/4babe72969b7373b5842bc9f75c3a641a4d0f8eb53af6b89fa714d4460ce03fb92b28de751d12ba415e96e7e02870c436d67412120555e2b382640535697305b
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:^2.0.0":
   version: 2.1.0
   resolution: "finalhandler@npm:2.1.0"
@@ -16885,17 +17098,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fresh@npm:0.5.2, fresh@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "fresh@npm:0.5.2"
+  checksum: 10/64c88e489b5d08e2f29664eb3c79c705ff9a8eb15d3e597198ef76546d4ade295897a44abb0abd2700e7ef784b2e3cbf1161e4fbf16f59129193fd1030d16da1
+  languageName: node
+  linkType: hard
+
 "fresh@npm:2.0.0":
   version: 2.0.0
   resolution: "fresh@npm:2.0.0"
   checksum: 10/44e1468488363074641991c1340d2a10c5a6f6d7c353d89fd161c49d120c58ebf9890720f7584f509058385836e3ce50ddb60e9f017315a4ba8c6c3461813bfc
-  languageName: node
-  linkType: hard
-
-"fresh@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "fresh@npm:0.5.2"
-  checksum: 10/64c88e489b5d08e2f29664eb3c79c705ff9a8eb15d3e597198ef76546d4ade295897a44abb0abd2700e7ef784b2e3cbf1161e4fbf16f59129193fd1030d16da1
   languageName: node
   linkType: hard
 
@@ -20832,6 +21045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:0.3.0":
+  version: 0.3.0
+  resolution: "media-typer@npm:0.3.0"
+  checksum: 10/38e0984db39139604756903a01397e29e17dcb04207bb3e081412ce725ab17338ecc47220c1b186b6bbe79a658aad1b0d41142884f5a481f36290cdefbe6aa46
+  languageName: node
+  linkType: hard
+
 "media-typer@npm:^1.1.0":
   version: 1.1.0
   resolution: "media-typer@npm:1.1.0"
@@ -20843,6 +21063,13 @@ __metadata:
   version: 13.2.0
   resolution: "meow@npm:13.2.0"
   checksum: 10/4eff5bc921fed0b8a471ad79069d741a0210036d717547d0c7f36fdaf84ef7a3036225f38b6a53830d84dc9cbf8b944b097fde62381b8b5b215119e735ce1063
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:1.0.3":
+  version: 1.0.3
+  resolution: "merge-descriptors@npm:1.0.3"
+  checksum: 10/52117adbe0313d5defa771c9993fe081e2d2df9b840597e966aadafde04ae8d0e3da46bac7ca4efc37d4d2b839436582659cd49c6a43eacb3fe3050896a105d1
   languageName: node
   linkType: hard
 
@@ -21362,7 +21589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.35":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -21380,7 +21607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:^1.3.4":
+"mime@npm:1.6.0, mime@npm:^1.3.4":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
@@ -21962,7 +22189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
+"negotiator@npm:0.6.3, negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 10/2723fb822a17ad55c93a588a4bc44d53b22855bf4be5499916ca0cab1e7165409d0b288ba2577d7b029f10ce18cf2ed8e703e5af31c984e1e2304277ef979837
@@ -23225,6 +23452,13 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10/285ae0c2d6c34ae91dc1d5378ede21981c9a2f6de1ea9ca5a88b5a270ce9763b83dbadc7a324d512211d8d36b0c540427d3d0817030849d97a60fa840a2c59ec
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: 10/2e30f6a0144679c1f95c98e166b96e6acd1e72be9417830fefc8de7ac1992147eb9a4c7acaa59119fb1b3c34eec393b2129ef27e24b2054a3906fc4fb0d1398e
   languageName: node
   linkType: hard
 
@@ -24536,6 +24770,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10/3775f08015bdd33e22589117fe168fc3a386ddc56e0798a9d47e75aeb4abce86cff9dfe1f3393fbe7dd036d9cfc755cb10e3645a980824e6a69eec0bef1377e3
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:2.5.2":
+  version: 2.5.2
+  resolution: "raw-body@npm:2.5.2"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    unpipe: "npm:1.0.0"
+  checksum: 10/863b5171e140546a4d99f349b720abac4410338e23df5e409cfcc3752538c9caf947ce382c89129ba976f71894bd38b5806c774edac35ebf168d02aa1ac11a95
   languageName: node
   linkType: hard
 
@@ -25931,6 +26177,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:0.19.0":
+  version: 0.19.0
+  resolution: "send@npm:0.19.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:2.4.1"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:2.0.1"
+  checksum: 10/1f6064dea0ae4cbe4878437aedc9270c33f2a6650a77b56a16b62d057527f2766d96ee282997dd53ec0339082f2aad935bc7d989b46b48c82fc610800dc3a1d0
+  languageName: node
+  linkType: hard
+
 "send@npm:^1.0.0, send@npm:^1.1.0":
   version: 1.1.0
   resolution: "send@npm:1.1.0"
@@ -25986,6 +26253,18 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:1.16.2":
+  version: 1.16.2
+  resolution: "serve-static@npm:1.16.2"
+  dependencies:
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.19.0"
+  checksum: 10/7fa9d9c68090f6289976b34fc13c50ac8cd7f16ae6bce08d16459300f7fc61fbc2d7ebfa02884c073ec9d6ab9e7e704c89561882bbe338e99fcacb2912fde737
   languageName: node
   linkType: hard
 
@@ -26504,6 +26783,53 @@ __metadata:
     snake-case: "npm:^3.0.4"
     type-fest: "npm:^4.15.0"
   checksum: 10/d8062a06ec95fbacea2f5c4a3f02cdbff113e1fa6c4a25a90840186d9d0b428ddee245d4af34019267d93447632b90d8852a962de60f0d8d5871c1abaac3e29b
+  languageName: node
+  linkType: hard
+
+"socket.io-adapter@npm:~2.5.2":
+  version: 2.5.5
+  resolution: "socket.io-adapter@npm:2.5.5"
+  dependencies:
+    debug: "npm:~4.3.4"
+    ws: "npm:~8.17.1"
+  checksum: 10/e364733a4c34ff1d4a02219e409bd48074fd614b7f5b0568ccfa30dd553252a5b9a41056931306a276891d13ea76a19e2c6f2128a4675c37323f642896874d80
+  languageName: node
+  linkType: hard
+
+"socket.io-client@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io-client@npm:4.8.1"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.2"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10/7480cf1ab30eba371a96dd1ce2ce9018dcbeaf81035a066fb89d99df0d0a6388b05840c92d970317c739956b68b28b0f4833f3b18e460a24eef557b9bca127c1
+  languageName: node
+  linkType: hard
+
+"socket.io-parser@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "socket.io-parser@npm:4.2.4"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+  checksum: 10/4be500a9ff7e79c50ec25af11048a3ed34b4c003a9500d656786a1e5bceae68421a8394cf3eb0aa9041f85f36c1a9a737617f4aee91a42ab4ce16ffb2aa0c89c
+  languageName: node
+  linkType: hard
+
+"socket.io@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io@npm:4.8.1"
+  dependencies:
+    accepts: "npm:~1.3.4"
+    base64id: "npm:~2.0.0"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.2"
+    engine.io: "npm:~6.6.0"
+    socket.io-adapter: "npm:~2.5.2"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10/b9b362b7f63fc7ebb58482b8a3ade6c971da7783b7611dfeebaa8b02be23cb948137ec218491ccda8be57e434e97d65b64edf1e9811e5245b23a888d41636f4a
   languageName: node
   linkType: hard
 
@@ -28428,6 +28754,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:~1.6.18":
+  version: 1.6.18
+  resolution: "type-is@npm:1.6.18"
+  dependencies:
+    media-typer: "npm:0.3.0"
+    mime-types: "npm:~2.1.24"
+  checksum: 10/0bd9eeae5efd27d98fd63519f999908c009e148039d8e7179a074f105362d4fcc214c38b24f6cda79c87e563cbd12083a4691381ed28559220d4a10c2047bed4
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
@@ -28926,7 +29262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:1.0.0":
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10/4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
@@ -30088,6 +30424,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:~8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
+  languageName: node
+  linkType: hard
+
 "wsl-utils@npm:^0.1.0":
   version: 0.1.0
   resolution: "wsl-utils@npm:0.1.0"
@@ -30153,6 +30504,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10/4ad5924974efd004a47cce6acf5c0269aee0e62f9a805a426db3337af7bcbd331099df174b024ace4fb18971b8a56de386d2e73a1c4b020e3abd63a4a9b917f1
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10/708a177fe41c6c8cd4ec7c04d965b4c01801d87f44383ec639be58bdc14418142969841659e0850db44feee8bec0a3d3e7d33fed22519415f3d0daab04d3f160
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes previously `@internal` types and classes in `@tldraw/sync-core` public so they can be used directly by third-party integrations. It also adds a new custom Socket.IO server example template and updates the documentation to show how to integrate tldraw sync using custom socket.

### Change type

* [x] `feature`
* [x] `api`

### Test plan

1. Install and build the repo.
2. Verify there are no warnings in the `api-report.api.md` that everything is properly switched to `@public`.
3. Run the new `templates/custom-server-example` to verify Socket.IO integration works.

### Release notes

* Exposed previously internal types and classes in `@tldraw/sync-core` as public.
* Added new **custom Socket.IO server example template** for tldraw sync.
* Updated documentation to reference the new example.