### PR TITLE
fix(dotcom): disable sidebar file drag without groups flag

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -201,6 +201,7 @@ export function TlaSidebarFileLinkInner({
 
 	const wrapperRef = useRef<HTMLDivElement>(null)
 	const hasGroups = useHasFlag('groups_frontend')
+	const isDragEnabled = hasGroups && !isCoarsePointer
 
 	if (!file) return null
 
@@ -231,11 +232,10 @@ export function TlaSidebarFileLinkInner({
 			// We use this id to scroll the active file link into view when creating or deleting files.
 			id={isActive ? ACTIVE_FILE_LINK_ID : undefined}
 			role="listitem"
-			draggable={!isCoarsePointer}
+			draggable={isDragEnabled}
 			onDragStart={
-				isCoarsePointer
-					? undefined
-					: (event) => {
+				isDragEnabled
+					? (event) => {
 							// Set native drag data for drag-to-new-tab functionality
 							const fileUrl = routes.tlaFile(fileId, { asUrl: true })
 							event.dataTransfer.effectAllowed = 'move'
@@ -247,6 +247,7 @@ export function TlaSidebarFileLinkInner({
 								clientY: event.clientY,
 							})
 						}
+					: undefined
 			}
 		>
 			<Link


### PR DESCRIPTION
## Summary
- gate sidebar file dragging on the groups feature flag so drag-and-drop is disabled for users without the flag

### Change type

- [x] `bugfix` 

### Test plan

1. Verify that dragging sidebar files is disabled when the 'groups_frontend' flag is off.
2. Verify that dragging is disabled on coarse pointer devices (mobile).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Disabled sidebar file dragging for users without the groups feature flag enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925774b242083219b294d017154f942)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable sidebar file dragging only when `groups_frontend` is on and the pointer is not coarse (e.g., mobile).
> 
> - **Sidebar**:
>   - Gate file drag interactions in `TlaSidebarFileLink.tsx` behind `useHasFlag('groups_frontend')`.
>     - Introduce `isDragEnabled = hasGroups && !isCoarsePointer`.
>     - Apply to `draggable` and `onDragStart` so dragging is disabled without the flag and on coarse pointers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b620a3f1aeda8982d26542dc63535f8726345221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->