### PR TITLE
fix: remove scrollbar in kbd dialog

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1729,11 +1729,11 @@ tldraw? probably.
 	/* Terrible fix to allow firefox users to scroll the dialog */
 	overflow-x: auto;
 
-	scrollbar-width: none; 
+	scrollbar-width: none;
 }
 
 .tlui-shortcuts-dialog__body::-webkit-scrollbar {
-	display: none; 
+	display: none;
 }
 
 .tlui-shortcuts-dialog__body__tablet {


### PR DESCRIPTION
be gone with you scrollbar!

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes visible scrollbars in the keyboard shortcuts dialog while keeping Firefox scrollability.
> 
> - Adds `scrollbar-width: none` and `::-webkit-scrollbar { display: none; }` to `tlui-shortcuts-dialog__body` to hide scrollbars across browsers
> - Retains `overflow-x: auto` to preserve scrolling behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ff497f9dcbe9f2764ba722e273123f63d37df52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->