### PR TITLE
feat(dotcom): add analytics tracking to fairy teaser

### DIFF
--- a/apps/dotcom/client/src/fairy/FairyGroupChat.tsx
+++ b/apps/dotcom/client/src/fairy/FairyGroupChat.tsx
@@ -1,6 +1,7 @@
 import { CancelIcon, FairyProject, LipsIcon } from '@tldraw/fairy-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { uniqueId, useValue } from 'tldraw'
+import { useTldrawAppUiEvents } from '../tla/utils/app-ui-events'
 import { F, useMsg } from '../tla/utils/i18n'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { fairyMessages } from './fairy-messages'
@@ -14,6 +15,7 @@ export function FairyGroupChat({
 	onStartProject(orchestratorAgent: FairyAgent): void
 }) {
 	const leaderAgentId = agents[0]?.id ?? null
+	const trackEvent = useTldrawAppUiEvents()
 
 	const [instruction, setInstruction] = useState('')
 	const instructionTextareaRef = useRef<HTMLTextAreaElement>(null)
@@ -90,6 +92,8 @@ Make sure to give the approximate locations of the work to be done, if relevant,
 				return
 			}
 
+			trackEvent('fairy-group-chat-message', { source: 'fairy-panel', feat: 'fairy' })
+
 			// Check if this is a duo project (exactly 2 fairies: 1 leader + 1 follower)
 			const isDuo = followerAgents.length === 1
 
@@ -131,12 +135,21 @@ Make sure to give the approximate locations of the work to be done, if relevant,
 			})
 
 			// Select the orchestrator and switch to their chat panel
+			trackEvent('fairy-start-project', { source: 'fairy-panel', feat: 'fairy' })
 			onStartProject(leaderAgent)
 
 			// Clear the input
 			setInstruction('')
 		},
