### PR TITLE
feat(dotcom): add max fairies selection with placeholder and icons

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyHUD.tsx
+++ b/apps/dotcom/client/src/fairy/FairyHUD.tsx
@@ -16,7 +16,6 @@ import {
 	useQuickReactor,
 	useValue,
 } from 'tldraw'
-import { MAX_FAIRY_COUNT } from '../tla/components/TlaEditor/TlaEditor'
 import { useApp } from '../tla/hooks/useAppState'
 import '../tla/styles/fairy.css'
 import { F, useMsg } from '../tla/utils/i18n'
@@ -31,50 +30,6 @@ import { $fairyTasks } from './FairyTaskList'
 import { FairyTaskListDropdownContent } from './FairyTaskListDropdownContent'
 import { FairyTaskListInline } from './FairyTaskListInline'
 import { getRandomFairyName } from './getRandomFairyName'
-
-function NewFairyButton({ agents }: { agents: FairyAgent[] }) {
-	const app = useApp()
-	const handleClick = useCallback(() => {
-		if (!app) return
-		const randomOutfit = {
-			body: Object.keys(FAIRY_VARIANTS.body)[
-				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.body).length)
-			] as FairyVariantType<'body'>,
-			hat: Object.keys(FAIRY_VARIANTS.hat)[
-				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.hat).length)
-			] as FairyVariantType<'hat'>,
-			wings: Object.keys(FAIRY_VARIANTS.wings)[
-				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.wings).length)
-			] as FairyVariantType<'wings'>,
-		}
-
-		// Create a unique ID for the new fairy
-		const id = uniqueId()
-
-		// Create the config for the new fairy
-		const config: FairyConfig = {
-			name: getRandomFairyName(),
-			outfit: randomOutfit,
-			personality: 'Friendly and helpful',
-		}
-
-		// Add the config, which will trigger agent creation in FairyApp
-		app.z.mutate.user.updateFairyConfig({ id, properties: config })
-	}, [app])
-
-	const newFairyLabel = useMsg(fairyMessages.newFairy)
-
-	return (
-		<TldrawUiButton
-			type="icon"
-			className="fairy-toolbar-sidebar-button"
-			onClick={handleClick}
-			disabled={agents.length >= MAX_FAIRY_COUNT}
-		>
-			<TldrawUiIcon icon="plus" label={newFairyLabel} />
-		</TldrawUiButton>
-	)
-}
 
 type PanelState = 'task-list' | 'fairy' | 'closed'
 
