### PR TITLE
refactor(dotcom): modularize analytics clients

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -1,279 +1,43 @@
-import posthog, { PostHogConfig, Properties } from 'posthog-js'
-import 'posthog-js/dist/web-vitals'
 import { useEffect } from 'react'
-import ReactGA from 'react-ga4'
 import { useLocation } from 'react-router-dom'
-import { atom, getFromLocalStorage, react, setInLocalStorage, useValue, warnOnce } from 'tldraw'
+import { useValue } from 'tldraw'
 import { useApp } from '../tla/hooks/useAppState'
+import { setStoredAnalyticsConsent, useAnalyticsConsentValue } from './analytics/cookie-consent'
+import { ga4Client } from './analytics/ga4-client'
+import { posthogClient } from './analytics/posthog-client'
+import { setupReo } from './analytics/reo-client'
+import { AnalyticsOptions } from './analytics/shared'
 
-// Local storage key for cookie consent
-export const COOKIE_CONSENT_KEY = 'tldraw_cookie_consent'
+// Re-export cookie consent utilities
+export {
+	COOKIE_CONSENT_KEY,
+	cookieConsent,
+	getStoredCookieConsent,
+	setStoredAnalyticsConsent,
+	setStoredCookieConsent,
+	useAnalyticsConsentValue,
+} from './analytics/cookie-consent'
 
