### PR TITLE
perf(geo): cache label size measurements with WeakCache

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -399,8 +399,13 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const wasEmpty = isEmptyRichText(prevProps.richText)
 		const isEmpty = isEmptyRichText(nextProps.richText)
 
+		// If label is empty and used to be empty, skip label measurement and dimension adjustment
+		if (wasEmpty && isEmpty) {
+			return
+		}
+
 		// Text was removed - reset growY
-		if (!wasEmpty && isEmpty) {
+		if (isEmpty) {
 			return nextProps.growY !== 0 ? { ...next, props: { ...nextProps, growY: 0 } } : undefined
 		}
 


### PR DESCRIPTION
To improve performance when resizing geo shapes with labels, this PR adds a WeakCache for label size measurements and refactors the sizing logic for better maintainability.

The main optimization uses WeakCache to cache label size measurements per shape instance. During resize operations, the code now uses the initialShape (which is stable) for label measurement instead of creating temporary shapes with new dimensions. This prevents expensive measureHtml calls from running on every resize frame.

### Change type

- [x] `improvement`

### Test plan

1. Create a geo shape (rectangle, ellipse, etc.)
2. Add a label to the shape
3. Resize the shape - should feel smooth
4. Try with multiple labeled geo shapes

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance when resizing geo shapes with labels by caching label size measurements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches geo label measurements with WeakCache and refactors geometry/resize/update to use cached sizes and new helpers for faster, more consistent label fitting.
> 
> - **Performance**:
>   - Cache label sizes per shape via `WeakCache`; avoid re-measuring on resize by using `initialShape`.
>   - Skip measurement for empty labels (`EMPTY_LABEL_SIZE`).
> - **Geometry / Label**:
>   - Compute label rect via `getLabelBounds` using unscaled dims, alignment, and scale; use `path.toGeometry()` result.
>   - Introduce `LABEL_EDGE_MARGIN`; handle min label dims within shape.
> - **Resize behavior**:
>   - Constrain width/height to label size and `MIN_SIZE_WITH_LABEL`; prevent overshrink and preserve handle offsets.
>   - Always return `growY: 0` on resize result.
> - **Lifecycle (create/update)**:
>   - `onBeforeCreate`: ensure `growY` is 0 for empty labels; otherwise set from `calculateGrowY`.
>   - `onBeforeUpdate`: no-op if text/font/size unchanged; reset `growY` when text removed; on first text add, expand shape via `expandShapeForFirstLabel`; on text edits, adjust `w` and `growY` using cached label size.
> - **Utilities / Constants**:
>   - Add helpers: `getUnscaledGeoProps`, `calculateGrowY`, `expandShapeForFirstLabel`, cached `getUnscaledLabelSize` and `measureUnscaledLabelSize`.
>   - Rename `minWidths`→`MIN_WIDTHS`, `extraPaddings`→`EXTRA_PADDINGS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1c16d9f6aa2445a9155e067805250556453d44e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->