### PR TITLE
docs: add pricing page for fairies

### DIFF
--- a/apps/docs/app/fairy-pricing/page.tsx
+++ b/apps/docs/app/fairy-pricing/page.tsx
@@ -1,0 +1,115 @@
+import { TldrawLink } from '@/components/common/tldraw-link'
+import { FairyPricingSelector } from '@/components/fairy/fairy-pricing-selector'
+import { Metadata } from 'next'
+
+const PRICE_PER_FAIRY = 10
+const MIN_FAIRIES = 1
+const MAX_FAIRIES = 5
+const PADDLE_CHECKOUT_URL =
+	process.env.NEXT_PUBLIC_PADDLE_FAIRY_CHECKOUT_URL ??
+	'https://checkout.paddle.com/checkout/custom/tldraw-fairy'
+
+export const metadata: Metadata = {
+	title: 'December Fairies Pricing',
+	description: 'Fairies are AI assistants that live inside tldraw.',
+}
+
+export default function FairyPricingPage() {
+	return (
+		<main className="relative overflow-hidden bg-gradient-to-b from-blue-50 via-white to-white pb-24 pt-16 dark:from-zinc-900 dark:via-zinc-950 dark:pb-32">
+			<div className="pointer-events-none absolute inset-0 -z-10 opacity-70 blur-3xl">
+				<div className="absolute left-1/4 top-10 h-72 w-72 rounded-full bg-blue-200/40 dark:bg-blue-500/10" />
+				<div className="absolute bottom-0 right-1/4 h-72 w-72 rounded-full bg-pink-100/40 dark:bg-pink-500/10" />
+			</div>
+			<div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-5 sm:px-8">
+				<section className="mt-8 max-w-3xl">
+					<p className="text-xs font-semibold uppercase tracking-[0.3em] text-blue-500">
+						December limited run
+					</p>
+					<h1 className="mt-4 text-4xl font-semibold tracking-tight text-zinc-900 dark:text-white sm:text-5xl">
+						Fairies for your tldraw canvases
+					</h1>
+					<p className="mt-4 text-lg text-zinc-600 dark:text-zinc-300">
+						Fairies are AI assistants that live inside tldraw. Each Fairy is a creative collaborator
+						that can sketch, organize, and respond to your prompts right on the canvas.
+					</p>
+				</section>
+				<section className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr]">
+					<FairyPricingSelector
+						pricePerFairy={PRICE_PER_FAIRY}
+						minFairies={MIN_FAIRIES}
+						maxFairies={MAX_FAIRIES}
+						checkoutUrl={PADDLE_CHECKOUT_URL}
+					/>
+					<div className="rounded-3xl border border-zinc-200 bg-white/80 p-6 shadow-[0_35px_120px_-50px_rgba(15,23,42,0.35)] backdrop-blur-md dark:border-zinc-800 dark:bg-zinc-900/70">
+						<div>
+							<p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+								What you get
+							</p>
+							<h2 className="mt-3 text-2xl font-semibold text-zinc-900 dark:text-white">
+								A tldraw drop
+							</h2>
+							<p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">
+								You decide how many Fairies you need, and they stay with you for the entire month of
+								December.
+							</p>
+						</div>
+						<div className="mt-6 space-y-4">
+							<div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4 dark:border-zinc-800 dark:bg-zinc-950/40">
+								<p className="text-xs uppercase tracking-[0.3em] text-zinc-500">Fairies</p>
+								<p className="mt-1 text-lg font-semibold text-zinc-900 dark:text-white">
+									Choose 1 – 5 Fairies
+								</p>
+								<p className="text-sm text-zinc-600 dark:text-zinc-400">
+									Mix and match personalities or keep a single specialist—every Fairy costs $10
+									flat.
+								</p>
+							</div>
+							<div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4 dark:border-zinc-800 dark:bg-zinc-950/40">
+								<p className="text-xs uppercase tracking-[0.3em] text-zinc-500">Access window</p>
+								<p className="mt-1 text-lg font-semibold text-zinc-900 dark:text-white">
+									December 1 – 31
+								</p>
+								<p className="text-sm text-zinc-600 dark:text-zinc-400">
+									Access automatically ends at 23:59 on 12/31.
+								</p>
+							</div>
+						</div>
+						<ul className="mt-6 list-disc space-y-2 pl-5 text-sm text-zinc-600 dark:text-zinc-400">
+							<li>Works in the latest tldraw builds—no extra installs.</li>
+							<li>Fairies respond directly in your canvas chat or via prompts.</li>
+							<li>Perfect for rapid ideation, wireframing, and playful December projects.</li>
+						</ul>
+					</div>
+				</section>
+				<section className="border-t border-zinc-200/60 pt-6 text-center text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+					<p className="text-sm text-zinc-600 dark:text-zinc-300">
+						Questions about the drop? Contact us at{' '}
+						<TldrawLink
+							href="mailto:hello@tldraw.com"
+							className="font-medium text-blue-600 dark:text-blue-300"
+						>
+							hello@tldraw.com
+						</TldrawLink>
+						.
+					</p>
+					<div className="mt-4 flex items-center justify-center gap-4 text-xs font-medium">
+						<TldrawLink
+							href="https://tldraw.com/tos.html"
+							className="text-zinc-600 underline-offset-4 hover:underline dark:text-zinc-300"
+						>
+							Terms of Service
+						</TldrawLink>
+						<span aria-hidden="true">•</span>
+						<TldrawLink
+							href="https://tldraw.com/privacy.html"
+							className="text-zinc-600 underline-offset-4 hover:underline dark:text-zinc-300"
+						>
+							Privacy Policy
+						</TldrawLink>
+					</div>
+				</section>
+			</div>
+		</main>
+	)
+}

