### PR TITLE
feat(fairy)!: make task bounds required

### DIFF
--- a/apps/dotcom/client/src/fairy/CONTEXT.md
+++ b/apps/dotcom/client/src/fairy/CONTEXT.md
@@ -807,7 +807,7 @@ fairyApp.projects.disbandProject(projectId)
 fairyApp.projects.resumeProject(projectId)
 
 // Task management
-fairyApp.tasks.createTask({ id, title, projectId })
+fairyApp.tasks.createTask({ id, title, projectId, x: 0, y: 0, w: 0, h: 0 })
 fairyApp.tasks.setTaskStatusAndNotify(taskId, 'done')
 ```
 

--- a/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartDuoTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartDuoTaskActionUtil.ts
@@ -91,20 +91,8 @@ export class DirectToStartDuoTaskActionUtil extends AgentActionUtil<DirectToStar
 			userMessages: [`Asked by ${firstName} to do${task.title ? `: ${task.title}` : ' a task'}`],
 			source: 'other-agent',
 		}
-		if (
-			task.x !== undefined &&
-			task.y !== undefined &&
-			task.w !== undefined &&
-			task.h !== undefined
-		) {
-			otherFairyInput.bounds = {
-				x: task.x,
-				y: task.y,
-				w: task.w,
-				h: task.h,
-			}
-			otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
-		}
+		otherFairyInput.bounds = { x: task.x, y: task.y, w: task.w, h: task.h }
+		otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
 
 		otherFairy.interrupt({ mode: 'working-drone', input: otherFairyInput })
 	}

--- a/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/DirectToStartTaskActionUtil.ts
@@ -90,20 +90,8 @@ export class DirectToStartTaskActionUtil extends AgentActionUtil<DirectToStartTa
 			userMessages: [`Asked by ${firstName} to do${task.title ? `: ${task.title}` : ' a task'}`],
 			source: 'other-agent',
 		}
-		if (
-			task.x !== undefined &&
-			task.y !== undefined &&
-			task.w !== undefined &&
-			task.h !== undefined
-		) {
-			otherFairyInput.bounds = {
-				x: task.x,
-				y: task.y,
-				w: task.w,
-				h: task.h,
-			}
-			otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
-		}
+		otherFairyInput.bounds = { x: task.x, y: task.y, w: task.w, h: task.h }
+		otherFairy.position.moveTo(Box.From(otherFairyInput.bounds).center)
 
 		otherFairy.interrupt({
 			mode: 'working-drone',

--- a/apps/dotcom/client/src/fairy/fairy-actions/StartDuoTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/StartDuoTaskActionUtil.ts
@@ -49,9 +49,6 @@ export class StartDuoTaskActionUtil extends AgentActionUtil<StartDuoTaskAction> 
 
 		this.agent.fairyApp.tasks.setTaskStatus(action.taskId, 'in-progress')
 
-		const currentBounds = this.agent.requests.getActiveRequest()?.bounds
-		if (!currentBounds) return
-
 		this.agent.interrupt({
 			mode: 'working-orchestrator',
 			input: {
@@ -59,10 +56,10 @@ export class StartDuoTaskActionUtil extends AgentActionUtil<StartDuoTaskAction> 
 					`You just decided to start working on a task.\nID: "${task.id}"\nTitle: "${task.title}"\nDescription: "${task.text}".`,
 				],
 				bounds: {
-					x: task.x ?? currentBounds.x,
-					y: task.y ?? currentBounds.y,
-					w: task.w ?? currentBounds.w,
-					h: task.h ?? currentBounds.h,
+					x: task.x,
+					y: task.y,
+					w: task.w,
+					h: task.h,
 				},
 			},
 		})

--- a/apps/dotcom/client/src/fairy/fairy-actions/StartSoloTaskActionUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-actions/StartSoloTaskActionUtil.ts
@@ -34,9 +34,6 @@ export class StartSoloTaskActionUtil extends AgentActionUtil<StartSoloTaskAction
 
 		this.agent.fairyApp.tasks.setTaskStatus(action.taskId, 'in-progress')
 
-		const currentBounds = this.agent.requests.getActiveRequest()?.bounds
-		if (!currentBounds) return
-
 		this.agent.interrupt({
 			mode: 'working-solo',
 			input: {
@@ -44,10 +41,10 @@ export class StartSoloTaskActionUtil extends AgentActionUtil<StartSoloTaskAction
 					`You just decided to start working on a task.\nID: "${task.id}"\nTitle: "${task.title}"\nDescription: "${task.text}".`,
 				],
 				bounds: {
-					x: task.x ?? currentBounds.x,
-					y: task.y ?? currentBounds.y,
-					w: task.w ?? currentBounds.w,
-					h: task.h ?? currentBounds.h,
+					x: task.x,
+					y: task.y,
+					w: task.w,
+					h: task.h,
 				},
 			},
 		})

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppTaskListManager.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppTaskListManager.ts
@@ -33,22 +33,46 @@ export class FairyAppTaskListManager extends BaseFairyAppManager {
 	 * Set all tasks (used during state loading).
 	 */
 	setTasks(tasks: FairyTask[]) {
-		this.$tasks.set(tasks)
+		// Normalize bounds for backwards compatibility with older persisted tasks
+		this.$tasks.set(
+			tasks.map((task) => ({
+				...task,
+				x: task.x ?? 0,
+				y: task.y ?? 0,
+				w: task.w ?? 0,
+				h: task.h ?? 0,
+			}))
+		)
 	}
 
 	/**
 	 * Create a new task.
 	 */
-	createTask(newPartialTask: Partial<FairyTask> & { id: TaskId }) {
+	createTask(
+		newTask: Partial<FairyTask> & {
+			id: TaskId
+			title: string
+			x: number
+			y: number
+			w: number
+			h: number
+		}
+	) {
 		this.$tasks.update((tasks) => {
+			const { id, title, x, y, w, h, ...rest } = newTask
 			const task = createAgentTask({
-				title: newPartialTask.title || '',
+				id,
+				title,
 				text: '',
 				projectId: null,
 				assignedTo: null,
 				status: 'todo',
 				pageId: undefined,
-				...newPartialTask,
+				x,
+				y,
+				w,
+				h,
+				...rest,
 			})
 			return [...tasks, task]
 		})

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppWaitManager.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/FairyAppWaitManager.ts
@@ -84,25 +84,12 @@ ID:${task.id}
 Title: "${task.title}"
 Description: "${task.text}"`
 
