### PR TITLE
Shape alignment validation error

### DIFF
--- a/templates/agent/shared/format/convertFocusedShapeToTldrawShape.ts
+++ b/templates/agent/shared/format/convertFocusedShapeToTldrawShape.ts
@@ -485,6 +485,22 @@ function convertGeoShapeToTldrawShape(
 		fill = convertFocusedFillToTldrawFill('none')
 	}
 
+	// Handle align value - ensure we always provide a valid value
+	// During streaming, textAlign might be undefined or have invalid values temporarily
+	let align: TLGeoShape['props']['align'] = 'middle'
+
+	// Check if focusedShape.textAlign is valid
+	if (focusedShape.textAlign) {
+		// Validate it's one of the expected values
+		const validNonLegacyValues = ['start', 'middle', 'end'] as const
+		if (validNonLegacyValues.includes(focusedShape.textAlign as any)) {
+			align = focusedShape.textAlign as TLGeoShape['props']['align']
+		}
+	} else if (defaultGeoShape.props?.align) {
+		// Use the default if no valid textAlign from focusedShape
+		align = defaultGeoShape.props.align
+	}
+
 	return {
 		shape: {
 			id: shapeId,
@@ -498,7 +514,7 @@ function convertGeoShapeToTldrawShape(
 			isLocked: defaultGeoShape.isLocked ?? false,
 			opacity: defaultGeoShape.opacity ?? 1,
 			props: {
-				align: focusedShape.textAlign ?? defaultGeoShape.props?.align ?? 'middle',
+				align, // Use the validated align value
 				color: asColor(focusedShape.color ?? defaultGeoShape.props?.color ?? 'black'),
 				dash: defaultGeoShape.props?.dash ?? 'draw',
 				fill,


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

This PR fixes a validation error that occurred when streaming partial geo shapes. Previously, the `align` property could receive an invalid value if `focusedShape.textAlign` was temporarily empty or invalid during the streaming process, leading to a Tldraw error.

The fix ensures that the `align` property in `convertGeoShapeToTldrawShape` always receives a valid 'start', 'middle', or 'end' value by adding explicit validation and falling back to default values if `focusedShape.textAlign` is invalid.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1.  Start streaming a geo shape (e.g., by typing "create a red square with text" in the agent).
2.  Observe that no `align` validation errors occur during the partial shape creation.
3.  Verify that the final shape's text alignment is correctly applied.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where streaming partial geo shapes could cause a validation error due to an invalid `align` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-7351e23a-5d0d-4db2-a28f-96a168427fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7351e23a-5d0d-4db2-a28f-96a168427fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

