### PR TITLE
revert: "fix(dotcom): prevent flash of white when loading in dark mode"

### DIFF
--- a/apps/dotcom/client/index.html
+++ b/apps/dotcom/client/index.html
@@ -3,37 +3,6 @@
 	<head>
 		<meta charset="UTF-8" />
 
-		<!-- Theme detection script - must run before any CSS to prevent flash -->
-		<script>
-			;(function () {
-				try {
-					const stored = localStorage.getItem('tldrawapp_session_3')
-					if (stored) {
-						const parsed = JSON.parse(stored)
-						if (parsed && parsed.theme === 'dark') {
-							document.documentElement.classList.add('tldraw-preload-dark')
-							// Update theme-color meta tag for dark mode
-							document.addEventListener('DOMContentLoaded', function () {
-								const meta = document.querySelector('meta[name="theme-color"]')
-								if (meta) meta.setAttribute('content', '#000000')
-							})
-						}
-					}
-				} catch (e) {
-					// Ignore localStorage errors
-				}
-			})()
-		</script>
-		<style>
-			/* Pre-render background to prevent flash of white */
-			html {
-				background-color: hsl(0, 0%, 99%);
-			}
-			html.tldraw-preload-dark {
-				background-color: hsl(0, 0%, 5%);
-			}
-		</style>
-
 		<link rel="manifest" href="/manifest.webmanifest" />
 		<meta
 			name="keywords"


### PR DESCRIPTION
Reverts https://github.com/tldraw/tldraw/pull/7402

This doesn't work because of CSP rules https://github.com/tldraw/tldraw/pull/7402

### Change type

- [x] `other`

### Test plan

1. Verify that the dotcom site loads correctly without CSP errors.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reverted a change that caused CSP issues on the dotcom site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove dark-mode theme detection script and pre-render background CSS from `apps/dotcom/client/index.html`, reverting the flash-prevention change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57310a366e6806e102547b607126e571a258892a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->