### PR TITLE
fix(dotcom): resolve file deletion error toast

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -734,19 +734,21 @@ export class TldrawApp {
 	}
 
 	updateFileState(fileId: string, partial: Omit<TlaFileStatePartial, 'fileId' | 'userId'>) {
+		// ignore updates to files that have been deleted
+		const file = this.getFile(fileId)
+		if (!file || file.isDeleted) return
 		this.z.mutate.file_state.update({ ...partial, fileId, userId: this.userId })
 	}
 
 	updateFile(fileId: string, partial: Partial<TlaFile>) {
+		// ignore updates to files that have been deleted
+		const file = this.getFile(fileId)
+		if (!file || file.isDeleted) return
 		this.z.mutate.file.update({ id: fileId, ...partial })
 	}
 
 	async onFileEnter(fileId: string) {
 		this.z.mutate.onEnterFile({ fileId, time: Date.now() })
-	}
-
-	onFileExit(fileId: string) {
-		this.updateFileState(fileId, { lastVisitAt: Date.now() })
 	}
 
 	static async create(opts: {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -232,7 +232,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		return () => {
 			clearTimeout(timer)
 			if (didEnter && !storeError.current) {
-				app.onFileExit(fileId)
+				app.updateFileState(fileId, { lastVisitAt: Date.now() })
 			}
 		}
 	}, [app, fileId, store.status])


### PR DESCRIPTION
deletions were going through but we were also triggering an error due to a 'on file exit' behaviour where a file_state update was triggered and that was failing due to the fact that the file had been deleted.

### Change type

- [x] `bugfix` 

### Test plan

1. Delete a file in the dotcom app.
2. Verify that no error toast appears after the file is successfully deleted.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where deleting a file would trigger an unnecessary error toast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents updates on deleted files and replaces onFileExit with a direct lastVisitAt update to avoid deletion-related errors.
> 
> - **App logic (`TldrawApp.ts`)**:
>   - Add guards in `updateFileState` and `updateFile` to skip updates when the file is missing or `isDeleted`.
>   - Remove `onFileExit` method.
> - **Editor (`TlaEditor.tsx`)**:
>   - In unmount cleanup, replace `app.onFileExit(fileId)` with `app.updateFileState(fileId, { lastVisitAt })`, preserving the existing error guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba0e318d3063aa7e2ac53035e3f00ee44c8c4fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->