### PR TITLE
chore(dotcom): update license fallback key

### DIFF
--- a/packages/dotcom-shared/src/license.ts
+++ b/packages/dotcom-shared/src/license.ts
@@ -1,4 +1,4 @@
 const getLicenseKey = () =>
 	process.env.TLDRAW_LICENSE ||
-	'tldraw-tldraw-2026-07-10/WyJES1F3eDE5TCIsWyIqLnRsZHJhdy5jb20iXSw5LCIyMDI2LTA3LTEwIl0.ESLyxHZvYuMQYvHuiXqWlmVT6Gkq7vZcs1HeSXpsttYSGmqMgfilSIsrw6hEw53PzrqBMwIjjcmcvPl9Iil/nw'
+	'tldraw-tldraw-2026-07-10/WyIyU3h6ZzhTZyIsWyIqLnRsZHJhdy5jb20iLCIqLnRsZHJhdy5kZXYiLCIqLnRsZHJhdy5jbHViIiwiKi50bGRyYXcud29ya2Vycy5kZXYiXSw5LCIyMDI2LTA3LTEwIl0.+21jrvz5ZFmIvvA/DusCcnFV6Ab1iQQYR+INTqw/i/MmZe/5I/lhdLtqm9nprkQ1MfWL2PeyBmQui1+rjoQS1w'
 export default getLicenseKey


### PR DESCRIPTION
Updates the fallback license key to include additional allowed domains.

### Change type

- [x] `other`

### Test plan

1. Verify license key functionality on the specified domains.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated fallback license key for dotcom domains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the fallback license key in `packages/dotcom-shared/src/license.ts` to a new value including additional allowed domains.
> 
> - **License**:
>   - Update fallback license key in `packages/dotcom-shared/src/license.ts` to new value covering `*.tldraw.com`, `*.tldraw.dev`, `*.tldraw.club`, and `*.tldraw.workers.dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d19202344fd1be71812f6d173ae71ac533aec96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->