### PR TITLE
chore: improve hotfix pr checking timeout

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -85,7 +85,7 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 			if (elapsedTime >= maxWaitTimeMs) {
 				nicelog(`Timeout: PR #${createdPr.data.number} checks did not complete in time`)
 				throw new Error(
-					`Hotfix PR #${createdPr.data.number} checks timed out after ${Math.round((elapsedTime + 5 * 60 * 1000) / 60000)} minutes. Please check the PR manually: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
+					`Hotfix PR #${createdPr.data.number} checks timed out after ${Math.round(elapsedTime / 60000)} minutes. Please check the PR manually: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
 				)
 			}
 			const prStatus = await getPrDetailsByNumber(octokit, createdPr.data.number)


### PR DESCRIPTION
Add 15-minute timeout to dotcom hotfix script to prevent action timeouts. Now throws an error (sent to Discord) if PR checks don't complete in time,  leaving 5 minutes buffer before the 20-minute GitHub Action timeout.

### Change type

- [x] `other`

### Test plan

1. Run the script manually and verify timeout behavior.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved reliability of hotfix scripts by adding timeouts for PR checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 15-minute timeout to the dotcom hotfix script while waiting for PR checks, throwing an error if not ready in time.
> 
> - **Scripts**:
>   - `internal/scripts/trigger-dotcom-hotfix.ts`
>     - Add 15-minute maximum wait with elapsed-time tracking when polling PR `mergeable_state`.
>     - On timeout, log and throw an error with PR link.
>     - Retains initial 5-minute delay and 15s polling cadence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3dfe88188a8437d193bfcc09e54520efd716f60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->