### PR TITLE
chore(dotcom): improve copy in sign in dialog

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -51,12 +51,6 @@
       "value": "Account"
     }
   ],
-  "08d2d725a9": [
-    {
-      "type": 0,
-      "value": "Create a free account to save your work, collaborate in real-time, and more."
-    }
-  ],
   "0b27918290": [
     {
       "type": 0,
@@ -67,12 +61,6 @@
     {
       "type": 0,
       "value": "File menu"
-    }
-  ],
-  "0beb3ca97b": [
-    {
-      "type": 0,
-      "value": "tldraw is a free and instant virtual whiteboard."
     }
   ],
   "0d1f2bb523": [
@@ -569,6 +557,12 @@
       "value": "Please reload"
     }
   ],
+  "76dea3c9ca": [
+    {
+      "type": 0,
+      "value": "tldraw is a free online whiteboard. Create an account to save your files and work with your friends."
+    }
+  ],
   "777f9e90cf": [
     {
       "type": 0,
@@ -1043,12 +1037,6 @@
     {
       "type": 0,
       "value": "Essential cookies"
-    }
-  ],
-  "c5c5a10435": [
-    {
-      "type": 0,
-      "value": "Sign in or create an account to accept the invitation."
     }
   ],
   "c6155aaecc": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -23,17 +23,11 @@
   "08bd40c754": {
     "translation": "Account"
   },
-  "08d2d725a9": {
-    "translation": "Create a free account to save your work, collaborate in real-time, and more."
-  },
   "0b27918290": {
     "translation": "File"
   },
   "0b9a4cde72": {
     "translation": "File menu"
-  },
-  "0beb3ca97b": {
-    "translation": "tldraw is a free and instant virtual whiteboard."
   },
   "0d1f2bb523": {
     "translation": "Send feedback"
@@ -263,6 +257,9 @@
   "7697920637": {
     "translation": "Please reload"
   },
+  "76dea3c9ca": {
+    "translation": "tldraw is a free online whiteboard. Create an account to save your files and work with your friends."
+  },
   "777f9e90cf": {
     "translation": "Invalid request."
   },
@@ -446,9 +443,6 @@
   },
   "c4b39a1cc3": {
     "translation": "Essential cookies"
-  },
-  "c5c5a10435": {
-    "translation": "Sign in or create an account to accept the invitation."
   },
   "c6155aaecc": {
     "translation": "Group name"

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -217,17 +217,12 @@ function TlaEnterEmailStep({
 					<>
 						<F {...messages.inviteMessage} /> {inviteInfo.groupName}
 						<br />
-						<F defaultMessage="Sign in or create an account to accept the invitation." />
 						<br />
-						<br />
-						<F defaultMessage="tldraw is a free and instant virtual whiteboard." />
+						<F defaultMessage="tldraw is a free online whiteboard. Create an account to save your files and work with your friends." />
 					</>
 				) : (
 					<>
-						<F defaultMessage="tldraw is a free and instant virtual whiteboard." />
-						<br />
-						<br />
-						<F defaultMessage="Create a free account to save your work, collaborate in real-time, and more." />
+						<F defaultMessage="tldraw is a free online whiteboard. Create an account to save your files and work with your friends." />
 					</>
 				)}
 			</div>


### PR DESCRIPTION
This pull request updates the English localization and sign-in dialog messaging to unify and simplify the description of tldraw as a product. Several older, redundant, or less concise messages have been removed and replaced with a single, clearer message about tldraw being a free online whiteboard and the benefits of creating an account. This ensures consistency across the UI and improves the onboarding experience for new users.

**Localization and Messaging Updates:**

* Replaced multiple older messages (e.g., "tldraw is a free and instant virtual whiteboard.", "Create a free account to save your work, collaborate in real-time, and more.", and "Sign in or create an account to accept the invitation.") with a new, unified message: "tldraw is a free online whiteboard. Create an account to save your files and work with your friends." in both `en.json` and `locales-compiled/en.json`.

* Updated the `TlaSignInDialog.tsx` component to use the new unified message in both the invitation and default sign-in flows, removing references to the older, now-deleted messages.

### Change type

- [x] `other`

### Test plan

1. Open the sign-in dialog on the dotcom site.
2. Verify the new copy is displayed correctly in both the standard sign-in and invitation flows.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Updated and unified the copy in the sign-in dialog for a clearer onboarding experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies sign-in dialog copy by replacing multiple older strings with a single message and updating the dialog to use it in both invite and default flows.
> 
> - **Localization (en)**
>   - Remove redundant strings from `apps/dotcom/client/public/tla/locales/en.json` and compiled `locales-compiled/en.json`.
>   - Add unified message `"76dea3c9ca"`: `"tldraw is a free online whiteboard. Create an account to save your files and work with your friends."`.
> - **UI**
>   - Update `src/tla/components/dialogs/TlaSignInDialog.tsx` to display the new unified message for both invite and default sign-in cases; remove references to deleted strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bfc21399fabcfc51034010728c281d1c17dd486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->