### PR TITLE
improvement(fairy): improve manual panel video behavior and scroll persistence

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/manual/FairyManualPanel.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/manual/FairyManualPanel.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef } from 'react'
+import { MouseEvent, RefObject, useEffect, useRef } from 'react'
 import { getFromLocalStorage, setInLocalStorage, useValue } from 'tldraw'
 import { getLocalSessionState } from '../../../tla/utils/local-session-state'
 
@@ -55,7 +55,7 @@ export function FairyManualPanel() {
 	}
 
 	// Handle video play/pause on click (desktop only)
-	const handleVideoClick = (e: React.MouseEvent<HTMLVideoElement>) => {
+	const handleVideoClick = (e: MouseEvent<HTMLVideoElement>) => {
 		// Only handle mouse clicks (e.detail > 0 indicates mouse click, not touch)
 		if (e.detail > 0 && videoRef.current) {
 			if (videoRef.current.paused) {


### PR DESCRIPTION
Improves the fairy manual panel video and scroll behavior:

- Video no longer autoplays - users can click to play/pause on desktop
- Video preload set to 'none' to save bandwidth until user wants to watch
- Click to toggle play/pause functionality for desktop users (mouse clicks only, preserves mobile touch behavior)

### Change type

- [x] `improvement`

### Test plan

1. Open the fairy manual panel
2. Video should not autoplay
3. Click the video to play it
4. Click again to pause
5. Scroll position should be preserved when switching tabs

### Release notes

- Improved fairy manual video: no longer autoplays, click to play/pause on desktop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Intro video in the fairy manual no longer autoplays, doesn’t preload, and toggles play/pause on desktop click.
> 
> - **Fairy manual (introduction tab)**:
>   - Add `videoRef` and `handleVideoClick` to toggle play/pause on mouse click.
>   - Update `<video>`: remove `autoPlay`, set `autoPlay={false}`, add `preload="none"`, keep `loop` and `muted`, and attach `onClick` handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8453ba23d6bc3b133d3300b55240cbf41430adf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->