### PR TITLE
chore(ci): notify tldraw-desktop on next releases

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -25,10 +25,32 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Publish Prerelease Packages
-        run: yarn tsx ./internal/scripts/publish-prerelease.ts ${{ github.ref == 'refs/heads/production' && 'next' || 'canary' }}
+        id: publish
+        run: |
+          yarn tsx ./internal/scripts/publish-prerelease.ts ${{ github.ref == 'refs/heads/production' && 'next' || 'canary' }}
+          echo "VERSION=$(jq -r .version ./packages/tldraw/package.json)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_ACCESS_KEY_SECRET }}
           TLDRAW_BEMO_URL: https://canary-demo.tldraw.xyz
+
+      - name: Generate a token
+        if: github.ref == 'refs/heads/production'
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.HUPPY_APP_ID }}
+          private-key: ${{ secrets.HUPPY_PRIVATE_KEY }}
+          owner: tldraw
+          repositories: tldraw-desktop
+
+      - name: Notify tldraw-desktop
+        if: github.ref == 'refs/heads/production'
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
+            https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
+            -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.publish.outputs.VERSION }}","tag":"next"}}'


### PR DESCRIPTION
After publishing packages to npm with the "next" tag (production branch), this PR adds a step to dispatch a `repository_dispatch` event to `tldraw/tldraw-desktop` with the version and tag. This triggers the desktop app to automatically create a PR updating its tldraw dependencies.

### Change type

- [x] `other`

### Test plan

This is a CI workflow change. It will be tested when the next release is published from the production branch.

### Release notes

- Added automatic notification to tldraw-desktop repository when publishing next releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automated desktop repo notification to the prerelease workflow.
> 
> - Exposes `VERSION` from `packages/tldraw/package.json` as an output of the `publish` step
> - On `production` branch: generates a GitHub App token and sends a `repository_dispatch` to `tldraw-desktop` with `event_type` `tldraw-release` and `client_payload` `{ version, tag: "next" }`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79c39dc2a0466cf9d9dd8991ab68298ee10d472b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->