### PR TITLE
chore(dotcom): allow analytics.google.com in csp

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -14,6 +14,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`https://*.ingest.sentry.io`,
 		`https://*.ingest.us.sentry.io`,
 		'https://*.analytics.google.com',
+		'https://analytics.google.com',
 		'https://www.google-analytics.com',
 		'https://*.googletagmanager.com',
 		'https://www.googletagmanager.com',


### PR DESCRIPTION
Adds `https://analytics.google.com` to CSP `connect-src` allowlist.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated Content Security Policy to allow Google Analytics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `https://analytics.google.com` to CSP `connect-src` allowlist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e97fc56a6975196d0ff02a574e133238b4f837c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->