@@ -169,6 +124,7 @@ function FairyHUDHeader({
 }
 
 export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
+	const app = useApp()
 	const editor = useEditor()
 	const [headerMenuPopoverOpen, setHeaderMenuPopoverOpen] = useState(false)
 	const [fairyMenuPopoverOpen, setFairyMenuPopoverOpen] = useState(false)
@@ -183,6 +139,7 @@ export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 	const selectMessage = useMsg(fairyMessages.selectFairy)
 	const switchToFairyChatLabel = useMsg(fairyMessages.switchToFairyChat)
 	const switchToTaskListLabel = useMsg(fairyMessages.switchToTaskList)
+	const newFairyLabel = useMsg(fairyMessages.newFairy)
 
 	// Create a reactive value that tracks which fairies are selected
 	const selectedFairies = useValue(
@@ -285,6 +242,34 @@ export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 		e.stopPropagation()
 	}
 
+	const handleCreateFairy = useCallback(() => {
+		if (!app) return
+		const randomOutfit = {
+			body: Object.keys(FAIRY_VARIANTS.body)[
+				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.body).length)
+			] as FairyVariantType<'body'>,
+			hat: Object.keys(FAIRY_VARIANTS.hat)[
+				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.hat).length)
+			] as FairyVariantType<'hat'>,
+			wings: Object.keys(FAIRY_VARIANTS.wings)[
+				Math.floor(Math.random() * Object.keys(FAIRY_VARIANTS.wings).length)
+			] as FairyVariantType<'wings'>,
+		}
+
+		// Create a unique ID for the new fairy
+		const id = uniqueId()
+
+		// Create the config for the new fairy
+		const config: FairyConfig = {
+			name: getRandomFairyName(),
+			outfit: randomOutfit,
+			personality: 'Friendly and helpful',
+		}
+
+		// Add the config, which will trigger agent creation in FairyApp
+		app.z.mutate.user.updateFairyConfig({ id, properties: config })
+	}, [app])
+
 	// Keep todoLastChecked in sync when the panel is open
 	useQuickReactor(
 		'update-task-list-last-checked',
@@ -384,7 +369,8 @@ export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 							onClickFairy={handleClickFairy}
 							onDoubleClickFairy={handleDoubleClickFairy}
 							onTogglePanel={handleTogglePanel}
-							newFairyButton={<NewFairyButton agents={agents} />}
+							onCreateFairy={handleCreateFairy}
+							newFairyLabel={newFairyLabel}
 						/>
 					</div>
 				</div>

--- a/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
+++ b/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
@@ -1,6 +1,7 @@
 import { ContextMenu as _ContextMenu } from 'radix-ui'
-import { MouseEvent, ReactNode } from 'react'
-import { TldrawUiButton, TldrawUiButtonIcon, TldrawUiToolbar } from 'tldraw'
+import { MouseEvent } from 'react'
+import { TldrawUiButton, TldrawUiButtonIcon, TldrawUiIcon, TldrawUiToolbar } from 'tldraw'
+import { MAX_FAIRY_COUNT } from '../tla/components/TlaEditor/TlaEditor'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { FairySidebarButton } from './FairySidebarButton'
 import { FairyTaskListContextMenuContent } from './FairyTaskListContextMenuContent'
@@ -14,7 +15,8 @@ interface FairyListSidebarProps {
 	onClickFairy(agent: FairyAgent, event: MouseEvent): void
 	onDoubleClickFairy(agent: FairyAgent): void
 	onTogglePanel(): void
-	newFairyButton: ReactNode
+	onCreateFairy(): void
+	newFairyLabel: string
 }
 
 export function FairyListSidebar({
@@ -26,8 +28,15 @@ export function FairyListSidebar({
 	onClickFairy,
 	onDoubleClickFairy,
 	onTogglePanel,
-	newFairyButton,
+	onCreateFairy,
+	newFairyLabel,
 }: FairyListSidebarProps) {
+	const slots = Array.from({ length: MAX_FAIRY_COUNT }, (_, index) => {
+		return agents[index] || null
+	})
+
+	const nextAvailableSlot = agents.length < MAX_FAIRY_COUNT ? agents.length : -1
+
 	return (
 		<div className="fairy-buttons-container">
 			<div className="fairy-toolbar-header">
@@ -42,9 +51,9 @@ export function FairyListSidebar({
 					<FairyTaskListContextMenuContent agents={agents} />
 				</_ContextMenu.Root>
 			</div>
-			<div className="fairy-list-scrollable">
-				<TldrawUiToolbar label={toolbarMessage} orientation="vertical">
-					{agents.map((agent) => {
+			<TldrawUiToolbar label={toolbarMessage} orientation="vertical">
+				{slots.map((agent, index) => {
+					if (agent) {
 						return (
 							<FairySidebarButton
 								key={agent.id}
@@ -55,11 +64,22 @@ export function FairyListSidebar({
 								deselectMessage={deselectMessage}
 							/>
 						)
-					})}
-				</TldrawUiToolbar>
-			</div>
-			{/* New Fairy Button - always at the bottom */}
-			<div style={{ marginTop: '4px' }}>{newFairyButton}</div>
+					}
+
+					const isNextAvailable = index === nextAvailableSlot
+					return (
+						<TldrawUiButton
+							key={`empty-slot-${index}`}
+							type="icon"
+							className="fairy-toolbar-sidebar-button"
+							onClick={isNextAvailable ? onCreateFairy : undefined}
+							disabled={!isNextAvailable}
+						>
+							<TldrawUiIcon icon="plus" label={newFairyLabel} />
+						</TldrawUiButton>
+					)
+				})}
+			</TldrawUiToolbar>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -58,7 +58,7 @@ import { useExtraDragIconOverrides } from './useExtraToolDragIcons'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 // Lazy load fairy components
-export const MAX_FAIRY_COUNT = 10
+export const MAX_FAIRY_COUNT = 5
 const FairyApp = lazy(() =>
 	import('../../../fairy/FairyApp').then((m) => ({
 		default: m.FairyApp,

--- a/apps/dotcom/client/src/tla/styles/fairy.css
+++ b/apps/dotcom/client/src/tla/styles/fairy.css
@@ -337,6 +337,10 @@
 	font-size: 14px;
 }
 
+.fairy-toolbar-sidebar-button:disabled {
+	cursor: not-allowed;
+}
+
 .fairy-new-button {
 	width: 40px;
 	height: 40px;


### PR DESCRIPTION
<img width="430" height="257" alt="image" src="https://github.com/user-attachments/assets/acc26109-a570-4c4f-9073-0a01452165ee" />

### Change type

- [ ] `bugfix` 
- [ ] `improvement` 
- [x] `feature` 
- [ ] `api` 
- [ ] `other` 

### Test plan

1. Open the fairy HUD/sidebar.
2. Verify that there are exactly 5 slots for fairies.
3. Verify that the next available slot shows a '+' placeholder and is clickable to create a new fairy.
4. Verify that subsequent empty slots are disabled.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a fixed-slot fairy selection UI with placeholders and limited the maximum fairy count to 5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert fairy list to fixed slots with '+' placeholders and creation handler, and reduce MAX_FAIRY_COUNT to 5.
> 
> - **Fairy UI**:
>   - Replace `NewFairyButton` with inline creation flow in `FairyHUD` (`handleCreateFairy`) and pass `onCreateFairy`/`newFairyLabel` to `FairyListSidebar`.
>   - Update `FairyListSidebar` to render `MAX_FAIRY_COUNT` fixed slots; empty slots show a disabled/enabled `+` placeholder (only next available slot clickable).
>   - Add disabled-state styling for `fairy-toolbar-sidebar-button` in `tla/styles/fairy.css`.
> - **Config**:
>   - Lower `MAX_FAIRY_COUNT` from `10` to `5` in `tla/components/TlaEditor/TlaEditor.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2056de3c0fd4da2b50672bfc705788b23d129c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->