### PR TITLE
perf: optimize object utility functions

### DIFF
--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -181,7 +181,9 @@ export function filterEntries<Key extends string, Value>(
 ): { [K in Key]: Value } {
 	const result: { [K in Key]?: Value } = {}
 	let didChange = false
-	for (const [key, value] of objectMapEntries(object)) {
+	for (const key in object) {
+		if (!Object.prototype.hasOwnProperty.call(object, key)) continue
+		const value = object[key]
 		if (predicate(key, value)) {
 			result[key] = value
 		} else {
@@ -238,11 +240,10 @@ export function mapObjectMapValues<Key extends string, ValueBefore, ValueAfter>(
  */
 export function areObjectsShallowEqual<T extends object>(obj1: T, obj2: T): boolean {
 	if (obj1 === obj2) return true
-	const keys1 = new Set(Object.keys(obj1))
-	const keys2 = new Set(Object.keys(obj2))
-	if (keys1.size !== keys2.size) return false
+	const keys1 = Object.keys(obj1)
+	if (keys1.length !== Object.keys(obj2).length) return false
 	for (const key of keys1) {
-		if (!keys2.has(key)) return false
+		if (!hasOwnProperty(obj2, key)) return false
 		if (!Object.is((obj1 as any)[key], (obj2 as any)[key])) return false
 	}
 	return true


### PR DESCRIPTION
This PR optimizes two object utility functions to improve performance and reduce memory allocations.

**Key optimizations:**

1. **`filterEntries`** - Replaces `objectMapEntries` with a direct `for...in` loop using own-property checks. This avoids creating an intermediate array of entries, reducing allocations.

2. **`areObjectsShallowEqual`** - Uses `Object.keys()` arrays directly instead of creating two `Set` instances for comparison. This reduces allocations and simplifies the comparison logic while maintaining the same functionality.

### Change type

- [x] `improvement`

### Test plan

1. Existing tests in the utils package pass
2. No functional changes - only performance improvements

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved performance of object utility functions by reducing allocations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves performance and reduces allocations in object utilities.
>
> - `filterEntries`: Replace `objectMapEntries` with a `for...in` loop guarded by own-property checks to avoid intermediate arrays
> - `areObjectsShallowEqual`: Use `Object.keys(obj1)` length comparison and own-property checks instead of building `Set`s; compare values with `Object.is`
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d07545c155225c2014e3a21e6ad8cdc855d8e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->