### PR TITLE
embeds: fix replit if it has a hash present

### DIFF
--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -428,7 +428,8 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(/\/@([^/]+)\/([^/]+)/)) {
-				return `${url}?embed=true`
+				urlObj.searchParams.append('embed', 'true')
+				return urlObj.href
 			}
 			return
 		},

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -276,6 +276,14 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		},
 	},
 	{
+		url: 'https://replit.com/@omar/Blob-Generator#index.html',
+		match: true,
+		output: {
+			type: 'replit',
+			embedUrl: `https://replit.com/@omar/Blob-Generator?embed=true#index.html`,
+		},
+	},
+	{
 		url: 'https://replit.com/foobar',
 		match: false,
 	},
@@ -597,6 +605,14 @@ const MATCH_EMBED_TEST_URLS: (MatchEmbedTestMatchDef | MatchEmbedTestNoMatchDef)
 		output: {
 			type: 'replit',
 			url: `https://replit.com/@omar/Blob-Generator`,
+		},
+	},
+	{
+		embedUrl: 'https://replit.com/@omar/Blob-Generator?embed=true#index.html',
+		match: true,
+		output: {
+			type: 'replit',
+			url: `https://replit.com/@omar/Blob-Generator#index.html`,
 		},
 	},
 	{


### PR DESCRIPTION
if a Replit URL is like: https://replit.com/@omar/Blob-Generator#index.html it was failing.

before: "https://replit.com/@omar/Blob-Generator#index.html?embed=true"
after: "https://replit.com/@omar/Blob-Generator?embed=true#index.html"

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- embeds: fix replit if it has a hash present