### PR TITLE
improvement(fairy): improve sign part wording

### DIFF
--- a/packages/fairy-shared/src/schema/PromptPartDefinitions.ts
+++ b/packages/fairy-shared/src/schema/PromptPartDefinitions.ts
@@ -269,7 +269,7 @@ export const SignPartDefinition: PromptPartDefinition<SignPart> = {
 			if (sign.sun === sign.moon && sign.moon === sign.rising) {
 				return [`You're a triple ${sign.sun}.`]
 			}
-			return [`You're a ${sign.sun} sun, ${sign.moon} moon, and ${sign.rising} rising fairy.`]
+			return [`You're a ${sign.sun} sun, ${sign.moon} moon, and ${sign.rising} rising.`]
 		}
 
 		return []


### PR DESCRIPTION
In order to make astrological sign descriptions more natural and concise, this PR updates the wording for the sign part definition to use a more conversational tone and adds a special case for triple signs (when sun, moon, and rising are all the same).

### Change type

- [x] `improvement`

### Test plan

1. Test with different sign combinations to verify the new wording displays correctly
2. Test with a triple sign (same sun, moon, and rising) to verify the special case works

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved wording for astrological sign descriptions in fairy prompts to be more natural and conversational
- Added special case for triple signs (when sun, moon, and rising are all the same)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `SignPartDefinition.buildContent` to use more natural phrasing and adds a special case for triple signs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ebf9e944dc76e11e0f13543ecec46afbaebf22a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->