### PR TITLE
fix(dotcom): alter Escape hack to not prevent kbd shortcuts

### DIFF
--- a/apps/dotcom/client/src/fairy/Fairy.tsx
+++ b/apps/dotcom/client/src/fairy/Fairy.tsx
@@ -244,6 +244,7 @@ function useFairyPointerInteraction(
 
 				// hack: dispatch an escape event to the document body to close any open context menus
 				document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+				document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }))
 
 				editor.inputs.isPointing = true
 				editor.inputs.isDragging = false


### PR DESCRIPTION
@steveruizok lemme know if you wanted to even just rm this hack altogether

### Change type

- [x] `other`

### Test plan

1. Interact with the fairy on dotcom.
2. Verify context menus close on pointer-down.
3. Verify keyboard shortcuts still function correctly.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the fairy's escape key hack prevented keyboard shortcuts from working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `Escape` keyup dispatch after keydown in `Fairy.tsx` pointer-down to close context menus without interfering with shortcuts.
> 
> - **UI (fairy interaction)**
>   - In `apps/dotcom/client/src/fairy/Fairy.tsx`, on fairy pointer-down, dispatch `KeyboardEvent('keyup', { key: 'Escape' })` immediately after `keydown` to ensure context menus close while preserving keyboard shortcuts.
>   - No other behavior changes to dragging/selection or event listeners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7d637c112f92d59fcccfac65cf44097e153ddde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->