### PR TITLE
fix: properly clean up WebGL contexts in MinimapManager.close()

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -21,6 +21,39 @@ export class MinimapManager {
 
 	@bind
 	close() {
+		// Clean up WebGL resources
+		const { context } = this.gl
+
+		// Delete WebGL buffers
+		if (this.gl.selectedShapes?.buffer) {
+			context.deleteBuffer(this.gl.selectedShapes.buffer)
+		}
+		if (this.gl.unselectedShapes?.buffer) {
+			context.deleteBuffer(this.gl.unselectedShapes.buffer)
+		}
+		if (this.gl.viewport?.buffer) {
+			context.deleteBuffer(this.gl.viewport.buffer)
+		}
+		if (this.gl.collaborators?.buffer) {
+			context.deleteBuffer(this.gl.collaborators.buffer)
+		}
+
+		// Delete shaders and program
+		if (this.gl.program) {
+			context.deleteProgram(this.gl.program)
+		}
+		if (this.gl.vertexShader) {
+			context.deleteShader(this.gl.vertexShader)
+		}
+		if (this.gl.fragmentShader) {
+			context.deleteShader(this.gl.fragmentShader)
+		}
+
+		// Force context loss as final cleanup
+		const loseContextExtension = context.getExtension('WEBGL_lose_context')
+		loseContextExtension?.loseContext()
+
+		// Clean up React/DOM resources
 		return this.disposables.forEach((d) => d())
 	}
 	gl: ReturnType<typeof setupWebGl>

--- a/packages/tldraw/src/lib/ui/components/Minimap/minimap-webgl-setup.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/minimap-webgl-setup.ts
@@ -92,6 +92,9 @@ export function setupWebGl(canvas: HTMLCanvasElement | null) {
 
 	return {
 		context,
+		vertexShader,
+		fragmentShader,
+		program,
 		selectedShapes: allocateBuffer(context, 1024),
 		unselectedShapes: allocateBuffer(context, 4096),
 		viewport: allocateBuffer(context, roundedRectangleDataSize),


### PR DESCRIPTION
### Description


- fixed minimap WebGL context leak when switching documents. Wasn't cleaning up WebGL resources properly, causing browser warnings about too many contexts.

## Change type

fix: #7688

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses WebGL resource leakage in the minimap.
> 
> - Add comprehensive cleanup in `MinimapManager.close()`: delete buffers (`selectedShapes`, `unselectedShapes`, `viewport`, `collaborators`), delete `program` and shaders, and invoke `WEBGL_lose_context.loseContext()`
> - Expose `vertexShader`, `fragmentShader`, and `program` from `minimap-webgl-setup` to enable proper disposal
> - Mitigates browser warnings and context/resource leaks when switching documents
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7656cd0e06760355fb390a4f43a8f81c3986a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->