### PR TITLE
docs: improve clean-copy command instructions

### DIFF
--- a/.claude/commands/clean-copy.md
+++ b/.claude/commands/clean-copy.md
@@ -1,20 +1,37 @@
-You should now "reimplement" the current branch on a new branch with a perfect git commit log in order to produce a branch that can be cleanly read and understood by a reviewer.
+Reimplement the current branch on a new branch with a clean, narrative-quality git commit history suitable for reviewer comprehension.
 
-First check that the current branch does not have merge conflicts, uncommit changes, or other problems that need fixing. You should have a good, clean source branch to work from.
+### Steps
 
-Next you should create a new branch, from the current branch, and populate it with an "ideal git commit log." The goal is to reproduce the current state of the branch (its diff against the main branch) in the new branch, but with a narratively perfect git commit log. Essentially we want to "reimplement" the current branch with perfect information about our target end state.
+1. **Validate the source branch**
+   - Ensure the current branch has no merge conflicts, uncommitted changes, or other issues.
+   - Confirm it is up to date with `main`.
 
-Each commit should be a contained step in the progress of the implementation. Imagine a tutorial that walks through the implementation step by step. Each commit should be a single step in the tutorial. The commit should be named, described, and perhaps even commented (using GitHub comments or inline comments) to explain the added or changed code.
+2. **Analyze the diff**
+   - Study all changes between the current branch and `main`.
+   - Form a clear understanding of the final intended state.
 
-The result should be a branch that can be cleanly read and understood by a reviewer. The reviewer should be able to follow the branch, step by step, and understand the code changes at each step. The reviewer should be able to see the progress of the implementation, and the changes made at each step. It should look like the work of a single master developer who began with a perfect understanding of their change, and implemented it step by step, producing a clean logical narrative via its git commit log and comments.
+3. **Create the clean branch**
+   - Create a new branch named `{branch_name}-clean` from the current branch.
 
-- verify that the current branch is up to date with the main branch
-- study the changes in the current branch against the main branch
-- create the new branch ({branch_name}-clean)
-- make a plan for your commits in the clean branch
-- implement the clean branch, following your plan, commit by commit, using comments or inline comments where needed to explain your changes
-- verify that the end state of the clean branch is the same as the end state of the original branch
-- create a pull request from the clean branch to the main branch
+4. **Plan the commit storyline**
+   - Break the implementation down into a sequence of self-contained steps.
+   - Each step should reflect a logical stage of development—as if writing a tutorial.
+
+5. **Reimplement the work**
+   - Recreate the changes in the clean branch, committing step by step according to your plan.
+   - Each commit must:
+     - Introduce a single coherent idea.
+     - Include a clear commit message and description.
+     - Add comments or inline GitHub comments when needed to explain intent.
+
+6. **Verify correctness**
+   - Confirm that the final state of `{branch_name}-clean` exactly matches the final state of the original branch.
+   - Use `--no-verify` only when necessary (e.g., to bypass known issues). Individual commits do not need to pass tests, but this should be rare.
+
+7. **Open a pull request**
+   - Create a PR from the clean branch to `main`.
+   - Write the PR following the instructions in `pr.md`.
+   - Include a link to the original branch.
 
 There may be cases where you will need to push commits with --no-verify in order to avoid known issues. It is not necessary that every commit pass tests or checks, though this should be the exception if you're doing your job correctly. It is essential that the end state of your new branch be identical to the end state of the source branch.
 


### PR DESCRIPTION
Improves the `.claude/commands/clean-copy.md` command file with clearer, more structured instructions for creating clean commit histories.

### Change type

- [x] `improvement`

### Test plan

This is a documentation/command file change that doesn't require testing.

### Release notes

- Improved the clean-copy Claude command with clearer step-by-step instructions for creating narrative-quality git histories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites `.claude/commands/clean-copy.md` into a structured, step-by-step guide for producing a clean commit history and opening a PR.
> 
> - **Docs**:
>   - **Restructure `/.claude/commands/clean-copy.md`**:
>     - Add a numbered "Steps" workflow: validate source, analyze diff, create clean branch, plan commit storyline, reimplement, verify, open PR.
>     - Clarify commit granularity, messaging, and optional use of `--no-verify`.
>     - Add PR-writing guidance and miscellaneous guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4028e09570453de489f2f5f26ab53a18c8888ab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->