### PR TITLE
fix(fairy): prevent lints from being resurfaced after shape changes

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-agent/managers/FairyAgentLintManager.ts
+++ b/apps/dotcom/client/src/fairy/fairy-agent/managers/FairyAgentLintManager.ts
@@ -65,51 +65,17 @@ export class FairyAgentLintManager extends BaseFairyAgentManager {
 	/**
 	 * Track shapes created from a diff.
 	 * Should be called after each action is applied.
-	 * Also clears surfaced lint keys for any shapes that were modified/removed.
 	 */
 	trackShapesFromDiff(diff: RecordsDiff<TLRecord>): void {
-		const modifiedShapeIds = new Set<TLShapeId>()
-
 		for (const [id, record] of Object.entries(diff.added)) {
 			if (record.typeName === 'shape') {
 				this.createdShapeIds.add(id as TLShapeId)
 			}
 		}
 
-		// Track updated shapes
-		for (const id of Object.keys(diff.updated)) {
-			modifiedShapeIds.add(id as TLShapeId)
-		}
-
 		// Track removed shapes and remove from created set
 		for (const id of Object.keys(diff.removed)) {
 			this.createdShapeIds.delete(id as TLShapeId)
-			modifiedShapeIds.add(id as TLShapeId)
-		}
-
-		// Clear surfaced lint keys for any lints involving modified shapes
-		if (modifiedShapeIds.size > 0) {
-			this.clearSurfacedLintsForShapes(modifiedShapeIds)
-		}
-	}
-
-	/**
-	 * Clear surfaced status for any lints that involve the given shapes.
-	 * This allows lints to be re-surfaced if a shape was modified but the lint still exists.
-	 */
-	private clearSurfacedLintsForShapes(shapeIds: Set<TLShapeId>): void {
-		// Convert TLShapeId to simple string for comparison
-		const simpleShapeIds = new Set(
-			Array.from(shapeIds).map((id) => convertTldrawIdToSimpleId(id) as string)
-		)
-
-		// Remove any surfaced lint keys that involve the modified shapes
-		for (const key of this.surfacedLintKeys) {
-			const [, shapeIdsPart] = key.split(':')
-			const lintShapeIds = shapeIdsPart.split(',')
-			if (lintShapeIds.some((id) => simpleShapeIds.has(id))) {
-				this.surfacedLintKeys.delete(key)
-			}
 		}
 	}
 


### PR DESCRIPTION
In order to prevent lints from being repeatedly shown to the agent after shapes are modified, this PR removes the logic that clears surfaced lint keys when shapes are updated. Once a lint has been surfaced to the agent, it will remain marked as surfaced even if the involved shapes are later modified.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create shapes that trigger lints (e.g., overlapping text, friendless arrows)
2. Verify lints are surfaced to the agent
3. Modify the shapes involved in the lints
4. Verify that the lints are not resurfaced after the modification

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where lints would be resurfaced to the fairy agent after shapes were modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop clearing surfaced lint keys on shape modifications/removals so previously surfaced lints are not resurfaced.
> 
> - **FairyAgentLintManager (`apps/dotcom/client/src/fairy/fairy-agent/managers/FairyAgentLintManager.ts`)**:
>   - Simplify `trackShapesFromDiff` to only track added/removed shapes; no longer clears surfaced lint keys on updates/removals.
>   - Remove modified-shape tracking and helper `clearSurfacedLintsForShapes`, eliminating logic that reset `surfacedLintKeys` for affected shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03078580d00509c1d68f941f4a8737f2c463d326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->