### PR TITLE
docs: add podcast redirect

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -155,9 +155,10 @@ const nextConfig = {
 			},
 			{
 				source: '/codewithjason',
-				destination: '/?utm_source=codewithjason&utm_medium=podcast&utm_campaign=steve_codewithjason_2025',
+				destination:
+					'/?utm_source=codewithjason&utm_medium=podcast&utm_campaign=steve_codewithjason_2025',
 				permanent: true,
-			}
+			},
 		]
 	},
 	async rewrites() {


### PR DESCRIPTION
Add a permanent redirect from `/codewithjason` to `/` with UTM campaign parameters.

### Change type

- [x] `other`

### Test plan

1. Verify that navigating to `/codewithjason` redirects to the homepage with the correct UTM parameters.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a redirect for the podcast campaign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a permanent redirect from `/codewithjason` to `/` with UTM campaign parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 928d799bef0c9bc58aaf9014ecd95baf66176cf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->