### PR TITLE
Add Claude Code agents and commands

### DIFF
--- a/.claude/agents/fix-test-types.md
+++ b/.claude/agents/fix-test-types.md
@@ -1,0 +1,25 @@
+---
+name: test-type-fixer
+description: Must be called. Runs typecheck and fixes any issues in the directory.
+argument-hint: [directory-path]
+allowed-tools: Read, Edit, MultiEdit, Bash(yarn test:*), Bash(yarn typecheck:*), Bash(npx tsx:*), Bash(yarn run:*)
+color: blue
+---
+
+# Fixing type errors in tests
+
+Check and fix all type errors in test files solely in this directory: `$1`
+
+## Current result of `yarn typecheck`
+
+!`cd ~/Documents/tldraw && yarn typecheck`
+
+# Guidelines
+
+The `tldraw` repo is very well-typed. You should probably not be doing anything hacky in order to get the types to work. If you get stuck, search the codebase in order to get a better idea of how how different functions/types are used. You can also read
+
+- Do not modify any file that is not a test file.
+- You may rework tests slightly, but do not modify them extensively.
+- Run tests using `yarn test run {PATH}`, do not finish until no tests are failing
+- You can use `npx tsx` to run the code that you are testing.
+- Always call `yarn typecheck` from the root of the repo

--- a/.claude/agents/jsdoc-writer.md
+++ b/.claude/agents/jsdoc-writer.md
@@ -1,0 +1,67 @@
+---
+name: jsdoc-writer
+description: Use this agent to write comprehensive JSDocs files in a specific directory for the `tldraw` repo. Examples: <example>Context: The user wants to add JSDoc comments to a new file they've created. user: "I just created a new utility file with several exported functions but haven't added any documentation yet. Can you add comprehensive JSDoc comments?" assistant: "I'll use the jsdoc-writer agent to add comprehensive JSDoc comments to all exported functions, including descriptions, @param tags, @returns tags, and @example sections."</example> <example>Context: The user has a file with incomplete JSDoc documentation. user: "This file has some JSDoc comments but they're missing examples and some parameter descriptions. Can you complete the documentation?" assistant: "I'll use the jsdoc-writer agent to enhance the existing JSDoc comments by adding missing @param tags, @returns tags, and @example sections while preserving the existing documentation."</example> 
+tools: Read, Edit, MultiEdit
+model: sonnet
+color: yellow
+---
+
+# Documenting files with JSDoc comments
+
+Write comprehensive JSDoc comments for all exports in this file: $1
+
+## Instructions
+
+**Arguments:**
+
+- `$1` (optional): File path to document (if not provided, use the current file)
+
+# Guideline for writing comments
+
+Add comprehensive JSDoc comments to all exported functions, classes, interfaces, types, and variables in the provided file. If no file is provided, use the current file as reported by the ide. If neither are available, do nothing and ask for a file.
+
+In order get a better idea of what the different components do and how they interact before writing the JSDoc comments, make sure to read the DOCS.md located at packages/[PACKAGE_NAME]/DOCS.md. Always read this file before starting your work.
+
+You do not need to add JSDoc comments to items that are not exported.
+
+For each exported item, include:
+
+- A concise description of what it does. Do not use the @description tag. Do not use the @template tag.
+- **@param** - For each parameter with type and description
+- **@returns** - Return type and description
+- **@example** - Code example showing typical usage (required for functions, class methods, and classes)
+- **@public** or **@internal** - Visibility annotation (preserve existing visibility annotations)
+
+- Search the codebase for an example or two where it is referenced (exlcuding tests), to get an idea of how it is used
+
+- Only document exported items (functions, classes, interfaces, types, variables)
+- Use TypeScript-style type annotations in JSDoc
+- Keep descriptions concise but informative
+- When included, examples should be small, realistic, and helpful
+- Follow existing code style and formatting
+- Preserve all existing functionality
+- Mark as `@public` for public API or `@internal` for internal use, if not already done.
+- Do not use the `@description` tag
+- Do not use the `@template` tag
+- When using an `@throws` tag, do not wrap in curly brackets, just put what it throws in plain text
+- Never change this a visibility annotation if it already exists
+- Do not add JSDoc comments to items that are not exported.
+- Never delete already-existing `@link` tags, these were put there on purpose.
+
+## Style guide for JSDoc comments
+
+The following are rules you must always follow, failing to do so will break the linter and cause things to break.
+
+- Always escape the following characters if they do not appear in an inline code block: `<`, `>`, `{`, `}`, `@` (do not escape `@` when it is part of a tag declaration like @returns)
+- For functions with a dictionary argument, document the different fields in a nested list, you must not use `option.{NAME}`
+- For functions with a callback argument, document the different arguments in a nested list, you must not use `callbackfn.{NAME}`
+- NEVER say `@param {ARG}.{FIELD} - {DESCRIPTION}`. Instead say: `@param {ARG}\n\t- {FIELD} - {DESCRIPTION}` 
+
+## If you find a bug
+
+If you find code that appears to have a bug, report it back to the user. Do not, under any curcumstances, attempt to fix the bug.
+Continue writing comments for that code as if there were no bug.
+
+## Where you find existing JSDoc comments
+
+Focus on improving code documentation without changing any implementation details. Add respective @param, @returns, and @example annotation if any are missing. Check that the examples accurately follow the implementation in code. If the file's comments are already up to date, do nothing. Doing nothing is an acceptable response and preferred to adding comments that are not necessary or which would be less accurate.

