### PR TITLE
fix: zoom-inconsistent line bend distance threshold

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -51,9 +51,12 @@ export class Pointing extends StateNode {
 			const nextPoint = maybeSnapToGrid(nudgedPoint, this.editor)
 			const points = structuredClone(this.shape.props.points)
 
+			// Convert screen pixel threshold to page pixel threshold for consistent behavior across zoom levels
+			const minDistance = MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES / this.editor.getZoomLevel()
+
 			if (
-				Vec.DistMin(endHandle, prevEndHandle, MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES) ||
-				Vec.DistMin(nextPoint, endHandle, MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES)
+				Vec.DistMin(endHandle, prevEndHandle, minDistance) ||
+				Vec.DistMin(nextPoint, endHandle, minDistance)
 			) {
 				// Don't add a new point if the distance between the last two points is too small
 				points[endHandle.id] = {


### PR DESCRIPTION
## Fix zoom-inconsistent line bend distance

- fixed inconsistent bend point placement when extending lines with shift-click at different zoom levels by converting screen pixel threshold to page pixels.

### Change type

fix: #7661

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent bend point placement when extending lines with shift-click at different zoom levels.
> 
> - In `Pointing.ts`, converts the screen-pixel threshold to page pixels by dividing `MINIMUM_DISTANCE_BETWEEN_SHIFT_CLICKED_HANDLES` by `editor.getZoomLevel()` and uses this `minDistance` in proximity checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77af7d35ee428574638bdb8c971353a4f42ee87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->