### PR TITLE
fix(sync-core): improve diffing logic for nested objects

### DIFF
--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -207,16 +207,22 @@ function diffObject(
 			result[key] = [ValueOpType.Delete]
 			continue
 		}
-		if (nestedKeys?.has(key)) {
+		const prevValue = (prev as any)[key]
+		const nextValue = (next as any)[key]
+		if (
+			nestedKeys?.has(key) ||
+			(Array.isArray(prevValue) && Array.isArray(nextValue)) ||
+			(typeof prevValue === 'string' && typeof nextValue === 'string')
+		) {
 			// if key is in both places, then compare values
-			const diff = diffValue((prev as any)[key], (next as any)[key], legacyAppendMode)
+			const diff = diffValue(prevValue, nextValue, legacyAppendMode)
 			if (diff) {
 				if (!result) result = {}
 				result[key] = diff
 			}
-		} else if (!isEqual((prev as any)[key], (next as any)[key])) {
+		} else if (!isEqual(prevValue, nextValue)) {
 			if (!result) result = {}
-			result[key] = [ValueOpType.Put, (next as any)[key]]
+			result[key] = [ValueOpType.Put, nextValue]
 		}
 	}
 	for (const key of Object.keys(next)) {


### PR DESCRIPTION
doing fine grained diffs on the tip tap documents was no bueno

### Change type

- [x] `bugfix` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved diffing logic for nested objects in sync-core.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat `props` and `meta` as nested patches, while defaulting non-string/non-array object fields to full `put` when changed; update diffing internals accordingly.
> 
> - **Diffing behavior**:
>   - Treat `props` and `meta` as nested keys for patching via `diffObject`.
>   - For other object fields, emit `put` when changed unless values are arrays or strings (which still diff/append).
>   - Maintain fine-grained handling for arrays (`diffArray`) and strings (append optimization).
> - **API/Internal changes**:
>   - `diffRecord` now calls `diffObject(prev, next, new Set(['props','meta']), legacyAppendMode)`.
>   - `diffObject` signature includes `nestedKeys` and uses shallow equality to choose between nested `diffValue` vs `put`.
>   - Recursive calls to `diffObject` pass `undefined` for `nestedKeys` to limit deep nesting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83297106531ef2eba1f00ce2b01a6e2a10c8146a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->