### PR TITLE
fix(templates): enable decorators for shader starter

### DIFF
--- a/templates/shader/tsconfig.json
+++ b/templates/shader/tsconfig.json
@@ -14,7 +14,8 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
+		"noFallthroughCasesInSwitch": true,
+		"experimentalDecorators": true
 	},
 	"include": ["src", "vite.config.ts", "vite-env.d.ts"],
 	"references": [{ "path": "../../packages/tldraw" }]

--- a/templates/shader/vite.config.ts
+++ b/templates/shader/vite.config.ts
@@ -3,11 +3,5 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [
-		react(
-			/* EXCLUDE_FROM_TEMPLATE_EXPORT_START */
-			{ tsDecorators: true }
-			/* EXCLUDE_FROM_TEMPLATE_EXPORT_END */
-		),
-	],
+	plugins: [react({ tsDecorators: true })],
 })


### PR DESCRIPTION
This PR fixes the shader starter not working when you do a fresh install from `npm create tldraw@latest`. The issue was caused by the starter using decorators but we didn't have the right config for this in the exported starter itself.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed fresh installs of the shader starter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable TypeScript decorators for the shader template and streamline Vite config to ensure decorator support on fresh installs.
> 
> - **Shader template**:
>   - **TypeScript config**: Add `"experimentalDecorators": true` in `templates/shader/tsconfig.json` to enable decorators.
>   - **Vite config**: Simplify `templates/shader/vite.config.ts` plugin setup to `react({ tsDecorators: true })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 394f781e924088af77a1e81fa32fbeed32ce8e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->