### PR TITLE
fix: allow eraser to delete shapes inside groups when starting drag

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -136,7 +136,12 @@ export class Erasing extends StateNode {
 			}
 
 			if (geometry.hitTestLineSegment(A, B, minDist)) {
-				erasing.add(editor.getOutermostSelectableShape(shape).id)
+				const outermostShape = editor.getOutermostSelectableShape(shape)
+				if (excludedShapeIds.has(outermostShape.id) && editor.getShapeParent(shape)?.id === outermostShape.id) {
+					erasing.add(shape.id)
+				} else {
+					erasing.add(outermostShape.id)
+				}
 			}
 
 			this._erasingShapeIds = [...erasing]


### PR DESCRIPTION
### Description

- fixes bug where eraser tool couldn't delete shapes inside groups when starting drag from within the group's bounds. The tool now properly erases child shapes while protecting container shapes from accidental erasure.

### Change type

fix: #7684

### Test plan

1. Create group with shapes inside
2. Start eraser drag from within group bounds
3. Verify shapes are erased during drag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves eraser behavior inside grouped or framed areas, ensuring containers aren't erased when the drag starts within them.
> 
> - In `Erasing.update()`, when a hit is detected, if the `outermostShape` is in `excludedShapeIds` and is the parent, add the child `shape.id` to `erasing`; otherwise add `outermostShape.id`.
> - Continues excluding locked shapes and respecting accel-key single-target erase behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1471601626cb1763b2e7bda4948173c49663aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->