### PR TITLE
feat(dotcom): reset analytics on sign out

### DIFF
--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -15,6 +15,7 @@ import {
 } from 'tldraw'
 import { useOpenUrlAndTrack } from '../../../hooks/useOpenUrlAndTrack'
 import { routes } from '../../../routeDefs'
+import { signoutAnalytics } from '../../../utils/analytics'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getCurrentEditor } from '../../utils/getCurrentEditor'
@@ -54,6 +55,7 @@ export function SignOutMenuItem() {
 	const label = useMsg(messages.signOut)
 
 	const handleSignout = useCallback(() => {
+		signoutAnalytics()
 		auth.signOut().then(clearLocalSessionState)
 		trackEvent('sign-out-clicked', { source: 'sidebar' })
 	}, [auth, trackEvent])

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -363,3 +363,8 @@ function useTrackPageViews() {
 		trackEvent('$pageview')
 	}, [location])
 }
+
+export function signoutAnalytics() {
+	if (shouldUsePosthog) posthog.reset()
+	if (shouldUseGA4) ReactGA.reset()
+}


### PR DESCRIPTION
Reset PostHog and GA4 analytics on user sign-out and wire it into the sign-out menu action.

### Change type

- [x] `other`

### Test plan

1. Sign in to the dotcom site.
2. Sign out.
3. Verify that analytics (PostHog/GA4) are reset.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reset analytics state when a user signs out of the website.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reset PostHog and GA4 analytics on user sign-out and wire it into the sign-out menu action.
> 
> - **Analytics**:
>   - Add `signoutAnalytics()` in `apps/dotcom/client/src/utils/analytics.tsx` to reset PostHog and GA4 (`posthog.reset()`, `ReactGA.reset()`).
> - **UI**:
>   - Update `SignOutMenuItem` in `apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx` to call `signoutAnalytics()` before `auth.signOut()` and tracking the `sign-out-clicked` event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ef344ec806948ed4e17d249da762b5b97c0bf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->