### PR TITLE
fix(dotcom): hide inline pin icon from people without groups

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -15,6 +15,7 @@ import {
 import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
 import { useDragTracking } from '../../../hooks/useDragTracking'
+import { useHasFlag } from '../../../hooks/useHasFlag'
 import { useIsDragging } from '../../../hooks/useIsDragging'
 import { useHasFileAdminRights } from '../../../hooks/useIsFileOwner'
 import { useIsFilePinned } from '../../../hooks/useIsFilePinned'
@@ -199,6 +200,7 @@ export function TlaSidebarFileLinkInner({
 	const isCoarsePointer = getIsCoarsePointer()
 
 	const wrapperRef = useRef<HTMLDivElement>(null)
+	const hasGroups = useHasFlag('groups_frontend')
 
 	if (!file) return null
 
@@ -272,7 +274,7 @@ export function TlaSidebarFileLinkInner({
 				draggable={false}
 			/>
 			<div className={styles.sidebarFileListItemContent}>
-				{isPinned && pinIcon}
+				{isPinned && hasGroups && pinIcon}
 				<div
 					className={classNames(
 						styles.sidebarFileListItemLabel,

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarInlineInput.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarInlineInput.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import { useCallback, useRef } from 'react'
 import { TldrawUiInput } from 'tldraw'
+import { useHasFlag } from '../../../hooks/useHasFlag'
 import styles from '../sidebar.module.css'
 import { pinIcon } from './pinIcon'
 
@@ -49,9 +50,11 @@ export function TlaSidebarInlineInput({
 		onCancel()
 	}, [onCancel])
 
+	const hasGroups = useHasFlag('groups_frontend')
+
 	return (
 		<div className={classNames(styles.sidebarFileListItemRenameInputWrapper, wrapperClassName)}>
-			{isPinned && pinIcon}
+			{isPinned && hasGroups && pinIcon}
 			<TldrawUiInput
 				ref={ref}
 				data-testid={dataTestId}


### PR DESCRIPTION
we forgot to put this pin icon behind the feature flag.

<img width="261" height="175" alt="image" src="https://github.com/user-attachments/assets/8cc45169-02ab-4bf9-a4c3-dd993fac3b4d" />


### Change type

- [x] `other`

### Test plan

1. Verify that the pin icon in the sidebar is only visible when the 'groups_frontend' feature flag is enabled.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Hide sidebar pin icon when groups feature flag is disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show the sidebar inline pin icon only when `groups_frontend` flag is enabled (in file link and rename input).
> 
> - **Sidebar**:
>   - `TlaSidebarFileLinkInner` and `TlaSidebarInlineInput` now render `pinIcon` only when `isPinned` and `useHasFlag('groups_frontend')` are true.
>   - Added `useHasFlag` usage to both components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bcb01dd305dcf71e7a19af8afdb14f9d807b08c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->