### PR TITLE
chore: print PR link in dotcom hotfix script

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -83,6 +83,9 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		})
 
 		nicelog(`Created hotfix PR: ${hotfixBranchName} -> hotfixes`)
+		await discord.message(
+			`📝 Created hotfix PR: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
+		)
 		nicelog(`Waiting for PR #${createdPr.data.number} to be ready for merge...`)
 
 		// Maximum wait time: 15 minutes total (action timeout is 20 mins, we need buffer for Discord notification)


### PR DESCRIPTION
### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Print the PR link when triggering a dotcom hotfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Notify Discord with the newly created dotcom hotfix PR link after the script opens the PR.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54a2085445cb027854dc40749c4e69ea3dc57498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->