### PR TITLE
fix(dotcom): restore arrow hint indicator on tldraw.com

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -11,6 +11,7 @@ import {
 	TLSessionStateSnapshot,
 	TLUiDialogsContextType,
 	Tldraw,
+	TldrawOverlays,
 	TldrawUiMenuItem,
 	createSessionStateSnapshotSignal,
 	getDefaultUserPresence,
@@ -305,6 +306,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			...components,
 			Overlays: () => (
 				<>
+					<TldrawOverlays />
 					{canShowFairies ? (
 						<Suspense fallback={<div />}>
 							<FairyVision agents={agents} />


### PR DESCRIPTION
The arrow hint indicator (shown when pointing an arrow at a shape) was not displaying on tldraw.com because the custom `Overlays` component completely replaced `TldrawOverlays` with fairy-only components.

This adds `TldrawOverlays` back to the custom `Overlays` component so arrow hints render alongside fairy overlays.

### Change type

- [x] `bugfix`

### Test plan

1. Go to tldraw.com
2. Create a rectangle shape
3. Select the arrow tool and draw an arrow pointing at the rectangle
4. Verify the shape indicator (outline) appears around the rectangle when the arrow endpoint is near it

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed arrow hint indicator not appearing on tldraw.com when pointing an arrow at a shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `TldrawOverlays` to the custom `Overlays` in `TlaEditor` so arrow hint indicators render alongside fairy overlays.
> 
> - **Editor UI (dotcom)**
>   - **Overlays**: Add `TldrawOverlays` to `TlaEditor`'s custom `Overlays` so default overlay behaviors (e.g., arrow hint indicators) render with fairy overlays.
>   - Import `TldrawOverlays` in `apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c366c923da09c17d305e38e171deb82c86005c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->