### PR TITLE
`useSync` custom socket api

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -84,7 +84,7 @@ export function getNetworkDiff<R extends UnknownRecord>(diff: RecordsDiff<R>): N
 // @internal (undocumented)
 export function getTlsyncProtocolVersion(): number;
 
-// @internal
+// @public
 export interface NetworkDiff<R extends UnknownRecord> {
     // (undocumented)
     [id: string]: RecordOp<R>;
@@ -132,17 +132,19 @@ export class ReconnectManager {
     maybeReconnected(): void;
 }
 
-// @internal (undocumented)
+// Warning: (ae-incompatible-release-tags) The symbol "RecordOp" is marked as @public, but its signature references "ObjectDiff" which is marked as @internal
+//
+// @public (undocumented)
 export type RecordOp<R extends UnknownRecord> = [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R] | [typeof RecordOpType.Remove];
 
-// @internal (undocumented)
+// @public (undocumented)
 export const RecordOpType: {
     readonly Patch: "patch";
     readonly Put: "put";
     readonly Remove: "remove";
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType];
 
 // @internal (undocumented)
@@ -219,10 +221,10 @@ export interface RoomStoreMethods<R extends UnknownRecord = UnknownRecord> {
     put(record: R): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void;
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLConnectRequest {
     // (undocumented)
     connectRequestId: string;
@@ -250,10 +252,12 @@ export const TLIncompatibilityReason: {
 // @internal @deprecated (undocumented)
 export type TLIncompatibilityReason = (typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason];
 
-// @internal
+// @public
 export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> {
+    close(): void;
     connectionStatus: 'error' | 'offline' | 'online';
     onReceiveMessage: SubscribingFn<TLSocketServerSentEvent<R>>;
+    // Warning: (ae-incompatible-release-tags) The symbol "onStatusChange" is marked as @public, but its signature references "TlSocketStatusChangeEvent" which is marked as @internal
     onStatusChange: SubscribingFn<TlSocketStatusChangeEvent>;
     restart(): void;
     sendMessage(msg: TLSocketClientSentEvent<R>): void;
@@ -262,7 +266,7 @@ export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecor
 // @internal (undocumented)
 export type TLPersistentClientSocketStatus = 'error' | 'offline' | 'online';
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLPingRequest {
     // (undocumented)
     type: 'ping';
@@ -271,12 +275,14 @@ export interface TLPingRequest {
 // @internal (undocumented)
 export type TLPresenceMode = 'full' | 'solo';
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface TLPushRequest<R extends UnknownRecord> {
     // (undocumented)
     clientClock: number;
     // (undocumented)
     diff?: NetworkDiff<R>;
+    // Warning: (ae-incompatible-release-tags) The symbol "presence" is marked as @public, but its signature references "ObjectDiff" which is marked as @internal
+    //
     // (undocumented)
     presence?: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R];
     // (undocumented)
@@ -302,7 +308,7 @@ export interface TLRoomSocket<R extends UnknownRecord> {
     sendMessage(msg: TLSocketServerSentEvent<R>): void;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketClientSentEvent<R extends UnknownRecord> = TLConnectRequest | TLPingRequest | TLPushRequest<R>;
 
 // @public (undocumented)
@@ -393,7 +399,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     updateStore(updater: (store: RoomStoreMethods<R>) => Promise<void> | void): Promise<void>;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketServerSentDataEvent<R extends UnknownRecord> = {
     action: 'commit' | 'discard' | {
         rebaseWithDiff: NetworkDiff<R>;
@@ -407,7 +413,7 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> = {
     type: 'patch';
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type TLSocketServerSentEvent<R extends UnknownRecord> = {
     connectRequestId: string;
     diff: NetworkDiff<R>;
@@ -599,6 +605,10 @@ export interface WebSocketMinimal {
     // (undocumented)
     send: (data: string) => void;
 }
+
+// Warnings were encountered during analysis:
+//
+// src/lib/protocol.ts:49:20 - (ae-incompatible-release-tags) The symbol "reason" is marked as @public, but its signature references "TLIncompatibilityReason" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -24,7 +24,7 @@ import {
 	getTlsyncProtocolVersion,
 } from './protocol'
 
-/** @internal */
+/** @public */
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void
 
 /**
@@ -96,7 +96,7 @@ export type TLPresenceMode = 'solo' | 'full'
  * open and reconnecting when the connection is lost. In actual client code this will be a wrapper
  * around a websocket or socket.io or something similar.
  *
- * @internal
+ * @public
  */
 export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecord> {
 	/** Whether there is currently an open connection to the server. */
@@ -109,6 +109,8 @@ export interface TLPersistentClientSocket<R extends UnknownRecord = UnknownRecor
 	onStatusChange: SubscribingFn<TlSocketStatusChangeEvent>
 	/** Restart the connection */
 	restart(): void
+	/** Close the connection */
+	close(): void
 }
 
 const PING_INTERVAL = 5000

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -1,17 +1,17 @@
 import { RecordsDiff, UnknownRecord } from '@tldraw/store'
 import { isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
 
-/** @internal */
+/** @public */
 export const RecordOpType = {
 	Put: 'put',
 	Patch: 'patch',
 	Remove: 'remove',
 } as const
 
-/** @internal */
+/** @public */
 export type RecordOpType = (typeof RecordOpType)[keyof typeof RecordOpType]
 
-/** @internal */
+/** @public */
 export type RecordOp<R extends UnknownRecord> =
 	| [typeof RecordOpType.Put, R]
 	| [typeof RecordOpType.Patch, ObjectDiff]
@@ -24,7 +24,7 @@ export type RecordOp<R extends UnknownRecord> =
  *
  * Each key in this object is the id of a record that has been added, updated, or removed.
  *
- * @internal
+ * @public
  */
 export interface NetworkDiff<R extends UnknownRecord> {
 	[id: string]: RecordOp<R>

--- a/packages/sync-core/src/lib/protocol.ts
+++ b/packages/sync-core/src/lib/protocol.ts
@@ -26,7 +26,7 @@ export const TLIncompatibilityReason = {
 export type TLIncompatibilityReason =
 	(typeof TLIncompatibilityReason)[keyof typeof TLIncompatibilityReason]
 
-/** @internal */
+/** @public */
 export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	| {
 			type: 'connect'
@@ -50,7 +50,7 @@ export type TLSocketServerSentEvent<R extends UnknownRecord> =
 	| { type: 'custom'; data: any }
 	| TLSocketServerSentDataEvent<R>
 
-/** @internal */
+/** @public */
 export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 	| {
 			type: 'patch'
@@ -64,7 +64,7 @@ export type TLSocketServerSentDataEvent<R extends UnknownRecord> =
 			action: 'discard' | 'commit' | { rebaseWithDiff: NetworkDiff<R> }
 	  }
 
-/** @internal */
+/** @public */
 export interface TLPushRequest<R extends UnknownRecord> {
 	type: 'push'
 	clientClock: number
@@ -72,7 +72,7 @@ export interface TLPushRequest<R extends UnknownRecord> {
 	presence?: [typeof RecordOpType.Patch, ObjectDiff] | [typeof RecordOpType.Put, R]
 }
 
-/** @internal */
+/** @public */
 export interface TLConnectRequest {
 	type: 'connect'
 	connectRequestId: string
@@ -81,12 +81,12 @@ export interface TLConnectRequest {
 	schema: SerializedSchema
 }
 
-/** @internal */
+/** @public */
 export interface TLPingRequest {
 	type: 'ping'
 }
 
-/** @internal */
+/** @public */
 export type TLSocketClientSentEvent<R extends UnknownRecord> =
 	| TLPushRequest<R>
 	| TLConnectRequest

--- a/packages/sync-core/src/test/TestSocketPair.ts
+++ b/packages/sync-core/src/test/TestSocketPair.ts
@@ -87,6 +87,9 @@ export class TestSocketPair<R extends UnknownRecord> {
 			this.disconnect()
 			this.connect()
 		},
+		close: () => {
+			this.disconnect()
+		},
 	}
 
 	callbacks = {

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -7,8 +7,10 @@
 import { Editor } from 'tldraw';
 import { Signal } from 'tldraw';
 import { TLAssetStore } from 'tldraw';
+import { TLPersistentClientSocket } from '@tldraw/sync-core';
 import { TLPresenceStateInfo } from 'tldraw';
 import { TLPresenceUserInfo } from 'tldraw';
+import { TLRecord } from 'tldraw';
 import { TLStore } from 'tldraw';
 import { TLStoreSchemaOptions } from 'tldraw';
 import { TLStoreWithStatus } from 'tldraw';
@@ -23,11 +25,20 @@ export type RemoteTLStoreWithStatus = Exclude<TLStoreWithStatus, {
 // @public
 export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLStoreWithStatus;
 
+// @public (undocumented)
+export type UseSyncConnectFn = (query: {
+    sessionId: string;
+    storeId: string;
+}) => TLPersistentClientSocket<TLRecord>;
+
 // @public
 export function useSyncDemo(options: UseSyncDemoOptions & TLStoreSchemaOptions): RemoteTLStoreWithStatus;
 
 // @public (undocumented)
 export interface UseSyncDemoOptions {
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: No member was found with name "getUserPresence"
+    //
+    // (undocumented)
     getUserPresence?(store: TLStore, user: TLPresenceUserInfo): null | TLPresenceStateInfo;
     // @internal (undocumented)
     host?: string;
@@ -36,7 +47,10 @@ export interface UseSyncDemoOptions {
 }
 
 // @public
-export interface UseSyncOptions {
+export type UseSyncOptions = UseSyncOptionsWithConnectFn | UseSyncOptionsWithUri;
+
+// @public
+export interface UseSyncOptionsBase {
     assets: TLAssetStore;
     getUserPresence?(store: TLStore, user: TLPresenceUserInfo): null | TLPresenceStateInfo;
     onCustomMessageReceived?(data: any): void;
@@ -48,8 +62,22 @@ export interface UseSyncOptions {
     trackAnalyticsEvent?(name: string, data: {
         [key: string]: any;
     }): void;
-    uri: (() => Promise<string> | string) | string;
     userInfo?: Signal<TLPresenceUserInfo> | TLPresenceUserInfo;
+}
+
+// @public (undocumented)
+export interface UseSyncOptionsWithConnectFn extends UseSyncOptionsBase {
+    // (undocumented)
+    connect: UseSyncConnectFn;
+    // (undocumented)
+    uri?: undefined;
+}
+
+// @public (undocumented)
+export interface UseSyncOptionsWithUri extends UseSyncOptionsBase {
+    // (undocumented)
+    connect?: undefined;
+    uri: (() => Promise<string> | string) | string;
 }
 
 

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -2,7 +2,15 @@ import { registerTldrawLibraryVersion } from '@tldraw/utils'
 // eslint-disable-next-line local/no-export-star
 export * from '@tldraw/sync-core'
 
-export { useSync, type RemoteTLStoreWithStatus, type UseSyncOptions } from './useSync'
+export {
+	useSync,
+	type RemoteTLStoreWithStatus,
+	type UseSyncConnectFn,
+	type UseSyncOptions,
+	type UseSyncOptionsBase,
+	type UseSyncOptionsWithConnectFn,
+	type UseSyncOptionsWithUri,
+} from './useSync'
 export { useSyncDemo, type UseSyncDemoOptions } from './useSyncDemo'
 
 registerTldrawLibraryVersion(

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -3,6 +3,7 @@ import { useAtom } from '@tldraw/state-react'
 import {
 	ClientWebSocketAdapter,
 	TLCustomMessageHandler,
+	TLPersistentClientSocket,
 	TLPresenceMode,
 	TLRemoteSyncError,
 	TLSyncClient,
@@ -21,6 +22,7 @@ import {
 	TLStore,
 	TLStoreSchemaOptions,
 	TLStoreWithStatus,
+	assert,
 	computed,
 	createTLStore,
 	defaultUserPreferences,
@@ -76,6 +78,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 	} | null>(null)
 	const {
 		uri,
+		connect,
 		roomId = 'default',
 		assets,
 		onMount,
@@ -122,32 +125,50 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			}
 		)
 
-		const socket = new ClientWebSocketAdapter(async () => {
-			const uriString = typeof uri === 'string' ? uri : await uri()
+		let socket: TLPersistentClientSocket<TLRecord>
+		if (connect) {
+			assert(!uri, 'uri and connect cannot be used together')
 
-			// set sessionId as a query param on the uri
-			const withParams = new URL(uriString)
-			if (withParams.searchParams.has('sessionId')) {
-				throw new Error(
-					'useSync. "sessionId" is a reserved query param name. Please use a different name'
-				)
-			}
-			if (withParams.searchParams.has('storeId')) {
-				throw new Error(
-					'useSync. "storeId" is a reserved query param name. Please use a different name'
-				)
-			}
+			socket = connect({
+				sessionId: TAB_ID,
+				storeId,
+			})
+		} else if (uri) {
+			assert(!connect, 'uri and connect cannot be used together')
 
-			withParams.searchParams.set('sessionId', TAB_ID)
-			withParams.searchParams.set('storeId', storeId)
-			return withParams.toString()
-		})
+			socket = new ClientWebSocketAdapter(async () => {
+				const uriString = typeof uri === 'string' ? uri : await uri()
+
+				// set sessionId as a query param on the uri
+				const withParams = new URL(uriString)
+				if (withParams.searchParams.has('sessionId')) {
+					throw new Error(
+						'useSync. "sessionId" is a reserved query param name. Please use a different name'
+					)
+				}
+				if (withParams.searchParams.has('storeId')) {
+					throw new Error(
+						'useSync. "storeId" is a reserved query param name. Please use a different name'
+					)
+				}
+
+				withParams.searchParams.set('sessionId', TAB_ID)
+				withParams.searchParams.set('storeId', storeId)
+				return withParams.toString()
+			})
+		} else {
+			throw new Error('uri or connect must be provided')
+		}
 
 		let didCancel = false
 
-		const collaborationStatusSignal = computed('collaboration status', () =>
-			socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
-		)
+		function getConnectionStatus() {
+			return socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
+		}
+		const collaborationStatusSignal = atom('collaboration status', getConnectionStatus())
+		const unsubscribeFromConnectionStatus = socket.onStatusChange(() => {
+			collaborationStatusSignal.set(getConnectionStatus())
+		})
 
 		const syncMode = atom('sync mode', 'readwrite' as 'readonly' | 'readwrite')
 
@@ -232,9 +253,9 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 
 		return () => {
 			didCancel = true
+			unsubscribeFromConnectionStatus()
 			client.close()
 			socket.close()
-			setState(null)
 		}
 	}, [
 		assets,
@@ -245,6 +266,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		setState,
 		track,
 		uri,
+		connect,
 		getUserPresence,
 		onCustomMessageReceived,
 	])
@@ -267,23 +289,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 }
 
 /**
- * Options for the {@link useSync} hook.
+ * Common options for the {@link useSync} hook.
  * @public
  */
-export interface UseSyncOptions {
-	/**
-	 * The URI of the multiplayer server. This must include the protocol,
-	 *
-	 *   e.g. `wss://server.example.com/my-room` or `ws://localhost:5858/my-room`.
-	 *
-	 * Note that the protocol can also be `https` or `http` and it will upgrade to a websocket
-	 * connection.
-	 *
-	 * Optionally, you can pass a function which will be called each time a connection is
-	 * established to get the URI. This is useful if you need to include e.g. a short-lived session
-	 * token for authentication.
-	 */
-	uri: string | (() => string | Promise<string>)
+export interface UseSyncOptionsBase {
 	/**
 	 * A signal that contains the user information needed for multiplayer features.
 	 * This should be synchronized with the `userPreferences` configuration for the main `<Tldraw />` component.
@@ -318,3 +327,39 @@ export interface UseSyncOptions {
 	 */
 	getUserPresence?(store: TLStore, user: TLPresenceUserInfo): TLPresenceStateInfo | null
 }
+
+/** @public */
+export interface UseSyncOptionsWithUri extends UseSyncOptionsBase {
+	/**
+	 * The URI of the multiplayer server. This must include the protocol,
+	 *
+	 *   e.g. `wss://server.example.com/my-room` or `ws://localhost:5858/my-room`.
+	 *
+	 * Note that the protocol can also be `https` or `http` and it will upgrade to a websocket
+	 * connection.
+	 *
+	 * Optionally, you can pass a function which will be called each time a connection is
+	 * established to get the URI. This is useful if you need to include e.g. a short-lived session
+	 * token for authentication.
+	 */
+	uri: string | (() => string | Promise<string>)
+	connect?: undefined
+}
+
+/** @public */
+export interface UseSyncOptionsWithConnectFn extends UseSyncOptionsBase {
+	connect: UseSyncConnectFn
+	uri?: undefined
+}
+
+/** @public */
+export type UseSyncConnectFn = (query: {
+	sessionId: string
+	storeId: string
+}) => TLPersistentClientSocket<TLRecord>
+
+/**
+ * Options for the {@link useSync} hook.
+ * @public
+ */
+export type UseSyncOptions = UseSyncOptionsWithUri | UseSyncOptionsWithConnectFn

--- a/templates/socketio-server-example/.gitignore
+++ b/templates/socketio-server-example/.gitignore
@@ -1,0 +1,3 @@
+.rooms/
+.assets/
+.yarn

--- a/templates/socketio-server-example/README.md
+++ b/templates/socketio-server-example/README.md
@@ -1,0 +1,31 @@
+# tldraw sync, simple Node/Bun server example
+
+This is a simple example of a backend for [tldraw sync](https://tldraw.dev/docs/sync) with a Node or Bun server.
+
+Run `yarn dev-node` or `yarn dev-bun` in this folder to start the server + client.
+
+For a production-ready example specific to Cloudflare, see /templates/sync-cloudflare.
+
+## License
+
+This project is provided under the MIT license found [here](https://github.com/tldraw/tldraw/blob/main/apps/simple-server-example/LICENSE.md). The tldraw SDK is provided under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
+
+## Trademarks
+
+Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.
+
+## Distributions
+
+You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?activeTab=versions).
+
+## Contribution
+
+Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+
+## Community
+
+Have questions, comments or feedback? [Join our discord](https://discord.tldraw.com/?utm_source=github&utm_medium=readme&utm_campaign=sociallink). For the latest news and release notes, visit [tldraw.dev](https://tldraw.dev).
+
+## Contact
+
+Find us on Twitter/X at [@tldraw](https://twitter.com/tldraw).

--- a/templates/socketio-server-example/package.json
+++ b/templates/socketio-server-example/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@tldraw/socketio-server-example",
+	"description": "tldraw infinite canvas SDK (example socket.io server).",
+	"version": "0.0.0",
+	"private": true,
+	"author": {
+		"name": "tldraw GB Ltd.",
+		"email": "hello@tldraw.com"
+	},
+	"license": "MIT",
+	"main": "./src/server/server.ts",
+	"scripts": {
+		"dev": "concurrently -n server,client -c red,blue \"yarn dev-server\" \"yarn dev-client\"",
+		"dev-server": "yarn run -T tsx watch ./src/server/server.ts",
+		"dev-client": "vite dev",
+		"test-ci": "echo 'No tests yet'",
+		"test": "yarn run -T vitest run --passWithNoTests",
+		"test-coverage": "lazy inherit",
+		"lint": "yarn run -T tsx ../../internal/scripts/lint.ts"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.1.6",
+		"@types/express": "^4.17.21",
+		"@types/react": "^18.3.18",
+		"@types/react-dom": "^18.3.5",
+		"@types/ws": "^8.18.1",
+		"concurrently": "^9.1.2",
+		"lazyrepo": "0.0.0-alpha.27",
+		"tsx": "^4.19.2",
+		"typescript": "^5.8.3"
+	},
+	"dependencies": {
+		"@tldraw/sync": "workspace:*",
+		"@tldraw/sync-core": "workspace:*",
+		"@vitejs/plugin-react-swc": "^3.10.2",
+		"express": "^5.1.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"react-router-dom": "^6.28.2",
+		"socket.io": "^4.8.1",
+		"socket.io-client": "^4.8.1",
+		"tldraw": "workspace:*",
+		"unfurl.js": "^6.4.0",
+		"vite": "^7.0.1"
+	}
+}

--- a/templates/socketio-server-example/src/client/App.tsx
+++ b/templates/socketio-server-example/src/client/App.tsx
@@ -1,0 +1,192 @@
+import { TLPersistentClientSocket, TlSocketStatusChangeEvent, useSync } from '@tldraw/sync'
+import { useCallback } from 'react'
+import { io, Socket } from 'socket.io-client'
+import {
+	AssetRecordType,
+	getHashForString,
+	TLAssetStore,
+	TLBookmarkAsset,
+	Tldraw,
+	TLRecord,
+	uniqueId,
+} from 'tldraw'
+
+const WORKER_URL = `http://localhost:5858`
+
+// In this example, the room ID is hard-coded. You can set this however you like though.
+const roomId = 'test-room'
+
+function App() {
+	// Create a store connected to multiplayer.
+	const store = useSync({
+		// We need a connection to the server:
+		connect: useCallback((query) => {
+			const socket = io(WORKER_URL, {
+				query: { ...query, roomId },
+			})
+			return socketIoToTldrawSocket(socket)
+		}, []),
+		// ...and how to handle static assets like images & videos
+		assets: multiplayerAssets,
+	})
+
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw
+				// we can pass the connected store into the Tldraw component which will handle
+				// loading states & enable multiplayer UX like cursors & a presence menu
+				store={store}
+				onMount={(editor) => {
+					// @ts-expect-error
+					window.editor = editor
+					// when the editor is ready, we need to register out bookmark unfurling service
+					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
+				}}
+			/>
+		</div>
+	)
+}
+
+// Helper function to convert Socket.IO to TLPersistentClientSocket
+function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRecord> {
+	const statusChangeListeners = new Set<(event: TlSocketStatusChangeEvent) => void>()
+	const tldrawSocket: TLPersistentClientSocket<TLRecord> = {
+		connectionStatus: 'offline',
+
+		sendMessage: (message) => {
+			console.log('📤 Sending:', message)
+			ioSocket.emit('tldraw-message', JSON.stringify(message))
+		},
+
+		onReceiveMessage: (callback) => {
+			// Listen for tldraw sync protocol messages
+			const handler = (message: any) => {
+				console.log('📥 Received:', message)
+				callback(message)
+			}
+
+			ioSocket.on('tldraw-message', handler)
+
+			// Return cleanup function
+			return () => {
+				ioSocket.off('tldraw-message', handler)
+			}
+		},
+
+		onStatusChange: (callback) => {
+			statusChangeListeners.add(callback)
+			return () => {
+				statusChangeListeners.delete(callback)
+			}
+		},
+
+		restart: () => {
+			console.log('🔄 Restarting Socket.IO connection...')
+			ioSocket.disconnect()
+			ioSocket.connect()
+		},
+
+		close: () => {
+			ioSocket.off('connect', connectHandler)
+			ioSocket.off('disconnect', disconnectHandler)
+			ioSocket.off('connect_error', errorHandler)
+			clearTimeout(initialStatusTimeout)
+			ioSocket.disconnect()
+		},
+	}
+
+	// Map Socket.IO events to TLPersistentClientSocket status
+	const connectHandler = () => {
+		tldrawSocket.connectionStatus = 'online'
+		statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
+	}
+
+	const disconnectHandler = () => {
+		tldrawSocket.connectionStatus = 'offline'
+		statusChangeListeners.forEach((cb) => cb({ status: 'offline' }))
+	}
+
+	const errorHandler = (error: any) => {
+		tldrawSocket.connectionStatus = 'error'
+		statusChangeListeners.forEach((cb) =>
+			cb({
+				status: 'error',
+				reason: error.message || 'Connection error',
+			})
+		)
+	}
+
+	ioSocket.on('connect', connectHandler)
+	ioSocket.on('disconnect', disconnectHandler)
+	ioSocket.on('connect_error', errorHandler)
+
+	// Set initial status
+	const initialStatusTimeout = setTimeout(() => {
+		if (ioSocket.connected) {
+			tldrawSocket.connectionStatus = 'online'
+			statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
+		}
+	}, 0)
+
+	return tldrawSocket
+}
+
+// How does our server handle assets like images and videos?
+const multiplayerAssets: TLAssetStore = {
+	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
+	async upload(_asset, file) {
+		const id = uniqueId()
+
+		const objectName = `${id}-${file.name}`
+		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
+
+		const response = await fetch(url, {
+			method: 'PUT',
+			body: file,
+		})
+
+		if (!response.ok) {
+			throw new Error(`Failed to upload asset: ${response.statusText}`)
+		}
+
+		return { src: url }
+	},
+	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
+	// auth, or to serve optimized versions / sizes of the asset.
+	resolve(asset) {
+		return asset.props.src
+	},
+}
+
+// How does our server handle bookmark unfurling?
+async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
+	const asset: TLBookmarkAsset = {
+		id: AssetRecordType.createId(getHashForString(url)),
+		typeName: 'asset',
+		type: 'bookmark',
+		meta: {},
+		props: {
+			src: url,
+			description: '',
+			image: '',
+			favicon: '',
+			title: '',
+		},
+	}
+
+	try {
+		const response = await fetch(`${WORKER_URL}/unfurl?url=${encodeURIComponent(url)}`)
+		const data = await response.json()
+
+		asset.props.description = data?.description ?? ''
+		asset.props.image = data?.image ?? ''
+		asset.props.favicon = data?.favicon ?? ''
+		asset.props.title = data?.title ?? ''
+	} catch (e) {
+		console.error(e)
+	}
+
+	return asset
+}
+
+export default App

--- a/templates/socketio-server-example/src/client/index.css
+++ b/templates/socketio-server-example/src/client/index.css
@@ -1,0 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
+@import url('tldraw/tldraw.css');
+
+body {
+	font-family: 'Inter', sans-serif;
+	overscroll-behavior: none;
+}

--- a/templates/socketio-server-example/src/client/index.html
+++ b/templates/socketio-server-example/src/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<title>tldraw node/bun server example</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./main.tsx"></script>
+		<noscript>You need to enable JavaScript to run tldraw. ✌️</noscript>
+	</body>
+</html>

--- a/templates/socketio-server-example/src/client/main.tsx
+++ b/templates/socketio-server-example/src/client/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
+)

--- a/templates/socketio-server-example/src/client/vite-env.d.ts
+++ b/templates/socketio-server-example/src/client/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/templates/socketio-server-example/src/server/assets.ts
+++ b/templates/socketio-server-example/src/server/assets.ts
@@ -1,0 +1,15 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join, resolve } from 'path'
+import { Readable } from 'stream'
+
+// We are just using the filesystem to store assets
+const DIR = resolve('./.assets')
+
+export async function storeAsset(id: string, stream: Readable) {
+	await mkdir(DIR, { recursive: true })
+	await writeFile(join(DIR, id), stream)
+}
+
+export async function loadAsset(id: string) {
+	return await readFile(join(DIR, id))
+}

--- a/templates/socketio-server-example/src/server/rooms.ts
+++ b/templates/socketio-server-example/src/server/rooms.ts
@@ -1,0 +1,90 @@
+import { RoomSnapshot, TLSocketRoom } from '@tldraw/sync-core'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+// For this example we're just saving data to the local filesystem
+const DIR = './.rooms'
+async function readSnapshotIfExists(roomId: string) {
+	try {
+		const data = await readFile(join(DIR, roomId))
+		return JSON.parse(data.toString()) ?? undefined
+	} catch {
+		return undefined
+	}
+}
+async function saveSnapshot(roomId: string, snapshot: RoomSnapshot) {
+	await mkdir(DIR, { recursive: true })
+	await writeFile(join(DIR, roomId), JSON.stringify(snapshot))
+}
+
+// We'll keep an in-memory map of rooms and their data
+interface RoomState {
+	room: TLSocketRoom<any, void>
+	id: string
+	needsPersist: boolean
+}
+const rooms = new Map<string, RoomState>()
+
+// Very simple mutex using promise chaining, to avoid race conditions
+// when loading rooms. In production you probably want one mutex per room
+// to avoid unnecessary blocking!
+let mutex = Promise.resolve<null | Error>(null)
+
+export async function makeOrLoadRoom(roomId: string) {
+	mutex = mutex
+		.then(async () => {
+			if (rooms.has(roomId)) {
+				const roomState = await rooms.get(roomId)!
+				if (!roomState.room.isClosed()) {
+					return null // all good
+				}
+			}
+			console.log('loading room', roomId)
+			const initialSnapshot = await readSnapshotIfExists(roomId)
+
+			const roomState: RoomState = {
+				needsPersist: false,
+				id: roomId,
+				room: new TLSocketRoom({
+					initialSnapshot,
+					onSessionRemoved(room, args) {
+						console.log('client disconnected', args.sessionId, roomId)
+						if (args.numSessionsRemaining === 0) {
+							console.log('closing room', roomId)
+							room.close()
+						}
+					},
+					onDataChange() {
+						roomState.needsPersist = true
+					},
+				}),
+			}
+			rooms.set(roomId, roomState)
+			return null // all good
+		})
+		.catch((error) => {
+			// return errors as normal values to avoid stopping the mutex chain
+			return error
+		})
+
+	const err = await mutex
+	if (err) throw err
+	return rooms.get(roomId)!.room
+}
+
+// Do persistence on a regular interval.
+// In production you probably want a smarter system with throttling.
+setInterval(() => {
+	for (const roomState of rooms.values()) {
+		if (roomState.needsPersist) {
+			// persist room
+			roomState.needsPersist = false
+			console.log('saving snapshot', roomState.id)
+			saveSnapshot(roomState.id, roomState.room.getCurrentSnapshot())
+		}
+		if (roomState.room.isClosed()) {
+			console.log('deleting room', roomState.id)
+			rooms.delete(roomState.id)
+		}
+	}
+}, 2000)

--- a/templates/socketio-server-example/src/server/server.ts
+++ b/templates/socketio-server-example/src/server/server.ts
@@ -1,0 +1,139 @@
+import { WebSocketMinimal } from '@tldraw/sync-core'
+import express from 'express'
+import { createServer } from 'http'
+import { Server } from 'socket.io'
+import { loadAsset, storeAsset } from './assets'
+import { makeOrLoadRoom } from './rooms'
+import { unfurl } from './unfurl'
+
+const PORT = 5858
+
+// For this example we use Socket.IO with Express
+// To keep things simple we're skipping normal production concerns like rate limiting and input validation.
+// Create Express app and HTTP server for Socket.IO
+const app = express()
+const server = createServer(app)
+
+// Enable CORS and parse JSON
+app.use(express.json())
+app.use((req, res, next) => {
+	res.header('Access-Control-Allow-Origin', '*')
+	res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+	next()
+})
+
+export interface ServerToClientMessage {
+	'tldraw-message': (message: string) => void
+}
+
+export interface ClientToServerMessage {
+	'tldraw-message': (message: string) => void
+}
+
+// Create Socket.IO server
+const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
+	cors: {
+		origin: '*',
+		methods: ['GET', 'POST'],
+	},
+})
+
+// This is the main entrypoint for the multiplayer sync
+io.on('connection', async (socket) => {
+	console.log('Socket.IO client connected:', socket.id)
+
+	// The roomId and sessionId are passed from the client as query params,
+	// you need to extract them and pass them to the room.
+	const sessionId = socket.handshake.query.sessionId as string
+	const roomId = socket.handshake.query.roomId as string
+
+	if (!sessionId || !roomId) {
+		console.log('Missing required parameters, disconnecting:', socket.id)
+		socket.disconnect()
+		return
+	}
+
+	console.log('Connecting to room:', roomId, 'with session:', sessionId)
+
+	try {
+		// Here we make or get an existing instance of TLSocketRoom for the given roomId
+		const room = await makeOrLoadRoom(roomId)
+
+		// Create a socket adapter for TLSocketRoom
+		const socketAdapter: WebSocketMinimal = {
+			send: (message) => {
+				socket.emit('tldraw-message', JSON.parse(message))
+			},
+			close: () => {
+				socket.disconnect()
+			},
+			get readyState() {
+				return socket.connected ? 1 : 3 // 1 = OPEN, 3 = CLOSED
+			},
+		}
+
+		// and finally connect the socket to the room
+		room.handleSocketConnect({
+			sessionId: sessionId,
+			socket: socketAdapter,
+		})
+
+		// Handle tldraw sync messages
+		socket.on('tldraw-message', (message) => {
+			// Ensure message is a string - Socket.IO might send it as an object or buffer
+			room.handleSocketMessage(sessionId, message)
+		})
+
+		// Handle disconnect
+		socket.on('disconnect', () => {
+			console.log('Socket.IO client disconnected:', socket.id)
+		})
+	} catch (error) {
+		console.error('Error setting up room connection:', error)
+		socket.disconnect()
+	}
+})
+
+// To enable blob storage for assets, we add simple endpoints supporting PUT and GET requests
+app.put('/uploads/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+	try {
+		const id = req.params.id
+		await storeAsset(id, req.body)
+		res.json({ ok: true })
+	} catch (error) {
+		console.error('Asset upload error:', error)
+		res.status(500).json({ error: 'Upload failed' })
+	}
+})
+
+app.get('/uploads/:id', async (req, res) => {
+	try {
+		const id = req.params.id
+		const data = await loadAsset(id)
+		res.send(data)
+	} catch (error) {
+		console.error('Asset download error:', error)
+		res.status(404).json({ error: 'Asset not found' })
+	}
+})
+
+// To enable unfurling of bookmarks, we add a simple endpoint that takes a URL query param
+app.get('/unfurl', async (req, res) => {
+	try {
+		const url = req.query.url as string
+		if (!url) {
+			return res.status(400).json({ error: 'URL parameter required' })
+		}
+		const result = await unfurl(url)
+		return res.json(result)
+	} catch (error) {
+		console.error('Unfurl error:', error)
+		return res.status(500).json({ error: 'Unfurl failed' })
+	}
+})
+
+// Start server
+server.listen(PORT, () => {
+	console.log(`Server started on port ${PORT}`)
+})

--- a/templates/socketio-server-example/src/server/unfurl.ts
+++ b/templates/socketio-server-example/src/server/unfurl.ts
@@ -1,0 +1,14 @@
+import _unfurl from 'unfurl.js'
+
+export async function unfurl(url: string) {
+	const { title, description, open_graph, twitter_card, favicon } = await _unfurl.unfurl(url)
+
+	const image = open_graph?.images?.[0]?.url || twitter_card?.images?.[0]?.url
+
+	return {
+		title,
+		description,
+		image,
+		favicon,
+	}
+}

--- a/templates/socketio-server-example/tsconfig.json
+++ b/templates/socketio-server-example/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../internal/config/tsconfig.base.json",
+	"include": ["src", "scripts", "vite.config.mts"],
+	"exclude": ["node_modules", "dist", ".tsbuild*"],
+	"compilerOptions": { "noEmit": true, "emitDeclarationOnly": false, "types": ["bun", "node"] },
+	"references": [
+		{ "path": "../../packages/sync" },
+		{ "path": "../../packages/sync-core" },
+		{ "path": "../../packages/tldraw" }
+	]
+}

--- a/templates/socketio-server-example/vite.config.mts
+++ b/templates/socketio-server-example/vite.config.mts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react-swc'
+import path from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig(() => ({
+	plugins: [react({ tsDecorators: true })],
+	root: path.join(__dirname, 'src/client'),
+	publicDir: path.join(__dirname, 'public'),
+	server: {
+		port: 5757,
+	},
+	optimizeDeps: {
+		exclude: ['@tldraw/assets'],
+	},
+}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -8433,6 +8433,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socket.io/component-emitter@npm:~3.1.0":
+  version: 3.1.2
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
+  checksum: 10/89888f00699eb34e3070624eb7b8161fa29f064aeb1389a48f02195d55dd7c52a504e52160016859f6d6dffddd54324623cdd47fd34b3d46f9ed96c18c456edc
+  languageName: node
+  linkType: hard
+
 "@speed-highlight/core@npm:^1.2.7":
   version: 1.2.7
   resolution: "@speed-highlight/core@npm:1.2.7"
@@ -9436,6 +9443,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@tldraw/socketio-server-example@workspace:templates/socketio-server-example":
+  version: 0.0.0-use.local
+  resolution: "@tldraw/socketio-server-example@workspace:templates/socketio-server-example"
+  dependencies:
+    "@tldraw/sync": "workspace:*"
+    "@tldraw/sync-core": "workspace:*"
+    "@types/bun": "npm:^1.1.6"
+    "@types/express": "npm:^4.17.21"
+    "@types/react": "npm:^18.3.18"
+    "@types/react-dom": "npm:^18.3.5"
+    "@types/ws": "npm:^8.18.1"
+    "@vitejs/plugin-react-swc": "npm:^3.10.2"
+    concurrently: "npm:^9.1.2"
+    express: "npm:^5.1.0"
+    lazyrepo: "npm:0.0.0-alpha.27"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    react-router-dom: "npm:^6.28.2"
+    socket.io: "npm:^4.8.1"
+    socket.io-client: "npm:^4.8.1"
+    tldraw: "workspace:*"
+    tsx: "npm:^4.19.2"
+    typescript: "npm:^5.8.3"
+    unfurl.js: "npm:^6.4.0"
+    vite: "npm:^7.0.1"
+  languageName: unknown
+  linkType: soft
+
 "@tldraw/state-react@workspace:*, @tldraw/state-react@workspace:packages/state-react":
   version: 0.0.0-use.local
   resolution: "@tldraw/state-react@workspace:packages/state-react"
@@ -9889,6 +9924,15 @@ __metadata:
   version: 2.5.8
   resolution: "@types/core-js@npm:2.5.8"
   checksum: 10/58c4b86102b13b778d3631d38913c788ef7f688d99fbd741f6241a9cedc7e986e670011bdccd58b32e28e97b9c0fa6fffedef6ba0f670a005b321788a5a01a65
+  languageName: node
+  linkType: hard
+
+"@types/cors@npm:^2.8.12":
+  version: 2.8.19
+  resolution: "@types/cors@npm:2.8.19"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/9545cc532c9218754443f48a0c98c1a9ba4af1fe54a3425c95de75ff3158147bb39e666cb7c6bf98cc56a9c6dc7b4ce5b2cbdae6b55d5942e50c81b76ed6b825
   languageName: node
   linkType: hard
 
@@ -11603,6 +11647,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:~1.3.4":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 10/67eaaa90e2917c58418e7a9b89392002d2b1ccd69bcca4799135d0c632f3b082f23f4ae4ddeedbced5aa59bcc7bdf4699c69ebed4593696c922462b7bc5744d6
+  languageName: node
+  linkType: hard
+
 "acorn-import-attributes@npm:^1.9.5":
   version: 1.9.5
   resolution: "acorn-import-attributes@npm:1.9.5"
@@ -12565,6 +12619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64id@npm:2.0.0, base64id@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "base64id@npm:2.0.0"
+  checksum: 10/e3312328429e512b0713469c5312f80b447e71592cae0a5bddf3f1adc9c89d1b2ed94156ad7bb9f529398f310df7ff6f3dbe9550735c6a759f247c088ea67364
+  languageName: node
+  linkType: hard
+
 "basic-auth@npm:^2.0.1":
   version: 2.0.1
   resolution: "basic-auth@npm:2.0.1"
@@ -12671,6 +12732,23 @@ __metadata:
     raw-body: "npm:^3.0.0"
     type-is: "npm:^2.0.0"
   checksum: 10/689e25d649527793bb3577ace9c122d4987cfb248ef0e78b4a4494a1c9ad79908c45c05682d27d1a261b441cea9f7cc5d4bf1c295b43e961d2a41bd27f1d9377
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "body-parser@npm:2.2.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.0"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.6.3"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.0"
+    raw-body: "npm:^3.0.0"
+    type-is: "npm:^2.0.0"
+  checksum: 10/e9d844b036bd15970df00a16f373c7ed28e1ef870974a0a1d4d6ef60d70e01087cc20a0dbb2081c49a88e3c08ce1d87caf1e2898c615dffa193f63e8faa8a84e
   languageName: node
   linkType: hard
 
@@ -13851,7 +13929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.0":
+"cookie@npm:^0.7.0, cookie@npm:^0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
@@ -13881,7 +13959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:^2.8.5":
+"cors@npm:^2.8.5, cors@npm:~2.8.5":
   version: 2.8.5
   resolution: "cors@npm:2.8.5"
   dependencies:
@@ -14205,6 +14283,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/71168908b9a78227ab29d5d25fe03c5867750e31ce24bf2c44a86efc5af041758bb56569b0a3d48a9b5344c00a24a777e6f4100ed6dfd9534a42c1dde285125a
+  languageName: node
+  linkType: hard
+
 "decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
@@ -14376,7 +14466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0":
+"depd@npm:2.0.0, depd@npm:^2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10/c0c8ff36079ce5ada64f46cc9d6fd47ebcf38241105b6e0c98f412e8ad91f084bcf906ff644cc3a4bd876ca27a62accb8b0fff72ea6ed1a414b89d8506f4a5ca
@@ -14880,6 +14970,43 @@ __metadata:
     fast-json-parse: "npm:^1.0.3"
     objectorarray: "npm:^1.0.5"
   checksum: 10/c352831088fce745a39ddbd5f87a17e073ea6556e7e96e9010d945a3f3020f836b9a84657123fa01e897db9216f4b080d950b5ded9bf3a8227f14a34efaaaf7c
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.3
+  resolution: "engine.io-client@npm:6.6.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10/c5b8e7eb0f2637b21a63780214878b842306247f540cccab7a4d15606d142e42878cc79607f8f77fa29f016b6854702b7d5ad275df7ad6150f08954a1e2c332a
+  languageName: node
+  linkType: hard
+
+"engine.io-parser@npm:~5.2.1":
+  version: 5.2.3
+  resolution: "engine.io-parser@npm:5.2.3"
+  checksum: 10/eb0023fff5766e7ae9d59e52d92df53fea06d472cfd7b52e5d2c36b4c1dbf78cab5fde1052bcb3d4bb85bdb5aee10ae85d8a1c6c04676dac0c6cdf16bcba6380
+  languageName: node
+  linkType: hard
+
+"engine.io@npm:~6.6.0":
+  version: 6.6.4
+  resolution: "engine.io@npm:6.6.4"
+  dependencies:
+    "@types/cors": "npm:^2.8.12"
+    "@types/node": "npm:>=10.0.0"
+    accepts: "npm:~1.3.4"
+    base64id: "npm:2.0.0"
+    cookie: "npm:~0.7.2"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+  checksum: 10/005b43b392d5b4b9bb196d1ae2a8cc1334a7dc70af3cfb50627d257de407ca1afae725fcd8571f9621cd12ed437abaac819c64cf22f09d5ae02b954a7e7bf4f8
   languageName: node
   linkType: hard
 
@@ -16273,6 +16400,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "express@npm:5.1.0"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.0"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10/6dba00bbdf308f43a84ed3f07a7e9870d5208f2a0b8f60f39459dda089750379747819863fad250849d3c9163833f33f94ce69d73938df31e0c5a430800d7e56
+  languageName: node
+  linkType: hard
+
 "exsolve@npm:^1.0.7":
   version: 1.0.7
   resolution: "exsolve@npm:1.0.7"
@@ -16641,7 +16803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:^2.0.0":
+"finalhandler@npm:^2.0.0, finalhandler@npm:^2.1.0":
   version: 2.1.0
   resolution: "finalhandler@npm:2.1.0"
   dependencies:
@@ -16885,7 +17047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:2.0.0":
+"fresh@npm:2.0.0, fresh@npm:^2.0.0":
   version: 2.0.0
   resolution: "fresh@npm:2.0.0"
   checksum: 10/44e1468488363074641991c1340d2a10c5a6f6d7c353d89fd161c49d120c58ebf9890720f7584f509058385836e3ce50ddb60e9f017315a4ba8c6c3461813bfc
@@ -21355,14 +21517,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:^1.53.0":
+"mime-db@npm:^1.53.0, mime-db@npm:^1.54.0":
   version: 1.54.0
   resolution: "mime-db@npm:1.54.0"
   checksum: 10/9e7834be3d66ae7f10eaa69215732c6d389692b194f876198dca79b2b90cbf96688d9d5d05ef7987b20f749b769b11c01766564264ea5f919c88b32a29011311
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.35":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -21377,6 +21539,15 @@ __metadata:
   dependencies:
     mime-db: "npm:^1.53.0"
   checksum: 10/819584a951124b1cdee21e0c5515d174e1df018407b837297cef0da0620e4c0551336909fc3704166fca3a3fc141d19976bcc34e94eb720af04bbf4b50b43545
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10/fa1d3a928363723a8046c346d87bf85d35014dae4285ad70a3ff92bd35957992b3094f8417973cfe677330916c6ef30885109624f1fb3b1e61a78af509dba120
   languageName: node
   linkType: hard
 
@@ -21962,7 +22133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
+"negotiator@npm:0.6.3, negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 10/2723fb822a17ad55c93a588a4bc44d53b22855bf4be5499916ca0cab1e7165409d0b288ba2577d7b029f10ce18cf2ed8e703e5af31c984e1e2304277ef979837
@@ -25659,6 +25830,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10/8949bd1d3da5403cc024e2989fee58d7fda0f3ffe9f2dc5b8a192f295f400b3cde307b0b554f7d44851077640f36962ca469a766b3d57410d7d96245a7ba6c91
+  languageName: node
+  linkType: hard
+
 "rrweb-cssom@npm:^0.7.1":
   version: 0.7.1
   resolution: "rrweb-cssom@npm:0.7.1"
@@ -25951,6 +26135,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "send@npm:1.2.0"
+  dependencies:
+    debug: "npm:^4.3.5"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.1"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.1"
+  checksum: 10/9fa3b1a3b9a06b7b4ab00c25e8228326d9665a9745753a34d1ffab8ac63c7c206727331d1dc5be73647f1b658d259a1aa8e275b0e0eee51349370af02e9da506
+  languageName: node
+  linkType: hard
+
 "sentence-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "sentence-case@npm:3.0.4"
@@ -25998,6 +26201,18 @@ __metadata:
     parseurl: "npm:^1.3.3"
     send: "npm:^1.0.0"
   checksum: 10/ecb5969b66520e6546721454e72ee3fbe827fee16224a563d258d71ab68d9316991c81910b94bd2a7b75112669ef887068ab0ef66a4bf524ed8ed9c919a01de0
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "serve-static@npm:2.2.0"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10/9f1a900738c5bb02258275ce3bd1273379c4c3072b622e15d44e8f47d89a1ba2d639ec2d63b11c263ca936096b40758acb7a0d989cd6989018a65a12f9433ada
   languageName: node
   linkType: hard
 
@@ -26504,6 +26719,53 @@ __metadata:
     snake-case: "npm:^3.0.4"
     type-fest: "npm:^4.15.0"
   checksum: 10/d8062a06ec95fbacea2f5c4a3f02cdbff113e1fa6c4a25a90840186d9d0b428ddee245d4af34019267d93447632b90d8852a962de60f0d8d5871c1abaac3e29b
+  languageName: node
+  linkType: hard
+
+"socket.io-adapter@npm:~2.5.2":
+  version: 2.5.5
+  resolution: "socket.io-adapter@npm:2.5.5"
+  dependencies:
+    debug: "npm:~4.3.4"
+    ws: "npm:~8.17.1"
+  checksum: 10/e364733a4c34ff1d4a02219e409bd48074fd614b7f5b0568ccfa30dd553252a5b9a41056931306a276891d13ea76a19e2c6f2128a4675c37323f642896874d80
+  languageName: node
+  linkType: hard
+
+"socket.io-client@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io-client@npm:4.8.1"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.2"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10/7480cf1ab30eba371a96dd1ce2ce9018dcbeaf81035a066fb89d99df0d0a6388b05840c92d970317c739956b68b28b0f4833f3b18e460a24eef557b9bca127c1
+  languageName: node
+  linkType: hard
+
+"socket.io-parser@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "socket.io-parser@npm:4.2.4"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+  checksum: 10/4be500a9ff7e79c50ec25af11048a3ed34b4c003a9500d656786a1e5bceae68421a8394cf3eb0aa9041f85f36c1a9a737617f4aee91a42ab4ce16ffb2aa0c89c
+  languageName: node
+  linkType: hard
+
+"socket.io@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io@npm:4.8.1"
+  dependencies:
+    accepts: "npm:~1.3.4"
+    base64id: "npm:~2.0.0"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.2"
+    engine.io: "npm:~6.6.0"
+    socket.io-adapter: "npm:~2.5.2"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10/b9b362b7f63fc7ebb58482b8a3ade6c971da7783b7611dfeebaa8b02be23cb948137ec218491ccda8be57e434e97d65b64edf1e9811e5245b23a888d41636f4a
   languageName: node
   linkType: hard
 
@@ -28428,6 +28690,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10/bacdb23c872dacb7bd40fbd9095e6b2fca2895eedbb689160c05534d7d4810a7f4b3fd1ae87e96133c505958f6d602967a68db5ff577b85dd6be76eaa75d58af
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
@@ -29170,7 +29443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:^1, vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:^1.1.2, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
@@ -30088,6 +30361,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:~8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
+  languageName: node
+  linkType: hard
+
 "wsl-utils@npm:^0.1.0":
   version: 0.1.0
   resolution: "wsl-utils@npm:0.1.0"
@@ -30153,6 +30441,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10/4ad5924974efd004a47cce6acf5c0269aee0e62f9a805a426db3337af7bcbd331099df174b024ace4fb18971b8a56de386d2e73a1c4b020e3abd63a4a9b917f1
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10/708a177fe41c6c8cd4ec7c04d965b4c01801d87f44383ec639be58bdc14418142969841659e0850db44feee8bec0a3d3e7d33fed22519415f3d0daab04d3f160
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Alternative take on #6855.

Instead of exposing `TLSyncClient` and forcing people to re-implement most of `useSync`, this is a little more targeted. As an alternative to passing `uri`, you can now pass a `connect` function that returns a `TLPersistentClientSocket`. With this hook, it's possible to use a custom transport with tldraw sync without having to re-implement all the complex logic around the store and presence that lives in `useSync`.

This also adds a template that uses this custom hook with socket.io. Thanks @Digital39999 - that's mostly copied from your version.

### Change type

- [x] `api`

### API changes

- `useSync` now accepts a `connect` method, which allows creating custom transports for tldraw sync.