### PR TITLE
fix: gate Fairies menu and CSS class by server-authoritative access

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
@@ -19,6 +19,7 @@ import {
 	useAreFairiesDebugEnabled,
 	useAreFairiesEnabled,
 } from '../../../utils/local-session-state'
+import { useFairyAccess } from '../../../hooks/useFairyAccess'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import {
 	ColorThemeSubmenu,
@@ -85,11 +86,14 @@ export function TlaUserSettingsMenu() {
 }
 
 function FairiesSubmenu() {
+	const hasFairyAccess = useFairyAccess()
 	const areFairiesEnabled = useAreFairiesEnabled()
 	const areFairiesDebugEnabled = useAreFairiesDebugEnabled()
 	const fairiesLbl = useMsg(messages.fairies)
 	const enableFairiesLbl = useMsg(messages.enableFairies)
 	const debugFairiesLbl = useMsg(messages.debugFairies)
+
+	if (!hasFairyAccess) return null
 
 	return (
 		<TldrawUiMenuSubmenu id="fairies" label={fairiesLbl}>


### PR DESCRIPTION
## Summary

Fixes issue #7709 by aligning Fairies UI visibility and global CSS side effects with server-authoritative access control.

---

## Root cause

Local session state (`useAreFairiesEnabled`) was controlling permissioned UI and watermark visibility in production, instead of server-authoritative access (`useFairyAccess`).  
This allowed unauthorized users to see fairy controls and hide the watermark via a CSS side effect.



## Fix

- FairiesSubmenu now gates visibility by `useFairyAccess()`
- Introduced `FairiesClassManager` to control the `tla-fairies-enabled` root class
- The class is applied **only** when both fairy access **and** local preference are true

This ensures local session state cannot produce observable effects without access.



## Invariants restored

- Unauthorized users cannot see fairy controls
- Local state is inert without access
- Watermark visibility is unaffected for unauthorized users
- Authorized user behavior is unchanged



Fixes #7709



Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.



### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`



### Test plan

1. Sign in with a user **without** fairy access  
   - Verify Fairies submenu is not visible  
   - Verify watermark is visible  
   - Verify `tla-fairies-enabled` is not present on the root container  

2. Sign in with a user **with** fairy access  
   - Verify Fairies submenu is visible  
   - Verify local toggle works as expected  
   - Verify watermark behavior is unchanged  

- [ ] Unit tests
- [ ] End to end tests



### Release notes

- Fixed an issue where unauthorized users could see Fairies controls and hide the watermark in production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Fairies UI and CSS side effects with server-authoritative access.
> 
> - `TlaSidebarUserSettingsMenu.tsx`: `FairiesSubmenu` now renders only when `useFairyAccess()` is true
> - `TlaRootProviders.tsx`: replaces className-based `tla-fairies-enabled` toggle with `FairiesClassManager` that adds/removes the class based on both `useFairyAccess()` and `useAreFairiesEnabled()`
> - Wires `FairiesClassManager` into the container context; removes previous conditional class binding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c59ac230facc3b9b3bdd826df9511f24d9b5d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->