### PR TITLE
perf(bindings): skip unnecessary arrow updates when translating

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -200,7 +200,7 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
     // (undocumented)
     onAfterChange({ bindingAfter }: BindingOnChangeOptions<TLArrowBinding>): void;
     // (undocumented)
-    onAfterChangeFromShape({ shapeAfter, }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
+    onAfterChangeFromShape({ shapeBefore, shapeAfter, reason, }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
     // (undocumented)
     onAfterChangeToShape({ binding, shapeBefore, shapeAfter, reason, }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
     // (undocumented)

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -58,8 +58,20 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 
 	// when the arrow itself changes
 	override onAfterChangeFromShape({
+		shapeBefore,
 		shapeAfter,
+		reason,
 	}: BindingOnShapeChangeOptions<TLArrowBinding>): void {
+		// When translating arrows together with their bound shapes, only x/y changes.
+		// In this case, bindings remain valid and no reparenting is needed.
+		// This is a significant performance optimization when moving many bound shapes.
+		if (
+			reason !== 'ancestry' &&
+			shapeBefore.parentId === shapeAfter.parentId &&
+			shapeBefore.index === shapeAfter.index
+		) {
+			return
+		}
 		arrowDidUpdate(this.editor, shapeAfter as TLArrowShape)
 	}
 


### PR DESCRIPTION
In order to improve performance when translating arrows together with their bound shapes, this PR adds an early-return check in `ArrowBindingUtil.onAfterChangeFromShape` to skip unnecessary updates.

https://github.com/user-attachments/assets/e8d3d131-33e5-4b14-b813-12e81fd8a4f6

https://github.com/user-attachments/assets/86a34211-292a-40f7-8d99-6104e800f951

Previously, `onAfterChangeFromShape` would always call `arrowDidUpdate()` which performs expensive `reparentArrow()` operations involving common ancestor lookups, sibling searches, and index recalculations. When arrows and their bound shapes are moved together, the bindings remain valid and no reparenting is needed.

This optimization mirrors the existing check in `onAfterChangeToShape`, now applied to the arrow's own changes.

### Change type

- [x] `improvement`

### Test plan

1. Create multiple shapes and connect them with arrows
2. Select all shapes and arrows together
3. Drag/translate the selection
4. Verify the arrows maintain their bindings correctly
5. Verify performance improvement when moving many connected shapes

### API changes

- Changed `ArrowBindingUtil.onAfterChangeFromShape` to use `shapeBefore` and `reason` parameters from options (internal implementation change, no breaking changes to public API)

### Release notes

- Improve performance when translating arrows together with their bound shapes