### PR TITLE
docs: add hanselminutes podcast redirect

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -171,7 +171,8 @@ const nextConfig = {
 			},
 			{
 				source: '/hanselminutes',
-				destination: '/?utm_source=hanselminutes&utm_medium=paid_podcast&utm_campaign=ad_hanselminutes_2025',
+				destination:
+					'/?utm_source=hanselminutes&utm_medium=paid_podcast&utm_campaign=ad_hanselminutes_2025',
 				permanent: true,
 			},
 		]


### PR DESCRIPTION
Adds a redirect for the Hanselminutes podcast with UTM tracking parameters.

### Change type

- [x] `other`

### Test plan

1. Navigate to /hanselminutes and verify it redirects to the homepage with the correct UTM parameters.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a redirect for the Hanselminutes podcast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds redirect from `/hanselminutes` to the homepage with UTM tracking parameters.
> 
> - **Docs config (`apps/docs/next.config.js`)**: Add redirect mapping `/hanselminutes` → `/?utm_source=hanselminutes&utm_medium=paid_podcast&utm_campaign=ad_hanselminutes_2025`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e7f3e8c31c801b4b164139040b21b2d8160465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->