### PR TITLE
fix(dotcom): restore primary color for fairy invite dialog button

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaFairyInviteDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaFairyInviteDialog.module.css
@@ -48,8 +48,7 @@
 	font-weight: 500;
 	cursor: pointer;
 }
-
-.acceptButton:hover {
+.acceptButton:hover:not(:disabled) {
 	background-color: var(--tla-color-cta-hover);
 }
 


### PR DESCRIPTION
Not sure what happened, lost the primary color 🤷‍♂️

### Change type

- [x] `bugfix`

### Test plan

1. Open the Fairy Invite Dialog and verify the accept button uses the correct primary CTA color and hover state.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed the primary color on the Fairy Invite Dialog accept button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the accept button to use themed CTA colors (including hover) with white text.
> 
> - **UI / Styles**:
>   - `apps/dotcom/client/src/tla/components/dialogs/TlaFairyInviteDialog.module.css`:
>     - Update `.acceptButton` to use `var(--tla-color-cta)` and `var(--tla-color-cta-hover)` with white text.
>     - Retains disabled styling; no structural changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d74d560a61e02ba56711632fa47104a51b927c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->