-		[getGroupChatPrompt, leaderAgent, followerAgents, onStartProject, agents, shouldCancel]
+		[
+			getGroupChatPrompt,
+			leaderAgent,
+			followerAgents,
+			onStartProject,
+			agents,
+			shouldCancel,
+			trackEvent,
+		]
 	)
 
 	const handleButtonClick = () => {

--- a/apps/dotcom/client/src/fairy/FairyHUDTeaser.tsx
+++ b/apps/dotcom/client/src/fairy/FairyHUDTeaser.tsx
@@ -87,7 +87,7 @@ export function FairyHUDTeaser() {
 										aria-label="Fairies"
 										value="off"
 										onClick={() => {
-											trackEvent('click-fairy-teaser', { source: 'fairy-teaser' })
+											trackEvent('click-fairy-teaser', { source: 'fairy-teaser', feat: 'fairy' })
 											addDialog({
 												component: FairyComingSoonDialog,
 											})

--- a/apps/dotcom/client/src/fairy/FairySidebarButton.tsx
+++ b/apps/dotcom/client/src/fairy/FairySidebarButton.tsx
@@ -1,6 +1,7 @@
 import { ContextMenu as _ContextMenu } from 'radix-ui'
 import { MouseEvent } from 'react'
 import { TldrawUiToolbarToggleGroup, TldrawUiToolbarToggleItem, useValue } from 'tldraw'
+import { useTldrawAppUiEvents } from '../tla/utils/app-ui-events'
 import { useMsg } from '../tla/utils/i18n'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { fairyMessages } from './fairy-messages'
@@ -27,6 +28,7 @@ export function FairySidebarButton({
 	hasAnyActiveProjects: boolean
 }) {
 	const joinSelectedFairiesLabel = useMsg(fairyMessages.joinSelectedFairies)
+	const trackEvent = useTldrawAppUiEvents()
 
 	const fairyIsSelected = useValue(
 		'fairy-button-selected',
@@ -50,7 +52,11 @@ export function FairySidebarButton({
 		e.preventDefault()
 		e.stopPropagation()
 		// Toggle selection like shift-clicking would
-		agent.$fairyEntity.update((f) => (f ? { ...f, isSelected: !fairyIsSelected } : f))
+		const newSelectedState = !fairyIsSelected
+		agent.$fairyEntity.update((f) => (f ? { ...f, isSelected: newSelectedState } : f))
+		if (newSelectedState) {
+			trackEvent('fairy-add-to-selection', { source: 'fairy-panel', feat: 'fairy' })
+		}
 	}
 
 	if (!fairyEntity || !fairyOutfit) return null

--- a/apps/dotcom/client/src/fairy/FairyTaskListMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/FairyTaskListMenuContent.tsx
@@ -5,6 +5,7 @@ import {
 	TldrawUiMenuItem,
 	useDefaultHelpers,
 } from 'tldraw'
+import { useTldrawAppUiEvents } from '../tla/utils/app-ui-events'
 import { useMsg } from '../tla/utils/i18n'
 import { FairyAgent } from './fairy-agent/agent/FairyAgent'
 import { fairyMessages } from './fairy-messages'
@@ -18,6 +19,7 @@ export function FairyTaskListMenuContent({
 	menuType?: 'menu' | 'context-menu'
 }) {
 	const { addDialog } = useDefaultHelpers()
+	const trackEvent = useTldrawAppUiEvents()
 
 	const resetSelectedChats = useCallback(() => {
 		const selectedAgents = agents.filter((agent) => agent.$fairyEntity.get()?.isSelected)
@@ -38,6 +40,8 @@ export function FairyTaskListMenuContent({
 		const selectedAgents = agents.filter((agent) => agent.$fairyEntity.get()?.isSelected)
 		if (selectedAgents.length === 0) return
 
+		trackEvent('fairy-summon-selected', { source: 'fairy-panel', feat: 'fairy' })
+
 		const spacing = 150 // Distance between fairies
 		selectedAgents.forEach((agent, index) => {
 			if (agents.length === 1) {
@@ -53,17 +57,19 @@ export function FairyTaskListMenuContent({
 				agent.summon(offset)
 			}
 		})
-	}, [agents])
+	}, [agents, trackEvent])
 
 	const putAwayFairies = useCallback(() => {
 		const selectedAgents = agents.filter((agent) => agent.$fairyEntity.get()?.isSelected)
 		if (selectedAgents.length === 0) return
 
+		trackEvent('fairy-put-away-selected', { source: 'fairy-panel', feat: 'fairy' })
+
 		selectedAgents.forEach((agent) => {
 			agent.$fairyEntity.update((f) => (f ? { ...f, isSelected: false, pose: 'sleeping' } : f))
 			agent.setMode('sleeping')
 		})
-	}, [agents])
+	}, [agents, trackEvent])
 
 	const summonFairiesLabel = useMsg(fairyMessages.summonFairies)
 	const putAwayFairiesLabel = useMsg(fairyMessages.putAwayFairies)

--- a/apps/dotcom/client/src/fairy/fairy-agent/input/FairyBasicInput.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-agent/input/FairyBasicInput.tsx
@@ -1,6 +1,7 @@
 import { CancelIcon, FAIRY_VISION_DIMENSIONS, LipsIcon } from '@tldraw/fairy-shared'
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Box, useValue } from 'tldraw'
+import { useTldrawAppUiEvents } from '../../../tla/utils/app-ui-events'
 import { useMsg } from '../../../tla/utils/i18n'
 import { fairyMessages } from '../../fairy-messages'
 // import { $fairyTasks } from '../../FairyTaskList'
@@ -12,6 +13,7 @@ export function FairyBasicInput({ agent, onCancel }: { agent: FairyAgent; onCanc
 	const [inputValue, setInputValue] = useState('')
 	const isGenerating = useValue('isGenerating', () => agent.isGenerating(), [agent])
 	const enterMsg = useMsg(fairyMessages.enterMsg)
+	const trackEvent = useTldrawAppUiEvents()
 
 	const fairyEntity = useValue('fairyEntity', () => agent.$fairyEntity.get(), [agent])
 	const fairyConfig = useValue('fairyConfig', () => agent.$fairyConfig.get(), [agent])
@@ -38,6 +40,8 @@ export function FairyBasicInput({ agent, onCancel }: { agent: FairyAgent; onCanc
 			const fairyPosition = fairyEntity.position
 			const fairyVision = Box.FromCenter(fairyPosition, FAIRY_VISION_DIMENSIONS)
 
+			trackEvent('fairy-send-message', { source: 'fairy-panel', feat: 'fairy' })
+
 			agent.interrupt({
 				input: {
 					agentMessages: [value],
@@ -47,7 +51,7 @@ export function FairyBasicInput({ agent, onCancel }: { agent: FairyAgent; onCanc
 				},
 			})
 		},
-		[agent, fairyEntity]
+		[agent, fairyEntity, trackEvent]
 	)
 
 	const handleComplete = useCallback(

--- a/apps/dotcom/client/src/fairy/fairy-sprite/sprites/SleepingSprite.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-sprite/sprites/SleepingSprite.tsx
@@ -54,10 +54,18 @@ export function SleepingSprite({
 				fill="var(--tl-color-fairy-dark)"
 			/>
 			<path
+				className="asleep-right-eye"
 				d="M48.6738 42.3267C48.6738 42.3267 49.8288 43.7894 51.4491 44.1565C53.0694 44.5236 54.4968 43.6459 54.4968 43.6459"
 				stroke="var(--tl-color-fairy-dark)"
 				strokeWidth="4"
 				strokeLinecap="round"
+			/>
+			<circle
+				className="awake-right-eye"
+				cx="51.4836"
+				cy="42.3008"
+				r="3.63675"
+				fill="var(--tl-color-fairy-dark)"
 			/>
 			<path
 				d="M63.4446 43.7061C63.4446 43.7061 64.933 44.5425 66.5486 44.1429C68.1642 43.7434 69.2506 42.2701 69.2506 42.2701"

--- a/apps/dotcom/client/src/tla/styles/fairy.css
+++ b/apps/dotcom/client/src/tla/styles/fairy.css
@@ -118,7 +118,7 @@
 	display: block;
 }
 
-.fairy-toggle-button[data-is-sleeping='true'] {
+.fairy-toggle-button[data-is-sleeping='true'] .fairy-sprite {
 	opacity: 0.45;
 }
 
@@ -1637,4 +1637,20 @@
 
 .tla {
 	--tl-layer-canvas-in-front: 499;
+}
+
+.fairy-toggle-button .awake-right-eye {
+	opacity: 0;
+}
+
+.fairy-toggle-button .asleep-right-eye {
+	opacity: 1;
+}
+
+.fairy-toggle-button:hover .awake-right-eye {
+	opacity: 1;
+}
+
+.fairy-toggle-button:hover .asleep-right-eye {
+	opacity: 0;
 }

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -22,6 +22,7 @@ export type TLAppUiEventSource =
 	| 'cookie-settings'
 	| 'dialog'
 	| 'fairy-teaser'
+	| 'fairy-panel'
 
 /** @public */
 export interface TLAppUiEventMap {
@@ -66,7 +67,28 @@ export interface TLAppUiEventMap {
 	'room-size-limit-dialog-shown': null
 	'accept-group-invite': null
 	'add-file-link': null
-	'click-fairy-teaser': null
+	'click-fairy-teaser': { feat: 'fairy' }
+	'fairy-send-message': { feat: 'fairy' }
+	'fairy-summon': { feat: 'fairy' }
+	'fairy-summon-all': { feat: 'fairy' }
+	'fairy-summon-selected': { feat: 'fairy' }
+	'fairy-sleep': { feat: 'fairy' }
+	'fairy-sleep-all': { feat: 'fairy' }
+	'fairy-put-away-selected': { feat: 'fairy' }
+	'fairy-group-chat-message': { feat: 'fairy' }
+	'fairy-reset-chat': { feat: 'fairy' }
+	'fairy-reset-all-chats': { feat: 'fairy' }
+	'fairy-follow': { feat: 'fairy' }
+	'fairy-unfollow': { feat: 'fairy' }
+	'fairy-zoom-to': { feat: 'fairy' }
+	'fairy-disband-group': { feat: 'fairy' }
+	'fairy-select': { feat: 'fairy' }
+	'fairy-deselect': { feat: 'fairy' }
+	'fairy-double-click': { feat: 'fairy' }
+	'fairy-switch-to-task-list': { feat: 'fairy' }
+	'fairy-switch-to-chat': { feat: 'fairy' }
+	'fairy-start-project': { feat: 'fairy' }
+	'fairy-add-to-selection': { feat: 'fairy' }
 }
 
 /** @public */


### PR DESCRIPTION
Add analytics tracking event when users click on the fairy teaser button to help measure user interest.

### Change type

- [x] `other`

### Test plan

1. Open the fairy teaser
2. Click on the fairy button
3. Verify tracking event is sent

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add analytics tracking for fairy teaser clicks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive analytics events across the fairy UI (teaser, panel, chat, menus) and tweaks visuals/selection handling.
> 
> - **Analytics/Telemetry**:
>   - Add `useTldrawAppUiEvents` usage and fire events for actions: `fairy-send-message`, `fairy-group-chat-message`, `fairy-start-project`, `fairy-select`/`fairy-deselect`/`fairy-add-to-selection`, `fairy-double-click`, `fairy-switch-to-task-list`/`fairy-switch-to-chat`, `fairy-summon`/`fairy-summon-all`/`fairy-summon-selected`, `fairy-sleep`/`fairy-sleep-all`/`fairy-put-away-selected`, `fairy-follow`/`fairy-unfollow`, `fairy-zoom-to`, `fairy-disband-group`, `fairy-reset-chat`/`fairy-reset-all-chats`, `click-fairy-teaser`.
>   - Extend `TLAppUiEventSource` with `fairy-teaser` and `fairy-panel`; expand `TLAppUiEventMap` with all above events.
> - **Fairy UI logic**:
>   - `FairyHUD`, `FairyGroupChat`, `FairyMenuContent`, `FairyTaskListMenuContent`, `FairySidebarButton`, `FairyBasicInput`: wire tracking calls into user actions and refine multi-select toggling/deselect behaviors.
> - **Visuals/CSS/SVG**:
>   - In `SleepingSprite`, add classes for right-eye states; in `fairy.css`, toggle awake/asleep eye visibility on hover and adjust sleeping opacity selector to `.fairy-toggle-button[data-is-sleeping='true'] .fairy-sprite`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a3b2fffde3ca959a22d0d0de6e00724a7d207c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->