### PR TITLE
fix(tldraw): don't debounce asset resolution if asset changed

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -62,8 +62,8 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 	// Track the previous assetId to detect when the asset itself changes
 	const previousAssetId = useRef<TLAssetId | null>(null)
 
-	// Track whether we should skip debouncing for the next immediate resolution
-	const shouldSkipDebounce = useRef(false)
+	// Track whether we should run immediately (skip debouncing) for the next resolution
+	const shouldRunImmediately = useRef(false)
 
 	// The last URL that we've seen for the shape
 	const previousUrl = useRef<string | null>(null)
@@ -73,9 +73,9 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		const assetIdChanged = previousAssetId.current !== assetId
 		previousAssetId.current = assetId
 
-		// Set flag to skip debouncing for the next immediate resolution
+		// Set flag to run immediately (skip debouncing) for the next resolution
 		if (assetIdChanged) {
-			shouldSkipDebounce.current = true
+			shouldRunImmediately.current = true
 		}
 
 		if (!assetId) return
@@ -124,7 +124,7 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 
 			// Debounce fetching potentially multiple image variations (e.g. during zoom or resize).
 			// Don't debounce when the asset itself changes - resolve immediately.
-			if (didAlreadyResolve.current && !shouldSkipDebounce.current) {
+			if (didAlreadyResolve.current && !shouldRunImmediately.current) {
 				let tick = 0
 
 				const resolveAssetAfterAWhile = () => {
@@ -145,7 +145,7 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 				cancelDebounceFn?.()
 				resolveAssetUrl(editor, assetId, screenScale, exportInfo, (url) => resolve(asset, url))
 				// Reset the flag after immediate resolution so subsequent updates are debounced
-				shouldSkipDebounce.current = false
+				shouldRunImmediately.current = false
 			}
 		})
 


### PR DESCRIPTION
Asset debouncing (PR #5361) introduced a regression where updating the assetId of an ImageShape is noticeably slow due to a 500ms debounce. This PR fixes the issue by only skipping the debounce when the asset id has changed.

Closes #7611

### Change type

- [x] `bugfix`

### Test plan

1. Add an image shape to the canvas
2. Update its `assetId` programmatically via `editor.updateShape()`
3. The new image should appear immediately without delay
4. Zoom in/out rapidly - debouncing should still apply during camera movement for performance

### Release notes

- Fixed a regression where updating an image shape's asset was delayed by 500ms due to incorrect debouncing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a React hook’s debouncing control flow; main risk is subtle timing/cleanup issues around tick listener cancellation.
> 
> **Overview**
> Fixes a regression in `useImageOrVideoAsset` where swapping an image/video shape’s `assetId` could be delayed by the existing 500ms debounce.
> 
> The hook now tracks the previous `assetId` and **bypasses debouncing on asset changes**, resolving the new URL immediately (and cancelling any pending debounced tick handler), while keeping the debounce behavior for repeated scale/zoom-driven URL variations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8715f2a40193ee225dcea0b88421ec4b337f7b59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->