### PR TITLE
docs: clarify clean-copy command workflow

### DIFF
--- a/.claude/commands/clean-copy.md
+++ b/.claude/commands/clean-copy.md
@@ -1,5 +1,7 @@
 Reimplement the current branch on a new branch with a clean, narrative-quality git commit history suitable for reviewer comprehension.
 
+**New Branch Name**. Decide on the new branch name. The name should be $ARGUMENTS or, if this is not provided, it should be `{source_branch_name}-clean`.
+
 ### Steps
 
 1. **Validate the source branch**
@@ -12,7 +14,7 @@ Reimplement the current branch on a new branch with a clean, narrative-quality g
    - Form a clear understanding of the final intended state.
 
 3. **Create the clean branch**
-   - Create a new branch off of main named `{branch_name}-clean`.
+   - Create a new branch off of main using the New Branch Name.
 
 4. **Plan the commit storyline**
    - Break the implementation down into a sequence of self-contained steps.


### PR DESCRIPTION
Clarifies the clean-copy Claude Code command to make the workflow more explicit. The previous wording could be interpreted ambiguously regarding which branch to create the clean branch from.

### Change type

- [x] `other`

### Test plan

This is a documentation-only change to a Claude Code command file. No testing required.

### Release notes

- Clarified the clean-copy command workflow documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the clean-copy command with explicit branch naming, creation off main, and expanded verification and PR steps.
> 
> - **Docs** (`.claude/commands/clean-copy.md`):
>   - **Branch workflow**:
>     - Add explicit "New Branch Name" rule (`$ARGUMENTS` or `{source_branch_name}-clean`).
>     - Define the source branch as the current branch.
>     - Change creation to a new branch off `main` using the New Branch Name.
>   - **Process steps**:
>     - Clarify analyzing diffs between the current source branch and `main`.
>     - Add guidance to include comments/inline GitHub comments in commits when needed.
>     - Expand verification: final state of `{branch_name}-clean` must match original; use `--no-verify` only when necessary.
>     - Expand PR instructions: create PR from clean branch to `main`, follow `pr.md`, include link to original branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802bddb18e6cdd62e88d5c0055bb33f9f8405ec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->