### PR TITLE
fix(analytics): resolve consent tracking and GTM event issues

### DIFF
--- a/apps/analytics/src/analytics-services/analytics-service.ts
+++ b/apps/analytics/src/analytics-services/analytics-service.ts
@@ -39,12 +39,13 @@ export class AnalyticsService {
 	// Track when user submits a form.
 	trackFormSubmission?(data: {
 		enquiry_type: string
+		page_category?: string
 		company_size?: string
 		company_website?: string
-		user_email: string
-		user_email_sha256: string
-		user_first_name: string
-		user_last_name: string
+		user_email?: string
+		user_email_sha256?: string
+		user_first_name?: string
+		user_last_name?: string
 		user_phone_number?: string
 	}): void
 }

--- a/apps/analytics/src/analytics-services/gtm.ts
+++ b/apps/analytics/src/analytics-services/gtm.ts
@@ -57,12 +57,10 @@ class GTMAnalyticsService extends AnalyticsService {
 	}
 
 	override enable() {
-		if (this.isEnabled) return
 		this.isEnabled = true
 	}
 
 	override disable() {
-		if (!this.isEnabled) return
 		this.isEnabled = false
 	}
 
@@ -76,7 +74,6 @@ class GTMAnalyticsService extends AnalyticsService {
 	}
 
 	override trackEvent(name: string, data?: { [key: string]: any }) {
-		if (!this.isEnabled) return
 		dataLayerPush({
 			event: name,
 			...data,
@@ -84,7 +81,6 @@ class GTMAnalyticsService extends AnalyticsService {
 	}
 
 	override trackPageview() {
-		if (!this.isEnabled) return
 		dataLayerPush({
 			event: 'page_view',
 		})
@@ -119,7 +115,6 @@ class GTMAnalyticsService extends AnalyticsService {
 		user_last_name?: string
 		user_phone_number?: string
 	}) {
-		if (!this.isEnabled) return
 		const payload: any = {
 			event: 'click_copy_code',
 			id: crypto.randomUUID(),
@@ -153,29 +148,23 @@ class GTMAnalyticsService extends AnalyticsService {
 
 	override trackFormSubmission(data: {
 		enquiry_type: string
+		page_category?: string
 		company_size?: string
 		company_website?: string
-		user_email: string
-		user_email_sha256: string
-		user_first_name: string
-		user_last_name: string
+		user_email?: string
+		user_email_sha256?: string
+		user_first_name?: string
+		user_last_name?: string
 		user_phone_number?: string
 	}) {
-		if (!this.isEnabled) return
 		const payload: any = {
 			event: 'generate_lead',
 			id: crypto.randomUUID(),
 			page: {
-				category: 'enquiry',
+				category: (data.page_category || 'enquiry').toLowerCase(),
 			},
 			data: {
 				enquiry_type: data.enquiry_type.toLowerCase(),
-			},
-			user: {
-				email: data.user_email.toLowerCase(),
-				email_sha256: data.user_email_sha256.toLowerCase(),
-				first_name: data.user_first_name.toLowerCase(),
-				last_name: data.user_last_name.toLowerCase(),
 			},
 			_clear: true,
 		}
@@ -183,7 +172,22 @@ class GTMAnalyticsService extends AnalyticsService {
 		// Add optional company data
 		if (data.company_size) payload.data.company_size = data.company_size.toLowerCase()
 		if (data.company_website) payload.data.company_website = data.company_website.toLowerCase()
-		if (data.user_phone_number) payload.user.phone_number = data.user_phone_number
+
+		// Only include user object if we have user data
+		if (
+			data.user_email ||
+			data.user_email_sha256 ||
+			data.user_first_name ||
+			data.user_last_name ||
+			data.user_phone_number
+		) {
+			payload.user = {}
+			if (data.user_email) payload.user.email = data.user_email.toLowerCase()
+			if (data.user_email_sha256) payload.user.email_sha256 = data.user_email_sha256.toLowerCase()
+			if (data.user_first_name) payload.user.first_name = data.user_first_name.toLowerCase()
+			if (data.user_last_name) payload.user.last_name = data.user_last_name.toLowerCase()
+			if (data.user_phone_number) payload.user.phone_number = data.user_phone_number
+		}
 
 		dataLayerPush(payload)
 	}

--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -82,12 +82,13 @@ declare global {
 			}): void
 			trackFormSubmission(data: {
 				enquiry_type: string
+				page_category?: string
 				company_size?: string
 				company_website?: string
-				user_email: string
-				user_email_sha256: string
-				user_first_name: string
-				user_last_name: string
+				user_email?: string
+				user_email_sha256?: string
+				user_first_name?: string
+				user_last_name?: string
 				user_phone_number?: string
 			}): void
 		}


### PR DESCRIPTION
Cherrypicking #7160  and #7166 

### Change type

- [x] `other`

### Test plan

1. Verify analytics events are pushed to GTM dataLayer regardless of initial enabled state
2. Test form submission with and without user fields
3. Verify consent tracking flow (opt-in/opt-out)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixes issues with analytics consent tracking and GTM event propagation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes form submission user fields optional (with optional page category), refines consent tracking order/conditions, and updates GTM to always push events and include user data only when present.
> 
> - **Analytics Core (`apps/analytics/src/index.ts`)**
>   - Add `shouldTrackConsentChanges` helper and adjust consent flow: enable then track on opt-in; track then disable on opt-out; only track when the user interacts (post-init and from unknown state).
> - **GTM Service (`apps/analytics/src/analytics-services/gtm.ts`)**
>   - Remove `isEnabled` guards for generic event/pageview/copy/form tracking so events always push to `dataLayer`.
>   - `trackFormSubmission`: accept optional `page_category` (defaults to `enquiry`), include `user` only if any user fields are provided; normalize casing.
>   - `trackCopyCode`: include `user` only if any user fields are provided; normalize casing and truncate snippet.
> - **Types/API (`analytics-service.ts`, `index.ts`, `apps/docs/app/analytics.tsx`)**
>   - Make form submission user fields (`user_email`, `user_email_sha256`, `user_first_name`, `user_last_name`) optional and add optional `page_category`.
>   - Propagate updated types to window `tlanalytics` declarations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d429b5c74497b69b428aeb95d7a56112ed49fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->