### PR TITLE
fix(text): exit edit mode when text input blurs

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
@@ -52,10 +52,17 @@ export function useEditableRichText(
 		[editor, shapeId, type]
 	)
 
+	const handleBlur = useCallback(() => {
+		if (editor.getEditingShapeId() === shapeId) {
+			editor.complete()
+		}
+	}, [editor, shapeId])
+
 	return {
 		rInput,
 		handleKeyDown,
 		handleChange,
+		handleBlur,
 		isEmpty,
 		...commonUseEditableTextHandlers,
 	}


### PR DESCRIPTION
This PR ensures that the editor exits edit mode when the text input loses focus. Previously, dragging the mouse slightly could cause the input to lose focus while remaining in edit mode, which prevented actions like copying the shape.

### Change type

- [x] `bugfix`

### Test plan

1. Enter edit mode on a text shape.
2. Cause the input to blur (e.g., by clicking away or dragging slightly).
3. Verify the editor exits edit mode and handles reappear.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- If the text input loses focus we now exit editing mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes text editing when inputs blur, with a Safari-specific guard to avoid unintended completion.
> 
> - **Text editing**:
>   - **Plain text (`useEditablePlainText`)**:
>     - Add `handleBlur` to call `editor.complete()` when the input blurs.
>     - Introduce `ignoreNextBlurRef` to suppress the synthetic blur from the Safari caret "shake" (blur→focus).
>   - **Rich text (`useEditableRichText`)**:
>     - Add `handleBlur` to complete editing on blur.
>   - **Shared handlers**:
>     - Remove noop `handleBlur` from `useEditableTextCommon` return.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33407447cffb4b11a5c8f99b4e8ef754343dffdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->