### PR TITLE
fix(dotcom): flush file state on beforeunload

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -343,6 +343,14 @@ class FileStateUpdater {
 				{ scope: 'document', source: 'user' }
 			)
 		)
+		const flush = () => {
+			this.update.flush()
+		}
+		window.addEventListener('beforeunload', flush)
+		this.disposables.add(() => {
+			window.removeEventListener('beforeunload', flush)
+		})
+
 		const sessionState$ = createSessionStateSnapshotSignal(editor.store)
 		let firstTime = true
 		this.disposables.add(


### PR DESCRIPTION
If you close tab or refresh, your latest viewport position might not be saved. Adding this beforeunload callback seems to work locally (_most_ of the time?) 

anyway it can't hurt.

### Change type

- [x] `bugfix` 

### Test plan

1. Open the editor and move the viewport.
2. Refresh the page or close the tab immediately.
3. Verify that the viewport position is persisted upon return.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the latest viewport position might not be saved when closing or refreshing the tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Flushes pending file state updates on tab close/refresh to persist the latest session/viewport state.
> 
> - **Editor**:
>   - Add `beforeunload` listener in `TlaEditor.tsx` `FileStateUpdater` to `flush` throttled `update`, ensuring latest `session state` and timestamps are saved when the page is closed or refreshed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e8b0c2f267d7f86a549f7e98dcc93cba2325137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->