### PR TITLE
feat(dotcom): add pricing page

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -231,6 +231,12 @@
       "value": "i18n: Highlight Missing"
     }
   ],
+  "3209f407ed": [
+    {
+      "type": 0,
+      "value": "three fairies"
+    }
+  ],
   "32210b37e4": [
     {
       "type": 0,
@@ -265,6 +271,12 @@
     {
       "type": 0,
       "value": "Add a new task…"
+    }
+  ],
+  "3b6c2b4caa": [
+    {
+      "type": 0,
+      "value": "Terms of Service"
     }
   ],
   "3bc7d6ea2f": [
@@ -695,6 +707,12 @@
       "value": "Submit an issue on GitHub"
     }
   ],
+  "79cc22ac6b": [
+    {
+      "type": 0,
+      "value": "A fairy is a little guy that can work with you on the canvas. Fairies can work alone or as a team. There is no limit to what a fairy can do. Nobody knows where they came from."
+    }
+  ],
   "7a3113b0ba": [
     {
       "type": 0,
@@ -801,6 +819,12 @@
       "value": "Show tasks on canvas"
     }
   ],
+  "8472a551f1": [
+    {
+      "type": 0,
+      "value": "Fairies have come to tldraw for the month of December."
+    }
+  ],
   "85a082de1b": [
     {
       "type": 0,
@@ -827,6 +851,12 @@
       "value": "Rename file"
     }
   ],
