### PR TITLE
revert: bump up the target rate to 120fps (#6868)

### DIFF
--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -35,12 +35,6 @@ import {
  */
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void
 
-/** Network sync frame rate when in solo mode (no collaborators) @internal */
-const SOLO_MODE_FPS = 1
-
-/** Network sync frame rate when in collaborative mode (with collaborators) @internal */
-const COLLABORATIVE_MODE_FPS = 30
-
 /**
  * WebSocket close code used by the server to signal a non-recoverable sync error.
  * This close code indicates that the connection is being terminated due to an error
@@ -806,11 +800,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.flushPendingPushRequests()
 	}
 
-	/** Get the target FPS for network operations based on presence mode */
-	private getSyncFps(): number {
-		return this.presenceMode?.get() === 'solo' ? SOLO_MODE_FPS : COLLABORATIVE_MODE_FPS
-	}
-
 	/** Send any unsent push requests to the server */
 	private flushPendingPushRequests = fpsThrottle(() => {
 		this.debug('flushing pending push requests', {
@@ -830,7 +819,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				pendingPushRequest.sent = true
 			}
 		}
-	}, this.getSyncFps.bind(this))
+	})
 
 	/**
 	 * Applies a 'network' diff to the store this does value-based equality checking so that if the
@@ -938,5 +927,5 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		}
 	}
 
-	private scheduleRebase = fpsThrottle(this.rebase, this.getSyncFps.bind(this))
+	private scheduleRebase = fpsThrottle(this.rebase)
 }

--- a/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
@@ -110,7 +110,7 @@ function FPS() {
 					isSlow = !isSlow
 				}
 
-				fpsRef.current!.innerHTML = `FPS ${fps.toString()} (max: ${maxKnownFps})`
+				fpsRef.current!.innerHTML = `FPS ${fps.toString()}`
 				fpsRef.current!.className =
 					`tlui-debug-panel__fps` + (isSlow ? ` tlui-debug-panel__fps__slow` : ``)
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -126,7 +126,7 @@ export function filterEntries<Key extends string, Value>(object: {
 export function fpsThrottle(fn: {
     (): void;
     cancel?(): void;
-}, getTargetFps?: () => number): {
+}): {
     (): void;
     cancel?(): void;
 };

--- a/packages/utils/src/lib/throttle.ts
+++ b/packages/utils/src/lib/throttle.ts
@@ -5,28 +5,15 @@ const isTest = () =>
 	!globalThis.__FORCE_RAF_IN_TESTS__
 
 const fpsQueue: Array<() => void> = []
-const targetFps = 120
-// Browsers aren't precise with frame timing - this factor prevents skipping frames unnecessarily
-// by aiming slightly below the theoretical frame duration (e.g., ~7.5ms instead of 8.33ms for 120fps)
-const timingVarianceFactor = 0.9
-const targetTimePerFrame = Math.floor(1000 / targetFps) * timingVarianceFactor // ~7ms
+const targetFps = 60
+const targetTimePerFrame = Math.floor(1000 / targetFps) * 0.9 // ~15ms - we allow for some variance as browsers aren't that precise.
 let frameRaf: undefined | number
 let flushRaf: undefined | number
 let lastFlushTime = -targetTimePerFrame
 
-// Track custom FPS timing per function
-const customFpsLastRunTime = new WeakMap<() => void, number>()
-// Map function to its custom FPS getter
-const customFpsGetters = new WeakMap<() => void, () => number>()
-
 const flush = () => {
 	const queue = fpsQueue.splice(0, fpsQueue.length)
 	for (const fn of queue) {
-		// If this function has custom FPS, update timestamp when executing
-		const getTargetFps = customFpsGetters.get(fn)
-		if (getTargetFps) {
-			customFpsLastRunTime.set(fn, Date.now())
-		}
 		fn()
 	}
 }
@@ -65,41 +52,30 @@ function tick(isOnNextFrame = false) {
 }
 
 /**
- * Creates a throttled version of a function that executes at most once per frame.
- * The default target frame rate is 120fps, but can be customized per function.
+ * Creates a throttled version of a function that executes at most once per frame (60fps).
  * Subsequent calls within the same frame are ignored, ensuring smooth performance
  * for high-frequency events like mouse movements or scroll events.
  *
  * @param fn - The function to throttle, optionally with a cancel method
- * @param getTargetFps - Optional function that returns the current target FPS rate for custom throttling
  * @returns A throttled function with an optional cancel method to remove pending calls
  *
  * @example
  * ```ts
- * // Default 120fps throttling
  * const updateCanvas = fpsThrottle(() => {
- *   // This will run at most once per frame (~8.33ms)
+ *   // This will run at most once per frame (~16.67ms)
  *   redrawCanvas()
  * })
  *
- * // Call as often as you want - automatically throttled to 120fps
+ * // Call as often as you want - automatically throttled to 60fps
  * document.addEventListener('mousemove', updateCanvas)
  *
  * // Cancel pending calls if needed
  * updateCanvas.cancel?.()
- *
- * // Custom FPS throttling for less critical updates
- * const slowUpdate = fpsThrottle(() => {
- *   heavyComputation()
- * }, () => 30) // Throttle to 30fps
  * ```
  *
  * @internal
  */
