### PR TITLE
Make sure templates don't use internal functions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -401,6 +401,7 @@ export default [
 			'no-restricted-syntax': 'off',
 			'no-console': 'off',
 			'@typescript-eslint/method-signature-style': 'off',
+			'local/no-at-internal': 'error',
 		},
 	},
 ]

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1240,7 +1240,6 @@ export class Editor extends EventEmitter<TLEventMap> {
         hitInside?: boolean;
         margin?: number;
     }): TLShape[];
-    // @internal (undocumented)
     getShapesPageBounds(shapeIds: TLShapeId[]): Box | null;
     // @internal (undocumented)
     getShapesRotatedPageBounds(shapeIds: TLShapeId[]): Box | undefined;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2019,7 +2019,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
-	 * @internal
+	 * Get the page bounds of all the provided shapes.
+	 *
+	 * @public
 	 */
 	getShapesPageBounds(shapeIds: TLShapeId[]): Box | null {
 		const bounds = compact(shapeIds.map((id) => this.getShapePageBounds(id)))

--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -155,7 +155,7 @@ export class IncrementalSetConstructor<T> {
     remove(item: T): void;
 }
 
-// @internal
+// @public
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>): boolean;
 
 // @public (undocumented)

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -28,7 +28,7 @@ export function reverseRecordsDiff(diff: RecordsDiff<any>) {
 
 /**
  * Is a records diff empty?
- * @internal
+ * @public
  */
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>) {
 	return (

--- a/templates/agent/client/agent/TldrawAgent.ts
+++ b/templates/agent/client/agent/TldrawAgent.ts
@@ -3,7 +3,6 @@ import {
 	atom,
 	Box,
 	Editor,
-	exhaustiveSwitchError,
 	react,
 	RecordsDiff,
 	reverseRecordsDiff,
@@ -969,4 +968,15 @@ function persistAtomInLocalStorage<T>(atom: Atom<T>, key: string) {
 	react(`save ${key} to localStorage`, () => {
 		localStorage.setItem(key, JSON.stringify(atom.get()))
 	})
+}
+
+/**
+ * Throw an error if a switch case is not exhaustive.
+ *
+ * This is a helper function that is used internally by the agent.
+ */
+function exhaustiveSwitchError(value: never, property?: string): never {
+	const debugValue =
+		property && value && typeof value === 'object' && property in value ? value[property] : value
+	throw new Error(`Unknown switch case ${debugValue}`)
 }

--- a/templates/workflow/src/nodes/types/AddNode.tsx
+++ b/templates/workflow/src/nodes/types/AddNode.tsx
@@ -1,4 +1,4 @@
-import { Editor, getIndexAbove, getIndicesBetween, IndexKey, sleep, T, useEditor } from 'tldraw'
+import { Editor, getIndexAbove, getIndicesBetween, IndexKey, T, useEditor } from 'tldraw'
 import { AddIcon } from '../../components/icons/AddIcon'
 import {
 	NODE_HEADER_HEIGHT_PX,
@@ -8,6 +8,7 @@ import {
 } from '../../constants'
 import { ShapePort } from '../../ports/Port'
 import { indexList, indexListEntries, indexListLength } from '../../utils'
+import { sleep } from '../../utils/sleep'
 import { getNodePortConnections } from '../nodePorts'
 import { NodeShape } from '../NodeShapeUtil'
 import {

--- a/templates/workflow/src/nodes/types/ConditionalNode.tsx
+++ b/templates/workflow/src/nodes/types/ConditionalNode.tsx
@@ -1,4 +1,4 @@
-import { sleep, T, useEditor } from 'tldraw'
+import { T, useEditor } from 'tldraw'
 import { ConditionalIcon } from '../../components/icons/ConditionalIcon'
 import {
 	NODE_HEADER_HEIGHT_PX,
@@ -8,6 +8,7 @@ import {
 	NODE_WIDTH_PX,
 } from '../../constants'
 import { Port, ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	areAnyInputsOutOfDate,

--- a/templates/workflow/src/nodes/types/DivideNode.tsx
+++ b/templates/workflow/src/nodes/types/DivideNode.tsx
@@ -1,4 +1,4 @@
-import { sleep, T, useEditor } from 'tldraw'
+import { T, useEditor } from 'tldraw'
 import { DivideIcon } from '../../components/icons/DivideIcon'
 import {
 	NODE_HEADER_HEIGHT_PX,
@@ -7,6 +7,7 @@ import {
 	NODE_WIDTH_PX,
 } from '../../constants'
 import { ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	areAnyInputsOutOfDate,

--- a/templates/workflow/src/nodes/types/EarthquakeNode.tsx
+++ b/templates/workflow/src/nodes/types/EarthquakeNode.tsx
@@ -1,7 +1,8 @@
-import { sleep, T } from 'tldraw'
+import { T } from 'tldraw'
 import { EarthquakeIcon } from '../../components/icons/EarthquakeIcon'
 import { NODE_HEADER_HEIGHT_PX, NODE_ROW_HEIGHT_PX, NODE_WIDTH_PX } from '../../constants'
 import { ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	ExecutionResult,

--- a/templates/workflow/src/nodes/types/MultiplyNode.tsx
+++ b/templates/workflow/src/nodes/types/MultiplyNode.tsx
@@ -1,4 +1,4 @@
-import { sleep, T, useEditor } from 'tldraw'
+import { T, useEditor } from 'tldraw'
 import { MultiplyIcon } from '../../components/icons/MultiplyIcon'
 import {
 	NODE_HEADER_HEIGHT_PX,
@@ -7,6 +7,7 @@ import {
 	NODE_WIDTH_PX,
 } from '../../constants'
 import { ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	areAnyInputsOutOfDate,

--- a/templates/workflow/src/nodes/types/SliderNode.tsx
+++ b/templates/workflow/src/nodes/types/SliderNode.tsx
@@ -1,7 +1,8 @@
-import { sleep, T, TldrawUiSlider, useEditor } from 'tldraw'
+import { T, TldrawUiSlider, useEditor } from 'tldraw'
 import { SliderIcon } from '../../components/icons/SliderIcon'
 import { NODE_HEADER_HEIGHT_PX, NODE_ROW_HEIGHT_PX, NODE_WIDTH_PX } from '../../constants'
 import { ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	ExecutionResult,

--- a/templates/workflow/src/nodes/types/SubtractNode.tsx
+++ b/templates/workflow/src/nodes/types/SubtractNode.tsx
@@ -1,4 +1,4 @@
-import { sleep, T, useEditor } from 'tldraw'
+import { T, useEditor } from 'tldraw'
 import { SubtractIcon } from '../../components/icons/SubtractIcon'
 import {
 	NODE_HEADER_HEIGHT_PX,
@@ -7,6 +7,7 @@ import {
 	NODE_WIDTH_PX,
 } from '../../constants'
 import { ShapePort } from '../../ports/Port'
+import { sleep } from '../../utils/sleep'
 import { NodeShape } from '../NodeShapeUtil'
 import {
 	areAnyInputsOutOfDate,

--- a/templates/workflow/src/utils/sleep.ts
+++ b/templates/workflow/src/utils/sleep.ts
@@ -1,0 +1,8 @@
+/**
+ * Delays execution for a specified number of milliseconds.
+ * @param ms - The number of milliseconds to delay.
+ * @returns A promise that resolves after the specified delay.
+ */
+export function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
The agent and workflow starters used some internal functions. This caused problems for some people on discord. This PR fixes that by either inlining functions or making them public, and by adding an eslint rule to make sure this never happens again.


### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`


### Release notes

- Removed imports of internal functions from the agent and workflow starters.

### API Changes

- We now publicly export the `isRecordsDiffEmpty` function.
- We now publicly expose the `editor.getShapesPageBounds` method.