### PR TITLE
feat(analytics): add consent property to identify and ui events

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -45,6 +45,7 @@ export default function Analytics() {
 	const onConsentChanged = (hasConsent: boolean) => {
 		Cookies.set('allowTracking', hasConsent ? 'true' : 'false')
 		setHasConsent(hasConsent ? 'opted-in' : 'opted-out')
+		track('consent_changed', { consent: hasConsent })
 	}
 
 	useEffect(() => {
@@ -123,6 +124,7 @@ export default function Analytics() {
 				document.head.appendChild(reoScriptTag)
 			}
 		} else {
+			posthog.setPersonProperties({ analytics_consent: false })
 			posthog.reset()
 			posthog.set_config({ persistence: 'memory' })
 			posthog.opt_out_capturing()
@@ -179,7 +181,10 @@ export function identify(userId: string, properties?: { [key: string]: any }) {
 
 	if (storedHasConsent !== 'opted-in') return
 
-	posthog.identify(userId, properties)
+	posthog.identify(userId, {
+		properties,
+		analytics_consent: true,
+	})
 	ReactGA.set({ userId })
 	ReactGA.set(properties)
 	window.Reo?.identify?.({

--- a/apps/dotcom/client/src/tla/hooks/useAnalyticsConsent.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAnalyticsConsent.tsx
@@ -4,6 +4,7 @@ import { useValue } from 'tldraw'
 import {
 	configureAnalytics,
 	setStoredAnalyticsConsent,
+	trackEvent,
 	useAnalyticsConsentValue,
 } from '../../utils/analytics'
 import { useMaybeApp } from '../hooks/useAppState'
@@ -35,6 +36,7 @@ export function useAnalyticsConsent() {
 				// Immediately configure analytics for signed-out users
 				configureAnalytics(newConsent, undefined)
 			}
+			trackEvent('consent_changed', { consent: newConsent })
 		},
 		[isSignedIn, user, app]
 	)

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -178,9 +178,11 @@ function configurePosthog(options: AnalyticsOptions) {
 			posthog.identify(options.user.id, {
 				email: options.user.email,
 				name: options.user.name,
+				analytics_consent: true,
 			})
 		}
 	} else if (currentOptionsPosthog?.optedIn) {
+		posthog.setPersonProperties({ analytics_consent: false })
 		posthog.reset()
 	}
 


### PR DESCRIPTION
Add analytics_consent property to a person and add a UI event when changing the consent state.

### Change type

- [x] `other` 

### Test plan

1. Change analytics consent settings and verify the UI event is triggered.
2. Verify the analytics_consent property is correctly associated with the user identity.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added analytics consent tracking to user identification and UI events.