### PR TITLE
feat(editor): add tracking to watermark to identify usage

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -180,6 +180,7 @@ export class LicenseManager {
 						: 'unknown'
 			url.searchParams.set('sku', sku)
 		}
+		url.searchParams.set('url', window.location.href)
 		if (process.env.NODE_ENV) {
 			url.searchParams.set('environment', process.env.NODE_ENV)
 		}


### PR DESCRIPTION
adds `url` so that we can discover which sites are using tldraw

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added URL tracking to the watermark evaluation to help identify usage sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the current page URL to the watermark/evaluation tracking fetch in `LicenseManager.maybeTrack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3343b8c055c83a189437c0b147bdcda74cf464a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->