### PR TITLE
docs: add shoptalk podcast redirect

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -164,6 +164,11 @@ const nextConfig = {
 				destination: '/?utm_source=diveclub&utm_medium=podcast&utm_campaign=steve_diveclub_2025',
 				permanent: true,
 			},
+			{
+				source: '/shoptalk',
+				destination: '/?utm_source=shoptalk&utm_medium=podcast&utm_campaign=steve_shoptalk_2025',
+				permanent: true,
+			},
 		]
 	},
 	async rewrites() {


### PR DESCRIPTION
Adds a new `/shoptalk` redirect with UTM params in the docs Next.js config.

### Change type

- [x] `other` 

### Test plan

1. Verify that navigating to `/shoptalk` on the docs site redirects to the homepage with the correct UTM parameters.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a redirect for the ShopTalk podcast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `/shoptalk` redirect with UTM params in the docs Next.js config.
> 
> - **Docs config (`apps/docs/next.config.js`)**:
>   - **Redirects**: Add `'/shoptalk'` redirect to `'/?utm_source=shoptalk&utm_medium=podcast&utm_campaign=steve_shoptalk_2025'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57cb97be4d7eabfe53af820292097cb12abcae61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->