### PR TITLE
fix(ui): resolve clipboard functionality in cross-realm apps

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -820,16 +820,16 @@ export function useNativeClipboardEvents() {
 			trackEvent('paste', { source: 'kbd' })
 		}
 
-		ownerDocument.addEventListener('copy', copy)
-		ownerDocument.addEventListener('cut', cut)
-		ownerDocument.addEventListener('paste', paste)
-		ownerDocument.addEventListener('pointerup', pointerUpHandler)
+		ownerDocument?.addEventListener('copy', copy)
+		ownerDocument?.addEventListener('cut', cut)
+		ownerDocument?.addEventListener('paste', paste)
+		ownerDocument?.addEventListener('pointerup', pointerUpHandler)
 
 		return () => {
-			ownerDocument.removeEventListener('copy', copy)
-			ownerDocument.removeEventListener('cut', cut)
-			ownerDocument.removeEventListener('paste', paste)
-			ownerDocument.removeEventListener('pointerup', pointerUpHandler)
+			ownerDocument?.removeEventListener('copy', copy)
+			ownerDocument?.removeEventListener('cut', cut)
+			ownerDocument?.removeEventListener('paste', paste)
+			ownerDocument?.removeEventListener('pointerup', pointerUpHandler)
 		}
 	}, [editor, trackEvent, appIsFocused, ownerDocument])
 }


### PR DESCRIPTION
fix https://github.com/tldraw/tldraw/issues/6354

sorry for the delay @derekcicerone!

### Change type

- [x] `bugfix`

### Test plan

1. Use tldraw in a cross-realm environment (e.g. an iframe or separate window context).
2. Verify that copy, cut, and paste operations work correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes clipboard functionality when tldraw is running in a cross-realm environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scope clipboard APIs and event listeners to the editor's ownerDocument to support cross-realm environments.
> 
> - **Clipboard handling**:
>   - Resolve `navigator` from `editor.getContainer().ownerDocument?.defaultView` (fallback to `globalThis.navigator`) for copy operations.
> - **Native events**:
>   - Bind `copy`/`cut`/`paste`/`pointerup` listeners to `ownerDocument` from the editor container instead of `document`.
>   - Include `ownerDocument` in `useEffect` dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9bc2f7de91e2a9f87321c7cee8abb2e83364f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->