### PR TITLE
refactor: remove stale useValue in RichTextLabel

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -13,7 +13,6 @@ import {
 	preventDefault,
 	useEditor,
 	useReactor,
-	useValue,
 } from '@tldraw/editor'
 import classNames from 'classnames'
 import React, { useMemo } from 'react'
@@ -87,12 +86,6 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 		}
 	}, [editor, richText])
 
-	const selectToolActive = useValue(
-		'isSelectToolActive',
-		() => editor.getCurrentToolId() === 'select',
-		[editor]
-	)
-
 	useReactor(
 		'isDragging',
 		() => {
@@ -109,7 +102,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			// This mousedown prevent default is to let dragging when over a link work.
 			preventDefault(e)
 
-			if (!selectToolActive) return
+			if (editor.getCurrentToolId() !== 'select') return
 			const link = e.target.closest('a')?.getAttribute('href') ?? ''
 			// We don't get the mouseup event later because we preventDefault
 			// so we have to do it manually.
@@ -166,7 +159,6 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 					{richText && (
 						<div
 							className="tl-rich-text"
-							data-is-select-tool-active={selectToolActive}
 							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}


### PR DESCRIPTION
This PR removes an unnecessary `useValue` hook in the `RichTextLabel` component that was caching the select tool active state. Instead, the tool check is now done inline at the moment it's needed (in the `handlePointerDown` callback).

The previous implementation had a reactive hook tracking the select tool state, but this value was only used once in a pointer event handler. Reading the value directly from the editor at the time of the event is simpler and avoids the extra reactive subscription.

### Change type

- [x] `improvement`

### Test plan

1. Create a geo shape with a link in its label
2. Click on the link - it should open the URL
3. Switch to a different tool (e.g., draw tool)
4. Click on the link - it should NOT open the URL (link clicks only work in select tool)

### Release notes

- Simplified RichTextLabel component by removing unnecessary reactive state tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies RichTextLabel by inlining the select-tool check and removing the unused useValue subscription and related data attribute.
> 
> - **RichTextLabel (`packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx`)**:
>   - Inline tool check with `editor.getCurrentToolId() !== 'select'` inside `handlePointerDown`.
>   - Remove stale `useValue` subscription for select tool state.
>   - Drop `data-is-select-tool-active` attribute from `.tl-rich-text` element.
>   - No behavioral changes elsewhere; event handling and rendering remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a43092097ea7d5e70f74adb98b6f3f5fba1ed4f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->