### PR TITLE
fix(editor): re-focus text input on shape label click

### DIFF
--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -279,7 +279,7 @@ test.describe('Focus', () => {
 		const contenteditable = page.locator('.tl-shape [contenteditable]')
 		await expect(contenteditable).toHaveText('test')
 
-		// Blur input while staying in editing mode by clicking on canvas
+		// Blur input while staying in editing mode by clicking on the text label (but not the input itself)
 		await page.mouse.click(200, 230)
 		await page.waitForTimeout(100)
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -192,6 +192,8 @@ export class EditingShape extends StateNode {
 		if (this.didPointerDownOnEditingShape) {
 			this.didPointerDownOnEditingShape = false
 			if (!this.isTextInputFocused()) {
+				// We clicked on the text label, which blured the input.
+				// We want to stay in edit mode and select all the text.
 				this.editor.getRichTextEditor()?.commands.focus('all')
 				return
 			}


### PR DESCRIPTION
When clicking text label (but not inside the input) we now:
  - Re-focuses input
  - Selects all text

Follow up to #7289 

### Before

https://github.com/user-attachments/assets/074ceeab-c4fa-4d62-97a7-582410725f50

### After

This now also works the same as when you click on a text label of a different shape (selects all text).

https://github.com/user-attachments/assets/e21382be-1ad5-474d-8b6c-dacd202d189c

### Change type

- [x] `bugfix` 

### Test plan

1. Enter edit mode on a shape with a text label.
2. Click outside the input but on the label.
3. Verify the input re-focuses and selects all text.

- [x] Unit tests
- [x] End to end tests

### Release notes

- Fixed an issue where clicking a shape's text label while editing would blur the input without re-focusing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clicking a shape’s text label while editing now re-focuses the input and selects all text; dragging from a blurred label exits edit mode and starts translating, with new e2e coverage.
> 
> - **Editor / SelectTool (`EditingShape`)**
>   - Add tracking for pointer-down on the currently editing shape to detect label clicks vs. drags.
>   - On pointer up: if input was blurred by clicking the label, stay in edit mode and `focus('all')` in the rich text editor.
>   - On pointer move: when dragging after clicking the editing shape’s label and the text input is blurred, exit edit mode and transition to `translating`.
>   - Add helper to detect focused text inputs/contenteditable.
> - **E2E Tests (`apps/examples/e2e/tests/test-focus.spec.ts`)**
>   - Add test ensuring clicking the blurred text label re-focuses and selects all text while staying in edit mode.
>   - Keep test ensuring dragging from blurred label exits edit mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ea1601071e3c99259f0fa0889e96eac1f15a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->