### PR TITLE
license: rm old licensing phrasing

### DIFF
--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -46,8 +46,6 @@ This will run our [examples app](https://github.com/tldraw/tldraw/tree/main/apps
 
 This project is part of the tldraw SDK. It is provided under the [tldraw SDK license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).
 
-You can use the tldraw SDK in commercial or non-commercial projects so long as you preserve the "Made with tldraw" watermark on the canvas. To remove the watermark, you can purchase a [business license](https://tldraw.dev#pricing). Visit [tldraw.dev](https://tldraw.dev) to learn more.
-
 ## Trademarks
 
 Copyright (c) 2024-present tldraw Inc. The tldraw name and logo are trademarks of tldraw. Please see our [trademark guidelines](https://github.com/tldraw/tldraw/blob/main/TRADEMARKS.md) for info on acceptable usage.


### PR DESCRIPTION
just nix the old stuff, via https://github.com/tldraw/tldraw/issues/7567#issuecomment-3718351180

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation only.
> 
> - Removes outdated licensing/watermark sentence from `packages/tldraw/README.md` under the License section
> - No code or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 907e0a543fddfd050bb26115829cec0627e8d34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->