### PR TITLE
test: add a small test to guard against missing keys in `TLUserPreferences`

### DIFF
--- a/packages/editor/src/lib/config/TLUserPreferences.test.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { defaultUserPreferences, userTypeValidator } from './TLUserPreferences'
+
+describe('TLUserPreferences consistency', () => {
+	// When adding a new user preference, add it to this list AND update:
+	// 1. TLUserPreferences interface
+	// 2. userTypeValidator
+	// 3. defaultUserPreferences
+	// 4. Versions enum and migrateSnapshot()
+	const interfaceKeys = [
+		'name',
+		'color',
+		'locale',
+		'animationSpeed',
+		'areKeyboardShortcutsEnabled',
+		'edgeScrollSpeed',
+		'colorScheme',
+		'isSnapMode',
+		'isWrapMode',
+		'isDynamicSizeMode',
+		'isPasteAtCursorMode',
+		'enhancedA11yMode',
+		'inputMode',
+	] as const
+
+	it('defaultUserPreferences contains all TLUserPreferences keys (except id)', () => {
+		const defaultKeys = Object.keys(defaultUserPreferences).sort()
+		const expected = [...interfaceKeys].sort()
+
+		expect(defaultKeys).toEqual(expected)
+	})
+
+	it('userTypeValidator validates all TLUserPreferences keys', () => {
+		// Access the internal config property to check which keys the validator covers
+		const validatorKeys = Object.keys((userTypeValidator as any).config).sort()
+		const expected = ['id', ...interfaceKeys].sort()
+
+		expect(validatorKeys).toEqual(expected)
+	})
+})


### PR DESCRIPTION
When I implemented the input mode preference feature #6755, we missed a couple of changes that needed to come with it, and that introduced bugs #6854 one of which was adding the key to the `UserPreferencesKeys` type. This small test catches out that bug.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a small consistency test to guard against missing user preference keys.
> 
> - New `packages/editor/src/lib/config/TLUserPreferences.test.ts` verifies `defaultUserPreferences` includes all `TLUserPreferences` keys and that `userTypeValidator` validates `id` plus those keys
> - Helps catch omissions when adding new preferences (e.g., `inputMode`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a29576931d508d8d1cae89626a49678960a13846. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->