### PR TITLE
fix(tiptap): resolve focus issue when editor not mounted

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbarContent.tsx
@@ -54,6 +54,9 @@ export function DefaultRichTextToolbarContent({
 	// todo: we could make this a prop
 	const actions = useMemo(() => {
 		function handleOp(name: string, op: string) {
+			// Check if the editor view is available before calling operations
+			if (!textEditor.view) return
+
 			trackEvent('rich-text', { operation: name as any, source })
 			// @ts-expect-error typing this is annoying at the moment.
 			textEditor.chain().focus()[op]().run()
@@ -109,7 +112,7 @@ export function DefaultRichTextToolbarContent({
 	}, [textEditor, trackEvent, onEditLinkStart])
 
 	return actions.map(({ name, attrs, onSelect }) => {
-		const isActive = textEditor.isActive(name, attrs)
+		const isActive = textEditor.view ? textEditor.isActive(name, attrs) : false
 		return (
 			<TldrawUiToolbarButton
 				key={name}


### PR DESCRIPTION
tiptap: fix focus issue when editor not mounted

### Change type

- [x] `bugfix`

### Test plan

1. Open a rich text editor.
2. Interact with the toolbar before the editor is fully mounted or in a state where the view is undefined.
3. Verify no focus errors occur.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- tiptap: fix minor focus issue if editor isn't mounted yet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard Tiptap toolbar actions and active-state checks when the editor view isn't mounted to prevent focus errors.
> 
> - **Rich Text Toolbar (`DefaultRichTextToolbarContent.tsx`)**:
>   - Add guard to avoid invoking Tiptap operations when `textEditor.view` is undefined.
>   - Compute `isActive` defensively using `textEditor.view ? ... : false` to prevent access before mount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 299507fe5599357a20ba5e235b6799ba514aed04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->