### PR TITLE
refactor(editor): remove preallocated array in parentsToChildren

### DIFF
--- a/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
+++ b/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
@@ -1,6 +1,6 @@
 import { Computed, computed, isUninitialized, RESET_VALUE } from '@tldraw/state'
 import { CollectionDiff, RecordsDiff } from '@tldraw/store'
-import { isShape, TLParentId, TLRecord, TLShape, TLShapeId, TLStore } from '@tldraw/tlschema'
+import { isShape, TLParentId, TLRecord, TLShapeId, TLStore } from '@tldraw/tlschema'
 import { compact, sortByIndex } from '@tldraw/utils'
 
 type ParentShapeIdsToChildShapeIds = Record<TLParentId, TLShapeId[]>
@@ -11,17 +11,11 @@ function fromScratch(
 ) {
 	const result: ParentShapeIdsToChildShapeIds = {}
 	const shapeIds = shapeIdsQuery.get()
-	const shapes = Array(shapeIds.size) as TLShape[]
-	shapeIds.forEach((id) => shapes.push(store.get(id)!))
-
-	// Sort the shapes by index
-	shapes.sort(sortByIndex)
+	const sortedShapes = Array.from(shapeIds, (id) => store.get(id)!).sort(sortByIndex)
 
 	// Populate the result object with an array for each parent.
-	shapes.forEach((shape) => {
-		if (!result[shape.parentId]) {
-			result[shape.parentId] = []
-		}
+	sortedShapes.forEach((shape) => {
+		result[shape.parentId] ??= []
 		result[shape.parentId].push(shape.id)
 	})
 


### PR DESCRIPTION
This is just an internal change to remove a tricky behavior spotted by Cursor [here](https://github.com/tldraw/tldraw/pull/6739#discussion_r2431748869).

empty slots are usually skipped by iteration methods so all of this works fine, see:
```ts
let arr = Array(3)

arr.push('foo')
arr.push('bar')

console.log('length', arr.length)

arr.sort((a, b) => {
    console.log('sort', { a, b })
    return a.length - b.length
})

arr.forEach((v) => {
    console.log('forEach', { v })
})
```

But the array is preallocated for no reason at all given the `.push` usage. In cases like that a direct index-based assignment should be used instead but it feels to me this preallocation doesn't matter anyway so I just decided to replace it with an idiomatic `Array.from` call.

### Change type

- [x] `improvement` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal refactor to improve array handling in derivations.