-		let bounds: BoxModel | undefined
-		if (
-			task.x !== undefined &&
-			task.y !== undefined &&
-			task.w !== undefined &&
-			task.h !== undefined
-		) {
-			bounds = {
-				x: task.x,
-				y: task.y,
-				w: task.w,
-				h: task.h,
-			}
-		}
+		const bounds: BoxModel = { x: task.x, y: task.y, w: task.w, h: task.h }
 
 		this.notifyWaitingAgents({
 			event: { type: 'task-completed', task },
 			getAgentFacingMessage: () => agentFacingMessage,
-			getBounds: bounds ? () => bounds : undefined,
+			getBounds: () => bounds,
 		})
 	}
 

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppPersistenceManager.test.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppPersistenceManager.test.ts
@@ -83,6 +83,10 @@ describe('FairyAppPersistenceManager', () => {
 						status: 'todo',
 						projectId: null,
 						assignedTo: null,
+						x: 0,
+						y: 0,
+						w: 0,
+						h: 0,
 					},
 				],
 				projects: [getFairyProject()],
@@ -107,6 +111,10 @@ describe('FairyAppPersistenceManager', () => {
 						status: 'todo',
 						projectId: null,
 						assignedTo: null,
+						x: 0,
+						y: 0,
+						w: 0,
+						h: 0,
 					},
 				],
 				projects: [],
@@ -126,6 +134,10 @@ describe('FairyAppPersistenceManager', () => {
 						status: 'todo',
 						projectId: null,
 						assignedTo: null,
+						x: 0,
+						y: 0,
+						w: 0,
+						h: 0,
 					},
 				],
 				projects: [],
