### PR TITLE
fix(dotcom): resolve color and border of sidebar rename field

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -491,8 +491,6 @@
 }
 
 .sidebarFileListItemRenameInputWrapper {
-	background-color: var(--tla-color-sidebar);
-	outline: 1px solid var(--tl-color-primary);
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
@@ -508,7 +506,6 @@
 	bottom: 0px;
 	inset: 0px;
 	border-radius: 6px;
-	background-color: white;
 	border: 1px solid var(--tla-color-primary);
 }
 


### PR DESCRIPTION
we accidentally had two borders applied and a hard-coded `white` value

### Change type

- [x] `bugfix`

### Test plan

1. Open the sidebar and rename a file.
2. Verify the input field has a single themed border and no hard-coded white background.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed styling issues in the sidebar rename field where redundant borders and hard-coded colors were used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant outline and hardcoded white background from the sidebar rename input, using themed primary border instead.
> 
> - **UI/CSS**:
>   - Adjust `apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css` for rename field styling:
>     - In `
> .sidebarFileListItemRenameInputWrapper`, remove `background-color` and redundant `outline`.
>     - In `
> .sidebarFileListItemRenameInputWrapper::before`, remove hardcoded `background-color: white` and keep `border: 1px solid var(--tla-color-primary)` for consistent theming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52075b1b7308bfb3df007c1f26ad2779dac4682c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->