### PR TITLE
docs(examples): add menu system hover example

### DIFF
--- a/apps/examples/src/examples/menu-system-hover/MenuSystemHoverExample.tsx
+++ b/apps/examples/src/examples/menu-system-hover/MenuSystemHoverExample.tsx
@@ -1,0 +1,101 @@
+import {
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiDropdownMenuContent,
+	TldrawUiDropdownMenuItem,
+	TldrawUiDropdownMenuRoot,
+	TldrawUiDropdownMenuTrigger,
+	useEditor,
+	useMenuIsOpen,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './menu-system-hover.css'
+
+// [1]
+function HoverControlledMenu() {
+	const editor = useEditor()
+	const [isOpen] = useMenuIsOpen('hover-menu')
+
+	return (
+		<div className="hover-menu-container">
+			{/* [2] */}
+			<div
+				className="hover-zone hover-zone-open"
+				onMouseEnter={() => editor.menus.addOpenMenu('hover-menu')}
+			>
+				Hover to open menu
+			</div>
+
+			{/* [3] */}
+			<div
+				className="hover-zone hover-zone-close"
+				onMouseEnter={() => editor.menus.deleteOpenMenu('hover-menu')}
+			>
+				Hover to close menu
+			</div>
+
+			{/* [4] */}
+			<TldrawUiDropdownMenuRoot id="hover-menu">
+				<TldrawUiDropdownMenuTrigger>
+					<TldrawUiButton type="normal">
+						<TldrawUiButtonLabel>Menu {isOpen ? '(open)' : '(closed)'}</TldrawUiButtonLabel>
+					</TldrawUiButton>
+				</TldrawUiDropdownMenuTrigger>
+				<TldrawUiDropdownMenuContent>
+					<TldrawUiDropdownMenuItem>
+						<TldrawUiButton type="menu">
+							<TldrawUiButtonLabel>Menu item 1</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					</TldrawUiDropdownMenuItem>
+					<TldrawUiDropdownMenuItem>
+						<TldrawUiButton type="menu">
+							<TldrawUiButtonLabel>Menu item 2</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					</TldrawUiDropdownMenuItem>
+					<TldrawUiDropdownMenuItem>
+						<TldrawUiButton type="menu">
+							<TldrawUiButtonLabel>Menu item 3</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					</TldrawUiDropdownMenuItem>
+				</TldrawUiDropdownMenuContent>
+			</TldrawUiDropdownMenuRoot>
+		</div>
+	)
+}
+
+export default function MenuSystemHoverExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				components={{
+					InFrontOfTheCanvas: HoverControlledMenu,
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+This example shows how to programmatically control menus using hover events.
+
+[1]
+The HoverControlledMenu component uses useMenuIsOpen to track the current state
+of our menu. The hook returns a tuple where the first element is a boolean
+indicating whether the menu is open.
+
+[2]
+The first hover zone calls editor.menus.addOpenMenu('hover-menu') on mouse enter.
+This registers the menu as open in the global menu tracking system. The
+TldrawUiDropdownMenuRoot will automatically respond to this state change.
+
+[3]
+The second hover zone calls editor.menus.deleteOpenMenu('hover-menu') on mouse
+enter, which closes the menu.
+
+[4]
+The TldrawUiDropdownMenuRoot is linked to our menu ID ('hover-menu'). It
+automatically syncs with the menu tracking system, so when we call addOpenMenu
+or deleteOpenMenu, the dropdown responds accordingly. You can also click the
+trigger button to toggle the menu normally.
+*/

--- a/apps/examples/src/examples/menu-system-hover/README.md
+++ b/apps/examples/src/examples/menu-system-hover/README.md
@@ -1,0 +1,21 @@
+---
+title: Menu system hover
+component: ./MenuSystemHoverExample.tsx
+category: ui
+priority: 1
+keywords: [menu, hover, dropdown, programmatic, control]
+---
+
+Programmatically control dropdown menus via hover interactions using the editor's menu tracking API.
+
+---
+
+This example demonstrates how to open and close menus programmatically using the `editor.menus` API. Instead of relying solely on click triggers, you can control menu state in response to any UI event—in this case, hovering over specific zones.
+
+The key APIs used are:
+
+- `editor.menus.addOpenMenu(id)` - Register a menu as open
+- `editor.menus.deleteOpenMenu(id)` - Close a specific menu
+- `useMenuIsOpen(id)` - Subscribe to menu state reactively
+
+This pattern is useful for building custom toolbars, navigation systems, or any UI where menus should respond to external events rather than just their own triggers.

--- a/apps/examples/src/examples/menu-system-hover/menu-system-hover.css
+++ b/apps/examples/src/examples/menu-system-hover/menu-system-hover.css
@@ -1,0 +1,34 @@
+.hover-menu-container {
+	position: absolute;
+	top: 100px;
+	left: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--tl-space-3);
+	padding: var(--tl-space-3);
+	z-index: var(--tl-layer-panels);
+}
+
+.hover-zone {
+	padding: var(--tl-space-3) var(--tl-space-5);
+	border-radius: var(--tl-radius-2);
+	font-size: 13px;
+	font-weight: 500;
+	cursor: default;
+	user-select: none;
+	transition: opacity 0.15s ease;
+	background-color: var(--tl-color-low);
+	pointer-events: auto;
+}
+
+.hover-zone:hover {
+	opacity: 0.8;
+}
+
+.hover-zone-open {
+	color: var(--tl-color-success);
+}
+
+.hover-zone-close {
+	color: var(--tl-color-danger);
+}


### PR DESCRIPTION
Add a new SDK example demonstrating how to programmatically control dropdown menus via hover interactions using the editor's menu tracking API.

Closes #7601

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev` and navigate to the "Menu system hover" example
2. Hover over the "Hover to open menu" zone - the dropdown should open
3. Hover over the "Hover to close menu" zone - the dropdown should close
4. Click the menu button to verify normal click behavior still works

### Release notes

- Add menu system hover example showing programmatic menu control via `editor.menus` API