### PR TITLE
Improve mobile breakpoints

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -39,7 +39,7 @@ export function TlaEditorTopRightPanel({
 
 	if (isAnonUser) {
 		return (
-			<div ref={ref} className={classNames(styles.topRightPanel)}>
+			<div ref={ref} className={styles.topRightPanel}>
 				<PeopleMenu />
 				<SignedOutShareButton fileId={fileId} context={context} />
 				<SignInButton

--- a/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
@@ -77,6 +77,16 @@
 	flex-shrink: 2;
 }
 
+@media (max-width: 550px) {
+	.topLeftPanelButtons:has(.topLeftOfflineLogo) .topLeftInputWrapper {
+		display: none;
+	}
+
+	.topLeftPanelButtons:has(.topLeftOfflineLogo) .topLeftPanelSeparator:has(+ .topLeftInputWrapper) {
+		display: none;
+	}
+}
+
 .topLeftInputWrapper > * {
 	width: 100%;
 	overflow: hidden;
@@ -88,7 +98,7 @@
 	width: fit-content;
 	max-width: 320px;
 	width: 100%;
-	white-space: no-wrap;
+	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	opacity: 0;
@@ -295,5 +305,11 @@ button.topLeftInputNameWidthSetter {
 @media (hover: hover) {
 	.topRightAnonShareButton:hover::after {
 		visibility: visible;
+	}
+}
+
+@media (max-width: 550px) {
+	.topRightAnonShareButton {
+		display: none;
 	}
 }

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -224,8 +224,10 @@
 	max-width: 100%;
 	min-width: 0px;
 	height: auto;
-	overflow: hidden;
 	position: relative;
+
+	/* Stop helper buttons getting cut off by the top right panel */
+	overflow: visible;
 }
 
 .tlui-layout__top__right {

--- a/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/PeopleMenu.tsx
@@ -1,6 +1,8 @@
 import { useContainer, useEditor, usePeerIds, useValue } from '@tldraw/editor'
 import { Popover as _Popover } from 'radix-ui'
 import { ReactNode } from 'react'
+import { PORTRAIT_BREAKPOINT } from '../../constants'
+import { useBreakpoint } from '../../context/breakpoints'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { PeopleMenuAvatar } from './PeopleMenuAvatar'
@@ -25,6 +27,8 @@ export function PeopleMenu({ children }: PeopleMenuProps) {
 	const userName = useValue('user', () => editor.user.getName(), [editor])
 
 	const [isOpen, onOpenChange] = useMenuIsOpen('people menu')
+	const breakpoint = useBreakpoint()
+	const maxAvatars = breakpoint <= PORTRAIT_BREAKPOINT.MOBILE_XS ? 1 : 5
 
 	if (!userIds.length) return null
 
@@ -33,7 +37,7 @@ export function PeopleMenu({ children }: PeopleMenuProps) {
 			<_Popover.Trigger dir="ltr" asChild>
 				<button className="tlui-people-menu__avatars-button" title={msg('people-menu.title')}>
 					<div className="tlui-people-menu__avatars">
-						{userIds.slice(-5).map((userId) => (
+						{userIds.slice(-maxAvatars).map((userId) => (
 							<PeopleMenuAvatar key={userId} userId={userId} />
 						))}
 						{userIds.length > 0 && (
@@ -46,7 +50,7 @@ export function PeopleMenu({ children }: PeopleMenuProps) {
 								{userName?.[0] ?? ''}
 							</div>
 						)}
-						{userIds.length > 5 && <PeopleMenuMore count={userIds.length - 5} />}
+						{userIds.length > maxAvatars && <PeopleMenuMore count={userIds.length - maxAvatars} />}
 					</div>
 				</button>
 			</_Popover.Trigger>


### PR DESCRIPTION
This PR makes more things disappear from the top of the screen on dotcom on small mobile screens. This mostly affects logged out users. There are still more improvements we could make but this covers most cases.

Before


https://github.com/user-attachments/assets/0a8d73cc-22b6-4c3f-a2b2-d1c67e0dafe8



After


https://github.com/user-attachments/assets/569e3743-6131-43f9-bff3-81d249b8dbc1





### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
