### PR TITLE
chore(dotcom): bump min z protocol version

### DIFF
--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -171,7 +171,7 @@ export type ZErrorCode = keyof typeof ZErrorCode
 // increment this to force clients to reload
 // e.g. if we make backwards-incompatible changes to the schema
 export const Z_PROTOCOL_VERSION = 3
-export const MIN_Z_PROTOCOL_VERSION = 2
+export const MIN_Z_PROTOCOL_VERSION = 3
 
 export type ZServerSentPacket =
 	| {


### PR DESCRIPTION
gonna do the incremental groups backend rollout in staging

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Bump minimum Z protocol version to 3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise `MIN_Z_PROTOCOL_VERSION` from 2 to 3 in `packages/dotcom-shared/src/types.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5482c0abfbe190da2bd80d9aeb2dec9c5fa0779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->