### PR TITLE
refactor(fairy): remove unnecessary logic from notifyWaitConditionFulfilled

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-agent/managers/FairyAgentWaitManager.ts
+++ b/apps/dotcom/client/src/fairy/fairy-agent/managers/FairyAgentWaitManager.ts
@@ -118,20 +118,11 @@ export class FairyAgentWaitManager extends BaseFairyAgentManager {
 		agentFacingMessage: string
 		userFacingMessage: string | null
 	}): Promise<void> {
-		const { agent } = this
-		if (agent.requests.isGenerating()) {
-			agent.schedule({
-				agentMessages: [agentFacingMessage],
-				userMessages: userFacingMessage ? [userFacingMessage] : undefined,
-				source: 'other-agent',
-			})
-		} else {
-			await agent.prompt({
-				agentMessages: [agentFacingMessage],
-				userMessages: userFacingMessage ? [userFacingMessage] : undefined,
-				source: 'other-agent',
-			})
-		}
+		this.agent.schedule({
+			agentMessages: [agentFacingMessage],
+			userMessages: userFacingMessage ? [userFacingMessage] : undefined,
+			source: 'other-agent',
+		})
 	}
 
 	/**


### PR DESCRIPTION
In order to simplify the wait condition notification logic, this PR removes the unnecessary conditional check in `notifyWaitConditionFulfilled` that differentiated between scheduling and prompting based on whether the agent was generating.

Previously, the method checked if the agent was generating and would either schedule or prompt accordingly. Since `schedule` handles both cases appropriately, this conditional logic was unnecessary and has been removed.

### Change type

- [x] `improvement`

### Test plan

1. Verify that wait condition notifications still work correctly when agents are waiting for events
2. Verify that notifications are properly scheduled regardless of agent state

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Simplified wait condition notification logic by removing unnecessary conditional check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines `notifyWaitConditionFulfilled` to always call `agent.schedule(...)`, removing branching/await logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57d6dc4af2cf93ee6da9c6915fb69ca11cf99cd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->