### PR TITLE
docs: fix princing link  in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to the public monorepo for [tldraw](https://github.com/tldraw/tldraw). t
 - Read the docs and learn more at [tldraw.dev](https://tldraw.dev).
 - Learn about [our license](https://github.com/tldraw/tldraw#License).
 
-> [Click here](https://tldraw.dev/#pricing) to learn about our license and pricing.
+> [Click here](https://tldraw.dev/pricing) to learn about our license and pricing.
 
 ## Installation
 


### PR DESCRIPTION
### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

- Documentation update only.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a redirect on https://tldraw.dev/#pricing to https://tldraw.dev/pricing on the README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Update `README.md` pricing URL to `https://tldraw.dev/pricing` (from `https://tldraw.dev/#pricing`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00a05d7de6957f0dbf4d6d6dbcd349c12df1dd87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->