### PR TITLE
fix(dotcom): refine fairy hud and sidebar layout

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyHUD.tsx
+++ b/apps/dotcom/client/src/fairy/FairyHUD.tsx
@@ -406,7 +406,7 @@ export function FairyHUD({ agents }: { agents: FairyAgent[] }) {
 				className={`tla-fairy-hud ${panelState !== 'closed' ? 'tla-fairy-hud--open' : ''}`}
 				style={{
 					bottom: isDebugMode ? '112px' : '72px',
-					right: mobileMenuOffset !== null ? `${mobileMenuOffset}px` : '0px',
+					right: mobileMenuOffset !== null ? `${mobileMenuOffset}px` : '8px',
 					display: isMobileStylePanelOpen ? 'none' : 'block',
 				}}
 				onContextMenu={handleContextMenu}

--- a/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
+++ b/apps/dotcom/client/src/fairy/FairyListSidebar.tsx
@@ -130,7 +130,7 @@ export function FairyListSidebar({
 					<FairyTaskListContextMenuContent agents={agents} />
 				</_ContextMenu.Root>
 			</div>
-			<div className="fairy-list-scrollable">
+			<div className="fairy-list">
 				<TldrawUiToolbar label={toolbarMessage} orientation="vertical">
 					{sidebarEntries.map((entry) => {
 						if (entry.type === 'group') {

--- a/apps/dotcom/client/src/tla/styles/fairy.css
+++ b/apps/dotcom/client/src/tla/styles/fairy.css
@@ -373,18 +373,13 @@ div:not(.fairy-sidebar-group) > .fairy-toggle-button[data-isactive='true']::befo
 }
 
 .fairy-chat-panel[data-panel-state='open'] + .fairy-buttons-container {
+	width: 44px;
 	border-left: 1px solid var(--tl-color-divider);
 	border-radius: 0 var(--tl-radius-2) var(--tl-radius-2) 0;
 }
 
-.fairy-list-scrollable {
-	overflow-y: auto;
-	scrollbar-width: none; /* Firefox */
-	-ms-overflow-style: none; /* IE and Edge */
-}
-
-.fairy-list-scrollable::-webkit-scrollbar {
-	display: none; /* Chrome, Safari, Opera */
+.fairy-list {
+	height: calc(48px * 4);
 }
 
 .fairy-sidebar-group {


### PR DESCRIPTION
Refine the Fairy HUD spacing and sidebar layout, and update project selection logic to open the orchestrator's chat when available.

### Change type

- [x] `other`

### Test plan

1. Open the dotcom app and verify Fairy HUD positioning.
2. Select a project with an orchestrator and ensure it opens the chat.
3. Verify sidebar list layout and scrolling.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Refined Fairy HUD spacing and sidebar layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Selecting a started project now opens the orchestrator’s chat; sidebar list/layout and HUD spacing refined.
> 
> - **Fairy HUD**:
>   - Project selection: When a project has an `orchestrator`/`duo-orchestrator`, selecting it opens that agent’s chat; otherwise selects members for group creation (`FairyHUD.tsx`).
>   - Hook deps: include `selectFairy` in `selectProjectGroup` dependencies.
>   - Positioning: default `right` offset changed to `8px` when no mobile offset.
> - **Sidebar**:
>   - Replace `fairy-list-scrollable` with `fairy-list` and update layout in `FairyListSidebar.tsx` and `fairy.css`.
>   - Set fixed list height to `calc(48px * 4)`; remove custom scroll styling.
> - **Styling**:
>   - Adjust `.fairy-chat-panel + .fairy-buttons-container` width to `44px` and refine borders/radius.
>   - Remove fixed height from `.fairy-toolbar-sidebar-button`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67636fa51b9393fd05639247f3b8103e5a7481b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->