### PR TITLE
feat(editor): add parent option for setTool and removeTool

### DIFF
--- a/apps/examples/src/examples/dynamic-tools/DynamicToolsExample.tsx
+++ b/apps/examples/src/examples/dynamic-tools/DynamicToolsExample.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react'
+import {
+	DefaultToolbar,
+	DefaultToolbarContent,
+	Editor,
+	StateNode,
+	TLComponents,
+	TLTextShape,
+	TLUiAssetUrlOverrides,
+	TLUiOverrides,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiMenuItem,
+	toRichText,
+	useIsToolSelected,
+	useTools,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './dynamic-tools.css'
+
+// There's a guide at the bottom of this file!
+
+const OFFSET = 12
+
+// [1]
+class HeartTool extends StateNode {
+	static override id = 'heart'
+
+	override onEnter() {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown() {
+		const { currentPagePoint } = this.editor.inputs
+		this.editor.createShape<TLTextShape>({
+			type: 'text',
+			x: currentPagePoint.x - OFFSET,
+			y: currentPagePoint.y - OFFSET,
+			props: { richText: toRichText('❤️') },
+		})
+	}
+}
+
+// [2]
+const uiOverrides: TLUiOverrides = {
+	tools(editor, tools) {
+		// Create a tool item in the ui's context.
+		tools.heart = {
+			id: 'heart',
+			icon: 'heart-icon',
+			label: 'Heart',
+			kbd: 'r',
+			onSelect: () => {
+				editor.setCurrentTool('heart')
+			},
+		}
+		return tools
+	},
+}
+
+// [3]
+export const customAssetUrls: TLUiAssetUrlOverrides = {
+	icons: {
+		'heart-icon': '/heart-icon.svg',
+	},
+}
+
+// [4]
+export default function DynamicToolsExample() {
+	const [editor, setEditor] = useState<Editor | null>(null)
+	const [isHeartToolEnabled, setIsHeartToolEnabled] = useState(false)
+
+	// [5]
+	const components: TLComponents = useMemo(
+		() => ({
+			Toolbar: (props) => {
+				const tools = useTools()
+				const isHeartSelected = useIsToolSelected(tools['heart'])
+
+				return (
+					<DefaultToolbar {...props}>
+						{isHeartToolEnabled && (
+							<TldrawUiMenuItem {...tools['heart']} isSelected={isHeartSelected} />
+						)}
+						<DefaultToolbarContent />
+					</DefaultToolbar>
+				)
+			},
+			InFrontOfTheCanvas: () => {
+				const toggleHeartTool = () => {
+					if (!editor) return
+					if (isHeartToolEnabled) {
+						// [6]
+						editor.removeTool(HeartTool)
+						// Switch to select tool if we're currently on the heart tool
+						if (editor.getCurrentToolId() === 'heart') {
+							editor.setCurrentTool('select')
+						}
+					} else {
+						// [7]
+						editor.setTool(HeartTool)
+					}
+					setIsHeartToolEnabled(!isHeartToolEnabled)
+				}
+
+				return (
+					<div className="toggle-button-container">
+						<TldrawUiButton onClick={toggleHeartTool} type="normal">
+							{isHeartToolEnabled ? '💔 Remove Heart Tool' : '💖 Add Heart Tool'}
+						</TldrawUiButton>
+					</div>
+				)
+			},
+		}),
+		[editor, isHeartToolEnabled]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				overrides={uiOverrides}
+				components={components}
+				onMount={(editor) => setEditor(editor)}
+				// pass in our custom asset urls
+				assetUrls={customAssetUrls}
+			/>
+		</div>
+	)
+}
+
+/*
+Introduction:
+
+This example demonstrates how to use the `setTool` and `removeTool` methods to dynamically
+add and remove tools from the editor's state chart after initialization. When the tool is
+added, it also appears in the toolbar dynamically. This is useful when you need to 
+conditionally enable or disable tools based on runtime conditions like user permissions, 
+feature flags, or application state.
+
+[1]
+We define a simple HeartTool that extends StateNode. It creates a heart emoji sticker 
+when you click on the canvas. This tool is NOT passed to the Tldraw component initially - 
+it will be added dynamically using setTool.
+
+[2]
+We define UI overrides to add the heart tool to the UI context. This makes it available
+for the toolbar component to reference, even if the tool hasn't been added to the state
+chart yet.
+
+[3]
+We override the Toolbar component to conditionally show the heart tool. The tool only
+appears in the toolbar when it exists in the state chart (isHeartToolEnabled is true).
+This creates a nice dynamic behavior where the toolbar updates when you add/remove the tool.
+
+[4]
+We pass the overrides and components to the Tldraw component. The toggle button will
+appear on top of the canvas, and clicking it will add/remove the heart tool dynamically.
+When added, the tool appears in the toolbar and can be used immediately.
+
+[5]
+We define the components object. We override the Toolbar component to conditionally show the heart tool. The tool only
+appears in the toolbar when it exists in the state chart (isHeartToolEnabled is true).
+This creates a nice dynamic behavior where the toolbar updates when you add/remove the tool.
+
+[6]
+We remove the heart tool from the state chart if it exists, and adds it back if it doesn't.
+
+[7]
+We add the heart tool to the state chart if it doesn't exist.
+
+*/

--- a/apps/examples/src/examples/dynamic-tools/README.md
+++ b/apps/examples/src/examples/dynamic-tools/README.md
@@ -1,0 +1,13 @@
+---
+title: Dynamic tools with setTool and removeTool
+component: ./DynamicToolsExample.tsx
+category: editor-api
+priority: 2
+keywords: [setTool, removeTool, dynamic, tools, state chart, toolbar]
+---
+
+Dynamically add and remove tools from the editor and toolbar after initialization.
+
+---
+
+The `setTool` and `removeTool` methods allow you to add and remove tools from the editor's state chart on demand, after the editor has been initialized. This example shows how to dynamically add a tool that appears in the toolbar when added and disappears when removed. This is useful when you need to conditionally enable or disable tools based on user permissions, feature flags, or other runtime conditions.

--- a/apps/examples/src/examples/dynamic-tools/dynamic-tools.css
+++ b/apps/examples/src/examples/dynamic-tools/dynamic-tools.css
@@ -1,0 +1,11 @@
+.toggle-button-container {
+	position: absolute;
+	top: 16px;
+	left: 50%;
+	transform: translateX(-50%);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	pointer-events: auto;
+}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1385,7 +1385,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     registerExternalContentHandler<T extends TLExternalContent<E>['type'], E>(type: T, handler: ((info: T extends TLExternalContent<E>['type'] ? Extract<TLExternalContent<E>, {
         type: T;
     }> : TLExternalContent<E>) => void) | null): this;
-    removeTool(Tool: TLStateNodeConstructor): void;
+    removeTool(Tool: TLStateNodeConstructor, parent?: StateNode): void;
     renamePage(page: TLPage | TLPageId, name: string): this;
     reparentShapes(shapes: TLShape[] | TLShapeId[], parentId: TLParentId, insertIndex?: IndexKey): this;
     replaceExternalContent<E>(info: TLExternalContent<E>, opts?: {
@@ -1445,7 +1445,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     _setShiftKeyTimeout(): void;
     setStyleForNextShapes<T>(style: StyleProp<T>, value: T, historyOptions?: TLHistoryBatchOptions): this;
     setStyleForSelectedShapes<S extends StyleProp<any>>(style: S, value: StylePropValue<S>): this;
-    setTool(Tool: TLStateNodeConstructor): void;
+    setTool(Tool: TLStateNodeConstructor, parent?: StateNode): void;
     shapeUtils: {
         readonly [K in string]?: ShapeUtil<TLUnknownShape>;
     };

--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -11,6 +11,7 @@ import {
 	createTLStore,
 } from '../..'
 import { Editor } from './Editor'
+import { StateNode } from './tools/StateNode'
 
 type ICustomShape = TLBaseShape<
 	'my-custom-shape',
@@ -921,5 +922,272 @@ describe('replaceExternalContent', () => {
 		await editor.replaceExternalContent(info, { force: false })
 
 		expect(mockHandler).toHaveBeenCalledWith(info)
+	})
+})
+
+describe('setTool', () => {
+	class CustomToolA extends StateNode {
+		static override id = 'custom-tool-a'
+	}
+
+	class CustomToolB extends StateNode {
+		static override id = 'custom-tool-b'
+	}
+
+	class CustomToolC extends StateNode {
+		static override id = 'custom-tool-c'
+	}
+
+	class ParentTool extends StateNode {
+		static override id = 'parent-tool'
+		static override initial = 'child-tool-1'
+		static override children() {
+			return [ChildTool1]
+		}
+	}
+
+	class ChildTool1 extends StateNode {
+		static override id = 'child-tool-1'
+	}
+
+	class ChildTool2 extends StateNode {
+		static override id = 'child-tool-2'
+	}
+
+	let toolEditor: Editor
+
+	beforeEach(() => {
+		toolEditor = new Editor({
+			shapeUtils: [],
+			bindingUtils: [],
+			tools: [CustomToolA, ParentTool],
+			store: createTLStore({ shapeUtils: [], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+	})
+
+	it('should add a tool to the root state', () => {
+		// Initially CustomToolB should not exist
+		expect(toolEditor.root.children!['custom-tool-b']).toBeUndefined()
+
+		// Add CustomToolB
+		toolEditor.setTool(CustomToolB)
+
+		// CustomToolB should now exist in root
+		expect(toolEditor.root.children!['custom-tool-b']).toBeDefined()
+		expect(toolEditor.root.children!['custom-tool-b']).toBeInstanceOf(CustomToolB)
+	})
+
+	it('should add a tool to a specific parent state', () => {
+		const parentTool = toolEditor.root.children!['parent-tool'] as ParentTool
+
+		// Initially should only have child-tool-1
+		expect(Object.keys(parentTool.children!)).toHaveLength(1)
+		expect(parentTool.children!['child-tool-1']).toBeDefined()
+		expect(parentTool.children!['child-tool-2']).toBeUndefined()
+
+		// Add ChildTool2 to ParentTool
+		toolEditor.setTool(ChildTool2, parentTool)
+
+		// Should now have both children
+		expect(Object.keys(parentTool.children!)).toHaveLength(2)
+		expect(parentTool.children!['child-tool-1']).toBeDefined()
+		expect(parentTool.children!['child-tool-2']).toBeDefined()
+		expect(parentTool.children!['child-tool-2']).toBeInstanceOf(ChildTool2)
+	})
+
+	it('should throw an error when trying to override an existing tool', () => {
+		// CustomToolA is already in the root (added in beforeEach)
+		expect(toolEditor.root.children!['custom-tool-a']).toBeDefined()
+
+		// Should throw error when trying to add another tool with the same ID
+		expect(() => {
+			toolEditor.setTool(CustomToolA)
+		}).toThrow('Can\'t override tool with id "custom-tool-a"')
+	})
+
+	it('should allow transitioning to a newly added tool', () => {
+		// Add CustomToolB
+		toolEditor.setTool(CustomToolB)
+
+		// Should be able to transition to the new tool
+		expect(() => {
+			toolEditor.setCurrentTool('custom-tool-b')
+		}).not.toThrow()
+
+		// Should now be on the new tool
+		expect(toolEditor.getCurrentToolId()).toBe('custom-tool-b')
+	})
+
+	it('should create the tool with the correct editor and parent', () => {
+		// Add CustomToolB to root
+		toolEditor.setTool(CustomToolB)
+
+		const customToolB = toolEditor.root.children!['custom-tool-b'] as CustomToolB
+
+		expect(customToolB.editor).toBe(toolEditor)
+		expect(customToolB.parent).toBe(toolEditor.root)
+	})
+
+	it('should maintain existing tools when adding new ones', () => {
+		const originalTool = toolEditor.root.children!['custom-tool-a']
+
+		// Add CustomToolB
+		toolEditor.setTool(CustomToolB)
+
+		// Original tool should still exist
+		expect(toolEditor.root.children!['custom-tool-a']).toBe(originalTool)
+		expect(toolEditor.root.children!['custom-tool-a']).toBeInstanceOf(CustomToolA)
+	})
+
+	it('should allow adding multiple tools', () => {
+		// Add multiple tools
+		toolEditor.setTool(CustomToolB)
+		toolEditor.setTool(CustomToolC)
+
+		// All tools should exist
+		expect(toolEditor.root.children!['custom-tool-a']).toBeDefined()
+		expect(toolEditor.root.children!['custom-tool-b']).toBeDefined()
+		expect(toolEditor.root.children!['custom-tool-c']).toBeDefined()
+		expect(toolEditor.root.children!['custom-tool-b']).toBeInstanceOf(CustomToolB)
+		expect(toolEditor.root.children!['custom-tool-c']).toBeInstanceOf(CustomToolC)
+	})
+})
+
+describe('removeTool', () => {
+	class CustomToolA extends StateNode {
+		static override id = 'custom-tool-a'
+	}
+
+	class CustomToolB extends StateNode {
+		static override id = 'custom-tool-b'
+	}
+
+	class CustomToolC extends StateNode {
+		static override id = 'custom-tool-c'
+	}
+
+	class ParentTool extends StateNode {
+		static override id = 'parent-tool'
+		static override initial = 'child-tool-1'
+		static override children() {
+			return [ChildTool1, ChildTool2]
+		}
+	}
+
+	class ChildTool1 extends StateNode {
+		static override id = 'child-tool-1'
+	}
+
+	class ChildTool2 extends StateNode {
+		static override id = 'child-tool-2'
+	}
+
+	let toolEditor: Editor
+
+	beforeEach(() => {
+		toolEditor = new Editor({
+			shapeUtils: [],
+			bindingUtils: [],
+			tools: [CustomToolA, CustomToolB, CustomToolC, ParentTool],
+			store: createTLStore({ shapeUtils: [], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+	})
+
+	it('should remove a tool from the root state', () => {
+		// CustomToolB should exist initially
+		expect(toolEditor.root.children!['custom-tool-b']).toBeDefined()
+
+		// Remove CustomToolB
+		toolEditor.removeTool(CustomToolB)
+
+		// CustomToolB should no longer exist
+		expect(toolEditor.root.children!['custom-tool-b']).toBeUndefined()
+	})
+
+	it('should remove a tool from a specific parent state', () => {
+		const parentTool = toolEditor.root.children!['parent-tool'] as ParentTool
+
+		// Initially should have both children
+		expect(Object.keys(parentTool.children!)).toHaveLength(2)
+		expect(parentTool.children!['child-tool-1']).toBeDefined()
+		expect(parentTool.children!['child-tool-2']).toBeDefined()
+
+		// Remove ChildTool2 from ParentTool
+		toolEditor.removeTool(ChildTool2, parentTool)
+
+		// Should now only have child-tool-1
+		expect(Object.keys(parentTool.children!)).toHaveLength(1)
+		expect(parentTool.children!['child-tool-1']).toBeDefined()
+		expect(parentTool.children!['child-tool-2']).toBeUndefined()
+	})
+
+	it('should not throw an error when trying to remove a non-existent tool', () => {
+		// First remove CustomToolB
+		toolEditor.removeTool(CustomToolB)
+		expect(toolEditor.root.children!['custom-tool-b']).toBeUndefined()
+
+		// Trying to remove it again should not throw
+		expect(() => {
+			toolEditor.removeTool(CustomToolB)
+		}).not.toThrow()
+	})
+
+	it('should maintain other tools when removing one', () => {
+		const originalToolA = toolEditor.root.children!['custom-tool-a']
+		const originalToolC = toolEditor.root.children!['custom-tool-c']
+
+		// Remove CustomToolB
+		toolEditor.removeTool(CustomToolB)
+
+		// Other tools should still exist
+		expect(toolEditor.root.children!['custom-tool-a']).toBe(originalToolA)
+		expect(toolEditor.root.children!['custom-tool-c']).toBe(originalToolC)
+		expect(toolEditor.root.children!['custom-tool-a']).toBeInstanceOf(CustomToolA)
+		expect(toolEditor.root.children!['custom-tool-c']).toBeInstanceOf(CustomToolC)
+	})
+
+	it('should not be able to transition to a removed tool', () => {
+		// Remove CustomToolB
+		toolEditor.removeTool(CustomToolB)
+
+		// Should throw when trying to transition to removed tool
+		expect(() => {
+			toolEditor.setCurrentTool('custom-tool-b')
+		}).toThrow()
+	})
+
+	it('should allow removing multiple tools', () => {
+		// Remove multiple tools
+		toolEditor.removeTool(CustomToolB)
+		toolEditor.removeTool(CustomToolC)
+
+		// Removed tools should not exist
+		expect(toolEditor.root.children!['custom-tool-b']).toBeUndefined()
+		expect(toolEditor.root.children!['custom-tool-c']).toBeUndefined()
+
+		// Other tools should still exist
+		expect(toolEditor.root.children!['custom-tool-a']).toBeDefined()
+		expect(toolEditor.root.children!['parent-tool']).toBeDefined()
+	})
+
+	it('should allow re-adding a tool after removing it', () => {
+		// Remove CustomToolB
+		toolEditor.removeTool(CustomToolB)
+		expect(toolEditor.root.children!['custom-tool-b']).toBeUndefined()
+
+		// Re-add CustomToolB
+		toolEditor.setTool(CustomToolB)
+
+		// CustomToolB should exist again
+		expect(toolEditor.root.children!['custom-tool-b']).toBeDefined()
+		expect(toolEditor.root.children!['custom-tool-b']).toBeInstanceOf(CustomToolB)
+
+		// Should be able to transition to it
+		expect(() => {
+			toolEditor.setCurrentTool('custom-tool-b')
+		}).not.toThrow()
+		expect(toolEditor.getCurrentToolId()).toBe('custom-tool-b')
 	})
 })

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -842,14 +842,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * after the editor has already been initialized.
 	 *
 	 * @param Tool - The tool to set.
+	 * @param parent - The parent state node to set the tool on.
 	 *
 	 * @public
 	 */
-	setTool(Tool: TLStateNodeConstructor) {
-		if (hasOwnProperty(this.root.children!, Tool.id)) {
+	setTool(Tool: TLStateNodeConstructor, parent?: StateNode) {
+		parent ??= this.root
+		if (hasOwnProperty(parent.children!, Tool.id)) {
 			throw Error(`Can't override tool with id "${Tool.id}"`)
 		}
-		this.root.children![Tool.id] = new Tool(this, this.root)
+		parent.children![Tool.id] = new Tool(this, parent)
 	}
 
 	/**
@@ -857,12 +859,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * after the editor has already been initialized.
 	 *
 	 * @param Tool - The tool to delete.
+	 * @param parent - The parent state node to remove the tool from.
 	 *
 	 * @public
 	 */
-	removeTool(Tool: TLStateNodeConstructor) {
-		if (hasOwnProperty(this.root.children!, Tool.id)) {
-			delete this.root.children![Tool.id]
+	removeTool(Tool: TLStateNodeConstructor, parent?: StateNode) {
+		parent ??= this.root
+		if (hasOwnProperty(parent.children!, Tool.id)) {
+			delete parent.children![Tool.id]
 		}
 	}
 


### PR DESCRIPTION
this is work that was in the fairy branch, landing this `parent` tweak ahead of the SDK release

### Change type

- [x] `api`

### Test plan

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added an optional `parent` parameter to `Editor.setTool` and `Editor.removeTool` to support nested tool management.

### API changes

- add `parent` as an option to setTool/removeTool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `parent` to `Editor.setTool`/`removeTool` for nested tool management and introduces an example demonstrating dynamic tool add/remove with UI integration.
> 
> - **Editor API**:
>   - `Editor.setTool` and `Editor.removeTool` accept optional `parent?: StateNode` to add/remove tools under specific parent states.
>   - Implements parent-aware logic in `Editor.ts` and updates API report.
> - **Tests**:
>   - Extensive unit tests for `setTool`/`removeTool`, including root vs. parent state, errors on duplicate ids, transitions, and re-adding tools.
> - **Examples**:
>   - New `dynamic-tools` example showcasing runtime add/remove of a custom `HeartTool`, dynamic toolbar item, and toggle UI (`DynamicToolsExample.tsx`, CSS, README).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8c22f04354e7d4a9d0ddf0b116412a998827807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->