### PR TITLE
fix: don't use debounced zoom level for zoom menu

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
@@ -48,7 +48,7 @@ export const DefaultZoomMenu = memo(function DefaultZoomMenu({ children }: TLUiZ
 const ZoomTriggerButton = () => {
 	const editor = useEditor()
 	const breakpoint = useBreakpoint()
-	const zoom = useValue('zoom', () => editor.getEfficientZoomLevel(), [editor])
+	const zoom = useValue('zoom', () => editor.getZoomLevel(), [editor])
 	const msg = useTranslation()
 
 	const handleDoubleClick = useCallback(() => {


### PR DESCRIPTION
the zoom menu values for over 300+ shapes would use debounced zoom levels, lets not do that. Fixes #7580

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Zoom menu to display the immediate zoom value.
> 
> - Replace `getEfficientZoomLevel` with `getZoomLevel` in `DefaultZoomMenu.tsx` so the Zoom menu shows the current zoom without debounce
> - No other functional changes; double-click to reset zoom remains the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e21c353567a28370589844c9bbf927cec2416a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->