### PR TITLE
fix(editor): move event handling and click capture inside canvas div

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -294,8 +294,13 @@ input,
 	cursor: var(--tl-cursor);
 	overflow: clip;
 	content-visibility: auto;
-	touch-action: none;
 	contain: strict;
+}
+
+.tl-canvas__inner {
+	height: 100%;
+	width: 100%;
+	touch-action: none;
 }
 
 .tl-canvas__in-front {
@@ -847,7 +852,7 @@ input,
  *  - draw/line shapes, because it feels restrictive to have them be 'in the way' of clicking on a textfield
  *  - shapes that are not filled
  */
-.tl-canvas:is([data-iseditinganything='true'], [data-isselectinganything='true'])
+.tl-canvas__inner:is([data-iseditinganything='true'], [data-isselectinganything='true'])
 	.tl-shape:not(
 		[data-shape-type='arrow'],
 		[data-shape-type='draw'],
@@ -1789,7 +1794,7 @@ it from receiving any pointer events or affecting the cursor. */
 
 	/* These three rules help preserve clicking into specific points in text areas *while*
  * already in edit mode when jumping from shape to shape. */
-	.tl-canvas[data-iseditinganything='true'] .tl-text-wrapper:hover .tl-text-input {
+	.tl-canvas__inner[data-iseditinganything='true'] .tl-text-wrapper:hover .tl-text-input {
 		z-index: var(--tl-layer-text-editor);
 		pointer-events: all;
 	}

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -129,14 +129,14 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 
 	return (
 		<>
-			<div
-				draggable={false}
-				data-iseditinganything={isEditingAnything}
-				data-isselectinganything={isSelectingAnything}
-				className={classNames('tl-canvas', className)}
-				data-testid="canvas"
-			>
-				<div style={{ width: '100%', height: '100%' }} ref={rCanvas} {...events}>
+			<div draggable={false} className={classNames('tl-canvas', className)} data-testid="canvas">
+				<div
+					data-iseditinganything={isEditingAnything}
+					data-isselectinganything={isSelectingAnything}
+					className="tl-canvas__inner"
+					ref={rCanvas}
+					{...events}
+				>
 					<svg className="tl-svg-context" aria-hidden="true">
 						<defs>
 							{shapeSvgDefs}
@@ -180,8 +180,8 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 					>
 						<InFrontOfTheCanvasWrapper />
 					</div>
+					<MovingCameraHitTestBlocker />
 				</div>
-				<MovingCameraHitTestBlocker />
 				<MenuClickCapture />
 			</div>
 		</>

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -30,7 +30,7 @@ export function useDocumentEvents() {
 			if ((e as any).isSpecialRedispatchedEvent) return
 			preventDefault(e)
 			e.stopPropagation()
-			const cvs = container.querySelector('.tl-canvas')
+			const cvs = container.querySelector('.tl-canvas__inner')
 			if (!cvs) return
 			const newEvent = new DragEvent(e.type, e)
 			;(newEvent as any).isSpecialRedispatchedEvent = true

--- a/packages/editor/src/lib/hooks/usePassThroughMouseOverEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughMouseOverEvents.ts
@@ -14,7 +14,7 @@ export function usePassThroughMouseOverEvents(ref: RefObject<HTMLElement>) {
 			if (!editor?.getInstanceState().isFocused) return
 			if ((e as any).isSpecialRedispatchedEvent) return
 			preventDefault(e)
-			const cvs = container.querySelector('.tl-canvas')
+			const cvs = container.querySelector('.tl-canvas__inner')
 			if (!cvs) return
 			const newEvent = new PointerEvent(e.type, e as any)
 			;(newEvent as any).isSpecialRedispatchedEvent = true

--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -23,7 +23,7 @@ export function usePassThroughWheelEvents(ref: RefObject<HTMLElement>) {
 			}
 
 			preventDefault(e)
-			const cvs = container.querySelector('.tl-canvas')
+			const cvs = container.querySelector('.tl-canvas__inner')
 			if (!cvs) return
 			const newEvent = new WheelEvent('wheel', e as any)
 			;(newEvent as any).isSpecialRedispatchedEvent = true

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1622,7 +1622,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					// Dispatch a contextmenu event directly at the center of the selection
 					editor
 						.getContainer()
-						.querySelector('.tl-canvas')
+						.querySelector('.tl-canvas__inner')
 						?.dispatchEvent(
 							new PointerEvent('contextmenu', {
 								clientX: screenPoint.x,

--- a/templates/workflow/src/hooks/useDragToCreate.ts
+++ b/templates/workflow/src/hooks/useDragToCreate.ts
@@ -166,7 +166,7 @@ export function useDragToCreate<T = any>(config: DragToCreateConfig<T>) {
 				el.style.opacity = ''
 
 				// Move the pointer capture to the canvas so tldraw can handle subsequent events
-				const cvs = document.querySelector('.tl-canvas') as HTMLDivElement
+				const cvs = document.querySelector('.tl-canvas__inner') as HTMLDivElement
 				if (cvs) cvs.setPointerCapture(down.pointerId)
 			}
 


### PR DESCRIPTION
Hopefully fixes https://discord.com/channels/859816885297741824/1429837310920495229/1429837310920495229

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug affecting menus rendered by the `InFrontOfTheCanvas` component, wherein pointer events were being blocked while a menu is open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes canvas event handling to a new inner full-size div and moves `MenuClickCapture` inside `.tl-canvas`.
> 
> - **Canvas structure**:
>   - Move `ref={rCanvas}` and canvas `...events` from the outer `.tl-canvas` div to a new inner full-size div (`style={{ width: '100%', height: '100%' }}`) that wraps all canvas content.
>   - Nest all previous canvas layers (`svg` defs, `Background`, `GridWrapper`, HTML layers, overlays, `InFrontOfTheCanvasWrapper`) inside this new inner div.
> - **Event/click handling**:
>   - Relocate `MenuClickCapture` from outside the canvas to inside the `.tl-canvas` container (after `MovingCameraHitTestBlocker`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a11ba4de28dc4ff6bd6d54977c507dedcc79f0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->