### PR TITLE
chore(vscode): add pre-release support for Open VSX

### DIFF
--- a/apps/vscode/extension/scripts/publish.ts
+++ b/apps/vscode/extension/scripts/publish.ts
@@ -28,7 +28,7 @@ async function publishToOpenVSX(preRelease: boolean) {
 	// eslint-disable-next-line no-console
 	console.log('Publishing to Open VSX...')
 	// OVSX_PAT is read from environment variable by ovsx CLI
-	await execAsync(`npx ovsx publish ${vsixPath}${preRelease ? ' --pre-release' : ''}`)
+	await execAsync(`npx ovsx publish${preRelease ? ' --pre-release' : ''} ${vsixPath}`)
 	// eslint-disable-next-line no-console
 	console.log('Successfully published to Open VSX')
 }


### PR DESCRIPTION
Looks like they do support pre releases as well.
<img width="740" height="263" alt="image" src="https://github.com/user-attachments/assets/172cf576-3d5d-47d0-8566-2ec1871103c3" />

### Change type

- [x] `other`

### Test plan

1. Verify the publish script correctly appends the --pre-release flag when running the Open VSX publish command.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Added pre-release support for Open VSX publishing in the VS Code extension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pre-release support for Open VSX and always publishes there, passing the `--pre-release` flag through the publish script.
> 
> - **VS Code extension publish script** (`apps/vscode/extension/scripts/publish.ts`):
>   - Pass `preRelease` into `publishToOpenVSX` and append `--pre-release` to `ovsx publish` when applicable.
>   - Remove conditional that skipped Open VSX for pre-releases; always publish to Open VSX.
>   - Preserve pre-release handling for VS Code Marketplace via `vsce publish`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7915954463175a7795d7e28f9e84d391c48eb5b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->