### PR TITLE
chore: update next.js packages to resolve security CVE

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -68,7 +68,7 @@
 		"gray-matter": "^4.0.3",
 		"instantsearch.js": "^4.77.1",
 		"js-cookie": "^3.0.5",
-		"next": "^15.4.8",
+		"next": "^15.4.10",
 		"next-mdx-remote-client": "^1.1.2",
 		"next-themes": "^0.3.0",
 		"query-string": "^9.1.1",

--- a/templates/chat/package.json
+++ b/templates/chat/package.json
@@ -34,7 +34,7 @@
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
 		"ai": "^5.0.63",
-		"next": "^15.4.8",
+		"next": "^15.4.10",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-markdown": "^10.1.0",

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -24,7 +24,7 @@
 		"@types/node": "^22.15.31",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
-		"next": "^15.4.8",
+		"next": "^15.4.10",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tldraw": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4359,10 +4359,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/env@npm:15.5.7"
-  checksum: 10/11f971691018bd62a5bf253fc843fb2a6cf1431468f5c3a9d4d41753a6ff3e8bf7f539f46aba3f58f8bac59e681bf05fb5d771ac08d7dbd966a601257e1368bf
+"@next/env@npm:15.5.9":
+  version: 15.5.9
+  resolution: "@next/env@npm:15.5.9"
+  checksum: 10/962329701343c2617c85ae99ef35adfd9e8f7b58d9c0316f2f0857f82875a91ef3151ef0743c50964b0066aa3d1214c5193cf229f7757d7c9329f7fb95605a4a
   languageName: node
   linkType: hard
 
@@ -9036,7 +9036,7 @@ __metadata:
     js-cookie: "npm:^3.0.5"
     linkinator: "npm:^6.1.2"
     mdast-util-mdx: "npm:^3.0.0"
-    next: "npm:^15.4.8"
+    next: "npm:^15.4.10"
     next-mdx-remote-client: "npm:^1.1.2"
     next-themes: "npm:^0.3.0"
     octokit: "npm:^3.2.1"
@@ -21540,11 +21540,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^15.4.8":
-  version: 15.5.7
-  resolution: "next@npm:15.5.7"
+"next@npm:^15.4.10":
+  version: 15.5.9
+  resolution: "next@npm:15.5.9"
   dependencies:
-    "@next/env": "npm:15.5.7"
+    "@next/env": "npm:15.5.9"
     "@next/swc-darwin-arm64": "npm:15.5.7"
     "@next/swc-darwin-x64": "npm:15.5.7"
     "@next/swc-linux-arm64-gnu": "npm:15.5.7"
@@ -21595,7 +21595,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10/bfac0cbac41b36227ec91d3a0727561f73dfc35d6a78eafd0200528ef95fa2e9d2dba5a8c8922864b4f4e4321ae6a07c6cf8f5766ac3192ad03e68516c3a458a
+  checksum: 10/ac27b82de08c9720e8e99cd64102af5e30306a8c861630d50da347a02c288cc441273ada64875c47e7a4d5991ff69cc92b23e906ce3271f9835a7911a0f060cc
   languageName: node
   linkType: hard
 
@@ -27085,7 +27085,7 @@ __metadata:
     "@types/react": "npm:^18.3.18"
     "@types/react-dom": "npm:^18.3.5"
     ai: "npm:^5.0.63"
-    next: "npm:^15.4.8"
+    next: "npm:^15.4.10"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-markdown: "npm:^10.1.0"
@@ -27102,7 +27102,7 @@ __metadata:
     "@types/node": "npm:^22.15.31"
     "@types/react": "npm:^18.3.18"
     "@types/react-dom": "npm:^18.3.5"
-    next: "npm:^15.4.8"
+    next: "npm:^15.4.10"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tldraw: "workspace:*"


### PR DESCRIPTION
hot off the heels of https://github.com/tldraw/tldraw/pull/7324 CVE: https://nextjs.org/blog/security-update-2025-12-11

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- security: update Next.js packages due to latest CVE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Next.js to ^15.4.10 across docs and templates with lockfile updated to resolve next 15.5.9 and @next/env 15.5.9.
> 
> - **Dependencies**:
>   - Upgrade `next` to `^15.4.10` in `apps/docs`, `templates/chat`, and `templates/nextjs`.
>   - Update lockfile resolutions: `next` → `15.5.9`, `@next/env` → `15.5.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b9902200ae476cb0d27f4c33ad0dfa4bf8e8f90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->