### PR TITLE
fix(dotcom): resolve scrollbar issue in sign-in dialog

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -66,8 +66,8 @@ export function TlaSignInDialog({ onClose }: { onClose?(): void }) {
 				</TldrawUiDialogTitle>
 				{onClose && <TldrawUiDialogCloseButton />}
 			</TldrawUiDialogHeader>
-			<TldrawUiDialogBody className={styles.authBody}>
-				{innerContent}
+			<TldrawUiDialogBody className={styles.authDialogBody}>
+				<div className={styles.authBody}>{innerContent}</div>
 
 				{/* Clerk's CAPTCHA widget */}
 				<div id="clerk-captcha" className={styles.clerkCaptcha} />

--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -18,6 +18,10 @@
 	overflow-y: auto;
 }
 
+.authDialogBody {
+	padding: 0;
+}
+
 .authBody {
 	display: flex;
 	flex-direction: column;
@@ -148,8 +152,9 @@
 	font-weight: 500;
 }
 
-.clerkCaptcha {
-	margin-bottom: calc(-1 * var(--tl-space-8));
+.clerkCaptcha:not(:empty) {
+	padding: var(--tl-space-8);
+	margin-top: calc(-1 * var(--tl-space-8));
 }
 
 .authTermsOfUse {


### PR DESCRIPTION
ugh, didn't notice the scrollbar (esp. with mac os hidden scrollbars)

### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Open the sign-in dialog on dotcom.
2. Verify that the scrollbar behavior is correct and layout is refined.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a layout issue in the sign-in dialog that caused unnecessary scrollbars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines sign-in dialog layout by zero-padding the dialog body, wrapping content in an inner container, and only applying CAPTCHA spacing when rendered.
> 
> - **UI/Layout**:
>   - Update `apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx`:
>     - Apply `styles.authDialogBody` to `TldrawUiDialogBody` and wrap `innerContent` in a `div` with `styles.authBody`.
>   - Update `apps/dotcom/client/src/tla/components/dialogs/auth.module.css`:
>     - Add `.` `authDialogBody` with zero padding.
>     - Replace `.clerkCaptcha` rule with `.clerkCaptcha:not(:empty)` to add padding and adjust top margin only when CAPTCHA renders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19010a1d17c01509dfa9ae9f8960219a0ab792b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->