### PR TITLE
chore: remove cursor summary from generated changelog

### DIFF
--- a/internal/scripts/extract-draft-changelog.tsx
+++ b/internal/scripts/extract-draft-changelog.tsx
@@ -140,6 +140,8 @@ export async function extractChangelog(startRef: string, endRef: string): Promis
 
 		// Remove the Change type section and all checkboxes
 		restOfMessage = restOfMessage
+			// remove cursor summary
+			.replace(/<!-- CURSOR_SUMMARY -->(.|\s)*/gm, '')
 			// remove Change type section
 			.replace(/### Change type[\s\n]*/g, '')
 			// remove checkboxes


### PR DESCRIPTION
see title

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal script update to exclude cursor summaries from changelog generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops including <!-- CURSOR_SUMMARY --> sections when generating the draft changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbfa8d7b6775be6c73f3fc91299e2165b979d050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->