### PR TITLE
fix(dotcom): resolve overflowing text in invite dialog

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
@@ -24,7 +24,9 @@
 	font-size: 12px;
 	text-align: center;
 	padding-right: var(--tl-space-4);
-	height: 20px;
+	min-height: 20px;
+	word-break: break-word;
+	overflow-wrap: break-word;
 }
 
 .acceptButton {


### PR DESCRIPTION
This PR fixes a layout issue where text was overflowing in the TlaInviteDialog component.

### Before

<img width="662" height="506" alt="CleanShot 2025-12-11 at 10 46 55@2x" src="https://github.com/user-attachments/assets/7e407a12-fb40-41e1-b37f-3ee7a411241c" />

### After

<img width="678" height="566" alt="CleanShot 2025-12-11 at 10 46 41@2x" src="https://github.com/user-attachments/assets/a7b571b1-f63a-4bba-ad3d-c0868e9f05af" />

### Change type

- [x] `other`

### Test plan

1. Open the TlaInviteDialog and verify that text no longer overflows.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed text overflow in the invite dialog.