### PR TITLE
fix guest badge position

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -480,7 +480,7 @@
 }
 
 .sidebarFileListItemLabel {
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
previously
<img width="238" height="350" alt="image" src="https://github.com/user-attachments/assets/f8f4ce4f-4bbc-4097-82de-43ad7983ab79" />

now
<img width="253" height="345" alt="image" src="https://github.com/user-attachments/assets/e8a07ed4-d7c8-458b-a374-6c1491114737" />


### Change type

- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns guest badge and trailing controls in the TLA sidebar file list.
> 
> - Update `sidebar.module.css`: set `.sidebarFileListItemLabel` to `flex: 0 1 auto` (was `1 1 auto`) so the filename doesn't consume extra space, preventing overlap/misalignment with the guest badge and menu trigger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d368de54e11e6998981b83af6e88f3fe455ce5cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->