### PR TITLE
feat(dotcom): separate tables for fairies

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyApp.tsx
+++ b/apps/dotcom/client/src/fairy/FairyApp.tsx
@@ -195,9 +195,7 @@ export function FairyApp({
 			}
 
 			try {
-				const user = app.getUser()
-				app.z.mutate.user.update({
-					id: user.id,
+				app.z.mutate.user.updateFairies({
 					fairies: JSON.stringify(configs),
 				})
 			} catch (e) {

--- a/apps/dotcom/client/src/tla/app/ClientQuery.ts
+++ b/apps/dotcom/client/src/tla/app/ClientQuery.ts
@@ -4,6 +4,7 @@ import {
 	TlaGroupUser,
 	TlaRow,
 	TlaSchema,
+	TlaUser,
 } from '@tldraw/dotcom-shared'
 import { assert, compact, computed, react, sleep } from 'tldraw'
 
@@ -39,6 +40,15 @@ export class ClientQuery<Row extends TlaRow, isOne extends boolean = false> {
 			this.wheres.every(([key, value]) => row[key] === value)
 		) as any[]
 
+		if (this.table === 'user') {
+			rows = rows.map((row: TlaUser) => {
+				return {
+					...row,
+					fairies: data.user_fairies.find((uf) => uf.userId === row.id)?.fairies || null,
+				}
+			})
+		}
+
 		if (this.table === 'file_state') {
 			rows = compact(
 				rows.map((row: TlaFileState) => {
@@ -47,6 +57,8 @@ export class ClientQuery<Row extends TlaRow, isOne extends boolean = false> {
 					return {
 						...row,
 						file,
+						fairyState:
+							data.file_fairies.find((ff) => ff.fileId === row.fileId)?.fairyState || null,
 					}
 				})
 			)

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -89,8 +89,8 @@ export class TldrawApp {
 
 	readonly z: ZeroPolyfill | Zero<TlaSchema, TlaMutators>
 
-	private readonly user$: Signal<TlaUser | undefined>
-	private readonly fileStates$: Signal<(TlaFileState & { file: TlaFile })[]>
+	private readonly user$: Signal<(TlaUser & { fairies: string }) | undefined>
+	private readonly fileStates$: Signal<(TlaFileState & { file: TlaFile; fairyState: string })[]>
 	private readonly groupMemberships$: Signal<
 		(TlaGroupUser & {
 			group: TlaGroup
@@ -752,9 +752,9 @@ export class TldrawApp {
 	}
 
 	onFairyStateUpdate(fileId: string, fairyState: any) {
-		this.updateFileState(fileId, {
+		this.z.mutate.file_state.updateFairies({
+			fileId,
 			fairyState: JSON.stringify(fairyState),
-			lastVisitAt: Date.now(),
 		})
 	}
 
@@ -792,7 +792,6 @@ export class TldrawApp {
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			flags: '',
-			fairies: null,
 			allowAnalyticsCookie: null,
 			...restOfPreferences,
 			inputMode: restOfPreferences.inputMode ?? null,

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -28,7 +28,7 @@ import {
 import { getResumeType } from './replicator/getResumeType'
 import { pruneTopicSubscriptionsSql } from './replicator/pruneTopicSubscriptions'
 import { migrate } from './replicator/replicatorMigrations'
-import { ChangeV2, ReplicationEvent, relevantTables } from './replicator/replicatorTypes'
+import { ChangeV2, ReplicationEvent, replicatedTables } from './replicator/replicatorTypes'
 import {
 	Analytics,
 	Environment,
@@ -476,7 +476,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private parseChange(change: Wal2Json.Change): ChangeV2 | null {
 		const table = change.table as ReplicationEvent['table']
-		if (change.kind === 'truncate' || change.kind === 'message' || !(table in relevantTables)) {
+		if (change.kind === 'truncate' || change.kind === 'message' || !(table in replicatedTables)) {
 			return null
 		}
 

--- a/apps/dotcom/sync-worker/src/fetchEverythingSql.snap.ts
+++ b/apps/dotcom/sync-worker/src/fetchEverythingSql.snap.ts
@@ -11,7 +11,9 @@ WITH
   all_group_users AS (SELECT ug.* FROM my_groups mg JOIN public."group_user" ug ON ug."groupId" = mg."id"),
   group_file_ownership AS (SELECT fg.* FROM my_groups mg JOIN public."group_file" fg ON fg."groupId" = mg."id"),
   group_files AS (SELECT f.* FROM group_file_ownership gfo JOIN public."file" f ON f.id = gfo."fileId"),
-  all_files AS (SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from group_files)
+  all_files AS (SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from group_files),
+  my_fairies AS (SELECT * FROM public."user_fairies" WHERE "userId" = $1),
+  file_fairies AS (SELECT * FROM public."file_fairies" WHERE "userId" = $1)
 SELECT
   'user' as "table",
   "allowAnalyticsCookie"::boolean as "0",
@@ -56,10 +58,10 @@ SELECT
   "lastEditAt"::bigint as "10",
   "lastVisitAt"::bigint as "11",
   null::bigint as "12",
-  "fairyState"::text as "13",
-  "fileId"::text as "14",
-  "lastSessionState"::text as "15",
-  "userId"::text as "16",
+  "fileId"::text as "13",
+  "lastSessionState"::text as "14",
+  "userId"::text as "15",
+  null::text as "16",
   null::text as "17",
   null::text as "18",
   null::text as "19",
@@ -182,6 +184,62 @@ SELECT
 FROM all_group_users
 UNION ALL
 SELECT
+  'user_fairies' as "table",
+  null::boolean as "0",
+  null::boolean as "1",
+  null::boolean as "2",
+  null::boolean as "3",
+  null::boolean as "4",
+  null::boolean as "5",
+  null::boolean as "6",
+  null::boolean as "7",
+  null::boolean as "8",
+  null::bigint as "9",
+  null::bigint as "10",
+  null::bigint as "11",
+  null::bigint as "12",
+  "fairies"::text as "13",
+  "userId"::text as "14",
+  null::text as "15",
+  null::text as "16",
+  null::text as "17",
+  null::text as "18",
+  null::text as "19",
+  null::text as "20",
+  null::text as "21",
+  null::text as "22",
+  null::text as "23"
+FROM my_fairies
+UNION ALL
+SELECT
+  'file_fairies' as "table",
+  null::boolean as "0",
+  null::boolean as "1",
+  null::boolean as "2",
+  null::boolean as "3",
+  null::boolean as "4",
+  null::boolean as "5",
+  null::boolean as "6",
+  null::boolean as "7",
+  null::boolean as "8",
+  null::bigint as "9",
+  null::bigint as "10",
+  null::bigint as "11",
+  null::bigint as "12",
+  "fairyState"::text as "13",
+  "fileId"::text as "14",
+  "userId"::text as "15",
+  null::text as "16",
+  null::text as "17",
+  null::text as "18",
+  null::text as "19",
+  null::text as "20",
+  null::text as "21",
+  null::text as "22",
+  null::text as "23"
+FROM file_fairies
+UNION ALL
+SELECT
   'user_mutation_number' as "table",
   null::boolean as "0",
   null::boolean as "1",
@@ -271,10 +329,9 @@ export const columnNamesByAlias = {
 		'9': 'firstVisitAt',
 		'10': 'lastEditAt',
 		'11': 'lastVisitAt',
-		'13': 'fairyState',
-		'14': 'fileId',
-		'15': 'lastSessionState',
-		'16': 'userId',
+		'13': 'fileId',
+		'14': 'lastSessionState',
+		'15': 'userId',
 	},
 	file: {
 		'0': 'isDeleted',
@@ -319,6 +376,15 @@ export const columnNamesByAlias = {
 		'16': 'userColor',
 		'17': 'userId',
 		'18': 'userName',
+	},
+	user_fairies: {
+		'13': 'fairies',
+		'14': 'userId',
+	},
+	file_fairies: {
+		'13': 'fairyState',
+		'14': 'fileId',
+		'15': 'userId',
 	},
 	user_mutation_number: {
 		'9': 'mutationNumber',

--- a/apps/dotcom/sync-worker/src/fetchEverythingSql.test.ts
+++ b/apps/dotcom/sync-worker/src/fetchEverythingSql.test.ts
@@ -79,6 +79,14 @@ const withs = [
 		expression:
 			'SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from group_files',
 	},
+	{
+		alias: 'my_fairies',
+		expression: 'SELECT * FROM public."user_fairies" WHERE "userId" = $1',
+	},
+	{
+		alias: 'file_fairies',
+		expression: 'SELECT * FROM public."file_fairies" WHERE "userId" = $1',
+	},
 ] as const satisfies WithClause[]
 
 type WithTable = (typeof withs)[number]['alias']
@@ -121,6 +129,16 @@ const selects: SelectClause[] = [
 		from: 'all_group_users',
 		outputTableName: 'group_user',
 		columns: makeColumnStuff(schema.tables.group_user),
+	},
+	{
+		from: 'my_fairies',
+		outputTableName: 'user_fairies',
+		columns: makeColumnStuff(schema.tables.user_fairies),
+	},
+	{
+		from: 'file_fairies',
+		outputTableName: 'file_fairies',
+		columns: makeColumnStuff(schema.tables.file_fairies),
 	},
 	{
 		from: 'public."user_mutation_number"',

--- a/apps/dotcom/sync-worker/src/replicator/ChangeCollator.test.ts
+++ b/apps/dotcom/sync-worker/src/replicator/ChangeCollator.test.ts
@@ -44,7 +44,6 @@ describe('ChangeCollator', () => {
 					firstVisitAt: null,
 					lastEditAt: null,
 					lastSessionState: null,
-					fairyState: null,
 					lastVisitAt: null,
 					isFileOwner: false,
 					isPinned: null,

--- a/apps/dotcom/sync-worker/src/replicator/ChangeCollator.ts
+++ b/apps/dotcom/sync-worker/src/replicator/ChangeCollator.ts
@@ -7,13 +7,19 @@ import {
 	TlaRow,
 	TlaUser,
 	TlaUserMutationNumber,
-	ZTable,
 } from '@tldraw/dotcom-shared'
 import { exhaustiveSwitchError } from '@tldraw/utils'
 import { DurableObject } from 'cloudflare:workers'
 import { ZReplicationChange } from '../UserDataSyncer'
 import { Subscription } from './Subscription'
-import { ChangeV2, ReplicationEvent, ReplicatorEffect, Topic } from './replicatorTypes'
+import {
+	ChangeV2,
+	ReplicatedRow,
+	ReplicatedTable,
+	ReplicationEvent,
+	ReplicatorEffect,
+	Topic,
+} from './replicatorTypes'
 
 /**
  * Interface for collecting and organizing database changes for delivery to users.
@@ -217,8 +223,8 @@ export class LiveChangeCollator implements ChangeCollator {
 					}
 				: {
 						type: 'row_update',
-						row: change.row,
-						table: table as ZTable,
+						row: change.row as ReplicatedRow,
+						table: table as ReplicatedTable,
 						event: command,
 					}
 

--- a/apps/dotcom/sync-worker/src/replicator/replicatorTypes.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorTypes.ts
@@ -1,9 +1,9 @@
-import { TlaFile, TlaRow } from '@tldraw/dotcom-shared'
+import { TlaFile, TlaFileFairy, TlaRow, TlaUserFairy } from '@tldraw/dotcom-shared'
 import { stringEnum } from '@tldraw/utils'
 
 export type Topic = `user:${string}` | `file:${string}` | `group:${string}`
 
-export const relevantTables = stringEnum(
+export const replicatedTables = stringEnum(
 	'user',
 	'file',
 	'file_state',
@@ -12,10 +12,12 @@ export const relevantTables = stringEnum(
 	'group_user',
 	'group_file'
 )
+export type ReplicatedTable = keyof typeof replicatedTables
+export type ReplicatedRow = Exclude<TlaRow, TlaUserFairy | TlaFileFairy>
 
 export interface ReplicationEvent {
 	command: 'insert' | 'update' | 'delete'
-	table: keyof typeof relevantTables
+	table: keyof typeof replicatedTables
 }
 
 export interface ChangeV1 {

--- a/apps/dotcom/sync-worker/src/zero/ServerCrud.ts
+++ b/apps/dotcom/sync-worker/src/zero/ServerCrud.ts
@@ -1,6 +1,14 @@
 import { SchemaValue } from '@rocicorp/zero'
 import { TableCRUD } from '@rocicorp/zero/out/zql/src/mutate/custom'
-import { DB, TlaFile, TlaSchema, ZErrorCode } from '@tldraw/dotcom-shared'
+import {
+	DB,
+	TlaFile,
+	TlaRow,
+	TlaRowPartial,
+	TlaSchema,
+	ZErrorCode,
+	ZTable,
+} from '@tldraw/dotcom-shared'
 import { assert, omit } from '@tldraw/utils'
 import {
 	CompiledQuery,
@@ -14,16 +22,12 @@ import { PoolClient, QueryResult, QueryResultRow } from 'pg'
 import { ZMutationError } from './ZMutationError'
 const quote = (s: string) => JSON.stringify(s)
 
-/**
- * This perf hack allows us to get file data into the client more quickly.
- * For new files, we wake up that file's DO immediately after the file is created, rather
- * than waiting for the update to trickle through to the replicator.
- *
- * For files that are not owned by the user, we add the file to the user DO's store and
- * broadcast it to the client immediately so that it's ready to be used asap.
- */
-export interface PerfHackHooks {
-	newFiles: TlaFile[]
+export type ChangeAccumulator = {
+	[table in ZTable]?: {
+		added?: TlaRow[]
+		updated?: TlaRow[]
+		removed?: TlaRowPartial[]
+	}
 }
 
 // this is a kind of 'headless' kysely client that we use to compile queries
@@ -41,20 +45,55 @@ export class ServerCRUD implements TableCRUD<TlaSchema['tables'][keyof TlaSchema
 		private readonly client: PoolClient,
 		private readonly table: TlaSchema['tables'][keyof TlaSchema['tables']],
 		private readonly signal: AbortSignal,
-		private readonly perfHackHooks?: PerfHackHooks
+		private readonly changeAccumulator?: ChangeAccumulator
 	) {}
-	private async _onNewRow(data: any) {
-		if (!this.perfHackHooks) return
-		if (this.table.name === 'file_state') {
+	private async _trackAdded(data: any) {
+		if (!this.changeAccumulator) return
+
+		// Special case: when file_state is added, track the corresponding file
+		if (this.table.name === 'file_state' && this.changeAccumulator.file?.added) {
 			const res = await this.client.query<TlaFile>(
 				`select * from public.${quote('file')} where id = $1`,
 				[data.fileId]
 			)
 			assert(res.rowCount === 1, 'file not found')
-			this.perfHackHooks.newFiles.push(res.rows[0])
-		} else if (this.table.name === 'file') {
-			this.perfHackHooks.newFiles.push(data as TlaFile)
+			this.changeAccumulator.file.added.push(res.rows[0])
 		}
+
+		// Track the added row for this table
+		if (this.changeAccumulator[this.table.name]?.added) {
+			const res = await this.client.query(
+				`select * from public.${quote(this.table.name)} where ${this.table.primaryKey
+					.map((key, i) => `${quote(key)} = $${i + 1}`)
+					.join(' AND ')}`,
+				this.table.primaryKey.map((key) => data[key])
+			)
+			assert(res.rowCount === 1, 'row not found')
+			this.changeAccumulator[this.table.name]?.added!.push(res.rows[0])
+		}
+	}
+
+	private async _trackUpdated(data: any) {
+		if (!this.changeAccumulator?.[this.table.name]?.updated) return
+
+		const res = await this.client.query(
+			`select * from public.${quote(this.table.name)} where ${this.table.primaryKey
+				.map((key, i) => `${quote(key)} = $${i + 1}`)
+				.join(' AND ')}`,
+			this.table.primaryKey.map((key) => data[key])
+		)
+		assert(res.rowCount === 1, 'row not found')
+		this.changeAccumulator[this.table.name]?.updated!.push(res.rows[0])
+	}
+
+	private async _trackRemoved(data: any) {
+		if (!this.changeAccumulator?.[this.table.name]?.removed) return
+
+		const primaryKeyData: any = {}
+		for (const key of this.table.primaryKey) {
+			primaryKeyData[key] = data[key]
+		}
+		this.changeAccumulator[this.table.name]?.removed!.push(primaryKeyData)
 	}
 
 	private async _exec<T extends QueryResultRow>(query: {
@@ -85,14 +124,13 @@ export class ServerCRUD implements TableCRUD<TlaSchema['tables'][keyof TlaSchema
 		assert(!this.signal.aborted, 'CRUD usage outside of mutator scope')
 		assertRowIsValid(data, this.table)
 		await this._exec(db.insertInto(this.table.name).values(data))
-		await this._onNewRow(data)
+		await this._trackAdded(data)
 	}
 
 	async upsert(data: any) {
 		assert(!this.signal.aborted, 'CRUD usage outside of mutator scope')
 		assertRowIsValid(data, this.table)
 
-		// we only need this for the perf hack
 		const didExist = await this._doesExist(data)
 
 		await this._exec(
@@ -105,7 +143,9 @@ export class ServerCRUD implements TableCRUD<TlaSchema['tables'][keyof TlaSchema
 		)
 
 		if (!didExist) {
-			await this._onNewRow(data)
+			await this._trackAdded(data)
+		} else {
+			await this._trackUpdated(data)
 		}
 	}
 
@@ -113,6 +153,7 @@ export class ServerCRUD implements TableCRUD<TlaSchema['tables'][keyof TlaSchema
 		assert(!this.signal.aborted, 'CRUD usage outside of mutator scope')
 		assertRowIsValid(data, this.table)
 		await this._exec(this._wherePrimaryKey(db.deleteFrom(this.table.name), data))
+		await this._trackRemoved(data)
 	}
 
 	async update(data: any) {
@@ -134,6 +175,7 @@ export class ServerCRUD implements TableCRUD<TlaSchema['tables'][keyof TlaSchema
 				throw new ZMutationError(ZErrorCode.bad_request, `update failed, no matching rows`)
 			}
 		}
+		await this._trackUpdated(data)
 	}
 }
 

--- a/apps/dotcom/zero-cache/CONTEXT.md
+++ b/apps/dotcom/zero-cache/CONTEXT.md
@@ -79,7 +79,6 @@ CREATE TABLE "file_state" (
   "firstVisitAt" BIGINT,
   "lastEditAt" BIGINT,
   "lastSessionState" VARCHAR,
-  "fairyState" VARCHAR,
   "lastVisitAt" BIGINT,
   PRIMARY KEY ("userId", "fileId"),
   FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE,

--- a/apps/dotcom/zero-cache/migrations/024_add_fairies.sql
+++ b/apps/dotcom/zero-cache/migrations/024_add_fairies.sql
@@ -1,0 +1,15 @@
+
+CREATE TABLE user_fairies (
+  "userId" VARCHAR PRIMARY KEY,
+  "fairies" VARCHAR,
+  CONSTRAINT user_fairies_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE file_fairies (
+  "fileId" VARCHAR,
+  "userId" VARCHAR,
+  "fairyState" VARCHAR,
+  PRIMARY KEY ("fileId", "userId"),
+  CONSTRAINT file_fairies_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
+  CONSTRAINT file_fairies_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE
+);

--- a/apps/dotcom/zero-cache/migrations/024_add_fairy_state.sql
+++ b/apps/dotcom/zero-cache/migrations/024_add_fairy_state.sql
@@ -1,5 +1,0 @@
--- Purpose: Add a fairyState column to the file_state table that stores per-user, per-file fairy agent state.
-
-ALTER TABLE file_state
-ADD COLUMN "fairyState" VARCHAR;
-

--- a/apps/dotcom/zero-cache/migrations/025_add_fairies_column.sql
+++ b/apps/dotcom/zero-cache/migrations/025_add_fairies_column.sql
@@ -1,5 +1,0 @@
--- Purpose: Add a fairies column to the user table to store per-user fairy configurations (outfit, personality, wand).
-
-ALTER TABLE "user"
-ADD COLUMN "fairies" VARCHAR;
-

--- a/packages/dotcom-shared/CONTEXT.md
+++ b/packages/dotcom-shared/CONTEXT.md
@@ -40,7 +40,6 @@ const user = table('user')
 		isPasteAtCursorMode: boolean().optional(),
 		enhancedA11yMode: boolean().optional(),
 		allowAnalyticsCookie: boolean().optional(),
-		fairies: string().optional(),
 	})
 	.primaryKey('id')
 
@@ -77,7 +76,6 @@ const file_state = table('file_state')
 		lastVisitAt: number().optional(),
 		isFileOwner: boolean().optional(),
 		isPinned: boolean().optional(),
-		fairyState: string().optional(),
 	})
 	.primaryKey('userId', 'fileId')
 ```

--- a/packages/dotcom-shared/src/OptimisticAppStore.ts
+++ b/packages/dotcom-shared/src/OptimisticAppStore.ts
@@ -113,7 +113,6 @@ export class OptimisticAppStore {
 			case 'insert':
 				return { ...prev, [table]: [...rows.filter((r) => !matchExisting(r)), row] }
 			case 'update':
-				assert(rows.some(matchExisting), 'row not found ' + table + ' ' + JSON.stringify(row))
 				return {
 					...prev,
 					[table]: rows.map((existing) => {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -155,6 +155,9 @@ export function createMutators(userId: string) {
 				disallowImmutableMutations(user, immutableColumns.user)
 				await tx.mutate.user.update(user)
 			},
+			updateFairies: async (tx, { fairies }: { fairies: string }) => {
+				await tx.mutate.user_fairies.upsert({ userId, fairies })
+			},
 		},
 		file: {
 			/** @deprecated */
@@ -232,6 +235,9 @@ export function createMutators(userId: string) {
 
 				await tx.mutate.file_state.upsert(fileState)
 			},
+			updateFairies: async (tx, { fileId, fairyState }: { fileId: string; fairyState: string }) => {
+				await tx.mutate.file_fairies.upsert({ fileId, userId, fairyState })
+			},
 		},
 
 		init: async (tx, { user, time }: { user: TlaUser; time: number }) => {
@@ -307,7 +313,6 @@ export function createMutators(userId: string) {
 						lastVisitAt: null,
 						isFileOwner: true,
 						isPinned: false,
-						fairyState: null,
 					},
 				})
 				return
@@ -360,7 +365,6 @@ export function createMutators(userId: string) {
 				lastVisitAt: null,
 				firstVisitAt: null,
 				lastSessionState: null,
-				fairyState: null,
 				// isFileOwner is no longer used in new model.
 				isFileOwner: false,
 			})

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -44,7 +44,6 @@ export const user = table('user')
 		inputMode: string().optional(),
 		enhancedA11yMode: boolean().optional(),
 		allowAnalyticsCookie: boolean().optional(),
-		fairies: string().optional(),
 	})
 	.primaryKey('id')
 
@@ -58,7 +57,6 @@ export const file_state = table('file_state')
 		lastVisitAt: number().optional(),
 		isFileOwner: boolean().optional(),
 		isPinned: boolean().optional(),
-		fairyState: string().optional(),
 	})
 	.primaryKey('userId', 'fileId')
 
@@ -117,6 +115,21 @@ export const group_file = table('group_file')
 		index: string<IndexKey>().optional(),
 	})
 	.primaryKey('fileId', 'groupId')
+
+export const user_fairies = table('user_fairies')
+	.columns({
+		userId: string(),
+		fairies: string(),
+	})
+	.primaryKey('userId')
+
+export const file_fairies = table('file_fairies')
+	.columns({
+		fileId: string(),
+		userId: string(),
+		fairyState: string(),
+	})
+	.primaryKey('fileId', 'userId')
 
 const fileRelationships = relationships(file, ({ one, many }) => ({
 	owner: one({
@@ -229,7 +242,33 @@ export type TlaGroupFilePartial = Partial<TlaGroupFile> & {
 	groupId: TlaGroupFile['groupId']
 }
 
-export type TlaRow = TlaFile | TlaFileState | TlaUser | TlaGroup | TlaGroupUser | TlaGroupFile
+export type TlaUserFairyPartial = Partial<TlaUserFairy> & {
+	userId: TlaUserFairy['userId']
+}
+
+export type TlaFileFairyPartial = Partial<TlaFileFairy> & {
+	fileId: TlaFileFairy['fileId']
+	userId: TlaFileFairy['userId']
+}
+
+export type TlaRow =
+	| TlaFile
+	| TlaFileState
+	| TlaUser
+	| TlaGroup
+	| TlaGroupUser
+	| TlaGroupFile
+	| TlaUserFairy
+	| TlaFileFairy
+export type TlaRowPartial =
+	| TlaFilePartial
+	| TlaFileStatePartial
+	| TlaUserPartial
+	| TlaGroupPartial
+	| TlaGroupUserPartial
+	| TlaGroupFilePartial
+	| TlaUserFairyPartial
+	| TlaFileFairyPartial
 export interface TlaUserMutationNumber {
 	userId: string
 	mutationNumber: number
@@ -269,12 +308,14 @@ export interface DB {
 	group: TlaGroup
 	group_user: TlaGroupUser
 	group_file: TlaGroupFile
+	user_fairies: TlaUserFairy
+	file_fairies: TlaFileFairy
 	user_mutation_number: TlaUserMutationNumber
 	asset: TlaAsset
 }
 
 export const schema = createSchema({
-	tables: [user, file, file_state, group, group_user, group_file],
+	tables: [user, file, file_state, group, group_user, group_file, user_fairies, file_fairies],
 	relationships: [
 		fileRelationships,
 		fileStateRelationships,
@@ -291,6 +332,8 @@ export type TlaFileState = Row<typeof schema.tables.file_state>
 export type TlaGroup = Row<typeof schema.tables.group>
 export type TlaGroupUser = Row<typeof schema.tables.group_user>
 export type TlaGroupFile = Row<typeof schema.tables.group_file>
+export type TlaUserFairy = Row<typeof schema.tables.user_fairies>
+export type TlaFileFairy = Row<typeof schema.tables.file_fairies>
 
 interface AuthData {
 	sub: string | null

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -2,18 +2,15 @@ import { stringEnum } from '@tldraw/utils'
 import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaFile,
-	TlaFilePartial,
+	TlaFileFairy,
 	TlaFileState,
-	TlaFileStatePartial,
 	TlaGroup,
 	TlaGroupFile,
-	TlaGroupFilePartial,
-	TlaGroupPartial,
 	TlaGroupUser,
-	TlaGroupUserPartial,
 	TlaRow,
+	TlaRowPartial,
 	TlaUser,
-	TlaUserPartial,
+	TlaUserFairy,
 } from './tlaSchema'
 
 export interface Snapshot {
@@ -127,6 +124,8 @@ export interface ZStoreData {
 	group: TlaGroup[]
 	group_user: TlaGroupUser[]
 	group_file: TlaGroupFile[]
+	user_fairies: TlaUserFairy[]
+	file_fairies: TlaFileFairy[]
 	lsn: string
 }
 
@@ -139,18 +138,20 @@ export interface ZRowInsert {
 }
 
 export interface ZRowDeleteOrUpdate {
-	row:
-		| TlaFilePartial
-		| TlaFileStatePartial
-		| TlaUserPartial
-		| TlaGroupPartial
-		| TlaGroupUserPartial
-		| TlaGroupFilePartial
+	row: TlaRowPartial
 	table: ZTable
 	event: 'update' | 'delete'
 }
 
-export type ZTable = 'file' | 'file_state' | 'user' | 'group' | 'group_user' | 'group_file'
+export type ZTable =
+	| 'file'
+	| 'file_state'
+	| 'user'
+	| 'group'
+	| 'group_user'
+	| 'group_file'
+	| 'user_fairies'
+	| 'file_fairies'
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 

--- a/packages/store/src/lib/RecordType.ts
+++ b/packages/store/src/lib/RecordType.ts
@@ -105,7 +105,7 @@ export class RecordType<
 		const ephemeralKeySet = new Set<string>()
 		if (config.ephemeralKeys) {
 			for (const [key, isEphemeral] of objectMapEntries(config.ephemeralKeys)) {
-				if (isEphemeral) ephemeralKeySet.add(key)
+				if (isEphemeral) ephemeralKeySet.add(key as string)
 			}
 		}
 		this.ephemeralKeySet = ephemeralKeySet

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -319,9 +319,7 @@ export function modulate(value: number, rangeA: number[], rangeB: number[], clam
 export const noop: () => void;
 
 // @internal
-export function objectMapEntries<Key extends string, Value>(object: {
-    [K in Key]: Value;
-}): Array<[Key, Value]>;
+export function objectMapEntries<Obj extends object>(object: Obj): Array<[keyof Obj, Obj[keyof Obj]]>;
 
 // @internal
 export function objectMapEntriesIterable<Key extends string, Value>(object: {

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -108,10 +108,10 @@ export function objectMapValues<Key extends string, Value>(object: {
  * ```
  * @internal
  */
-export function objectMapEntries<Key extends string, Value>(object: {
-	[K in Key]: Value
-}): Array<[Key, Value]> {
-	return Object.entries(object) as [Key, Value][]
+export function objectMapEntries<Obj extends object>(
+	object: Obj
+): Array<[keyof Obj, Obj[keyof Obj]]> {
+	return Object.entries(object) as [keyof Obj, Obj[keyof Obj]][]
 }
 
 /**


### PR DESCRIPTION
Giving fairy state its own tables so it doesn't go through the replicator when it changes.

@TodePond I replaced the postgres migrations obviously so you'll need to `yarn clean` to test this locally, and you'll need to add the `reset-preview-db` label to your pr before merging this in to it if you want to test in the preview env. 

### Change type

- [x] `other` (or improvement, feature, api, other - pick ONE)

### Test plan

1. <Manual test steps if applicable>

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Separate fairy state into dedicated database tables to bypass replication

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move fairy configs/state to new user_fairies and file_fairies tables and update client, mutators, sync, and SQL to use them.
> 
> - **Data Model & Types**:
>   - Add `user_fairies` and `file_fairies` tables; remove `user.fairies` and `file_state.fairyState` usage.
>   - Extend `ZStoreData`, `ZTable`, row unions, and partials; exclude fairy tables from `ReplicatedTable`.
> - **Mutations & Client API**:
>   - New mutators: `user.updateFairies` and `file_state.updateFairies` writing to new tables.
>   - `TldrawApp.onFairyStateUpdate` now calls `file_state.updateFairies`.
>   - Client queries (`ClientQuery`) join in `fairies` and `fairyState` via `user_fairies`/`file_fairies`.
> - **Sync/Replicator**:
>   - Introduce `replicatedTables` (replacing `relevantTables`) to ignore fairy tables in replication.
>   - `UserDataSyncer` snapshot version bump (v4); initial data fetch includes `user_fairies`/`file_fairies` and migration path updated.
>   - `fetchEverythingSql` (+ tests) selects new tables; column mappings adjusted.
>   - `ServerCRUD` adds change accumulator to collect unsynced changes; `TLUserDurableObject` integrates and applies them instead of prior perf hooks.
> - **Client**:
>   - `TldrawApp` signals/types updated to include `fairies` and `fairyState` fields from joins.
>   - `FairyApp` saves configs via `user.updateFairies`.
> - **Misc**:
>   - Migrations: create `024_add_fairies.sql` to add new tables; remove prior column-add migrations.
>   - Minor util typing improvements (`objectMapEntries`) and store update behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27ff698addcdeb352a4189459987075e3cba80ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->