### PR TITLE
fix(dotcom): add profitwell to csp for paddle support

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -36,6 +36,8 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'https://fonts.googleapis.com',
 		// paddle
 		'https://*.paddle.com',
+		// profitwell (loaded by paddle)
+		'https://public.profitwell.com',
 	],
 	'font-src': [`'self'`, `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, 'data:'],
 	'frame-src': [
@@ -62,6 +64,8 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'https://static.reo.dev',
 		// paddle
 		'https://*.paddle.com',
+		// profitwell (loaded by paddle)
+		'https://public.profitwell.com',
 	],
 	'worker-src': [`'self'`, `blob:`],
 	'style-src': [`'self'`, `'unsafe-inline'`, `https://fonts.googleapis.com`],


### PR DESCRIPTION
Looks like paddle loads profitwell, let's add it to csp.

### Change type

- [x] `other` 

### Test plan

1. Verify that Paddle and ProfitWell load correctly on the dotcom site without CSP violations.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added ProfitWell to Content Security Policy to support Paddle integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `https://public.profitwell.com` to CSP `connect-src` and `script-src` to support Paddle-loaded ProfitWell.
> 
> - **CSP updates** (`apps/dotcom/client/src/utils/csp.ts`):
>   - `connect-src`: add `https://public.profitwell.com`.
>   - `script-src`: add `https://public.profitwell.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2c010703572bb084308fcbae0160e097bb8eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->