### PR TITLE
docs: fix pricing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to the public monorepo for [tldraw](https://github.com/tldraw/tldraw). t
 - Read the docs and learn more at [tldraw.dev](https://tldraw.dev).
 - Learn about [our license](https://github.com/tldraw/tldraw#License).
 
-> [Click here](https://tldraw.dev/#pricing) to learn about our license and pricing.
+> [Click here](https://tldraw.dev/pricing) to learn about our license and pricing.
 
 ## Installation
 

--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -69,13 +69,13 @@ This may not be critical to [Tldraw](?) performing correctly, however some featu
 
 ## License
 
-If you have purchased a [business license](https://tldraw.dev/#pricing), you can register your license key using the [Tldraw](?) component's `licenseKey` prop. This will disable the "Made with tldraw" link while your license is active.
+If you have purchased a [business license](https://tldraw.dev/pricing), you can register your license key using the [Tldraw](?) component's `licenseKey` prop. This will disable the "Made with tldraw" link while your license is active.
 
 ```tsx
 <Tldraw licenseKey={YOUR_LICENSE_KEY} />
 ```
 
-To learn more about the license and license key, visit [our pricing page](https://tldraw.dev/#pricing).
+To learn more about the license and license key, visit [our pricing page](https://tldraw.dev/pricing).
 
 ## Static Assets
 


### PR DESCRIPTION
fix https://github.com/tldraw/tldraw/issues/7697

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates outdated pricing links to the canonical `https://tldraw.dev/pricing`.
> 
> - Replaces `tldraw.dev/#pricing` with `tldraw.dev/pricing` in `README.md`
> - Updates pricing links in `apps/docs/content/getting-started/installation.mdx` under the License section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7af76f3e85026c4f2651b2c02fe0809e7b4740e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->