### PR TITLE
fix(editor): restore rotated shape positions after double flip

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7705,8 +7705,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// then if the shape is flipped in one axis only, we need to apply an extra rotation
 		// to make sure the shape is mirrored correctly
 		if (Math.sign(scale.x) * Math.sign(scale.y) < 0) {
-			let { rotation } = Mat.Decompose(options.initialPageTransform)
-			rotation -= 2 * rotation
+			// We need to compute the new local rotation that will result in the negated page rotation.
+			// For a shape with local rotation `localRot` and parent page rotation `parentRot`:
+			// - pageRot = parentRot + localRot
+			// - newPageRot = -pageRot (we want to negate the page rotation)
+			// - newPageRot = parentRot + newLocalRot (parent hasn't changed)
+			// - Therefore: newLocalRot = -pageRot - parentRot = -(parentRot + localRot) - parentRot = -localRot - 2*parentRot
+			const parentRotation = this.getShapeParentTransform(id).rotation()
+			const rotation = -options.initialShape.rotation - 2 * parentRotation
 			this.updateShapes([{ id, type, rotation }])
 		}
 
@@ -7726,9 +7732,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		)
 
 		// now calculate how far away the shape is from where it needs to be
-		const pageBounds = this.getShapePageBounds(id)!
 		const pageTransform = this.getShapePageTransform(id)!
-		const currentPageCenter = pageBounds.center
+		// We need to use the local bounds center transformed to page space, not the axis-aligned
+		// page bounds center. This is because the page bounds are axis-aligned and their center
+		// changes when the rotation changes, but we want to use the same reference point as
+		// preScaleShapePageCenter (which used initialBounds.center transformed by the page transform).
+		const currentLocalBounds = this.getShapeGeometry(id).bounds
+		const currentPageCenter = Mat.applyToPoint(pageTransform, currentLocalBounds.center)
 		const shapePageTransformOrigin = pageTransform.point()
 		if (!currentPageCenter || !shapePageTransformOrigin) return this
 		const pageDelta = Vec.Sub(postScaleShapePageCenter, currentPageCenter)

--- a/packages/tldraw/src/test/flipShapes.test.ts
+++ b/packages/tldraw/src/test/flipShapes.test.ts
@@ -637,3 +637,35 @@ it('Updates the image shape flip properties when flipped', () => {
 	editor.flipShapes(editor.getSelectedShapeIds(), 'vertical')
 	expect(editor.getLastCreatedShape<TLImageShape>().props.flipY).toBe(true)
 })
+
+it('Restores flipped shape positions when shape is rotated', () => {
+	editor.selectAll().rotateSelection(PI / 2.5)
+	const before = editor.getSelectedShapes()
+	editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+	editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+	const after = editor.getSelectedShapes()
+	expect(after.length).toBe(before.length)
+	for (let i = 0; i < before.length; i++) {
+		expect(after[i]).toCloselyMatchObject(before[i])
+	}
+})
+
+it('Restores flipped shape positions with draw shapes when shape is rotated', () => {
+	editor
+		.setCurrentTool('draw')
+		.pointerDown(0, 0)
+		.pointerMove(-100, -100)
+		.pointerMove(0, -100)
+		.pointerMove(100, 100)
+		.pointerUp()
+
+	editor.selectAll().rotateSelection(PI / 2.5)
+	const before = editor.getSelectedShapes()
+	editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+	editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+	const after = editor.getSelectedShapes()
+	expect(after.length).toBe(before.length)
+	for (let i = 0; i < before.length; i++) {
+		expect(after[i]).toCloselyMatchObject(before[i])
+	}
+})


### PR DESCRIPTION
Flipping a rotated shape twice should restore it to its original position and rotation. This PR fixes two issues in `_resizeUnalignedShape` that prevented this from working correctly.

https://github.com/user-attachments/assets/8c832422-7e56-4b3a-a763-6049596c0bca

### Change type

- [x] `bugfix`

### Test plan

1. Create several shapes on the canvas
2. Select all shapes and rotate them by an arbitrary angle (e.g., 45 degrees)
3. Flip the selection horizontally twice
4. Verify that all shapes return to their exact original positions and rotations

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where flipping rotated shapes twice did not restore them to their original positions.

### Technical details

**Issue 1: Rotation normalization**
The code was using `Mat.Decompose()` to extract rotation from the page transform matrix, but `Decompose` normalizes rotations to `[-PI, PI]`. This caused the rotation value to differ after flipping, even though it was mathematically equivalent. The fix uses the shape's stored rotation directly and properly accounts for parent rotation.

**Issue 2: Center point calculation**
After changing a shape's rotation, the code was using `pageBounds.center` to compute the translation delta. However, page bounds are axis-aligned, so their center changes when rotation changes. The fix uses the local bounds center transformed by the page transform, which remains consistent regardless of rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes rotation and center calculations during unaligned flips so double-flipping rotated shapes restores their exact positions/rotations; adds tests covering regular and draw shapes.
> 
> - **Editor**
>   - `Editor._resizeUnalignedShape`
>     - Compute new local `rotation` using parent rotation: `rotation = -initial.rotation - 2*parentRotation` when flipping one axis.
>     - Use transformed local bounds center (`Mat.applyToPoint(pageTransform, localBounds.center)`) instead of axis-aligned page bounds center to compute translation.
> - **Tests**
>   - Add specs ensuring horizontally double-flipped, rotated selections return to original state.
>   - Add coverage for draw tool shapes under the same scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c6d345ff38722a41571a3b41a45e20585ca15f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->