### PR TITLE
fix(templates): resolve Durable Object export in cloudflare template

### DIFF
--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -10,6 +10,7 @@ import {
 	// defaultBindingSchemas,
 	defaultShapeSchemas,
 } from '@tldraw/tlschema'
+import { DurableObject } from 'cloudflare:workers'
 import { AutoRouter, IRequest, error } from 'itty-router'
 import throttle from 'lodash.throttle'
 
@@ -24,7 +25,7 @@ const schema = createTLSchema({
 
 // there's only ever one durable object instance per room. it keeps all the room state in memory and
 // handles websocket connections. periodically, it persists the room state to the R2 bucket.
-export class TldrawDurableObject {
+export class TldrawDurableObject extends DurableObject {
 	private r2: R2Bucket
 	// the room ID will be missing while the room is being initialized
 	private roomId: string | null = null
@@ -32,10 +33,8 @@ export class TldrawDurableObject {
 	// load it once.
 	private roomPromise: Promise<TLSocketRoom<TLRecord, void>> | null = null
 
-	constructor(
-		private readonly ctx: DurableObjectState,
-		env: Env
-	) {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env)
 		this.r2 = env.TLDRAW_BUCKET
 
 		ctx.blockConcurrencyWhile(async () => {


### PR DESCRIPTION
Running this template resulted in the following:

> A DurableObjectNamespace in the config referenced the class "TldrawDurableObject", but no such Durable Object class is exported from the worker. Please make sure the class name matches, it is exported, and the class extends 'DurableObject'. Attempts to call to this Durable Object class will fail at runtime, but historically this was not a startup-time error. Future versions of workerd may make this a startup-time error.

Then a runtime error:

> Error: internal error; reference = ntutl490g1bj7tphtk4d47e1
    at Object.fetch (/Users/mitja/Code/multi/node_modules/.vite/deps_multiplayer_template/itty-router.js:19:44)
    at maybeCaptureError (workers/runner-worker.js:47:10) {
  durableObjectReset: true
} 


### Change type

- [x] `other`

### Test plan

1. Run the cloudflare-sync template and verify the Durable Object is correctly instantiated without runtime errors.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where the Cloudflare multiplayer template failed due to an incorrect Durable Object definition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `TldrawDurableObject` is a valid Cloudflare Durable Object by extending `DurableObject`, importing it, and updating the constructor to call `super`.
> 
> - **Worker / Cloudflare Durable Object**:
>   - Import `DurableObject` from `cloudflare:workers`.
>   - Make `TldrawDurableObject` extend `DurableObject`.
>   - Update constructor signature and call `super(ctx, env)`; adjust `ctx` usage accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11c99181f836906e02dfd24d7fba657f44855574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->