### PR TITLE
feat(dotcom): add cookieless mode followup for analytics

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -170,7 +170,12 @@ function configurePosthog(options: AnalyticsOptions) {
 				: undefined,
 	}
 	if (!currentOptionsPosthog) {
+		// First time initialization only
 		posthog.init(POSTHOG_KEY, config)
+	} else {
+		// We need to call _before_ opt_in/opt_out to avoid interfering with
+		// their state management
+		posthog.set_config(config)
 	}
 
 	if (options.optedIn) {


### PR DESCRIPTION
### Change type

- [x] `other`

### Test plan

1. Verify analytics initialization on dotcom

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Update PostHog configuration logic to use set_config for cookieless mode updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch PostHog reconfiguration to posthog.set_config after the first init to avoid interfering with opt-in/opt-out state.
> 
> - **Analytics (PostHog)**:
>   - Only call `posthog.init` on first setup; subsequent updates use `posthog.set_config(config)` to reconfigure without disrupting opt-in/opt-out state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01fc22c2890c5fbbf5a4fdf26298756cc0d03855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->