### PR TITLE
chore(ci): remove s3 uploads from playwright workflows

### DIFF
--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -75,24 +75,3 @@ jobs:
           name: playwright-report
           path: apps/dotcom/client/playwright-report
           retention-days: 30
-
-      - uses: shallwefootball/s3-upload-action@master
-        # only upload if we have AWS credentials:
-        env:
-          HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
-        name: Upload S3
-        id: s3
-        with:
-          aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
-          source_dir: apps/dotcom/client/playwright-report
-
-      - name: Log report to summary
-        if: always()
-        run: |
-          report_url="https://playwright-reports.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
-          echo "Report: $report_url"
-          echo "## Playwright report" >> $GITHUB_STEP_SUMMARY
-          echo "* $report_url" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -59,24 +59,3 @@ jobs:
           name: playwright-report
           path: apps/examples/playwright-report
           retention-days: 30
-
-      - uses: shallwefootball/s3-upload-action@master
-        # only upload if we have AWS credentials:
-        env:
-          HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
-        name: Upload S3
-        id: s3
-        with:
-          aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
-          source_dir: apps/examples/playwright-report
-
-      - name: Log report to summary
-        if: always()
-        run: |
-          report_url="https://playwright-reports.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
-          echo "Report: $report_url"
-          echo "## Playwright report" >> $GITHUB_STEP_SUMMARY
-          echo "* $report_url" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -60,24 +60,3 @@ jobs:
           name: playwright-report
           path: apps/examples/playwright-report
           retention-days: 30
-
-      - uses: shallwefootball/s3-upload-action@master
-        # only upload if we have AWS credentials:
-        env:
-          HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
-        name: Upload S3
-        id: s3
-        with:
-          aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
-          source_dir: apps/examples/playwright-report
-
-      - name: Log report to summary
-        if: always()
-        run: |
-          report_url="https://playwright-reports.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
-          echo "Report: $report_url"
-          echo "## Playwright report" >> $GITHUB_STEP_SUMMARY
-          echo "* $report_url" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fix our playwright tests while we figure out what's wrong with s3.

### Change type

- [x] `other`

### Test plan

1. Verify CI runs pass without S3 upload steps

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal CI updates to playwright workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes S3 upload and summary logging steps from Playwright workflows, retaining artifact uploads.
> 
> - **CI workflows (Playwright)**:
>   - Remove S3 upload steps and summary logging from:
>     - `/.github/workflows/playwright-dotcom.yml`
>     - `/.github/workflows/playwright-examples.yml`
>     - `/.github/workflows/playwright-perf.yml`
>   - Keep `actions/upload-artifact@v4` for storing `playwright-report` artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7d2167adc44ddc4897db09d430bab75ec52c0e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->