### PR TITLE
revert: handle redirect properly for Google OAuth (#7117)

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.todo.md
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.todo.md
@@ -1,8 +1,0 @@
-# TlaSignInDialog TODO
-
-- [x] Surface Clerk errors on the terms acceptance step so users see failures.
-- [x] Disable the “Accept and continue” action while the legal acceptance request is pending.
-- [x] Show analytics toggle unless the user was already opted in when the dialog mounted (allowing toggling during the session).
-- [x] Prevent duplicate email submissions by guarding the form’s submit handler and button state.
-- [x] Add resend cooldown/error handling so the verification step treats resend like other actions.
-- [x] Only show the terms step when Clerk reports `legal_accepted` as missing to avoid spurious sign-up updates.

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -1,4 +1,6 @@
 import { useClerk, useSignIn } from '@clerk/clerk-react'
+import * as Clerk from '@clerk/elements/common'
+import * as SignIn from '@clerk/elements/sign-in'
 import { GetInviteInfoResponseBody } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { ChangeEvent, ReactNode, useCallback, useEffect, useState, type FormEvent } from 'react'
@@ -9,7 +11,6 @@ import {
 	TldrawUiDialogHeader,
 	TldrawUiDialogTitle,
 } from 'tldraw'
-import { routes } from '../../../routeDefs'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
 import { TlaLogo } from '../TlaLogo/TlaLogo'
@@ -113,32 +114,6 @@ function TlaEnterEmailStep({
 		error: null,
 	})
 
-	const handleGoogleSignIn = useCallback(async () => {
-		if (!isSignInLoaded || !signIn) return
-
-		try {
-			const redirectUrl = inviteInfo
-				? routes.tlaInvite(inviteInfo.inviteSecret, {
-						asUrl: true,
-						searchParams: { accept: 'true' },
-					})
-				: window.location.href
-
-			const result = await signIn.create({
-				strategy: 'oauth_google',
-				redirectUrl,
-			})
-
-			// Redirect to Google's OAuth page
-			const externalUrl = result.firstFactorVerification?.externalVerificationRedirectURL
-			if (externalUrl) {
-				window.location.href = externalUrl.toString()
-			}
-		} catch (err: any) {
-			console.error('Google sign-in error:', err)
-		}
-	}, [signIn, isSignInLoaded, inviteInfo])
-
 	const handleEmailSubmit = useCallback(
 		async (e: FormEvent) => {
 			e.preventDefault()
@@ -226,20 +201,22 @@ function TlaEnterEmailStep({
 					</>
 				)}
 			</div>
-			<div className={styles.authGoogleButtonWrapper}>
-				<TlaCtaButton
-					data-testid="tla-google-sign-in-button"
-					className={styles.authCtaButton}
-					onClick={handleGoogleSignIn}
-				>
-					<img
-						src="https://img.clerk.com/static/google.svg"
-						alt="Google"
-						referrerPolicy="strict-origin-when-cross-origin"
-					/>
-					<F defaultMessage="Sign in with Google" />
-				</TlaCtaButton>
-			</div>
+			<SignIn.Root routing="virtual">
+				<SignIn.Step name="start">
+					<div className={styles.authGoogleButtonWrapper}>
+						{/* @ts-ignore this is fine */}
+						<Clerk.Connection name="google" asChild>
+							<TlaCtaButton
+								data-testid="tla-google-sign-in-button"
+								className={styles.authCtaButton}
+							>
+								<Clerk.Icon icon="google" />
+								<F defaultMessage="Sign in with Google" />
+							</TlaCtaButton>
+						</Clerk.Connection>
+					</div>
+				</SignIn.Step>
+			</SignIn.Root>
 
 			<div className={styles.authDivider}>
 				<span>


### PR DESCRIPTION
This reverts commit 38d8ff5d9375c2accdc83706fe3d925cdfbb8472.

was causing new signups to fail 😢 

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Revert Google OAuth redirect changes that were causing signup failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces custom Google OAuth sign-in handler with Clerk Elements `Connection` inside `SignIn.Root` and removes the related redirect logic; deletes the obsolete TODO file.
> 
> - **Auth UI (`apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx`)**:
>   - Replace custom Google OAuth handler and redirect logic with Clerk Elements:
>     - Add `@clerk/elements/common` and `@clerk/elements/sign-in` imports.
>     - Use `<SignIn.Root>` and `<Clerk.Connection name="google" asChild>` for the Google button with `<Clerk.Icon>`.
>     - Remove bespoke `handleGoogleSignIn` function and routing-based redirect URL construction.
> - **Chore**:
>   - Delete `TlaSignInDialog.todo.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21db85a6edecacf31d85f0cebbcf72aa956c6ea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->