### PR TITLE
fix(templates): update starter kit document titles

### DIFF
--- a/templates/shader/index.html
+++ b/templates/shader/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>tldraw Vite template</title>
+		<title>tldraw shader template</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/templates/sync-cloudflare/index.html
+++ b/templates/sync-cloudflare/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>tldraw Vite template</title>
+		<title>tldraw multiplayer template</title>
 	</head>
 	<body>
 		<div id="root"></div>


### PR DESCRIPTION
This PR fixes the document titles for the shader and multiplayer starter templates.

<img width="688" height="217" alt="image"
src="https://github.com/user-attachments/assets/1fad1021-5ea0-4d9f-9aa3-56a5ed7fb27a" />

### Change type

- [x] `other`

### Test plan

1. Open the shader template and verify the browser tab title is "tldraw shader template"
2. Open the sync-cloudflare template and verify the browser tab title is "tldraw multiplayer template"

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated HTML document titles for shader and multiplayer starter templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update HTML document titles for shader and multiplayer starter templates.
> 
> - **Templates**:
>   - Update page titles in `templates/shader/index.html` ("tldraw shader template") and `templates/sync-cloudflare/index.html` ("tldraw multiplayer template").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d32c355d58297fa5393610a03316b01354d97839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->