### PR TITLE
fix(editor): handle pointercancel events to prevent drawing from stopping

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -4770,6 +4770,7 @@ export const userTypeValidator: T.Validator<TLUserPreferences>;
 
 // @public (undocumented)
 export function useSelectionEvents(handle: TLSelectionHandle): {
+    onPointerCancel: PointerEventHandler<Element>;
     onPointerDown: PointerEventHandler<Element>;
     onPointerMove: (e: React.PointerEvent) => void;
     onPointerUp: PointerEventHandler<Element>;

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -52,6 +52,26 @@ export function useCanvasEvents() {
 				})
 			}
 
+			function onPointerCancel(e: React.PointerEvent) {
+				if (editor.wasEventAlreadyHandled(e)) return
+
+				// pointercancel fires when the browser decides to take over pointer handling
+				// (e.g., for scrolling, zooming, or other system gestures). This commonly happens
+				// on mobile/tablet devices during rapid pen input. We treat it as a pointer_up
+				// to properly end any ongoing interaction like drawing.
+				releasePointerCapture(e.currentTarget, e)
+
+				editor.dispatch({
+					type: 'pointer',
+					target: 'canvas',
+					name: 'pointer_up',
+					...getPointerInfo(editor, e),
+					// pointercancel doesn't have a meaningful button value, so we use 0
+					// (primary button) since that's what most interactions use
+					button: 0,
+				})
+			}
+
 			function onPointerEnter(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
@@ -132,6 +152,7 @@ export function useCanvasEvents() {
 			return {
 				onPointerDown,
 				onPointerUp,
+				onPointerCancel,
 				onPointerEnter,
 				onPointerLeave,
 				onDragOver,

--- a/packages/editor/src/lib/hooks/useHandleEvents.ts
+++ b/packages/editor/src/lib/hooks/useHandleEvents.ts
@@ -79,10 +79,32 @@ export function useHandleEvents(id: TLShapeId, handleId: string) {
 			})
 		}
 
+		const onPointerCancel = (e: React.PointerEvent) => {
+			if (editor.wasEventAlreadyHandled(e)) return
+
+			const target = loopToHtmlElement(e.currentTarget)
+			releasePointerCapture(target, e)
+
+			const { shape, handle } = getHandle(editor, id, handleId)
+
+			if (!handle) return
+
+			editor.dispatch({
+				type: 'pointer',
+				target: 'handle',
+				handle,
+				shape,
+				name: 'pointer_up',
+				...getPointerInfo(editor, e),
+				button: 0,
+			})
+		}
+
 		return {
 			onPointerDown,
 			onPointerMove,
 			onPointerUp,
+			onPointerCancel,
 		}
 	}, [editor, id, handleId])
 }

--- a/packages/editor/src/lib/hooks/useSelectionEvents.ts
+++ b/packages/editor/src/lib/hooks/useSelectionEvents.ts
@@ -36,11 +36,13 @@ export function useSelectionEvents(handle: TLSelectionHandle) {
 
 				function releaseCapture() {
 					elm.removeEventListener('pointerup', releaseCapture)
+					elm.removeEventListener('pointercancel', releaseCapture)
 					releasePointerCapture(elm, e)
 				}
 
 				setPointerCapture(elm, e)
 				elm.addEventListener('pointerup', releaseCapture)
+				elm.addEventListener('pointercancel', releaseCapture)
 
 				editor.dispatch({
 					name: 'pointer_down',
@@ -84,10 +86,24 @@ export function useSelectionEvents(handle: TLSelectionHandle) {
 				})
 			}
 
+			const onPointerCancel: React.PointerEventHandler = (e) => {
+				if (editor.wasEventAlreadyHandled(e)) return
+
+				editor.dispatch({
+					name: 'pointer_up',
+					type: 'pointer',
+					target: 'selection',
+					handle,
+					...getPointerInfo(editor, e),
+					button: 0,
+				})
+			}
+
 			return {
 				onPointerDown,
 				onPointerMove,
 				onPointerUp,
+				onPointerCancel,
 			}
 		},
 		[editor, handle]


### PR DESCRIPTION
In order to prevent drawing from freezing on Android tablets during rapid pen input, this PR adds `pointercancel` event handlers to the pointer event hooks. Closes #7647.

When using a pen/stylus on Android tablets, the browser may fire `pointercancel` events during rapid continuous drawing (the browser decides to take over pointer handling for system gestures, scrolling detection, etc.). Previously, tldraw wasn't handling these events, causing the drawing to appear frozen until the user lifted and placed the pen again.

This adds `onPointerCancel` handlers to:
- `useCanvasEvents` - main canvas pointer handling
- `useSelectionEvents` - selection handle interactions
- `useHandleEvents` - shape handle interactions

The handlers treat `pointercancel` as a `pointer_up` event, properly ending any ongoing interaction.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw on an Android tablet with a stylus/pen
2. Select the draw tool
3. Make very quick, rapid scribbling motions continuously without lifting the pen
4. Verify that drawing continues to record strokes even during rapid continuous input

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix drawing stopping on Android tablets during rapid pen/stylus input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bugfix: reliably end interactions on `pointercancel`**
> 
> - Add `onPointerCancel` to `useCanvasEvents`, `useSelectionEvents`, and `useHandleEvents`; dispatch `pointer_up` with `button: 0` and call `releasePointerCapture` to end interactions cleanly
> - In `useSelectionEvents`, attach/remove `pointercancel` alongside `pointerup` for capture cleanup; API surface now includes `onPointerCancel` in `useSelectionEvents` return
> - Aims to prevent drawing/handles from freezing during rapid pen input (e.g., Android)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff3b981b1a2e17bb91a0d065ee06135dc2e5ab7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->