@@ -193,6 +205,10 @@ describe('FairyAppPersistenceManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			fairyApp.projects.addProject(getFairyProject())
@@ -273,6 +289,10 @@ describe('FairyAppPersistenceManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			// Wait for throttled update
@@ -305,6 +325,10 @@ describe('FairyAppPersistenceManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			// Wait a bit for any potential throttled saves
@@ -331,6 +355,10 @@ describe('FairyAppPersistenceManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			// Should not save after stopping
@@ -352,6 +380,10 @@ describe('FairyAppPersistenceManager', () => {
 						status: 'todo',
 						projectId: null,
 						assignedTo: null,
+						x: 0,
+						y: 0,
+						w: 0,
+						h: 0,
 					},
 				],
 				projects: [],
@@ -401,6 +433,10 @@ describe('FairyAppPersistenceManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			// Should not save after disposing

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppProjectsManager.test.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppProjectsManager.test.ts
@@ -291,6 +291,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId1,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			fairyApp.tasks.createTask({
@@ -300,6 +304,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId1,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			expect(fairyApp.tasks.getTasks()).toHaveLength(2)
@@ -457,6 +465,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId1,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			fairyApp.tasks.createTask({
@@ -466,6 +478,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId2,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			expect(manager.getProjects()).toHaveLength(2)
@@ -509,6 +525,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId1,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			expect(manager.getProjects()).toHaveLength(1)
@@ -552,6 +572,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId1,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			fairyApp.tasks.createTask({
@@ -561,6 +585,10 @@ describe('FairyAppProjectsManager', () => {
 				status: 'todo',
 				projectId: projectId2,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			// Soft delete both projects

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppTaskListManager.test.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppTaskListManager.test.ts
@@ -41,6 +41,10 @@ describe('FairyAppTaskListManager', () => {
 					status: 'todo',
 					projectId: null,
 					assignedTo: null,
+					x: 0,
+					y: 0,
+					w: 0,
+					h: 0,
 				},
 			]
 
@@ -52,7 +56,7 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('createTask', () => {
 		it('should create a new task with defaults', () => {
-			manager.createTask({ id: toTaskId('task-1') })
+			manager.createTask({ id: toTaskId('task-1'), title: '', x: 0, y: 0, w: 0, h: 0 })
 
 			const tasks = manager.getTasks()
 			expect(tasks).toHaveLength(1)
@@ -63,6 +67,10 @@ describe('FairyAppTaskListManager', () => {
 				status: 'todo',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 		})
 
@@ -74,6 +82,10 @@ describe('FairyAppTaskListManager', () => {
 				status: 'in-progress',
 				projectId: toProjectId('project-1'),
 				assignedTo: toAgentId('agent-1'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			const task = manager.getTaskById(toTaskId('task-1'))
@@ -90,7 +102,7 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('deleteTask', () => {
 		it('should delete a task by ID', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1' })
+			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1', x: 0, y: 0, w: 0, h: 0 })
 			expect(manager.getTasks()).toHaveLength(1)
 
 			manager.deleteTask(toTaskId('task-1'))
@@ -101,7 +113,14 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('getTaskById', () => {
 		it('should return a task by ID', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			const task = manager.getTaskById(toTaskId('task-1'))
 
@@ -117,7 +136,14 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('setTaskStatus', () => {
 		it('should set a task status', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			manager.setTaskStatus(toTaskId('task-1'), 'in-progress')
 
@@ -125,8 +151,8 @@ describe('FairyAppTaskListManager', () => {
 		})
 
 		it('should not affect other tasks', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1' })
-			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2' })
+			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1', x: 0, y: 0, w: 0, h: 0 })
+			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2', x: 0, y: 0, w: 0, h: 0 })
 
 			manager.setTaskStatus(toTaskId('task-1'), 'done')
 
@@ -137,7 +163,14 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('setTaskStatusAndNotify', () => {
 		it('should set task status and notify waiting agents when done', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			const notifyTaskCompletedSpy = vi.spyOn(fairyApp.waits, 'notifyTaskCompleted')
 
@@ -150,7 +183,14 @@ describe('FairyAppTaskListManager', () => {
 		})
 
 		it('should not notify when status is not done', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			const notifyTaskCompletedSpy = vi.spyOn(fairyApp.waits, 'notifyTaskCompleted')
 
@@ -174,16 +214,28 @@ describe('FairyAppTaskListManager', () => {
 				id: toTaskId('task-1'),
 				title: 'Task 1',
 				projectId: toProjectId('project-1'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 			manager.createTask({
 				id: toTaskId('task-2'),
 				title: 'Task 2',
 				projectId: toProjectId('project-1'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 			manager.createTask({
 				id: toTaskId('task-3'),
 				title: 'Task 3',
 				projectId: toProjectId('project-2'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			const projectTasks = manager.getTasksByProjectId(toProjectId('project-1'))
@@ -203,16 +255,28 @@ describe('FairyAppTaskListManager', () => {
 				id: toTaskId('task-1'),
 				title: 'Task 1',
 				assignedTo: toAgentId('agent-1'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 			manager.createTask({
 				id: toTaskId('task-2'),
 				title: 'Task 2',
 				assignedTo: toAgentId('agent-1'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 			manager.createTask({
 				id: toTaskId('task-3'),
 				title: 'Task 3',
 				assignedTo: toAgentId('agent-2'),
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			})
 
 			const agentTasks = manager.getTasksByAgentId(toAgentId('agent-1'))
@@ -237,7 +301,14 @@ describe('FairyAppTaskListManager', () => {
 			const agents = fairyApp.agents.getAgents()
 			const agentIdValue = agents[0]!.id
 
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			manager.assignFairyToTask(toTaskId('task-1'), agentIdValue, agents)
 
@@ -254,7 +325,15 @@ describe('FairyAppTaskListManager', () => {
 			const agents = fairyApp.agents.getAgents()
 			const agentIdValue = agents[0]!.id
 
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task', assignedTo: agentIdValue })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				assignedTo: agentIdValue,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			manager.assignFairyToTask(toTaskId('task-1'), null, agents)
 
@@ -270,7 +349,14 @@ describe('FairyAppTaskListManager', () => {
 			fairyApp.agents.syncAgentsWithConfigs({}, options)
 			const agents = fairyApp.agents.getAgents()
 
-			manager.createTask({ id: toTaskId('task-1'), title: 'Test Task' })
+			manager.createTask({
+				id: toTaskId('task-1'),
+				title: 'Test Task',
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
+			})
 
 			manager.assignFairyToTask(toTaskId('task-1'), toAgentId('non-existent'), agents)
 
@@ -280,8 +366,8 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('clearTasksAndProjects', () => {
 		it('should clear all tasks and projects', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1' })
-			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2' })
+			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1', x: 0, y: 0, w: 0, h: 0 })
+			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2', x: 0, y: 0, w: 0, h: 0 })
 
 			fairyApp.projects.addProject(getFairyProject())
 
@@ -297,8 +383,8 @@ describe('FairyAppTaskListManager', () => {
 
 	describe('reset', () => {
 		it('should reset the manager', () => {
-			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1' })
-			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2' })
+			manager.createTask({ id: toTaskId('task-1'), title: 'Task 1', x: 0, y: 0, w: 0, h: 0 })
+			manager.createTask({ id: toTaskId('task-2'), title: 'Task 2', x: 0, y: 0, w: 0, h: 0 })
 
 			expect(manager.getTasks()).toHaveLength(2)
 

--- a/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppWaitManager.test.ts
+++ b/apps/dotcom/client/src/fairy/fairy-app/managers/__test__/FairyAppWaitManager.test.ts
@@ -47,6 +47,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			// Mock the agent's wait methods
@@ -96,6 +100,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			const waitCondition: FairyWaitCondition<TaskCompletedEvent> = {
@@ -134,6 +142,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			const waitCondition: FairyWaitCondition<TaskCompletedEvent> = {
@@ -172,6 +184,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			const notifySpy = vi.spyOn(manager, 'notifyWaitingAgents')
@@ -242,6 +258,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			const nonMatchingTask: FairyTask = {
@@ -251,6 +271,10 @@ describe('FairyAppWaitManager', () => {
 				status: 'done',
 				projectId: null,
 				assignedTo: null,
+				x: 0,
+				y: 0,
+				w: 0,
+				h: 0,
 			}
 
 			expect(condition.matcher({ type: 'task-completed', task: matchingTask })).toBe(true)

--- a/apps/dotcom/client/src/fairy/fairy-part-utils/SoloTasksPartUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-part-utils/SoloTasksPartUtil.ts
@@ -11,15 +11,12 @@ export class SoloTasksPartUtil extends PromptPartUtil<SoloTasksPart> {
 			.filter((task: FairyTask) => task.assignedTo === this.agent.id)
 			.filter((task: FairyTask) => task.projectId === null) // should never happen
 			.map((task: FairyTask) => {
-				const transformedTaskBounds =
-					task.x !== undefined &&
-					task.y !== undefined &&
-					task.w !== undefined &&
-					task.h !== undefined
-						? helpers.applyOffsetToBox({ x: task.x, y: task.y, w: task.w, h: task.h })
-						: task.x !== undefined && task.y !== undefined
-							? helpers.applyOffsetToVec({ x: task.x, y: task.y })
-							: { x: task.x, y: task.y, w: task.w, h: task.h }
+				const transformedTaskBounds = helpers.applyOffsetToBox({
+					x: task.x,
+					y: task.y,
+					w: task.w,
+					h: task.h,
+				})
 
 				return {
 					...task,

--- a/apps/dotcom/client/src/fairy/fairy-part-utils/WorkingTasksPartUtil.ts
+++ b/apps/dotcom/client/src/fairy/fairy-part-utils/WorkingTasksPartUtil.ts
@@ -12,15 +12,12 @@ export class WorkingTasksPartUtil extends PromptPartUtil<WorkingTasksPart> {
 				(task: FairyTask) => task.assignedTo === this.agent.id && task.status === 'in-progress'
 			)
 			.map((task: FairyTask) => {
-				const transformedTaskBounds =
-					task.x !== undefined &&
-					task.y !== undefined &&
-					task.w !== undefined &&
-					task.h !== undefined
-						? helpers.applyOffsetToBox({ x: task.x, y: task.y, w: task.w, h: task.h })
-						: task.x !== undefined && task.y !== undefined
-							? helpers.applyOffsetToVec({ x: task.x, y: task.y })
-							: { x: task.x, y: task.y, w: task.w, h: task.h }
+				const transformedTaskBounds = helpers.applyOffsetToBox({
+					x: task.x,
+					y: task.y,
+					w: task.w,
+					h: task.h,
+				})
 
 				return {
 					...task,

--- a/packages/fairy-shared/src/types/FairyTask.ts
+++ b/packages/fairy-shared/src/types/FairyTask.ts
@@ -4,14 +4,13 @@ export interface FairyTask {
 	id: TaskId
 	title: string
 	text: string
-	// description: string,
 	projectId: ProjectId | null
 	assignedTo: AgentId | null
 	status: FairyTaskStatus
-	x?: number
-	y?: number
-	w?: number
-	h?: number
+	x: number
+	y: number
+	w: number
+	h: number
 	pageId?: string
 }
 


### PR DESCRIPTION
In order to ensure all tasks have valid bounds for positioning and viewport management, this PR makes the `x`, `y`, `w`, and `h` properties required in the `FairyTask` interface instead of optional.

Previously, task bounds were optional, which led to code needing to handle fallback cases when bounds were missing. By making bounds required, we simplify the codebase and ensure all tasks have explicit positioning information.

The change includes backwards compatibility handling in `FairyAppTaskListManager.setTasks` to normalize older persisted tasks that may not have bounds, defaulting them to (0, 0, 0, 0).

### Change type

- [x] `api`

### Test plan

1. Create a new task and verify it has bounds
2. Load persisted state with old tasks and verify they are normalized correctly
3. Start a task and verify the agent moves to the correct bounds

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Breaking! Task bounds (`x`, `y`, `w`, `h`) are now required when creating `FairyTask` objects. Older persisted tasks without bounds will be automatically normalized to (0, 0, 0, 0).

### API changes

- Breaking! `FairyTask` interface: `x`, `y`, `w`, and `h` properties are now required (previously optional)
- Updated `FairyAppTaskListManager.createTask` to require bounds parameters
- Updated task action utilities to assume bounds are always present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require `x,y,w,h` on `FairyTask`, update creation/actions to always use bounds, and normalize older tasks to `(0,0,0,0)`.
> 
> - **API/Types**:
>   - `FairyTask` now requires `x`, `y`, `w`, `h` (removed optionals) in `packages/fairy-shared/src/types/FairyTask.ts`.
> - **Task Manager**:
>   - `FairyAppTaskListManager.setTasks()` normalizes missing bounds to `0`.
>   - `createTask()` now requires `id`, `title`, and bounds; constructs tasks with explicit bounds.
> - **Actions/Parts**:
>   - `DirectToStartTaskActionUtil` / `DirectToStartDuoTaskActionUtil`: set `bounds` unconditionally and move partner to center.
>   - `StartSoloTaskActionUtil` / `StartDuoTaskActionUtil`: always pass task bounds (no fallbacks).
>   - `SoloTasksPartUtil` / `WorkingTasksPartUtil`: always apply `applyOffsetToBox` with task bounds.
>   - `FairyAppWaitManager.notifyTaskCompleted()`: always include bounds and use them for movement.
> - **Docs**:
>   - Update `CONTEXT.md` task creation example to include required bounds.
> - **Tests**:
>   - Adjust unit tests to provide bounds and assert normalized/serialized values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae1ce46676c1bbadffa260ceac3050172dbf5101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->