### PR TITLE
fix(rich-text): resolve CommonJS issue with TipTap imports

### DIFF
--- a/apps/examples/src/examples/outlined-text/OutlinedTextExample.tsx
+++ b/apps/examples/src/examples/outlined-text/OutlinedTextExample.tsx
@@ -1,5 +1,5 @@
 import { Mark, mergeAttributes } from '@tiptap/core'
-import StarterKit from '@tiptap/starter-kit'
+import { StarterKit } from '@tiptap/starter-kit'
 import {
 	DefaultRichTextToolbar,
 	TLComponents,

--- a/apps/examples/src/examples/rich-text-custom-extension/RichTextCustomExtension.tsx
+++ b/apps/examples/src/examples/rich-text-custom-extension/RichTextCustomExtension.tsx
@@ -1,5 +1,5 @@
 import { Mark, mergeAttributes } from '@tiptap/core'
-import StarterKit from '@tiptap/starter-kit'
+import { StarterKit } from '@tiptap/starter-kit'
 import {
 	DefaultRichTextToolbar,
 	TLComponents,

--- a/apps/examples/src/examples/rich-text-font-extensions/RichTextFontExtension.tsx
+++ b/apps/examples/src/examples/rich-text-font-extensions/RichTextFontExtension.tsx
@@ -1,5 +1,5 @@
 import { EditorEvents as TextEditorEvents } from '@tiptap/core'
-import FontFamily from '@tiptap/extension-font-family'
+import { FontFamily } from '@tiptap/extension-font-family'
 import { TextStyleKit } from '@tiptap/extension-text-style'
 import { EditorState as TextEditorState } from '@tiptap/pm/state'
 import { useEffect, useState } from 'react'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -153,6 +153,7 @@ export default [
 			'local/prefer-class-methods': 'error',
 			'local/tsdoc-param-matching': 'error',
 			'local/no-whilst': 'error',
+			'local/no-tiptap-default-import': 'error',
 			'no-only-tests/no-only-tests': 'error',
 			'formatjs/enforce-default-message': ['error', 'literal'],
 

--- a/internal/scripts/eslint/eslint-plugin.mjs
+++ b/internal/scripts/eslint/eslint-plugin.mjs
@@ -4,6 +4,8 @@ import * as utils from '@typescript-eslint/utils';
 import { isReassignmentTarget } from 'tsutils';
 import ts from 'typescript';
 const { AST_NODE_TYPES, ESLintUtils } = utils;
+const TIPTAP_IMPORT_PREFIX = '@tiptap/';
+
 const rules = {
     // Rule to enforce using "while" instead of "whilst"
     'no-whilst': ESLintUtils.RuleCreator.withoutDocs({
@@ -56,6 +58,36 @@ const rules = {
             type: 'problem',
             schema: [],
             fixable: 'code',
+        },
+        defaultOptions: [],
+    }),
+    'no-tiptap-default-import': ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            return {
+                ImportDeclaration(node) {
+                    const source = node.source.value;
+                    if (typeof source !== 'string' || !source.startsWith(TIPTAP_IMPORT_PREFIX)) {
+                        return;
+                    }
+                    for (const spec of node.specifiers) {
+                        if (spec.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
+                            spec.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+                            context.report({
+                                node: spec,
+                                messageId: 'noDefault',
+                                data: { module: source },
+                            });
+                        }
+                    }
+                },
+            };
+        },
+        meta: {
+            messages: {
+                noDefault: 'Use named imports when importing from {{module}} to avoid CommonJS interop issues.',
+            },
+            type: 'problem',
+            schema: [],
         },
         defaultOptions: [],
     }),

--- a/internal/scripts/eslint/eslint-plugin.mts
+++ b/internal/scripts/eslint/eslint-plugin.mts
@@ -7,6 +7,7 @@ import ts from 'typescript'
 
 const { AST_NODE_TYPES, ESLintUtils } = utils
 import TSESTree = utils.TSESTree
+const TIPTAP_IMPORT_PREFIX = '@tiptap/'
 
 const rules = {
 	// Rule to enforce using "while" instead of "whilst"
@@ -61,6 +62,40 @@ const rules = {
 			type: 'problem',
 			schema: [],
 			fixable: 'code',
+		},
+		defaultOptions: [],
+	}),
+	'no-tiptap-default-import': ESLintUtils.RuleCreator.withoutDocs({
+		create(context) {
+			return {
+				ImportDeclaration(node) {
+					const source = node.source.value
+					if (typeof source !== 'string' || !source.startsWith(TIPTAP_IMPORT_PREFIX)) {
+						return
+					}
+
+					for (const spec of node.specifiers) {
+						if (
+							spec.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
+							spec.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+						) {
+							context.report({
+								node: spec,
+								messageId: 'noDefault',
+								data: { module: source },
+							})
+						}
+					}
+				},
+			}
+		},
+		meta: {
+			messages: {
+				noDefault:
+					'Use named imports when importing from {{module}} to avoid CommonJS interop issues.',
+			},
+			type: 'problem',
+			schema: [],
 		},
 		defaultOptions: [],
 	}),

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -6,10 +6,10 @@ import {
 	generateText,
 	JSONContent,
 } from '@tiptap/core'
-import Code from '@tiptap/extension-code'
-import Highlight from '@tiptap/extension-highlight'
+import { Code } from '@tiptap/extension-code'
+import { Highlight } from '@tiptap/extension-highlight'
 import { Node } from '@tiptap/pm/model'
-import StarterKit from '@tiptap/starter-kit'
+import { StarterKit } from '@tiptap/starter-kit'
 import {
 	Editor,
 	getOwnProperty,


### PR DESCRIPTION
Had a helpful report on Discord about cjs builds failing. Turns out it was a really mundane import issue with TipTap 🤦 
thread: https://discord.com/channels/859816885297741824/859816885801713728/1442524021328580730

Created some eslint rules to prevent this from happening again.

### Change type

- [x] `bugfix`

### Test plan

1. Verify that the project builds correctly in CommonJS environments.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- rich text: fix CommonJS/cjs issue with TipTap imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces TipTap default imports with named imports and introduces/enables an ESLint rule (`local/no-tiptap-default-import`) to prevent regressions.
> 
> - **Rich Text / Examples**
>   - Replace TipTap default imports with named imports in `apps/examples/*/OutlinedTextExample.tsx`, `RichTextCustomExtension.tsx`, `RichTextFontExtension.tsx`.
>   - Update `packages/tldraw/src/lib/utils/text/richText.ts` to use named imports for `Code`, `Highlight`, and `StarterKit`.
> - **ESLint**
>   - Add `local/no-tiptap-default-import` rule in `internal/scripts/eslint/eslint-plugin.{mjs,mts}` to forbid default/namespace imports from `@tiptap/*`.
>   - Enable the rule in `eslint.config.mjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 034d5da61fbaf411f885381ce85c9bdae9695d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->