+  "88e83b88c5": [
+    {
+      "type": 0,
+      "value": "Purchase Fairy Bundle"
+    }
+  ],
   "8ad4303b83": [
     {
       "type": 0,
@@ -837,6 +867,12 @@
     {
       "type": 0,
       "value": "To continue editing please copy the room to your files."
+    }
+  ],
+  "8be569f100": [
+    {
+      "type": 0,
+      "value": "one time payment"
     }
   ],
   "8c2d3d730c": [
@@ -1469,6 +1505,26 @@
     {
       "type": 0,
       "value": "Select a fairy on the right to chat with"
+    }
+  ],
+  "df6ff49394": [
+    {
+      "type": 0,
+      "value": "Fairies are a "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "temporary"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " feature. On January 1st, 2026, all fairies will be removed from the application. Perhaps they will return again someday. Your purchase is for access to fairies for December 2025 only."
     }
   ],
   "dfdb78a4e4": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -113,6 +113,9 @@
   "31418ce4ad": {
     "translation": "i18n: Highlight Missing"
   },
+  "3209f407ed": {
+    "translation": "three fairies"
+  },
   "32210b37e4": {
     "translation": "Add link"
   },
@@ -130,6 +133,9 @@
   },
   "3a77f951ca": {
     "translation": "Add a new task…"
+  },
+  "3b6c2b4caa": {
+    "translation": "Terms of Service"
   },
   "3bc7d6ea2f": {
     "translation": "Continue with email"
@@ -326,6 +332,9 @@
   "797799f35e": {
     "translation": "Submit an issue on GitHub"
   },
+  "79cc22ac6b": {
+    "translation": "A fairy is a little guy that can work with you on the canvas. Fairies can work alone or as a team. There is no limit to what a fairy can do. Nobody knows where they came from."
+  },
   "7a3113b0ba": {
     "translation": "Drag to canvas"
   },
@@ -365,6 +374,9 @@
   "81d48c2f3a": {
     "translation": "Show tasks on canvas"
   },
+  "8472a551f1": {
+    "translation": "Fairies have come to tldraw for the month of December."
+  },
   "85a082de1b": {
     "translation": "Please refresh the page to get the latest version of tldraw."
   },
@@ -374,11 +386,17 @@
   "86c66437fd": {
     "translation": "Rename file"
   },
+  "88e83b88c5": {
+    "translation": "Purchase Fairy Bundle"
+  },
   "8ad4303b83": {
     "translation": "No thanks"
   },
   "8b1946f965": {
     "translation": "To continue editing please copy the room to your files."
+  },
+  "8be569f100": {
+    "translation": "one time payment"
   },
   "8c2d3d730c": {
     "translation": "Check your email for a verification code."
@@ -641,6 +659,9 @@
   },
   "de290d52ef": {
     "translation": "Select a fairy on the right to chat with"
+  },
+  "df6ff49394": {
+    "translation": "Fairies are a <strong>temporary</strong> feature. On January 1st, 2026, all fairies will be removed from the application. Perhaps they will return again someday. Your purchase is for access to fairies for December 2025 only."
   },
   "dfdb78a4e4": {
     "translation": "App debug flags"

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -59,6 +59,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/preview/?$",
   },
   {
+    "reactRouterPattern": "/pricing",
+    "vercelRouterPattern": "^/pricing/?$",
+  },
+  {
     "reactRouterPattern": "/r/:boardId/history",
     "vercelRouterPattern": "^/r/[^/]*/history/?$",
   },

--- a/apps/dotcom/client/src/pages/pricing.module.css
+++ b/apps/dotcom/client/src/pages/pricing.module.css
@@ -1,0 +1,135 @@
+.container {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background-color: var(--tl-color-background);
+	overflow: auto;
+}
+
+.content {
+	max-width: 540px;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.logo {
+	width: 120px;
+	height: 32px;
+	background-color: var(--tl-color-text);
+	mask: url(/tldraw_sidebar_logo.svg) center 100% / 100% no-repeat;
+	-webkit-mask: url(/tldraw_sidebar_logo.svg) center 100% / 100% no-repeat;
+}
+
+.title {
+	font-size: 20px;
+	font-weight: 400;
+	line-height: 1.5;
+	margin: 0;
+	color: var(--tl-color-text);
+}
+
+.description {
+	font-size: 14px;
+	line-height: 1.6;
+	margin: 0;
+	color: var(--tl-color-text);
+}
+
+.temporaryNotice {
+	font-size: 14px;
+	line-height: 1.6;
+	margin: 0;
+	color: var(--tl-color-text);
+}
+
+.pricingCard {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 24px;
+	border: 1px solid var(--tl-color-muted-1);
+	border-radius: 8px;
+	background-color: var(--tl-color-background);
+}
+
+.pricingInfo {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.price {
+	font-size: 48px;
+	font-weight: 400;
+	line-height: 1;
+	color: var(--tl-color-text);
+}
+
+.priceDetails {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.priceDetail {
+	font-size: 12px;
+	line-height: 1.3;
+	color: var(--tl-color-text-3);
+}
+
+.fairyIcons {
+	display: flex;
+	gap: 8px;
+}
+
+.fairyIcon {
+	width: 48px;
+	height: 48px;
+}
+
+.purchaseButton {
+	width: 100%;
+	height: 48px;
+	border: none;
+	border-radius: 8px;
+	background-color: #2d7ff9;
+	color: #ffffff;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+.purchaseButton:hover {
+	background-color: #1d6fe8;
+}
+
+.purchaseButton:active {
+	background-color: #0d5fd7;
+}
+
+.footer {
+	display: flex;
+	justify-content: center;
+	gap: 24px;
+	padding-top: 24px;
+}
+
+.footerLink {
+	font-size: 12px;
+	color: var(--tl-color-text-3);
+	text-decoration: none;
+}
+
+.footerLink:hover {
+	color: var(--tl-color-text-1);
+	text-decoration: underline;
+}

--- a/apps/dotcom/client/src/pages/pricing.tsx
+++ b/apps/dotcom/client/src/pages/pricing.tsx
@@ -1,0 +1,64 @@
+import { F } from '../tla/utils/i18n'
+import styles from './pricing.module.css'
+
+export function Component() {
+	return (
+		<div className={styles.container}>
+			<div className={styles.content}>
+				<div className={styles.logo} />
+
+				<h1 className={styles.title}>
+					<F defaultMessage="Fairies have come to tldraw for the month of December." />
+				</h1>
+
+				<p className={styles.description}>
+					<F defaultMessage="A fairy is a little guy that can work with you on the canvas. Fairies can work alone or as a team. There is no limit to what a fairy can do. Nobody knows where they came from." />
+				</p>
+
+				<p className={styles.temporaryNotice}>
+					<F
+						defaultMessage="Fairies are a <strong>temporary</strong> feature. On January 1st, 2026, all fairies will be removed from the application. Perhaps they will return again someday. Your purchase is for access to fairies for December 2025 only."
+						values={{
+							strong: (chunks) => <strong>{chunks}</strong>,
+						}}
+					/>
+				</p>
+
+				<div className={styles.pricingCard}>
+					<div className={styles.pricingInfo}>
+						<div className={styles.price}>$25</div>
+						<div className={styles.priceDetails}>
+							<div className={styles.priceDetail}>
+								<F defaultMessage="three fairies" />
+							</div>
+							<div className={styles.priceDetail}>
+								<F defaultMessage="one time payment" />
+							</div>
+						</div>
+					</div>
+					<div className={styles.fairyIcons}>
+						<img src="/fairy/fairy-placeholder-1.svg" alt="Fairy" className={styles.fairyIcon} />
+						<img src="/fairy/fairy-placeholder-2.svg" alt="Fairy" className={styles.fairyIcon} />
+						<img src="/fairy/fairy-placeholder-1.svg" alt="Fairy" className={styles.fairyIcon} />
+					</div>
+				</div>
+
+				<button className={styles.purchaseButton}>
+					<F defaultMessage="Purchase Fairy Bundle" />
+				</button>
+
+				<footer className={styles.footer}>
+					<a href="/privacy-policy" className={styles.footerLink}>
+						<F defaultMessage="Privacy Policy" />
+					</a>
+					<a href="/terms-of-service" className={styles.footerLink}>
+						<F defaultMessage="Terms of Service" />
+					</a>
+					<a href="https://tldraw.dev" className={styles.footerLink}>
+						<F defaultMessage="Build with the tldraw SDK" />
+					</a>
+				</footer>
+			</div>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
 
 	tlaRoot: `/`,
 	tlaNew: `/new`,
+	pricing: `/pricing`,
 	tlaFile: `/f/:fileSlug`,
 	tlaFileHistory: `/f/:fileSlug/history`,
 	tlaFileHistorySnapshot: `/f/:fileSlug/history/:timestamp`,

--- a/apps/dotcom/client/src/routes.test.tsx
+++ b/apps/dotcom/client/src/routes.test.tsx
@@ -124,6 +124,7 @@ test("non-react routes don't match", () => {
 	// lil smoke test for basic patterns
 	expect('/').toMatchAny(allVercelRouterPatterns)
 	expect('/new').toMatchAny(allVercelRouterPatterns)
+	expect('/pricing').toMatchAny(allVercelRouterPatterns)
 	expect('/r/whatever').toMatchAny(allVercelRouterPatterns)
 	expect('/r/whatever/').toMatchAny(allVercelRouterPatterns)
 

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -63,6 +63,7 @@ export const router = createRoutesFromElements(
 	>
 		<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
 			<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />
+			<Route path={ROUTES.pricing} lazy={() => import('./pages/pricing')} />
 			<Route element={<NoIndex />}>
 				<Route path={ROUTES.tlaNew} lazy={() => import('./pages/tla-new')} />
 				<Route path={ROUTES.tlaOptIn} loader={() => redirect(routes.tlaRoot())} />


### PR DESCRIPTION
Pricing page hotfix 
- [x] `other` 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new /pricing page (fairy bundle) with styling, routes, tests, and i18n strings.
> 
> - **Frontend**:
>   - **New Page**: `src/pages/pricing.tsx` with styles in `src/pages/pricing.module.css` showing fairy bundle details and purchase CTA.
> - **Routing**:
>   - Adds `ROUTES.pricing` and registers route in `src/routes.tsx` to serve `/pricing`.
> - **Tests**:
>   - Updates route tests and snapshot to include `/pricing` (`routes.test.tsx`, `__snapshots__/routes.test.tsx.snap`).
> - **i18n**:
>   - Adds pricing-related strings in `public/tla/locales/en.json` and compiled `locales-compiled/en.json` (e.g., "Fairies have come…", "Purchase Fairy Bundle", "one time payment").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dab3e968e06b953f672eb7b476f0a0c47485593. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Adds a new pricing page for the fairy bundle to the dotcom site.

### Change type

- [x] `other`

### Test plan

1. Navigate to /pricing and verify the page renders correctly with the fairy bundle details.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Added a new pricing page for the fairy bundle.