### PR TITLE
fix(ui): resolve togglegroup warning for shared state

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
@@ -132,7 +132,7 @@ export const StylePanelButtonPicker = memo(function StylePanelButtonPicker<T ext
 				<TldrawUiToolbarToggleGroup
 					data-testid={`style.${uiType}`}
 					type="single"
-					value={value.type === 'shared' ? value.value : undefined}
+					value={value.type === 'shared' ? value.value : null}
 					asChild
 				>
 					<Layout>


### PR DESCRIPTION
fix up warning in console, this happens when selecting multiple shapes, some that don't have a `size` property set.

<img width="2594" height="998" alt="Screenshot 2025-10-09 at 12 17 55" src="https://github.com/user-attachments/assets/1e36e023-3eef-4d48-93fc-f01be0536cb0" />

### Change type

- [x] `bugfix` 
- [ ] `improvement` 
- [ ] `feature` 
- [ ] `api` 
- [ ] `other` 

### Test plan

1. Select multiple shapes where some lack a size property.
2. Verify no console warning appears for the ToggleGroup.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a console warning in the style panel when selecting multiple shapes with mixed properties.