### PR TITLE
feat(tldraw): export freehand stroke utilities

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1809,6 +1809,12 @@ export function getPointsFromDrawSegment(segment: TLDrawShapeSegment, scaleX: nu
 export function getPointsFromDrawSegments(segments: TLDrawShapeSegment[], scaleX?: number, scaleY?: number): Vec[];
 
 // @public
+export function getStroke(points: VecLike[], options?: StrokeOptions): Vec[];
+
+// @public
+export function getStrokeOutlinePoints(strokePoints: StrokePoint[], options?: StrokeOptions): Vec[];
+
+// @public
 export function getStrokePoints(rawInputPoints: VecLike[], options?: StrokeOptions): StrokePoint[];
 
 // @public
@@ -2712,6 +2718,9 @@ export function setDefaultEditorAssetUrls(assetUrls: TLEditorAssetUrls): void;
 
 // @internal (undocumented)
 export function setDefaultUiAssetUrls(urls: TLUiAssetUrls): void;
+
+// @public (undocumented)
+export function setStrokePointRadii(strokePoints: StrokePoint[], options: StrokeOptions): StrokePoint[];
 
 // @public (undocumented)
 export interface SolidPathBuilderOpts extends BasePathBuilderOpts {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -178,7 +178,10 @@ export {
 	type TLDefaultFont,
 	type TLDefaultFonts,
 } from './lib/shapes/shared/defaultFonts'
+export { getStroke } from './lib/shapes/shared/freehand/getStroke'
+export { getStrokeOutlinePoints } from './lib/shapes/shared/freehand/getStrokeOutlinePoints'
 export { getStrokePoints } from './lib/shapes/shared/freehand/getStrokePoints'
+export { setStrokePointRadii } from './lib/shapes/shared/freehand/setStrokePointRadii'
 export { getSvgPathFromStrokePoints } from './lib/shapes/shared/freehand/svg'
 export { type StrokeOptions, type StrokePoint } from './lib/shapes/shared/freehand/types'
 export { PlainTextLabel, type PlainTextLabelProps } from './lib/shapes/shared/PlainTextLabel'


### PR DESCRIPTION
I would love to be able to use some of the functions that are currently not exported from `packages/tldraw/src/lib/shapes/shared/freehand`. This PR exports `getStroke`, `getStrokeOutlinePoints` and `setStrokePointRadii`. (Every function that was marked with `@public` but was not currently exported.) Strictly speaking I only need `getStroke` for my use-case, however since the other functions were also marked `@public` I thought it would only be appropriate to export them as well.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Exported freehand stroke utilities: getStroke, getStrokeOutlinePoints, and setStrokePointRadii.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose freehand stroke utilities by exporting `getStroke`, `getStrokeOutlinePoints`, and `setStrokePointRadii` from `packages/tldraw/src/index.ts` and reflecting them in the API report.
> 
> - **API/Exports**:
>   - Export freehand utilities from `packages/tldraw/src/index.ts`:
>     - `getStroke`
>     - `getStrokeOutlinePoints`
>     - `setStrokePointRadii`
>   - Update `packages/tldraw/api-report.api.md` to include the new public functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd7be56fb12ace7fb69a3b919e4b4a83c3c5a767. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->