### PR TITLE
fix(dotcom): handle redirect properly for Google OAuth

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -200,7 +200,11 @@ function TlaEnterEmailStep({
 					className={styles.authCtaButton}
 					onClick={handleGoogleSignIn}
 				>
-					<img src="https://img.clerk.com/static/google.svg" alt="Google" />
+					<img
+						src="https://img.clerk.com/static/google.svg"
+						alt="Google"
+						referrerPolicy="strict-origin-when-cross-origin"
+					/>
 					<F defaultMessage="Sign in with Google" />
 				</TlaCtaButton>
 			</div>


### PR DESCRIPTION
@MitjaBezensek noticed that for Google sign-in we weren't redirecting properly. We have to go closer to the metal to make that work, took a while to figure out this magic incantation ✨ 🪄 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Open the sign-in dialog
2. Click the Google sign-in button
3. Verify that you are redirected to the Google OAuth page and back to the app correctly

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where Google sign-in would not redirect correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Clerk Elements Google sign-in with a custom button that initiates Clerk OAuth and redirects via externalVerificationRedirectURL.
> 
> - **Auth (TlaSignInDialog.tsx)**:
>   - **Google OAuth**:
>     - Add `handleGoogleSignIn` to initiate `signIn.create({ strategy: 'oauth_google', redirectUrl })` and redirect using `firstFactorVerification.externalVerificationRedirectURL`.
>     - Replace Clerk Elements UI (`SignIn.Root/Step`, `Clerk.Connection`) with a custom `TlaCtaButton` and static Google icon.
>     - Remove unused Clerk Elements imports.
>   - **Email sign-in**: Existing email flow retained; no functional changes shown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becd5df2044a897da5ce60b4c297d8619ad0620c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->