### PR TITLE
fix: text paste positioning to prevent shapes from running off screen

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -526,7 +526,18 @@ export async function defaultHandleExternalTextContent(
 		p.y = editor.getViewportPageBounds().minY + 40 + h / 2
 	}
 
-	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)
+	const viewportBounds = editor.getViewportPageBounds()
+	let newX = p.x - w / 2
+
+	if (newX + w > viewportBounds.maxX - 20) {
+		newX = viewportBounds.maxX - w - 20
+	}
+
+	if (newX < viewportBounds.minX + 20) {
+		newX = viewportBounds.minX + 20
+	}
+
+	const newPoint = maybeSnapToGrid(new Vec(newX, p.y - h / 2), editor)
 	const shapeId = createShapeId()
 
 	// Allow this to trigger the max shapes reached alert

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -235,10 +235,37 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		// Will always be a fresh call to getTextSize
 		const boundsB = getTextSize(this.editor, next.props)
 
-		const wA = boundsA.width * prev.props.scale
-		const hA = boundsA.height * prev.props.scale
-		const wB = boundsB.width * next.props.scale
-		const hB = boundsB.height * next.props.scale
+		let wA = boundsA.width * prev.props.scale
+		let hA = boundsA.height * prev.props.scale
+		let wB = boundsB.width * next.props.scale
+		let hB = boundsB.height * next.props.scale
+
+		const viewportBounds = this.editor.getViewportPageBounds()
+		const maxWidth = viewportBounds.width * 0.9
+
+		if (wB > maxWidth) {
+			const constrainedSize = this.editor.textMeasure.measureHtml(
+				renderHtmlFromRichTextForMeasurement(this.editor, next.props.richText),
+				{
+					...TEXT_PROPS,
+					fontFamily: FONT_FAMILIES[next.props.font],
+					fontSize: FONT_SIZES[next.props.size],
+					maxWidth: maxWidth,
+				}
+			)
+			wB = Math.max(16, constrainedSize.w + 1)
+			hB = Math.max(FONT_SIZES[next.props.size], constrainedSize.h)
+
+			return {
+				...next,
+				props: {
+					...next.props,
+					w: wB,
+					autoSize: false,
+					textAlign: next.props.textAlign === 'middle' ? 'start' : next.props.textAlign,
+				},
+			}
+		}
 
 		let delta: Vec | undefined
 


### PR DESCRIPTION
### Description

-fixes text paste behavior where text shapes would run off the screen when pasting at cursor position or when pasting into auto-sizing text boxes with long content.

**Before:** Text could extend beyond viewport boundaries, making it partially or completely invisible.

**After:** Text shapes are automatically constrained to fit within screen boundaries with proper wrapping and positioning.

### Change type

- [x] `bugfix`