### PR TITLE
fix(dotcom): resolve immutable headers error in sync-worker

### DIFF
--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -184,9 +184,12 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 			ctx: this.ctx,
 			after: (response, request) => {
 				const setCookies = response.headers.getAll('set-cookie')
+				// Create a new Response with mutable headers before passing to corsify
+				// to avoid "Can't modify immutable headers" error
+				const mutableResponse = new Response(response.body, response)
 				// unfortunately corsify mishandles the set-cookie header, so
 				// we need to manually add it back in
-				const result = corsify(response, request)
+				const result = corsify(mutableResponse, request)
 				if ([...setCookies].length === 0) {
 					return result
 				}


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/6951

we were getting these errors which it seems happens when there's a server error, and it's trying to set an error response code (e.g. 4xx/5xx): https://tldraw.sentry.io/issues/6965320409/events/97f5af83422748fc82dc345776874544/events/?environment=production-tldraw-multiplayer&project=4503966963662848&query=user.display%3A2a06%3A98c0%3A3600%3A%3A103&referrer=previous-event

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging and verify that 4xx/5xx errors no longer trigger immutable header exceptions in the worker.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug in the sync worker where server errors could cause header mutation failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap the response in `worker.ts` before calling `corsify` to prevent immutable headers errors while preserving `set-cookie` handling.
> 
> - **Worker CORS handling**
>   - In `apps/dotcom/sync-worker/src/worker.ts` `after` hook, create a mutable `Response` (`new Response(response.body, response)`) and pass it to `corsify`.
>   - Continue manually restoring `set-cookie` headers on the final response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d83e76d9595a92c82b616e7a285dab686ab8b4ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->