### PR TITLE
fix(editor): dragging behavior when menu is open

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -40,6 +40,7 @@ export function MenuClickCapture() {
 					isDragging: false,
 					start: new Vec(e.clientX, e.clientY),
 				}
+				rDidAPointerDownAndDragWhileMenuWasOpen.current = false
 			}
 			editor.menus.clearOpenMenus()
 		},


### PR DESCRIPTION
Fixes dragging behavior when a menu overlay is open, ensures pointer move events are properly dispatched after drag starts, and prevents duplicate pointer down events during drag sequences.

### Change type

- [x] `bugfix` 

### Test plan

1. Open a menu in the editor
2. Click and drag over the canvas while the menu is open
3. Verify that dragging works correctly and the interaction is smooth
4. Verify that pointer move events are properly tracked during the drag

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where dragging interactions weren't properly handled when initiated over a menu overlay.