### PR TITLE
fix(dotcom): prevent crash when connected to invalid remote fairies

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-canvas-ui/RemoteFairies.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-canvas-ui/RemoteFairies.tsx
@@ -61,7 +61,7 @@ function RemoteFairy({ userId }: { userId: string }) {
 			if (!fairyPresenceValidator.isValid(fairy)) {
 				return null
 			}
-			return fairyPresenceValidator.validate(fairy)
+			return fairy as FairyPresence
 		})
 		.filter(
 			(fairyPresence): fairyPresence is FairyPresence =>


### PR DESCRIPTION
This PR fixes the app crashing when you're connected to a collaborator with an invalid fairy presence. As we don't have proper migrations in place, we should handle this safely and filter out any out-of-date fairies.

<img width="489" height="222" alt="Screenshot 2025-12-11 at 15 06 22" src="https://github.com/user-attachments/assets/c11e4499-c811-4202-b1bf-f466d58601fa" />


### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Connect to a session with a collaborator having an invalid fairy presence.
2. Verify the app no longer crashes and filters out the invalid entries.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a crash occurring when encountering invalid collaborator fairy data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely validate and filter remote fairies to ignore invalid or sleeping entries before rendering.
> 
> - **Fairy canvas UI (`RemoteFairies.tsx`)**:
>   - Replace validation pipeline for `meta.fairies` to use `fairyPresenceValidator.isValid` and a type-guard filter, safely discarding invalid entries and those with `entity.pose === 'sleeping'` before rendering `RemoteFairyIndicator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd2592905c2397ccd32ef513d766bf30a66c4fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->