### PR TITLE
fix(ui): add file input to DOM for iOS Safari compatibility

### DIFF
--- a/packages/tldraw/src/lib/ui/getLocalFiles.ts
+++ b/packages/tldraw/src/lib/ui/getLocalFiles.ts
@@ -21,6 +21,7 @@ export function getLocalFiles(options?: {
 			const fileList = (e.target as HTMLInputElement).files
 			if (!fileList || fileList.length === 0) {
 				resolve([])
+				dispose()
 				return
 			}
 			const files = Array.from(fileList)


### PR DESCRIPTION
Apparently, for iOS, an [undocumented](https://stackoverflow.com/questions/47664777/javascript-file-input-onchange-not-working-ios-safari-only) requirement is for `input` elements to be added to the DOM for `onchange` events to fire reliably. 

We don't do this for uploading files locally, and therefore image uploads fail silently and flakily for iOS users using Safari. Lets add the `input` to the DOM. I also made sure that we resolve the promise if we find no files, to avoid hanging promises.

### Change type

- [x] `bugfix` 

### Test plan

1. Open tldraw on iOS Safari
2. Attempt to upload an image
3. Verify the upload succeeds reliably

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with iOS image uploads on Safari