### PR TITLE
chore(dotcom): server-side-init followup

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -66,6 +66,7 @@ import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
 import { TLAppUiContextType } from '../utils/app-ui-events'
 import { getDateFormat } from '../utils/dates'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
+import { updateLocalSessionState } from '../utils/local-session-state'
 import { Zero as ZeroPolyfill } from './zero-polyfill'
 
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
@@ -782,6 +783,7 @@ export class TldrawApp {
 			})
 
 			opts.trackEvent('create-user', { source: 'app' })
+			updateLocalSessionState((state) => ({ ...state, shouldShowWelcomeDialog: true }))
 		}
 		return { app, userId: user.id }
 	}

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -96,6 +96,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 						if (await tx.selectFrom('user').where('id', '=', id).select('id').executeTakeFirst()) {
 							return
 						}
+						const now = Date.now()
 						await tx
 							.insertInto('user')
 							.values({
@@ -108,8 +109,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								exportTheme: 'light',
 								exportBackground: true,
 								exportPadding: true,
-								createdAt: Date.now(),
-								updatedAt: Date.now(),
+								createdAt: now,
+								updatedAt: now,
 								flags: '',
 							})
 							.execute()
@@ -118,8 +119,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 							.values({
 								id,
 								name: clerkUser.fullName ?? '',
-								createdAt: Date.now(),
-								updatedAt: Date.now(),
+								createdAt: now,
+								updatedAt: now,
 								isDeleted: false,
 								inviteSecret: null,
 							})
@@ -129,8 +130,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 							.values({
 								userId: id,
 								groupId: id,
-								createdAt: Date.now(),
-								updatedAt: Date.now(),
+								createdAt: now,
+								updatedAt: now,
 								role: 'owner',
 								index: 'a1' as IndexKey,
 								userName: clerkUser.fullName ?? '',


### PR DESCRIPTION
accidentally merged #7058 without these commits

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal server-side initialization improvements for dotcom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Triggers a welcome dialog on first-time user init and hardens server-side user creation with a duplicate-check and unified timestamps.
> 
> - **Client (TldrawApp)**
>   - Show welcome dialog after initializing a brand-new user by updating local session state (`updateLocalSessionState` in `TldrawApp.create`).
> - **Sync Worker (TLUserDurableObject)**
>   - Guard user/group creation inside transaction to avoid duplicate inserts if concurrent requests race.
>   - Use a single `now` timestamp for `createdAt`/`updatedAt` across inserted rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a90eac16419e5eed9653b7fd0d2fbcde818d0b24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->