-// Cookie consent structure
-interface CookieConsent {
-	analytics: boolean
-	// Future consent types can be added here
-	// marketing?: boolean
-	// functional?: boolean
-}
-
-// Cookie consent atom - stores the full consent object
-export const cookieConsent = atom<CookieConsent | null>('cookie consent', getStoredCookieConsent())
-
-// React to changes in the atom and sync with localStorage
-react('sync cookie consent to localStorage', () => {
-	const consent = cookieConsent.get()
-	if (consent !== null) {
-		try {
-			setInLocalStorage(COOKIE_CONSENT_KEY, JSON.stringify(consent))
-		} catch {
-			// Ignore localStorage errors
-		}
-	}
-})
-
-// Helper function to get analytics consent from the atom
-export function useAnalyticsConsentValue(): boolean | null {
-	return useValue('analytics consent', () => cookieConsent.get()?.analytics ?? null, [
-		cookieConsent,
-	])
-}
-
-export type AnalyticsOptions =
-	| {
-			optedIn: true
-			user:
-				| {
-						id: string
-						name: string
-						email: string
-				  }
-				| undefined
-	  }
-	| {
-			optedIn: false
-			user?: {
-				id: string
-				name: string
-				email: string
-			}
-	  }
-
-// @ts-ignore this is fine
-const POSTHOG_KEY: string | undefined = import.meta.env.VITE_POSTHOG_KEY
-const shouldUsePosthog = POSTHOG_KEY !== undefined
-
-// @ts-ignore this is fine
-const GA4_MEASUREMENT_ID: string | undefined = import.meta.env.VITE_GA4_MEASUREMENT_ID
-const shouldUseGA4 = GA4_MEASUREMENT_ID !== undefined
-
-const PROPERTIES_TO_REDACT = ['url', 'href', 'pathname']
-
-// Match property names against the defined list
-function filterProperties(value: { [key: string]: any }) {
-	return Object.entries(value).reduce<{ [key: string]: any }>((acc, [key, value]) => {
-		// N.B. This isn't super obvious but Posthog has keys that can be like
-		// `$pathname` for native events, but also you could have `pathname` for custom events.
-		// So we check for both here.
-		if (PROPERTIES_TO_REDACT.some((prop) => key.includes(prop))) {
-			acc[key] = 'redacted'
-		} else {
-			acc[key] = value
-		}
-		return acc
-	}, {})
-}
-
-// Helper functions for localStorage consent management
-export function getStoredCookieConsent(): CookieConsent | null {
-	try {
-		const stored = getFromLocalStorage(COOKIE_CONSENT_KEY)
-		if (!stored) return null
-		return JSON.parse(stored) as CookieConsent
-	} catch {
-		return null
-	}
-}
-
-export function setStoredCookieConsent(consent: Partial<CookieConsent>): void {
-	const existing = cookieConsent.get() || {}
-	const updated = { ...existing, ...consent }
-	// Ensure we only set the atom if we have a complete CookieConsent object
-	if (updated.analytics !== undefined) {
-		cookieConsent.set(updated as CookieConsent)
-	}
-}
-
-export function setStoredAnalyticsConsent(consent: boolean): void {
-	setStoredCookieConsent({ analytics: consent })
-}
-
-// Function to configure analytics when consent changes
 export function configureAnalytics(
 	consent: boolean,
 	user: { id: string; name: string; email: string } | undefined
 ) {
-	configurePosthog({
+	const options: AnalyticsOptions = {
 		optedIn: consent,
 		user,
-	} as AnalyticsOptions)
+	}
 
-	configureGA4({
-		optedIn: consent,
-		user,
-	} as AnalyticsOptions)
+	posthogClient.configure(options)
+	ga4Client.configure(options)
 
 	if (user) {
-		setupReo({
-			optedIn: consent,
-			user,
-		})
+		setupReo(options)
 	}
-}
-
-let currentOptionsPosthog: AnalyticsOptions | null = null
-let eventBufferPosthog: null | Array<{ name: string; data: Properties | null | undefined }> = []
-function configurePosthog(options: AnalyticsOptions) {
-	if (!shouldUsePosthog) return
-
-	const hashParams = new URLSearchParams(window.location.hash.substring(1))
-	const sessionID = hashParams.get('session_id')
-	const distinctID = hashParams.get('distinct_id')
-	const config: Partial<PostHogConfig> = {
-		api_host: 'https://analytics.tldraw.com/i',
-		ui_host: 'https://eu.i.posthog.com',
-		capture_pageview: false,
-		persistence: options.optedIn ? 'localStorage+cookie' : 'memory',
-		before_send: (payload) => {
-			if (!payload) return null
-			payload.properties.is_signed_in = !!options.user
-
-			const redactedProperties = filterProperties(payload.properties || {})
-			payload.properties = redactedProperties
-
-			// $set
-			const redactedSet = filterProperties(payload.$set || {})
-			payload.$set = redactedSet
-
-			// $set_once
-			const redactedSetOnce = filterProperties(payload.$set_once || {})
-			payload.$set_once = redactedSetOnce
-
-			return payload
-		},
-		bootstrap:
-			sessionID && distinctID
-				? {
-						sessionID,
-						distinctID,
-					}
-				: undefined,
-	}
-	if (!currentOptionsPosthog) {
-		posthog.init(POSTHOG_KEY, config)
-	}
-
-	if (options.optedIn) {
-		if (options.user) {
-			posthog.identify(options.user.id, {
-				email: options.user.email,
-				name: options.user.name,
-				analytics_consent: true,
-			})
-		}
-	} else if (currentOptionsPosthog?.optedIn) {
-		posthog.setPersonProperties({ analytics_consent: false })
-		posthog.reset()
-	}
-
-	posthog.set_config(config)
-	currentOptionsPosthog = options
-	eventBufferPosthog?.forEach((event) => posthog.capture(event.name, event.data))
-	eventBufferPosthog = null
-}
-
-let currentOptionsGA4: AnalyticsOptions | null = null
-let eventBufferGA4: null | Array<{ name: string; data: Properties | null | undefined }> = []
-function configureGA4(options: AnalyticsOptions) {
-	if (!shouldUseGA4) return
-
-	if (!currentOptionsGA4) {
-		ReactGA.gtag('consent', 'default', {
-			ad_storage: 'denied',
-			ad_user_data: 'denied',
-			ad_personalization: 'denied',
-			analytics_storage: 'denied',
-			// Wait for our cookie to load.
-			wait_for_update: 500,
-		})
-
-		ReactGA.initialize(GA4_MEASUREMENT_ID, {
-			gtagOptions: {
-				send_page_view: false,
-			},
-		})
-	}
-
-	if (options.optedIn) {
-		if (options.user) {
-			ReactGA.set({ userId: options.user.id, anonymize_ip: false })
-		}
-		ReactGA.gtag('consent', 'update', {
-			ad_user_data: 'granted',
-			ad_personalization: 'granted',
-			ad_storage: 'granted',
-			analytics_storage: 'granted',
-		})
-	} else if (currentOptionsGA4?.optedIn) {
-		ReactGA.set({ anonymize_ip: true })
-		ReactGA.reset()
-
-		ReactGA.gtag('consent', 'update', {
-			ad_user_data: 'denied',
-			ad_personalization: 'denied',
-			ad_storage: 'denied',
-			analytics_storage: 'denied',
-		})
-	}
-
-	currentOptionsGA4 = options
-	eventBufferGA4?.forEach((event) => ReactGA!.event(event.name, event.data ?? {}))
-	eventBufferGA4 = null
-}
-
-function getPosthog() {
-	if (!shouldUsePosthog) return null
-	if (!currentOptionsPosthog) {
-		warnOnce('getPosthog called before configurePosthog - buffering')
-		return {
-			capture(name: string, data: any) {
-				eventBufferPosthog?.push({ name, data })
-			},
-		}
-	}
-	return posthog
-}
-
-function getGA4() {
-	if (!shouldUseGA4) return null
-	if (!currentOptionsGA4) {
-		warnOnce('getGA4 called before configureGA4 - buffering')
-		return {
-			event(name: string, data: any) {
-				eventBufferGA4?.push({ name, data })
-			},
-		}
-	}
-	return ReactGA
 }
 
 export function trackEvent(name: string, data?: { [key: string]: any }) {
-	getPosthog()?.capture(name, data)
-
-	// Send pageviews to both platforms, but other app-specific events only to PostHog
-	if (name === '$pageview') {
-		getGA4()?.event('page_view', data)
-	}
+	posthogClient.trackEvent(name, data)
+	ga4Client.trackEvent(name, data)
 }
 
 export function useHandleUiEvents() {
@@ -291,38 +55,6 @@ export function SignedOutAnalytics() {
 	useTrackPageViews()
 
 	return null
-}
-
-function setupReo(options: AnalyticsOptions) {
-	if (options.optedIn === false) return
-
-	const user = options.user
-
-	function postToReoIframe(type: 'identify', payload?: any) {
-		const iframe = document.getElementById('reo-iframe-loader') as HTMLIFrameElement | null
-		if (iframe?.contentWindow) {
-			iframe.contentWindow.postMessage({ type, payload })
-		}
-	}
-
-	const reoIdentify = () =>
-		postToReoIframe('identify', {
-			firstname: user?.name || '',
-			username: user?.email || '',
-			type: 'email',
-			userId: user?.id || '',
-		})
-
-	if (!document.getElementById('reo-iframe-loader')) {
-		const iframeTag = document.createElement('iframe')
-		iframeTag.id = 'reo-iframe-loader'
-		iframeTag.style.display = 'none'
-		iframeTag.src = '/reo.html'
-		iframeTag.onload = () => reoIdentify()
-		document.body.appendChild(iframeTag)
-	} else {
-		reoIdentify()
-	}
 }
 
 export function SignedInAnalytics() {

--- a/apps/dotcom/client/src/utils/analytics/cookie-consent.ts
+++ b/apps/dotcom/client/src/utils/analytics/cookie-consent.ts
@@ -1,0 +1,48 @@
+import { atom, getFromLocalStorage, react, setInLocalStorage, useValue } from 'tldraw'
+
+export const COOKIE_CONSENT_KEY = 'tldraw_cookie_consent'
+
+export interface CookieConsent {
+	analytics: boolean
+}
+
+export const cookieConsent = atom<CookieConsent | null>('cookie consent', getStoredCookieConsent())
+
+react('sync cookie consent to localStorage', () => {
+	const consent = cookieConsent.get()
+	if (consent !== null) {
+		try {
+			setInLocalStorage(COOKIE_CONSENT_KEY, JSON.stringify(consent))
+		} catch {
+			// Ignore localStorage errors
+		}
+	}
+})
+
+export function useAnalyticsConsentValue(): boolean | null {
+	return useValue('analytics consent', () => cookieConsent.get()?.analytics ?? null, [
+		cookieConsent,
+	])
+}
+
+export function getStoredCookieConsent(): CookieConsent | null {
+	try {
+		const stored = getFromLocalStorage(COOKIE_CONSENT_KEY)
+		if (!stored) return null
+		return JSON.parse(stored) as CookieConsent
+	} catch {
+		return null
+	}
+}
+
+export function setStoredCookieConsent(consent: Partial<CookieConsent>): void {
+	const existing = cookieConsent.get() || {}
+	const updated = { ...existing, ...consent }
+	if (updated.analytics !== undefined) {
+		cookieConsent.set(updated as CookieConsent)
+	}
+}
+
+export function setStoredAnalyticsConsent(consent: boolean): void {
+	setStoredCookieConsent({ analytics: consent })
+}

--- a/apps/dotcom/client/src/utils/analytics/ga4-client.ts
+++ b/apps/dotcom/client/src/utils/analytics/ga4-client.ts
@@ -1,0 +1,79 @@
+import { Properties } from 'posthog-js'
+import ReactGA from 'react-ga4'
+import { warnOnce } from 'tldraw'
+import { AnalyticsClient, AnalyticsOptions, EventBufferManager } from './shared'
+
+// @ts-ignore this is fine
+const GA4_MEASUREMENT_ID: string | undefined = import.meta.env.VITE_GA4_MEASUREMENT_ID
+const shouldUseGA4 = GA4_MEASUREMENT_ID !== undefined
+
+export class GA4Client implements AnalyticsClient {
+	private currentOptions: AnalyticsOptions | null = null
+	private eventBuffer = new EventBufferManager()
+
+	configure(options: AnalyticsOptions) {
+		if (!shouldUseGA4) return
+
+		if (!this.currentOptions) {
+			ReactGA.gtag('consent', 'default', {
+				ad_storage: 'denied',
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+				analytics_storage: 'denied',
+				wait_for_update: 500,
+			})
+
+			ReactGA.initialize(GA4_MEASUREMENT_ID, {
+				gtagOptions: {
+					send_page_view: false,
+				},
+			})
+		}
+
+		if (options.optedIn) {
+			if (options.user) {
+				ReactGA.set({ userId: options.user.id, anonymize_ip: false })
+			}
+			ReactGA.gtag('consent', 'update', {
+				ad_user_data: 'granted',
+				ad_personalization: 'granted',
+				ad_storage: 'granted',
+				analytics_storage: 'granted',
+			})
+		} else if (this.currentOptions?.optedIn) {
+			ReactGA.set({ anonymize_ip: true })
+			ReactGA.reset()
+
+			ReactGA.gtag('consent', 'update', {
+				ad_user_data: 'denied',
+				ad_personalization: 'denied',
+				ad_storage: 'denied',
+				analytics_storage: 'denied',
+			})
+		}
+
+		this.currentOptions = options
+		this.eventBuffer.flush((event) => ReactGA.event(event.name, event.data ?? {}))
+	}
+
+	trackEvent(name: string, data?: Properties) {
+		if (!shouldUseGA4) return
+		if (name !== '$pageview') return
+
+		const eventData = data ?? {}
+
+		if (!this.currentOptions) {
+			warnOnce('GA4 page view received before configure - buffering')
+			this.eventBuffer.add('page_view', eventData)
+			return
+		}
+
+		ReactGA.event('page_view', eventData)
+	}
+
+	isConfigured(): boolean {
+		return this.currentOptions !== null
+	}
+}
+
+export const ga4Client = new GA4Client()

--- a/apps/dotcom/client/src/utils/analytics/posthog-client.ts
+++ b/apps/dotcom/client/src/utils/analytics/posthog-client.ts
@@ -1,0 +1,89 @@
+import posthog, { PostHogConfig, Properties } from 'posthog-js'
+import 'posthog-js/dist/web-vitals'
+import { warnOnce } from 'tldraw'
+import { AnalyticsClient, AnalyticsOptions, EventBufferManager, filterProperties } from './shared'
+
+// @ts-ignore this is fine
+const POSTHOG_KEY: string | undefined = import.meta.env.VITE_POSTHOG_KEY
+const shouldUsePosthog = POSTHOG_KEY !== undefined
+
+export class PostHogClient implements AnalyticsClient {
+	private currentOptions: AnalyticsOptions | null = null
+	private eventBuffer = new EventBufferManager()
+
+	configure(options: AnalyticsOptions) {
+		if (!shouldUsePosthog) return
+
+		const hashParams = new URLSearchParams(window.location.hash.substring(1))
+		const sessionID = hashParams.get('session_id')
+		const distinctID = hashParams.get('distinct_id')
+
+		const config: Partial<PostHogConfig> = {
+			api_host: 'https://analytics.tldraw.com/i',
+			ui_host: 'https://eu.i.posthog.com',
+			capture_pageview: false,
+			persistence: options.optedIn ? 'localStorage+cookie' : 'memory',
+			before_send: (payload) => {
+				if (!payload) return null
+				payload.properties.is_signed_in = !!options.user
+
+				const redactedProperties = filterProperties(payload.properties || {})
+				payload.properties = redactedProperties
+
+				const redactedSet = filterProperties(payload.$set || {})
+				payload.$set = redactedSet
+
+				const redactedSetOnce = filterProperties(payload.$set_once || {})
+				payload.$set_once = redactedSetOnce
+
+				return payload
+			},
+			bootstrap:
+				sessionID && distinctID
+					? {
+							sessionID,
+							distinctID,
+						}
+					: undefined,
+		}
+
+		if (!this.currentOptions) {
+			posthog.init(POSTHOG_KEY, config)
+		}
+
+		if (options.optedIn) {
+			if (options.user) {
+				posthog.identify(options.user.id, {
+					email: options.user.email,
+					name: options.user.name,
+					analytics_consent: true,
+				})
+			}
+		} else if (this.currentOptions?.optedIn) {
+			posthog.setPersonProperties({ analytics_consent: false })
+			posthog.reset()
+		}
+
+		posthog.set_config(config)
+		this.currentOptions = options
+		this.eventBuffer.flush((event) => posthog.capture(event.name, event.data))
+	}
+
+	trackEvent(name: string, data?: Properties) {
+		if (!shouldUsePosthog) return
+
+		if (!this.currentOptions) {
+			warnOnce('PostHog trackEvent called before configure - buffering')
+			this.eventBuffer.add(name, data)
+			return
+		}
+
+		posthog.capture(name, data)
+	}
+
+	isConfigured(): boolean {
+		return this.currentOptions !== null
+	}
+}
+
+export const posthogClient = new PostHogClient()

--- a/apps/dotcom/client/src/utils/analytics/reo-client.ts
+++ b/apps/dotcom/client/src/utils/analytics/reo-client.ts
@@ -1,0 +1,33 @@
+import { AnalyticsOptions } from './shared'
+
+export function setupReo(options: AnalyticsOptions) {
+	if (options.optedIn === false) return
+
+	const user = options.user
+
+	function postToReoIframe(type: 'identify', payload?: any) {
+		const iframe = document.getElementById('reo-iframe-loader') as HTMLIFrameElement | null
+		if (iframe?.contentWindow) {
+			iframe.contentWindow.postMessage({ type, payload })
+		}
+	}
+
+	const reoIdentify = () =>
+		postToReoIframe('identify', {
+			firstname: user?.name || '',
+			username: user?.email || '',
+			type: 'email',
+			userId: user?.id || '',
+		})
+
+	if (!document.getElementById('reo-iframe-loader')) {
+		const iframeTag = document.createElement('iframe')
+		iframeTag.id = 'reo-iframe-loader'
+		iframeTag.style.display = 'none'
+		iframeTag.src = '/reo.html'
+		iframeTag.onload = () => reoIdentify()
+		document.body.appendChild(iframeTag)
+	} else {
+		reoIdentify()
+	}
+}

--- a/apps/dotcom/client/src/utils/analytics/shared.ts
+++ b/apps/dotcom/client/src/utils/analytics/shared.ts
@@ -1,0 +1,56 @@
+import { Properties } from 'posthog-js'
+
+export interface AnalyticsOptions {
+	optedIn: boolean
+	user?: {
+		id: string
+		name: string
+		email: string
+	}
+}
+
+export interface AnalyticsClient {
+	configure(options: AnalyticsOptions): void
+	trackEvent(name: string, data?: Properties): void
+	isConfigured(): boolean
+}
+
+export interface EventBuffer {
+	name: string
+	data: Properties | null | undefined
+}
+
+export class EventBufferManager {
+	private buffer: EventBuffer[] = []
+	private isBuffering = true
+
+	add(name: string, data?: Properties) {
+		if (this.isBuffering) {
+			this.buffer.push({ name, data })
+		}
+	}
+
+	flush(callback: (event: EventBuffer) => void) {
+		this.buffer.forEach(callback)
+		this.buffer = []
+		this.isBuffering = false
+	}
+
+	reset() {
+		this.buffer = []
+		this.isBuffering = true
+	}
+}
+
+const PROPERTIES_TO_REDACT = ['url', 'href', 'pathname']
+
+export function filterProperties(value: { [key: string]: any }) {
+	return Object.entries(value).reduce<{ [key: string]: any }>((acc, [key, value]) => {
+		if (PROPERTIES_TO_REDACT.some((prop) => key.includes(prop))) {
+			acc[key] = 'redacted'
+		} else {
+			acc[key] = value
+		}
+		return acc
+	}, {})
+}


### PR DESCRIPTION
This is a Codex refactor of the analytics package, which I found really difficult to parse myself.

Split analytics implementation into separate modules for PostHog, GA4, REO, and cookie consent management. Centralized shared types and utilities, improving maintainability and separation of concerns. The main analytics utility now delegates to these clients, simplifying configuration and event tracking.

### Change type

- [x] `other`

### Test plan

1. Verify analytics events are still firing correctly in the network tab for PostHog and GA4.
2. Verify cookie consent changes still trigger the appropriate client initializations.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Refactored analytics implementation into modular clients for better maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Splits analytics into modular PostHog, GA4, and REO clients with shared utilities and cookie-consent management, simplifying configuration and event tracking.
> 
> - **Analytics**:
>   - **Modular clients**: Add `analytics/posthog-client.ts`, `analytics/ga4-client.ts`, `analytics/reo-client.ts`, and `analytics/shared.ts` with shared types, event buffering, and property redaction.
>   - **Cookie consent**: Extract to `analytics/cookie-consent.ts`; provide `COOKIE_CONSENT_KEY`, atom, getters/setters, and `useAnalyticsConsentValue`.
>   - **Main entry (`utils/analytics.tsx`)**:
>     - Delegate `configureAnalytics` and `trackEvent` to `posthogClient` and `ga4Client`; `setupReo` separated.
>     - Re-export consent utilities; remove in-file implementations and direct GA4/PostHog setup logic.
>     - Keep pageview tracking via clients and consent sync for signed-in/out flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab969370af35e52a262c38619f72f67b604c501e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->