### PR TITLE
style panel: address zooming in/out wrapping unnecessarily sometimes

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -993,8 +993,16 @@
 	position: relative;
 	z-index: var(--tl-layer-panels);
 	pointer-events: all;
-	width: 148px;
-	max-width: 148px;
+	/*
+	  This is a fractional width because when zooming in/out with the browser the
+	  width of this panel can become something like 147.995. The browser tries it's
+	  best but since the buttons within are exact size they start wrapping where
+		we don't want them to.
+		We need the flex-wrap on the items btw because if "Enhanced a11y mode" is on,
+	  the labels and buttons need to wrap appropriately.
+	*/
+	width: 148.05px;
+	max-width: 148.05px;
 }
 
 .tlui-style-panel[data-enhanced-a11y-mode='true'] .tlui-button[data-isactive='true'] {


### PR DESCRIPTION
open to other suggestions / hacks but this is as best as I can come up with for this predicament.

solves this issue when zoomed at 90% (browser zoom). this also happens on zoom in, btw.
<img width="362" height="220" alt="Screenshot 2025-10-08 at 12 25 20" src="https://github.com/user-attachments/assets/be9b2332-ede1-41f1-8fcf-3baf1b5dc681" />


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- style panel: address zooming in/out wrapping unnecessarily sometimes