### PR TITLE
feat(dotcom): add back default debug menu

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -4,6 +4,7 @@ import { useSync } from '@tldraw/sync'
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	DefaultDebugMenu,
+	DefaultDebugMenuContent,
 	Editor,
 	TLComponents,
 	TLPresenceStateInfo,
@@ -383,6 +384,7 @@ function CustomDebugMenu() {
 					)}
 				</>
 			)}
+			<DefaultDebugMenuContent />
 		</DefaultDebugMenu>
 	)
 }


### PR DESCRIPTION
Restores the built-in debug menu content in the TLA editor’s custom debug menu.

### Change type

- [x] `other`

### Test plan

1. Open the TLA editor
2. Open the debug menu
3. Verify default debug items are visible alongside custom entries

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Restored default debug menu items in the TLA editor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the built-in debug menu content in the TLA editor’s custom debug menu.
> 
> - **UI/Editor**
>   - **Debug Menu**: In `apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx`, import and render `DefaultDebugMenuContent` inside `CustomDebugMenu` to restore default debug items alongside existing custom entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80eec1ed524c238b83c59a0d9f5327c9a74cbaf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->