### PR TITLE
fix(scripts): push tag and branch together in publish script

### DIFF
--- a/internal/scripts/publish-new.ts
+++ b/internal/scripts/publish-new.ts
@@ -120,8 +120,7 @@ async function main() {
 	const branchName = `v${major}.${minor}.x`
 	// create and push a new tag to the release branch
 	await exec('git', ['tag', '-a', gitTag, '-m', gitTag, '-f'])
-	await exec('git', ['push', 'origin', `${gitTag}:refs/heads/${branchName}`])
-	await exec('git', ['push', 'origin', 'tag', gitTag, '-f'])
+	await exec('git', ['push', 'origin', `${gitTag}:${branchName}`, '--follow-tags'])
 	await publishProductionDocsAndExamplesAndBemo()
 
 	// convert draft release to published release


### PR DESCRIPTION
we were pushing the new branch using the tag as a ref before the tag had been pushed, this command pushes the tag in addition to the branch

### Change type

- [x] `other`

### Test plan

1. Run the publish script and verify both branch and tag are pushed correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes an issue in the release script where tags were not pushed correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `internal/scripts/publish-new.ts` to push the release branch and tag in one command using `--follow-tags`.
> 
> - **Release script (`internal/scripts/publish-new.ts`)**:
>   - Replace two separate `git push` calls with a single `git push origin ${gitTag}:${branchName} --follow-tags` to push both the release branch and annotated tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd29e6e40ff76e07a80c723eb55c75b0eb4c7b39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->