### PR TITLE
fix(dotcom): dedupe persistence_bad event

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -821,7 +821,7 @@ export class TLDrawDurableObject extends DurableObject {
 			.push(async () => {
 				await retry(
 					async ({ attempt }) => {
-						if (attempt === PERSIST_RETRIES_NOTIFY_THRESHOLD) {
+						if (attempt === PERSIST_RETRIES_NOTIFY_THRESHOLD && !this.persistenceBad) {
 							this.broadcastPersistenceEvent({ type: 'persistence_bad' })
 							this.persistenceBad = true
 						}


### PR DESCRIPTION
Prevents duplicate `persistence_bad` events by gating the retry-threshold notification on the `persistenceBad` flag.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Deduplicate persistence_bad events in sync-worker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate `persistence_bad` events by gating the retry-threshold notification on the `persistenceBad` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee7483de9bc56c47e991c491ddef2c52a8e5380c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->