### PR TITLE
perf(dotcom): disable PostHog surveys module

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -144,6 +144,7 @@ function configurePosthog(options: AnalyticsOptions) {
 		ui_host: 'https://eu.i.posthog.com',
 		capture_pageview: false,
 		cookieless_mode: 'on_reject',
+		disable_surveys: true,
 		before_send: (payload) => {
 			if (!payload) return null
 			payload.properties.is_signed_in = !!options.user


### PR DESCRIPTION
We're not using PostHog surveys, so disable the surveys module to prevent loading an unnecessary 30.2 kB script at runtime.

This adds `disable_surveys: true` to the PostHog configuration to prevent the surveys module from being dynamically loaded.

### Change type

- [x] `improvement`

### Test plan

1. Verify that `surveys.js` is no longer requested in the network tab when loading tldraw.com
2. Verify that analytics still work as expected (event tracking, page views, etc.)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance by disabling unused PostHog surveys module.

## References

- PostHog PR adding the `disable_surveys` option: https://github.com/PostHog/posthog-js/pull/1123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable PostHog surveys by setting `disable_surveys: true` in the analytics config to avoid loading the surveys module.
> 
> - **Analytics**:
>   - Update `apps/dotcom/client/src/utils/analytics.tsx` PostHog config to set `disable_surveys: true`, preventing the surveys module from loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451912a09aac161f56ee80f619c57af25ca3aec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->