### PR TITLE
perf: avoid closure allocation in signal traversal

### DIFF
--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -177,6 +177,7 @@ function flushChanges(atoms: Iterable<_Atom>) {
 		inst.cleanupReactors = null
 		inst.globalIsReacting = false
 		inst.currentTransaction = outerTxn
+		traverseReactors = undefined! // free memory
 	}
 }
 


### PR DESCRIPTION
In order to improve signal graph traversal performance, this PR refactors the `traverse` function to avoid creating a new closure on each recursive call. The change uses a module-level variable to hold the reactors set instead of passing it through closure, reducing allocation pressure in this hot path.

### Change type

- [x] `improvement`

### Test plan

- [ ] Unit tests

### Release notes

- Improved signal graph traversal performance by eliminating per-recursion closure allocations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes the hot-path signal graph traversal to reduce allocations.
> 
> - Introduces module-scope `traverseReactors` and splits traversal into `traverseChild` + wrapper `traverse(reactors, child)` to avoid per-recursion closure creation
> - Replaces inline visitor with `traverseChild` and clears `traverseReactors` in `flushChanges` `finally` to free memory
> - Affects `packages/state/src/lib/transactions.ts` only; reaction flushing and cleanup scheduling remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee879ec40a6c11a7000d495494598d6a2e047fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->