### PR TITLE
chore: improve issue triage workflow prompt

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -40,58 +40,61 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            You are an issue triage bot for the tldraw repository. You need to evaluate and tidy up issue #${{ env.ISSUE_NUMBER }}.
+            You are an issue triage bot for the tldraw repository. Evaluate and label issue #${{ env.ISSUE_NUMBER }}.
 
             ## Issue details
             ```json
             ${{ steps.issue.outputs.details }}
             ```
 
-            ## Your tasks
+            ## Tasks
 
-            ### 1. Evaluate the title and body
-            - If the title and body are clear and acceptable, leave them as-is
-            - Only suggest improvements if there are significant clarity issues
+            ### 1. Classify the issue type
+            Determine if this is a:
+            - **Bug**: Something is broken or not working as designed (crashes, rendering errors, data loss)
+            - **Improvement**: A request to enhance existing behavior (UX preferences, "I wish X worked like Y")
+            - **Feature**: A request for entirely new functionality
+            - **Task**: Internal team task
+            - **Example**: Request for a new SDK example
 
-            ### 2. Evaluate and assign the correct Type
-            The issue template system uses these types:
-            - **Bug**: Actual bugs where something is broken or not working as designed
-            - **Feature**: New feature requests or enhancements
-            - **Task**: Internal tasks for the team
-            - **Example**: Requests for new SDK examples
+            IMPORTANT: Many issues filed as "bugs" are actually improvement requests. A true bug is something objectively broken. "The menu should be on the left" or "I don't like the animation" are improvements, not bugs.
 
-            Important: Distinguish between TRUE bugs and UX preferences disguised as bugs:
-            - TRUE BUG: "Clicking save crashes the app" or "Text doesn't render correctly"
-            - NOT A BUG (UX preference): "I don't like the color of the button" or "The menu should be on the left instead of right"
-
-            If an issue is filed as a Bug but is actually a UX preference or feature request, update the type accordingly.
-
-            ### 3. Apply appropriate labels
-            Use these labels as appropriate:
-            - `sdk` - Affects the tldraw SDK (@tldraw/tldraw package)
+            ### 2. Apply labels
+            Add appropriate labels using `gh issue edit --add-label`:
+            - `sdk` - Affects @tldraw/tldraw package
             - `dotcom` - Related to tldraw.com
-            - `docs` - Changes only affect documentation
-            - `examples` - Request for a new SDK example
-            - `performance` - Performance-related issues
-            - `a11y` - Accessibility-related issues
-            - `bugfix` - For confirmed bug fixes
-            - `feature` - For new features
-            - `improvement` - For product improvements
-            - `More Info Needed` - If the issue lacks critical information needed to understand or reproduce
+            - `docs` - Documentation changes
+            - `examples` - SDK example requests
+            - `performance` - Performance issues
+            - `a11y` - Accessibility issues
+            - `bugfix` - Confirmed bugs (use only for TRUE bugs)
+            - `feature` - New features
+            - `improvement` - Product improvements (use this for UX preferences)
+            - `More Info Needed` - Issue lacks critical info to understand/reproduce
 
-            ### 4. For TRUE bug reports, research the codebase
-            If this is a genuine bug report (not a UX preference), use your Explore capability to:
-            - Search the codebase for relevant files and code paths
-            - Identify where the bug might originate
-            - Look for related code, tests, or previous fixes
-            - Add a comment with your findings to help developers investigate
+            ### 3. Research the codebase (for bugs and improvements)
+            For bugs and improvements, research the codebase to identify:
+            - Relevant files and code paths
+            - Where the issue likely originates
+            - Related code, tests, or previous fixes
 
-            ## Output format
-            After your analysis:
-            1. If labels need to be added, use `gh issue edit` to add them
-            2. If the type needs to be changed, update it accordingly
-            3. For bug reports, add a comment with your research findings
-            4. If no changes are needed, you can simply acknowledge the issue is well-formed
+            Keep research focused - identify 3-5 key files maximum.
 
-            Use the GitHub CLI (`gh`) to make any changes to the issue.
-          claude_args: '--allowedTools "Bash(gh issue:*),Bash(gh api:*),Read,Glob,Grep,Task"'
+            ### 4. Add a comment with findings
+            Write a brief comment summarizing:
+            - What type of issue this is and why
+            - Key files involved (with line numbers if helpful)
+            - Suggested approach (1-2 sentences)
+
+            IMPORTANT for comments:
+            - Write the comment to /tmp/comment.md first using Write tool
+            - Then post with: gh issue comment ${{ env.ISSUE_NUMBER }} --body-file /tmp/comment.md
+            - Keep comments concise (under 500 words)
+            - Use simple markdown (headers, bullets, bold) - avoid complex code blocks
+
+            ## Execution order
+            1. Read the issue and classify it
+            2. Add labels with `gh issue edit`
+            3. Research codebase if needed
+            4. Write and post comment
+          claude_args: '--allowedTools "Bash(gh issue:*),Bash(gh api:*),Read,Glob,Grep,Task,Write"'


### PR DESCRIPTION
This PR improves the issue triage workflow by restructuring the prompt for better clarity and reliability.

### Change type

- [x] `other`

### Test plan

- [x] Tested manually by triggering the workflow on existing issues using `workflow_dispatch`

### Release notes

- Improved GitHub issue triage workflow prompt for clearer task structure and better classification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the GitHub issue triage workflow for clearer, more actionable automation.
> 
> - Clarifies issue classification (Bug, Improvement, Feature, Task, Example) and emphasizes distinguishing true bugs from UX preferences
> - Adds explicit labeling guidance and commands, plus an execution order for consistent actions
> - Introduces a focused research step (3–5 key files) for bugs/improvements with concise findings
> - Requires writing a brief comment to `/tmp/comment.md` and posting via `gh issue comment` with formatting constraints
> - Expands allowed tools to include `Write` in `claude_args`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4fe278af251ff2bf56e6ec209aa9a9c0926ed39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->