### PR TITLE
fix(fairy): handle incorrect fills from the model

### DIFF
--- a/packages/fairy-shared/src/format/FocusFill.ts
+++ b/packages/fairy-shared/src/format/FocusFill.ts
@@ -23,7 +23,7 @@ const TLDRAW_TO_FOCUS_FILLS: Record<TLDefaultFillStyle, FocusFill> = {
 }
 
 export function convertFocusFillToTldrawFill(fill: FocusFill): TLDefaultFillStyle {
-	return FOCUS_TO_TLDRAW_FILLS[fill] ?? 'none'
+	return FOCUS_TO_TLDRAW_FILLS[fill]
 }
 
 export function convertTldrawFillToFocusFill(fill: TLDefaultFillStyle): FocusFill {

--- a/packages/fairy-shared/src/format/convertFocusedShapeToTldrawShape.ts
+++ b/packages/fairy-shared/src/format/convertFocusedShapeToTldrawShape.ts
@@ -476,7 +476,7 @@ function convertGeoShapeToTldrawShape(
 	// Handle fill properly - simpleShape takes priority
 	let fill
 	if (focusedShape.fill !== undefined) {
-		fill = convertFocusFillToTldrawFill(focusedShape.fill)
+		fill = convertFocusFillToTldrawFill(focusedShape.fill) ?? 'none'
 	} else if (defaultGeoShape.props?.fill) {
 		fill = defaultGeoShape.props.fill
 	} else {
@@ -581,7 +581,7 @@ function convertDrawShapeToTldrawShape(
 	// Handle fill properly - simpleShape takes priority
 	let fill
 	if (focusedShape.fill !== undefined) {
-		fill = convertFocusFillToTldrawFill(focusedShape.fill)
+		fill = convertFocusFillToTldrawFill(focusedShape.fill) ?? 'none'
 	} else if (defaultDrawShape.props?.fill) {
 		fill = defaultDrawShape.props.fill
 	} else {


### PR DESCRIPTION
This PR fixes an error that happens if the model hallucinates an incorrect fill type. If that happens, we now default to "none".

### Change type

- [x] `bugfix`

### Test plan

1. Use the model to generate a shape with an invalid fill type.
2. Verify the shape defaults to "none" instead of crashing.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed a bug where invalid fill types from the model would cause errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fallback to `none` when an invalid `fill` is provided for geo and draw shapes during FocusedShape → tldraw conversion.
> 
> - **Format conversion (`packages/fairy-shared/src/format/convertFocusedShapeToTldrawShape.ts`)**:
>   - **Fill handling**:
>     - Geo shapes: `convertFocusFillToTldrawFill(focusedShape.fill) ?? 'none'` ensures invalid fills default to `none`.
>     - Draw shapes: same fallback to `none` when `focusedShape.fill` is invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52e3eaaaf6b50f518d8f9263d5cb5a967b85478c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->