### PR TITLE
fix(bookmark): consolidate logic and expose createBookmarkFromUrl

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -441,7 +441,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
         opacity: TLOpacityType;
         parentId: TLParentId;
         props: {
-            assetId: null | TLAssetId;
+            assetId: TLAssetId | null;
             h: number;
             url: string;
             w: number;
@@ -461,7 +461,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
         opacity: TLOpacityType;
         parentId: TLParentId;
         props: {
-            assetId: null | TLAssetId;
+            assetId: TLAssetId | null;
             h: number;
             url: string;
             w: number;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -134,7 +134,8 @@ export {
 	getArrowTerminalsInArrowSpace,
 	type TLArrowBindings,
 } from './lib/shapes/arrow/shared'
-export { BookmarkShapeUtil, createBookmarkFromUrl } from './lib/shapes/bookmark/BookmarkShapeUtil'
+export { createBookmarkFromUrl } from './lib/shapes/bookmark/bookmarks'
+export { BookmarkShapeUtil } from './lib/shapes/bookmark/BookmarkShapeUtil'
 export { DrawShapeTool } from './lib/shapes/draw/DrawShapeTool'
 export { DrawShapeUtil, type DrawShapeOptions } from './lib/shapes/draw/DrawShapeUtil'
 export { EmbedShapeUtil } from './lib/shapes/embed/EmbedShapeUtil'

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -31,7 +31,7 @@ import {
 	toRichText,
 } from '@tldraw/editor'
 import { EmbedDefinition } from './defaultEmbedDefinitions'
-import { createBookmarkFromUrl } from './shapes/bookmark/BookmarkShapeUtil'
+import { createBookmarkFromUrl } from './shapes/bookmark/bookmarks'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
 import { getCroppedImageDataForReplacedImage } from './shapes/shared/crop'
 import { FONT_FAMILIES, FONT_SIZES, TEXT_PROPS } from './shapes/shared/default-shape-constants'

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -1,20 +1,12 @@
 import {
-	AssetRecordType,
 	BaseBoxShapeUtil,
-	Editor,
 	HTMLContainer,
-	Result,
 	T,
-	TLAssetId,
 	TLBookmarkAsset,
 	TLBookmarkShape,
 	TLBookmarkShapeProps,
-	TLShapePartial,
 	bookmarkShapeMigrations,
 	bookmarkShapeProps,
-	createShapeId,
-	debounce,
-	getHashForString,
 	lerp,
 	tlenv,
 	toDomPrecision,
@@ -27,11 +19,13 @@ import { convertCommonTitleHTMLEntities } from '../../utils/text/text'
 import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { LINK_ICON } from '../shared/icons-editor'
 import { getRotatedBoxShadow } from '../shared/rotated-box-shadow'
-
-const BOOKMARK_WIDTH = 300
-const BOOKMARK_HEIGHT = 320
-const BOOKMARK_JUST_URL_HEIGHT = 46
-const SHORT_BOOKMARK_HEIGHT = 101
+import {
+	BOOKMARK_HEIGHT,
+	BOOKMARK_WIDTH,
+	getHumanReadableAddress,
+	setBookmarkHeight,
+	updateBookmarkAssetOnUrlChange,
+} from './bookmarks'
 
 /** @public */
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
@@ -220,156 +214,4 @@ function BookmarkShapeComponent({ shape }: { shape: TLBookmarkShape }) {
 			</div>
 		</HTMLContainer>
 	)
-}
-
-function getBookmarkHeight(editor: Editor, assetId?: TLAssetId | null) {
-	const asset = (assetId ? editor.getAsset(assetId) : null) as TLBookmarkAsset | null
-
-	if (asset) {
-		if (!asset.props.image) {
-			if (!asset.props.title) {
-				return BOOKMARK_JUST_URL_HEIGHT
-			} else {
-				return SHORT_BOOKMARK_HEIGHT
-			}
-		}
-	}
-
-	return BOOKMARK_HEIGHT
-}
-
-function setBookmarkHeight(editor: Editor, shape: TLBookmarkShape) {
-	return {
-		...shape,
-		props: { ...shape.props, h: getBookmarkHeight(editor, shape.props.assetId) },
-	}
-}
-
-/** @internal */
-export const getHumanReadableAddress = (shape: TLBookmarkShape) => {
-	try {
-		const url = new URL(shape.props.url)
-		// we want the hostname without any www
-		return url.hostname.replace(/^www\./, '')
-	} catch {
-		return shape.props.url
-	}
-}
-
-function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
-	const { url } = shape.props
-
-	// Derive the asset id from the URL
-	const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
-
-	if (editor.getAsset(assetId)) {
-		// Existing asset for this URL?
-		if (shape.props.assetId !== assetId) {
-			editor.updateShapes<TLBookmarkShape>([
-				{
-					id: shape.id,
-					type: shape.type,
-					props: { assetId },
-				},
-			])
-		}
-	} else {
-		// No asset for this URL?
-
-		// First, clear out the existing asset reference
-		editor.updateShapes<TLBookmarkShape>([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { assetId: null },
-			},
-		])
-
-		// Then try to asyncronously create a new one
-		createBookmarkAssetOnUrlChange(editor, shape)
-	}
-}
-
-const createBookmarkAssetOnUrlChange = debounce(async (editor: Editor, shape: TLBookmarkShape) => {
-	if (editor.isDisposed) return
-
-	const { url } = shape.props
-
-	// Create the asset using the external content manager's createAssetFromUrl method.
-	// This may be overwritten by the user (for example, we overwrite it on tldraw.com)
-	const asset = await editor.getAssetForExternalContent({ type: 'url', url })
-
-	if (!asset) {
-		// No asset? Just leave the bookmark as a null assetId.
-		return
-	}
-
-	editor.run(() => {
-		// Create the new asset
-		editor.createAssets([asset])
-
-		// And update the shape
-		editor.updateShapes<TLBookmarkShape>([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { assetId: asset.id },
-			},
-		])
-	})
-}, 500)
-
-/**
- * Creates a bookmark shape from a URL with unfurled metadata.
- *
- * @returns A Result containing the created bookmark shape or an error
- * @public
- */
-export async function createBookmarkFromUrl(
-	editor: Editor,
-	{
-		url,
-		center = editor.getViewportPageBounds().center,
-	}: {
-		url: string
-		center?: { x: number; y: number }
-	}
-): Promise<Result<TLBookmarkShape, string>> {
-	try {
-		// Create the bookmark asset with unfurled metadata
-		const asset = await editor.getAssetForExternalContent({ type: 'url', url })
-
-		// Create the bookmark shape
-		const shapeId = createShapeId()
-		const shapePartial: TLShapePartial<TLBookmarkShape> = {
-			id: shapeId,
-			type: 'bookmark',
-			x: center.x - BOOKMARK_WIDTH / 2,
-			y: center.y - BOOKMARK_HEIGHT / 2,
-			rotation: 0,
-			opacity: 1,
-			props: {
-				url,
-				assetId: asset?.id || null,
-				w: BOOKMARK_WIDTH,
-				h: getBookmarkHeight(editor, asset?.id),
-			},
-		}
-
-		editor.run(() => {
-			// Create the asset if we have one
-			if (asset) {
-				editor.createAssets([asset])
-			}
-
-			// Create the shape
-			editor.createShapes([shapePartial])
-		})
-
-		// Get the created shape
-		const createdShape = editor.getShape(shapeId) as TLBookmarkShape
-		return Result.ok(createdShape)
-	} catch (error) {
-		return Result.err(error instanceof Error ? error.message : 'Failed to create bookmark')
-	}
 }

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -1,0 +1,170 @@
+import {
+	AssetRecordType,
+	Editor,
+	Result,
+	TLAssetId,
+	TLBookmarkAsset,
+	TLBookmarkShape,
+	TLShapePartial,
+	createShapeId,
+	debounce,
+	getHashForString,
+} from '@tldraw/editor'
+
+export const BOOKMARK_WIDTH = 300
+export const BOOKMARK_HEIGHT = 320
+const BOOKMARK_JUST_URL_HEIGHT = 46
+const SHORT_BOOKMARK_HEIGHT = 101
+
+export function getBookmarkHeight(editor: Editor, assetId?: TLAssetId | null) {
+	const asset = (assetId ? editor.getAsset(assetId) : null) as TLBookmarkAsset | null
+
+	if (asset) {
+		if (!asset.props.image) {
+			if (!asset.props.title) {
+				return BOOKMARK_JUST_URL_HEIGHT
+			} else {
+				return SHORT_BOOKMARK_HEIGHT
+			}
+		}
+	}
+
+	return BOOKMARK_HEIGHT
+}
+
+export function setBookmarkHeight(editor: Editor, shape: TLBookmarkShape) {
+	return {
+		...shape,
+		props: { ...shape.props, h: getBookmarkHeight(editor, shape.props.assetId) },
+	}
+}
+
+/** @internal */
+export const getHumanReadableAddress = (shape: TLBookmarkShape) => {
+	try {
+		const url = new URL(shape.props.url)
+		// we want the hostname without any www
+		return url.hostname.replace(/^www\./, '')
+	} catch {
+		return shape.props.url
+	}
+}
+
+export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
+	const { url } = shape.props
+
+	// Derive the asset id from the URL
+	const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
+
+	if (editor.getAsset(assetId)) {
+		// Existing asset for this URL?
+		if (shape.props.assetId !== assetId) {
+			editor.updateShapes<TLBookmarkShape>([
+				{
+					id: shape.id,
+					type: shape.type,
+					props: { assetId },
+				},
+			])
+		}
+	} else {
+		// No asset for this URL?
+
+		// First, clear out the existing asset reference
+		editor.updateShapes<TLBookmarkShape>([
+			{
+				id: shape.id,
+				type: shape.type,
+				props: { assetId: null },
+			},
+		])
+
+		// Then try to asyncronously create a new one
+		createBookmarkAssetOnUrlChange(editor, shape)
+	}
+}
+
+const createBookmarkAssetOnUrlChange = debounce(async (editor: Editor, shape: TLBookmarkShape) => {
+	if (editor.isDisposed) return
+
+	const { url } = shape.props
+
+	// Create the asset using the external content manager's createAssetFromUrl method.
+	// This may be overwritten by the user (for example, we overwrite it on tldraw.com)
+	const asset = await editor.getAssetForExternalContent({ type: 'url', url })
+
+	if (!asset) {
+		// No asset? Just leave the bookmark as a null assetId.
+		return
+	}
+
+	editor.run(() => {
+		// Create the new asset
+		editor.createAssets([asset])
+
+		// And update the shape
+		editor.updateShapes<TLBookmarkShape>([
+			{
+				id: shape.id,
+				type: shape.type,
+				props: { assetId: asset.id },
+			},
+		])
+	})
+}, 500)
+
+/**
+ * Creates a bookmark shape from a URL with unfurled metadata.
+ *
+ * @returns A Result containing the created bookmark shape or an error
+ * @public
+ */
+
+export async function createBookmarkFromUrl(
+	editor: Editor,
+	{
+		url,
+		center = editor.getViewportPageBounds().center,
+	}: {
+		url: string
+		center?: { x: number; y: number }
+	}
+): Promise<Result<TLBookmarkShape, string>> {
+	try {
+		// Create the bookmark asset with unfurled metadata
+		const asset = await editor.getAssetForExternalContent({ type: 'url', url })
+
+		// Create the bookmark shape
+		const shapeId = createShapeId()
+		const shapePartial: TLShapePartial<TLBookmarkShape> = {
+			id: shapeId,
+			type: 'bookmark',
+			x: center.x - BOOKMARK_WIDTH / 2,
+			y: center.y - BOOKMARK_HEIGHT / 2,
+			rotation: 0,
+			opacity: 1,
+			props: {
+				url,
+				assetId: asset?.id || null,
+				w: BOOKMARK_WIDTH,
+				h: getBookmarkHeight(editor, asset?.id),
+			},
+		}
+
+		editor.run(() => {
+			// Create the asset if we have one
+			if (asset) {
+				editor.createAssets([asset])
+			}
+
+			// Create the shape
+			editor.createShapes([shapePartial])
+		})
+
+		// Get the created shape
+		const createdShape = editor.getShape(shapeId) as TLBookmarkShape
+		return Result.ok(createdShape)
+	} catch (error) {
+		return Result.err(error instanceof Error ? error.message : 'Failed to create bookmark')
+	}
+}

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -20,13 +20,12 @@ import {
 	approximately,
 	compact,
 	createShapeId,
-	deferAsyncEffects,
 	kickoutOccludedShapes,
 	openWindow,
 	useMaybeEditor,
 } from '@tldraw/editor'
 import * as React from 'react'
