### PR TITLE
refactor(sync): rename SqlLiteSyncStorage to SQLiteSyncStorage

### DIFF
--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -142,15 +142,15 @@ const storage = new InMemorySyncStorage({
 const room = new TLSocketRoom({ storage })
 ```
 
-#### SqlLiteSyncStorage (recommended for persistence)
+#### SQLiteSyncStorage (recommended for persistence)
 
-[`SqlLiteSyncStorage`](?) stores document state in SQLite, providing automatic persistence that survives process restarts. This is the recommended approach for production deployments.
+[`SQLiteSyncStorage`](?) stores document state in SQLite, providing automatic persistence that survives process restarts. This is the recommended approach for production deployments.
 
 **For Cloudflare Durable Objects:**
 
 ```tsx
 import { DurableObject } from 'cloudflare:workers'
-import { SqlLiteSyncStorage, DurableObjectSqliteSyncWrapper, TLSocketRoom } from '@tldraw/sync-core'
+import { SQLiteSyncStorage, DurableObjectSqliteSyncWrapper, TLSocketRoom } from '@tldraw/sync-core'
 
 export class TLSyncDurableObject extends DurableObject {
 	private room: TLSocketRoom
@@ -158,7 +158,7 @@ export class TLSyncDurableObject extends DurableObject {
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env)
 		const sql = new DurableObjectSqliteSyncWrapper(ctx.storage)
-		const storage = new SqlLiteSyncStorage({ sql })
+		const storage = new SQLiteSyncStorage({ sql })
 		this.room = new TLSocketRoom({ storage })
 	}
 }
@@ -168,16 +168,16 @@ export class TLSyncDurableObject extends DurableObject {
 
 ```tsx
 import Database from 'better-sqlite3' // replace with 'node:sqlite' if using
-import { SqlLiteSyncStorage, NodeSqliteWrapper, TLSocketRoom } from '@tldraw/sync-core'
+import { SQLiteSyncStorage, NodeSqliteWrapper, TLSocketRoom } from '@tldraw/sync-core'
 
 const db = new Database('rooms.db')
 const sql = new NodeSqliteWrapper(db)
-const storage = new SqlLiteSyncStorage({ sql })
+const storage = new SQLiteSyncStorage({ sql })
 const room = new TLSocketRoom({ storage })
 ```
 
 <Callout type="info">
-	`SqlLiteSyncStorage` automatically creates and manages its database tables. You can use the
+	`SQLiteSyncStorage` automatically creates and manages its database tables. You can use the
 	`tablePrefix` option to avoid conflicts if you're sharing a database with other data.
 </Callout>
 
@@ -297,20 +297,20 @@ clients on different versions won't be able to collaborate without errors.
 
 If you have been using some other solution for data sync, you can migrate your existing data to the tldraw sync format.
 
-Both [`InMemorySyncStorage`](?) and [`SqlLiteSyncStorage`](?) support loading [`TLStoreSnapshot`](?) snapshots, so you can add a backwards-compatibility layer that lazily imports data from your old system and converts it to a `TLStoreSnapshot`.
+Both [`InMemorySyncStorage`](?) and [`SQLiteSyncStorage`](?) support loading [`TLStoreSnapshot`](?) snapshots, so you can add a backwards-compatibility layer that lazily imports data from your old system and converts it to a `TLStoreSnapshot`.
 
-**Example with SqlLiteSyncStorage (recommended):**
+**Example with SQLiteSyncStorage (recommended):**
 
 ```tsx
-import { SqlLiteSyncStorage, NodeSqliteWrapper, TLSocketRoom } from '@tldraw/sync-core'
+import { SQLiteSyncStorage, NodeSqliteWrapper, TLSocketRoom } from '@tldraw/sync-core'
 import Database from 'better-sqlite3'
 
 function loadOrMakeRoom(roomId: string, db: Database.Database) {
 	const sql = new NodeSqliteWrapper(db, { tablePrefix: `room_${roomId}_` })
 
 	// Check if we already have data in SQLite
-	if (SqlLiteSyncStorage.hasBeenInitialized(sql)) {
-		const storage = new SqlLiteSyncStorage({ sql })
+	if (SQLiteSyncStorage.hasBeenInitialized(sql)) {
+		const storage = new SQLiteSyncStorage({ sql })
 		return new TLSocketRoom({ storage })
 	}
 
@@ -318,13 +318,13 @@ function loadOrMakeRoom(roomId: string, db: Database.Database) {
 	const legacyData = loadRoomDataFromLegacyStore(roomId)
 	if (legacyData) {
 		const snapshot = convertOldDataToSnapshot(legacyData)
-		const storage = new SqlLiteSyncStorage({ sql, snapshot })
+		const storage = new SQLiteSyncStorage({ sql, snapshot })
 		deleteLegacyRoomData(roomId)
 		return new TLSocketRoom({ storage })
 	}
 
 	// No data - create a new empty room
-	return new TLSocketRoom({ storage: new SqlLiteSyncStorage({ sql }) })
+	return new TLSocketRoom({ storage: new SQLiteSyncStorage({ sql }) })
 }
 ```
 
@@ -394,7 +394,7 @@ Rename your existing class (e.g. `TldrawDurableObject` → `TldrawDurableObjectS
 import {
 	DurableObjectSqliteSyncWrapper,
 	RoomSnapshot,
-	SqlLiteSyncStorage,
+	SQLiteSyncStorage,
 	TLSocketRoom,
 } from '@tldraw/sync-core'
 import { TLRecord, createTLSchema, defaultShapeSchemas } from '@tldraw/tlschema'
@@ -426,8 +426,8 @@ export class TldrawDurableObjectSqlite {
 		const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
 
 		// If SQLite already has data, use it directly
-		if (SqlLiteSyncStorage.hasBeenInitialized(sql)) {
-			const storage = new SqlLiteSyncStorage<TLRecord>({ sql })
+		if (SQLiteSyncStorage.hasBeenInitialized(sql)) {
+			const storage = new SQLiteSyncStorage<TLRecord>({ sql })
 			return new TLSocketRoom<TLRecord, void>({ schema, storage })
 		}
 
@@ -436,7 +436,7 @@ export class TldrawDurableObjectSqlite {
 			const r2Object = await this.env.TLDRAW_BUCKET.get(`rooms/${this.roomId}`)
 			if (r2Object) {
 				const snapshot = (await r2Object.json()) as RoomSnapshot
-				const storage = new SqlLiteSyncStorage<TLRecord>({ sql, snapshot })
+				const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot })
 
 				// Optionally delete the R2 object after successful migration
 				// await this.env.TLDRAW_BUCKET.delete(`rooms/${this.roomId}`)
@@ -446,7 +446,7 @@ export class TldrawDurableObjectSqlite {
 		}
 
 		// No existing data - create fresh room
-		const storage = new SqlLiteSyncStorage<TLRecord>({ sql })
+		const storage = new SQLiteSyncStorage<TLRecord>({ sql })
 		return new TLSocketRoom<TLRecord, void>({ schema, storage })
 	}
 }

--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -23,7 +23,7 @@ import {
 	DEFAULT_INITIAL_SNAPSHOT,
 	InMemorySyncStorage,
 	RoomSnapshot,
-	SqlLiteSyncStorage,
+	SQLiteSyncStorage,
 	TLSocketRoom,
 	TLSyncErrorCloseEventCode,
 	TLSyncErrorCloseEventReason,
@@ -924,8 +924,8 @@ export class TLDrawDurableObject extends DurableObject {
 						const slug = this.documentInfo.slug
 						const storage = await this.getStorage()
 						assert(
-							storage instanceof InMemorySyncStorage || storage instanceof SqlLiteSyncStorage,
-							'storage must be an InMemorySyncStorage or SqlLiteSyncStorage'
+							storage instanceof InMemorySyncStorage || storage instanceof SQLiteSyncStorage,
+							'storage must be an InMemorySyncStorage or SQLiteSyncStorage'
 						)
 						if (this._lastPersistedClock === storage.getClock()) return
 						if (this._isRestoring) return

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1,8 +1,4 @@
-import {
-	DurableObjectSqliteSyncWrapper,
-	SqlLiteSyncStorage,
-	TLSyncStorage,
-} from '@tldraw/sync-core'
+import { DurableObjectSqliteSyncWrapper, SQLiteSyncStorage, TLSyncStorage } from '@tldraw/sync-core'
 import { TLRecord } from '@tldraw/tlschema'
 import { TLDrawDurableObject } from './TLDrawDurableObject'
 import { getFeatureFlag } from './utils/featureFlags'
@@ -20,7 +16,7 @@ export class TLFileDurableObject extends TLDrawDurableObject {
 		}
 
 		const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
-		const sqliteClock = SqlLiteSyncStorage.getDocumentClock(sql)
+		const sqliteClock = SQLiteSyncStorage.getDocumentClock(sql)
 
 		// If SQLite has been initialized, we need to check if R2 has fresher data.
 		// This can happen if the sqlite_file_storage flag was toggled OFF then back ON,
@@ -33,18 +29,18 @@ export class TLFileDurableObject extends TLDrawDurableObject {
 			if (lastR2Clock > sqliteClock) {
 				// R2 has fresher data, reinitialize SQLite from R2
 				const result = await this.loadFromDatabase(slug)
-				const storage = new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+				const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
 				this.setRoomStorageUsedPercentage(result.roomSizeMB)
 				return storage
 			}
 
 			// SQLite is up-to-date or fresher, use it directly
-			return new SqlLiteSyncStorage<TLRecord>({ sql })
+			return new SQLiteSyncStorage<TLRecord>({ sql })
 		}
 
 		// SQLite not initialized yet, load from R2 and initialize
 		const result = await this.loadFromDatabase(slug)
-		const storage = new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+		const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
 		// We should not await on setRoomStorageUsedPercentage because it calls
 		// getStorage under the hood which will only resolve once this function has returned.
 		this.setRoomStorageUsedPercentage(result.roomSizeMB)

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -301,7 +301,7 @@ export interface RoomStoreMethods<R extends UnknownRecord = UnknownRecord> {
 }
 
 // @public
-export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
+export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
     constructor({ sql, snapshot, onChange, }: {
         onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown;
         snapshot?: RoomSnapshot | StoreSnapshot<R>;

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -33,14 +33,14 @@ export { RoomSessionState, type RoomSession, type RoomSessionBase } from './lib/
 export type { PersistedRoomSnapshotForSupabase } from './lib/server-types'
 export type { WebSocketMinimal } from './lib/ServerSocketAdapter'
 export {
-	SqlLiteSyncStorage,
+	SQLiteSyncStorage,
 	type TLSqliteInputValue,
 	type TLSqliteOutputValue,
 	type TLSqliteRow,
 	type TLSyncSqliteStatement,
 	type TLSyncSqliteWrapper,
 	type TLSyncSqliteWrapperConfig,
-} from './lib/SqlLiteSyncStorage'
+} from './lib/SQLiteSyncStorage'
 export { TLRemoteSyncError } from './lib/TLRemoteSyncError'
 export {
 	TLSocketRoom,

--- a/packages/sync-core/src/lib/DurableObjectSqliteSyncWrapper.ts
+++ b/packages/sync-core/src/lib/DurableObjectSqliteSyncWrapper.ts
@@ -4,7 +4,7 @@ import {
 	type TLSyncSqliteStatement,
 	type TLSyncSqliteWrapper,
 	type TLSyncSqliteWrapperConfig,
-} from './SqlLiteSyncStorage'
+} from './SQLiteSyncStorage'
 
 /**
  * Mimics a prepared statement interface for Durable Objects SQLite.
@@ -41,22 +41,22 @@ class DurableObjectStatement<
 /**
  * A wrapper around Cloudflare Durable Object's SqlStorage that implements TLSyncSqliteWrapper.
  *
- * Use this wrapper with SqlLiteSyncStorage to persist tldraw sync state using
+ * Use this wrapper with SQLiteSyncStorage to persist tldraw sync state using
  * Cloudflare Durable Object's built-in SQLite storage. This provides automatic
  * persistence that survives Durable Object hibernation and restarts.
  *
  * @example
  * ```ts
- * import { SqlLiteSyncStorage, DurableObjectSqliteSyncWrapper } from '@tldraw/sync-core'
+ * import { SQLiteSyncStorage, DurableObjectSqliteSyncWrapper } from '@tldraw/sync-core'
  *
  * // In your Durable Object class:
  * class MyDurableObject extends DurableObject {
- *   private storage: SqlLiteSyncStorage
+ *   private storage: SQLiteSyncStorage
  *
  *   constructor(ctx: DurableObjectState, env: Env) {
  *     super(ctx, env)
  *     const sql = new DurableObjectSqliteSyncWrapper(ctx.storage)
- *     this.storage = new SqlLiteSyncStorage({ sql })
+ *     this.storage = new SQLiteSyncStorage({ sql })
  *   }
  * }
  * ```

--- a/packages/sync-core/src/lib/NodeSqliteSyncWrapper.integration.test.ts
+++ b/packages/sync-core/src/lib/NodeSqliteSyncWrapper.integration.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { RecordId, StoreSchema } from 'tldraw'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { NodeSqliteWrapper } from './NodeSqliteWrapper'
-import { migrateSqliteSyncStorage, SqlLiteSyncStorage } from './SqlLiteSyncStorage'
+import { migrateSqliteSyncStorage, SQLiteSyncStorage } from './SQLiteSyncStorage'
 import { RoomSnapshot } from './TLSyncRoom'
 
 // Simple record type for testing
@@ -15,7 +15,7 @@ interface TestRecord {
 
 type ID = RecordId<TestRecord>
 
-// SqlLiteSyncStorage uses multi-statement DDL in constructor which node:sqlite
+// SQLiteSyncStorage uses multi-statement DDL in constructor which node:sqlite
 // doesn't support (prepare() only handles one statement). We need to initialize
 // the tables separately before creating the storage.
 function initializeTables(db: DatabaseSync) {
@@ -28,17 +28,17 @@ const defaultSnapshot: RoomSnapshot = {
 	schema: StoreSchema.create({}).serialize(),
 }
 
-describe('NodeSqliteSyncWrapper + SqlLiteSyncStorage integration', () => {
+describe('NodeSqliteSyncWrapper + SQLiteSyncStorage integration', () => {
 	let db: DatabaseSync
 	let sql: NodeSqliteWrapper
-	let storage: SqlLiteSyncStorage<TestRecord>
+	let storage: SQLiteSyncStorage<TestRecord>
 
 	beforeEach(() => {
 		db = new DatabaseSync(':memory:')
 		initializeTables(db)
 		sql = new NodeSqliteWrapper(db)
 		// Pass undefined snapshot since we already initialized the tables
-		storage = new SqlLiteSyncStorage<TestRecord>({
+		storage = new SQLiteSyncStorage<TestRecord>({
 			sql,
 			snapshot: defaultSnapshot,
 		})
@@ -258,13 +258,13 @@ describe('NodeSqliteSyncWrapper + SqlLiteSyncStorage integration', () => {
 
 	describe('hasBeenInitialized', () => {
 		it('returns true for initialized storage', () => {
-			expect(SqlLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
+			expect(SQLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
 		})
 
 		it('returns false for uninitialized storage', () => {
 			const freshDb = new DatabaseSync(':memory:')
 			const freshWrapper = new NodeSqliteWrapper(freshDb)
-			expect(SqlLiteSyncStorage.hasBeenInitialized(freshWrapper)).toBe(false)
+			expect(SQLiteSyncStorage.hasBeenInitialized(freshWrapper)).toBe(false)
 		})
 	})
 })

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.ts
@@ -4,7 +4,7 @@ import {
 	type TLSyncSqliteStatement,
 	type TLSyncSqliteWrapper,
 	type TLSyncSqliteWrapperConfig,
-} from './SqlLiteSyncStorage'
+} from './SQLiteSyncStorage'
 
 /**
  * Minimal interface for a synchronous SQLite database.
@@ -33,29 +33,29 @@ export interface SyncSqliteDatabase {
  * A wrapper around synchronous SQLite databases that implements TLSyncSqliteWrapper.
  * Works with both `node:sqlite` DatabaseSync (Node.js 22.5+) and `better-sqlite3` Database.
  *
- * Use this wrapper with SqlLiteSyncStorage to persist tldraw sync state to a SQLite database
+ * Use this wrapper with SQLiteSyncStorage to persist tldraw sync state to a SQLite database
  * in Node.js environments.
  *
  * @example
  * ```ts
  * // With node:sqlite (Node.js 22.5+)
  * import { DatabaseSync } from 'node:sqlite'
- * import { SqlLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
+ * import { SQLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
  *
  * const db = new DatabaseSync(':memory:')
  * const sql = new NodeSqliteWrapper(db)
- * const storage = new SqlLiteSyncStorage({ sql })
+ * const storage = new SQLiteSyncStorage({ sql })
  * ```
  *
  * @example
  * ```ts
  * // With better-sqlite3
  * import Database from 'better-sqlite3'
- * import { SqlLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
+ * import { SQLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
  *
  * const db = new Database(':memory:')
  * const sql = new NodeSqliteWrapper(db)
- * const storage = new SqlLiteSyncStorage({ sql })
+ * const storage = new SQLiteSyncStorage({ sql })
  * ```
  *
  * @example

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -57,7 +57,7 @@ export interface TLSyncSqliteStatement<
 }
 
 /**
- * Configuration for SqlLiteSyncStorage.
+ * Configuration for SQLiteSyncStorage.
  * @public
  */
 export interface TLSyncSqliteWrapperConfig {
@@ -147,32 +147,32 @@ export function migrateSqliteSyncStorage(
  * @example
  * ```ts
  * // With Cloudflare Durable Objects
- * import { SqlLiteSyncStorage, DurableObjectSqliteSyncWrapper } from '@tldraw/sync-core'
+ * import { SQLiteSyncStorage, DurableObjectSqliteSyncWrapper } from '@tldraw/sync-core'
  *
  * const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
- * const storage = new SqlLiteSyncStorage({ sql })
+ * const storage = new SQLiteSyncStorage({ sql })
  * ```
  *
  * @example
  * ```ts
  * // With Node.js sqlite (Node 22.5+)
  * import { DatabaseSync } from 'node:sqlite'
- * import { SqlLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
+ * import { SQLiteSyncStorage, NodeSqliteWrapper } from '@tldraw/sync-core'
  *
  * const db = new DatabaseSync('sync-state.db')
  * const sql = new NodeSqliteWrapper(db)
- * const storage = new SqlLiteSyncStorage({ sql })
+ * const storage = new SQLiteSyncStorage({ sql })
  * ```
  *
  * @example
  * ```ts
  * // Initialize with an existing snapshot
- * const storage = new SqlLiteSyncStorage({ sql, snapshot: existingSnapshot })
+ * const storage = new SQLiteSyncStorage({ sql, snapshot: existingSnapshot })
  * ```
  *
  * @public
  */
-export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
+export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
 	/**
 	 * Check if the storage has been initialized (has data in the clock table).
 	 * Useful for determining whether to load from an external source on first access.
@@ -201,7 +201,7 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
 				.prepare<{ documentClock: number }>(`SELECT documentClock FROM ${prefix}metadata LIMIT 1`)
 				.all()[0]
 			// documentClock exists but could be 0, so we check if the storage is initialized
-			if (row && SqlLiteSyncStorage.hasBeenInitialized(storage)) {
+			if (row && SQLiteSyncStorage.hasBeenInitialized(storage)) {
 				return row.documentClock
 			}
 			return null
@@ -307,7 +307,7 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
 		}
 
 		// Check if we already have data
-		const hasData = SqlLiteSyncStorage.hasBeenInitialized(sql)
+		const hasData = SQLiteSyncStorage.hasBeenInitialized(sql)
 
 		if (snapshot || !hasData) {
 			snapshot = convertStoreSnapshotToRoomSnapshot(snapshot ?? DEFAULT_INITIAL_SNAPSHOT)
@@ -357,7 +357,7 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
 		const clockBefore = this.getClock()
 		const trackChanges = opts?.emitChanges === 'always'
 		return this.sql.transaction(() => {
-			const txn = new SqlLiteSyncStorageTransaction<R>(this, this.stmts)
+			const txn = new SQLiteSyncStorageTransaction<R>(this, this.stmts)
 			let result: T
 			let changes: TLSyncForwardDiff<R> | undefined
 			try {
@@ -456,21 +456,19 @@ export class SqlLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorag
 }
 
 /**
- * Transaction implementation for SqlLiteSyncStorage.
+ * Transaction implementation for SQLiteSyncStorage.
  * Provides access to documents, tombstones, and metadata within a transaction.
  *
  * @internal
  */
-class SqlLiteSyncStorageTransaction<R extends UnknownRecord>
-	implements TLSyncStorageTransaction<R>
-{
+class SQLiteSyncStorageTransaction<R extends UnknownRecord> implements TLSyncStorageTransaction<R> {
 	private _clock: number
 	private _closed = false
 	private _didIncrementClock: boolean = false
 
 	constructor(
-		private storage: SqlLiteSyncStorage<R>,
-		private stmts: SqlLiteSyncStorage<R>['stmts']
+		private storage: SQLiteSyncStorage<R>,
+		private stmts: SQLiteSyncStorage<R>['stmts']
 	) {
 		this._clock = this.storage.getClock()
 	}

--- a/packages/sync-core/src/test/SQLiteSyncStorage.test.ts
+++ b/packages/sync-core/src/test/SQLiteSyncStorage.test.ts
@@ -10,7 +10,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { vi } from 'vitest'
 import { MAX_TOMBSTONES, TOMBSTONE_PRUNE_BUFFER_SIZE } from '../lib/InMemorySyncStorage'
 import { NodeSqliteWrapper } from '../lib/NodeSqliteWrapper'
-import { SqlLiteSyncStorage } from '../lib/SqlLiteSyncStorage'
+import { SQLiteSyncStorage } from '../lib/SQLiteSyncStorage'
 import { RoomSnapshot } from '../lib/TLSyncRoom'
 
 const tlSchema = createTLSchema()
@@ -50,58 +50,58 @@ function createWrapper(config?: { tablePrefix?: string }) {
 
 function getStorage(snapshot: RoomSnapshot, wrapperConfig?: { tablePrefix?: string }) {
 	const sql = createWrapper(wrapperConfig)
-	return new SqlLiteSyncStorage<TLRecord>({ sql, snapshot })
+	return new SQLiteSyncStorage<TLRecord>({ sql, snapshot })
 }
 
-describe('SqlLiteSyncStorage', () => {
+describe('SQLiteSyncStorage', () => {
 	describe('Static methods', () => {
 		describe('hasBeenInitialized', () => {
 			it('returns false for empty database', () => {
 				const sql = createWrapper()
-				expect(SqlLiteSyncStorage.hasBeenInitialized(sql)).toBe(false)
+				expect(SQLiteSyncStorage.hasBeenInitialized(sql)).toBe(false)
 			})
 
 			it('returns true after storage is initialized', () => {
 				const sql = createWrapper()
-				new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
-				expect(SqlLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
+				new SQLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
+				expect(SQLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
 			})
 
 			it('respects table prefix', () => {
 				const sql = createWrapper({ tablePrefix: 'test_' })
-				expect(SqlLiteSyncStorage.hasBeenInitialized(sql)).toBe(false)
-				new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
-				expect(SqlLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
+				expect(SQLiteSyncStorage.hasBeenInitialized(sql)).toBe(false)
+				new SQLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
+				expect(SQLiteSyncStorage.hasBeenInitialized(sql)).toBe(true)
 			})
 		})
 
 		describe('getDocumentClock', () => {
 			it('returns null for empty database', () => {
 				const sql = createWrapper()
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(null)
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(null)
 			})
 
 			it('returns 0 for newly initialized storage with default snapshot', () => {
 				const sql = createWrapper()
-				new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(0)
+				new SQLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(0)
 			})
 
 			it('returns the documentClock value from snapshot', () => {
 				const sql = createWrapper()
 				const snapshot = makeSnapshot(defaultRecords)
 				snapshot.documentClock = 42
-				new SqlLiteSyncStorage<TLRecord>({ sql, snapshot })
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(42)
+				new SQLiteSyncStorage<TLRecord>({ sql, snapshot })
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(42)
 			})
 
 			it('returns updated clock after transactions', () => {
 				const sql = createWrapper()
-				const storage = new SqlLiteSyncStorage<TLRecord>({
+				const storage = new SQLiteSyncStorage<TLRecord>({
 					sql,
 					snapshot: makeSnapshot(defaultRecords),
 				})
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(0)
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(0)
 
 				const newPage = PageRecordType.create({
 					id: PageRecordType.createId('test_page'),
@@ -111,14 +111,14 @@ describe('SqlLiteSyncStorage', () => {
 				storage.transaction((txn) => {
 					txn.set(newPage.id, newPage)
 				})
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(1)
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(1)
 			})
 
 			it('respects table prefix', () => {
 				const sql = createWrapper({ tablePrefix: 'test_' })
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(null)
-				new SqlLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
-				expect(SqlLiteSyncStorage.getDocumentClock(sql)).toBe(0)
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(null)
+				new SQLiteSyncStorage<TLRecord>({ sql, snapshot: makeSnapshot(defaultRecords) })
+				expect(SQLiteSyncStorage.getDocumentClock(sql)).toBe(0)
 			})
 		})
 	})
@@ -215,14 +215,14 @@ describe('SqlLiteSyncStorage', () => {
 			const sql = createWrapper()
 
 			// First initialization
-			new SqlLiteSyncStorage<TLRecord>({
+			new SQLiteSyncStorage<TLRecord>({
 				sql,
 				snapshot: makeSnapshot(defaultRecords, { documentClock: 10 }),
 			})
 
 			// Second initialization with different data
 			const newRecords = [DocumentRecordType.create({ id: TLDOCUMENT_ID })]
-			const storage2 = new SqlLiteSyncStorage<TLRecord>({
+			const storage2 = new SQLiteSyncStorage<TLRecord>({
 				sql,
 				snapshot: makeSnapshot(newRecords, { documentClock: 20 }),
 			})
@@ -703,7 +703,7 @@ describe('SqlLiteSyncStorage', () => {
 		it('accepts onChange callback in constructor', async () => {
 			const listener = vi.fn()
 			const sql = createWrapper()
-			const storage = new SqlLiteSyncStorage<TLRecord>({
+			const storage = new SQLiteSyncStorage<TLRecord>({
 				sql,
 				snapshot: makeSnapshot(defaultRecords),
 				onChange: listener,

--- a/templates/simple-server-example/README.md
+++ b/templates/simple-server-example/README.md
@@ -4,7 +4,7 @@ This is a simple example of a backend for [tldraw sync](https://tldraw.dev/docs/
 
 Run `yarn dev` in this folder to start the server + client.
 
-Room data is automatically persisted to SQLite databases in the `.rooms` directory using `SqlLiteSyncStorage`.
+Room data is automatically persisted to SQLite databases in the `.rooms` directory using `SQLiteSyncStorage`.
 
 For a production-ready example specific to Cloudflare, see /templates/sync-cloudflare.
 

--- a/templates/simple-server-example/src/server/rooms.ts
+++ b/templates/simple-server-example/src/server/rooms.ts
@@ -1,4 +1,4 @@
-import { NodeSqliteWrapper, SqlLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
+import { NodeSqliteWrapper, SQLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
 import Database from 'better-sqlite3'
 import { mkdirSync } from 'fs'
 import { join } from 'path'
@@ -27,7 +27,7 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
-	const storage = new SqlLiteSyncStorage({ sql })
+	const storage = new SQLiteSyncStorage({ sql })
 
 	const room = new TLSocketRoom({
 		storage,

--- a/templates/socketio-server-example/README.md
+++ b/templates/socketio-server-example/README.md
@@ -4,7 +4,7 @@ This is a simple example of a backend for [tldraw sync](https://tldraw.dev/docs/
 
 Run `yarn dev` in this folder to start the server + client.
 
-Room data is automatically persisted to SQLite databases in the `.rooms` directory using `SqlLiteSyncStorage`.
+Room data is automatically persisted to SQLite databases in the `.rooms` directory using `SQLiteSyncStorage`.
 
 For a production-ready example specific to Cloudflare, see /templates/sync-cloudflare.
 

--- a/templates/socketio-server-example/src/server/rooms.ts
+++ b/templates/socketio-server-example/src/server/rooms.ts
@@ -1,4 +1,4 @@
-import { NodeSqliteWrapper, SqlLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
+import { NodeSqliteWrapper, SQLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
 import Database from 'better-sqlite3'
 import { mkdirSync } from 'fs'
 import { join } from 'path'
@@ -28,7 +28,7 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
-	const storage = new SqlLiteSyncStorage({ sql })
+	const storage = new SQLiteSyncStorage({ sql })
 
 	const room = new TLSocketRoom({
 		storage,

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -1,4 +1,4 @@
-import { DurableObjectSqliteSyncWrapper, SqlLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
+import { DurableObjectSqliteSyncWrapper, SQLiteSyncStorage, TLSocketRoom } from '@tldraw/sync-core'
 import {
 	createTLSchema,
 	// defaultBindingSchemas,
@@ -26,7 +26,7 @@ export class TldrawDurableObject extends DurableObject {
 		super(ctx, env)
 		// Create SQLite-backed storage - persists automatically to Durable Object storage
 		const sql = new DurableObjectSqliteSyncWrapper(ctx.storage)
-		const storage = new SqlLiteSyncStorage<TLRecord>({ sql })
+		const storage = new SQLiteSyncStorage<TLRecord>({ sql })
 
 		// Create the room that handles sync protocol
 		this.room = new TLSocketRoom<TLRecord, void>({ schema, storage })


### PR DESCRIPTION
follow up to #7320 

How do things like this happen

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Renamed SqlLiteSyncStorage to SQLiteSyncStorage for consistent casing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `SqlLiteSyncStorage` to `SQLiteSyncStorage` throughout sync-core, workers, tests, docs, and templates.
> 
> - **sync-core**:
>   - Rename class `SqlLiteSyncStorage` → `SQLiteSyncStorage` and update all references (`exports`, type imports, assertions, error messages).
>   - Update related wrappers/imports to reference `./SQLiteSyncStorage` (`DurableObjectSqliteSyncWrapper`, `NodeSqliteWrapper`).
>   - Adjust tests to use `SQLiteSyncStorage`; keep migration helpers (`migrateSqliteSyncStorage`) pointing to new file.
>   - API report updated to expose `SQLiteSyncStorage`.
> - **Workers**:
>   - Update `apps/dotcom` durable objects to use `SQLiteSyncStorage` and revise instanceof checks/messages.
> - **Docs & Templates**:
>   - Replace all `SqlLiteSyncStorage` mentions with `SQLiteSyncStorage` in docs and example servers (Cloudflare, Node, socket.io).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e434b24a6cd16c00bafe7ff4ee2430f8cd61763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->