### PR TITLE
chore: prevent link unfurling in discord notifications

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -84,7 +84,7 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 
 		nicelog(`Created hotfix PR: ${hotfixBranchName} -> hotfixes`)
 		await discord.message(
-			`📝 Created hotfix PR: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
+			`📝 Created hotfix PR: <https://github.com/tldraw/tldraw/pull/${createdPr.data.number}>`
 		)
 		nicelog(`Waiting for PR #${createdPr.data.number} to be ready for merge...`)
 


### PR DESCRIPTION
Apparently this should prevent the unfurl from happening (it broke up the messages and I didn't like it).

### Change type
- [x] `other` 

### Test plan

1. Trigger a hotfix and verify the Discord notification link is wrapped in angle brackets.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Prevent link unfurling in Discord notifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the PR URL in the Discord notification with angle brackets to prevent link unfurling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d0799cfbb56c9f81b5dd0000097df55209e5a3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->