### PR TITLE
chore: update Claude config to run prettier on stop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,11 @@
 {
 	"hooks": {
-		"PostToolUse": [
+		"Stop": [
 			{
-				"matcher": "Edit|MultiEdit|Write",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "jq -r '.tool_input.file_path' | { read file_path; yarn run -T prettier --write \"$file_path\"; }"
+						"command": "git diff --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx|js|jsx|json|md)$' | xargs -r yarn run -T prettier --write"
 					}
 				]
 			}


### PR DESCRIPTION
Our claude config has a hook set to run prettier on `Edit|MultiEdit|Write`. This causes issues with imports as it always does the import first, then writes (which runs prettier and removes the unused import), only then it adds the usage.

This PR uses an alternative. What if we only trigger prettier on `Stop` event, which triggers when claude is done. Think it wont trigger if claude gets interrupted by the user.

Worth a try, can always revert.

### Change type

- [x] `other`

### Test plan

1. Use Claude to edit a file and verify prettier runs at the end.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Update Claude configuration to improve import handling during edits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Claude hook to run Prettier on Stop, formatting only changed files detected by git diff.
> 
> - **Config (`.claude/settings.json`)**:
>   - Switch hook from `PostToolUse` to `Stop`.
>   - Update Prettier command to format only changed files (`git diff --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx|json|md)$' | xargs -r yarn run -T prettier --write`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ff3d465c4a61309e18a74a30e9f51c5df0dba63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->