### PR TITLE
fix(dotcom): prevent flash of white when loading in dark mode

### DIFF
--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -7,14 +7,14 @@
 		<script>
 			;(function () {
 				try {
-					var stored = localStorage.getItem('tldrawapp_session_3')
+					const stored = localStorage.getItem('tldrawapp_session_3')
 					if (stored) {
-						var parsed = JSON.parse(stored)
+						const parsed = JSON.parse(stored)
 						if (parsed && parsed.theme === 'dark') {
 							document.documentElement.classList.add('tldraw-preload-dark')
 							// Update theme-color meta tag for dark mode
 							document.addEventListener('DOMContentLoaded', function () {
-								var meta = document.querySelector('meta[name="theme-color"]')
+								const meta = document.querySelector('meta[name="theme-color"]')
 								if (meta) meta.setAttribute('content', '#000000')
 							})
 						}


### PR DESCRIPTION
When users have dark mode enabled, loading tldraw.com would briefly flash a white background before the React app hydrated and applied the correct theme. This was particularly jarring for users in dark environments.

This PR adds an inline script and styles at the top of the HTML that:
1. Reads the user's theme preference from localStorage before any CSS loads
2. Applies a dark background color immediately if dark mode is enabled
3. Updates the theme-color meta tag for consistent browser chrome

The script runs synchronously in the `<head>` to ensure the background is set before the browser paints anything.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw.com in dark mode
2. Hard refresh (Cmd+Shift+R / Ctrl+Shift+R)
3. Observe that the page no longer flashes white before loading

### Release notes

- Fixed flash of white background when loading tldraw.com with dark mode enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds early theme detection and pre-rendered dark background in `apps/dotcom/client/index.html` to eliminate white flash and set dark `theme-color`.
> 
> - **Dotcom client** (`apps/dotcom/client/index.html`):
>   - Add inline theme-detection script that reads `localStorage` (`tldrawapp_session_3`) and applies `html.tldraw-preload-dark` before CSS loads.
>   - Pre-render background colors via inline `<style>` to match light/dark themes and prevent white flash.
>   - Update `theme-color` meta dynamically to `#000000` when dark mode is detected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5207d261b8ee23fdb89c5e7973a2fce9204a80d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->