### PR TITLE
chore: re-enable s3 uploads for playwright reports

### DIFF
--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
+          aws_bucket: playwright.tldraw.xyz
           source_dir: apps/dotcom/client/playwright-report
 
       - name: Log report to summary

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
+          aws_bucket: playwright.tldraw.xyz
           source_dir: apps/examples/playwright-report
 
       - name: Log report to summary

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           aws_key_id: ${{ secrets.AWS_S3_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_KEY}}
-          aws_bucket: playwright-reports.tldraw.xyz
+          aws_bucket: playwright.tldraw.xyz
           source_dir: apps/examples/playwright-report
 
       - name: Log report to summary


### PR DESCRIPTION
revert https://github.com/tldraw/tldraw/pull/7194
made some new keys / new bucket / pointed DNS to the new bucket

### Change type

- [x] `other`

### Test plan

1. Verify CI workflows run and upload reports to S3

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Re-enabled S3 uploads for Playwright test reports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables S3 uploads of Playwright reports across dotcom, examples, and perf workflows and adds a summary with the report URL.
> 
> - **CI Workflows**:
>   - **S3 Uploads (conditional on AWS secrets)**:
>     - Add `shallwefootball/s3-upload-action@master` to upload Playwright reports to bucket `playwright.tldraw.xyz` from:
>       - `apps/dotcom/client/playwright-report` in `.github/workflows/playwright-dotcom.yml`
>       - `apps/examples/playwright-report` in `.github/workflows/playwright-examples.yml`
>       - `apps/examples/playwright-report` in `.github/workflows/playwright-perf.yml`
>   - **Reporting**:
>     - Append Playwright report URL (`https://playwright-reports.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html`) to the GitHub job summary in each workflow.
>   - **Artifacts**:
>     - Keep uploading `playwright-report` as a build artifact in all workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bdd9806760c9e9a744747c2d7f7bb84d0c696ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->