### PR TITLE
feat(dotcom): add max fairy placeholder buttons

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyHUD.tsx
+++ b/apps/dotcom/client/src/fairy/FairyHUD.tsx
@@ -37,7 +37,7 @@ import { FairyTaskListInline } from './FairyTaskListInline'
 import { getRandomFairyName } from './getRandomFairyName'
 import { getRandomFairyPersonality } from './getRandomFairyPersonality'
 
-function NewFairyButton({ agents }: { agents: FairyAgent[] }) {
+function NewFairyButton({ agents, disabled }: { agents: FairyAgent[]; disabled?: boolean }) {
 	const app = useApp()
 	const handleClick = useCallback(() => {
 		if (!app) return
@@ -74,7 +74,7 @@ function NewFairyButton({ agents }: { agents: FairyAgent[] }) {
 			type="icon"
 			className="fairy-toolbar-sidebar-button"
 			onClick={handleClick}
-			disabled={agents.length >= MAX_FAIRY_COUNT}
+			disabled={disabled ?? agents.length >= MAX_FAIRY_COUNT}
 		>
 			<TldrawUiIcon icon="plus" label={newFairyLabel} />
 		</TldrawUiButton>
@@ -464,7 +464,9 @@ export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 							onClickFairy={handleClickFairy}
 							onDoubleClickFairy={handleDoubleClickFairy}
 							onTogglePanel={handleTogglePanel}
-							newFairyButton={<NewFairyButton agents={agents} />}
+							renderNewFairyButton={(disabled) => (
+								<NewFairyButton agents={agents} disabled={disabled} />
+							)}
 						/>
 					</div>
 				</div>

--- a/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
+++ b/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
@@ -1,6 +1,7 @@
 import { ContextMenu as _ContextMenu } from 'radix-ui'
 import { MouseEvent, ReactNode } from 'react'
 import { TldrawUiButton, TldrawUiButtonIcon, TldrawUiToolbar, useValue } from 'tldraw'
+import { MAX_FAIRY_COUNT } from '../tla/components/TlaEditor/TlaEditor'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { FairySidebarButton } from './FairySidebarButton'
 import { FairyTaskListContextMenuContent } from './FairyTaskListContextMenuContent'
@@ -86,7 +87,7 @@ interface FairyListSidebarProps {
 	onClickFairy(agent: FairyAgent, event: MouseEvent): void
 	onDoubleClickFairy(agent: FairyAgent): void
 	onTogglePanel(): void
-	newFairyButton: ReactNode
+	renderNewFairyButton(disabled: boolean): ReactNode
 }
 
 export function FairyListSidebar({
@@ -98,7 +99,7 @@ export function FairyListSidebar({
 	onClickFairy,
 	onDoubleClickFairy,
 	onTogglePanel,
-	newFairyButton,
+	renderNewFairyButton,
 }: FairyListSidebarProps) {
 	const sidebarEntries = useValue('fairy-sidebar-entries', () => getSidebarEntries(agents), [
 		agents,
@@ -148,10 +149,11 @@ export function FairyListSidebar({
 
 						return renderFairySidebarButton(entry.agent)
 					})}
+					{Array.from({ length: MAX_FAIRY_COUNT - agents.length }).map((_, i) => (
+						<div key={`placeholder-${i}`}>{renderNewFairyButton(i > 0)}</div>
+					))}
 				</TldrawUiToolbar>
 			</div>
-			{/* New Fairy Button - always at the bottom */}
-			<div className="fairy-new-button">{newFairyButton}</div>
 		</>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -58,7 +58,7 @@ import { useExtraDragIconOverrides } from './useExtraToolDragIcons'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 // Lazy load fairy components
-export const MAX_FAIRY_COUNT = 10
+export const MAX_FAIRY_COUNT = 5
 const FairyApp = lazy(() =>
 	import('../../../fairy/FairyApp').then((m) => ({
 		default: m.FairyApp,

--- a/apps/dotcom/client/src/tla/styles/fairy.css
+++ b/apps/dotcom/client/src/tla/styles/fairy.css
@@ -350,6 +350,11 @@ div:not(.fairy-sidebar-group) > .fairy-toggle-button[data-isactive='true']::befo
 	font-size: 14px;
 }
 
+.fairy-toolbar-sidebar-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.4;
+}
+
 .fairy-new-button {
 	margin-top: 4px;
 	align-items: center;


### PR DESCRIPTION
add max fairy buttons

### Change type

- [ ] `bugfix` 
- [ ] `improvement` 
- [x] `feature` 
- [ ] `api` 
- [ ] `other` 

### Test plan

1. Open the fairy sidebar and verify that placeholder buttons are shown up to the maximum count (5).
2. Verify that the buttons have disabled styling when the limit is reached.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added placeholder buttons for the maximum number of fairies in the sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show placeholder “New Fairy” buttons up to the max in the sidebar (with disabled styling) and lower the max fairies to 5.
> 
> - **Fairy UI**:
>   - Replace single bottom "New Fairy" button with a vertical stack of placeholders in `FairyListSidebar`, rendering `renderNewFairyButton(disabled)` up to `MAX_FAIRY_COUNT`.
>   - `NewFairyButton` now accepts an optional `disabled` prop; disabled state passed in from sidebar placeholders.
>   - Update `FairyHUD` to pass `renderNewFairyButton` instead of a node.
> - **Config**:
>   - Reduce `MAX_FAIRY_COUNT` from `10` to `5` in `TlaEditor` and consume in fairy components.
> - **Styles**:
>   - Add disabled styling for `.fairy-toolbar-sidebar-button` in `fairy.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ac8d58712fa665e2bf07b6d7be6637acbd88c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->