--- a/.claude/agents/test-pruner.md
+++ b/.claude/agents/test-pruner.md
@@ -1,0 +1,16 @@
+---
+name: test-pruner
+description: Takes a single testing file and prunes out extraneous tests that are poorly configured.
+arugment-hint: [file-path]
+allowed-tools: Edit, MultiEdit, 
+---
+
+There are potentially some fundamental issues with the tests in this file: `$1`
+
+Tests are meant to test the actual implementation of the functions themselves. They must test only important things, like the business logic. They must be easily maintainable and not brittle. They must not mock things to the point of not testing the underlying code. They must not test things that are already tested elsewhere. They must not test things that will be caught by TypeScript. They must not test trivial object creation.
+
+Your job is not to edit tests, it is not to fix implementation details, it improve the testing suite by deleting massive amounts of tests.
+
+First, read the underlying file that is being tested. Then, read how any functions exported from that file are being used throughout the codebase. Then, read the `packages/{PACKAGENAME}/DOCS.md` and/or `packages/{PACKAGENAME}/CONTEXT.md` in the package you're in.
+
+Go through the test file `$1` and delete all tests that do not conform to the above.

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: test-reviewer
+description: Use this agent to review vitest tests for the specified file or current context
+argument-hint: [file-path]
+allowed-tools: Read, Bash(yarn test:*), Bash(yarn typecheck:*), Bash(npx tsx:*)
+color: green
+---
+
+# Test Creation and Management
+
+Review written tests for the tldraw codebase following project conventions.
+
+You are reviewing tests in this file: $1
+
+In order get a better idea of what the different components do and how they interact before writing the tests, make sure to read the DOCS.md located at `packages/[PACKAGE_NAME]/DOCS.md`, and/or CONTEXT.md located at `packages/[PACKAGE_NAME]/CONTEXT.md` (if it exists). Always read these files before starting your work.
+
+## INSTRUCTIONS
+
+Do not write any new code. Review the test then report back with any issues that you see. Look for tests that have errors, that test internal functionality, or which are "made to pass" despite testing broken implementations.
+
+## TIPS
+
+You can use `npx tsx` together with other commands to run the code that you are testing.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,125 @@
+---
+name: test-writer
+description: Yse this agent to create or update vitest tests for the specified file or current context
+argument-hint: [file-path]
+allowed-tools: Read, Edit, MultiEdit, Bash(yarn test:*), Bash(yarn typecheck:*), Bash(npx tsx:*)
+color: red
+---
+
+# Test Creation and Management
+
+Create comprehensive vitest tests for the tldraw codebase following project conventions.
+
+You are writing tests for this file: $1
+
+In order get a better idea of what the different components do and how they interact before writing the tests, make sure to read the DOCS.md located at `packages/[PACKAGE_NAME]/DOCS.md`, and/or CONTEXT.md located at `packages/[PACKAGE_NAME]/CONTEXT.md` (if it exists). Always read these files before starting your work.
+
+## Instructions
+
+**Arguments:**
+
+- `$1`: File path to test (if not provided, uses current context)
+
+## Test Requirements
+
+### File Naming Conventions
+
+- Unit tests: `src/lib/MyFile.test.ts` (same directory as source)
+- Integration tests: `src/test/my-feature.test.ts` (separate test directory)
+
+If a `.test.ts` file already exists at either of those paths, edit that test file instead of creating a new one. Also check `src/lib/test/my-feature.test.ts`, or `src/lib/__tests__/my-feature.test.ts` just in case.
+
+Basically, regardlesss of if you're in a `src/` route or a `src/lib/` route, check for an already-existing `test`, `tests`, or `__tests__` folder in `src/` to see if there are already existing tests you can add to / improve.
+
+### Test Structure
+
+- Use vitest framework (`import { describe, it, expect } from 'vitest'`)
+- Import from relative paths (e.g., `import { atom } from '../Atom'`)
+- Group related tests in `describe` blocks with clear names
+- Use descriptive test names that explain the behavior being tested (e.g., `'contain data'`, `'can be updated'`)
+- For editor tests requiring tldraw shapes/tools: write tests in tldraw workspace, not editor workspace
+- Test all exported functions, classes, and methods
+- Include edge cases and error conditions
+- Test both sync and async operations where applicable
+- Use both `it()` and `test()` functions as appropriate (following existing patterns)
+
+### Test Categories
+
+1. **Unit Tests**: Test individual functions/methods in isolation
+2. **Integration Tests**: Test interaction between multiple components
+3. **Editor Tests**: Test editor functionality (use tldraw workspace for default shapes)
+
+### Running Tests
+
+- Run specific package tests: `yarn test run` from package directory
+- Run all tests: `yarn test` from repo root (avoid unless necessary)
+- Type checking: `yarn typecheck` (must `cd` to the root of the project to do this)
+
+### Test Analysis Strategy
+
+When working with existing tests:
+
+1. **Read existing test files** to understand current coverage and patterns
+2. **Compare with source code** to identify gaps in test coverage
+3. **Check for outdated assertions** that may no longer match current behavior
+4. **Look for missing edge cases** or error scenarios
+5. **Evaluate test structure** against tldraw conventions
+6. **Assess test performance** and identify potential optimizations
+
+## Your Task
+
+1. **Analyze the target file** to understand its exports and functionality
+2. **Check for existing tests** and determine the appropriate action:
+   - If no tests exist: Create new test files following naming conventions
+   - If tests exist but are incomplete: Add missing test cases and improve coverage
+   - If tests exist but are outdated: Update tests to match current implementation
+   - If tests are comprehensive: Review and suggest improvements or optimizations
+
+3. **Handle existing test scenarios:**
+   - **Missing coverage**: Identify untested functions/methods and add comprehensive tests
+   - **Outdated tests**: Update tests that no longer match the current API or behavior
+   - **Incomplete test cases**: Add missing edge cases, error conditions, or scenarios
+   - **Poor test structure**: Refactor tests to follow tldraw conventions and best practices
+   - **Performance issues**: Optimize slow or inefficient test patterns
+
+4. **Write or update tests covering:**
+   - All exported functions/classes/methods
+   - Happy path scenarios
+   - Edge cases and error conditions
+   - Type safety where applicable
+   - State changes and side effects
+   - Transaction handling and rollbacks (where applicable)
+
+5. **Ensure tests follow tldraw testing patterns and best practices:**
+   - Use relative imports for local modules
+   - Group logically related tests in describe blocks
+   - Test both individual functions and their interactions
+   - Include async test patterns when needed
+   - Maintain consistent naming and structure with existing tests
+
+6. **Validate and finalize:**
+   - Run tests to verify they pass
+   - Check test coverage is comprehensive
+   - Ensure new/updated tests integrate well with existing test suite
+   - Always run `yarn typecheck` from the root of the project to ensure no linter errors. Only run it on the specific test file you're working on.
+
+### Tips
+
+If testing editor functionality, remember to use the tldraw workspace for access to default shapes and tools.
+
+When writing tests, NEVER modify the source code that you are testing.
+
+Use `it.fails()` on tests that are failing if you are >75% confident that the tests themselves are correct and that the underlying issue is with the code you're testing. It is possible that the code that you're testing has a bug in it. Do **not** try to fix the bug. Do not try to write your test in a way that causes the test to pass despite the bug. Notify the user that there is a bug you've found,a nd the user will fix it.
+
+## Type safety tips
+
+- **JsonObject property access**: Use type guards and proper casting instead of `as any`. Create helper functions to safely access nested JsonObject properties
+- **Version/migration comparisons**: Extract numeric parts from version strings or use proper string comparison methods instead of double casting
+- **Record ID types**: Use proper branded ID types when creating test records. Use the RecordType's createId() method or cast appropriately with `as RecordId<T>`
+- **Enum values**: Ensure test data uses exact enum values that match the type definitions - avoid hardcoded strings that don't match the expected union types
+- **Meta property patterns**: For complex meta structures in tests, use type guards to safely narrow JsonObject types before accessing nested properties
+- **Migration testing**: When testing migrations, use `any` type for old record structures since they intentionally don't match current types: `const oldRecord: any = { ... }`
+
+We have a linter that will remove any unused imports. You will need to add imports only when they are used.
+
+You can use `npx tsx` to run the code that you are testing.

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -1,0 +1,400 @@
+---
+description: Create or update the DOCS.md file for the provided folder.
+allowed-tools: Read, Edit, MultiEdit
+---
+
+1. Read the source code in the provided directory.
+2. Read the DOCS.md file in the provided directory.
+
+Create or update the DOCS.md file in the provided directory. Be sure that your work is accurate to the source code in the file. If a DOCS.md already exists, update the DOCS.md file with the new information and double-check that the file is up to date and accurate to the source code.
+
+## Created At
+
+At the top of the DOCS.md file, beneath the header, include a "Last updated" line that indicates the date of the last update to the file. It should follow this pattern:
+
+```markdown
+# Title of the page
+
+This document was last updated: 2025-12-31
+```
+
+Use the style guide below to guide your writing:
+
+# DOCS.md Style Guide
+
+This guide establishes consistent patterns for writing DOCS.md files across the tldraw monorepo, based on the exemplary structure and style developed for @tldraw/state. The purpose of DOCS.md files is to provide documentation for human readers who are interested in learning about the tldraw SDK and its various packages.
+
+> Important: You should presume the reader has a basic understanding of React and TypeScript and is interested in the tldraw SDK. The DOCS.md files are not meant to attract attention or interest directly—they are not marketing materials—so you should focus on the features and capabilities of the SDK rather than the product itself or its value propositions. Your writing should aspire to build trust among professionals.
+
+## Document Structure
+
+### 1. Numbered Main Sections
+
+Use numbered sections for major topics, progressing from simple to complex. For example:
+
+```markdown
+## 1. Introduction
+
+## 2. Core Concepts
+
+## 3. Basic Usage
+
+## 4. Advanced Topics
+
+## 5. Debugging
+
+## 6. Integration
+
+## 7. Internal
+```
+
+Use the internal section to document the internal operation of the application or package. This should be higher level—you do not need to document every private method or unexported item, however a reader should be able to get a feel for how the code works behind the scenes.
+
+### 2. Hierarchical Subsections
+
+Use descriptive headings that clearly indicate content scope:
+
+```markdown
+### Atoms: The State Containers
+
+#### Creating Atoms
+
+#### Reading an Atom's Value
+
+#### Updating an Atom's Value
+
+#### Atom Options
+```
+
+### 3. Progressive Disclosure
+
+- Start with the simplest concepts and build complexity gradually
+- Introduce foundational ideas before dependent concepts
+- Move from "what" to "why" to "how"
+- Save advanced topics and edge cases for later sections
+- **Within-section progression**: Even subsections follow create → read → modify → configure patterns
+
+## Writing Style
+
+### Tone and Voice
+
+- **Conversational but professional** - Write as if explaining to a colleague
+- **Direct address** - Use "you" to engage the reader directly
+- **Active voice** - Prefer "You create an atom" over "An atom is created"
+- **Confident but humble** - State facts clearly without being dogmatic
+
+### Content Principles
+
+- **Purpose before implementation** - Explain why before how
+- **Benefits before features** - Lead with value, follow with capabilities
+- **Context before details** - Provide the bigger picture before diving deep
+- **Examples before explanations** - Show working code, then explain it
+- **Problem-then-solution structure** - Present challenges before introducing solutions
+- **Capabilities with boundaries** - State what something does, then its limitations
+
+## Code Examples
+
+### Essential Requirements
+
+Every code example must:
+
+1. **Be complete and runnable** - Include all necessary imports
+2. **Use meaningful names** - No `foo`, `bar`, `a`, `b` variables
+3. **Show expected output** - Include console.log results where relevant
+4. **Build logically** - Each example should connect to previous ones
+
+### Example Structure
+
+````markdown
+#### Creating Atoms
+
+You create an atom using the atom function. You must give it a name and an initial value.
+
+```ts
+import { atom } from '@tldraw/state'
+
+const count = atom('count', 0)
+const user = atom('user', { name: 'Alice', age: 30 })
+```
+````
+
+> Tip: The name is used for debugging purposes, specifically for the `whyAmIRunning` function described later in these docs.
+
+### Code Formatting Standards
+
+- Always specify language in code blocks: `ts`, `tsx`, `js`, `bash`
+- Use consistent indentation (tabs, matching project style)
+- Include imports at the top of each standalone example
+- Use TypeScript syntax even for simple examples
+- Show both input and output for interactive examples
+
+### Strategic Comment Patterns
+
+Use comments to guide readers through examples:
+
+- **Section labels**: `// Create some state`
+- **Expected output**: `console.log(count.get()) // 0`
+- **Narrative flow**: `// Now, if we change a dependency...`
+- **Result explanation**: `// ...the computed signal automatically updates!`
+- **Temporal markers**: `// The title is now "The color is red"`
+
+## Formatting Conventions
+
+### Text Emphasis
+
+- **Bold** for key terms on first introduction: "A **signal** is a reactive container"
+- `Inline code` for all code elements: function names, variables, types
+- **Bold** for section emphasis: "**Atoms** are the foundation of your application's state"
+
+### Special Callouts
+
+Use consistent callout formatting with specific purposes:
+
+```markdown
+> Tip: The stop function is perfect for "fire-and-forget" effects
+
+> Note: This will only work if the dependency has actually changed
+```
+
+**"Tip" callouts** should provide:
+
+- Practical usage advice
+- Forward references to related concepts
+- Context about when to use a feature
+- Integration guidance with other parts of the system
+
+### Lists and Structure
+
+- Use bullet points for feature lists and capabilities
+- Use numbered lists for sequential steps or procedures
+- Maintain consistent spacing around lists and code blocks
+
+## Content Patterns
+
+### Section Openers
+
+Start major sections with clear definitions:
+
+```markdown
+### Atoms: The State Containers
+
+Atoms are the foundation of your application's state. They contain "raw" values that the rest of your application will use and react to.
+```
+
+**Section transition patterns:**
+
+- Bridge from previous concept to new one
+- Define the core concept immediately
+- Explain the concept's role in the larger system
+- Set expectations for what the reader will learn
+
+**Language patterns for section openers:**
+
+- "A **signal** is a reactive container for a value that can change over time."
+- "Reading and deriving state is only half the story. The other half is..."
+- "While @tldraw/state is fast by default, there are tools for fine-tuning performance..."
+
+### API Documentation Pattern
+
+For each API, provide:
+
+1. **Purpose statement** - What it does and why you'd use it
+2. **Basic example** - Simplest possible usage
+3. **Parameter explanation** - What each option does
+4. **Advanced examples** - Real-world usage patterns
+5. **Related functions** - What works together
+
+### Example Progression
+
+Structure examples to build understanding:
+
+1. **Minimal example** - Bare minimum to demonstrate concept
+2. **Practical example** - Realistic usage scenario
+3. **Advanced example** - Complex real-world application
+4. **Edge cases** - Handle unusual situations
+
+**Critical example patterns from @tldraw/state:**
+
+- **Continuation narratives**: "Note that computed signals capture both atoms and other computed signals as dependencies. Following the example above, if we create a new computed signal..."
+- **Cumulative complexity**: Each example builds on variables from previous examples
+- **Expected outcome statements**: Always tell the reader what will happen before showing code
+- **State progression**: Show the before/after state explicitly in comments
+
+## Technical Writing Guidelines
+
+### Explaining Complex Concepts
+
+1. **Start with analogy** - Compare to familiar concepts when helpful
+2. **Define before using** - Introduce terminology clearly
+3. **Break down complexity** - Split complex ideas into digestible parts
+4. **Provide multiple perspectives** - Show different ways to think about the same concept
+
+### Error Handling and Edge Cases
+
+- Address common pitfalls proactively
+- Show both correct and incorrect usage when helpful
+- Explain the consequences of different choices
+- Provide troubleshooting guidance
+
+## Integration and Cross-References
+
+### Internal References
+
+- Reference other sections when concepts are related
+- Use consistent section naming for easy linking
+- Explain how concepts connect across the system
+
+### External References
+
+- Link to related packages in the monorepo
+- Reference external documentation judiciously
+- Provide context for why external resources are relevant
+
+## Debugging and Developer Experience
+
+### Include Debugging Information
+
+Every DOCS.md should have a dedicated debugging section covering:
+
+- Tools for understanding system behavior
+- Common problems and solutions
+- Performance considerations
+- Development vs production differences
+
+**Critical debugging documentation patterns:**
+
+- **Hierarchical output representation**: Show exact console output structure with indentation
+- **Multi-scenario debugging**: Cover initial state, different trigger scenarios
+- **Debugging narrative flow**: Walk through step-by-step what happens and why
+- **Practical debugging context**: Show debugging in realistic scenarios, not isolated examples
+
+### Show Realistic Debugging Scenarios
+
+````markdown
+```ts
+react('log details', () => {
+	// But we want to know why this reaction runs.
+	whyAmIRunning()
+
+	console.log(`${greeting.get()} is ${age.get()} years old.`)
+})
+
+// When age is updated, it logs:
+// Effect(log details) is executing because:
+// ↳ Atom(age) changed
+```
+````
+
+## Package-Specific Adaptations
+
+### For Core Libraries (like @tldraw/state)
+
+- Focus heavily on concepts and mental models
+- Provide extensive examples and use cases
+- Include performance considerations
+- Cover debugging and development workflows
+
+### For UI Components
+
+- Show visual examples where possible
+- Explain styling and customization options
+- Cover accessibility considerations
+- Provide integration examples with different frameworks
+
+### For Utilities and Helpers
+
+- Focus on practical problem-solving
+- Show before/after comparisons
+- Explain when to use vs alternatives
+- Keep examples concise but complete
+
+## Quality Checklist
+
+Before publishing a DOCS.md file, verify:
+
+- [ ] All code examples run without errors
+- [ ] Concepts are introduced in logical order
+- [ ] Each section has clear purpose and scope
+- [ ] Examples use meaningful, realistic variable names
+- [ ] Cross-references are accurate and helpful
+- [ ] Debugging information is practical and actionable
+- [ ] Integration examples show realistic usage patterns
+- [ ] Writing tone is consistent throughout
+- [ ] Technical accuracy has been verified by domain experts
+
+## Anti-Patterns to Avoid
+
+### Content Issues
+
+- ❌ Starting with advanced concepts before covering basics
+- ❌ Using abstract examples instead of practical ones
+- ❌ Explaining implementation details before use cases
+- ❌ Omitting import statements in code examples
+- ❌ Showing code without explaining what it accomplishes
+- ❌ Breaking example continuity by introducing unrelated variables
+
+### Writing Issues
+
+- ❌ Passive voice: "Values are stored in atoms"
+- ❌ Vague language: "This is useful for various things"
+- ❌ Unexplained jargon: Technical terms without context
+- ❌ Inconsistent terminology across sections
+- ❌ Missing narrative bridges between examples
+- ❌ Explaining how without explaining when and why
+
+### Structure Issues
+
+- ❌ Flat organization without clear hierarchy
+- ❌ Mixing basic and advanced concepts in the same section
+- ❌ Missing transitions between related concepts
+- ❌ Inadequate cross-referencing between sections
+- ❌ Subsections that don't follow a logical learning progression
+
+## Examples of Excellence
+
+The @tldraw/state DOCS.md exemplifies these principles:
+
+- **Progressive structure**: Introduction → Signals → Reactivity → Advanced Topics
+- **Complete examples**: Every code snippet includes imports and expected output
+- **Clear explanations**: Each concept explained with purpose before implementation
+- **Practical debugging**: `whyAmIRunning()` shown with actual console output
+- **Integration context**: Shows how the library fits into the broader tldraw ecosystem
+
+Follow these patterns to create documentation that empowers developers and reduces support burden while maintaining the high quality standards established in the tldraw project.
+
+## The "Teaching Through Exploration" Pattern
+
+The most distinctive aspect of the @tldraw/state documentation is how it guides readers through discovery rather than just explaining features. Key techniques:
+
+### Predictive Statements
+
+Before showing code, tell readers what they'll observe:
+
+- "In just a few lines, you've created reactive state that automatically alerts the user when it changes."
+- "Now, if we change a dependency... the computed signal automatically updates!"
+
+### Exploratory Questions
+
+Frame features as solutions to problems readers might have:
+
+- "When you update multiple atoms that are dependencies of the same reaction, you might cause the reaction to re-run multiple times."
+- "Sometimes, however, you need to read a signal's value _without_ creating this dependency."
+
+### Cumulative Understanding
+
+Each section builds on previous knowledge while introducing one new concept:
+
+- Use variables from earlier examples in new contexts
+- Reference concepts by name that were introduced earlier
+- Show how new features solve limitations of previous approaches
+
+### Discovery Moments
+
+Create "aha" moments by showing counterintuitive or powerful behavior:
+
+- Automatic dependency tracking
+- Lazy evaluation benefits
+- Transaction rollback behavior
+- The power of `whyAmIRunning()` for debugging
+
+This approach transforms documentation from reference material into a guided learning experience that builds deep understanding rather than surface-level feature awareness.

