### PR TITLE
chore: improve issue triage workflow with type and milestone handling

### DIFF
--- a/packages/editor/src/lib/exports/parseCss.test.ts
+++ b/packages/editor/src/lib/exports/parseCss.test.ts
@@ -364,4 +364,5 @@ test('parseCssValueUrls', () => {
 		  },
 		]
 	`)
+	expect(parseCssValueUrls(`url(#arrowhead)`)).toMatchInlineSnapshot(`[]`)
 })

--- a/packages/editor/src/lib/exports/parseCss.ts
+++ b/packages/editor/src/lib/exports/parseCss.ts
@@ -108,5 +108,5 @@ export function parseCssValueUrls(value: string) {
 	return Array.from(value.matchAll(urlsRegex), (m) => ({
 		original: m[0],
 		url: m[1] || m[2] || m[3],
-	}))
+	})).filter((m) => !m.url.startsWith('#'))
 }


### PR DESCRIPTION
The GitHub CLI `--type` flag is not universally supported for setting issue types. This PR updates both the issue triage workflow and the Claude issue command to use the GitHub API directly for fetching and setting issue types, and adds support for milestone assignment.

### Changes

**Issue triage workflow (`.github/workflows/issue-triage.yml`):**
- Fetches issue type via GitHub API and merges it into the issue details JSON
- Restructured the triage prompt to be clearer and more focused
- Added instructions for setting issue types via API (`gh api ... -X PATCH`)
- Added milestone assignment capability with current milestones:
  - "Improve developer resources" - for examples, docs, starter kits, `npm create tldraw`
  - "Improve automations" - for GitHub Actions, review bots, CI/CD
- Added guidance for researching bug reports in the codebase
- Removed `Write` from allowed tools (not needed for triage)

**Issue command (`.claude/commands/issue.md`):**
- Replaced `--type` flag usage with API-based approach
- Added documentation for fetching issue node IDs and available type IDs via GraphQL
- Added milestone assignment step with available milestones

### Change type

- [x] `other`

### Test plan

This can be tested by triggering the issue triage workflow on a new issue.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved issue type and milestone handling in the automated triage workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes issue creation and triage to rely on the GitHub API for types and adds optional milestones.
> 
> - **Workflow updates (`.github/workflows/issue-triage.yml`)**
>   - Fetches issue type via `gh api` and injects `issueType` into details JSON
>   - Revamps triage prompt: title/body cleanup, clear bug vs feature guidance, label usage, and milestone assignment
>   - Adds commands to set issue type via `gh api ... -X PATCH`
>   - Narrows allowed tools to `Bash(gh issue:*)` and `Bash(gh api:*)`
> 
> - **Docs updates (`.claude/commands/issue.md`)**
>   - Replaces unsupported `--type` flag with GraphQL-based type setting and adds queries to get node/type IDs
>   - Adds milestone step with available milestones and keeps attribution guidance
>   - Minor step renumbering and clarity improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8108da05920731b6915eb415fc11caabd66b8bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->