### PR TITLE
ci: skip claude review in merge-queue or main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Skip if in merge queue or merged to main
+    # Skip if in merge queue
     if: |
       !contains(github.event.pull_request.base.ref, 'gh-readonly-queue') &&
-      !contains(github.event.pull_request.head.ref, 'gh-readonly-queue') &&
-      github.event.pull_request.merged != true
+      !contains(github.event.pull_request.head.ref, 'gh-readonly-queue')
     
     # Optional: Filter by PR author
     # if: |


### PR DESCRIPTION
### Change type

- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a job-level condition to skip the Claude review workflow when base or head refs contain `gh-readonly-queue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2417c7c0458297e1ba505aa29a229d027b7929df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->