### PR TITLE
fix(sync): allow safely toggling sqlite feature flag

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -939,6 +939,9 @@ export class TLDrawDurableObject extends DurableObject {
 
 						this.logEvent({ type: 'persist_success', attempts: attempt })
 						this._lastPersistedClock = snapshot.documentClock
+						// Store the clock in DO storage so we can compare against SQLite on next load.
+						// This enables safe flag toggling for sqlite_file_storage.
+						this.ctx.storage.put('lastPersistedR2Clock', snapshot.documentClock)
 						if (this.persistenceBad) {
 							this.broadcastPersistenceEvent({ type: 'persistence_good' })
 							this.persistenceBad = false

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -20,11 +20,29 @@ export class TLFileDurableObject extends TLDrawDurableObject {
 		}
 
 		const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
+		const sqliteClock = SqlLiteSyncStorage.getDocumentClock(sql)
 
-		if (SqlLiteSyncStorage.hasBeenInitialized(sql)) {
+		// If SQLite has been initialized, we need to check if R2 has fresher data.
+		// This can happen if the sqlite_file_storage flag was toggled OFF then back ON,
+		// since changes made while the flag was OFF would only be persisted to R2.
+		if (sqliteClock !== null) {
+			// Check the last persisted R2 clock (stored in DO storage during persist)
+			// This is fast - just reading a number from DO storage, no R2 fetch needed
+			const lastR2Clock = (await this.ctx.storage.get<number>('lastPersistedR2Clock')) ?? 0
+
+			if (lastR2Clock > sqliteClock) {
+				// R2 has fresher data, reinitialize SQLite from R2
+				const result = await this.loadFromDatabase(slug)
+				const storage = new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+				this.setRoomStorageUsedPercentage(result.roomSizeMB)
+				return storage
+			}
+
+			// SQLite is up-to-date or fresher, use it directly
 			return new SqlLiteSyncStorage<TLRecord>({ sql })
 		}
 
+		// SQLite not initialized yet, load from R2 and initialize
 		const result = await this.loadFromDatabase(slug)
 		const storage = new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
 		// We should not await on setRoomStorageUsedPercentage because it calls

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -309,6 +309,7 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
     });
     // (undocumented)
     getClock(): number;
+    static getDocumentClock(storage: TLSyncSqliteWrapper): null | number;
     // @internal (undocumented)
     _getSchema(): SerializedSchema;
     // (undocumented)

--- a/packages/sync-core/src/lib/SqlLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SqlLiteSyncStorage.ts
@@ -189,6 +189,27 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
 		}
 	}
 
+	/**
+	 * Get the current document clock value from storage without fully initializing.
+	 * Returns null if storage has not been initialized.
+	 * Useful for comparing storage freshness against external sources.
+	 */
+	static getDocumentClock(storage: TLSyncSqliteWrapper): number | null {
+		const prefix = storage.config?.tablePrefix ?? ''
+		try {
+			const row = storage
+				.prepare<{ documentClock: number }>(`SELECT documentClock FROM ${prefix}metadata LIMIT 1`)
+				.all()[0]
+			// documentClock exists but could be 0, so we check if the storage is initialized
+			if (row && SqlLiteSyncStorage.hasBeenInitialized(storage)) {
+				return row.documentClock
+			}
+			return null
+		} catch (_e) {
+			return null
+		}
+	}
+
 	// Prepared statements - created once, reused many times
 	private readonly stmts
 


### PR DESCRIPTION
little follow up to #7320 to fix a problem bugbot identified

> When sqlite_file_storage flag is toggled OFF then back ON, the code checks hasBeenInitialized(sql) which returns true if SQLite tables exist with data. However, while the flag was OFF, changes were stored only in R2 (not SQLite). When the flag is turned back ON, hasBeenInitialized returns true and the code uses potentially stale SQLite data instead of loading the newer R2 data. This could cause data loss during flag toggling. The check at line 24-26 should probably also compare clock values or timestamps between SQLite and R2 to ensure the freshest data is used.

### API changes
- Add a static getDocumentClock method to the SqlLiteSyncStorage class

### Change type

- [x] `bugfix`

### Test plan

1. Toggle sqlite_file_storage flag off and on and ensure data consistency.

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a potential data loss issue when toggling the SQLite storage feature flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely toggles `sqlite_file_storage` by persisting the last R2 clock and comparing it with SQLite’s clock to load the freshest snapshot.
> 
> - **Worker (DO persistence/load)**
>   - Persist last R2 `documentClock` to DO storage via `this.ctx.storage.put('lastPersistedR2Clock', ...)` in `apps/dotcom/sync-worker/src/TLDrawDurableObject.ts` after successful snapshot upload.
>   - In `apps/dotcom/sync-worker/src/TLFileDurableObject.ts` `loadStorage`:
>     - Read SQLite clock using `SqlLiteSyncStorage.getDocumentClock(sql)`.
>     - Compare against DO-stored `lastPersistedR2Clock`; if R2 is fresher, reload from R2 and reinitialize SQLite; otherwise use existing SQLite; initialize from R2 when SQLite is uninitialized.
> - **Sync-core**
>   - Add `SqlLiteSyncStorage.getDocumentClock(storage)` to read clock without full init; update API report.
>   - Add tests covering clock retrieval, updates via transactions, and table prefix handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a5993ae9a9f327c4e4a29d2413d3b1e7ec4fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->