### PR TITLE
sdk hotfix: fix broken docs script 

### DIFF
--- a/apps/docs/scripts/lib/fetchReleases.ts
+++ b/apps/docs/scripts/lib/fetchReleases.ts
@@ -72,6 +72,8 @@ export async function fetchReleases() {
 						.replace(/<([^>]+)\/?>(?=\s|$)/g, '`<$1>`')
 						.replace(/`<image(.*) \/>`/g, '<image$1 />')
 						.replace(/`<img(.*) \/>`/g, '<img$1 />')
+						.replace(/`<(\/?)details>`/g, '<$1details>')
+						.replace(/`<(\/?)summary>`/g, '<$1summary>')
 						.replace(/\/\/>/g, '/>')
 
 					m += body


### PR DESCRIPTION
The `fetchReleases` script wraps HTML-like tags in backticks to escape them for MDX. However, this was incorrectly converting `<details>` and `<summary>` tags (and their closing counterparts) into inline code, breaking the collapsible sections in release notes on the docs site.

This PR adds regex replacements to restore these tags after the general HTML escaping, similar to how `<image>` and `<img>` tags are already handled.

### Change type

- [x] `bugfix`

### Test plan

1. Run the release fetch script to regenerate changelog content
2. Verify that `<details>` and `<summary>` tags are preserved as HTML elements, not wrapped in backticks
3. Check that collapsible sections render correctly on the docs site

### Release notes

- Fix details/summary HTML tags being incorrectly escaped in auto-generated release changelog


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes release notes generation by preserving collapsible sections.
> 
> - In `fetchReleases.ts`, adds regex replacements to restore `<details>` and `<summary>` tags after generic HTML-to-code escaping, aligning with existing handling for `<image>`/`<img>`
> - Ensures generated MDX keeps these tags as HTML so collapse/expand works on the docs site
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefb059db5edb09ed845b9811cb9fceb3d2351dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…