### PR TITLE
fix: unused classname in frame indicator

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -333,13 +333,7 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	indicator(shape: TLFrameShape) {
-		return (
-			<rect
-				width={toDomPrecision(shape.props.w)}
-				height={toDomPrecision(shape.props.h)}
-				className={`tl-frame-indicator`}
-			/>
-		)
+		return <rect width={toDomPrecision(shape.props.w)} height={toDomPrecision(shape.props.h)} />
 	}
 
 	override providesBackgroundForChildren(): boolean {


### PR DESCRIPTION
Removes an unused CSS class `tl-frame-indicator` from the frame shape indicator. This class is referenced but never defined anywhere in the codebase, so it has no effect.

### Change type

- [x] `other`

### Test plan

1. Open the examples app
2. Create a frame shape
3. Hover or select it to see the indicator renders correctly

### Release notes

- Remove unused CSS class from frame indicator