### PR TITLE
revert: "fix: remove stale useValue in RichTextLabel (#7405)"

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -13,6 +13,7 @@ import {
 	preventDefault,
 	useEditor,
 	useReactor,
+	useValue,
 } from '@tldraw/editor'
 import classNames from 'classnames'
 import React, { useMemo } from 'react'
@@ -86,6 +87,12 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 		}
 	}, [editor, richText])
 
+	const selectToolActive = useValue(
+		'isSelectToolActive',
+		() => editor.getCurrentToolId() === 'select',
+		[editor]
+	)
+
 	useReactor(
 		'isDragging',
 		() => {
@@ -102,7 +109,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 			// This mousedown prevent default is to let dragging when over a link work.
 			preventDefault(e)
 
-			if (editor.getCurrentToolId() !== 'select') return
+			if (!selectToolActive) return
 			const link = e.target.closest('a')?.getAttribute('href') ?? ''
 			// We don't get the mouseup event later because we preventDefault
 			// so we have to do it manually.
@@ -159,6 +166,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 					{richText && (
 						<div
 							className="tl-rich-text"
+							data-is-select-tool-active={selectToolActive}
 							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}


### PR DESCRIPTION
This reverts https://github.com/tldraw/tldraw/pull/7405

We need this CSS rule to prevent the hand cursor when in a non-select tool (this code works with the corresponding rule in CSS)

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Revert "fix: remove stale useValue in RichTextLabel (#7405)"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores reactive select-tool state in RichTextLabel to control link handling and exposes it via a data attribute for CSS.
> 
> - **RichTextLabel (`packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx`)**:
>   - Restore `useValue` to track `select` tool state as `selectToolActive`.
>   - Gate link pointer handling with `selectToolActive` instead of checking `editor.getCurrentToolId()` inline.
>   - Expose tool state to DOM via `data-is-select-tool-active` on `.tl-rich-text` for CSS behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4412a16ca9589efd43de91f4553aee4ddb6b79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->