### PR TITLE
Handle no vertices gracefully

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -175,6 +175,8 @@ export abstract class Geometry2d {
 	interpolateAlongEdge(t: number, _filters?: Geometry2dFilters): Vec {
 		const { vertices } = this
 
+		if (vertices.length === 0) return new Vec(0, 0)
+		if (vertices.length === 1) return vertices[0]
 		if (t <= 0) return vertices[0]
 
 		const distanceToTravel = t * this.length
@@ -208,6 +210,8 @@ export abstract class Geometry2d {
 		let closestSegment = null
 		let closestDistance = Infinity
 		let distanceTraveled = 0
+
+		if (vertices.length === 0 || vertices.length === 1) return 0
 
 		for (let i = 0; i < (this.isClosed ? vertices.length : vertices.length - 1); i++) {
 			const curr = vertices[i]

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -120,6 +120,8 @@ export abstract class Geometry2d {
 	distanceToLineSegment(A: VecLike, B: VecLike, filters?: Geometry2dFilters) {
 		if (Vec.Equals(A, B)) return this.distanceToPoint(A, false, filters)
 		const { vertices } = this
+		if (vertices.length === 0) throw Error('nearest point not found')
+		if (vertices.length === 1) return Vec.Dist(A, vertices[0])
 		let nearest: Vec | undefined
 		let dist = Infinity
 		let d: number, p: Vec, q: Vec


### PR DESCRIPTION
Sometimes a shape geometry might contain no vertices. We handle this gracefully in some geometry methods, but not all. This PR makes us do it in all of them

Note: This issue was discovered by potentially a different issue related to arrow labels. See [discord](https://discord.com/channels/859816885297741824/1423260701006364704/1423260701006364704).

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes

- Fixed a bug with shapes that had zero geometry vertices.