### PR TITLE
chore: fix git push command in publish script

### DIFF
--- a/internal/scripts/publish-new.ts
+++ b/internal/scripts/publish-new.ts
@@ -120,7 +120,7 @@ async function main() {
 	const branchName = `v${major}.${minor}.x`
 	// create and push a new tag to the release branch
 	await exec('git', ['tag', '-a', gitTag, '-m', gitTag, '-f'])
-	await exec('git', ['push', 'origin', `${gitTag}:${branchName}`, '--follow-tags'])
+	await exec('git', ['push', 'origin', `HEAD:refs/heads/${branchName}`, '--follow-tags'])
 	await publishProductionDocsAndExamplesAndBemo()
 
 	// convert draft release to published release


### PR DESCRIPTION
argh so this wasn't creating a branch, chatgpt lied to me 😭

### Change type

- [x] `other`

### Test plan

1. Run the publish script and verify the branch is created correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the publish script failed to create the release branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects git push to create/update the release branch by pushing HEAD to `refs/heads/<branch>` with tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c451582d10582c45cd2f01e82e8343361c358f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->