-import { createBookmarkFromUrl } from '../../shapes/bookmark/BookmarkShapeUtil'
+import { createBookmarkFromUrl } from '../../shapes/bookmark/bookmarks'
 import { fitFrameToContent, removeFrame } from '../../utils/frames/frames'
 import { generateShapeAnnouncementMessage } from '../components/A11y'
 import { EditLinkDialog } from '../components/EditLinkDialog'
@@ -401,30 +400,28 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					const creationPromises: Promise<Result<any, any>>[] = []
 
-					await deferAsyncEffects(async () => {
-						for (const shape of shapes) {
-							if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed') || !shape.props.url)
-								continue
+					for (const shape of shapes) {
+						if (!shape || !editor.isShapeOfType<TLEmbedShape>(shape, 'embed') || !shape.props.url)
+							continue
 
-							const center = editor.getShapePageBounds(shape)?.center
+						const center = editor.getShapePageBounds(shape)?.center
 
-							if (!center) continue
-							editor.deleteShapes([shape.id])
+						if (!center) continue
+						editor.deleteShapes([shape.id])
 
-							creationPromises.push(
-								createBookmarkFromUrl(editor, { url: shape.props.url, center }).then((res) => {
-									if (!res.ok) {
-										throw new Error(res.error)
-									}
-									return res
-								})
-							)
-						}
+						creationPromises.push(
+							createBookmarkFromUrl(editor, { url: shape.props.url, center }).then((res) => {
+								if (!res.ok) {
+									throw new Error(res.error)
+								}
+								return res
+							})
+						)
+					}
 
-						await Promise.all(creationPromises).catch((error) => {
-							editor.bailToMark(markId)
-							console.error(error)
-						})
+					await Promise.all(creationPromises).catch((error) => {
+						editor.bailToMark(markId)
+						console.error(error)
 					})
 				},
 			},

--- a/packages/tldraw/src/test/bookmark-shapes.test.ts
+++ b/packages/tldraw/src/test/bookmark-shapes.test.ts
@@ -1,9 +1,6 @@
 import { TLBookmarkShape, createShapeId } from '@tldraw/editor'
 import { vi } from 'vitest'
-import {
-	createBookmarkFromUrl,
-	getHumanReadableAddress,
-} from '../lib/shapes/bookmark/BookmarkShapeUtil'
+import { createBookmarkFromUrl, getHumanReadableAddress } from '../lib/shapes/bookmark/bookmarks'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor


### PR DESCRIPTION
Consolidated the logic we use for pasting and the conversion action, and exposed it as a helper function for our users.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added `createBookmarkFromUrl` helper function for creating bookmark shapes more easily.
- Fixed an issue where the convert-to-bookmark action used different logic than pasting.