### PR TITLE
fix(editor): distanceToLineSegment now returns actual distance instead of squared

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -141,10 +141,7 @@ export abstract class Geometry2d {
 		}
 		if (!nearest) throw Error('nearest point not found')
 		dist = Math.sqrt(dist) // return the actual distance, not the squared distance
-		if (this.isClosed && this.isFilled && pointInPolygon(nearest, this.vertices)) {
-			return -dist
-		}
-		return dist
+		return this.isClosed && this.isFilled && pointInPolygon(nearest, this.vertices) ? -dist : dist
 	}
 
 	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0, filters?: Geometry2dFilters): boolean {


### PR DESCRIPTION
This PR fixes a bug in `Geometry2d.distanceToLineSegment` where it was returning squared distance instead of actual distance.

The method uses `Vec.Dist2` (squared distance) internally for efficient comparison, but was returning the raw squared value. This caused `hitTestLineSegment` to compare squared distance against non-squared margin values (like `hitTestMargin / zoomLevel`), making hit detection far too strict.

For example, with a default `hitTestMargin` of 8 pixels:
- Before: shapes only hit if within ~2.8px (`√8`) of the eraser stroke
- After: shapes correctly hit if within 8px of the eraser stroke

### Change type

- [x] `bugfix`

### Test plan

1. Use the eraser tool to erase shapes
2. Notice that shapes are now erased when the stroke comes within the expected margin (~8 screen pixels)

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where `distanceToLineSegment` returned squared distance instead of actual distance, causing hit testing (eraser, scribble select) to be too strict.