### PR TITLE
fix(docs): preserve details/summary tags in release changelog

### DIFF
--- a/apps/docs/scripts/lib/fetchReleases.ts
+++ b/apps/docs/scripts/lib/fetchReleases.ts
@@ -72,6 +72,8 @@ export async function fetchReleases() {
 						.replace(/<([^>]+)\/?>(?=\s|$)/g, '`<$1>`')
 						.replace(/`<image(.*) \/>`/g, '<image$1 />')
 						.replace(/`<img(.*) \/>`/g, '<img$1 />')
+						.replace(/`<(\/?)details>`/g, '<$1details>')
+						.replace(/`<(\/?)summary>`/g, '<$1summary>')
 						.replace(/\/\/>/g, '/>')
 
 					m += body


### PR DESCRIPTION
The `fetchReleases` script wraps HTML-like tags in backticks to escape them for MDX. However, this was incorrectly converting `<details>` and `<summary>` tags (and their closing counterparts) into inline code, breaking the collapsible sections in release notes on the docs site.

This PR adds regex replacements to restore these tags after the general HTML escaping, similar to how `<image>` and `<img>` tags are already handled.

### Change type

- [x] `bugfix`

### Test plan

1. Run the release fetch script to regenerate changelog content
2. Verify that `<details>` and `<summary>` tags are preserved as HTML elements, not wrapped in backticks
3. Check that collapsible sections render correctly on the docs site

### Release notes

- Fix details/summary HTML tags being incorrectly escaped in auto-generated release changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bug fix**: Preserve collapsible sections in docs release notes.
> 
> - In `fetchReleases.ts`, add regex replacements to restore backticked `details` and `summary` tags to HTML after generic tag-escaping
> - Keeps existing handling for `image`/`img` intact; no other files changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbda4e1b79dff8de35eea086579df3f81f371474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->