### PR TITLE
feat(license): record sku in watermark ping

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -171,6 +171,14 @@ export class LicenseManager {
 		url.searchParams.set('license_type', trackType)
 		if ('license' in result) {
 			url.searchParams.set('license_id', result.license.id)
+			const sku = this.isFlagEnabled(result.license.flags, FLAGS.EVALUATION_LICENSE)
+				? 'evaluation'
+				: this.isFlagEnabled(result.license.flags, FLAGS.ANNUAL_LICENSE)
+					? 'annual'
+					: this.isFlagEnabled(result.license.flags, FLAGS.PERPETUAL_LICENSE)
+						? 'perpetual'
+						: 'unknown'
+			url.searchParams.set('sku', sku)
 		}
 		if (process.env.NODE_ENV) {
 			url.searchParams.set('environment', process.env.NODE_ENV)


### PR DESCRIPTION
Record the SKU in the watermark ping to better track license usage.

### Change type

- [x] `feature`

### Test plan

1. Verify that the watermark ping now includes the SKU information.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added SKU tracking to license watermark pings.