### PR TITLE
improvement(scripts): add prefixes to Discord deployment notifications

### DIFF
--- a/internal/scripts/deploy-analytics.ts
+++ b/internal/scripts/deploy-analytics.ts
@@ -30,6 +30,7 @@ const discord = new Discord({
 	webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 	shouldNotify: env.TLDRAW_ENV === 'production',
 	totalSteps: 2,
+	messagePrefix: '[ANALYTICS]',
 })
 
 const { previewId, sha } = getDeployInfo()

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -105,6 +105,7 @@ const discord = new Discord({
 	webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 	shouldNotify: env.TLDRAW_ENV === 'production',
 	totalSteps: previewId ? 10 : 9,
+	messagePrefix: '[DOTCOM]',
 })
 
 const sentryReleaseName = `${env.TLDRAW_ENV}-${previewId ? previewId + '-' : ''}-${sha}`

--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -12,16 +12,23 @@ function sanitizeVariables(errorOutput: string): string {
 export class Discord {
 	static AT_TEAM_MENTION = '<@&959380625100513310>'
 
-	constructor(opts: { webhookUrl: string; shouldNotify: boolean; totalSteps?: number }) {
+	constructor(opts: {
+		webhookUrl: string
+		shouldNotify: boolean
+		totalSteps?: number
+		messagePrefix?: string
+	}) {
 		this.webhookUrl = opts.webhookUrl
 		this.shouldNotify = opts.shouldNotify
 		this.totalSteps = opts.totalSteps ?? 0
+		this.messagePrefix = opts.messagePrefix ?? ''
 	}
 
 	webhookUrl: string
 	shouldNotify: boolean
 	totalSteps: number
 	currentStep = 0
+	messagePrefix: string
 
 	private async send(method: string, url: string, body: unknown): Promise<any> {
 		const response = await fetch(`${this.webhookUrl}${url}`, {
@@ -44,12 +51,18 @@ export class Discord {
 			}
 		}
 
-		const message = await this.send('POST', '?wait=true', { content: sanitizeVariables(content) })
+		const prefixedContent = this.messagePrefix ? `${this.messagePrefix} ${content}` : content
+		const message = await this.send('POST', '?wait=true', {
+			content: sanitizeVariables(prefixedContent),
+		})
 
 		return {
 			edit: async (newContent: string) => {
+				const prefixedNewContent = this.messagePrefix
+					? `${this.messagePrefix} ${newContent}`
+					: newContent
 				await this.send('PATCH', `/messages/${message.id}`, {
-					content: sanitizeVariables(newContent),
+					content: sanitizeVariables(prefixedNewContent),
 				})
 			},
 		}


### PR DESCRIPTION
Fixes two issues with our production deployment Discord messages:

  1. Fixed step count for dotcom deployments
  2. Added deployment prefixes - Analytics and dotcom deployments now post with [ANALYTICS] and [DOTCOM] prefixes respectively, making it easier to distinguish which deployment posted each message when they run in parallel. An alternative approach would be for all steps to use the same message, which might be better? That said we would loose the timestamps so we wouldn't know how long the steps took 🤷‍♂️

### Before (dotcom and analytics worker deploy messages are interleaving)

```
--- production dotcom deploy pre-flight ---
setting up deploy ✅ 
--- production analytics worker deploy pre-flight ---
cloudflare deploy dry run ✅ 
building dotcom app ✅ 
--- pre-flight complete, starting real analytics worker deploy ---
deploying analytics worker to cloudflare ✅ 
Deploy complete!
cloudflare deploy dry run ✅ 
--- pre-flight complete, starting real dotcom deploy ---
deploying asset uploader to cloudflare ✅ 
deploying multiplayer worker to cloudflare ✅ 
deploying image resizer to cloudflare ✅ 
deploying health worker to cloudflare ✅ 
deploying fairy worker to cloudflare ✅ 
deploying dotcom app to vercel ✅ 
Deploy complete!
```

### After
```
  [DOTCOM] --- production dotcom deploy pre-flight ---
  [DOTCOM] setting up deploy ✅
  [ANALYTICS] --- production analytics worker deploy pre-flight ---
  [ANALYTICS] cloudflare deploy dry run ✅
  [DOTCOM] building dotcom app ✅
  [ANALYTICS] --- pre-flight complete, starting real analytics worker deploy ---
  [ANALYTICS] deploying analytics worker to cloudflare ✅
  [ANALYTICS] Deploy complete!
  [DOTCOM] cloudflare deploy dry run ✅
  [DOTCOM] --- pre-flight complete, starting real dotcom deploy ---
  [DOTCOM] deploying asset uploader to cloudflare ✅
  [DOTCOM] deploying multiplayer worker to cloudflare ✅
  [DOTCOM] deploying image resizer to cloudflare ✅
  [DOTCOM] deploying health worker to cloudflare ✅
  [DOTCOM] deploying fairy worker to cloudflare ✅
  [DOTCOM] deploying dotcom app to vercel ✅
  [DOTCOM] Deploy complete!
```


### Change type

- [x] `improvement`

### Test plan

1. Run a deployment script and verify Discord output includes prefixes.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added prefixes to Discord deployment notifications to distinguish between parallel runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds message prefixes to Discord deploy notifications for analytics/dotcom and fixes dotcom total step count; introduces `messagePrefix` support in the Discord helper.
> 
> - **Deploy Scripts**
>   - `internal/scripts/deploy-dotcom.ts`:
>     - Set Discord `totalSteps` to `previewId ? 10 : 9`.
>     - Add `messagePrefix: "[DOTCOM]"` to Discord notifications.
>   - `internal/scripts/deploy-analytics.ts`:
>     - Add `messagePrefix: "[ANALYTICS]"` to Discord notifications.
> - **Library**
>   - `internal/scripts/lib/discord.ts`:
>     - Extend `Discord` constructor to accept optional `messagePrefix`.
>     - Prefix all sent and edited messages with `messagePrefix` when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9aa6ec0691e6cb23703bc14e61ddf89ef7c5a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->