### PR TITLE
refactor(validate): use Number.isFinite for number validator fast path

### DIFF
--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -1193,8 +1193,8 @@ export const number = new Validator<number>((value) => {
  * @public
  */
 export const positiveNumber = new Validator<number>((value) => {
-	if (typeof value === 'number' && value - value === 0 && value >= 0) {
-		return value
+	if (Number.isFinite(value) && (value as number) >= 0) {
+		return value as number
 	}
 	if (typeof value !== 'number') {
 		throw new ValidationError(`Expected number, got ${typeToString(value)}`)
@@ -1219,8 +1219,8 @@ export const positiveNumber = new Validator<number>((value) => {
  * @public
  */
 export const nonZeroNumber = new Validator<number>((value) => {
-	if (typeof value === 'number' && value - value === 0 && value > 0) {
-		return value
+	if (Number.isFinite(value) && (value as number) > 0) {
+		return value as number
 	}
 	if (typeof value !== 'number') {
 		throw new ValidationError(`Expected number, got ${typeToString(value)}`)
@@ -1246,8 +1246,8 @@ export const nonZeroNumber = new Validator<number>((value) => {
  * @public
  */
 export const nonZeroFiniteNumber = new Validator<number>((value) => {
-	if (typeof value === 'number' && value - value === 0 && value !== 0) {
-		return value
+	if (Number.isFinite(value) && (value as number) !== 0) {
+		return value as number
 	}
 	if (typeof value !== 'number') {
 		throw new ValidationError(`Expected number, got ${typeToString(value)}`)
@@ -1275,8 +1275,8 @@ export const nonZeroFiniteNumber = new Validator<number>((value) => {
  * @public
  */
 export const unitInterval = new Validator<number>((value) => {
-	if (typeof value === 'number' && value >= 0 && value <= 1) {
-		return value
+	if (Number.isFinite(value) && (value as number) >= 0 && (value as number) <= 1) {
+		return value as number
 	}
 	if (typeof value !== 'number') {
 		throw new ValidationError(`Expected number, got ${typeToString(value)}`)


### PR DESCRIPTION
This PR updates the number validator's fast path to use `Number.isFinite()` instead of the manual arithmetic check (`typeof value === 'number' && value - value === 0`).

While the previous implementation was functionally correct, `Number.isFinite()` is more readable and self-documenting. Modern JavaScript engines optimize `Number.isFinite()` well, making it a better choice for code clarity without sacrificing performance.

### Change type

- [x] `improvement`

### Test plan

The validation behavior is unchanged - both approaches correctly:
- Accept finite numbers
- Reject `Infinity`, `-Infinity`, and `NaN`
- Reject non-number values

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved code readability in number validator by using `Number.isFinite()` instead of arithmetic trick.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch numeric validators to use Number.isFinite for fast-path checks while keeping error handling unchanged.
> 
> - **Validation** (`packages/validate/src/lib/validation.ts`):
>   - **Numeric validators**: Replace arithmetic finite checks with `Number.isFinite()` in `number`, `positiveNumber`, `nonZeroNumber`, `nonZeroFiniteNumber`, and `unitInterval`.
>   - Error paths/messages remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f39a6330627cd0981afcb8e9e4d5934dd0f1736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->