### PR TITLE
fix(dotcom): update pricing page footer links

### DIFF
--- a/apps/dotcom/client/src/pages/pricing.tsx
+++ b/apps/dotcom/client/src/pages/pricing.tsx
@@ -48,10 +48,10 @@ export function Component() {
 				</button>
 
 				<footer className={styles.footer}>
-					<a href="/privacy-policy" className={styles.footerLink}>
+					<a href="/privacy.html" className={styles.footerLink}>
 						<F defaultMessage="Privacy Policy" />
 					</a>
-					<a href="/terms-of-service" className={styles.footerLink}>
+					<a href="/tos.html" className={styles.footerLink}>
 						<F defaultMessage="Terms of Service" />
 					</a>
 					<a href="https://tldraw.dev" className={styles.footerLink}>


### PR DESCRIPTION
Update pricing page footer links to point to /privacy.html and /tos.html.

### Change type

- [x] `other`

### Test plan

1. Navigate to the pricing page and verify footer links.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated pricing page footer links to point to the correct privacy and terms pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update pricing page footer links to point to /privacy.html and /tos.html.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f3cb5b9f30321e533a759fc3734babcbfaf5bb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->