### PR TITLE
improvement(dotcom): rename 'room' to 'file' in user-facing UI

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -57,6 +57,12 @@
       "value": "Spiky"
     }
   ],
+  "0a91f7fa87": [
+    {
+      "type": 0,
+      "value": "This file has reached its size limit and changes might no longer be saved. Remove some content or start a new file."
+    }
+  ],
   "0b27918290": [
     {
       "type": 0,
@@ -165,18 +171,6 @@
       "value": "Instruct the group…"
     }
   ],
-  "20976e7bec": [
-    {
-      "type": 0,
-      "value": "Room is full"
-    }
-  ],
-  "21bfb2dc2e": [
-    {
-      "type": 0,
-      "value": "This room is approaching its size limit. Consider removing some content or starting a new file."
-    }
-  ],
   "2445e5e347": [
     {
       "type": 0,
@@ -211,12 +205,6 @@
     {
       "type": 0,
       "value": "My files"
-    }
-  ],
-  "2deec2cb74": [
-    {
-      "type": 0,
-      "value": "This room has reached its size limit and changes might no longer be saved. Remove some content or start a new file."
     }
   ],
   "2e86e6853d": [
@@ -351,6 +339,12 @@
       "value": "No fairies selected"
     }
   ],
+  "477df802ca": [
+    {
+      "type": 0,
+      "value": "To continue editing please copy the file to your files."
+    }
+  ],
   "47839e47a5": [
     {
       "type": 0,
@@ -435,6 +429,12 @@
       "value": "Page menu"
     }
   ],
+  "542248f0ba": [
+    {
+      "type": 0,
+      "value": "This file is now read-only"
+    }
+  ],
   "54286b1d01": [
     {
       "type": 0,
@@ -513,18 +513,6 @@
     {
       "type": 0,
       "value": "Share"
-    }
-  ],
-  "5bb6cf3b53": [
-    {
-      "type": 0,
-      "value": "Room getting large"
-    }
-  ],
-  "5bcc12ace8": [
-    {
-      "type": 0,
-      "value": "This room is now read-only"
     }
   ],
   "5bec508475": [
@@ -699,6 +687,12 @@
     {
       "type": 0,
       "value": "Invalid request."
+    }
+  ],
+  "7827371d1a": [
+    {
+      "type": 0,
+      "value": "This anonymous tldraw multiplayer file is now read-only. To continue editing, please sign in and copy it to your files."
     }
   ],
   "7835039819": [
@@ -881,12 +875,6 @@
       "value": "No thanks"
     }
   ],
-  "8b1946f965": [
-    {
-      "type": 0,
-      "value": "To continue editing please copy the room to your files."
-    }
-  ],
   "8be569f100": [
     {
       "type": 0,
@@ -1033,12 +1021,6 @@
       "value": "Delete file"
     }
   ],
-  "9c258b8f88": [
-    {
-      "type": 0,
-      "value": "This anonymous tldraw multiplayer room is now read-only. To continue editing, please sign in and copy it to your files."
-    }
-  ],
   "9ceb927baa": [
     {
       "type": 0,
@@ -1141,6 +1123,12 @@
       "value": "Leader fairy selection"
     }
   ],
