### PR TITLE
fix(editor): disable coalesced events on iOS to fix broken ink

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -162,6 +162,9 @@ export function useCanvasEvents() {
 			// For tools that benefit from a higher fidelity of events,
 			// we dispatch the coalesced events.
 			// N.B. Sometimes getCoalescedEvents isn't present on iOS, ugh.
+			// Specifically, in local mode (non-https) mode, iOS does not `useCoalescedEvents`
+			// so it appears like the ink is working locally, when really it's just that `useCoalescedEvents`
+			// is disabled. The intent here is to have `useCoalescedEvents` disabled for iOS.
 			const events =
 				!tlenv.isIos && currentTool.useCoalescedEvents && e.getCoalescedEvents
 					? e.getCoalescedEvents()

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -1,6 +1,7 @@
 import { useValue } from '@tldraw/state-react'
 import React, { useEffect, useMemo } from 'react'
 import { RIGHT_MOUSE_BUTTON } from '../constants'
+import { tlenv } from '../globals/environment'
 import { preventDefault, releasePointerCapture, setPointerCapture } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
 import { useEditor } from './useEditor'
@@ -162,7 +163,10 @@ export function useCanvasEvents() {
 			// we dispatch the coalesced events.
 			// N.B. Sometimes getCoalescedEvents isn't present on iOS, ugh.
 			const events =
-				currentTool.useCoalescedEvents && e.getCoalescedEvents ? e.getCoalescedEvents() : [e]
+				!tlenv.isIos && currentTool.useCoalescedEvents && e.getCoalescedEvents
+					? e.getCoalescedEvents()
+					: [e]
+
 			for (const singleEvent of events) {
 				editor.dispatch({
 					type: 'pointer',


### PR DESCRIPTION
This PR fixes ink/drawing issues on iOS by disabling coalesced pointer events on that platform. iOS sometimes doesn't have `getCoalescedEvents` available, causing broken drawing behavior. It adds a platform check to only use coalesced events when not on iOS.

### Change type

- [x] `bugfix` 

### Test plan

1. Test drawing/ink tool on iOS devices
2. Verify drawing works smoothly without breaks
3. Ensure drawing still works correctly on other platforms (desktop, Android)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where drawing with the ink tool could be broken on iOS devices.