### PR TITLE
fix(fairy): update note shape size in system prompt

### DIFF
--- a/apps/dotcom/fairy-worker/src/prompt/sections/rules-section.ts
+++ b/apps/dotcom/fairy-worker/src/prompt/sections/rules-section.ts
@@ -123,7 +123,7 @@ ${flagged(
 	- When drawing a shape with a label, be sure that the text will fit inside of the label. Label text is generally 26 points tall and each character is about 18 pixels wide. There are 32 pixels of padding around the the text on each side. You need to leave room for the padding. Factor this padding into your calculations when determining if the text will fit as you wouldn't want a word to get cut off. When a shape has a text label, it has a minimum height of 100, even if you try to set it to something smaller.
 	- You may also specify the alignment of the label text within the shape.
 	- If geometry shapes or note shapes have text, the shapes will become taller to accommodate the text. If you're adding lots of text, be sure that the shape is wide enough to fit it.
-	- Note shapes are 50x50. They're sticky notes and are only suitable for tiny sentences. Use a geometric shape or text shape if you need to write more.
+	- Note shapes are 200x200. They're sticky notes and are only suitable for tiny sentences. Use a geometric shape or text shape if you need to write more.
 	- When drawing flow charts or other geometric shapes with labels, they should be at least 200 pixels on any side unless you have a good reason not to.
 - Colors
 	- When specifying a fill, you can use \`background\` to make the shape the same color as the background${flagged(flags.hasScreenshotPart, ", which you'll see in your viewport")}. It will either be white or black, depending on the theme of the canvas.


### PR DESCRIPTION
In order to ensure agents have accurate information about note shape dimensions, this PR fixes the incorrect note shape size specification in the system prompt.

The system prompt incorrectly stated that note shapes are 50x50 pixels, when they are actually 200x200 pixels. This correction ensures that agents understand the proper size constraints when working with note shapes.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed incorrect note shape size specification in fairy agent system prompt (50x50 → 200x200)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the system prompt to state note shapes are 200x200 instead of 50x50.
> 
> - **Prompt rules**:
>   - In `apps/dotcom/fairy-worker/src/prompt/sections/rules-section.ts`, correct note shape dimensions from `50x50` to `200x200`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 166e269f2ee0aca9d34816e83208227ea5ae912a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->