### PR TITLE
feat(dotcom): hide fairyhud on mobile when style panel is open

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
+++ b/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
@@ -29,7 +29,7 @@ export function FairyListSidebar({
 	newFairyButton,
 }: FairyListSidebarProps) {
 	return (
-		<div className="fairy-buttons-container">
+		<>
 			<div className="fairy-toolbar-header">
 				<_ContextMenu.Root dir="ltr">
 					<_ContextMenu.Trigger asChild>
@@ -59,7 +59,7 @@ export function FairyListSidebar({
 				</TldrawUiToolbar>
 			</div>
 			{/* New Fairy Button - always at the bottom */}
-			<div style={{ marginTop: '4px' }}>{newFairyButton}</div>
-		</div>
+			<div className="fairy-new-button">{newFairyButton}</div>
+		</>
 	)
 }

--- a/apps/dotcom/client/src/tla/styles/fairy.css
+++ b/apps/dotcom/client/src/tla/styles/fairy.css
@@ -281,6 +281,7 @@
 .tla-fairy-hud .tlui-toolbar {
 	scrollbar-width: thin;
 	scrollbar-color: var(--tl-color-muted-1) transparent;
+	align-items: center;
 }
 
 /* Fairy Toolbar Header */
@@ -289,7 +290,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	justify-content: start;
+	justify-content: center;
 	border-bottom: 1px solid var(--tl-color-divider);
 	padding: 4px;
 	flex-shrink: 0;
@@ -338,32 +339,16 @@
 }
 
 .fairy-new-button {
-	width: 40px;
-	height: 40px;
-	font-size: 16px;
-	appearance: none;
-	border: 1px solid var(--tl-color-muted-2);
-	border-radius: 4px;
-	cursor: pointer;
-	background: transparent;
-	color: var(--tl-color-text);
-	display: flex;
+	margin-top: 4px;
 	align-items: center;
+	display: flex;
 	justify-content: center;
-}
-
-.fairy-new-button:hover:not(:disabled) {
-	background-color: var(--tl-color-hint);
-}
-
-.fairy-new-button:disabled {
-	opacity: 0.3;
-	cursor: not-allowed;
 }
 
 /* Fairy Buttons Container */
 
 .fairy-buttons-container {
+	width: 43px;
 	display: flex;
 	flex-direction: column;
 	background-color: var(--tl-color-panel);


### PR DESCRIPTION
Hide the `FairyHUD` when the style panel opens/closes on mobile + anchor HUD to above style panel button on mobile

### Change type

- [x] `other`

### Test plan

1. Open the app on a mobile device or emulator.
2. Open the style panel and verify that the FairyHUD is hidden.
3. Close the style panel and verify that the FairyHUD is visible and anchored correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved mobile UI by hiding the FairyHUD when the style panel is active.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides `FairyHUD` when the mobile style panel is open and anchors it above the mobile styles button; adjusts sidebar structure and related CSS for centering and sizing.
> 
> - **UI (FairyHUD)**
>   - Hide HUD on mobile when `tlmenus` mobile style menu is open (`display: none`).
>   - Anchor HUD to the right of the mobile styles button by computing `right` offset; updates on resize and breakpoint changes.
>   - Add breakpoint handling and refs; minor inline style updates.
> - **Sidebar (FairyListSidebar)**
>   - Restructure container (fragment + dedicated `fairy-new-button` area) and add scrollable list wrapper `fairy-list-scrollable`.
> - **CSS**
>   - Center header contents; align toolbar items; adjust `.fairy-new-button` and set `.fairy-buttons-container` width to `43px`.
>   - Add styles for `fairy-list-scrollable`; minor spacing/align tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5eb38b9c836debb2edb60741c38cc03dbc13946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->