### PR TITLE
refactor(dotcom): clean up FairyHUDHeader component

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
@@ -43,7 +43,6 @@ export function FairyHUDHeader({
 	shownFairy,
 	selectedFairies,
 	allAgents,
-	isMobile,
 	onToggleManual,
 }: FairyHUDHeaderProps) {
 	const trackEvent = useTldrawAppUiEvents()
@@ -79,11 +78,11 @@ export function FairyHUDHeader({
 		shownFairy.positionManager.zoomTo()
 	}, [shownFairy, fairyClickable, trackEvent])
 
-	// const hasChatHistory = useValue(
-	// 	'has-chat-history',
-	// 	() => shownFairy && shownFairy.$chatHistory.get().length > 0,
-	// 	[shownFairy]
-	// )
+	const hasChatHistory = useValue(
+		'has-chat-history',
+		() => shownFairy && shownFairy.chatManager.getHistory().length > 0,
+		[shownFairy]
+	)
 
 	const getDisplayName = () => {
 		if (!isProjectStarted || !project) {
@@ -176,18 +175,20 @@ export function FairyHUDHeader({
 	const onlySelectedFairy = selectedFairies.length === 1 ? selectedFairies[0] : null
 
 	// Show select all button on mobile when exactly one fairy is selected and there's more than one fairy total
-	const showSelectAllButton = isMobile && selectedFairies.length < allAgents.length && !project
+	const showSelectAllButton = selectedFairies.length < allAgents.length && !project // && isMobile
 
 	return (
 		<div className="fairy-toolbar-header">
 			{centerContent}
 			<div className="tlui-row">
-				{showSelectAllButton && (
+				{showSelectAllButton ? (
 					<TldrawUiButton type="icon" className="fairy-toolbar-button" onClick={selectAllFairies}>
 						<TldrawUiButtonIcon icon={<SelectAllIcon />} small />
 					</TldrawUiButton>
+				) : (
+					onlySelectedFairy &&
+					hasChatHistory && <ResetChatHistoryButton agent={onlySelectedFairy} />
 				)}
-				{onlySelectedFairy && !project && <ResetChatHistoryButton agent={onlySelectedFairy} />}
 				{<FairyMenuButton menuPopoverOpen={menuPopoverOpen}>{dropdownContent}</FairyMenuButton>}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- Remove unused `isMobile` prop from FairyHUDHeader
- Uncomment and update `hasChatHistory` to use `chatManager.getHistory()` instead of direct `$chatHistory` access
- Show select all button regardless of mobile status
- Only show reset chat history button when there's chat history to reset

- [x] internal

### Change type

- [x] `other`

### Test plan

1. Verify fairy HUD header displays correctly
2. Verify select all button appears when multiple fairies exist
3. Verify reset chat history button only appears when chat history exists

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Cleaned up Fairy HUD header logic and improved chat history visibility controls.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes mobile-only gating, switches chat history detection to chatManager, and conditionally shows reset button only when history exists.
> 
> - **UI (FairyHUDHeader)**
>   - Replace `$chatHistory` access with `chatManager.getHistory()` for `hasChatHistory`.
>   - Show `Select All` whenever `selectedFairies.length < allAgents.length` and no `project` (no longer mobile-only).
>   - Remove `isMobile` usage from component props and logic.
>   - Render `ResetChatHistoryButton` only when exactly one fairy is selected, it has chat history, and the select-all button is not shown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9527ad2e917ac1ab6f4c217c9752814a2d3ceed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->