### PR TITLE
fix(analytics): resolve regression on properties

### DIFF
--- a/apps/analytics/src/analytics.tsx
+++ b/apps/analytics/src/analytics.tsx
@@ -184,7 +184,7 @@ export function identify(userId: string, properties?: { [key: string]: any }) {
 	if (storedHasConsent !== 'opted-in') return
 
 	posthog.identify(userId, {
-		properties,
+		...properties,
 		analytics_consent: true,
 	})
 	ReactGA.set({ userId })


### PR DESCRIPTION
@steveruizok oh i see - yeah this is a regression from last week's change https://github.com/tldraw/tldraw/pull/6924

this app will just hotfix by itself when i land this PR

### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Verify that user properties are spread in PostHog identify call

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a regression where analytics properties were incorrectly nested in identify calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Spread user properties in PostHog `identify` call instead of nesting them under `properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76ea674504a88eec3772566503811908a3452190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->