### PR TITLE
feat(dotcom): add user email whitelist for fairy features

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -84,6 +84,15 @@ const customFeatureFlags = {
 	}),
 }
 
+/** Whitelisted emails with access to fairy features */
+const FAIRY_ACCESS_WHITELIST = ['jake@firstloop.ai']
+
+/** Check if user has access to fairy features */
+function canUserAccessFairies(user: ReturnType<typeof useTldrawUser>): boolean {
+	const email = user?.clerkUser.primaryEmailAddress?.emailAddress
+	return !!user?.isTldraw || isDevelopmentEnv || (!!email && FAIRY_ACCESS_WHITELIST.includes(email))
+}
+
 /** @internal */
 export const components: TLComponents = {
 	ErrorFallback: TlaEditorErrorFallback,
@@ -299,7 +308,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	}, [agents])
 
 	const instanceComponents = useMemo((): TLComponents => {
-		const canShowFairies = app && agents && hasFairiesFlag && (!!user?.isTldraw || isDevelopmentEnv)
+		const canShowFairies = app && agents && hasFairiesFlag && canUserAccessFairies(user)
 
 		return {
 			...components,
@@ -324,11 +333,9 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 					)}
 				</>
 			),
-			DebugMenu: () => (
-				<CustomDebugMenu showFairyFeatureFlags={!!user?.isTldraw || isDevelopmentEnv} />
-			),
+			DebugMenu: () => <CustomDebugMenu showFairyFeatureFlags={canUserAccessFairies(user)} />,
 		}
-	}, [agents, hasFairiesFlag, user?.isTldraw, app])
+	}, [agents, hasFairiesFlag, user, app])
 
 	return (
 		<TlaEditorWrapper>
@@ -351,7 +358,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				<SneakyToolSwitcher />
 				{app && <SneakyTldrawFileDropHandler />}
 				<SneakyLargeFileHander />
-				{app && hasFairiesFlag && (
+				{app && hasFairiesFlag && canUserAccessFairies(user) && (
 					<Suspense fallback={null}>
 						<FairyApp setAgents={setAgents} fileId={fileId} />
 					</Suspense>


### PR DESCRIPTION
Simple way to whitelist users. Add the first user to the whitelist.

### Change type

- [x] `other`

### Test plan

1. Log in with jake@firstloop.ai and verify fairy features are visible.
2. Log in with a different email and verify fairy features are hidden.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added an email whitelist to control access to experimental fairy features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `canUserAccessFairies` using an email whitelist to control access to fairy features and applies it across TlaEditor UI/components.
> 
> - **Editor (`TlaEditor.tsx`)**:
>   - Add `FAIRY_ACCESS_WHITELIST` and `canUserAccessFairies` helper (whitelists `jake@firstloop.ai`).
>   - Replace prior access checks with `canUserAccessFairies` for:
>     - `Overlays`, `InFrontOfTheCanvas`, `DebugMenu` (feature flags), and conditional `FairyApp` mounting.
>   - Update `useMemo` deps to include `user` instead of `user?.isTldraw`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b136295970f7bbf05d4c547da9863003eb95cb59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->