### PR TITLE
refactor(dotcom): simplify fairy state management and remove prop drilling

### DIFF
--- a/apps/dotcom/client/src/fairy/Fairies.tsx
+++ b/apps/dotcom/client/src/fairy/Fairies.tsx
@@ -2,13 +2,7 @@ import { useMemo } from 'react'
 import Fairy from './Fairy'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 
-export function Fairies({
-	agents,
-	onDeleteFairyConfig,
-}: {
-	agents: FairyAgent[]
-	onDeleteFairyConfig(id: string): void
-}) {
+export function Fairies({ agents }: { agents: FairyAgent[] }) {
 	const activeAgents = useMemo(
 		() => agents.filter((agent) => agent.$fairyEntity.get() !== undefined),
 		[agents]
@@ -17,7 +11,7 @@ export function Fairies({
 	return (
 		<>
 			{activeAgents.map((agent, i) => (
-				<Fairy key={i} agent={agent} onDeleteFairyConfig={onDeleteFairyConfig} />
+				<Fairy key={i} agent={agent} />
 			))}
 		</>
 	)

--- a/apps/dotcom/client/src/fairy/Fairy.tsx
+++ b/apps/dotcom/client/src/fairy/Fairy.tsx
@@ -14,13 +14,7 @@ const FAIRY_CLICKABLE_SIZE_SELECTED = 60
 
 // We use the agent directly here because we need to access the isGenerating method
 // which is not exposed on the fairy atom
-export default function Fairy({
-	agent,
-	onDeleteFairyConfig,
-}: {
-	agent: FairyAgent
-	onDeleteFairyConfig(id: string): void
-}) {
+export default function Fairy({ agent }: { agent: FairyAgent }) {
 	const editor = useEditor()
 	const fairyRef = useRef<HTMLDivElement>(null)
 	const fairy = agent.$fairyEntity
@@ -228,7 +222,6 @@ export default function Fairy({
 
 	// Early return if fairy doesn't exist (after all hooks)
 	const fairyEntity = fairy.get()
-	if (!fairyEntity) return null
 
 	return (
 		<_ContextMenu.Root dir="ltr">
@@ -268,7 +261,7 @@ export default function Fairy({
 					/>
 				</div>
 			</_ContextMenu.Trigger>
-			<FairyContextMenuContent agent={agent} onDeleteFairyConfig={onDeleteFairyConfig} />
+			<FairyContextMenuContent agent={agent} />
 		</_ContextMenu.Root>
 	)
 }

--- a/apps/dotcom/client/src/fairy/FairyConfigDialog.tsx
+++ b/apps/dotcom/client/src/fairy/FairyConfigDialog.tsx
@@ -32,14 +32,14 @@ export function FairyConfigDialog({ agent, onClose }: { agent: FairyAgent; onClo
 					<TldrawUiInput
 						className="fairy-config-input"
 						value={config.name}
-						onValueChange={(value) => agent.$fairyConfig.set({ ...config, name: value })}
+						onValueChange={(value) => agent.updateFairyConfig({ name: value })}
 						placeholder="Fairy's name"
 					/>
 					<label htmlFor="name">Personality</label>
 					<TldrawUiInput
 						className="fairy-config-input"
 						value={config.personality}
-						onValueChange={(value) => agent.$fairyConfig.set({ ...config, personality: value })}
+						onValueChange={(value) => agent.updateFairyConfig({ personality: value })}
 						placeholder="Fairy's personality"
 					/>
 					{/* <label htmlFor="mode">Mode</label>
@@ -70,8 +70,7 @@ export function FairyConfigDialog({ agent, onClose }: { agent: FairyAgent; onClo
 						id="hat"
 						value={config.outfit.hat}
 						onChange={(e) => {
-							agent.$fairyConfig.set({
-								...config,
+							agent.updateFairyConfig({
 								outfit: { ...config.outfit, hat: e.target.value as FairyVariantType<'hat'> },
 							})
 						}}

--- a/apps/dotcom/client/src/fairy/FairyContextMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/FairyContextMenuContent.tsx
@@ -3,13 +3,7 @@ import { useContainer } from 'tldraw'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { FairyMenuContent } from './FairyMenuContent'
 
-export function FairyContextMenuContent({
-	agent,
-	onDeleteFairyConfig,
-}: {
-	agent: FairyAgent
-	onDeleteFairyConfig(id: string): void
-}) {
+export function FairyContextMenuContent({ agent }: { agent: FairyAgent }) {
 	const container = useContainer()
 
 	return (
@@ -20,11 +14,7 @@ export function FairyContextMenuContent({
 				onClick={(e) => e.stopPropagation()}
 				style={{ zIndex: 10000000 }}
 			>
-				<FairyMenuContent
-					agent={agent}
-					onDeleteFairyConfig={onDeleteFairyConfig}
-					menuType="context-menu"
-				/>
+				<FairyMenuContent agent={agent} menuType="context-menu" />
 			</_ContextMenu.Content>
 		</_ContextMenu.Portal>
 	)

--- a/apps/dotcom/client/src/fairy/FairyDropdownContent.tsx
+++ b/apps/dotcom/client/src/fairy/FairyDropdownContent.tsx
@@ -5,13 +5,11 @@ import { FairyMenuContent } from './FairyMenuContent'
 
 export function FairyDropdownContent({
 	agent,
-	onDeleteFairyConfig,
 	alignOffset,
 	sideOffset,
 	side = 'top',
 }: {
 	agent: FairyAgent
-	onDeleteFairyConfig(id: string): void
 	alignOffset: number
 	sideOffset: number
 	side?: 'top' | 'bottom' | 'left' | 'right'
@@ -30,7 +28,7 @@ export function FairyDropdownContent({
 				onClick={(e) => e.stopPropagation()}
 				style={{ zIndex: 100000000 }}
 			>
-				<FairyMenuContent agent={agent} onDeleteFairyConfig={onDeleteFairyConfig} menuType="menu" />
+				<FairyMenuContent agent={agent} menuType="menu" />
 			</_DropdownMenu.Content>
 		</_DropdownMenu.Portal>
 	)

--- a/apps/dotcom/client/src/fairy/FairyGroupChat.tsx
+++ b/apps/dotcom/client/src/fairy/FairyGroupChat.tsx
@@ -75,18 +75,11 @@ export function FairyGroupChat({ agents }: { agents: FairyAgent[] }) {
 			}
 
 			// Set leader as orchestrator
-			leaderAgent.$fairyConfig.update((config) => ({
-				...config,
-				wand: 'orchestrator',
-			}))
+			leaderAgent.updateFairyConfig({ wand: 'orchestrator' })
 
 			// Set followers as drones
 			followerAgents.forEach((agent) => {
-				agent.$fairyConfig.update((config) => ({
-					...config,
-					wand: 'drone',
-					mode: 'drone',
-				}))
+				agent.updateFairyConfig({ wand: 'drone' })
 			})
 
 			const newProjectId = uniqueId(5)

--- a/apps/dotcom/client/src/fairy/FairyHUD.tsx
+++ b/apps/dotcom/client/src/fairy/FairyHUD.tsx
@@ -18,6 +18,7 @@ import {
 	useValue,
 } from 'tldraw'
 import { MAX_FAIRY_COUNT } from '../tla/components/TlaEditor/TlaEditor'
+import { useApp } from '../tla/hooks/useAppState'
 import '../tla/styles/fairy.css'
 import { defineMessages, useMsg } from '../tla/utils/i18n'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
@@ -38,14 +39,10 @@ const fairyMessages = defineMessages({
 	select: { defaultMessage: 'Select fairy' },
 })
 
-function NewFairyButton({
-	agents,
-	onAddFairyConfig,
-}: {
-	agents: FairyAgent[]
-	onAddFairyConfig(id: string, config: any): void
-}) {
+function NewFairyButton({ agents }: { agents: FairyAgent[] }) {
+	const app = useApp()
 	const handleClick = useCallback(() => {
+		if (!app) return
 		const randomOutfit = {
 			body: Object.keys(FAIRY_VARIANTS.body)[
 				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.body).length)
@@ -71,8 +68,8 @@ function NewFairyButton({
 		}
 
 		// Add the config, which will trigger agent creation in FairyApp
-		onAddFairyConfig(id, config)
-	}, [onAddFairyConfig])
+		app.z.mutate.user.updateFairyConfig({ id, properties: config })
+	}, [app])
 
 	return (
 		<TldrawUiButton
@@ -88,15 +85,7 @@ function NewFairyButton({
 
 type PanelState = 'todo-list' | 'fairy' | 'closed'
 
-export function FairyHUD({
-	agents,
-	onAddFairyConfig,
-	onDeleteFairyConfig,
-}: {
-	agents: FairyAgent[]
-	onAddFairyConfig(id: string, config: any): void
-	onDeleteFairyConfig(id: string): void
-}) {
+export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 	const editor = useEditor()
 	const [menuPopoverOpen, setMenuPopoverOpen] = useState(false)
 	const [todoMenuPopoverOpen, setTodoMenuPopoverOpen] = useState(false)
@@ -243,7 +232,6 @@ export function FairyHUD({
 												{shownFairy && (
 													<FairyDropdownContent
 														agent={shownFairy}
-														onDeleteFairyConfig={onDeleteFairyConfig}
 														alignOffset={4}
 														sideOffset={4}
 														side="bottom"
@@ -313,7 +301,6 @@ export function FairyHUD({
 										</_DropdownMenu.Trigger>
 										<TodoListDropdownContent
 											agents={agents}
-											onDeleteFairyConfig={onDeleteFairyConfig}
 											alignOffset={4}
 											sideOffset={4}
 											side="bottom"
@@ -343,7 +330,6 @@ export function FairyHUD({
 							onClick={handleClickTodoList}
 							hasUnreadTodos={hasUnreadTodos}
 							agents={agents}
-							onDeleteFairyConfig={onDeleteFairyConfig}
 						/>
 					</div>
 					<TldrawUiToolbar label={toolbarMessage} orientation="vertical">
@@ -356,11 +342,10 @@ export function FairyHUD({
 									onDoubleClick={() => handleDoubleClickFairy(agent)}
 									selectMessage={selectMessage}
 									deselectMessage={deselectMessage}
-									onDeleteFairyConfig={onDeleteFairyConfig}
 								/>
 							)
 						})}
-						<NewFairyButton agents={agents} onAddFairyConfig={onAddFairyConfig} />
+						<NewFairyButton agents={agents} />
 					</TldrawUiToolbar>
 				</div>
 			</div>

--- a/apps/dotcom/client/src/fairy/FairyMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/FairyMenuContent.tsx
@@ -10,11 +10,9 @@ import { FairyConfigDialog } from './FairyConfigDialog'
 
 export function FairyMenuContent({
 	agent,
-	onDeleteFairyConfig,
 	menuType = 'menu',
 }: {
 	agent: FairyAgent
-	onDeleteFairyConfig(id: string): void
 	menuType?: 'menu' | 'context-menu'
 }) {
 	const { addDialog } = useDefaultHelpers()
@@ -27,13 +25,10 @@ export function FairyMenuContent({
 		[addDialog]
 	)
 
-	const deleteFairy = useCallback(
-		(agent: FairyAgent) => {
-			agent.dispose()
-			onDeleteFairyConfig(agent.id)
-		},
-		[onDeleteFairyConfig]
-	)
+	const deleteFairy = useCallback(() => {
+		agent.dispose()
+		agent.deleteFairyConfig()
+	}, [agent])
 
 	return (
 		<TldrawUiMenuContextProvider type={menuType} sourceId="fairy-panel">
@@ -51,11 +46,7 @@ export function FairyMenuContent({
 					onSelect={() => configureFairy(agent)}
 					label="Customize fairy"
 				/>
-				<TldrawUiMenuItem
-					id="delete-fairy"
-					onSelect={() => deleteFairy(agent)}
-					label="Delete fairy"
-				/>
+				<TldrawUiMenuItem id="delete-fairy" onSelect={deleteFairy} label="Delete fairy" />
 			</TldrawUiMenuGroup>
 		</TldrawUiMenuContextProvider>
 	)

--- a/apps/dotcom/client/src/fairy/FairySidebarButton.tsx
+++ b/apps/dotcom/client/src/fairy/FairySidebarButton.tsx
@@ -12,14 +12,12 @@ export function FairySidebarButton({
 	onDoubleClick,
 	selectMessage,
 	deselectMessage,
-	onDeleteFairyConfig,
 }: {
 	agent: FairyAgent
 	onClick(): void
 	onDoubleClick(): void
 	selectMessage: string
 	deselectMessage: string
-	onDeleteFairyConfig(id: string): void
 }) {
 	const fairyIsSelected = useValue(
 		'fairy-button-selected',
@@ -36,6 +34,8 @@ export function FairySidebarButton({
 	const project = currentProjectId ? getProjectById(currentProjectId) : undefined
 	const isOrchestrator = project ? project.orchestratorId === agent.id : false
 	const projectColor = project ? getProjectColor(agent.editor, project.color) : undefined
+
+	if (!fairyEntity || !fairyOutfit) return null
 
 	return (
 		<_ContextMenu.Root dir="ltr">
@@ -64,7 +64,7 @@ export function FairySidebarButton({
 					</TldrawUiToolbarToggleItem>
 				</TldrawUiToolbarToggleGroup>
 			</_ContextMenu.Trigger>
-			<FairyContextMenuContent agent={agent} onDeleteFairyConfig={onDeleteFairyConfig} />
+			<FairyContextMenuContent agent={agent} />
 		</_ContextMenu.Root>
 	)
 }

--- a/apps/dotcom/client/src/fairy/TodoListContextMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/TodoListContextMenuContent.tsx
@@ -3,13 +3,7 @@ import { useContainer } from 'tldraw'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { TodoListMenuContent } from './TodoListMenuContent'
 
-export function TodoListContextMenuContent({
-	agents,
-	onDeleteFairyConfig,
-}: {
-	agents: FairyAgent[]
-	onDeleteFairyConfig(id: string): void
-}) {
+export function TodoListContextMenuContent({ agents }: { agents: FairyAgent[] }) {
 	const container = useContainer()
 
 	return (
@@ -20,11 +14,7 @@ export function TodoListContextMenuContent({
 				onClick={(e) => e.stopPropagation()}
 				style={{ zIndex: 100000000 }}
 			>
-				<TodoListMenuContent
-					agents={agents}
-					onDeleteFairyConfig={onDeleteFairyConfig}
-					menuType="context-menu"
-				/>
+				<TodoListMenuContent agents={agents} menuType="context-menu" />
 			</_ContextMenu.Content>
 		</_ContextMenu.Portal>
 	)

--- a/apps/dotcom/client/src/fairy/TodoListDropdownContent.tsx
+++ b/apps/dotcom/client/src/fairy/TodoListDropdownContent.tsx
@@ -5,13 +5,11 @@ import { TodoListMenuContent } from './TodoListMenuContent'
 
 export function TodoListDropdownContent({
 	agents,
-	onDeleteFairyConfig,
 	alignOffset,
 	sideOffset,
 	side = 'top',
 }: {
 	agents: FairyAgent[]
-	onDeleteFairyConfig(id: string): void
 	alignOffset: number
 	sideOffset: number
 	side?: 'top' | 'bottom' | 'left' | 'right'
@@ -30,11 +28,7 @@ export function TodoListDropdownContent({
 				onClick={(e) => e.stopPropagation()}
 				style={{ zIndex: 100000000 }}
 			>
-				<TodoListMenuContent
-					agents={agents}
-					onDeleteFairyConfig={onDeleteFairyConfig}
-					menuType="menu"
-				/>
+				<TodoListMenuContent agents={agents} menuType="menu" />
 			</_DropdownMenu.Content>
 		</_DropdownMenu.Portal>
 	)

--- a/apps/dotcom/client/src/fairy/TodoListMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/TodoListMenuContent.tsx
@@ -1,16 +1,15 @@
 import { useCallback } from 'react'
 import { TldrawUiMenuContextProvider, TldrawUiMenuGroup, TldrawUiMenuItem } from 'tldraw'
+import { useApp } from '../tla/hooks/useAppState'
 import { clearSharedTodoList, requestHelpFromEveryone } from './SharedTodoList'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 
 export function TodoListMenuContent({
 	agents,
 	menuType = 'menu',
-	onDeleteFairyConfig,
 }: {
 	agents: FairyAgent[]
 	menuType?: 'menu' | 'context-menu'
-	onDeleteFairyConfig(id: string): void
 }) {
 	const resetAllChats = useCallback(() => {
 		agents.forEach((agent) => {
@@ -20,18 +19,17 @@ export function TodoListMenuContent({
 
 	const resetAllWands = useCallback(() => {
 		agents.forEach((agent) => {
-			const config = agent.$fairyConfig.get()
-			if (config) {
-				agent.$fairyConfig.set({ ...config, wand: 'god' })
-			}
+			agent.updateFairyConfig({ wand: 'god' })
 		})
 	}, [agents])
 
+	const app = useApp()
 	const deleteAllFairies = useCallback(() => {
+		app.z.mutate.user.deleteAllFairyConfigs()
 		agents.forEach((agent) => {
-			onDeleteFairyConfig(agent.id)
+			agent.dispose()
 		})
-	}, [agents, onDeleteFairyConfig])
+	}, [app, agents])
 
 	return (
 		<TldrawUiMenuContextProvider type={menuType} sourceId="fairy-panel">

--- a/apps/dotcom/client/src/fairy/TodoListSidebarButton.tsx
+++ b/apps/dotcom/client/src/fairy/TodoListSidebarButton.tsx
@@ -7,12 +7,10 @@ export function TodoListSidebarButton({
 	onClick,
 	hasUnreadTodos,
 	agents,
-	onDeleteFairyConfig,
 }: {
 	onClick(): void
 	hasUnreadTodos: boolean
 	agents: FairyAgent[]
-	onDeleteFairyConfig(id: string): void
 }) {
 	return (
 		<div style={{ position: 'relative' }}>
@@ -22,7 +20,7 @@ export function TodoListSidebarButton({
 						<TldrawUiIcon icon="clipboard-copied" label="Todo list" />
 					</TldrawUiButton>
 				</_ContextMenu.Trigger>
-				<TodoListContextMenuContent agents={agents} onDeleteFairyConfig={onDeleteFairyConfig} />
+				<TodoListContextMenuContent agents={agents} />
 			</_ContextMenu.Root>
 			{hasUnreadTodos && <div className="fairy-todo-unread-indicator" />}
 		</div>

--- a/apps/dotcom/client/src/fairy/fairy-agent/agent/FairyAgentOptions.ts
+++ b/apps/dotcom/client/src/fairy/fairy-agent/agent/FairyAgentOptions.ts
@@ -1,11 +1,11 @@
-import { FairyConfig } from '@tldraw/fairy-shared'
 import { Editor } from 'tldraw'
+import { TldrawApp } from '../../../tla/app/TldrawApp'
 
 export interface FairyAgentOptions {
-	/** The fairy configuration associated with this agent. */
-	fairyConfig: FairyConfig
 	/** The editor to associate the agent with. */
 	editor: Editor
+	/** The app to associate the agent with. */
+	app: TldrawApp
 	/** A key used to differentiate the agent from other agents. */
 	id: string
 	/** A callback for when an error occurs. */

--- a/apps/dotcom/client/src/fairy/fairy-agent/agent/useFairyAgent.ts
+++ b/apps/dotcom/client/src/fairy/fairy-agent/agent/useFairyAgent.ts
@@ -1,6 +1,6 @@
-import { FairyConfig } from '@tldraw/fairy-shared'
 import { useCallback, useMemo } from 'react'
 import { Editor, useToasts } from 'tldraw'
+import { useApp } from '../../../tla/hooks/useAppState'
 import { FairyThrowTool } from '../../FairyThrowTool'
 import { FairyAgent } from './FairyAgent'
 import { $fairyAgentsAtom } from './fairyAgentsAtom'
@@ -26,16 +26,15 @@ import { $fairyAgentsAtom } from './fairyAgentsAtom'
  */
 export function useFairyAgent({
 	id,
-	fairyConfig,
 	editor,
 	getToken,
 }: {
 	id: string
-	fairyConfig: FairyConfig
 	editor: Editor
 	getToken(): Promise<string | undefined>
 }): FairyAgent {
 	const toasts = useToasts()
+	const app = useApp()
 
 	const handleError = useCallback(
 		(e: any) => {
@@ -61,8 +60,8 @@ export function useFairyAgent({
 		editor.setTool(FairyThrowTool)
 
 		// Create a new agent
-		return new FairyAgent({ id, fairyConfig, editor, onError: handleError, getToken })
-	}, [editor, handleError, id, getToken, fairyConfig])
+		return new FairyAgent({ id, editor, app, onError: handleError, getToken })
+	}, [editor, handleError, id, getToken, app])
 
 	return agent
 }

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -155,8 +155,30 @@ export function createMutators(userId: string) {
 				disallowImmutableMutations(user, immutableColumns.user)
 				await tx.mutate.user.update(user)
 			},
-			updateFairies: async (tx, { fairies }: { fairies: string }) => {
-				await tx.mutate.user_fairies.upsert({ userId, fairies })
+			updateFairyConfig: async (tx, { id, properties }: { id: string; properties: object }) => {
+				const current = await tx.query.user_fairies.where('userId', '=', userId).one().run()
+				const currentConfig = JSON.parse(current?.fairies || '{}')
+				await tx.mutate.user_fairies.upsert({
+					userId,
+					fairies: JSON.stringify({
+						...currentConfig,
+						[id]: {
+							...currentConfig[id],
+							...properties,
+						},
+					}),
+				})
+			},
+			deleteFairyConfig: async (tx, { id }: { id: string }) => {
+				const current = await tx.query.user_fairies.where('userId', '=', userId).one().run()
+				const currentConfig = JSON.parse(current?.fairies || '{}')
+				await tx.mutate.user_fairies.upsert({
+					userId,
+					fairies: JSON.stringify({ ...currentConfig, [id]: undefined }),
+				})
+			},
+			deleteAllFairyConfigs: async (tx) => {
+				await tx.mutate.user_fairies.upsert({ userId, fairies: '{}' })
 			},
 		},
 		file: {


### PR DESCRIPTION
1. use the app instance instead of prop drilling
2. sync fairy data using computed instead of atom
3. fine-grained mutations so you can update without throttles.

i think there's a lot more room for this kind of simplification but i guess it can wait.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Verify fairy configuration updates correctly in the UI
2. Verify fairy agents respond to configuration changes

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Refactored fairy state management to use app-scoped computed state and direct mutations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the fairies feature to read/write config via app-scoped computed state and new user mutators, removing prop drilling and simplifying UI/agents; includes minor CSS and pen action sanitization updates.
> 
> - **Fairy architecture**:
>   - Switch `FairyAgent.$fairyConfig` to a `computed` sourced from `app.getUser().fairies`; agents now constructed with `app` (no per-agent config prop).
>   - Remove prop drilling of `onAdd/DeleteFairyConfig`; components (`FairyHUD`, `Fairies`, menus, todo menus) now call agent/app mutators directly.
>   - Replace local fairy-config state in `TlaEditor`/`FairyApp` with `useValue` from app user state; simplify presence to read outfit via `$fairyConfig`.
> - **Mutations/API**:
>   - Add `user.updateFairyConfig`, `user.deleteFairyConfig`, and `user.deleteAllFairyConfigs` mutators; UI uses them for create/update/delete.
> - **Agent updates**:
>   - New methods `updateFairyConfig` and `deleteFairyConfig`; `setMode`/personality updates route through them.
> - **UI/UX**:
>   - New-fairy creation via `app.z.mutate.user.updateFairyConfig`; cleanup of context/dropdown/menu props; group chat wand changes via `updateFairyConfig`.
>   - Small CSS tweak: `.fairy-chat-history-section:last-child { min-height: 100% }`.
> - **Action utils**:
>   - `PenActionUtil.sanitizeAction` now validates all streamed points (no slicing of the last point).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bba17b9838ec970edbbeba6807bacd4da9f0933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->