### PR TITLE
fix(menu): remove icon from dropdown menu items

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -134,7 +134,6 @@ export function TldrawUiMenuItem<
 						{iconLeft && <TldrawUiButtonIcon icon={iconLeft} small />}
 						<TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>
 						{kbd && <TldrawUiKbd>{kbd}</TldrawUiKbd>}
-						{icon && <TldrawUiButtonIcon icon={icon} small />}
 					</TldrawUiButton>
 				</TldrawUiDropdownMenuItem>
 			)


### PR DESCRIPTION
Closes #7525

In PR #6974, dropdown menu items in the `TldrawUiMenuItem` component were incorrectly rendering the `icon` prop on the right side of menu items. This caused some menus (like the Zoom menu's "Zoom to 100%" option) to display an unexpected icon alongside the label.

This PR removes the redundant icon rendering from the `menu` case since dropdown menus should only use `iconLeft` for icons positioned before the label.

### Change type

- [x] `bugfix`

### Test plan

1. Open the zoom menu in the toolbar
2. Verify that "Zoom to 100%" no longer shows a magnifying glass icon on the right side
3. Verify that other zoom menu items remain consistent (no icons)

### Release notes

- Fixed a bug where dropdown menu items could incorrectly display an icon on the right side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bugfix:** dropdown menu items no longer render a right-side `icon`.
> 
> - In `TldrawUiMenuItem.tsx` `menu` case, removed rendering of `icon` after `kbd`; dropdown items now only support `iconLeft` (pre-label icon)
> - No changes to context menu, toolbar, or other menu types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd149bdc3b074fb80bae8030ebe1eb8162e140a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->