### PR TITLE
docs: fix ShapeUtil reference from getBounds to getGeometry

### DIFF
--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -142,7 +142,7 @@ class CardShapeUtil extends ShapeUtil<CardShape> {
 }
 ```
 
-This is a minimal [ShapeUtil](?). We've given it a static property `type` that matches the type of our shape, we've provided implementations for the abstract methods [ShapeUtil#getDefaultProps](?), [ShapeUtil#getBounds](?), [ShapeUtil#component](?), and [ShapeUtil#indicator](?).
+This is a minimal [ShapeUtil](?). We've given it a static property `type` that matches the type of our shape, we've provided implementations for the abstract methods [ShapeUtil#getDefaultProps](?), [ShapeUtil#getGeometry](?), [ShapeUtil#component](?), and [ShapeUtil#indicator](?).
 
 We still have work to do on the `CardShapeUtil` class, but we'll come back to it later. For now, let's put the shape onto the canvas by passing it to the [Tldraw](?) component.
 


### PR DESCRIPTION
Fixes the documentation in `apps/docs/content/docs/shapes.mdx` to reference the current `getGeometry()` method instead of the outdated `getBounds()` method.

Fixes #5469

Generated with [Claude Code](https://claude.ai/code)