### PR TITLE
fix(analytics): identify users after account creation

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -184,7 +184,7 @@ export function identify(userId: string, properties?: { [key: string]: any }) {
 	if (storedHasConsent !== 'opted-in') return
 
 	posthog.identify(userId, {
-		properties,
+		...properties,
 		analytics_consent: true,
 	})
 	ReactGA.set({ userId })

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -39,6 +39,7 @@ import {
 	uniqueId,
 } from '@tldraw/utils'
 import pick from 'lodash.pick'
+import posthog from 'posthog-js'
 import {
 	Atom,
 	Signal,
@@ -60,7 +61,7 @@ import {
 	react,
 	transact,
 } from 'tldraw'
-import { trackEvent } from '../../utils/analytics'
+import { getStoredCookieConsent, trackEvent } from '../../utils/analytics'
 import { MULTIPLAYER_SERVER, ZERO_SERVER } from '../../utils/config'
 import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
 import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
@@ -815,6 +816,14 @@ export class TldrawApp {
 			enhancedA11yMode: restOfPreferences.enhancedA11yMode ?? null,
 		})
 		if (didCreate) {
+			const consent = getStoredCookieConsent()
+			if (consent) {
+				posthog.identify(opts.userId, {
+					email: opts.email,
+					name: opts.fullName,
+					analytics_consent: true,
+				})
+			}
 			opts.trackEvent('create-user', { source: 'app' })
 		}
 		return { app, userId: opts.userId }


### PR DESCRIPTION
This PR makes two fixes to analytics:
- identifies users after they create an account
- spreads the properties object rather than creating a new property named `properties`

I've had a hell of a time trying to figure out why we couldn't get reliable data on user activity before account creation. It turned out we are not identifying users after the user creates their account, meaning the user's first session cannot be joined to the rest of our data about the identified user.

Separately, we also are not spreading the `properties` into the identification properties object, so instead we have a nice property named `properties` on our event, which is opaque to a lot of searches. Luckily this only seems to have mattered on tldraw.computer, where the analytics' identify method is called. 

### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Create a new account on dotcom.
2. Verify in PostHog that the user is identified and properties are spread correctly.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where users were not correctly identified in analytics after account creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Identify users in PostHog after account creation (respecting cookie consent) and spread `properties` in the identify payload.
> 
> - **Analytics**:
>   - Update `apps/analytics/src/analytics.tsx` to spread `...properties` in `posthog.identify` instead of nesting under `properties`.
> - **App (dotcom)**:
>   - In `apps/dotcom/client/src/tla/app/TldrawApp.ts`, on first user creation (`didCreate`), check consent via `getStoredCookieConsent()` and call `posthog.identify` with `email`, `name`, and `analytics_consent: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9897c07824ec236e5d0e162c6a89f902eb09c352. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->