+  "a8873770ab": [
+    {
+      "type": 0,
+      "value": "File is getting large"
+    }
+  ],
   "a9ded1e5ce": [
     {
       "type": 0,
@@ -1169,6 +1157,12 @@
     {
       "type": 0,
       "value": "Guest user"
+    }
+  ],
+  "b2c3c2e30c": [
+    {
+      "type": 0,
+      "value": "File is full"
     }
   ],
   "b34a671e2c": [
@@ -1379,6 +1373,12 @@
     {
       "type": 0,
       "value": "SVG"
+    }
+  ],
+  "ce0547606c": [
+    {
+      "type": 0,
+      "value": "This file is approaching its size limit. Consider removing some content or starting a new file."
     }
   ],
   "cea291e45e": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -26,6 +26,9 @@
   "090b807281": {
     "translation": "Spiky"
   },
+  "0a91f7fa87": {
+    "translation": "This file has reached its size limit and changes might no longer be saved. Remove some content or start a new file."
+  },
   "0b27918290": {
     "translation": "File"
   },
@@ -80,12 +83,6 @@
   "1fe250ea06": {
     "translation": "Instruct the group…"
   },
-  "20976e7bec": {
-    "translation": "Room is full"
-  },
-  "21bfb2dc2e": {
-    "translation": "This room is approaching its size limit. Consider removing some content or starting a new file."
-  },
   "2445e5e347": {
     "translation": "Create group"
   },
@@ -103,9 +100,6 @@
   },
   "2c3ef76333": {
     "translation": "My files"
-  },
-  "2deec2cb74": {
-    "translation": "This room has reached its size limit and changes might no longer be saved. Remove some content or start a new file."
   },
   "2e86e6853d": {
     "translation": "Select leader"
@@ -173,6 +167,9 @@
   "465a8a92a4": {
     "translation": "No fairies selected"
   },
+  "477df802ca": {
+    "translation": "To continue editing please copy the file to your files."
+  },
   "47839e47a5": {
     "translation": "tldraw"
   },
@@ -215,6 +212,9 @@
   "517bb809d9": {
     "translation": "Page menu"
   },
+  "542248f0ba": {
+    "translation": "This file is now read-only"
+  },
   "54286b1d01": {
     "translation": "Collaborator limit reached"
   },
@@ -235,12 +235,6 @@
   },
   "5a95a425f7": {
     "translation": "Share"
-  },
-  "5bb6cf3b53": {
-    "translation": "Room getting large"
-  },
-  "5bcc12ace8": {
-    "translation": "This room is now read-only"
   },
   "5bec508475": {
     "translation": "Old browser detected. Please update your browser to use this app."
@@ -329,6 +323,9 @@
   "777f9e90cf": {
     "translation": "Invalid request."
   },
+  "7827371d1a": {
+    "translation": "This anonymous tldraw multiplayer file is now read-only. To continue editing, please sign in and copy it to your files."
+  },
   "7835039819": {
     "translation": "Propeller"
   },
@@ -401,9 +398,6 @@
   "8ad4303b83": {
     "translation": "No thanks"
   },
-  "8b1946f965": {
-    "translation": "To continue editing please copy the room to your files."
-  },
   "8be569f100": {
     "translation": "one time payment"
   },
@@ -470,9 +464,6 @@
   "9bef626805": {
     "translation": "Delete file"
   },
-  "9c258b8f88": {
-    "translation": "This anonymous tldraw multiplayer room is now read-only. To continue editing, please sign in and copy it to your files."
-  },
   "9ceb927baa": {
     "translation": "Publish this file"
   },
@@ -524,6 +515,9 @@
   "a885eb91ac": {
     "translation": "Leader fairy selection"
   },
+  "a8873770ab": {
+    "translation": "File is getting large"
+  },
   "a9ded1e5ce": {
     "translation": "Background"
   },
@@ -536,6 +530,9 @@
   },
   "b028909917": {
     "translation": "Guest user"
+  },
+  "b2c3c2e30c": {
+    "translation": "File is full"
   },
   "b34a671e2c": {
     "translation": "Log response time"
@@ -614,6 +611,9 @@
   },
   "cd15a75c26": {
     "translation": "SVG"
+  },
+  "ce0547606c": {
+    "translation": "This file is approaching its size limit. Consider removing some content or starting a new file."
   },
   "cea291e45e": {
     "translation": "Learn more about publishing."

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLargeFileHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLargeFileHandler.tsx
@@ -19,12 +19,12 @@ function RoomSizeWarningDialog({ onClose }: { onClose(): void }) {
 		<>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle>
-					<F defaultMessage="Room getting large" />
+					<F defaultMessage="File is getting large" />
 				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
-				<F defaultMessage="This room is approaching its size limit. Consider removing some content or starting a new file." />
+				<F defaultMessage="This file is approaching its size limit. Consider removing some content or starting a new file." />
 			</TldrawUiDialogBody>
 			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
 				<TldrawUiButton type="primary" onClick={onClose}>
@@ -42,12 +42,12 @@ function RoomSizeLimitDialog({ onClose }: { onClose(): void }) {
 		<>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle>
-					<F defaultMessage="Room is full" />
+					<F defaultMessage="File is full" />
 				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
-				<F defaultMessage="This room has reached its size limit and changes might no longer be saved. Remove some content or start a new file." />
+				<F defaultMessage="This file has reached its size limit and changes might no longer be saved. Remove some content or start a new file." />
 			</TldrawUiDialogBody>
 			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
 				<TldrawUiButton type="primary" onClick={onClose}>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacyModal.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacyModal.tsx
@@ -43,16 +43,16 @@ function LegacyChangesModal({ onClose }: { onClose(): void }) {
 		<div className={styles.dialog}>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle>
-					<F defaultMessage="This room is now read-only" />
+					<F defaultMessage="This file is now read-only" />
 				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody>
 				<p>
 					{isSignedIn ? (
-						<F defaultMessage="To continue editing please copy the room to your files." />
+						<F defaultMessage="To continue editing please copy the file to your files." />
 					) : (
-						<F defaultMessage="This anonymous tldraw multiplayer room is now read-only. To continue editing, please sign in and copy it to your files." />
+						<F defaultMessage="This anonymous tldraw multiplayer file is now read-only. To continue editing, please sign in and copy it to your files." />
 					)}
 				</p>
 			</TldrawUiDialogBody>


### PR DESCRIPTION
Updates terminology in user-facing dialogs and messages to use "file" instead of "room" for consistency with the tldraw product language.

### Change type

- [x] `improvement`

### Test plan

1. Trigger the large file warning dialog by creating a file that approaches the size limit
2. Verify the dialog shows "File is getting large" instead of "Room getting large"
3. Trigger the read-only legacy file modal
4. Verify it shows "This file is now read-only" instead of "This room is now read-only"

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated user-facing messages to use "file" terminology instead of "room" for consistency.