### PR TITLE
chore(vscode): change watermark utm_source to extension

### DIFF
--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -27,6 +27,9 @@ import { vscode } from './utils/vscode'
 
 setRuntimeOverrides({
 	openWindow: (url, target) => {
+		if (url.includes('utm_campaign=watermark')) {
+			url = url.replace('utm_source=sdk', 'utm_source=extension')
+		}
 		vscode.postMessage({
 			type: 'vscode:open-window',
 			data: {


### PR DESCRIPTION
Better track watermark clicks that happen in our vs code extension.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Updated watermark links in VS Code extension to use extension source tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When opening watermark links, replace `utm_source=sdk` with `utm_source=extension` before sending the `vscode:open-window` message.
> 
> - **VS Code editor runtime overrides (`apps/vscode/editor/src/app.tsx`)**:
>   - Update `setRuntimeOverrides.openWindow` to detect watermark links and replace `utm_source=sdk` with `utm_source=extension` before posting `vscode:open-window`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69127a7c61d9e594ff912e961e8c3aa622b88b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->