### PR TITLE
fix(editor): resolve InFrontOfTheCanvas menu click handling

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -300,7 +300,7 @@ input,
 
 .tl-canvas__in-front {
 	position: absolute;
-	inset: 0;
+	/* this is positioned by the DefaultCanvas component via the useSizeMatching hook */
 	pointer-events: none;
 	z-index: var(--tl-layer-canvas-in-front);
 }


### PR DESCRIPTION
context: https://discord.com/channels/859816885297741824/1429837310920495229

alternative to #6980

### Change type

- [x] `bugfix` 

### Test plan

1. Open a menu rendered via InFrontOfTheCanvas.
2. Verify that pointer events are no longer blocked while the menu is open.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug affecting menus rendered by the InFrontOfTheCanvas component, wherein pointer events were being blocked while a menu is open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renders `InFrontOfTheCanvas` outside the canvas and syncs its size/position to overlays to fix menu click event blocking.
> 
> - **Editor (`DefaultCanvas.tsx`)**
>   - Move `InFrontOfTheCanvasWrapper` outside the canvas and render it in a separate `div` (`tl-canvas__in-front`).
>   - Introduce `useSizeMatching` (uses `useLayoutEffect`, `ResizeObserver`, `IntersectionObserver`) to mirror size/position between overlay leader (`.tl-overlays` via `leaderRef`) and follower (`.tl-canvas__in-front` via `followerRef`).
>   - Wire refs and event handlers accordingly; remove the inner `tl-canvas__in-front`.
> - **Styles (`packages/editor/editor.css`)**
>   - Update `.tl-canvas__in-front`: remove `inset: 0` and document that positioning is controlled by `DefaultCanvas` via `useSizeMatching`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b3c8803a22a1a4357a2ea2b8d2e6cf37a3acb07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->