### PR TITLE
improvement(dotcom): add sqlite load fallback and bump file record attempts

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -72,7 +72,7 @@ interface DocumentInfo {
 	deleted: boolean
 }
 
-const ROOM_NOT_FOUND = Symbol('room_not_found')
+export const ROOM_NOT_FOUND = Symbol('room_not_found')
 
 interface SessionMeta {
 	storeId: string
@@ -424,7 +424,7 @@ export class TLDrawDurableObject extends DurableObject {
 					return this._fileRecordCache
 				},
 				{
-					attempts: 10,
+					attempts: 20,
 					waitDuration: 100,
 				}
 			)
@@ -1128,7 +1128,7 @@ export class TLDrawDurableObject extends DurableObject {
 		}
 	}
 
-	private reportError(e: unknown) {
+	protected reportError(e: unknown) {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		this.sentry?.captureException(e)
 		console.error(e)

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1,6 +1,6 @@
 import { DurableObjectSqliteSyncWrapper, SQLiteSyncStorage, TLSyncStorage } from '@tldraw/sync-core'
 import { TLRecord } from '@tldraw/tlschema'
-import { TLDrawDurableObject } from './TLDrawDurableObject'
+import { ROOM_NOT_FOUND, TLDrawDurableObject } from './TLDrawDurableObject'
 import { getFeatureFlag } from './utils/featureFlags'
 
 /**
@@ -15,35 +15,44 @@ export class TLFileDurableObject extends TLDrawDurableObject {
 			return super.loadStorage(slug)
 		}
 
-		const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
-		const sqliteClock = SQLiteSyncStorage.getDocumentClock(sql)
+		try {
+			const sql = new DurableObjectSqliteSyncWrapper(this.ctx.storage)
+			const sqliteClock = SQLiteSyncStorage.getDocumentClock(sql)
 
-		// If SQLite has been initialized, we need to check if R2 has fresher data.
-		// This can happen if the sqlite_file_storage flag was toggled OFF then back ON,
-		// since changes made while the flag was OFF would only be persisted to R2.
-		if (sqliteClock !== null) {
-			// Check the last persisted R2 clock (stored in DO storage during persist)
-			// This is fast - just reading a number from DO storage, no R2 fetch needed
-			const lastR2Clock = (await this.ctx.storage.get<number>('lastPersistedR2Clock')) ?? 0
+			// If SQLite has been initialized, we need to check if R2 has fresher data.
+			// This can happen if the sqlite_file_storage flag was toggled OFF then back ON,
+			// since changes made while the flag was OFF would only be persisted to R2.
+			if (sqliteClock !== null) {
+				// Check the last persisted R2 clock (stored in DO storage during persist)
+				// This is fast - just reading a number from DO storage, no R2 fetch needed
+				const lastR2Clock = (await this.ctx.storage.get<number>('lastPersistedR2Clock')) ?? 0
 
-			if (lastR2Clock > sqliteClock) {
-				// R2 has fresher data, reinitialize SQLite from R2
-				const result = await this.loadFromDatabase(slug)
-				const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
-				this.setRoomStorageUsedPercentage(result.roomSizeMB)
-				return storage
+				if (lastR2Clock > sqliteClock) {
+					// R2 has fresher data, reinitialize SQLite from R2
+					const result = await this.loadFromDatabase(slug)
+					const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+					this.setRoomStorageUsedPercentage(result.roomSizeMB)
+					return storage
+				}
+
+				// SQLite is up-to-date or fresher, use it directly
+				return new SQLiteSyncStorage<TLRecord>({ sql })
 			}
 
-			// SQLite is up-to-date or fresher, use it directly
-			return new SQLiteSyncStorage<TLRecord>({ sql })
+			// SQLite not initialized yet, load from R2 and initialize
+			const result = await this.loadFromDatabase(slug)
+			const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+			// We should not await on setRoomStorageUsedPercentage because it calls
+			// getStorage under the hood which will only resolve once this function has returned.
+			this.setRoomStorageUsedPercentage(result.roomSizeMB)
+			return storage
+		} catch (error) {
+			if (error === ROOM_NOT_FOUND) {
+				throw error
+			}
+			// report error and fallback to in-memory storage
+			this.reportError(error)
+			return super.loadStorage(slug)
 		}
-
-		// SQLite not initialized yet, load from R2 and initialize
-		const result = await this.loadFromDatabase(slug)
-		const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
-		// We should not await on setRoomStorageUsedPercentage because it calls
-		// getStorage under the hood which will only resolve once this function has returned.
-		this.setRoomStorageUsedPercentage(result.roomSizeMB)
-		return storage
 	}
 }


### PR DESCRIPTION
these changes were supposed to be in #7350 

### Change type

- [x] `other`

### Test plan

1. Verify sync-worker behavior with SQLite load failures

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved SQLite loading reliability and increased file record fetch retry attempts in sync-worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a robust SQLite load path with R2 clock comparison and fallback to in-memory, exports ROOM_NOT_FOUND, and doubles file record fetch retry attempts.
> 
> - **Storage loading (TLFileDurableObject)**
>   - Wrap SQLite load in try/catch; on non-`ROOM_NOT_FOUND` errors, report and fallback to `super.loadStorage`.
>   - Compare `lastPersistedR2Clock` (DO storage) vs `sqliteClock`; reinitialize SQLite from R2 when R2 is fresher, otherwise use existing SQLite storage.
>   - Propagate `ROOM_NOT_FOUND` to callers.
> - **Error handling / API**
>   - Export `ROOM_NOT_FOUND` from `TLDrawDurableObject`.
>   - Change `reportError` visibility from `private` to `protected` for reuse in subclass.
> - **Reliability**
>   - Increase `getAppFileRecord` retry attempts from `10` to `20`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba7e5f46116c749fdc4d689b6d0fa5ca8480706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->