### PR TITLE
perf(dotcom): offload discord notifications to background tasks

### DIFF
--- a/apps/dotcom/sync-worker/src/paddleWebhooks.ts
+++ b/apps/dotcom/sync-worker/src/paddleWebhooks.ts
@@ -205,14 +205,15 @@ async function markTransactionError(
 async function handleTransactionCompleted(
 	env: Environment,
 	db: ReturnType<typeof createPostgresConnectionPool>,
-	event: PaddleWebhookEvent
+	event: PaddleWebhookEvent,
+	ctx: ExecutionContext
 ): Promise<void> {
 	const { data } = event
 	const { userId, email } = extractUserData(data.custom_data)
 	const webhookUrl = env.DISCORD_FAIRY_PURCHASE_WEBHOOK_URL
 
 	if (!userId) {
-		await sendDiscordNotification(webhookUrl, { type: 'missing_user', transactionId: data.id })
+		sendDiscordNotification(webhookUrl, { type: 'missing_user', transactionId: data.id }, ctx)
 		throw new Error('Missing userId in transaction custom_data')
 	}
 
@@ -237,11 +238,15 @@ async function handleTransactionCompleted(
 			stack: error instanceof Error ? error.stack : undefined,
 		})
 
-		await sendDiscordNotification(webhookUrl, {
-			type: 'error',
-			transactionId: data.id,
-			error: `UNEXPECTED ERROR: ${errorMessage}`,
-		})
+		sendDiscordNotification(
+			webhookUrl,
+			{
+				type: 'error',
+				transactionId: data.id,
+				error: `UNEXPECTED ERROR: ${errorMessage}`,
+			},
+			ctx
+		)
 
 		await markTransactionError(db, event.event_id, `UNEXPECTED: ${errorMessage}`)
 
@@ -259,11 +264,15 @@ async function handleTransactionCompleted(
 			error: errorMessage,
 		})
 
-		await sendDiscordNotification(webhookUrl, {
-			type: 'error',
-			transactionId: data.id,
-			error: errorMessage,
-		})
+		sendDiscordNotification(
+			webhookUrl,
+			{
+				type: 'error',
+				transactionId: data.id,
+				error: errorMessage,
+			},
+			ctx
+		)
 
 		await markTransactionError(db, event.event_id, errorMessage)
 
@@ -271,16 +280,15 @@ async function handleTransactionCompleted(
 		throw new Error(`Failed to grant fairy access: ${errorMessage}`)
 	}
 
-	await sendDiscordNotification(webhookUrl, {
-		type: 'success',
-		email: email ?? 'N/A',
-	})
+	// SUCCESS - mark processed FIRST, then notify async
 	await markTransactionProcessed(db, event.event_id)
+
+	sendDiscordNotification(webhookUrl, { type: 'success', email: email ?? 'N/A' }, ctx)
 }
 
 export const paddleWebhooks = createRouter<Environment>().post(
 	'/app/paddle/webhook',
-	async (req, env) => {
+	async (req, env, ctx) => {
 		const db = createPostgresConnectionPool(env, 'paddleWebhook')
 		try {
 			const event = await verifyWebhookSignature(env, req.clone())
@@ -292,13 +300,17 @@ export const paddleWebhooks = createRouter<Environment>().post(
 			}
 
 			if (event.event_type === 'transaction.completed') {
-				await handleTransactionCompleted(env, db, event)
+				await handleTransactionCompleted(env, db, event, ctx)
 			} else if (event.event_type === 'transaction.canceled' && userId) {
-				await sendDiscordNotification(env.DISCORD_FAIRY_PURCHASE_WEBHOOK_URL, {
-					type: 'refund',
-					transactionId: event.data.id,
-					userId,
-				})
+				sendDiscordNotification(
+					env.DISCORD_FAIRY_PURCHASE_WEBHOOK_URL,
+					{
+						type: 'refund',
+						transactionId: event.data.id,
+						userId,
+					},
+					ctx
+				)
 			}
 
 			return json({ received: true })

--- a/apps/dotcom/sync-worker/src/routes/tla/redeemFairyInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/redeemFairyInvite.ts
@@ -9,7 +9,11 @@ import { sendDiscordNotification } from '../../utils/discord'
 import { getFeatureFlag } from '../../utils/featureFlags'
 import { getClerkClient, requireAuth } from '../../utils/tla/getAuth'
 
-export async function redeemFairyInvite(request: IRequest, env: Environment): Promise<Response> {
+export async function redeemFairyInvite(
+	request: IRequest,
+	env: Environment,
+	ctx: ExecutionContext
+): Promise<Response> {
 	const fairiesEnabled = await getFeatureFlag(env, 'fairies')
 	if (!fairiesEnabled) {
 		throw new StatusError(403, 'Fairy invites are currently disabled')
@@ -100,11 +104,15 @@ export async function redeemFairyInvite(request: IRequest, env: Environment): Pr
 			throw new StatusError(500, `Failed to grant fairy access: ${result.error}`)
 		}
 
-		await sendDiscordNotification(env.DISCORD_FAIRY_PURCHASE_WEBHOOK_URL, {
-			type: 'invite_redeemed',
-			email: userEmail,
-			description: invite.description ?? undefined,
-		})
+		sendDiscordNotification(
+			env.DISCORD_FAIRY_PURCHASE_WEBHOOK_URL,
+			{
+				type: 'invite_redeemed',
+				email: userEmail,
+				description: invite.description ?? undefined,
+			},
+			ctx
+		)
 
 		return json({
 			success: true,


### PR DESCRIPTION
We'll no longer wait for discord notification to complete, we'll offload it to `waitUntil` 

### Change type

- [x] `other` 

### Test plan

1. Verify that Paddle webhooks and fairy invite redemptions still trigger Discord notifications.
2. Confirm that the response is returned to the client without waiting for the Discord fetch to complete.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance of webhooks and invite redemptions by offloading Discord notifications to background tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Offloads Discord notifications to background tasks using ctx.waitUntil, updating the helper signature and wiring ctx through Paddle webhooks and fairy invite redemption, with transaction processed before notify.
> 
> - **Utils**:
>   - **`utils/discord.ts`**: Change `sendDiscordNotification` to non-async, accept `ExecutionContext`, and dispatch via `ctx.waitUntil(...)` instead of awaiting `fetch`.
> - **Paddle Webhooks** (`paddleWebhooks.ts`):
>   - Plumb `ExecutionContext` through router handler and `handleTransactionCompleted(...)`; replace awaited notifications with non-blocking `sendDiscordNotification(..., ctx)`.
>   - Mark transaction as processed before sending success notification.
>   - Continue sending error/missing_user/refund notifications asynchronously.
> - **TLA Route** (`routes/tla/redeemFairyInvite.ts`):
>   - Add `ExecutionContext` param; send `invite_redeemed` Discord message via `sendDiscordNotification(..., ctx)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13de918e73c5fd6baa25e0f89280d9cd3be426ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->