### PR TITLE
ci: prevent empty PRs in i18n download workflow

### DIFF
--- a/.github/workflows/i18n-download-strings.yml
+++ b/.github/workflows/i18n-download-strings.yml
@@ -43,18 +43,25 @@ jobs:
         run: 'yarn i18n-check -f react-intl --locales ./apps/dotcom/client/public/tla/locales/ --source en'
 
       - name: Commit and push changes
-        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           git config --global user.name 'huppy-bot[bot]'
           git config --global user.email '128400622+huppy-bot[bot]@users.noreply.github.com'
-          git checkout -b update-i18n-strings
-          git add "*.json"
-          if git diff-index --quiet HEAD --; then
+          
+          # Check if there are any changes to JSON files
+          if ! git diff --quiet '*.json' || ! git diff --cached --quiet '*.json'; then
+            echo "Changes detected, creating PR..."
+          else
             echo "No changes to commit"
             exit 0
           fi
+          
+          # Delete the branch if it already exists
+          git push origin --delete update-i18n-strings 2>/dev/null || true
+          
+          git checkout -b update-i18n-strings
+          git add "*.json"
           git commit --no-verify -m '[automated] update i18n strings'
           git push --set-upstream origin update-i18n-strings
           gh pr create --title "[automated] update i18n strings" --body "This PR updates the i18n strings.


### PR DESCRIPTION
something that's been bugging me

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved i18n workflow to avoid creating empty pull requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the i18n download workflow to only open a PR when JSON changes are detected and to delete any existing branch before recreating it.
> 
> - **CI workflow (`.github/workflows/i18n-download-strings.yml`)**:
>   - Add guard to detect JSON changes (both staged and unstaged) and exit early if none, preventing empty PRs.
>   - Remove unconditional execution and branch creation; delete existing `update-i18n-strings` branch before recreating it.
>   - Keep commit/push/PR creation flow, now gated by the change check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b95b192d33aa205e5acfc9c23b581fac6d9ebe2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->