### PR TITLE
refactor(fairies): remove unnecessary FocusedLabelSchema

### DIFF
--- a/packages/fairy-shared/src/format/FocusedShape.ts
+++ b/packages/fairy-shared/src/format/FocusedShape.ts
@@ -3,8 +3,6 @@ import { FocusColorSchema } from './FocusColor'
 import { FocusFillSchema } from './FocusFill'
 import { FocusFontSizeSchema } from './FocusFontSize'
 
-const FocusedLabelSchema = z.string()
-
 export const FocusedGeoTypeSchema = z.enum([
 	'rectangle',
 	'ellipse',
@@ -37,7 +35,7 @@ export const FocusedGeoShapeSchema = z.object({
 	h: z.number(),
 	note: z.string(),
 	shapeId: z.string(),
-	text: FocusedLabelSchema.optional(),
+	text: z.string().optional(),
 	textAlign: z.enum(['start', 'middle', 'end']).optional(),
 	w: z.number(),
 	x: z.number(),
@@ -64,7 +62,7 @@ export const FocusedNoteShapeSchema = z.object({
 	color: FocusColorSchema,
 	note: z.string(),
 	shapeId: z.string(),
-	text: FocusedLabelSchema.optional(),
+	text: z.string().optional(),
 	x: z.number(),
 	y: z.number(),
 })
@@ -93,7 +91,7 @@ const FocusedTextShapeSchema = z
 		fontSize: FocusFontSizeSchema.optional(),
 		note: z.string(),
 		shapeId: z.string(),
-		text: FocusedLabelSchema,
+		text: z.string(),
 		width: z.number().optional(),
 		wrap: z.boolean().optional(),
 		x: z.number(),


### PR DESCRIPTION
Simplifies the FocusedShape schema by removing the FocusedLabelSchema constant and using z.string() directly inline.
This affects the system prompt schema.

### Change type

- [x] `improvement`

### Test plan

N/A - This is a refactoring change that doesn't affect behavior.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Simplified FocusedShape schema definitions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces FocusedLabelSchema with inline z.string() usages across geo, note, and text shape schemas.
> 
> - **FocusedShape schemas (`packages/fairy-shared/src/format/FocusedShape.ts`)**:
>   - Remove `FocusedLabelSchema`.
>   - Inline `z.string()` for `text` fields:
>     - `FocusedGeoShapeSchema`: `text: z.string().optional()`.
>     - `FocusedNoteShapeSchema`: `text: z.string().optional()`.
>     - `FocusedTextShapeSchema`: `text: z.string()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ceb120eacff95e218d538bb649ce906c70f94bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->