### PR TITLE
feat(fairy): add anchor property to move action

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-actions/MoveActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/MoveActionUtil.ts
@@ -51,8 +51,71 @@ export class MoveActionUtil extends AgentActionUtil<MoveAction> {
 		const shapeOrigin = new Vec(shape.x, shape.y)
 		const shapeBoundsOrigin = new Vec(shapeBounds.minX, shapeBounds.minY)
 
+		// Calculate the offset from the shape bounds origin to the shape origin
 		const shapeOriginDelta = shapeOrigin.sub(shapeBoundsOrigin)
-		const newTarget = moveTarget.add(shapeOriginDelta)
+
+		// Adjust the target position based on the anchor point
+		const boundsWidth = shapeBounds.w
+		const boundsHeight = shapeBounds.h
+
+		// Calculate the anchor point offset from the bounds origin
+		let anchorOffsetX = 0
+		let anchorOffsetY = 0
+
+		switch (action.anchor) {
+			case 'top-left': {
+				anchorOffsetX = 0
+				anchorOffsetY = 0
+				break
+			}
+			case 'top-center': {
+				anchorOffsetX = boundsWidth / 2
+				anchorOffsetY = 0
+				break
+			}
+			case 'top-right': {
+				anchorOffsetX = boundsWidth
+				anchorOffsetY = 0
+				break
+			}
+			case 'bottom-left': {
+				anchorOffsetX = 0
+				anchorOffsetY = boundsHeight
+				break
+			}
+			case 'bottom-center': {
+				anchorOffsetX = boundsWidth / 2
+				anchorOffsetY = boundsHeight
+				break
+			}
+			case 'bottom-right': {
+				anchorOffsetX = boundsWidth
+				anchorOffsetY = boundsHeight
+				break
+			}
+			case 'center-left': {
+				anchorOffsetX = 0
+				anchorOffsetY = boundsHeight / 2
+				break
+			}
+			case 'center-right': {
+				anchorOffsetX = boundsWidth
+				anchorOffsetY = boundsHeight / 2
+				break
+			}
+			case 'center': {
+				anchorOffsetX = boundsWidth / 2
+				anchorOffsetY = boundsHeight / 2
+				break
+			}
+		}
+
+		// Adjust the target to account for the anchor point
+		// The target x,y should be where the anchor point is positioned
+		// So we subtract the anchor offset to get the bounds origin position
+		const adjustedTarget = moveTarget.sub(new Vec(anchorOffsetX, anchorOffsetY))
+
+		const newTarget = adjustedTarget.add(shapeOriginDelta)
 
 		editor.updateShape({
 			id: shapeId,

--- a/apps/dotcom/client/src/fairy/fairy-actions/__test__/MoveActionUtil.test.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/__test__/MoveActionUtil.test.ts
@@ -31,6 +31,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -48,6 +49,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('nonexistent'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -68,6 +70,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: '100' as any,
 				y: '200' as any,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -89,6 +92,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 'invalid' as any,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -109,6 +113,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 'invalid' as any,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -126,6 +131,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: false,
 				time: 0,
@@ -149,6 +155,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: false,
 				time: 0,
@@ -174,6 +181,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'Move shape',
 				complete: true,
 				time: 0,
@@ -200,6 +208,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('nonexistent'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -223,6 +232,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -251,6 +261,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 200,
 				y: 200,
+				anchor: 'top-left',
 				intent: 'Move to 200, 200',
 				complete: true,
 				time: 0,
@@ -285,6 +296,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 150,
 				y: 150,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -313,6 +325,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 100,
 				y: 100,
+				anchor: 'top-left',
 				intent: 'test',
 				complete: true,
 				time: 0,
@@ -338,6 +351,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: -50,
 				y: -50,
+				anchor: 'top-left',
 				intent: 'Move to negative position',
 				complete: true,
 				time: 0,
@@ -367,6 +381,7 @@ describe('MoveActionUtil', () => {
 				shapeId: toSimpleShapeId('shape1'),
 				x: 0,
 				y: 0,
+				anchor: 'top-left',
 				intent: 'Move to origin',
 				complete: true,
 				time: 0,
@@ -381,6 +396,108 @@ describe('MoveActionUtil', () => {
 			expect(shapeAfter!.x).not.toBe(initialX)
 			expect(shapeAfter!.y).not.toBe(initialY)
 			expect(agent.position.moveTo).toHaveBeenCalled()
+		})
+
+		describe('anchor positioning', () => {
+			it('should position shape with top-left anchor', () => {
+				const id1 = createShapeId('shape1')
+				editor.createShape({ id: id1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+				const action = createAgentAction({
+					_type: 'move',
+					shapeId: toSimpleShapeId('shape1'),
+					x: 200,
+					y: 200,
+					anchor: 'top-left',
+					intent: 'Move with top-left anchor',
+					complete: true,
+					time: 0,
+				})
+
+				const helpers = new AgentHelpers(agent)
+				moveUtil.applyAction(action, helpers)
+
+				const bounds = editor.getShapePageBounds(id1)
+				expect(bounds).toBeDefined()
+				// Top-left corner should be at (200, 200)
+				expect(Math.abs(bounds!.minX - 200)).toBeLessThan(1)
+				expect(Math.abs(bounds!.minY - 200)).toBeLessThan(1)
+			})
+
+			it('should position shape with center anchor', () => {
+				const id1 = createShapeId('shape1')
+				editor.createShape({ id: id1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+				const action = createAgentAction({
+					_type: 'move',
+					shapeId: toSimpleShapeId('shape1'),
+					x: 200,
+					y: 200,
+					anchor: 'center',
+					intent: 'Move with center anchor',
+					complete: true,
+					time: 0,
+				})
+
+				const helpers = new AgentHelpers(agent)
+				moveUtil.applyAction(action, helpers)
+
+				const bounds = editor.getShapePageBounds(id1)
+				expect(bounds).toBeDefined()
+				// Center should be at (200, 200)
+				expect(Math.abs(bounds!.center.x - 200)).toBeLessThan(1)
+				expect(Math.abs(bounds!.center.y - 200)).toBeLessThan(1)
+			})
+
+			it('should position shape with bottom-right anchor', () => {
+				const id1 = createShapeId('shape1')
+				editor.createShape({ id: id1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+				const action = createAgentAction({
+					_type: 'move',
+					shapeId: toSimpleShapeId('shape1'),
+					x: 200,
+					y: 200,
+					anchor: 'bottom-right',
+					intent: 'Move with bottom-right anchor',
+					complete: true,
+					time: 0,
+				})
+
+				const helpers = new AgentHelpers(agent)
+				moveUtil.applyAction(action, helpers)
+
+				const bounds = editor.getShapePageBounds(id1)
+				expect(bounds).toBeDefined()
+				// Bottom-right corner should be at (200, 200)
+				expect(Math.abs(bounds!.maxX - 200)).toBeLessThan(1)
+				expect(Math.abs(bounds!.maxY - 200)).toBeLessThan(1)
+			})
+
+			it('should position shape with top-center anchor', () => {
+				const id1 = createShapeId('shape1')
+				editor.createShape({ id: id1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+				const action = createAgentAction({
+					_type: 'move',
+					shapeId: toSimpleShapeId('shape1'),
+					x: 200,
+					y: 200,
+					anchor: 'top-center',
+					intent: 'Move with top-center anchor',
+					complete: true,
+					time: 0,
+				})
+
+				const helpers = new AgentHelpers(agent)
+				moveUtil.applyAction(action, helpers)
+
+				const bounds = editor.getShapePageBounds(id1)
+				expect(bounds).toBeDefined()
+				// Top-center should be at (200, 200)
+				expect(Math.abs(bounds!.center.x - 200)).toBeLessThan(1)
+				expect(Math.abs(bounds!.minY - 200)).toBeLessThan(1)
+			})
 		})
 	})
 })

--- a/packages/fairy-shared/src/schema/AgentActionSchemas.ts
+++ b/packages/fairy-shared/src/schema/AgentActionSchemas.ts
@@ -1,7 +1,11 @@
 import z from 'zod'
 import { FocusColorSchema, ProjectColorSchema } from '../format/FocusColor'
 import { FocusFillSchema } from '../format/FocusFill'
-import { FocusedCreatableShapeSchema, FocusedShapeSchema } from '../format/FocusedShape'
+import {
+	FocusedCreatableShapeSchema,
+	FocusedShapeSchema,
+	FocusedTextAnchorSchema,
+} from '../format/FocusedShape'
 import { BaseAgentAction } from '../types/BaseAgentAction'
 import { AgentIdSchema, SimpleShapeIdSchema, TaskIdSchema, TodoIdSchema } from './id-schemas'
 
@@ -206,6 +210,7 @@ export const MoveActionSchema = z
 		shapeId: SimpleShapeIdSchema,
 		x: z.number(),
 		y: z.number(),
+		anchor: FocusedTextAnchorSchema,
 	})
 	.meta({ title: 'Move', description: 'The agent moves a shape to a new position.' })
 


### PR DESCRIPTION
This PR adds an anchor property to the move action. This helps the model to position text shapes better.

### Change type

- [x] `feature`

### Test plan

1. Verify that move actions now include an anchor property.
2. Confirm that text shapes are positioned correctly based on the specified anchor.

- [x] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Added anchor property to fairy move actions for better positioning control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add anchor-aware positioning to move actions and update schema/tests to require and validate `anchor`.
> 
> - **Client (fairy actions)**:
>   - Implement anchor-aware move logic in `MoveActionUtil.applyAction`, offsetting target by selected anchor (`top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center`, `bottom-right`, `center-left`, `center-right`, `center`).
> - **Shared schema**:
>   - Extend `MoveActionSchema` to include required `anchor: FocusedTextAnchorSchema` and import `FocusedTextAnchorSchema`.
> - **Tests**:
>   - Update existing move tests to pass `anchor`.
>   - Add anchor-specific positioning tests verifying bounds for `top-left`, `center`, `bottom-right`, and `top-center`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da2b9a53f6b914bb0bc877eada758f23cd5d931a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->