### PR TITLE
fix(claude): fix prettier hook for macOS compatibility

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "git diff --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx|js|jsx|json|md)$' | xargs -r yarn run -T prettier --write"
+						"command": "cd \"$(git rev-parse --show-toplevel)\" && git diff --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx|js|jsx|json|md)$' | xargs yarn run -T prettier --write 2>/dev/null || true"
 					}
 				]
 			}


### PR DESCRIPTION
This PR fixes the Claude Code prettier hook that runs on `PostToolUse` for edit tools. The hook was failing on macOS due to:

1. Running from subdirectories - the prettier command needs to run from the repo root
2. Using `-r` flag with `xargs` which isn't supported on macOS (it's a GNU extension)
3. Failing when no files match the pattern

The fix:
- Adds `cd "$(git rev-parse --show-toplevel)"` to ensure the command runs from repo root
- Removes the `-r` flag from `xargs`
- Adds `2>/dev/null || true` to gracefully handle cases with no matching files

### Change type

- [x] `bugfix`

### Test plan

1. Make edits with Claude Code in the tldraw repo
2. Verify the prettier hook runs successfully without errors

### Release notes

- Fixed Claude Code prettier hook for macOS compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the Claude Code Prettier Stop hook macOS-compatible by running from repo root, removing `xargs -r`, and gracefully handling no-match cases.
> 
> - **Hooks**:
>   - Update `/.claude/settings.json` Stop hook command:
>     - Run from repo root via `cd "$(git rev-parse --show-toplevel)"`.
>     - Remove GNU-only `-r` from `xargs` for macOS compatibility.
>     - Add `2>/dev/null || true` to avoid errors when no files match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef138abafd6cd86340c1e22e9adf0a6c8e01cbfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->