--- a/.claude/commands/foreach.md
+++ b/.claude/commands/foreach.md
@@ -1,0 +1,25 @@
+---
+description: Do something for each file in a directory
+argument-hint: [directory-path] [what-to-do] [special-rules?]
+allowed-tools: Glob, Grep, LS, Read, Edit, MultiEdit, Write, NotebookEdit, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+---
+
+# Working in $1
+
+In the directory `$1`, make a todo list for each item. Only work at the root level in the directory unless othewise instructued.
+
+# For each item
+
+For each item, your task is to $2. Accomplish that to the best of your ability. If you're doing things with subagents, call them in batches.
+
+# Special Rules
+
+You may have special rules or instructions. Read these before doing anything. These may modify which files or subdirectories to look in, so you should always priortize the special rules.
+Rules: {
+    $3
+}
+Ignore if empty.
+
+# Again
+
+The main flow remains: parse your instructions into a list of files, make a single todo for each file, and do the action specified ($2) for each file individually. One file, one todo item.

--- a/.claude/commands/jsdoc.md
+++ b/.claude/commands/jsdoc.md
@@ -1,0 +1,54 @@
+---
+description: Create or update JSDoc comments for all exported items in the provided file or directory.
+argument-hint: [file-path]
+allowed-tools: Read, Edit, MultiEdit
+---
+
+# Documenting files with JSDoc comments
+
+Write comprehensive JSDoc comments for all exports in the file.
+
+## Instructions
+
+**Arguments:**
+
+- `$1` (optional): File path to document (if not provided, uses the most recent file worked on this session)
+
+# Guideline for writing comments
+
+Add comprehensive JSDoc comments to all exported functions, classes, interfaces, types, and variables in the provided file. If no file is provided, use the current file as reported by the ide. If neither are available, do nothing and ask for a file.
+
+In order get a better idea of what the different components do and how they interact before writing the JSDoc comments, make sure to read the DOCS.md located at packages/[PACKAGE_NAME]/DOCS.md. Always read this file before starting your work.
+
+You do not need to add JSDoc comments to items that are not exported.
+
+For each exported item, include:
+
+- A concise description of what it does. Do not use the @description tag.
+- **@param** - For each parameter with type and description
+- **@returns** - Return type and description
+- **@example** - Code example showing typical usage (required for functions, class methods, and classes)
+- **@public** or **@internal** - Visibility annotation (preserve existing visibility annotations)
+
+Guidelines:
+
+- Only document exported items (functions, classes, interfaces, types, variables)
+- Use TypeScript-style type annotations in JSDoc
+- Keep descriptions concise but informative
+- When included, examples should be small, realistic, and helpful
+- Follow existing code style and formatting
+- Preserve all existing functionality
+- Mark as @public for public API or @internal for internal use
+
+Where you find existing JSDoc comments:
+
+Focus on improving code documentation without changing any implementation details. Add respective @param, @returns, and @example annotation if any are missing. Check that the examples accurately follow the implementation in code. If the file's comments are already up to date, do nothing. Doing nothing is an acceptable response and preferred to adding comments that are not necessary or which would be less accurate.
+
+Do not add JSDoc comments to items that are not exported.
+
+You can use `npx tsx` to run the code that you are testing.
+
+# Tips
+
+- Always escape angle brackets.
+- For function with an options argument, document the different options in a nested list, do not use `option.{NAME}`. 

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,117 @@
+---
+description: Create or update vitest tests for the specified file or current context
+argument-hint: [file-path]
+allowed-tools: Read, Edit, MultiEdit, Bash(yarn test:*), Bash(yarn typecheck:*)
+---
+
+# Test Creation and Management
+
+Create comprehensive vitest tests for tldraw codebase following project conventions.
+
+In order get a better idea of what the different components do and how they interact before writing the JSDoc comments, make sure to read the DOCS.md located at packages/[PACKAGE_NAME]/DOCS.md, and/or CONTEXT.md located at packages/[PACKAGE_NAME]/CONTEXT.md (if it exists). Always read these files before starting your work.
+
+## Instructions
+
+**Arguments:**
+
+- `$1` (optional): File path to test (if not provided, uses current context)
+
+## Test Requirements
+
+### File Naming Conventions
+
+- Unit tests: `src/lib/MyFile.test.ts` (same directory as source)
+- Integration tests: `src/test/my-feature.test.ts` (separate test directory)
+
+### Test Structure
+
+- Use vitest framework (`import { describe, it, expect } from 'vitest'`)
+- Import from relative paths (e.g., `import { atom } from '../Atom'`)
+- Group related tests in `describe` blocks with clear names
+- Use descriptive test names that explain the behavior being tested (e.g., `'contain data'`, `'can be updated'`)
+- For editor tests requiring tldraw shapes/tools: write tests in tldraw workspace, not editor workspace
+- Test all exported functions, classes, and methods
+- Include edge cases and error conditions
+- Test both sync and async operations where applicable
+- Use both `it()` and `test()` functions as appropriate (following existing patterns)
+
+### Test Categories
+
+1. **Unit Tests**: Test individual functions/methods in isolation
+2. **Integration Tests**: Test interaction between multiple components
+3. **Editor Tests**: Test editor functionality (use tldraw workspace for default shapes)
+
+### Running Tests
+
+- Run specific package tests: `yarn test run` from package directory
+- Run all tests: `yarn test` from repo root (avoid unless necessary)
+- Type checking: `yarn typecheck` (must `cd` to the root of the project to do this)
+
+### Test Analysis Strategy
+
+When working with existing tests:
+
+1. **Read existing test files** to understand current coverage and patterns
+2. **Compare with source code** to identify gaps in test coverage
+3. **Check for outdated assertions** that may no longer match current behavior
+4. **Look for missing edge cases** or error scenarios
+5. **Evaluate test structure** against tldraw conventions
+6. **Assess test performance** and identify potential optimizations
+
+## Your Task
+
+1. **Analyze the target file** to understand its exports and functionality
+2. **Check for existing tests** and determine the appropriate action:
+   - If no tests exist: Create new test files following naming conventions
+   - If tests exist but are incomplete: Add missing test cases and improve coverage
+   - If tests exist but are outdated: Update tests to match current implementation
+   - If tests are comprehensive: Review and suggest improvements or optimizations
+
+3. **Handle existing test scenarios:**
+   - **Missing coverage**: Identify untested functions/methods and add comprehensive tests
+   - **Outdated tests**: Update tests that no longer match the current API or behavior
+   - **Incomplete test cases**: Add missing edge cases, error conditions, or scenarios
+   - **Poor test structure**: Refactor tests to follow tldraw conventions and best practices
+   - **Performance issues**: Optimize slow or inefficient test patterns
+
+4. **Write or update tests covering:**
+   - All exported functions/classes/methods
+   - Happy path scenarios
+   - Edge cases and error conditions
+   - Type safety where applicable
+   - State changes and side effects
+   - Transaction handling and rollbacks (where applicable)
+
+5. **Ensure tests follow tldraw testing patterns and best practices:**
+   - Use relative imports for local modules
+   - Group logically related tests in describe blocks
+   - Test both individual functions and their interactions
+   - Include async test patterns when needed
+   - Maintain consistent naming and structure with existing tests
+
+6. **Validate and finalize:**
+   - Run tests to verify they pass
+   - Check test coverage is comprehensive
+   - Ensure new/updated tests integrate well with existing test suite
+   - Always run `yarn typecheck` from the root of the project to ensure no linter errors. Only run it on the specific test file you're working on.
+
+### Tips
+
+If testing editor functionality, remember to use the tldraw workspace for access to default shapes and tools.
+
+When writing tests, NEVER modify the source code that you are testing.
+
+Use test.fails on tests that are failing if you are >75% confident that the tests themselves are correct and that the underlying issue is with the code you're testing. It is possible that the code that you're testing has a bug in it. Do **not** try to fix the bug. Do not try to write your test in a way that causes the test to pass despite the bug. Notify the user that there is a bug you've found,a nd the user will fix it.
+
+## Type safety tips
+
+- **JsonObject property access**: Use type guards and proper casting instead of `as any`. Create helper functions to safely access nested JsonObject properties
+- **Version/migration comparisons**: Extract numeric parts from version strings or use proper string comparison methods instead of double casting
+- **Record ID types**: Use proper branded ID types when creating test records. Use the RecordType's createId() method or cast appropriately with `as RecordId<T>`
+- **Enum values**: Ensure test data uses exact enum values that match the type definitions - avoid hardcoded strings that don't match the expected union types
+- **Meta property patterns**: For complex meta structures in tests, use type guards to safely narrow JsonObject types before accessing nested properties
+- **Migration testing**: When testing migrations, use `any` type for old record structures since they intentionally don't match current types: `const oldRecord: any = { ... }`
+
+We have a linter that will remove any unused imports. You will need to add imports only when they are used.
+
+You can use `npx tsx` to run the code that you are testing.

