### PR TITLE
perf(dotcom): reduce idle timeout and db usage in sync-worker

### DIFF
--- a/apps/dotcom/sync-worker/src/postgres.ts
+++ b/apps/dotcom/sync-worker/src/postgres.ts
@@ -41,7 +41,7 @@ export function createPostgresConnectionPool(env: Environment, name: string, max
 	const pool = new pg.Pool({
 		connectionString: env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING,
 		application_name: name,
-		idleTimeoutMillis: 10_000,
+		idleTimeoutMillis: 5_000,
 		max,
 		Client: LoggingClient,
 	})


### PR DESCRIPTION
a couple of good changes suggested by @MitjaBezensek 

1. Reduce idle timeout
2. Reduce frequency of db usage in file db by not checking group membership for shared files (unless readonly state changed)

### Change type

- [x] `other`

### Test plan

1. Verify sync-worker still functions correctly under load

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance by reducing database idle timeouts and optimizing group membership checks in the sync worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce Postgres pool idle timeout and only query group membership when needed during session updates on file changes.
> 
> - **Sync worker**:
>   - **Session handling (`TLDrawDurableObject.appFileRecordDidUpdate`)**:
>     - Extract `isGroupMember()` helper and avoid group membership DB lookups unless required.
>     - For non-shared files, only disconnect sessions that are not owners or group members (`FORBIDDEN`).
>     - For shared files when readonly state flips, only force reconnect for non-owners/non-group members.
> - **Postgres**:
>   - Decrease `pg.Pool` `idleTimeoutMillis` from `10_000` to `5_000` in `apps/dotcom/sync-worker/src/postgres.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dd15be4ece2ddb97ba5b119bfa9de3a0b85ad1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->