### PR TITLE
fix(a11y): prevent shape navigation when pressing alt+tab

### DIFF
--- a/apps/examples/e2e/tests/test-kbds.spec.ts
+++ b/apps/examples/e2e/tests/test-kbds.spec.ts
@@ -818,4 +818,26 @@ test.describe('Shape Navigation', () => {
 			isInInnerFrame: true,
 		})
 	})
+
+	test('Tab navigation does not happen when alt key is pressed', async ({ isMobile }) => {
+		if (isMobile) return // can't test this on mobile
+
+		// Create multiple shapes
+		await page.keyboard.press('r')
+		await page.mouse.click(100, 100)
+		await page.keyboard.press('r')
+		await page.mouse.click(250, 100)
+		await page.keyboard.press('r')
+		await page.mouse.click(400, 100)
+		await page.keyboard.press('v')
+
+		// Click on the first shape to select it
+		await page.mouse.click(100, 100)
+
+		await page.keyboard.press('Alt+Tab')
+		expect(await page.evaluate(() => editor.getOnlySelectedShape())).toMatchObject({
+			x: 0,
+			y: 0,
+		})
+	})
 })

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -507,7 +507,7 @@ export class Idle extends StateNode {
 			}
 			case 'Tab': {
 				const selectedShapes = this.editor.getSelectedShapes()
-				if (selectedShapes.length) {
+				if (selectedShapes.length && !info.altKey) {
 					this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
 				}
 				break
@@ -557,7 +557,7 @@ export class Idle extends StateNode {
 			}
 			case 'Tab': {
 				const selectedShapes = this.editor.getSelectedShapes()
-				if (selectedShapes.length) {
+				if (selectedShapes.length && !info.altKey) {
 					this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
 				}
 				break


### PR DESCRIPTION
via dotcom-feedback, this affects Windows users

(h/t to @ds300, thx for flagging)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open tldraw on Windows.
2. Press Alt+Tab to switch windows.
3. Observe that shape selection does not change.

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fixed an issue where Alt+Tab would trigger shape navigation on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops Tab-based shape navigation when Alt is held and adds e2e coverage for Alt+Tab behavior.
> 
> - **Editor logic (`packages/tldraw/.../Idle.ts`)**:
>   - Modify `Tab` handling in `onKeyRepeat` and `onKeyUp` to navigate only when `!info.altKey`.
> - **E2E tests (`apps/examples/e2e/tests/test-kbds.spec.ts`)**:
>   - Add test ensuring Alt+Tab does not change selection.
>   - Keep existing shape navigation tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d1ab2c9be4e591b903912c5d5f4956b81a1e26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->