### PR TITLE
fix(clipboard): ensure pasting-at-cursor accounts for frames and parents

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9149,6 +9149,30 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 		}
 
+		if (point) {
+			const shapesById = new Map<TLShapeId, TLShape>(shapes.map((shape) => [shape.id, shape]))
+			const rootShapesFromContent = compact(rootShapeIds.map((id) => shapesById.get(id)))
+			if (rootShapesFromContent.length > 0) {
+				const targetParent = this.getShapeAtPoint(point, {
+					hitInside: true,
+					hitFrameInside: true,
+					hitLocked: true,
+					filter: (shape) => {
+						const util = this.getShapeUtil(shape)
+						if (!util.canReceiveNewChildrenOfType) return false
+						return rootShapesFromContent.every((rootShape) =>
+							util.canReceiveNewChildrenOfType!(shape, rootShape.type)
+						)
+					},
+				})
+
+				// When pasting at a specific point (e.g. paste-at-cursor) prefer the
+				// parent under the pointer so that we don't keep using the original
+				// selection's parent (which can keep shapes clipped inside frames).
+				pasteParentId = targetParent ? targetParent.id : currentPageId
+			}
+		}
+
 		let isDuplicating = false
 
 		if (!isPageId(pasteParentId)) {


### PR DESCRIPTION
fix https://github.com/tldraw/tldraw/issues/7214

### Change type

- [x] `bugfix` 

### Test plan

1. Create a shape...
2.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- clipboard: make sure pasting-at-cursor takes into account frames/parents

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pasting at cursor now picks the container under the pointer (if it accepts the shapes) or falls back to the page, instead of reusing the selection’s parent.
> 
> - **Clipboard/Paste behavior**
>   - In `Editor.putContentOntoCurrentPage`, when `opts.point` is provided, determine `pasteParentId` via `getShapeAtPoint` using `hitInside`, `hitFrameInside`, `hitLocked`, and a type-compatibility filter; default to the current page if no valid parent is under the cursor.
>   - Avoids reusing the original selection’s parent (prevents unwanted clipping in frames).
> - **Tests**
>   - Add unit tests in `packages/tldraw/src/test/commands/putContent.test.ts` to verify:
>     - Fallback to page when cursor is outside the original parent.
>     - Using the frame under the cursor when it can accept the pasted shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038c16597d67e47012e5f3fcef318dbf982c1417. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->