### PR TITLE
ci: update github api calls to handle paginated comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("🤖 Claude Code Review")) | .url | sub(".*issuecomment-"; "")' | xargs -I {} gh api --method DELETE "repos/${{ github.repository }}/issues/comments/{}" 2>/dev/null || true
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          
+          # Delete issue comments (conversation comments)
+          gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("🤖 Claude Code Review")) | .id' | \
+            xargs -I {} gh api --method DELETE "repos/$REPO/issues/comments/{}" 2>/dev/null || true
+          
+          # Delete review comments (inline code comments)
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("🤖 Claude Code Review")) | .id' | \
+            xargs -I {} gh api --method DELETE "repos/$REPO/pulls/comments/{}" 2>/dev/null || true
+          
+          # Delete reviews (review summaries)
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" --jq '.[] | select(.body | contains("🤖 Claude Code Review")) | .id' | \
+            xargs -I {} gh api --method DELETE "repos/$REPO/pulls/$PR_NUMBER/reviews/{}" 2>/dev/null || true
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
Enhances the GitHub Actions cleanup to delete Claude review issue comments, inline review comments, and review summaries using paginated GH API calls.

### Change type

- [x] `other` 

### Test plan

1. Run the CI workflow and verify that all Claude-related comments are correctly deleted even when multiple pages of results exist.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved CI cleanup reliability for Claude code reviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the GitHub Actions cleanup to delete Claude review issue comments, inline review comments, and review summaries using paginated GH API calls.
> 
> - **CI Workflow (`.github/workflows/claude-code-review.yml`)**:
>   - **Cleanup step**: Replaces single delete command with paginated, scoped deletions using `gh api`.
>     - Deletes `issues` comments containing "🤖 Claude Code Review".
>     - Deletes `pulls` review comments (inline code comments).
>     - Deletes `pulls` review summaries.
>     - Introduces `PR_NUMBER` and `REPO` env vars for API calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ccfc25ed2b7446cd517158ae5857d3f111a79d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->