### PR TITLE
fix(dotcom): use locks to prevent legacy mutations during migration

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -341,7 +341,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			// Acquire shared advisory lock to coordinate with migration
 			// This will wait if migrate_user_to_groups is running (which uses exclusive lock)
 			// but won't block other mutations (which also use shared locks)
-			await client.query('SELECT pg_advisory_lock_shared(hashtext($1))', [this.userId])
+			// Lock will be automatically released when transaction ends
+			await client.query('SELECT pg_advisory_xact_lock_shared(hashtext($1))', [this.userId])
 
 			const controller = new AbortController()
 			const mutate = this.makeCrud(client, controller.signal, { newFiles })
@@ -379,9 +380,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				`insert into user_mutation_number ("userId", "mutationNumber") values ($1, 1) on conflict ("userId") do update set "mutationNumber" = user_mutation_number."mutationNumber" + 1 returning "mutationNumber"`,
 				[this.userId]
 			)
-
-			// Release the shared advisory lock
-			await client.query('SELECT pg_advisory_unlock_shared(hashtext($1))', [this.userId])
 
 			const currentMutationNumber = this.cache.mutations.at(-1)?.mutationNumber ?? 0
 			const mutationNumber = res.rows[0].mutationNumber


### PR DESCRIPTION
prevent race conditions where legacy mutations may commit after the data migration has run.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Prevent race conditions during data migration by using advisory locks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add per-user advisory locks (shared in mutations, exclusive in migration) to prevent race conditions during groups migration.
> 
> - **Backend**:
>   - `apps/dotcom/sync-worker/src/TLUserDurableObject.ts`:
>     - Before running mutators, acquire a transaction-scoped shared advisory lock using `pg_advisory_xact_lock_shared(hashtext(userId))` to coordinate with migration.
>   - `apps/dotcom/zero-cache/migrations/023_groups.sql`:
>     - In `migrate_user_to_groups`, acquire a per-user transaction-scoped exclusive advisory lock via `pg_advisory_xact_lock(hashtext(target_user_id))` before migrating; add minimal notices for lock acquisition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b56b9764f05a85fd896f2300f78652082e3632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->