### PR TITLE
chore: add no-attribution rules and clarify release notes for internal PRs

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -55,5 +55,6 @@ Do NOT:
 - Use `--amend` unless explicitly requested
 - Skip hooks with `--no-verify`
 - Commit files that look like secrets (.env, credentials, API keys)
+- Include "Generated with Claude Code", "Co-Authored-By: Claude", or any AI attribution
 
 If the commit fails due to pre-commit hooks, fix the issues and try again.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -63,3 +63,5 @@ Committing automatically runs the linter. Fix any lint/type errors unless they r
 🚨 I can't create/update this PR because [reason]. Would you like me to [suggestion]?
 
 Never force commit or force push.
+
+**Important**: NEVER include "Generated with Claude Code", "Co-Authored-By: Claude", or any other AI attribution in commit messages, PR titles, or PR descriptions.

--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -83,6 +83,7 @@ Start with: "In order to X, this PR does Y."
 
 - Write brief notes describing user-facing changes
 - Use imperative mood: "Add...", "Fix...", "Remove..."
+- Omit this section entirely for internal work (CI, tooling, tests, etc.) that has no user-facing impact
 
 ## API changes section
 


### PR DESCRIPTION
The `/commit` command was missing the no-attribution rule that exists in `/pr` and `/issue`, causing Claude to fall back to system defaults that add "Generated with Claude Code" and "Co-Authored-By" lines.

This PR:
- Adds explicit no-attribution rules to `/commit` and `/pr` commands
- Clarifies that release notes can be omitted for internal PRs

### Change type

- [x] `improvement`

### Test plan

1. Run `/commit` with changes - commit message should not include any Claude attribution
2. Run `/pr` - PR description should not include any Claude attribution

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit no‑AI‑attribution rules to committing and PR workflows, plus a small docs tweak for release notes.
> 
> - Update `commands/commit.md` to forbid including `"Generated with Claude Code"`, `"Co-Authored-By: Claude"`, or any AI attribution in commit messages
> - Add bold "Important" note in `commands/pr.md` to never include AI attribution in commit messages, PR titles, or PR descriptions
> - Clarify in `skills/write-pr/SKILL.md` that release notes should be omitted for internal-only (CI/tooling/tests) changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b5eb8230ac45b3b326f11bd8289689f13d6c7d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->