### PR TITLE
perf(dotcom): reduce frequency of file_state updates

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -43,7 +43,6 @@ import {
 	Atom,
 	Signal,
 	TLDocument,
-	TLSessionStateSnapshot,
 	TLUiToastsContextType,
 	TLUserPreferences,
 	assertExists,
@@ -753,17 +752,6 @@ export class TldrawApp {
 
 	async onFileEnter(fileId: string) {
 		this.z.mutate.onEnterFile({ fileId, time: Date.now() })
-	}
-
-	onFileEdit(fileId: string) {
-		this.updateFileState(fileId, { lastEditAt: Date.now() })
-	}
-
-	onFileSessionStateUpdate(fileId: string, sessionState: TLSessionStateSnapshot) {
-		this.updateFileState(fileId, {
-			lastSessionState: JSON.stringify(sessionState),
-			lastVisitAt: Date.now(),
-		})
 	}
 
 	onFileExit(fileId: string) {


### PR DESCRIPTION
This should reduce the amount of traffic going through the replicator.

### Change type

- [x] `other` 

### Test plan

1. Open a file on dotcom and perform edits.
2. Verify that file_state updates are throttled and batched every 10s in the network tab.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance by throttling file state updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces per-event file_state updates with a single throttled updater that batches session, edit, and visit info every 10s, removing old handlers.
> 
> - **Editor**:
>   - Add `FileStateUpdater` to coalesce `lastSessionState`, `lastEditAt`, and `lastVisitAt` updates, throttled to 10,000ms.
>   - Replace ad-hoc session-state listener and remove `SneakyFileUpdateHandler` usage.
> - **App**:
>   - Remove `onFileEdit` and `onFileSessionStateUpdate` methods and related usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ed36219027c66a0f2a83c1993fd01d63400dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->