### PR TITLE
perf: add CSS containment to main toolbar

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1275,6 +1275,7 @@ tldraw? probably.
 	position: relative;
 	background: var(--tl-color-panel);
 	box-shadow: var(--tl-shadow-2);
+	contain: layout style paint;
 }
 
 .tlui-main-toolbar--horizontal .tlui-main-toolbar__mobile-style-panel {


### PR DESCRIPTION
This PR adds `contain: layout style paint` to the main toolbar element (`.tlui-main-toolbar`).

CSS containment isolates the toolbar's layout, style, and paint computations from the rest of the document. This prevents the browser from unnecessarily recalculating styles or relayouting the toolbar when unrelated parts of the page change, which can improve rendering performance during canvas interactions.

### Change type

- [x] `improvement`

### Test plan

1. Open the examples app
2. Interact with the canvas (draw, select, pan, etc.)
3. Verify the toolbar renders correctly and no visual regressions occur

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- Improved rendering performance by adding CSS containment to the main toolbar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `contain: layout style paint` to `.tlui-main-toolbar__tools` to isolate layout/style/paint for better rendering performance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12539eb9e33a772b896450dc1450c012c778b840. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->