### PR TITLE
fix: disable drag-out-of-toolbar for pen inputs (tldraw #7666)

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -289,19 +289,19 @@ function useDraggableEvents(
 	const events = useMemo(() => {
 		let state = { name: 'idle' } as
 			| {
-					name: 'idle'
-			  }
+				name: 'idle'
+			}
 			| {
-					name: 'pointing'
-					screenSpaceStart: VecModel
-			  }
+				name: 'pointing'
+				screenSpaceStart: VecModel
+			}
 			| {
-					name: 'dragging'
-					screenSpaceStart: VecModel
-			  }
+				name: 'dragging'
+				screenSpaceStart: VecModel
+			}
 			| {
-					name: 'dragged'
-			  }
+				name: 'dragged'
+			}
 
 		function handlePointerDown(e: React.PointerEvent<HTMLButtonElement>) {
 			state = {
@@ -314,6 +314,10 @@ function useDraggableEvents(
 
 		function handlePointerMove(e: React.PointerEvent<HTMLButtonElement>) {
 			if ((e as any).isSpecialRedispatchedEvent) return
+
+			// Disable drag-out-of-toolbar for pen inputs - pen users expect precise
+			// tap-to-select behavior and small movements during taps trigger false drags
+			if (e.pointerType === 'pen') return
 
 			if (state.name === 'pointing') {
 				const distanceSq = Vec.Dist2(state.screenSpaceStart, { x: e.clientX, y: e.clientY })


### PR DESCRIPTION
Pen users often trigger false positive drags when tapping toolbar tools due to small movements during pen input. This creates a distracting experience when trying to simply select tools with a stylus.

This adds an early return in [handlePointerMove](cci:1://file:///Users/lulu/Desktop/tldraw/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx:314:2-364:3) for pen-type inputs, disabling the drag-out-of-toolbar feature for pen while preserving it for mouse and touch users.

Fixes #7666

### Change type

- [x] `feature`

### Test plan

1. Use a pen/stylus to tap toolbar tools
2. Verify small movements during taps no longer trigger drag-out gestures
3. Verify mouse drag-out from toolbar still works
4. Verify touch drag-out from toolbar still works
5. Verify clicking to select tools works with all input types

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed false positive toolbar drags when using pen/stylus input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents unintended drags when tapping tools with a pen/stylus by skipping drag initiation for pen inputs.
> 
> - Adds `if (e.pointerType === 'pen') return` in `handlePointerMove` within `useDraggableEvents` in `TldrawUiMenuItem.tsx`
> - Mouse and touch drag-out behaviors remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad3d533c808abefc94056090e4cd43a19be49443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->