### PR TITLE
feat(embeds): allow fullscreen

### DIFF
--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -217,6 +217,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 						frameBorder="0"
 						referrerPolicy="no-referrer-when-downgrade"
 						tabIndex={isEditing ? 0 : -1}
+						allowFullScreen
 						style={{
 							border: 0,
 							pointerEvents: isInteractive ? 'auto' : 'none',


### PR DESCRIPTION
fixes https://github.com/tldraw/tldraw/issues/7411 

### Change type

- [x] `bugfix` (or improvement, feature, api, other - pick ONE)

### Test plan

1. Insert an embed shape (e.g. YouTube)
2. Verify that the fullscreen button in the iframe is now functional

- [ ] Unit tests (if present)
- [ ] End to end tests (if present)

### Release notes

- embeds: allow fullscreen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable fullscreen on embedded iframes by adding `allowFullScreen` to the embed shape iframe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04adc39ec27c1ffe0b340f1a47c55b2f179fb087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->