### PR TITLE
improvement(dotcom): redesign fairy invite dialog

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -5,12 +5,6 @@
       "value": "Export"
     }
   ],
-  "00b177e080": [
-    {
-      "type": 0,
-      "value": "Accept invitation"
-    }
-  ],
   "03b3e13197": [
     {
       "type": 0,
@@ -751,6 +745,22 @@
       "value": "Invalid request."
     }
   ],
+  "77f0abf1aa": [
+    {
+      "type": 0,
+      "value": "You've been invited to "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "tldraw fairies"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    }
+  ],
   "7827371d1a": [
     {
       "type": 0,
@@ -791,12 +801,6 @@
     {
       "type": 0,
       "value": "Open tldraw"
-    }
-  ],
-  "7cb471f815": [
-    {
-      "type": 0,
-      "value": "You've been invited to join tldraw fairies!"
     }
   ],
   "7cb5f8b4a5": [
@@ -1351,6 +1355,12 @@
     {
       "type": 0,
       "value": "Essential cookies"
+    }
+  ],
+  "c54a624f46": [
+    {
+      "type": 0,
+      "value": "Accept invite"
     }
   ],
   "c6155aaecc": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -2,9 +2,6 @@
   "0095a9fa74": {
     "translation": "Export"
   },
-  "00b177e080": {
-    "translation": "Accept invitation"
-  },
   "03b3e13197": {
     "translation": "Drag the file into the sidebar on this page. Or select the 'Import file' option from the user menu."
   },
@@ -338,6 +335,9 @@
   "777f9e90cf": {
     "translation": "Invalid request."
   },
+  "77f0abf1aa": {
+    "translation": "You've been invited to <strong>tldraw fairies</strong>"
+  },
   "7827371d1a": {
     "translation": "This anonymous tldraw multiplayer file is now read-only. To continue editing, please sign in and copy it to your files."
   },
@@ -358,9 +358,6 @@
   },
   "7c0747a5df": {
     "translation": "Open tldraw"
-  },
-  "7cb471f815": {
-    "translation": "You've been invited to join tldraw fairies!"
   },
   "7cb5f8b4a5": {
     "translation": "Forget"
@@ -584,6 +581,9 @@
   },
   "c4b39a1cc3": {
     "translation": "Essential cookies"
+  },
+  "c54a624f46": {
+    "translation": "Accept invite"
   },
   "c6155aaecc": {
     "translation": "Group name"

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaFairyInviteDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaFairyInviteDialog.module.css
@@ -1,0 +1,72 @@
+.dialogHeader {
+	height: 40px;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.dialogBody {
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding-left: 24px;
+	padding-right: 24px;
+	padding-bottom: 24px;
+	padding-top: 0px;
+	width: 300px;
+}
+
+.dialogBody :global(.fairy-sprite-container) {
+	height: 48px;
+	width: 48px;
+}
+
+.message {
+	font-size: 12px;
+	text-align: center;
+	padding-right: var(--tl-space-4);
+	height: 20px;
+}
+
+.buttonContainer {
+	padding: var(--tl-space-4);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 100%;
+}
+
+.acceptButton {
+	width: 100%;
+	height: 32px;
+	background-color: rgba(249, 250, 251, 1);
+	color: rgba(0, 0, 0, 1);
+	border: none;
+	border-radius: var(--tl-radius-1);
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.acceptButton:hover:not(:disabled) {
+	background-color: rgba(239, 240, 241, 1);
+}
+
+.acceptButton:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.declineButton {
+	background: none;
+	border: none;
+	color: var(--tl-color-text-3);
+	cursor: pointer;
+	padding: 8px;
+	height: 32px;
+}
+
+.declineButton:hover {
+	color: var(--tl-color-text-1);
+}


### PR DESCRIPTION
Redesigns the Fairy Invite dialog using a CSS module and lazy-loaded FairySprite, replaces buttons, and updates i18n strings.

### Change type

- [x] `other` 

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Redesigned the Fairy Invite dialog with updated styling and copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redesigns the Fairy Invite dialog using a CSS module and lazy-loaded FairySprite, replaces buttons, and updates i18n strings.
> 
> - **UI (TLA)**:
>   - **`src/tla/components/dialogs/TlaFairyInviteDialog.tsx`**:
>     - Applies new layout/styles via `TlaFairyInviteDialog.module.css` and `className` props.
>     - Adds lazy-loaded `FairySprite` with `Suspense` and shows invite message with `<strong>`.
>     - Replaces `TlaCtaButton`/`TldrawUiButton` with styled native buttons (`Accept invite` / `No thanks`).
>     - Keeps invite redemption flow; minor structure tweaks (header/close button placement).
>   - **`src/tla/components/dialogs/TlaFairyInviteDialog.module.css`**: New stylesheet defining dialog layout and button styles.
> - **i18n**:
>   - Updates copy and keys in `public/tla/locales/en.json` and compiled variant:
>     - Adds "77f0abf1aa" ("You've been invited to <strong>tldraw fairies</strong>") and "c54a624f46" ("Accept invite").
>     - Removes old invite strings (e.g., "7cb471f815", "00b177e080").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fdc8df39d48e1624f4ca05eff568ffc8e6b9001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->