### PR TITLE
fix(tldraw): dotted freehand lines visible at minimum zoom

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -260,7 +260,7 @@ function DrawShapeSvg({ shape, zoomOverride }: { shape: TLDrawShape; zoomOverrid
 			const zoomLevel = zoomOverride ?? editor.getEfficientZoomLevel()
 			// If we're zoomed way out (10%), then we need to make the dotted line go to 9 instead 0.1
 			// Chrome doesn't render anything otherwise.
-			return zoomLevel < 0.2 ? 0 : 0.1
+			return zoomLevel < 0.2 ? 9 : 0.1
 		},
 		[editor, zoomOverride]
 	)


### PR DESCRIPTION
In order to fix dotted freehand lines becoming invisible at minimum zoom (5%) on Chrome, this PR updates the `dotAdjustment` calculation to return `9` instead of `0` when zoomed below 20%.

The previous value of `0` created `strokeDasharray="0 {gap}"` which made dots invisible. The code comment already indicated it should return `9`, so this aligns the implementation with the documented intent.

Closes #7648

### Change type

- [x] `bugfix`

### Test plan

1. Create a freehand draw shape
2. Change the dash style to "dotted"
3. Zoom out to minimum zoom level (5%)
4. Verify the dotted line remains visible

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix dotted freehand lines becoming invisible at minimum zoom on Chrome