### PR TITLE
docs: add diveclub podcast redirect

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -161,8 +161,7 @@ const nextConfig = {
 			},
 			{
 				source: '/diveclub',
-				destination:
-					'/?utm_source=diveclub&utm_medium=podcast&utm_campaign=steve_diveclub_2025',
+				destination: '/?utm_source=diveclub&utm_medium=podcast&utm_campaign=steve_diveclub_2025',
 				permanent: true,
 			},
 		]


### PR DESCRIPTION
Adds a new redirect from '/diveclub' to the homepage with UTM tracking parameters for the podcast.

### Change type

- [x] `other`

### Test plan

1. Navigate to /diveclub and verify it redirects to the homepage with the correct UTM parameters.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a redirect for the Dive Club podcast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new redirect from `'/diveclub'` to the homepage with UTM tracking parameters.
> 
> - **Redirects**
>   - Add `'/diveclub'` → `'/?utm_source=diveclub&utm_medium=podcast&utm_campaign=steve_diveclub_2025'` in `apps/docs/next.config.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c10c2f78697c265c3c9bdd44ef3d94d6485f914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->