### PR TITLE
refactor(fairy): convert canvas lint shape IDs to simple IDs

### DIFF
--- a/packages/fairy-shared/src/types/FairyCanvasLint.ts
+++ b/packages/fairy-shared/src/types/FairyCanvasLint.ts
@@ -1,8 +1,6 @@
-import { TLShapeId } from 'tldraw'
-
 export interface FairyCanvasLint {
 	type: FairyCanvasLintType
-	shapeIds: TLShapeId[]
+	shapeIds: string[]
 }
 
 export type FairyCanvasLintType = 'growY-on-shape' | 'overlapping-text' | 'friendless-arrow'


### PR DESCRIPTION
Refactored canvas lint detection to convert shape IDs to simple IDs and improved code organization by separating shape collection from lint object creation.

### Change type

- [x] `improvement`

### Test plan

1. Create shapes with various lint conditions (growY, overlapping text, friendless arrows)
2. Verify that canvas lints are detected correctly
3. Check that shape IDs in lint objects are simple string IDs rather than TLShapeId

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Refactored canvas lint detection to use simple string IDs instead of TLShapeId
- Improved code organization by separating shape collection logic from lint object creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert canvas lint shape IDs to simple strings and refactor lint detection to separate shape collection from lint creation.
> 
> - **Types** (`packages/fairy-shared`):
>   - Change `FairyCanvasLint.shapeIds` from `TLShapeId[]` to `string[]`.
> - **Canvas Lints** (`apps/dotcom/client`):
>   - Convert shape IDs via `convertTldrawIdToSimpleId` when building lints.
>   - Refactor detection by separating shape collection from lint creation:
>     - `getShapesWithGrowY`, `getOverlappingTextGroups` (union-find + geo-edge checks), `getFriendlessArrows`.
>   - Keep detection logic but reorganize code and return grouped shapes before mapping to lint objects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1debfd865feb60fc3dc3508ed0778db405bb89ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->