--- a/apps/docs/components/fairy/fairy-pricing-selector.tsx
+++ b/apps/docs/components/fairy/fairy-pricing-selector.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { Button } from '@/components/common/button'
+import { cn } from '@/utils/cn'
+import { useMemo, useState } from 'react'
+
+const DEFAULT_COUNTS = [1, 2, 3, 4, 5]
+
+export interface FairyPricingSelectorProps {
+	pricePerFairy: number
+	minFairies: number
+	maxFairies: number
+	checkoutUrl: string
+}
+
+export function FairyPricingSelector({
+	pricePerFairy,
+	minFairies,
+	maxFairies,
+	checkoutUrl,
+}: FairyPricingSelectorProps) {
+	const allowedCounts = useMemo(
+		() => DEFAULT_COUNTS.filter((count) => count >= minFairies && count <= maxFairies),
+		[minFairies, maxFairies]
+	)
+
+	const initialCount = useMemo(() => {
+		const midpoint = Math.ceil((minFairies + maxFairies) / 2)
+		if (midpoint < minFairies) return minFairies
+		if (midpoint > maxFairies) return maxFairies
+		return midpoint
+	}, [minFairies, maxFairies])
+
+	const [count, setCount] = useState(initialCount)
+	const currencyFormatter = useMemo(
+		() =>
+			new Intl.NumberFormat('en-US', {
+				style: 'currency',
+				currency: 'USD',
+				minimumFractionDigits: 2,
+			}),
+		[]
+	)
+
+	const total = count * pricePerFairy
+
+	const checkoutHref = useMemo(() => {
+		const separator = checkoutUrl.includes('?') ? '&' : '?'
+		return `${checkoutUrl}${checkoutUrl ? `${separator}quantity=${count}` : ''}`
+	}, [checkoutUrl, count])
+
+	return (
+		<div className="rounded-3xl border border-zinc-200 bg-white/70 p-6 shadow-[0_35px_120px_-50px_rgba(15,23,42,0.45)] backdrop-blur-md dark:border-zinc-800 dark:bg-zinc-900/70">
+			<div className="flex items-center justify-between gap-4">
+				<div>
+					<p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-500">Pricing</p>
+					<h2 className="mt-2 text-4xl font-semibold text-zinc-900 dark:text-white">
+						${pricePerFairy} <span className="text-base font-medium text-zinc-500">/ Fairy</span>
+					</h2>
+				</div>
+				<span className="rounded-full bg-blue-100 px-4 py-1 text-sm font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300">
+					December only
+				</span>
+			</div>
+			<p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
+				Choose how many Fairies you want working in your tldraw canvases.
+			</p>
+			<div className="mt-6">
+				<p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+					Number of Fairies
+				</p>
+				<div className="mt-3 grid grid-cols-5 gap-2">
+					{allowedCounts.map((value) => {
+						const isActive = value === count
+						return (
+							<button
+								key={value}
+								type="button"
+								onClick={() => setCount(value)}
+								className={cn(
+									'flex flex-col items-center justify-center rounded-2xl border px-3 py-4 text-sm transition',
+									isActive
+										? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-500/20 dark:text-blue-100'
+										: 'border-zinc-200 bg-white text-zinc-600 hover:border-blue-200 hover:text-blue-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:border-blue-400'
+								)}
+								aria-pressed={isActive}
+							>
+								<span className="text-lg font-semibold text-zinc-900 dark:text-white">{value}</span>
+								<span className="text-xs text-zinc-500 dark:text-zinc-400">
+									{value > 1 ? 'Fairies' : 'Fairy'}
+								</span>
+							</button>
+						)
+					})}
+				</div>
+			</div>
+			<dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
+				<div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4 dark:border-zinc-800 dark:bg-zinc-900/70">
+					<dt className="text-xs uppercase tracking-[0.2em] text-zinc-500">Selected</dt>
+					<dd className="mt-1 text-lg font-semibold text-zinc-900 dark:text-white">
+						{count} {count > 1 ? 'Fairies' : 'Fairy'}
+					</dd>
+				</div>
+				<div className="rounded-2xl border border-zinc-100 bg-zinc-50/70 p-4 dark:border-zinc-800 dark:bg-zinc-900/70">
+					<dt className="text-xs uppercase tracking-[0.2em] text-zinc-500">Total</dt>
+					<dd className="mt-1 text-lg font-semibold text-green-600 dark:text-green-400">
+						{currencyFormatter.format(total)}
+					</dd>
+				</div>
+			</dl>
+			<div className="mt-6 rounded-2xl border border-dashed border-zinc-200 bg-white/60 p-4 dark:border-zinc-700 dark:bg-zinc-900/60">
+				<p className="text-xs uppercase tracking-[0.2em] text-zinc-500">Access window</p>
+				<p className="mt-1 text-sm text-zinc-700 dark:text-zinc-300">
+					December 1 – December 31, 23:59.
+				</p>
+			</div>
+			<Button
+				id="fairy-checkout"
+				href={checkoutHref || checkoutUrl || '#'}
+				caption={`Checkout ${count} ${count > 1 ? 'Fairies' : 'Fairy'}`}
+				className="mt-6 w-full justify-center"
+				size="lg"
+				type="black"
+			/>
+		</div>
+	)
+}


