### PR TITLE
chore: transfer API changes section to hotfix PRs

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -58,9 +58,8 @@ async function main() {
 			const bodyAfterHeader = pr.body.split(apiChangesHeader)[1]
 			// Extract until next ### header or end of body
 			const nextHeaderIndex = bodyAfterHeader.indexOf('\n###')
-			apiChangesSection = nextHeaderIndex > -1
-				? bodyAfterHeader.slice(0, nextHeaderIndex)
-				: bodyAfterHeader
+			apiChangesSection =
+				nextHeaderIndex > -1 ? bodyAfterHeader.slice(0, nextHeaderIndex) : bodyAfterHeader
 			apiChangesSection = `\n\n${apiChangesHeader}\n${apiChangesSection.trim()}\n`
 		}
 


### PR DESCRIPTION
Hotfix PRs now preserve `### API changes` section from original PR body. This will prevent the api changes check from failing.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Run the trigger-dotcom-hotfix script with a PR body containing an API changes section.
2. Verify the generated hotfix PR includes that section.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved hotfix PR generation to preserve API change documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hotfix PRs now copy the original PR’s `### API changes` section into the generated PR body.
> 
> - **Scripts**:
>   - `internal/scripts/trigger-dotcom-hotfix.ts`: Extracts the `### API changes` section from the original PR body (if present) and appends it to the hotfix PR body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bef8a6c4b90faeb67878a621715e866b0edd49b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->