### PR TITLE
refactor(globs): remove useEffect in favour of reactive inputs

### DIFF
--- a/apps/examples/src/examples/globs-editor/GlobShapeUtil.tsx
+++ b/apps/examples/src/examples/globs-editor/GlobShapeUtil.tsx
@@ -1,5 +1,4 @@
 import { round } from 'lodash'
-import { useEffect, useState } from 'react'
 import {
 	createComputedCache,
 	Editor,
@@ -22,6 +21,7 @@ import {
 	track,
 	uniqueId,
 	useEditor,
+	useValue,
 	Vec,
 	VecModel,
 	vecModelValidator,
@@ -908,34 +908,8 @@ export const GlobShape = track(function GlobShape({
 	const editor = useEditor()
 	const zoomLevel = editor.getZoomLevel()
 
-	const [fillGlob, setFillGlob] = useState(false)
-
-	// a small hack because editor inputs are not reactive, we need to use a keyboard event to fill the glob
-	// when space is pressed, fill the glob
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.code === 'Space') {
-				setFillGlob(true)
-			}
-		}
-
-		const handleKeyUp = (e: KeyboardEvent) => {
-			if (e.code === 'Space') {
-				setFillGlob(false)
-			}
-		}
-
-		const container = editor.getContainer()
-		const doc = container.ownerDocument
-
-		doc.addEventListener('keydown', handleKeyDown)
-		doc.addEventListener('keyup', handleKeyUp)
-
-		return () => {
-			doc.removeEventListener('keydown', handleKeyDown)
-			doc.removeEventListener('keyup', handleKeyUp)
-		}
-	})
+	// Use reactive inputs to track if space key is pressed
+	const fillGlob = useValue('space key pressed', () => editor.inputs.keys.has('Space'), [editor])
 
 	const globPoints = getGlobInfo(editor, shape)
 	if (!globPoints) return null

--- a/apps/examples/src/examples/globs-editor/NodeShapeUtil.tsx
+++ b/apps/examples/src/examples/globs-editor/NodeShapeUtil.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import {
 	Circle2d,
 	Editor,
@@ -152,34 +151,10 @@ function NodeComponent({
 	const { radius } = shape.props
 	const dashArray = `${3 / zoom} ${3 / zoom}`
 
-	const [isSpacePressed, setIsSpacePressed] = useState(false)
-
-	// a small hack because editor inputs are not reactive, we need to use a keyboard event to fill the node
-	// when space is pressed, fill the node
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.code === 'Space') {
-				setIsSpacePressed(true)
-			}
-		}
-
-		const handleKeyUp = (e: KeyboardEvent) => {
-			if (e.code === 'Space') {
-				setIsSpacePressed(false)
-			}
-		}
-
-		const container = editor.getContainer()
-		const doc = container.ownerDocument
-
-		doc.addEventListener('keydown', handleKeyDown)
-		doc.addEventListener('keyup', handleKeyUp)
-
-		return () => {
-			doc.removeEventListener('keydown', handleKeyDown)
-			doc.removeEventListener('keyup', handleKeyUp)
-		}
-	}, [editor])
+	// Use reactive inputs to track if space key is pressed
+	const isSpacePressed = useValue('space key pressed', () => editor.inputs.keys.has('Space'), [
+		editor,
+	])
 
 	const fillNode = isSingleNode && isSpacePressed
 	if (!isSingleNode && isSpacePressed) return null


### PR DESCRIPTION
now that inputs are reactive, we don't need the hacky `useEffect` 

### Change type

- [x] `improvement`

### Test plan

1. Open the globs example
2. Press and hold Space
3. Verify that the glob fill behavior still works as expected

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance in globs example by using reactive inputs instead of manual event listeners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces manual keydown/keyup state in glob and node components with reactive `useValue` based on `editor.inputs.keys` to control Space-press fill behavior.
> 
> - **Globs editor**
>   - `apps/examples/src/examples/globs-editor/GlobShapeUtil.tsx`
>     - Remove `useEffect`/`useState` keyboard listeners; use `useValue(() => editor.inputs.keys.has('Space'))` for `fillGlob`.
>   - `apps/examples/src/examples/globs-editor/NodeShapeUtil.tsx`
>     - Replace Space key handling with `useValue(() => editor.inputs.keys.has('Space'))`; maintain fill/visibility logic for single vs linked nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82559f5b5e6f74e32e7b74f7ca5639af5480943c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->