### PR TITLE
fix(dotcom): fallback to English for missing translations

### DIFF
--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -125,7 +125,10 @@ function IntlWrapper({ children, locale }: { children: ReactNode; locale: string
 
 			const res = await fetch(`/tla/locales-compiled/${locale}.json`)
 			const messages = await res.json()
-			setMessages(messages)
+			setMessages({
+				...translationsEnJson,
+				...messages,
+			})
 		}
 		fetchMessages()
 	}, [locale])


### PR DESCRIPTION
we usually get translations same day but the login stuff went out before translations were ready so we didn't notice this issue until now.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Ensure untranslated strings fall back to English for dotcom site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure untranslated strings fall back to English by merging fetched locale messages with the English bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59298bc846c03a444365f4dec9840a6a27fa6a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->