### PR TITLE
docs: link to sitemap from robots.txt

### DIFF
--- a/apps/docs/app/robots.txt
+++ b/apps/docs/app/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://www.tldraw.dev/sitemap.xml


### PR DESCRIPTION
Add a link to the sitemap in the robots.txt file to improve search engine indexing.

### Change type

- [x] `other`

### Test plan

1. Verify that robots.txt now contains the Sitemap directive.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added sitemap link to robots.txt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `Sitemap: https://www.tldraw.dev/sitemap.xml` to `apps/docs/app/robots.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a4e6f8f1dd147c23e985b75c1392fceb908702f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->