### PR TITLE
fix(dotcom): adjust fairy hud position for android chrome

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/FairyHUD.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/FairyHUD.tsx
@@ -71,7 +71,12 @@ export function FairyHUD() {
 				ref={hudRef}
 				className={`tla-fairy-hud ${panelState !== 'closed' ? 'tla-fairy-hud--open' : ''}`}
 				style={{
-					bottom: mobileMenuOffset !== null ? 64 : isDebugMode ? 48 : 8,
+					bottom:
+						mobileMenuOffset !== null
+							? 'calc(64px + env(safe-area-inset-bottom))'
+							: isDebugMode
+								? 48
+								: 8,
 					right: mobileMenuOffset !== null ? mobileMenuOffset : 8,
 					display: isMobileBottomToolbarsOpen ? 'none' : 'block',
 				}}

--- a/apps/dotcom/client/src/fairy/fairy-ui/FairyHUDTeaser.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/FairyHUDTeaser.tsx
@@ -129,7 +129,12 @@ export function FairyHUDTeaser() {
 		<div
 			className={`tla-fairy-hud ${isManualOpen ? 'tla-fairy-hud--open' : ''}`}
 			style={{
-				bottom: mobileMenuOffset !== null ? 64 : isDebugMode ? 48 : 8,
+				bottom:
+					mobileMenuOffset !== null
+						? 'calc(64px + env(safe-area-inset-bottom))'
+						: isDebugMode
+							? 48
+							: 8,
 				right: mobileMenuOffset === null ? 8 : mobileMenuOffset,
 				display: isMobileStylePanelOpen ? 'none' : 'block',
 			}}


### PR DESCRIPTION
Adjust Fairy HUD and teaser bottom offset to include safe-area inset when mobile menu offset is present.

### Change type

- [x] `bugfix`

### Test plan

1. Open the site on Android Chrome.
2. Verify the Fairy HUD position respects the safe area when the mobile menu is present.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix fairy HUD on chrome android

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust Fairy HUD and teaser bottom offset to include safe-area inset when mobile menu offset is present.
> 
> - **UI (Fairy HUD)**
>   - Update `bottom` style in `apps/dotcom/client/src/fairy/fairy-ui/FairyHUD.tsx` to use `calc(64px + env(safe-area-inset-bottom))` when `mobileMenuOffset` is set.
> - **UI (Fairy HUD Teaser)**
>   - Apply the same `bottom` calculation in `apps/dotcom/client/src/fairy/fairy-ui/FairyHUDTeaser.tsx` to respect device safe areas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f55d93eaa1cad1c8301f7ea1f7a695e8d007d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->