### PR TITLE
fix(dotcom): fairy hud teaser position on mobile layout

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/FairyHUDTeaser.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/FairyHUDTeaser.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../tla/utils/local-session-state'
 import { fairyMessages } from '../fairy-messages'
 import { FairySprite } from '../fairy-sprite/FairySprite'
+import { useMobilePositioning } from './hud/useMobilePositioning'
 import { FairyManualPanel } from './manual/FairyManualPanel'
 
 export function FairyHUDTeaser() {
@@ -42,7 +43,6 @@ export function FairyHUDTeaser() {
 	const trackEvent = useTldrawAppUiEvents()
 	const breakpoint = useBreakpoint()
 	const isDebugMode = useValue('debug', () => editor.getInstanceState().isDebugMode, [editor])
-	const [mobileMenuOffset, setMobileMenuOffset] = useState<number | null>(null)
 	const [isManualOpen, setIsManualOpen] = useState(false)
 
 	const isMobileStylePanelOpen = useValue(
@@ -55,6 +55,7 @@ export function FairyHUDTeaser() {
 	const { addDialog } = useDialogs()
 
 	const isMobile = breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM
+	const { mobileMenuOffset } = useMobilePositioning(isMobile)
 	const manualLabel = useMsg(fairyMessages.manual)
 	const hasManualBeenOpened = useHasManualBeenOpened()
 
@@ -99,31 +100,6 @@ export function FairyHUDTeaser() {
 			component: PricingDialog,
 		})
 	}, [isLoaded, flags.fairies.enabled, flags.fairies_purchase.enabled, trackEvent, addDialog])
-
-	// Position HUD above mobile style menu button on mobile
-	useEffect(() => {
-		if (!isMobile) {
-			setMobileMenuOffset(null)
-			return
-		}
-
-		const updatePosition = () => {
-			const mobileStyleButton = document.querySelector('[data-testid="mobile-styles.button"]')
-			if (mobileStyleButton) {
-				const buttonRect = mobileStyleButton.getBoundingClientRect()
-				const rightOffset = window.innerWidth - buttonRect.right
-				setMobileMenuOffset(rightOffset)
-				return
-			}
-			setMobileMenuOffset(null)
-		}
-
-		updatePosition()
-
-		window.addEventListener('resize', updatePosition)
-
-		return () => window.removeEventListener('resize', updatePosition)
-	}, [isMobile])
 
 	return (
 		<div


### PR DESCRIPTION
This PR fixes the position of the Fairy HUD teaser on mobile

### Change type

- [x] `bugfix` 

### Test plan

1. Open the site on a mobile device or emulator.
2. Verify the Fairy HUD teaser is correctly positioned.

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Fixed the position of the Fairy HUD teaser on mobile layouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces manual DOM-based positioning with a `useMobilePositioning` hook and updates HUD styles to fix mobile teaser placement.
> 
> - **Fairy HUD (Teaser)**:
>   - Replace local positioning state/effect with `useMobilePositioning(isMobile)` to derive `mobileMenuOffset`.
>   - Update inline styles to position HUD based on `mobileMenuOffset` (`bottom` and `right`), keeping debug fallback.
>   - Add hook import from `./hud/useMobilePositioning` and remove obsolete resize logic tied to the mobile styles button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67f738e1ad3c9aba6e6341a73e2efbda0b65f99b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->