### PR TITLE
fix sqlite double migration

### DIFF
--- a/packages/sync-core/src/test/InMemorySyncStorage.test.ts
+++ b/packages/sync-core/src/test/InMemorySyncStorage.test.ts
@@ -1,4 +1,11 @@
 import {
+	BaseRecord,
+	createMigrationSequence,
+	createRecordType,
+	RecordId,
+	StoreSchema,
+} from '@tldraw/store'
+import {
 	createTLSchema,
 	DocumentRecordType,
 	PageRecordType,
@@ -1679,6 +1686,94 @@ describe('InMemorySyncStorage', () => {
 				expect(result.documentClock).toBe(storage.getClock())
 				expect(result.documentClock).toBe(6)
 			})
+		})
+	})
+
+	describe('Schema migrations via migrateStorage', () => {
+		it('should apply record migrations exactly once per record', () => {
+			// This test verifies that record-level migrations are applied exactly once
+			// per record, not multiple times due to iterator issues.
+
+			// Track how many times each record is migrated
+			const migrationCounts = new Map<string, number>()
+
+			interface TestRecord extends BaseRecord<'test', RecordId<TestRecord>> {
+				value: number
+				migrated?: boolean
+			}
+
+			const TestRecordType = createRecordType<TestRecord>('test', {
+				validator: { validate: (r) => r as TestRecord },
+				scope: 'document',
+			})
+
+			const testMigrations = createMigrationSequence({
+				sequenceId: 'com.test.record',
+				retroactive: true,
+				sequence: [
+					{
+						id: 'com.test.record/1',
+						scope: 'record',
+						filter: (r: any) => r.typeName === 'test',
+						up: (record: any) => {
+							// Track how many times this record is migrated
+							const count = migrationCounts.get(record.id) ?? 0
+							migrationCounts.set(record.id, count + 1)
+							record.migrated = true
+						},
+					},
+				],
+			})
+
+			const oldSchema = StoreSchema.create({ test: TestRecordType })
+			const newSchema = StoreSchema.create(
+				{ test: TestRecordType },
+				{ migrations: [testMigrations] }
+			)
+
+			const numRecords = 100
+
+			// Build initial snapshot with many test records
+			const testRecords: TestRecord[] = []
+			for (let i = 0; i < numRecords; i++) {
+				testRecords.push({
+					id: `test:${i}` as RecordId<TestRecord>,
+					typeName: 'test',
+					value: i,
+				})
+			}
+
+			const snapshot = {
+				documents: testRecords.map((r) => ({ state: r, lastChangedClock: 0 })),
+				clock: 0,
+				documentClock: 0,
+				schema: oldSchema.serialize(),
+			}
+
+			const storage = new InMemorySyncStorage<TestRecord>({ snapshot })
+
+			// Run the migration within a transaction
+			storage.transaction((txn) => {
+				newSchema.migrateStorage(txn)
+			})
+
+			// Verify each record was migrated exactly once
+			const migrationCountValues = Array.from(migrationCounts.values())
+			const recordsMigratedMoreThanOnce = migrationCountValues.filter((count) => count > 1)
+
+			expect(recordsMigratedMoreThanOnce).toEqual([])
+
+			// Additional check: verify the total number of migrations equals number of records
+			expect(migrationCounts.size).toBe(numRecords)
+			for (const [_id, count] of migrationCounts) {
+				expect(count).toBe(1)
+			}
+
+			// Verify all records now have the migrated flag
+			const finalSnapshot = storage.getSnapshot()
+			for (const doc of finalSnapshot.documents) {
+				expect((doc.state as TestRecord).migrated).toBe(true)
+			}
 		})
 	})
 })

--- a/packages/tlschema/src/shapes/TLArrowShape.ts
+++ b/packages/tlschema/src/shapes/TLArrowShape.ts
@@ -363,6 +363,11 @@ export const arrowShapeMigrations = createMigrationSequence({
 
 				type OldArrow = TLBaseShape<'arrow', { start: OldArrowTerminal; end: OldArrowTerminal }>
 
+				// Collect all updates during iteration, then apply them after.
+				// This avoids issues with live iterators (e.g., SQLite) where updating
+				// records during iteration can cause them to be visited multiple times.
+				const updates: [string, unknown][] = []
+
 				for (const record of storage.values()) {
 					if (record.typeName !== 'shape' || (record as TLShape).type !== 'arrow') continue
 					const arrow = record as OldArrow
@@ -385,7 +390,7 @@ export const arrowShapeMigrations = createMigrationSequence({
 							},
 						}
 
-						storage.set(id, binding as any)
+						updates.push([id, binding])
 						newArrow.props.start = { x: 0, y: 0 }
 					} else {
 						delete newArrow.props.start.type
@@ -407,12 +412,16 @@ export const arrowShapeMigrations = createMigrationSequence({
 							},
 						}
 
-						storage.set(id, binding as any)
+						updates.push([id, binding])
 						newArrow.props.end = { x: 0, y: 0 }
 					} else {
 						delete newArrow.props.end.type
 					}
-					storage.set(arrow.id, newArrow)
+					updates.push([arrow.id, newArrow])
+				}
+
+				for (const [id, record] of updates) {
+					storage.set(id, record as any)
 				}
 			},
 		},


### PR DESCRIPTION
The problem was that updating records during the migration loop was causing them to be revisited due to how the sqlite iteration works.

### Change type

- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate application of record-level migrations caused by live SQLite iterators.
> 
> - Change `StoreSchema.migrateStorage` (record scope) to collect `updates` and apply after iteration
> - Update arrow shape storage migration (`TLArrowShape` ExtractBindings) to batch created bindings and arrow updates
> - Add regression tests in `InMemorySyncStorage.test.ts` and `SQLiteSyncStorage.test.ts` verifying migrations run exactly once per record
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3567e4aaa97e9fae183c52c2c90b439978e4bf83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->