### PR TITLE
fix(fairy-shared): remove obsolete width and wrap fields from FocusedTextShape

### DIFF
--- a/packages/fairy-shared/src/format/FocusedShape.ts
+++ b/packages/fairy-shared/src/format/FocusedShape.ts
@@ -98,8 +98,6 @@ const FocusedTextShapeSchema = z
 		note: z.string(),
 		shapeId: SimpleShapeIdSchema,
 		text: z.string(),
-		width: z.number().optional(),
-		wrap: z.boolean().optional(),
 		x: z.number(),
 		y: z.number(),
 	})


### PR DESCRIPTION
This PR removes obsolete `width` and `wrap` fields from the FocusedTextShape schema that are no longer used in the text shape conversion logic.

### Change type

- [x] `bugfix`

### Test plan

Type checking should pass without errors.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Removed obsolete width and wrap fields from FocusedTextShape schema.