### PR TITLE
improvement(editor): support cross-realm canvas events

### DIFF
--- a/.github/workflows/i18n-download-strings.yml
+++ b/.github/workflows/i18n-download-strings.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config --global user.name 'huppy-bot[bot]'
           git config --global user.email '128400622+huppy-bot[bot]@users.noreply.github.com'
-          
+
           # Check if there are any changes to JSON files
           if ! git diff --quiet '*.json' || ! git diff --cached --quiet '*.json'; then
             echo "Changes detected, creating PR..."
@@ -56,10 +56,10 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          
+
           # Delete the branch if it already exists
           git push origin --delete update-i18n-strings 2>/dev/null || true
-          
+
           git checkout -b update-i18n-strings
           git add "*.json"
           git commit --no-verify -m '[automated] update i18n strings'

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -8,7 +8,7 @@ import { useEditor } from './useEditor'
 
 export function useCanvasEvents() {
 	const editor = useEditor()
-	const ownerDocument = editor.getContainer().ownerDocument;
+	const ownerDocument = editor.getContainer().ownerDocument
 	const currentTool = useValue('current tool', () => editor.getCurrentTool(), [editor])
 
 	const events = useMemo(


### PR DESCRIPTION
cc @derekcicerone

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- cross-realm: adapt `useCanvasEvents`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes the canvas pointermove listener to the editor container’s ownerDocument to support cross-realm contexts.
> 
> - **Editor**:
>   - `useCanvasEvents`:
>     - Derives `ownerDocument` from `editor.getContainer().ownerDocument`.
>     - Attaches/removes `pointermove` listener on `ownerDocument.body` instead of `document.body`.
>     - Updates effect dependencies to include `ownerDocument`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bccc226ac5812442a13292c2f82cae7d0caabecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->