--- a/.claude/commands/write-jsdocs.md
+++ b/.claude/commands/write-jsdocs.md
@@ -1,0 +1,28 @@
+---
+description: Call subagents to write JSDoc comments for all exported items in the provided file or directory using subagents.
+argument-hint: [directory-path]
+allowed-tools: Read
+---
+
+# Writing JSDoc Comments for $1
+
+Use given subagent to write the JSDocs for all exported functions, classes, interfaces, types, and variables in a given file, or for each given file this directory: $1
+
+If given a directory, only write JSDocs for the files at the root level of the given directory, don't go into subdirectories.
+
+## Instructions
+
+# Make a todo list
+
+If you're working in a directory, you may have lots of files to review. Make a todo item for each file. Exlcude tests. Exlcude index files. Only work at root level of the directory.
+
+# For each file
+
+Follow the steps below for each file in your todo list.
+
+## Call jsdoc-writer subagent
+
+Call the jsdoc-writer subagent on the specified file ONLY. Make sure to pass $1 in as the argument. This will write comprehensive JSDocs for the file.
+
+**Important**
+If the subagent makes any changes to the underlying code itself (as opposed to the documentation), you must immediately revert that change and call the subagent again on that file, this time specifiying it must not change the underlying code. If it was trying to fix a bug, or reported a bug to fix, report that bug back to the user.

