### PR TITLE
fix(dotcom): prevent store overwriting and add random persistence keys

### DIFF
--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -85,7 +85,7 @@ export class Slurper {
 	constructor(private opts: SlurperOpts & { slurpPersistenceKey: string }) {}
 
 	async slurp() {
-		if (!this.opts.editor.getDocumentSettings().meta.slurpPersistenceKey) {
+		if (this.opts.editor.store.query.records('shape').get().length === 0) {
 			// This is a one-time operation.
 			// So we need to wait a tick for react strict mode to finish
 			// doing its nasty business before we start the migration.

--- a/apps/dotcom/client/src/utils/scratch-persistence-key.ts
+++ b/apps/dotcom/client/src/utils/scratch-persistence-key.ts
@@ -15,7 +15,7 @@ import { getFromLocalStorage, setInLocalStorage, uniqueId } from 'tldraw'
 const defaultDocumentKey = 'TLDRAW_DEFAULT_DOCUMENT_NAME_v2'
 
 export function getScratchPersistenceKey() {
-	return getFromLocalStorage(defaultDocumentKey) ?? 'tldraw_document_v3'
+	return getFromLocalStorage(defaultDocumentKey) ?? 'tldraw_document_v3_' + uniqueId()
 }
 
 setInLocalStorage(defaultDocumentKey, getScratchPersistenceKey())


### PR DESCRIPTION
- make it impossible to overwrite a store with shapes already in it
- add randomness to all local store ids.

### Change type

- [x] `other`

### Test plan

1. Open the dotcom app and verify that slurping only occurs when the store is empty.
2. Verify that scratch persistence keys are unique per user session.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where stores could be overwritten during slurping and improved local store ID randomness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only slurp when the store has no shapes, and generate per-user random scratch persistence keys.
> 
> - **Slurping behavior (`tla/utils/slurping.tsx`)**:
>   - Only perform `slurp()` when the editor store has no `shape` records (`records('shape').get().length === 0`).
>   - Keep uploading local assets in the background.
> - **Persistence keys (`utils/scratch-persistence-key.ts`)**:
>   - `getScratchPersistenceKey()` now returns `tldraw_document_v3_<uniqueId>` instead of a constant.
>   - `resetScratchPersistenceKey()` continues to set a new `tldraw_document_v3_<uniqueId>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ca25a52bdc218cc3bd79a00bc6cb60146bf8aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->