### PR TITLE
fix(fairy): move agent to request bounds only when explicitly intended

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartDuoTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartDuoTaskActionUtil.ts
@@ -4,6 +4,7 @@ import {
 	Streaming,
 	createAgentActionInfo,
 } from '@tldraw/fairy-shared'
+import { Box } from 'tldraw'
 import { FairyAgent } from '../fairy-agent/FairyAgent'
 import { AgentActionUtil } from './AgentActionUtil'
 
@@ -102,6 +103,7 @@ export class DirectToStartDuoTaskActionUtil extends AgentActionUtil<DirectToStar
 				w: task.w,
 				h: task.h,
 			}
+			otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
 		}
 
 		otherFairy.interrupt({ mode: 'working-drone', input: otherFairyInput })

--- a/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartTaskActionUtil.ts
@@ -4,6 +4,7 @@ import {
 	Streaming,
 	createAgentActionInfo,
 } from '@tldraw/fairy-shared'
+import { Box } from 'tldraw'
 import { FairyAgent } from '../fairy-agent/FairyAgent'
 import { AgentActionUtil } from './AgentActionUtil'
 
@@ -101,6 +102,7 @@ export class DirectToStartTaskActionUtil extends AgentActionUtil<DirectToStartTa
 				w: task.w,
 				h: task.h,
 			}
+			otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
 		}
 
 		otherFairy.interrupt({

--- a/apps/dotcom/client/src/fairy/fairy-agent/FairyAgent.ts
+++ b/apps/dotcom/client/src/fairy/fairy-agent/FairyAgent.ts
@@ -568,9 +568,6 @@ export class FairyAgent {
 	async request(input: AgentInput) {
 		const request = this.requests.getFullRequestFromInput(input)
 
-		// Move the fairy to request bounds (this means that the fairy will always be their bounds if their bounds are set programmatically somewhere else)
-		this.position.moveTo(Box.From(request.bounds).center)
-
 		// Interrupt any currently active request
 		if (this.requests.getActiveRequest() !== null) {
 			this.cancel()

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppWaitManager.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppWaitManager.ts
@@ -8,7 +8,7 @@ import {
 	type FairyWaitCondition,
 	type FairyWaitEvent,
 } from '@tldraw/fairy-shared'
-import { BoxModel } from 'tldraw'
+import { Box, BoxModel } from 'tldraw'
 import { BaseFairyAppManager } from './BaseFairyAppManager'
 
 /**
@@ -57,6 +57,11 @@ export class FairyAppWaitManager extends BaseFairyAppManager {
 				const userFacingMessage = getUserFacingMessage?.(agent.id, matchingCondition)
 				const bounds = getBounds?.(agent.id, matchingCondition)
 				// Fire and forget - we don't want to block on multiple agents
+
+				if (bounds) {
+					agent.position.moveTo(Box.From(bounds).center)
+				}
+
 				agent.waits
 					.notifyWaitConditionFulfilled({
 						agentMessages: [agentFacingMessage],


### PR DESCRIPTION
In order to fix an issue where agents were automatically moved to request bounds on every request, this PR removes the automatic movement from the `request()` method and adds explicit movement to bounds only in specific action utilities and wait manager where it's intended.

Previously, agents would always move to request bounds whenever a request was made, even when bounds weren't explicitly provided or when movement wasn't desired. This change ensures that agents are only moved to bounds when:
1. A task is assigned to another fairy via `DirectToStartTaskActionUtil` or `DirectToStartDuoTaskActionUtil`
2. A wait condition is fulfilled and bounds are provided in `FairyAppWaitManager`

### Change type

- [x] `bugfix`

### Test plan

1. Direct a fairy to start a task - verify the fairy moves to the task bounds
2. Set up a wait condition with bounds - verify the fairy moves to bounds when condition is fulfilled
3. Make a regular request without bounds - verify the fairy does not move unexpectedly

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where agents would automatically move to request bounds on every request, even when not intended

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops auto-moving agents on every request; explicitly moves agents to provided bounds in task-assignment actions and when wait conditions with bounds are fulfilled.
> 
> - **Core behavior**
>   - Remove automatic movement in `FairyAgent.request` (no longer moves to `request.bounds` center).
> - **Action utilities**
>   - `DirectToStartTaskActionUtil` and `DirectToStartDuoTaskActionUtil`:
>     - When a task has bounds, set `otherFairyInput.bounds` and move the other fairy to `Box.From(bounds).center`.
> - **Wait manager**
>   - `FairyAppWaitManager.notifyWaitingAgents`:
>     - If `bounds` are provided, move the agent to `Box.From(bounds).center` before notifying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e52ca611c07ba18dc4f6ca822f4ca46b11f47e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->