### PR TITLE
fix: disable dragging shapes out of toolbar when pen mode is on (tldraw #7662)

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -289,21 +289,26 @@ function useDraggableEvents(
 	const events = useMemo(() => {
 		let state = { name: 'idle' } as
 			| {
-					name: 'idle'
-			  }
+				name: 'idle'
+			}
 			| {
-					name: 'pointing'
-					screenSpaceStart: VecModel
-			  }
+				name: 'pointing'
+				screenSpaceStart: VecModel
+			}
 			| {
-					name: 'dragging'
-					screenSpaceStart: VecModel
-			  }
+				name: 'dragging'
+				screenSpaceStart: VecModel
+			}
 			| {
-					name: 'dragged'
-			  }
+				name: 'dragged'
+			}
 
 		function handlePointerDown(e: React.PointerEvent<HTMLButtonElement>) {
+			// In pen mode, ignore non-pen input for drag gestures
+			if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') {
+				return
+			}
+
 			state = {
 				name: 'pointing',
 				screenSpaceStart: { x: e.clientX, y: e.clientY },
@@ -314,6 +319,12 @@ function useDraggableEvents(
 
 		function handlePointerMove(e: React.PointerEvent<HTMLButtonElement>) {
 			if ((e as any).isSpecialRedispatchedEvent) return
+
+			// In pen mode, ignore non-pen input (also catches mid-gesture mode changes)
+			if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') {
+				state = { name: 'idle' }
+				return
+			}
 
 			if (state.name === 'pointing') {
 				const distanceSq = Vec.Dist2(state.screenSpaceStart, { x: e.clientX, y: e.clientY })

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -27,3 +27,56 @@ it('ignores touch events while in pen mode', async () => {
 
 	expect(editor.getCurrentPageShapes().length).toBe(0)
 })
+
+it('should allow pen input to create shapes when pen mode is on', async () => {
+	editor.setCurrentTool('draw')
+	editor.updateInstanceState({ isPenMode: true })
+
+	// Pen input should work
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_down',
+		isPen: true,
+		pointerId: 1,
+		point: new Vec(100, 100),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		button: 0,
+		target: 'canvas',
+	})
+
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_move',
+		isPen: true,
+		pointerId: 1,
+		point: new Vec(200, 200),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		button: 0,
+		target: 'canvas',
+	})
+
+	editor.dispatch({
+		type: 'pointer',
+		name: 'pointer_up',
+		isPen: true,
+		pointerId: 1,
+		point: new Vec(200, 200),
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		button: 0,
+		target: 'canvas',
+	})
+
+	expect(editor.getCurrentPageShapes().length).toBe(1)
+})


### PR DESCRIPTION
When pen mode is enabled, non-pen input (mouse or touch) should not be able to initiate a drag from the toolbar. Only pen input should be allowed to drag shapes out of the toolbar.

This change adds a pen mode guard to the `useDraggableEvents` hook’s `handlePointerDown` function, following the same input-filtering pattern already used in `useCanvasEvents.ts`.

Click-to-select behavior is intentionally preserved — users can still click or tap to select tools while in pen mode. Only the drag-out gesture is restricted.

Fixes #7662

---

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

---

### Test plan

1. Enable pen mode
2. Attempt to drag a shape from the toolbar using mouse or touch → **drag is blocked**
3. Drag a shape from the toolbar using pen input → **drag works**
4. Click/tap a toolbar tool in pen mode → **tool is selected**
5. Disable pen mode and drag from toolbar using mouse → **drag works**

- [x] Unit tests
- [ ] End to end tests

---

### Release notes

- Fixed an issue where shapes could be dragged from the toolbar using mouse or touch input while pen mode was enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces pen-only drag gestures from the toolbar when pen mode is active.
> 
> - Adds pen-mode guard in `useDraggableEvents` (`handlePointerDown`/`handlePointerMove`) to ignore non-pen input for drag gestures
> - Resets gesture state on non-pen `pointermove` in pen mode to handle mid-gesture mode changes
> - Adds unit test `penmode.test.ts` verifying pen input can still create shapes in pen mode
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fa94b2cf051b1a2b45fdbd065f8ebe332290b52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->