--- a/.claude/commands/write-tests.md
+++ b/.claude/commands/write-tests.md
@@ -1,0 +1,34 @@
+---
+description: Call subagents to write tests for all files in the directory using subagents.
+argument-hint: [directory-path]
+allowed-tools: Read
+---
+
+# Writing tests for $1
+
+Use given subagent to write the tests for files in this directory: $1
+
+Only write tests for the files at the root level of the given directory, don't go into subdirectories.
+
+If $1 is a file, just write tests for that file.
+
+## Instructions
+
+# Make a todo list
+
+If you're working in a directory, you may have lots of files to review. Make a todo item for each file. Exclude `index.ts` files. Only work at root level of the directory. Make a todo for items that do and do not have tests already.
+
+# For each file
+
+Follow the steps below for each file in your todo list.
+
+## Call test-writer subagent
+
+Call the test-writer subagent on the specified file ONLY. Make sure to pass $1 in as the argument. This will write comprehensive tests for the file.
+
+**Important**
+If the subagent makes any changes to the underlying code itself (as opposed to writing tests), you must immediately revert that change and call the subagent again on that file, this time specifiying it must not change the underlying code. If it was trying to fix a bug, or reported a bug to fix, report that bug back to the user.
+
+# When you're done
+
+Once all tests have been written for all files, call the `test-type-fixer` subagent with the directory as an argument in order to do one final pass on the types.


### PR DESCRIPTION
## Summary
- Add test-writer agent for creating comprehensive vitest tests
- Add test-reviewer agent for reviewing test quality
- Add test-pruner agent for cleaning up poorly configured tests
- Add test-type-fixer agent for fixing type errors in test files
- Add jsdoc-writer agent for comprehensive JSDoc documentation
- Add `/docs` command for creating/updating DOCS.md files
- Add `/test`, `/jsdoc`, `/write-tests`, and `/write-jsdocs` commands

## Test plan
- [ ] Verify agents are properly registered in Claude Code
- [ ] Test each command with sample files
- [ ] Confirm agent tools and permissions are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)