### PR TITLE
fix(dotcom): init user data server-side to prevent race condition

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -66,7 +66,6 @@ import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
 import { TLAppUiContextType } from '../utils/app-ui-events'
 import { getDateFormat } from '../utils/dates'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
-import { updateLocalSessionState } from '../utils/local-session-state'
 import { Zero as ZeroPolyfill } from './zero-polyfill'
 
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
@@ -202,27 +201,14 @@ export class TldrawApp {
 			.related('groupMembers')
 	}
 
-	async preload(initialUserData: TlaUser) {
-		let didCreate = false
+	async preload() {
 		await this.userQuery().preload().complete
 		await this.changesFlushed
-		if (!this.user$.get()) {
-			didCreate = true
-
-			// Always use new groups initialization for new users (protocol v3+)
-			await this.z.mutate.init({ user: initialUserData, time: Date.now() })
-
-			updateLocalSessionState((state) => ({ ...state, shouldShowWelcomeDialog: true }))
-		}
 		await new Promise((resolve) => {
 			let unlisten = () => {}
 			unlisten = react('wait for user', () => this.user$.get() && resolve(unlisten()))
 		})
-		if (!this.user$.get()) {
-			throw Error('could not create user')
-		}
 		await this.fileStateQuery().preload().complete
-		return didCreate
 	}
 
 	messages = defineMessages({
@@ -764,9 +750,6 @@ export class TldrawApp {
 
 	static async create(opts: {
 		userId: string
-		fullName: string
-		email: string
-		avatar: string
 		getToken(): Promise<string | undefined>
 		onClientTooOld(): void
 		trackEvent: TLAppUiContextType
@@ -779,37 +762,28 @@ export class TldrawApp {
 		const app = new TldrawApp(opts.userId, opts.getToken, opts.onClientTooOld, opts.trackEvent)
 		// @ts-expect-error
 		window.app = app
-		const didCreate = await app.preload({
-			id: opts.userId,
-			name: opts.fullName,
-			email: opts.email,
-			color: color ?? defaultUserPreferences.color,
-			avatar: opts.avatar,
-			exportFormat: 'png',
-			exportTheme: 'light',
-			exportBackground: false,
-			exportPadding: true,
-			createdAt: Date.now(),
-			updatedAt: Date.now(),
-			flags: '',
-			allowAnalyticsCookie: null,
-			...restOfPreferences,
-			inputMode: restOfPreferences.inputMode ?? null,
-			locale: restOfPreferences.locale ?? null,
-			animationSpeed: restOfPreferences.animationSpeed ?? null,
-			areKeyboardShortcutsEnabled: restOfPreferences.areKeyboardShortcutsEnabled ?? null,
-			edgeScrollSpeed: restOfPreferences.edgeScrollSpeed ?? null,
-			colorScheme: restOfPreferences.colorScheme ?? null,
-			isSnapMode: restOfPreferences.isSnapMode ?? null,
-			isWrapMode: restOfPreferences.isWrapMode ?? null,
-			isDynamicSizeMode: restOfPreferences.isDynamicSizeMode ?? null,
-			isPasteAtCursorMode: restOfPreferences.isPasteAtCursorMode ?? null,
-			enhancedA11yMode: restOfPreferences.enhancedA11yMode ?? null,
-		})
-		if (didCreate) {
+		await app.preload()
+		const user = app.getUser()
+		if (user.color === '___INIT___') {
+			app.updateUser({
+				color: color ?? defaultUserPreferences.color,
+				...restOfPreferences,
+				inputMode: restOfPreferences.inputMode ?? null,
+				locale: restOfPreferences.locale ?? null,
+				animationSpeed: restOfPreferences.animationSpeed ?? null,
+				areKeyboardShortcutsEnabled: restOfPreferences.areKeyboardShortcutsEnabled ?? null,
+				edgeScrollSpeed: restOfPreferences.edgeScrollSpeed ?? null,
+				colorScheme: restOfPreferences.colorScheme ?? null,
+				isSnapMode: restOfPreferences.isSnapMode ?? null,
+				isWrapMode: restOfPreferences.isWrapMode ?? null,
+				isDynamicSizeMode: restOfPreferences.isDynamicSizeMode ?? null,
+				isPasteAtCursorMode: restOfPreferences.isPasteAtCursorMode ?? null,
+				enhancedA11yMode: restOfPreferences.enhancedA11yMode ?? null,
+			})
+
 			opts.trackEvent('create-user', { source: 'app' })
 		}
-		return { app, userId: opts.userId }
+		return { app, userId: user.id }
 	}
 
 	getIntl() {

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -33,9 +33,6 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 			if (!token) throw new Error('no token')
 			TldrawApp.create({
 				userId: auth.userId,
-				fullName: user.fullName || '',
-				email: user.emailAddresses[0]?.emailAddress || '',
-				avatar: user.imageUrl || '',
 				getToken: async () => {
 					const token = await auth.getToken()
 					return token || undefined

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -24,6 +24,7 @@ import { Analytics, Environment, TLUserDurableObjectEvent, getUserDoSnapshotKey 
 import { EventData, writeDataPoint } from './utils/analytics'
 import { isRateLimited } from './utils/rateLimit'
 import { retryOnConnectionFailure } from './utils/retryOnConnectionFailure'
+import { getClerkClient } from './utils/tla/getAuth'
 import { ChangeAccumulator, ServerCRUD } from './zero/ServerCrud'
 import { ServerQuery } from './zero/ServerQuery'
 import { ZMutationError } from './zero/ZMutationError'
@@ -77,7 +78,63 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	readonly router = Router()
 		.all('/app/:userId/*', async (req) => {
 			if (!this.userId) {
-				this.userId = req.params.userId
+				const id = (this.userId = req.params.userId)
+				const user = await this.db
+					.selectFrom('user')
+					.where('id', '=', id)
+					.select('id')
+					.executeTakeFirst()
+				if (!user) {
+					// auth is checked in the main worker, before it gets here, so the clerk
+					// user definitely exists at this point.
+					const clerk = getClerkClient(this.env)
+					const clerkUser = await clerk.users.getUser(id)
+					assert(clerkUser, 'Clerk user not found')
+					await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, id))
+					await this.db.transaction().execute(async (tx) => {
+						await tx
+							.insertInto('user')
+							.values({
+								id,
+								name: clerkUser.fullName ?? '',
+								email: clerkUser.emailAddresses[0].emailAddress,
+								avatar: clerkUser.imageUrl,
+								color: '___INIT___',
+								exportFormat: 'png',
+								exportTheme: 'light',
+								exportBackground: true,
+								exportPadding: true,
+								createdAt: Date.now(),
+								updatedAt: Date.now(),
+								flags: '',
+							})
+							.execute()
+						await tx
+							.insertInto('group')
+							.values({
+								id,
+								name: clerkUser.fullName ?? '',
+								createdAt: Date.now(),
+								updatedAt: Date.now(),
+								isDeleted: false,
+								inviteSecret: null,
+							})
+							.execute()
+						await tx
+							.insertInto('group_user')
+							.values({
+								userId: id,
+								groupId: id,
+								createdAt: Date.now(),
+								updatedAt: Date.now(),
+								role: 'owner',
+								index: 'a1' as IndexKey,
+								userName: clerkUser.fullName ?? '',
+								userColor: '',
+							})
+							.execute()
+					})
+				}
 			}
 			const rateLimited = await isRateLimited(this.env, this.userId!)
 			if (rateLimited) {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -240,6 +240,7 @@ export function createMutators(userId: string) {
 			},
 		},
 
+		/** @deprecated */
 		init: async (tx, { user, time }: { user: TlaUser; time: number }) => {
 			assert(user.id === userId, ZErrorCode.forbidden)
 			time = ensureSensibleTimestamp(time)


### PR DESCRIPTION
Seems like when users signed up there was some kind of race condition where it would try to create a file and the userId foreign key check would fail because the user row hadn't been created yet.

This PR makes it create a user row before even accepting a websocket connection and should bonk the problem on the head.

### Change type

- [x] `bugfix` 

### Test plan

1. Sign up as a new user and ensure the user row is created server-side before the websocket connection is established.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a race condition where new user creation could fail during file creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Create user/group records on first server contact and remove client-side user creation, updating client bootstrap accordingly.
> 
> - **Backend (sync-worker)**:
>   - Initialize missing `user`, `group`, and `group_user` rows on first `/app/:userId/*` request by fetching profile from Clerk; clear `USER_DO_SNAPSHOTS` and seed defaults (e.g., `color: '___INIT___'`).
>   - Add `getClerkClient` usage; ensure rate limiting and cache init proceed after bootstrap.
> - **Client**:
>   - Remove client-driven user creation flow: `TldrawApp.preload()` no longer accepts `initialUserData`; `TldrawApp.create` no longer requires `fullName/email/avatar`.
>   - After preload, if user has `color === '___INIT___'`, set user preferences and emit `create-user` event; return `userId` from fetched user.
>   - Update hook `useAppState` to match new `TldrawApp.create` signature.
> - **Shared**:
>   - Mark `mutators.init` as deprecated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 881ca5ed285093f7f3d920de5bbcdd240b612a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->