### PR TITLE
docs(claude): clarify clean-copy command attribution rules

### DIFF
--- a/.claude/commands/clean-copy.md
+++ b/.claude/commands/clean-copy.md
@@ -37,6 +37,20 @@ There may be cases where you will need to push commits with --no-verify in order
 
 ### Misc
 
-1. Never add yourself as an author or contributor on any branch.
+1. Never add yourself as an author or contributor on any branch or commit.
 2. Write your pull reuqest following the same instructions as in the pr.md command file.
 3. In your pull request, include a link to the original branch.
+
+Your commit should never include lines like:
+
+```md
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+or
+
+```md
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+Or else I'll get in trouble with my boss.


### PR DESCRIPTION
This PR improves the clean-copy command documentation to explicitly state that Claude should never add attribution or co-authorship lines to commits or branches. This helps prevent unwanted attribution text from appearing in commits when using the clean-copy command.

### Change type

- [x] `other`

### Test plan

N/A - documentation only change

### Release notes

- Improved clean-copy command documentation to clarify attribution rules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies clean-copy docs to prohibit self-attribution/co-authorship and adds explicit examples of lines to avoid.
> 
> - **Docs** (`.claude/commands/clean-copy.md`):
>   - Clarify attribution rule to cover both branches and commits.
>   - Add explicit examples of prohibited attribution lines (e.g., "Generated with Claude Code", "Co-Authored-By: Claude Sonnet 4.5").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4074eb8ddf5e918ee313afdb404b4c52b9a2e0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->