### PR TITLE
fix(dotcom): restore awaits for file mutations to prevent stale state

### DIFF
--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -279,8 +279,6 @@ export function createMutators(userId: string) {
 				if (tx.location === 'server') {
 					// Verify the user has access to this file
 					const file = await tx.query.file.where('id', '=', fileState.fileId).one().run()
-					// If file is deleted, silently ignore the update
-					if (!file || file.isDeleted) return
 					await assertUserCanAccessFile(tx, userId, file!)
 				}
 				const exists = await tx.query.file_state


### PR DESCRIPTION
I removed awaits since the editor recommended it, but it was fake news 😂

Looks like the editor incorrectly sees the methods as sync (`'await' has no effect on the type of this expression.`, which is why I [removed them in this PR](https://github.com/tldraw/tldraw/pull/7069). But it looks like we still need them, or we don't get the most up to date state which causes a [few issues when deleting files](https://www.notion.so/tldraw/Deleting-files-is-glitchy-2a13e4c324c080d480b1c8f590b8133d?source=copy_link).

@ds300 maybe we should somehow fix these types?

### Change type

- [x] `bugfix` 

### Test plan

1. Delete files and ensure state updates correctly without glitches.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where deleting files could result in stale state due to missing awaits on mutations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Await async mutations for removing files from groups and adding file links to groups to prevent stale state during deletes.
> 
> - **App logic (`apps/dotcom/client/src/tla/app/TldrawApp.ts`)**:
>   - Await async mutations for state consistency:
>     - `deleteOrForgetFile` now `await this.z.mutate.removeFileFromGroup({ fileId, groupId })`.
>     - `addFileLinkToGroup` now `await this.z.mutate.addFileLinkToGroup({ fileId, groupId })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d2ee0f52be7e72a525698d039982a995c38f04e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->