### PR TITLE
feat(dotcom): add tos and privacy policy to sign in dialog

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -613,6 +613,12 @@
       "value": "This month"
     }
   ],
+  "985a4b720f": [
+    {
+      "type": 0,
+      "value": "Terms of Use"
+    }
+  ],
   "9914a0ce04": [
     {
       "type": 0,
@@ -1117,6 +1123,12 @@
     {
       "type": 0,
       "value": "Settings"
+    }
+  ],
+  "fa2ead697d": [
+    {
+      "type": 0,
+      "value": "Privacy Policy"
     }
   ],
   "fb15c53f22": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -281,6 +281,9 @@
   "96165d6df5": {
     "translation": "This month"
   },
+  "985a4b720f": {
+    "translation": "Terms of Use"
+  },
   "9914a0ce04": {
     "translation": "Light"
   },
@@ -476,6 +479,9 @@
   },
   "f4f70727dc": {
     "translation": "Settings"
+  },
+  "fa2ead697d": {
+    "translation": "Privacy Policy"
   },
   "fb15c53f22": {
     "translation": "Viewer"

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -70,7 +70,7 @@ export function TlaSignInDialog({ onClose }: { onClose?(): void }) {
 				{innerContent}
 
 				{/* Clerk's CAPTCHA widget */}
-				<div id="clerk-captcha" />
+				<div id="clerk-captcha" className={styles.clerkCaptcha} />
 			</TldrawUiDialogBody>
 		</div>
 	)
@@ -229,6 +229,17 @@ function TlaEnterEmailStep({
 				>
 					<F defaultMessage="Continue with email" />
 				</TlaCtaButton>
+
+				<p className={styles.authTermsOfUse}>
+					<a href="/tos.html" target="_blank" rel="noopener noreferrer">
+						<F defaultMessage="Terms of Use" />
+					</a>
+					{/* eslint-disable-next-line react/jsx-no-literals */}
+					{' · '}
+					<a href="/privacy.html" target="_blank" rel="noopener noreferrer">
+						<F defaultMessage="Privacy Policy" />
+					</a>
+				</p>
 			</form>
 		</>
 	)

--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -148,6 +148,19 @@
 	font-weight: 500;
 }
 
+.clerkCaptcha {
+	margin-bottom: calc(-1 * var(--tl-space-8));
+}
+
+.authTermsOfUse {
+	font-size: 12px;
+	color: var(--tl-color-text-2);
+	margin-top: var(--tl-space-8);
+	text-align: center;
+	text-wrap: balance;
+	font-weight: 500;
+}
+
 /* Continue Button */
 /* .authContinueButton {
 	width: 100%;


### PR DESCRIPTION
adds ToS/privacy policy to sign in dialog

<img width="493" height="569" alt="Screenshot 2025-11-14 at 09 43 40" src="https://github.com/user-attachments/assets/fb9fee4c-be3e-4802-9ce4-4917b3488e78" />

### Change type

- [x] `other`

### Test plan

1. Open the sign-in dialog.
2. Verify that the Terms of Use and Privacy Policy links are visible and styled correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added Terms of Use and Privacy Policy links to the sign-in dialog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Terms of Use and Privacy Policy links (with styling) to the sign-in dialog and updates i18n strings.
> 
> - **Sign-in Dialog UI**:
>   - Show links to `Terms of Use` (`/tos.html`) and `Privacy Policy` (`/privacy.html`) beneath the email form.
>   - Style additions: `authTermsOfUse` text and `clerkCaptcha` spacing; apply `className` to `#clerk-captcha`.
> - **i18n**:
>   - Add messages for `985a4b720f` (`Terms of Use`) and `fa2ead697d` (`Privacy Policy`) in `public/tla/locales/*.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9719d843e7ae3aa1278b7f456b3eea210b3a76f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->