### PR TITLE
docs: add redirect for mostlytechnical podcast

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -175,6 +175,12 @@ const nextConfig = {
 					'/?utm_source=hanselminutes&utm_medium=paid_podcast&utm_campaign=ad_hanselminutes_2025',
 				permanent: true,
 			},
+			{
+				source: '/mostlytechnical',
+				destination:
+					'/?utm_source=mostlytechnical&utm_medium=paid_podcast&utm_campaign=ad_mostlytechnical_2025',
+				permanent: true,
+			},
 		]
 	},
 	async rewrites() {


### PR DESCRIPTION
Adds a redirect in `apps/docs/next.config.js` from `/mostlytechnical` to the homepage with UTM tracking params.

### Change type

- [x] `other` 

### Test plan

1. Navigate to /mostlytechnical on the docs site and verify it redirects to the homepage with UTM parameters.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a redirect for the Mostly Technical podcast link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a redirect in `apps/docs/next.config.js` from `/mostlytechnical` to the homepage with UTM tracking params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74244a009cc2077afa6dbc4777ef03cb5e3231d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->