### PR TITLE
improvement(dotcom): update fairy select all button visibility

### DIFF
--- a/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
+++ b/apps/dotcom/client/src/fairy/fairy-ui/hud/FairyHUDHeader.tsx
@@ -116,6 +116,21 @@ export function FairyHUDHeader({
 		[allAgents, selectedFairies, fairyApp]
 	)
 
+	const awakeFairies = useValue(
+		'awake-fairies',
+		() => allAgents.filter((agent) => !agent.mode.isSleeping()),
+		[allAgents]
+	)
+
+	const allAwakeFairiesSelected = useValue(
+		'all-awake-fairies-selected',
+		() => {
+			const selectedIds = new Set(selectedFairies.map((f) => f.id))
+			return awakeFairies.every((agent) => selectedIds.has(agent.id))
+		},
+		[awakeFairies, selectedFairies]
+	)
+
 	const getDisplayName = () => {
 		if (!isProjectStarted || !project) {
 			return fairyConfig?.name
@@ -233,9 +248,14 @@ export function FairyHUDHeader({
 
 	const onlySelectedFairy = selectedFairies.length === 1 ? selectedFairies[0] : null
 
-	// Show select all button when there are unselected fairies without active projects
+	// Show select all button when there are unselected fairies without active projects,
+	// more than one fairy is awake, and not all awake fairies are already selected
 	const showSelectAllButton =
-		hasUnselectedFairiesWithoutActiveProjects && !project && !hasChatHistory // && isMobile
+		hasUnselectedFairiesWithoutActiveProjects &&
+		!project &&
+		!hasChatHistory &&
+		awakeFairies.length > 1 &&
+		!allAwakeFairiesSelected
 
 	return (
 		<div className="fairy-toolbar-header">
@@ -244,7 +264,11 @@ export function FairyHUDHeader({
 			<div className="tlui-row">
 				{panelState === 'fairy-project' && (
 					<TldrawUiTooltip content="Live feed" side="top">
-						<TldrawUiButton type="icon" className="fairy-toolbar-button" onClick={onToggleFeed}>
+						<TldrawUiButton
+							type="icon"
+							className="fairy-toolbar-button fairy-feed-button"
+							onClick={onToggleFeed}
+						>
 							<TldrawUiButtonIcon icon="comment" small />
 						</TldrawUiButton>
 					</TldrawUiTooltip>


### PR DESCRIPTION
Hide the fairy selection button (in FairyHUDHeader) when only one fairy is awake.

Also, hide it once all awake fairies are already selected.

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open the fairy HUD with only one fairy awake and verify the select all button is hidden.
2. Wake multiple fairies and verify the button appears.
3. Select all awake fairies and verify the button hides.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved the fairy selection UI by hiding the select-all button when redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the select-all button to show only when multiple awake fairies exist and not all are selected; also adds a specific class to the live feed button.
> 
> - **UI (FairyHUDHeader.tsx)**:
>   - Select-all visibility refined:
>     - Compute `awakeFairies` and `allAwakeFairiesSelected`.
>     - Show button only when there are unselected fairies without active projects, no project/chat history, more than one awake fairy, and not all awake fairies are selected.
>   - Styling hook: add `fairy-feed-button` class to the live feed icon button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0093a51d0fcafba0b2a2db16d2885e9c157c6fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->