### PR TITLE
fix(dotcom): resolve groups backend issues and sync home group names

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -635,13 +635,17 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		userId,
 		lsn,
 		topicSubscriptions,
+		guestFileIds,
 		bootId,
 	}: {
 		userId: string
 		lsn: string
 		topicSubscriptions: TopicSubscriptionTree
+		guestFileIds?: never
 		bootId: string
 	}): Promise<{ type: 'done'; sequenceId: string; sequenceNumber: number } | { type: 'reboot' }> {
+		if (guestFileIds) throw new Error('guestFileIds is no longer supported')
+
 		try {
 			while (!this.getCurrentLsn()) {
 				// this should only happen once per slot name change, which should never happen!


### PR DESCRIPTION
@MitjaBezensek and I did some frontend work and testing on staging and found a couple of things that need to be fixed before we push the groups data model to production tomorrow.

1. We should throw an error if old User DOs try to connect to the new replicator (cloudflare will kill them and restart them with the new worker script very soon after this happens so it's no biggie to throw an error)
2. We needed to propagate the user's name to their home group name so that the shared file name triggers work correctly for files shared from a user's home group.
3. We improved a check for the groups_backend flag.

### Change type

- [x] `bugfix`

### Test plan

1. Verify that legacy clients providing guestFileIds are rejected with an error.
2. Verify that updating a user's name correctly updates the associated home group name via the new database triggers.
3. Verify the groups_backend flag check works as expected.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed several issues with the groups backend, including home group name synchronization and legacy client rejection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reject legacy clients by erroring on guestFileIds in registerUser; add triggers to sync/initialize home group names from user names; update migration flag check to groups_backend.
> 
> - **Backend (replicator)**:
>   - `TLPostgresReplicator.registerUser`: remove support for `guestFileIds` and throw if provided to block legacy clients.
> - **Database (migrations)**:
>   - Add `update_home_group_name` trigger/function to sync a home group’s `name` when the corresponding `user.name` changes.
>   - Add `initialize_home_group_name` trigger/function to set a home group’s `name` from the corresponding `user.name` on insert.
>   - Update migration check to use `flags LIKE '%groups_backend%'` instead of `'%groups%'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b333e9759279d3c3aec84c25f3190b42aadedf9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->