### PR TITLE
improvement(dotcom): update fairy selection logic

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
@@ -120,6 +120,21 @@ export function FairyHUDHeader({
 		[allAgents, selectedFairies, fairyApp]
 	)
 
+	const awakeFairies = useValue(
+		'awake-fairies',
+		() => allAgents.filter((agent) => !agent.mode.isSleeping()),
+		[allAgents]
+	)
+
+	const allAwakeFairiesSelected = useValue(
+		'all-awake-fairies-selected',
+		() => {
+			const selectedIds = new Set(selectedFairies.map((f) => f.id))
+			return awakeFairies.every((agent) => selectedIds.has(agent.id))
+		},
+		[awakeFairies, selectedFairies]
+	)
+
 	const getDisplayName = () => {
 		if (!isProjectStarted || !project) {
 			return fairyConfig?.name
@@ -163,9 +178,12 @@ export function FairyHUDHeader({
 
 	const selectAllFairies = useCallback(() => {
 		trackEvent('fairy-select-all', { source: 'fairy-panel' })
-		allAgents.forEach((agent) => {
-			agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
-		})
+
+		allAgents
+			.filter((agent) => !agent.mode.isSleeping())
+			.forEach((agent) => {
+				agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
+			})
 	}, [allAgents, trackEvent])
 
 	if (panelState === 'manual') {
@@ -235,9 +253,14 @@ export function FairyHUDHeader({
 
 	const onlySelectedFairy = selectedFairies.length === 1 ? selectedFairies[0] : null
 
-	// Show select all button when there are unselected fairies without active projects
+	// Show select all button when there are unselected fairies without active projects,
+	// more than one fairy is awake, and not all awake fairies are already selected
 	const showSelectAllButton =
-		hasUnselectedFairiesWithoutActiveProjects && !project && !hasChatHistory // && isMobile
+		hasUnselectedFairiesWithoutActiveProjects &&
+		!project &&
+		!hasChatHistory &&
+		awakeFairies.length > 1 &&
+		!allAwakeFairiesSelected
 
 	return (
 		<div className="fairy-toolbar-header">

--- a/apps/dotcom/client/src/fairy/fairy-ui/menus/FairyMenuContent.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/menus/FairyMenuContent.tsx
@@ -209,7 +209,7 @@ export function FairyMenuContent({
 	const selectAllFairies = useCallback(() => {
 		trackEvent('fairy-select-all', { source: 'fairy-panel' })
 		allAgents
-			.filter((agent) => !agent.getProject())
+			.filter((agent) => !agent.getProject() && !agent.mode.isSleeping())
 			.forEach((agent: FairyAgent) => {
 				agent.updateEntity((f) => (f ? { ...f, isSelected: true } : f))
 			})


### PR DESCRIPTION
Hide the fairy selection button (in FairyHUDHeader) when only one fairy is awake.

Also, hide it once all awake fairies are already selected.

### Change type

- [x] `improvement`

### Test plan

1. Open the app with multiple fairies.
2. Ensure the selection button hides when only one fairy is awake.
3. Ensure the button hides when all awake fairies are selected.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved fairy selection UI to hide selection buttons when redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits selection to awake (non-sleeping) fairies and hides the Select All button when only one fairy is awake or all awake fairies are already selected.
> 
> - **HUD (`FairyHUDHeader.tsx`)**
>   - Add `awakeFairies` and `allAwakeFairiesSelected` state.
>   - Update `selectAllFairies` to select only awake fairies.
>   - Tighten `showSelectAllButton` conditions: require >1 awake fairy and not all awake fairies already selected (still gated by no project and no chat history).
> - **Menu (`FairyMenuContent.tsx`)**
>   - Update `selectAllFairies` to exclude fairies that are sleeping and those in a project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65f2d2172281e33825d6bf792e366d2ed76cca94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->