### PR TITLE
fix(dotcom): select all for only non-sleeping fairies

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
@@ -159,9 +159,11 @@ export function FairyHUDHeader({
 
 	const selectAllFairies = useCallback(() => {
 		trackEvent('fairy-select-all', { source: 'fairy-panel' })
-		allAgents.forEach((agent) => {
-			agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
-		})
+		allAgents
+			.filter((agent) => !agent.mode.isSleeping())
+			.forEach((agent) => {
+				agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
+			})
 	}, [allAgents, trackEvent])
 
 	if (panelState === 'manual') {

--- a/apps/dotcom/client/src/fairy/fairy-ui/menus/FairyMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/menus/FairyMenuContent.tsx
@@ -209,7 +209,7 @@ export function FairyMenuContent({
 	const selectAllFairies = useCallback(() => {
 		trackEvent('fairy-select-all', { source: 'fairy-panel' })
 		allAgents
-			.filter((agent) => !agent.getProject())
+			.filter((agent) => !agent.getProject() && !agent.mode.isSleeping())
 			.forEach((agent: FairyAgent) => {
 				agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
 			})


### PR DESCRIPTION
Updates "Select all" to only select non-sleeping fairies (and only those without projects in the menu).

### Change type

- [x] `bugfix` 

### Test plan

1. Open the fairy HUD or menu.
2. Use the "Select all" functionality.
3. Verify that sleeping fairies are not selected.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where "Select all" would include sleeping fairies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates "Select all" to only select non-sleeping fairies (and only those without projects in the menu).
> 
> - **Selection behavior**:
>   - `apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx`
>     - `selectAllFairies` now selects only agents where `agent.mode.isSleeping()` is false.
>   - `apps/dotcom/client/src/fairy/fairy-ui/menus/FairyMenuContent.tsx`
>     - `selectAllFairies` further restricts selection to agents with no project and not sleeping (`!agent.getProject() && !agent.mode.isSleeping()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fa2b10e2afea60e0812fcc56388a4b7d1b4b906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->