### PR TITLE
fix(tlschema): make Base64 migrations idempotent

### DIFF
--- a/packages/tlschema/src/shapes/TLDrawShape.ts
+++ b/packages/tlschema/src/shapes/TLDrawShape.ts
@@ -188,17 +188,26 @@ export const drawShapeMigrations = createShapePropsMigrationSequence({
 		{
 			id: Versions.Base64,
 			up: (props) => {
-				props.segments = props.segments.map((segment: any) => ({
-					...segment,
-					points: b64Vecs.encodePoints(segment.points),
-				}))
-				props.scaleX = 1
-				props.scaleY = 1
+				props.segments = props.segments.map((segment: any) => {
+					return {
+						...segment,
+						// Only encode if points is an array (not already base64 string)
+						points:
+							typeof segment.points === 'string'
+								? segment.points
+								: b64Vecs.encodePoints(segment.points),
+					}
+				})
+				props.scaleX = props.scaleX ?? 1
+				props.scaleY = props.scaleY ?? 1
 			},
 			down: (props) => {
 				props.segments = props.segments.map((segment: any) => ({
 					...segment,
-					points: b64Vecs.decodePoints(segment.points),
+					// Only decode if points is a string (not already VecModel[])
+					points: Array.isArray(segment.points)
+						? segment.points
+						: b64Vecs.decodePoints(segment.points),
 				}))
 				delete props.scaleX
 				delete props.scaleY

--- a/packages/tlschema/src/shapes/TLHighlightShape.ts
+++ b/packages/tlschema/src/shapes/TLHighlightShape.ts
@@ -134,17 +134,26 @@ export const highlightShapeMigrations = createShapePropsMigrationSequence({
 		{
 			id: Versions.Base64,
 			up: (props) => {
-				props.segments = props.segments.map((segment: any) => ({
-					...segment,
-					points: b64Vecs.encodePoints(segment.points),
-				}))
-				props.scaleX = 1
-				props.scaleY = 1
+				props.segments = props.segments.map((segment: any) => {
+					return {
+						...segment,
+						// Only encode if points is an array (not already base64 string)
+						points:
+							typeof segment.points === 'string'
+								? segment.points
+								: b64Vecs.encodePoints(segment.points),
+					}
+				})
+				props.scaleX = props.scaleX ?? 1
+				props.scaleY = props.scaleY ?? 1
 			},
 			down: (props) => {
 				props.segments = props.segments.map((segment: any) => ({
 					...segment,
-					points: b64Vecs.decodePoints(segment.points),
+					// Only decode if points is a string (not already VecModel[])
+					points: Array.isArray(segment.points)
+						? segment.points
+						: b64Vecs.decodePoints(segment.points),
 				}))
 				delete props.scaleX
 				delete props.scaleY


### PR DESCRIPTION
This PR makes the Base64 migrations for draw and highlight shapes idempotent (safe to run multiple times). Previously, running the migration twice would cause errors because it would try to encode already-encoded base64 strings or decode already-decoded arrays.

### Change type

- [x] `bugfix` 

### Test plan

1. Enable the SQL storage.
2. Load a document with draw/highlight shapes that might not have been migrated previously
3. Verify that the document loads.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed migrations for draw and highlight shapes to be idempotent, preventing errors when migrations run multiple times.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard Base64 encode/decode in draw/highlight migrations and default scaleX/scaleY to 1 to allow safe re-migration.
> 
> - **Schema migrations (`Versions.Base64`)**:
>   - `packages/tlschema/src/shapes/TLDrawShape.ts`
>     - Encode `segment.points` only if not already a base64 `string`; otherwise leave as-is.
>     - Decode `segment.points` only if a `string`; leave arrays unchanged.
>     - Set `props.scaleX`/`props.scaleY` to existing values or default to `1`.
>   - `packages/tlschema/src/shapes/TLHighlightShape.ts`
>     - Mirror the same guarded encode/decode logic for `segment.points`.
>     - Default `props.scaleX`/`props.scaleY` to `1` when undefined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3e1c5a3648344897fa5a5aae45c57bcbbfde1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->