### PR TITLE
fix(vscode): commit vsix after publishing to avoid partial state

### DIFF
--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -81,8 +81,9 @@ async function packageAndPublish(version: string) {
 	switch (env.TLDRAW_ENV) {
 		case 'production':
 			await exec('yarn', ['package'], { pwd: EXTENSION_DIR })
-			await copyExtensionToReleaseFolder(version)
 			await exec('yarn', ['publish'], { pwd: EXTENSION_DIR })
+			// commit vsix AFTER successful publish to avoid partial state on failure
+			await copyExtensionToReleaseFolder(version)
 			return
 		case 'staging':
 			await exec('yarn', ['package', '--pre-release'], { pwd: EXTENSION_DIR })


### PR DESCRIPTION
Reorders VSCode extension publish script to commit the `.vsix` file AFTER successfully publishing to the marketplace instead of before.

Previously, if publishing failed (e.g., expired token), the commit would already exist but pushing would fail. On re-run, the action couldn't push because remote had new commits.

### Change type

- [x] `bugfix`

### Test plan

1. Trigger publish workflow
2. Verify publish happens before commit

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed VS Code extension publish workflow to avoid partial state on failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the VS Code extension publish flow to prevent partial git state on failures.
> 
> - In `packageAndPublish`, for `production`, moves `copyExtensionToReleaseFolder(version)` to run after `yarn publish` so the `.vsix` is committed only post-success
> - No changes to `staging` flow; adds an inline comment clarifying the order
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8e664b404b1a7729c1fe05ec2fe80b6ccc43e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->