### PR TITLE
improvement(tooling): improve typecheck error reporting

### DIFF
--- a/internal/scripts/typecheck.ts
+++ b/internal/scripts/typecheck.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import path, { join } from 'path'
 import { REPO_ROOT, readJsonIfExists } from './lib/file'
 import { nicelog } from './lib/nicelog'
@@ -6,7 +6,7 @@ import { getAllWorkspacePackages } from './lib/workspace'
 
 async function main() {
 	const allWorkspaces = await getAllWorkspacePackages()
-	const tsconfigFiles = []
+	const tsconfigFiles: string[] = []
 	for (const workspace of allWorkspaces) {
 		const tsconfigFile = path.join(workspace.path, 'tsconfig.json')
 		const tsconfigExists = await readJsonIfExists(tsconfigFile)
@@ -16,12 +16,79 @@ async function main() {
 	nicelog('Typechecking files:', tsconfigFiles)
 
 	const args = ['--build']
+	const isWatchMode = process.argv.includes('--watch')
 	if (process.argv.includes('--force')) args.push('--force')
-	if (process.argv.includes('--watch')) args.push('--watch')
+	if (isWatchMode) args.push('--watch')
 	if (process.argv.includes('--preserveWatchOutput')) args.push('--preserveWatchOutput')
-	execFileSync(join(REPO_ROOT, 'node_modules/.bin/tsc'), [...args, ...tsconfigFiles], {
-		stdio: 'inherit',
+
+	const tscPath = join(REPO_ROOT, 'node_modules/.bin/tsc')
+
+	// In watch mode, use execFileSync with inherited stdio - it handles everything
+	if (isWatchMode) {
+		execFileSync(tscPath, [...args, ...tsconfigFiles], { stdio: 'inherit' })
+		return
+	}
+
+	// In non-watch mode, capture output so we can show a clear error summary
+	const output: string[] = []
+	const errors: string[] = []
+
+	return new Promise<void>((resolve) => {
+		const childProcess = execFile(
+			tscPath,
+			[...args, ...tsconfigFiles],
+			{ cwd: REPO_ROOT },
+			(err) => {
+				if (err) {
+					// Extract TypeScript errors from the output
+					const allOutput = output.join('') + errors.join('')
+					const tsErrors = allOutput.split('\n').filter((line) => {
+						// Match TypeScript error lines like: "file.ts(123,4): error TS2304: ..."
+						return /\.(ts|tsx|js|jsx)\(\d+,\d+\):\s+error\s+TS\d+:/i.test(line)
+					})
+
+					// Display a clear error summary at the end
+					console.error('\n' + '='.repeat(80))
+					console.error('❌ TypeScript type checking failed')
+					console.error('='.repeat(80) + '\n')
+
+					if (tsErrors.length > 0) {
+						console.error('TypeScript errors:')
+						tsErrors.forEach((error) => console.error(error))
+						console.error('')
+					} else if (errors.length > 0) {
+						// Fallback: show stderr if we couldn't extract specific errors
+						console.error('Error output:')
+						console.error(errors.join(''))
+						console.error('')
+					}
+
+					console.error('Please fix the errors above and try again.')
+					console.error('='.repeat(80) + '\n')
+					process.exit(err.code || 1)
+				} else {
+					resolve()
+				}
+			}
+		)
+
+		// Capture and display stdout in real-time
+		childProcess.stdout?.on('data', (chunk) => {
+			const text = chunk.toString()
+			output.push(text)
+			process.stdout.write(text)
+		})
+
+		// Capture and display stderr in real-time
+		childProcess.stderr?.on('data', (chunk) => {
+			const text = chunk.toString()
+			errors.push(text)
+			process.stderr.write(text)
+		})
 	})
 }
 
-main()
+main().catch((err) => {
+	console.error('Unexpected error:', err)
+	process.exit(1)
+})


### PR DESCRIPTION
Enhances the typecheck script to provide clearer error summaries when type checking fails in non-watch mode.

### Change type

- [x] `improvement`

### Test plan

The changes improve developer experience when type checking fails:

1. Run `yarn typecheck` with type errors present
2. Observe the clear error summary with extracted TypeScript errors
3. Verify that watch mode (`yarn typecheck --watch`) still works as before
4. Confirm that successful type checks complete without extra output

Manual testing verified the improved error display format.

### Release notes

- Improved typecheck script error reporting with clearer summaries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Typecheck script now captures non-watch output to summarize TypeScript errors, preserves watch behavior, and adds robust error handling.
> 
> - **Tooling**:
>   - **`internal/scripts/typecheck.ts`**:
>     - Non-watch: run `tsc` via `execFile`, stream output, extract TS error lines, and print a concise failure summary; exit with proper code.
>     - Watch: keep `execFileSync` with inherited stdio; detect `--watch` and pass through related flags.
>     - Minor: type `tsconfigFiles`, resolve on success, and add top-level `main().catch` for unexpected errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35220128c3eb50604b43f194e2462cf7ec848eb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->