### PR TITLE
fix(translations): update Spanish translation for bold text

### DIFF
--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -454,7 +454,7 @@
 	"tool.rectangle": "Rectángulo",
 	"tool.replace-media": "Sustituir contenido multimedia",
 	"tool.rhombus": "Rombo",
-	"tool.rich-text-bold": "Atrevido",
+	"tool.rich-text-bold": "Negrita",
 	"tool.rich-text-bulletList": "Lista con viñetas",
 	"tool.rich-text-code": "Código",
 	"tool.rich-text-header": "Encabezamiento",


### PR DESCRIPTION
Fixes translation as "Atrevido" is translation for a person being bold, not text.
<img width="808" height="250" alt="image" src="https://github.com/user-attachments/assets/ebaf94b7-32ac-482b-a0a5-fb56d97ffaaf" />


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

N/A

### Release notes

- Fixed Spanish translation for 'bold' text formatting button tooltip