### PR TITLE
fix(editor): correct spatial index removal for shapes moved between pages

### DIFF
--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -117,11 +117,10 @@ export class SpatialIndexManager {
 			}
 
 			// Handle updated shapes: page changes and bounds updates
-			for (const [from, to] of objectMapValues(changes.updated) as [TLShape, TLShape][]) {
+			for (const [, to] of objectMapValues(changes.updated) as [TLShape, TLShape][]) {
 				if (!isShape(to)) continue
 				processedShapeIds.add(to.id)
 
-				const wasOnPage = this.editor.getAncestorPageId(from) === this.lastPageId
 				const isOnPage = this.editor.getAncestorPageId(to) === this.lastPageId
 
 				if (isOnPage) {
@@ -129,7 +128,7 @@ export class SpatialIndexManager {
 					if (bounds) {
 						this.rbush.upsert(to.id, bounds)
 					}
-				} else if (wasOnPage) {
+				} else {
 					this.rbush.remove(to.id)
 				}
 			}


### PR DESCRIPTION
`getAncestorPageId` always fetches current shape state via `this.getShape(id)`, ignoring the passed shape object's `parentId`. When checking if a shape was previously on a page using the `from` state from a diff, it would return the current page instead of the previous page. This caused shapes moved away from the current page to remain in the spatial index incorrectly.

Simplifies the logic to just check if the shape is currently on the page - upsert if yes, remove if no. The remove is a no-op if the shape wasn't in the index.

### Change type

- [x] `bugfix`

### Test plan

1. Create shapes on page 1
2. Move some shapes to page 2
3. Verify shapes are correctly removed from page 1's spatial index

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix spatial index not removing shapes when moved to a different page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes spatial index updates so shapes moved off the current page are removed correctly.
> 
> - In `SpatialIndexManager`, updated-shape handling now only uses the `to` state: `getAncestorPageId(to)` determines if a shape is on the current page
> - If on page, `upsert` bounds; otherwise always `remove` (no reliance on previous `from` state)
> - Removes incorrect `wasOnPage` check that caused shapes moved between pages to linger in the index
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44801bfe1a87cf28f9af03ab2d3f08abcceea75a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->