### PR TITLE
chore(dotcom): allow crawling favicon and static assets

### DIFF
--- a/apps/dotcom/client/public/robots.txt
+++ b/apps/dotcom/client/public/robots.txt
@@ -1,5 +1,12 @@
 User-agent: *
 Disallow: /
 Allow: /$
+Allow: /favicon*
+Allow: /sitemap.xml
+Allow: /*.css
+Allow: /*.js
+Allow: /*.png
+Allow: /assets/*
+Allow: /manifest.webmanifest
 
 Sitemap: https://www.tldraw.com/sitemap.xml


### PR DESCRIPTION
related to Daniel's note that this was busted on google search

### Change type

- [x] `other`

### Test plan

1. Verify robots.txt content at apps/dotcom/client/public/robots.txt

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated robots.txt to allow search engines to crawl favicons and static assets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates robots.txt to allow crawling favicon, sitemap, and common static assets while keeping the rest of the site disallowed.
> 
> - **Robots config**: Update `apps/dotcom/client/public/robots.txt`
>   - Add `Allow` rules for `/favicon*`, `/sitemap.xml`, `/*.css`, `/*.js`, `/*.png`, `/assets/*`, and `/manifest.webmanifest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 444ce0a1b8a1498e320353f4d70013fe7280d54a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->