### PR TITLE
fix(dotcom): remove missing import icon

### DIFF
--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -168,7 +168,6 @@ export function ImportFileActionItem() {
 		<TldrawUiMenuItem
 			id="about"
 			label={importFileMsg}
-			icon="import"
 			readonlyOk
 			onSelect={async () => {
 				const editor = getCurrentEditor()


### PR DESCRIPTION
Fix missing import icon in sidebar menu.

### Change type

- [x] `bugfix`

### Test plan

1. Open the sidebar menu in the dotcom app
2. Verify the import menu item displays correctly without a broken icon

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where a missing icon was referenced in the sidebar menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `icon` prop from the `ImportFileActionItem` menu item in `menu-items.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5326607ee7b44c56fa5a34a5a36c5e7413373423. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->