### PR TITLE
fix(editor): restore toggle behavior for zoomToSelection

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3377,10 +3377,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const selectionPageBounds = this.getSelectionPageBounds()
 		if (selectionPageBounds) {
-			this.zoomToBounds(selectionPageBounds, {
-				targetZoom: Math.max(1, this.getZoomLevel()),
-				...opts,
-			})
+			const currentZoom = this.getZoomLevel()
+			// If already at 100%, zoom to fit the selection in the viewport
+			// Otherwise, zoom to 100% centered on the selection
+			if (Math.abs(currentZoom - 1) < 0.01) {
+				this.zoomToBounds(selectionPageBounds, opts)
+			} else {
+				this.zoomToBounds(selectionPageBounds, {
+					targetZoom: 1,
+					...opts,
+				})
+			}
 		}
 		return this
 	}

--- a/packages/tldraw/src/test/commands/zoomToSelection.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToSelection.test.ts
@@ -13,17 +13,28 @@ beforeEach(() => {
 	editor.createShapes(createDefaultShapes())
 })
 
-it('zooms to selection bounds', () => {
+it('zooms to 100% when not already at 100%', () => {
+	editor.zoomIn() // zoom to something other than 100%
 	editor.setSelectedShapes([ids.box1, ids.box2])
 	editor.zoomToSelection()
-	editor.expectCameraToBe(354.64, 139.29, 1)
+	expect(editor.getZoomLevel()).toBeCloseTo(1)
+})
+
+it('zooms to fit selection when already at 100%', () => {
+	// Editor starts at 100%, so first call zooms to fit
+	editor.setSelectedShapes([ids.box1, ids.box2])
+	editor.zoomToSelection()
+	// Should now be zoomed to fit the selection bounds (greater than 100% for small selection)
+	expect(editor.getZoomLevel()).toBeGreaterThan(1)
 })
 
 it('does not zoom past max', () => {
 	editor.updateShapes([{ id: ids.box1, type: 'geo', props: { w: 1, h: 1 } }])
 	editor.select(ids.box1)
 	editor.zoomToSelection()
-	expect(editor.getZoomLevel()).toBe(1) // double check again when we're zooming in hard
+	// When at 100%, zooms to fit but respects camera max zoom
+	const { zoomSteps } = editor.getCameraOptions()
+	expect(editor.getZoomLevel()).toBe(zoomSteps[zoomSteps.length - 1])
 })
 
 it('does not zoom past min', () => {


### PR DESCRIPTION
This PR restores the original toggle behavior for `zoomToSelection`. Previously, the method would zoom to 100% or maintain the current zoom if already above 100%. Now it provides the more useful toggle behavior:

- **If NOT at 100%**: Zoom to 100% centered on the selection
- **If at 100%**: Zoom to fit the selection in the viewport (with the same padding as `zoomToFit`)

This allows users to quickly toggle between a normalized view and a fitted view of their selection by pressing the zoom-to-selection shortcut repeatedly.

### Change type

- [x] `bugfix`

### Test plan

1. Create some shapes and select them
2. Zoom to something other than 100% (e.g., zoom in or out)
3. Press Shift+1 (zoom to selection) - should zoom to 100%
4. Press Shift+1 again - should zoom to fit the selection in the viewport

- [x] Unit tests

### Release notes

- Fixed `zoomToSelection` to toggle between 100% zoom and zoom-to-fit behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores toggle behavior for `zoomToSelection` and updates tests accordingly.
> 
> - Changes `Editor.zoomToSelection` to: when not at `1.0` zoom, zoom to `1.0` centered on selection; when at `1.0`, zoom to fit selection bounds
> - Updates `zoomToSelection.test.ts` to cover both paths and to assert min/max zoom constraints via camera options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b5d4e8e95d9f7c49c1f7bcc5e538124ca3b1ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->