### PR TITLE
fix(examples): reparent pin when bound shape parent changes

### DIFF
--- a/apps/examples/src/examples/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/pin-bindings/PinExample.tsx
@@ -274,8 +274,18 @@ class PinBindingUtil extends BindingUtil<PinBinding> {
 	}
 
 	// when the shape we're stuck to changes, update the pin's position
-	override onAfterChangeToShape({ binding }: BindingOnShapeChangeOptions<PinBinding>): void {
+	override onAfterChangeToShape({
+		binding,
+		shapeAfter,
+	}: BindingOnShapeChangeOptions<PinBinding>): void {
 		this.changedToShapes.add(binding.toId)
+		const pin = this.editor.getShape(binding.fromId)
+		if (!pin) return
+
+		// If the bound shape changed parents, reparent the pin to follow
+		if (pin.parentId !== shapeAfter.parentId) {
+			this.editor.reparentShapes([pin.id], shapeAfter.parentId)
+		}
 	}
 
 	// when the thing we're stuck to is deleted, delete the pin too


### PR DESCRIPTION
Fixes #6607 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reparents a pin to the bound shape’s new parent when the target shape changes, updating the `onAfterChangeToShape` handler to access `shapeAfter`.
> 
> - **Pin bindings example (`apps/examples/src/examples/pin-bindings/PinExample.tsx`)**:
>   - Update `onAfterChangeToShape` signature to include `shapeAfter`.
>   - Reparent pin (`fromId`) to follow the bound shape’s (`toId`) new `parentId` when it changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 733bbed65d64d4fe4fb9a045174e2c8fb763c915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->