### PR TITLE
fix(dotcom): ensure cache clearing for inactive users in migration

### DIFF
--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -262,7 +262,7 @@ export class UserDataSyncer {
 			this.ctx.abort()
 			return
 		}
-		this.log.debug('rebooting', source)
+		this.log.debug('rebooting', source, 'hard:', hard, 'delay:', delay)
 		this.logEvent({ type: 'reboot', id: this.userId })
 		await this.queue.push(async () => {
 			if (delay) {


### PR DESCRIPTION
testing this some more in production I noticed that it was not effectively clearing the cache data for users who aren't signed in and active. That's because if they aren't connected there's no cache so the reboot doesn't get called. this fixes that.

### Change type

- [x] `other`

### Test plan

1. Run migration for an inactive user
2. Verify R2 snapshot is deleted

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes an issue where user cache was not properly cleared during migration for inactive users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deletes the user's R2 snapshot before rebooting in `admin_migrateToGroups` to properly reset cache for offline users, and adds more detailed debug logs around migration and reboots.
> 
> - **Sync Worker**
>   - **Migration flow** (`apps/dotcom/sync-worker/src/TLUserDurableObject.ts`):
>     - Delete user snapshot `USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(...))` before cache reboot in `admin_migrateToGroups` to ensure fresh state.
>     - Add debug logs: start, result, and completion of migration.
>   - **Reboot logging** (`apps/dotcom/sync-worker/src/UserDataSyncer.ts`):
>     - Expand `reboot` debug message to include `hard` and `delay` flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e16b941798d497f62012850e76a0a6f791fb07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->