### PR TITLE
fix(dotcom): prevent error toast on file deletion

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -804,6 +804,8 @@ export class TldrawApp {
 	}
 
 	updateFileState(fileId: string, partial: Omit<TlaFileStatePartial, 'fileId' | 'userId'>) {
+		const file = this.getFile(fileId)
+		if (!file || file.isDeleted) return
 		this.z.mutate.file_state.update({ ...partial, fileId, userId: this.userId })
 	}
 


### PR DESCRIPTION
this is a common regression now. we should probably have a way of failing e2e tests if any unexpected error toasts pop up.

### Change type

- [x] `bugfix` 

### Test plan

1. Delete a file and verify no error toast appears.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed an issue where deleting a file would trigger an erroneous error toast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip updating `file_state` when the file is missing or marked deleted to prevent erroneous toasts/errors.
> 
> - **Client**:
>   - In `apps/dotcom/client/src/tla/app/TldrawApp.ts`, add a guard in `updateFileState` to check `getFile(fileId)` and `!file.isDeleted` before calling `file_state.update`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e53a05ce4e49adc433d9a26f970b7409cefa3a72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->