### PR TITLE
chore(tldraw): fix typo in embed permission comment

### DIFF
--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -626,7 +626,7 @@ export const embedShapePermissionDefaults = {
 	// [REASON] We want to allow embeds to link back to their original sites (e.g. YouTube).
 	'allow-popups': true,
 	// [MDN] Lets the sandboxed document open new windows without those windows inheriting the sandboxing. For example, this can safely sandbox an advertisement without forcing the same restrictions upon the page the ad links to.
-	// [REASON] We shouldn't allow popups as a embed could pretend to be us by opening a mocked version of tldraw. This is very unobvious when it is performed as an action within our app.
+	// [REASON] We shouldn't allow popups as an embed could pretend to be us by opening a mocked version of tldraw. This is very unobvious when it is performed as an action within our app.
 	'allow-popups-to-escape-sandbox': false,
 	// [MDN] Lets the resource start a presentation session.
 	// [REASON] Prevents embed from navigating away from tldraw and pretending to be us.


### PR DESCRIPTION
This PR makes a small change to trigger a new SDK release. Our release workflow was broken until yesterday, so this ensures packages get published correctly.

The actual change fixes a typo: "as a embed" → "as an embed" in a comment.

### Change type

- [x] `other`

### Test plan

- No testing needed (comment-only change)

### Release notes

- Fix typo in embed permission comment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 38148f32ee77bc16a206218cba23e287a61be028. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->