### PR DESCRIPTION
Adds a docs page for December Fairies with an interactive quantity selector that calculates totals and links to Paddle checkout with quantity.

### Change type

- [x] `other`

### Test plan

1. Navigate to /fairy-pricing
2. Interact with the quantity selector
3. Verify the total price updates correctly
4. Verify the checkout link includes the correct quantity

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added a new pricing page for December Fairies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a docs page for December Fairies with an interactive quantity selector that calculates totals and links to Paddle checkout with quantity.
> 
> - **Docs UI**:
>   - **New page** `apps/docs/app/fairy-pricing/page.tsx`
>     - Sets `metadata` and renders pricing content for a December drop.
>     - Uses `FairyPricingSelector` with constants (`PRICE_PER_FAIRY`, `MIN_FAIRIES`, `MAX_FAIRIES`) and `PADDLE_CHECKOUT_URL` from `process.env.NEXT_PUBLIC_PADDLE_FAIRY_CHECKOUT_URL` (with fallback).
>   - **New component** `apps/docs/components/fairy/fairy-pricing-selector.tsx`
>     - Interactive selector for 1–5 fairies; shows selected count and formatted USD total.
>     - Builds checkout link by appending `quantity` to provided `checkoutUrl` and renders a `Button` to proceed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31db550ee691e3a0d042325f9b49ed1f478d9330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->