-export function fpsThrottle(
-	fn: { (): void; cancel?(): void },
-	getTargetFps?: () => number
-): {
+export function fpsThrottle(fn: { (): void; cancel?(): void }): {
 	(): void
 	cancel?(): void
 } {
@@ -117,23 +93,7 @@ export function fpsThrottle(
 		return fn
 	}
 
-	// Store custom FPS getter if provided
-	if (getTargetFps) {
-		customFpsGetters.set(fn, getTargetFps)
-	}
-
 	const throttledFn = () => {
-		// Custom FPS - check timing before queuing
-		if (getTargetFps) {
-			const lastRun = customFpsLastRunTime.get(fn) ?? -Infinity
-			const customTimePerFrame = Math.floor(1000 / getTargetFps()) * timingVarianceFactor
-			const elapsed = Date.now() - lastRun
-
-			if (elapsed < customTimePerFrame) {
-				// Not ready yet, don't queue
-				return
-			}
-		}
 		if (fpsQueue.includes(fn)) {
 			return
 		}
@@ -150,7 +110,7 @@ export function fpsThrottle(
 }
 
 /**
- * Schedules a function to execute on the next animation frame, targeting 120fps.
+ * Schedules a function to execute on the next animation frame, targeting 60fps.
  * If the same function is passed multiple times before the frame executes,
  * it will only be called once, effectively batching multiple calls.
  *


### PR DESCRIPTION
This reverts commit 2e5f9f2def6fee2d814c723696f8a7cc89989b26.

### API changes
- Revert the 120 fps changes.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reverted the target frame rate to 60fps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes throttling to 60fps (removing custom/120fps logic), updates TLSyncClient scheduling, simplifies FPS debug display, and adjusts the utils API.
> 
> - **Utils**:
>   - Reverts `fpsThrottle` to fixed 60fps; removes custom FPS support and related state.
>   - Updates docs/comments and `throttleToNextFrame` to reference 60fps.
>   - API change: `fpsThrottle(fn)` no longer accepts `getTargetFps`.
> - **Sync Core** (`packages/sync-core/src/lib/TLSyncClient.ts`):
>   - Removes dynamic sync FPS logic (`SOLO_MODE_FPS`, `COLLABORATIVE_MODE_FPS`, `getSyncFps`).
>   - `flushPendingPushRequests` and `scheduleRebase` now use `fpsThrottle()` without FPS getter.
> - **UI** (`packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx`):
>   - Simplifies FPS output to `FPS <current>` (removes max FPS display).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9995c036e9e46a654a5ba8eb37e787292a7abd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->