### PR TITLE
feat(examples): add dynamic tools example

### DIFF
--- a/apps/examples/src/examples/dynamic-tools/DynamicToolsExample.tsx
+++ b/apps/examples/src/examples/dynamic-tools/DynamicToolsExample.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react'
+import {
+	DefaultToolbar,
+	DefaultToolbarContent,
+	Editor,
+	StateNode,
+	TLComponents,
+	TLTextShape,
+	TLUiAssetUrlOverrides,
+	TLUiOverrides,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiMenuItem,
+	toRichText,
+	useIsToolSelected,
+	useTools,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './dynamic-tools.css'
+
+// There's a guide at the bottom of this file!
+
+const OFFSET = 12
+
+// [1]
+class HeartTool extends StateNode {
+	static override id = 'heart'
+
+	override onEnter() {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown() {
+		const { currentPagePoint } = this.editor.inputs
+		this.editor.createShape<TLTextShape>({
+			type: 'text',
+			x: currentPagePoint.x - OFFSET,
+			y: currentPagePoint.y - OFFSET,
+			props: { richText: toRichText('❤️') },
+		})
+	}
+}
+
+// [2]
+const uiOverrides: TLUiOverrides = {
+	tools(editor, tools) {
+		// Create a tool item in the ui's context.
+		tools.heart = {
+			id: 'heart',
+			icon: 'heart-icon',
+			label: 'Heart',
+			kbd: 'r',
+			onSelect: () => {
+				editor.setCurrentTool('heart')
+			},
+		}
+		return tools
+	},
+}
+
+// [3]
+export const customAssetUrls: TLUiAssetUrlOverrides = {
+	icons: {
+		'heart-icon': '/heart-icon.svg',
+	},
+}
+
+// [4]
+export default function DynamicToolsExample() {
+	const [editor, setEditor] = useState<Editor | null>(null)
+	const [isHeartToolEnabled, setIsHeartToolEnabled] = useState(false)
+
+	// [5]
+	const components: TLComponents = useMemo(
+		() => ({
+			Toolbar: (props) => {
+				const tools = useTools()
+				const isHeartSelected = useIsToolSelected(tools['heart'])
+
+				return (
+					<DefaultToolbar {...props}>
+						{isHeartToolEnabled && (
+							<TldrawUiMenuItem {...tools['heart']} isSelected={isHeartSelected} />
+						)}
+						<DefaultToolbarContent />
+					</DefaultToolbar>
+				)
+			},
+			InFrontOfTheCanvas: () => {
+				const toggleHeartTool = () => {
+					if (!editor) return
+					if (isHeartToolEnabled) {
+						// [6]
+						editor.removeTool(HeartTool)
+						// Switch to select tool if we're currently on the heart tool
+						if (editor.getCurrentToolId() === 'heart') {
+							editor.setCurrentTool('select')
+						}
+					} else {
+						// [7]
+						editor.setTool(HeartTool)
+					}
+					setIsHeartToolEnabled(!isHeartToolEnabled)
+				}
+
+				return (
+					<div className="toggle-button-container">
+						<TldrawUiButton onClick={toggleHeartTool} type="normal">
+							{isHeartToolEnabled ? '💔 Remove Heart Tool' : '💖 Add Heart Tool'}
+						</TldrawUiButton>
+					</div>
+				)
+			},
+		}),
+		[editor, isHeartToolEnabled]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				overrides={uiOverrides}
+				components={components}
+				onMount={(editor) => setEditor(editor)}
+				// pass in our custom asset urls
+				assetUrls={customAssetUrls}
+			/>
+		</div>
+	)
+}
+
+/*
+Introduction:
+
+This example demonstrates how to use the `setTool` and `removeTool` methods to dynamically
+add and remove tools from the editor's state chart after initialization. When the tool is
+added, it also appears in the toolbar dynamically. This is useful when you need to 
+conditionally enable or disable tools based on runtime conditions like user permissions, 
+feature flags, or application state.
+
+[1]
+We define a simple HeartTool that extends StateNode. It creates a heart emoji sticker 
+when you click on the canvas. This tool is NOT passed to the Tldraw component initially - 
+it will be added dynamically using setTool.
+
+[2]
+We define UI overrides to add the heart tool to the UI context. This makes it available
+for the toolbar component to reference, even if the tool hasn't been added to the state
+chart yet.
+
+[3]
+We override the Toolbar component to conditionally show the heart tool. The tool only
+appears in the toolbar when it exists in the state chart (isHeartToolEnabled is true).
+This creates a nice dynamic behavior where the toolbar updates when you add/remove the tool.
+
+[4]
+We pass the overrides and components to the Tldraw component. The toggle button will
+appear on top of the canvas, and clicking it will add/remove the heart tool dynamically.
+When added, the tool appears in the toolbar and can be used immediately.
+
+[5]
+We define the components object. We override the Toolbar component to conditionally show the heart tool. The tool only
+appears in the toolbar when it exists in the state chart (isHeartToolEnabled is true).
+This creates a nice dynamic behavior where the toolbar updates when you add/remove the tool.
+
+[6]
+We remove the heart tool from the state chart if it exists, and adds it back if it doesn't.
+
+[7]
+We add the heart tool to the state chart if it doesn't exist.
+
+*/

--- a/apps/examples/src/examples/dynamic-tools/README.md
+++ b/apps/examples/src/examples/dynamic-tools/README.md
@@ -1,0 +1,13 @@
+---
+title: Dynamic tools with setTool and removeTool
+component: ./DynamicToolsExample.tsx
+category: editor-api
+priority: 2
+keywords: [setTool, removeTool, dynamic, tools, state chart, toolbar]
+---
+
+Dynamically add and remove tools from the editor and toolbar after initialization.
+
+---
+
+The `setTool` and `removeTool` methods allow you to add and remove tools from the editor's state chart on demand, after the editor has been initialized. This example shows how to dynamically add a tool that appears in the toolbar when added and disappears when removed. This is useful when you need to conditionally enable or disable tools based on user permissions, feature flags, or other runtime conditions.

--- a/apps/examples/src/examples/dynamic-tools/dynamic-tools.css
+++ b/apps/examples/src/examples/dynamic-tools/dynamic-tools.css
@@ -1,0 +1,11 @@
+.toggle-button-container {
+	position: absolute;
+	top: 16px;
+	left: 50%;
+	transform: translateX(-50%);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	pointer-events: auto;
+}


### PR DESCRIPTION
this is work that was in the fairy branch, landing this parent tweak ahead of the SDK release

### Change type

- [x] `feature`

### Test plan

1. Open the dynamic tools example
2. Use the toggle button to add/remove the Heart tool
3. Verify the tool appears/disappears from the toolbar and functions correctly

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a new example demonstrating how to dynamically add and remove custom tools at runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new example that dynamically adds/removes a custom Heart tool and updates the toolbar using setTool/removeTool.
> 
> - **Examples**:
>   - **New example** `apps/examples/src/examples/dynamic-tools/DynamicToolsExample.tsx`:
>     - Implements `HeartTool` (`StateNode`) creating a heart emoji on click.
>     - Uses `editor.setTool` / `editor.removeTool` to dynamically register/unregister the tool.
>     - Adds UI overrides to expose `tools.heart` with custom icon and toolbar item.
>     - Integrates a toggle button (in `InFrontOfTheCanvas`) to add/remove the tool at runtime.
>     - Supplies `customAssetUrls` for `heart-icon`.
> - **Docs**:
>   - Adds `README.md` describing dynamic tool addition/removal.
> - **Styles**:
>   - Adds `dynamic-tools.css` for the toggle button positioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e218db369205c4e3c625adf90be77388e070169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->