### PR TITLE
improvement(ui): refactor submenu trigger gradient logic

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -609,35 +609,31 @@
 
 /* Submenu triggers */
 
+.tlui-menu__submenu__trigger {
+	--gradient-angle: 90deg;
+}
+
+.tlui-menu__submenu__trigger[data-direction='left'] {
+	--gradient-angle: 270deg;
+}
+
 .tlui-menu__submenu__trigger[data-state='open']::after {
 	opacity: 1;
-	background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
+	background: linear-gradient(
+		var(--gradient-angle),
+		rgba(144, 144, 144, 0) 0%,
+		var(--tl-color-muted-2) 100%
+	);
 }
 
-.tlui-menu__submenu__trigger[data-direction='left'][data-state='open']::after {
-	opacity: 1;
-	background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-}
-
-@media (hover: hover) {	
-	.tlui-menu__submenu__trigger:hover::after {
+@media (hover: hover) {
+	.tlui-menu__submenu__trigger:is(:hover, [data-state='open'])::after {
 		opacity: 1;
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-	
-	.tlui-menu__submenu__trigger[data-direction='left']:hover::after {
-		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-
-	.tlui-menu__submenu__trigger[data-state='open']:not(:hover)::after {
-		opacity: 1;
-		background: linear-gradient(90deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
-	}
-
-	.tlui-menu__submenu__trigger[data-direction='left'][data-state='open']:not(:hover)::after {
-		opacity: 1;
-		background: linear-gradient(270deg, rgba(144, 144, 144, 0) 0%, var(--tl-color-muted-2) 100%);
+		background: linear-gradient(
+			var(--gradient-angle),
+			rgba(144, 144, 144, 0) 0%,
+			var(--tl-color-muted-2) 100%
+		);
 	}
 }
 


### PR DESCRIPTION
To simplify the CSS and eliminate duplication, this PR consolidates the submenu trigger gradient styling using CSS custom properties and `:is()` selector.

**Changes:**
- Introduced `--gradient-angle` CSS variable to avoid repeating gradient angles across rules
- Used `:is(:hover, [data-state='open'])` to combine hover and open states
- Reduced from 4 separate rules to 2 cleaner rules while maintaining identical functionality

This approach is more maintainable—if the gradient angles ever need to change, they only need to be updated in one place.

### Change type

- [x] `improvement`

### Release notes

- Improved CSS maintainability for submenu trigger gradients by using CSS variables and selector lists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors submenu trigger gradient CSS to remove duplication while preserving behavior.
> 
> - Introduces `--gradient-angle` on `tlui-menu__submenu__trigger` and overrides it for `[data-direction='left']`
> - Consolidates open/hover handling into one `::after` rule using `:is(:hover, [data-state='open'])`
> - Reduces four gradient rules to two without changing visuals
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb9840c40a4207f162a69c8405879d80f175b10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->