### PR TITLE
refactor(ui): style panel pickers for inline variants

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2725,7 +2725,10 @@ export function StylePanelArrowheadPicker(): JSX_2.Element | null;
 export function StylePanelArrowKindPicker(): JSX_2.Element | null;
 
 // @public (undocumented)
-export const StylePanelButtonPicker: <T extends string>(props: StylePanelButtonPickerProps<T>) => ReactElement;
+export const StylePanelButtonPicker: <T extends string>(props: StylePanelButtonPickerProps<T>) => React.JSX.Element;
+
+// @public (undocumented)
+export const StylePanelButtonPickerInline: <T extends string>(props: StylePanelButtonPickerProps<T>) => React.JSX.Element;
 
 // @public (undocumented)
 export interface StylePanelButtonPickerProps<T extends string> {
@@ -2778,6 +2781,9 @@ export function StylePanelDashPicker(): JSX_2.Element | null;
 export const StylePanelDoubleDropdownPicker: <T extends string>(props: StylePanelDoubleDropdownPickerProps<T>) => React_2.JSX.Element;
 
 // @public (undocumented)
+export const StylePanelDoubleDropdownPickerInline: <T extends string>(props: StylePanelDoubleDropdownPickerProps<T>) => React_2.JSX.Element;
+
+// @public (undocumented)
 export interface StylePanelDoubleDropdownPickerProps<T extends string> {
     // (undocumented)
     itemsA: StyleValuesForUi<T>;
@@ -2807,6 +2813,9 @@ export interface StylePanelDoubleDropdownPickerProps<T extends string> {
 
 // @public (undocumented)
 export const StylePanelDropdownPicker: <T extends string>(props: StylePanelDropdownPickerProps<T>) => React_2.JSX.Element;
+
+// @public (undocumented)
+export const StylePanelDropdownPickerInline: <T extends string>(props: StylePanelDropdownPickerProps<T>) => React_2.JSX.Element;
 
 // @public (undocumented)
 export interface StylePanelDropdownPickerProps<T extends string> {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -464,6 +464,7 @@ export {
 } from './lib/ui/components/StylePanel/DefaultStylePanelContent'
 export {
 	StylePanelButtonPicker,
+	StylePanelButtonPickerInline,
 	type StylePanelButtonPickerProps,
 } from './lib/ui/components/StylePanel/StylePanelButtonPicker'
 export {
@@ -474,10 +475,12 @@ export {
 } from './lib/ui/components/StylePanel/StylePanelContext'
 export {
 	StylePanelDoubleDropdownPicker,
+	StylePanelDoubleDropdownPickerInline,
 	type StylePanelDoubleDropdownPickerProps,
 } from './lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker'
 export {
 	StylePanelDropdownPicker,
+	StylePanelDropdownPickerInline,
 	type StylePanelDropdownPickerProps,
 } from './lib/ui/components/StylePanel/StylePanelDropdownPicker'
 export {

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -25,10 +25,13 @@ import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import { TldrawUiSlider } from '../primitives/TldrawUiSlider'
 import { TldrawUiToolbar, TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
-import { StylePanelButtonPicker } from './StylePanelButtonPicker'
+import { StylePanelButtonPicker, StylePanelButtonPickerInline } from './StylePanelButtonPicker'
 import { useStylePanelContext } from './StylePanelContext'
 import { StylePanelDoubleDropdownPicker } from './StylePanelDoubleDropdownPicker'
-import { StylePanelDropdownPicker } from './StylePanelDropdownPicker'
+import {
+	StylePanelDropdownPicker,
+	StylePanelDropdownPickerInline,
+} from './StylePanelDropdownPicker'
 import { StylePanelSubheading } from './StylePanelSubheading'
 
 /** @public @react */
@@ -225,50 +228,23 @@ export function StylePanelFontPicker() {
 
 /** @public @react */
 export function StylePanelTextAlignPicker() {
-	const { styles } = useStylePanelContext()
+	const { styles, enhancedA11yMode } = useStylePanelContext()
 	const msg = useTranslation()
 	const textAlign = styles.get(DefaultTextAlignStyle)
 	if (textAlign === undefined) return null
+	const title = msg('style-panel.align')
 
 	return (
-		<TldrawUiToolbar orientation="horizontal" label={msg('style-panel.align')}>
-			<StylePanelButtonPicker
-				title={msg('style-panel.align')}
-				uiType="align"
-				style={DefaultTextAlignStyle}
-				items={STYLES.textAlign}
-				value={textAlign}
-			/>
-			<TldrawUiToolbarButton
-				type="icon"
-				title={msg('style-panel.vertical-align')}
-				data-testid="vertical-align"
-				disabled
-			>
-				<TldrawUiButtonIcon icon="vertical-align-middle" />
-			</TldrawUiToolbarButton>
-		</TldrawUiToolbar>
-	)
-}
-
-/** @public @react */
-export function StylePanelLabelAlignPicker() {
-	const { styles } = useStylePanelContext()
-	const msg = useTranslation()
-	const labelAlign = styles.get(DefaultHorizontalAlignStyle)
-	const verticalLabelAlign = styles.get(DefaultVerticalAlignStyle)
-	if (labelAlign === undefined) return null
-
-	return (
-		<TldrawUiToolbar orientation="horizontal" label={msg('style-panel.label-align')}>
-			<StylePanelButtonPicker
-				title={msg('style-panel.label-align')}
-				uiType="align"
-				style={DefaultHorizontalAlignStyle}
-				items={STYLES.horizontalAlign}
-				value={labelAlign}
-			/>
-			{verticalLabelAlign === undefined ? (
+		<>
+			{enhancedA11yMode && <StylePanelSubheading>{title}</StylePanelSubheading>}
+			<TldrawUiToolbar orientation="horizontal" label={title}>
+				<StylePanelButtonPickerInline
+					title={title}
+					uiType="align"
+					style={DefaultTextAlignStyle}
+					items={STYLES.textAlign}
+					value={textAlign}
+				/>
 				<TldrawUiToolbarButton
 					type="icon"
 					title={msg('style-panel.vertical-align')}
@@ -277,18 +253,53 @@ export function StylePanelLabelAlignPicker() {
 				>
 					<TldrawUiButtonIcon icon="vertical-align-middle" />
 				</TldrawUiToolbarButton>
-			) : (
-				<StylePanelDropdownPicker
-					type="icon"
-					id="geo-vertical-alignment"
-					uiType="verticalAlign"
-					stylePanelType="vertical-align"
-					style={DefaultVerticalAlignStyle}
-					items={STYLES.verticalAlign}
-					value={verticalLabelAlign}
+			</TldrawUiToolbar>
+		</>
+	)
+}
+
+/** @public @react */
+export function StylePanelLabelAlignPicker() {
+	const { styles, enhancedA11yMode } = useStylePanelContext()
+	const msg = useTranslation()
+	const labelAlign = styles.get(DefaultHorizontalAlignStyle)
+	const verticalLabelAlign = styles.get(DefaultVerticalAlignStyle)
+	if (labelAlign === undefined) return null
+	const title = msg('style-panel.label-align')
+
+	return (
+		<>
+			{enhancedA11yMode && <StylePanelSubheading>{title}</StylePanelSubheading>}
+			<TldrawUiToolbar orientation="horizontal" label={title}>
+				<StylePanelButtonPickerInline
+					title={title}
+					uiType="align"
+					style={DefaultHorizontalAlignStyle}
+					items={STYLES.horizontalAlign}
+					value={labelAlign}
 				/>
-			)}
-		</TldrawUiToolbar>
+				{verticalLabelAlign === undefined ? (
+					<TldrawUiToolbarButton
+						type="icon"
+						title={msg('style-panel.vertical-align')}
+						data-testid="vertical-align"
+						disabled
+					>
+						<TldrawUiButtonIcon icon="vertical-align-middle" />
+					</TldrawUiToolbarButton>
+				) : (
+					<StylePanelDropdownPickerInline
+						type="icon"
+						id="geo-vertical-alignment"
+						uiType="verticalAlign"
+						stylePanelType="vertical-align"
+						style={DefaultVerticalAlignStyle}
+						items={STYLES.verticalAlign}
+						value={verticalLabelAlign}
+					/>
+				)}
+			</TldrawUiToolbar>
+		</>
 	)
 }
 

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
@@ -6,7 +6,7 @@ import {
 	TLDefaultColorStyle,
 	useEditor,
 } from '@tldraw/editor'
-import { memo, ReactElement, useMemo, useRef } from 'react'
+import { memo, useMemo, useRef } from 'react'
 import { useDefaultColorTheme } from '../../../shapes/shared/useDefaultColorTheme'
 import { StyleValuesForUi } from '../../../styles'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
@@ -34,8 +34,19 @@ export interface StylePanelButtonPickerProps<T extends string> {
 	onHistoryMark?(id: string): void
 }
 
-/** @public */
-export const StylePanelButtonPicker = memo(function StylePanelButtonPicker<T extends string>(
+function StylePanelButtonPickerInner<T extends string>(props: StylePanelButtonPickerProps<T>) {
+	const { enhancedA11yMode } = useStylePanelContext()
+	return (
+		<>
+			{enhancedA11yMode && <StylePanelSubheading>{props.title}</StylePanelSubheading>}
+			<TldrawUiToolbar label={props.title}>
+				<StylePanelButtonPickerInline {...props} />
+			</TldrawUiToolbar>
+		</>
+	)
+}
+
+function StylePanelButtonPickerInlineInner<T extends string>(
 	props: StylePanelButtonPickerProps<T>
 ) {
 	const ctx = useStylePanelContext()
@@ -126,54 +137,60 @@ export const StylePanelButtonPicker = memo(function StylePanelButtonPicker<T ext
 	const Layout = items.length > 4 ? TldrawUiGrid : TldrawUiRow
 
 	return (
-		<>
-			{ctx.enhancedA11yMode && <StylePanelSubheading>{title}</StylePanelSubheading>}
-			<TldrawUiToolbar label={title}>
-				<TldrawUiToolbarToggleGroup
-					data-testid={`style.${uiType}`}
-					type="single"
-					value={value.type === 'shared' ? value.value : undefined}
-					asChild
-				>
-					<Layout>
-						{items.map((item) => {
-							const isActive = value.type === 'shared' && value.value === item.value
-							const label =
-								title + ' — ' + msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
-							return (
-								<TldrawUiToolbarToggleItem
-									type="icon"
-									key={item.value}
-									data-id={item.value}
-									data-testid={`style.${uiType}.${item.value}`}
-									aria-label={label + (isActive ? ` (${msg('style-panel.selected')})` : '')}
-									tooltip={
-										<>
-											<div>{label}</div>
-											{isActive ? <div>({msg('style-panel.selected')})</div> : null}
-										</>
-									}
-									value={item.value}
-									data-state={value.type === 'shared' && value.value === item.value ? 'on' : 'off'}
-									data-isactive={isActive}
-									title={label}
-									style={
-										style === (DefaultColorStyle as StyleProp<unknown>)
-											? { color: getColorValue(theme, item.value as TLDefaultColorStyle, 'solid') }
-											: undefined
-									}
-									onPointerEnter={handleButtonPointerEnter}
-									onPointerDown={handleButtonPointerDown}
-									onPointerUp={handleButtonPointerUp}
-									onClick={handleButtonClick}
-								>
-									<TldrawUiButtonIcon icon={item.icon} />
-								</TldrawUiToolbarToggleItem>
-							)
-						})}
-					</Layout>
-				</TldrawUiToolbarToggleGroup>
-			</TldrawUiToolbar>
-		</>
+		<TldrawUiToolbarToggleGroup
+			data-testid={`style.${uiType}`}
+			type="single"
+			value={value.type === 'shared' ? value.value : null}
+			asChild
+		>
+			<Layout>
+				{items.map((item) => {
+					const isActive = value.type === 'shared' && value.value === item.value
+					const label = title + ' — ' + msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
+					return (
+						<TldrawUiToolbarToggleItem
+							type="icon"
+							key={item.value}
+							data-id={item.value}
+							data-testid={`style.${uiType}.${item.value}`}
+							aria-label={label + (isActive ? ` (${msg('style-panel.selected')})` : '')}
+							tooltip={
+								<>
+									<div>{label}</div>
+									{isActive ? <div>({msg('style-panel.selected')})</div> : null}
+								</>
+							}
+							value={item.value}
+							data-state={value.type === 'shared' && value.value === item.value ? 'on' : 'off'}
+							data-isactive={isActive}
+							title={label}
+							style={
+								style === (DefaultColorStyle as StyleProp<unknown>)
+									? { color: getColorValue(theme, item.value as TLDefaultColorStyle, 'solid') }
+									: undefined
+							}
+							onPointerEnter={handleButtonPointerEnter}
+							onPointerDown={handleButtonPointerDown}
+							onPointerUp={handleButtonPointerUp}
+							onClick={handleButtonClick}
+						>
+							<TldrawUiButtonIcon icon={item.icon} />
+						</TldrawUiToolbarToggleItem>
+					)
+				})}
+			</Layout>
+		</TldrawUiToolbarToggleGroup>
 	)
-}) as <T extends string>(props: StylePanelButtonPickerProps<T>) => ReactElement
+}
+
+/** @public @react */
+export const StylePanelButtonPicker = memo(StylePanelButtonPickerInner) as <T extends string>(
+	props: StylePanelButtonPickerProps<T>
+) => React.JSX.Element
+
+/** @public @react*/
+export const StylePanelButtonPickerInline = memo(StylePanelButtonPickerInlineInner) as <
+	T extends string,
+>(
+	props: StylePanelButtonPickerProps<T>
+) => React.JSX.Element

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
@@ -29,12 +29,27 @@ export interface StylePanelDoubleDropdownPickerProps<T extends string> {
 	onValueChange?(style: StyleProp<T>, value: T): void
 }
 
-function DoubleDropdownPickerInner<T extends string>(
+function StylePanelDoubleDropdownPickerInner<T extends string>(
+	props: StylePanelDoubleDropdownPickerProps<T>
+) {
+	const msg = useTranslation()
+	return (
+		<div className="tlui-style-panel__double-select-picker">
+			<div title={msg(props.label)} className="tlui-style-panel__double-select-picker-label">
+				{msg(props.label)}
+			</div>
+			<TldrawUiToolbar orientation="horizontal" label={msg(props.label)}>
+				<StylePanelDoubleDropdownPickerInline {...props} />
+			</TldrawUiToolbar>
+		</div>
+	)
+}
+
+function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 	props: StylePanelDoubleDropdownPickerProps<T>
 ) {
 	const ctx = useStylePanelContext()
 	const {
-		label,
 		uiTypeA,
 		uiTypeB,
 		labelA,
@@ -70,100 +85,100 @@ function DoubleDropdownPickerInner<T extends string>(
 	const idA = `style panel ${uiTypeA} A`
 	const idB = `style panel ${uiTypeB} B`
 	return (
-		<div className="tlui-style-panel__double-select-picker">
-			<div title={msg(label)} className="tlui-style-panel__double-select-picker-label">
-				{msg(label)}
-			</div>
-			<TldrawUiToolbar orientation="horizontal" label={msg(label)}>
-				<TldrawUiPopover id={idA} open={isOpenA} onOpenChange={setIsOpenA}>
-					<TldrawUiPopoverTrigger>
-						<TldrawUiToolbarButton
-							type="icon"
-							data-testid={`style.${uiTypeA}`}
-							title={
-								msg(labelA) +
-								' — ' +
-								(valueA === null || valueA.type === 'mixed'
-									? msg('style-panel.mixed')
-									: msg(`${uiTypeA}-style.${valueA.value}` as TLUiTranslationKey))
-							}
-						>
-							<TldrawUiButtonIcon icon={iconA} small invertIcon />
-						</TldrawUiToolbarButton>
-					</TldrawUiPopoverTrigger>
-					<TldrawUiPopoverContent side="left" align="center" sideOffset={80} alignOffset={0}>
-						<TldrawUiToolbar orientation="grid" label={msg(labelA)}>
-							<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
-								{itemsA.map((item) => {
-									return (
-										<TldrawUiToolbarButton
-											data-testid={`style.${uiTypeA}.${item.value}`}
-											type="icon"
-											key={item.value}
-											onClick={() => {
-												onValueChange(styleA, item.value)
-												tlmenus.deleteOpenMenu(idA, editor.contextId)
-												setIsOpenA(false)
-											}}
-											title={`${msg(labelA)} — ${msg(`${uiTypeA}-style.${item.value}`)}`}
-										>
-											<TldrawUiButtonIcon icon={item.icon} invertIcon />
-										</TldrawUiToolbarButton>
-									)
-								})}
-							</TldrawUiMenuContextProvider>
-						</TldrawUiToolbar>
-					</TldrawUiPopoverContent>
-				</TldrawUiPopover>
-				<TldrawUiPopover id={idB} open={isOpenB} onOpenChange={setIsOpenB}>
-					<TldrawUiPopoverTrigger>
-						<TldrawUiToolbarButton
-							type="icon"
-							data-testid={`style.${uiTypeB}`}
-							title={
-								msg(labelB) +
-								' — ' +
-								(valueB === null || valueB.type === 'mixed'
-									? msg('style-panel.mixed')
-									: msg(`${uiTypeB}-style.${valueB.value}` as TLUiTranslationKey))
-							}
-						>
-							<TldrawUiButtonIcon icon={iconB} small />
-						</TldrawUiToolbarButton>
-					</TldrawUiPopoverTrigger>
-					<TldrawUiPopoverContent side="left" align="center" sideOffset={116} alignOffset={0}>
-						<TldrawUiToolbar orientation="grid" label={msg(labelB)}>
-							<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
-								{itemsB.map((item) => {
-									return (
-										<TldrawUiToolbarButton
-											key={item.value}
-											type="icon"
-											title={`${msg(labelB)} — ${msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)}`}
-											data-testid={`style.${uiTypeB}.${item.value}`}
-											onClick={() => {
-												onValueChange(styleB, item.value)
-												tlmenus.deleteOpenMenu(idB, editor.contextId)
-												setIsOpenB(false)
-											}}
-										>
-											<TldrawUiButtonIcon icon={item.icon} />
-										</TldrawUiToolbarButton>
-									)
-								})}
-							</TldrawUiMenuContextProvider>
-						</TldrawUiToolbar>
-					</TldrawUiPopoverContent>
-				</TldrawUiPopover>
-			</TldrawUiToolbar>
-		</div>
+		<>
+			<TldrawUiPopover id={idA} open={isOpenA} onOpenChange={setIsOpenA}>
+				<TldrawUiPopoverTrigger>
+					<TldrawUiToolbarButton
+						type="icon"
+						data-testid={`style.${uiTypeA}`}
+						title={
+							msg(labelA) +
+							' — ' +
+							(valueA === null || valueA.type === 'mixed'
+								? msg('style-panel.mixed')
+								: msg(`${uiTypeA}-style.${valueA.value}` as TLUiTranslationKey))
+						}
+					>
+						<TldrawUiButtonIcon icon={iconA} small invertIcon />
+					</TldrawUiToolbarButton>
+				</TldrawUiPopoverTrigger>
+				<TldrawUiPopoverContent side="left" align="center" sideOffset={80} alignOffset={0}>
+					<TldrawUiToolbar orientation="grid" label={msg(labelA)}>
+						<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
+							{itemsA.map((item) => {
+								return (
+									<TldrawUiToolbarButton
+										data-testid={`style.${uiTypeA}.${item.value}`}
+										type="icon"
+										key={item.value}
+										onClick={() => {
+											onValueChange(styleA, item.value)
+											tlmenus.deleteOpenMenu(idA, editor.contextId)
+											setIsOpenA(false)
+										}}
+										title={`${msg(labelA)} — ${msg(`${uiTypeA}-style.${item.value}`)}`}
+									>
+										<TldrawUiButtonIcon icon={item.icon} invertIcon />
+									</TldrawUiToolbarButton>
+								)
+							})}
+						</TldrawUiMenuContextProvider>
+					</TldrawUiToolbar>
+				</TldrawUiPopoverContent>
+			</TldrawUiPopover>
+			<TldrawUiPopover id={idB} open={isOpenB} onOpenChange={setIsOpenB}>
+				<TldrawUiPopoverTrigger>
+					<TldrawUiToolbarButton
+						type="icon"
+						data-testid={`style.${uiTypeB}`}
+						title={
+							msg(labelB) +
+							' — ' +
+							(valueB === null || valueB.type === 'mixed'
+								? msg('style-panel.mixed')
+								: msg(`${uiTypeB}-style.${valueB.value}` as TLUiTranslationKey))
+						}
+					>
+						<TldrawUiButtonIcon icon={iconB} small />
+					</TldrawUiToolbarButton>
+				</TldrawUiPopoverTrigger>
+				<TldrawUiPopoverContent side="left" align="center" sideOffset={116} alignOffset={0}>
+					<TldrawUiToolbar orientation="grid" label={msg(labelB)}>
+						<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
+							{itemsB.map((item) => {
+								return (
+									<TldrawUiToolbarButton
+										key={item.value}
+										type="icon"
+										title={`${msg(labelB)} — ${msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)}`}
+										data-testid={`style.${uiTypeB}.${item.value}`}
+										onClick={() => {
+											onValueChange(styleB, item.value)
+											tlmenus.deleteOpenMenu(idB, editor.contextId)
+											setIsOpenB(false)
+										}}
+									>
+										<TldrawUiButtonIcon icon={item.icon} />
+									</TldrawUiToolbarButton>
+								)
+							})}
+						</TldrawUiMenuContextProvider>
+					</TldrawUiToolbar>
+				</TldrawUiPopoverContent>
+			</TldrawUiPopover>
+		</>
 	)
 }
 
 // need to memo like this to get generics
 /** @public @react */
-export const StylePanelDoubleDropdownPicker = React.memo(DoubleDropdownPickerInner) as <
+export const StylePanelDoubleDropdownPicker = React.memo(StylePanelDoubleDropdownPickerInner) as <
 	T extends string,
 >(
 	props: StylePanelDoubleDropdownPickerProps<T>
 ) => React.JSX.Element
+
+/** @public @react */
+export const StylePanelDoubleDropdownPickerInline = React.memo(
+	StylePanelDoubleDropdownPickerInlineInner
+) as <T extends string>(props: StylePanelDoubleDropdownPickerProps<T>) => React.JSX.Element

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -28,7 +28,21 @@ export interface StylePanelDropdownPickerProps<T extends string> {
 	onValueChange?(style: StyleProp<T>, value: T): void
 }
 
-function DropdownPickerInner<T extends string>(props: StylePanelDropdownPickerProps<T>) {
+function StylePanelDropdownPickerInner<T extends string>(props: StylePanelDropdownPickerProps<T>) {
+	const msg = useTranslation()
+	const toolbarLabel = props.label
+		? msg(props.label)
+		: msg(`style-panel.${props.stylePanelType}` as TLUiTranslationKey)
+	return (
+		<TldrawUiToolbar label={toolbarLabel}>
+			<StylePanelDropdownPickerInline {...props} />
+		</TldrawUiToolbar>
+	)
+}
+
+function StylePanelDropdownPickerInlineInner<T extends string>(
+	props: StylePanelDropdownPickerProps<T>
+) {
 	const ctx = useStylePanelContext()
 	const {
 		id,
@@ -60,60 +74,67 @@ function DropdownPickerInner<T extends string>(props: StylePanelDropdownPickerPr
 
 	const popoverId = `style panel ${id}`
 	return (
-		<TldrawUiToolbar label={stylePanelName}>
-			<TldrawUiPopover
-				id={popoverId}
-				open={isOpen}
-				onOpenChange={setIsOpen}
-				className="tlui-style-panel__dropdown-picker"
-			>
-				<TldrawUiPopoverTrigger>
-					<TldrawUiToolbarButton
-						type={type}
-						data-testid={`style.${uiType}`}
-						data-direction="left"
-						title={titleStr}
-					>
-						{labelStr && <TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>}
-						<TldrawUiButtonIcon icon={(icon as TLUiIconType) ?? 'mixed'} />
-					</TldrawUiToolbarButton>
-				</TldrawUiPopoverTrigger>
-				<TldrawUiPopoverContent side="left" align="center">
-					<TldrawUiToolbar orientation={items.length > 4 ? 'grid' : 'horizontal'} label={labelStr}>
-						<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
-							{items.map((item) => {
-								return (
-									<TldrawUiToolbarButton
-										key={item.value}
-										type="icon"
-										data-testid={`style.${uiType}.${item.value}`}
-										title={
-											stylePanelName +
-											' — ' +
-											msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
-										}
-										isActive={icon === item.icon}
-										onClick={() => {
-											ctx.onHistoryMark('select style dropdown item')
-											onValueChange(style, item.value)
-											tlmenus.deleteOpenMenu(popoverId, editor.contextId)
-											setIsOpen(false)
-										}}
-									>
-										<TldrawUiButtonIcon icon={item.icon} />
-									</TldrawUiToolbarButton>
-								)
-							})}
-						</TldrawUiMenuContextProvider>
-					</TldrawUiToolbar>
-				</TldrawUiPopoverContent>
-			</TldrawUiPopover>
-		</TldrawUiToolbar>
+		<TldrawUiPopover
+			id={popoverId}
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			className="tlui-style-panel__dropdown-picker"
+		>
+			<TldrawUiPopoverTrigger>
+				<TldrawUiToolbarButton
+					type={type}
+					data-testid={`style.${uiType}`}
+					data-direction="left"
+					title={titleStr}
+				>
+					{labelStr && <TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>}
+					<TldrawUiButtonIcon icon={(icon as TLUiIconType) ?? 'mixed'} />
+				</TldrawUiToolbarButton>
+			</TldrawUiPopoverTrigger>
+			<TldrawUiPopoverContent side="left" align="center">
+				<TldrawUiToolbar orientation={items.length > 4 ? 'grid' : 'horizontal'} label={labelStr}>
+					<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
+						{items.map((item) => {
+							return (
+								<TldrawUiToolbarButton
+									key={item.value}
+									type="icon"
+									data-testid={`style.${uiType}.${item.value}`}
+									title={
+										stylePanelName +
+										' — ' +
+										msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
+									}
+									isActive={icon === item.icon}
+									onClick={() => {
+										ctx.onHistoryMark('select style dropdown item')
+										onValueChange(style, item.value)
+										tlmenus.deleteOpenMenu(popoverId, editor.contextId)
+										setIsOpen(false)
+									}}
+								>
+									<TldrawUiButtonIcon icon={item.icon} />
+								</TldrawUiToolbarButton>
+							)
+						})}
+					</TldrawUiMenuContextProvider>
+				</TldrawUiToolbar>
+			</TldrawUiPopoverContent>
+		</TldrawUiPopover>
 	)
 }
 
 // need to export like this to get generics
 /** @public @react */
-export const StylePanelDropdownPicker = React.memo(DropdownPickerInner) as <T extends string>(
+export const StylePanelDropdownPicker = React.memo(StylePanelDropdownPickerInner) as <
+	T extends string,
+>(
+	props: StylePanelDropdownPickerProps<T>
+) => React.JSX.Element
+
+/** @public @react */
+export const StylePanelDropdownPickerInline = React.memo(StylePanelDropdownPickerInlineInner) as <
+	T extends string,
+>(
 	props: StylePanelDropdownPickerProps<T>
 ) => React.JSX.Element


### PR DESCRIPTION
This PR refactors the style panel pickers to support inline variants, improving accessibility and component reuse.

### Change type

- [x] `improvement` 

### Test plan

1. Open the style panel in the editor.
2. Verify that pickers render correctly.
3. Enable enhanced accessibility mode and verify subheadings appear.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Refactored style panel pickers to support inline variants and improved accessibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces inline variants of style panel pickers and updates DefaultStylePanelContent to use them with enhanced a11y, plus exports and minor type adjustments.
> 
> - **UI • Style Panel**:
>   - **Inline variants**: Add `StylePanelButtonPickerInline`, `StylePanelDropdownPickerInline`, and `StylePanelDoubleDropdownPickerInline`.
>   - **Refactor**: Split pickers into wrapper (with toolbar/subheading) and core inline implementations; `DefaultStylePanelContent` now uses inline variants and shows subheadings when `enhancedA11yMode` is enabled.
> - **Exports/APIs**:
>   - Export new inline components from `src/index.ts`; API report updated accordingly.
>   - Adjust `StylePanelButtonPicker` return type to `React.JSX.Element`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f686e6c2e98b54e56aa46ce4a66f35ffae26db2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->