### PR TITLE
feat(examples): add language picker example

### DIFF
--- a/apps/examples/src/examples/language-picker/LanguagePickerExample.tsx
+++ b/apps/examples/src/examples/language-picker/LanguagePickerExample.tsx
@@ -1,0 +1,71 @@
+import { LANGUAGES, TLComponents, Tldraw, useEditor, useValue } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// [1]
+function LanguagePicker() {
+	const editor = useEditor()
+
+	// [2]
+	const currentLocale = useValue('locale', () => editor.user.getLocale(), [editor])
+
+	return (
+		<select
+			style={{ pointerEvents: 'all' }}
+			value={currentLocale}
+			onChange={(e) => {
+				// [3]
+				editor.user.updateUserPreferences({ locale: e.target.value })
+			}}
+		>
+			{/* [4] */}
+			{LANGUAGES.map(({ locale, label }) => (
+				<option key={locale} value={locale}>
+					{label}
+				</option>
+			))}
+		</select>
+	)
+}
+
+// [5]
+const components: TLComponents = {
+	TopPanel: LanguagePicker,
+}
+
+export default function LanguagePickerExample() {
+	return (
+		<div className="tldraw__editor">
+			{/* [6] */}
+			<Tldraw components={components} />
+		</div>
+	)
+}
+
+/*
+[1]
+Create a language picker component. Since it's rendered via the `components` prop,
+it has access to `useEditor()` without needing an EditorProvider wrapper.
+
+[2]
+Use `useValue` to reactively read the current locale. This hook will automatically
+re-render the component when the locale changes. The first argument is a debug name,
+the second is a function that returns the value to track, and the third is a dependency array.
+
+[3]
+Update the locale by calling `editor.user.updateUserPreferences()`. This will update
+the editor's internal state and persist the preference to local storage.
+
+[4]
+The `LANGUAGES` constant contains all available languages with their locale codes and
+display labels. Each entry has a `locale` (e.g., 'en', 'fr') and a `label` (e.g.,
+'English', 'Français').
+
+[5]
+Define your component overrides outside of the React component so that they're static.
+Here we replace the TopPanel with our language picker.
+
+[6]
+Pass the components to the `components` prop. The language picker will be rendered
+in the top panel area of the editor.
+
+*/

--- a/apps/examples/src/examples/language-picker/README.md
+++ b/apps/examples/src/examples/language-picker/README.md
@@ -1,0 +1,25 @@
+---
+title: Language picker
+component: ./LanguagePickerExample.tsx
+category: ui
+priority: 3
+keywords: [locale, language, i18n, internationalization, translation, preferences]
+---
+
+Change the editor's locale with a language picker.
+
+---
+
+This example demonstrates how to build a language picker that changes the editor's locale. This is useful when you need to:
+
+- Sync tldraw's language with your app's language setting
+- Let users choose their preferred language from a dropdown
+- Override browser language preferences
+
+The example shows how to:
+
+1. Read the current locale reactively using `useValue` and `editor.user.getLocale()`
+2. Update the locale using `editor.user.updateUserPreferences({ locale })`
+3. Access available languages from the `LANGUAGES` constant
+
+The language preference is automatically persisted to local storage and will be remembered across sessions.


### PR DESCRIPTION
Add a new example demonstrating how to build a language picker that changes the editor's locale. Shows how to reactively read and update user preferences using the editor API.

for  #7504

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a minimal example for switching locales at runtime.
> 
> - New `LanguagePickerExample.tsx` renders a `<select>` in the editor’s top panel via `components` override
> - Reads current locale with `useValue(() => editor.user.getLocale())`
> - Updates preferences with `editor.user.updateUserPreferences({ locale })` and uses `LANGUAGES` for options
> - Docs (`README.md`) explain usage and note preference persistence to local storage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b78220f3628bee0c5e05adfce025594f00e1a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->