### PR TITLE
chore(ci): add path filtering to analytics worker deployment workflow

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -5,6 +5,12 @@ permissions:
 
 on:
   pull_request:
+    paths:
+      - 'apps/analytics-worker/**'
+      - 'internal/scripts/deploy-analytics.ts'
+      - 'internal/scripts/lib/deploy.ts'
+      - '.github/workflows/deploy-analytics.yml'
+      - '.github/actions/setup/**'
   push:
     branches:
       - main


### PR DESCRIPTION
This PR adds path filtering to the `pull_request` trigger in the analytics worker deployment workflow (`.github/workflows/deploy-analytics.yml`), reducing unnecessary CI runs when PRs don't touch analytics-related code.

Closes #7614

### Change type

- [x] `improvement`

### Test plan

This is a CI workflow change. To verify:
1. Create a PR that doesn't touch any of the filtered paths - the analytics worker deployment workflow should not run
2. Create a PR that touches `apps/analytics-worker/**` - the workflow should run

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improved CI efficiency by adding path filtering to the analytics worker deployment workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds path filtering to the analytics worker deployment workflow to limit PR-triggered runs to relevant changes.
> 
> - Updates `pull_request` trigger in `.github/workflows/deploy-analytics.yml` to run only when changes occur in `apps/analytics-worker/**`, `internal/scripts/deploy-analytics.ts`, `internal/scripts/lib/deploy.ts`, `.github/workflows/deploy-analytics.yml`, or `.github/actions/setup/**`
> - No changes to deployment logic or jobs; only trigger conditions adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6045104c97674a97e8035a937f54671236c08193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->