### PR TITLE
Shape alignment validation error

### DIFF
--- a/templates/agent/shared/format/convertFocusedShapeToTldrawShape.ts
+++ b/templates/agent/shared/format/convertFocusedShapeToTldrawShape.ts
@@ -456,6 +456,36 @@ function convertArrowShapeToTldrawShape(
 	}
 }
 
+/**
+ * Ensure we have a valid align value for geo shapes
+ */
+function getValidAlign(
+	focusedAlign: string | undefined,
+	defaultAlign: string | undefined
+): TLGeoShape['props']['align'] {
+	const validAligns: TLGeoShape['props']['align'][] = [
+		'start',
+		'middle',
+		'end',
+		'start-legacy',
+		'end-legacy',
+		'middle-legacy',
+	]
+	
+	// Check if focusedAlign is valid
+	if (focusedAlign && validAligns.includes(focusedAlign as TLGeoShape['props']['align'])) {
+		return focusedAlign as TLGeoShape['props']['align']
+	}
+	
+	// Check if defaultAlign is valid
+	if (defaultAlign && validAligns.includes(defaultAlign as TLGeoShape['props']['align'])) {
+		return defaultAlign as TLGeoShape['props']['align']
+	}
+	
+	// Return 'middle' as the safe default
+	return 'middle'
+}
+
 function convertGeoShapeToTldrawShape(
 	editor: Editor,
 	focusedShape: FocusedGeoShape,
@@ -498,7 +528,7 @@ function convertGeoShapeToTldrawShape(
 			isLocked: defaultGeoShape.isLocked ?? false,
 			opacity: defaultGeoShape.opacity ?? 1,
 			props: {
-				align: focusedShape.textAlign ?? defaultGeoShape.props?.align ?? 'middle',
+				align: getValidAlign(focusedShape.textAlign, defaultGeoShape.props?.align),
 				color: asColor(focusedShape.color ?? defaultGeoShape.props?.color ?? 'black'),
 				dash: defaultGeoShape.props?.dash ?? 'draw',
 				fill,
@@ -786,6 +816,8 @@ export function convertPartialFocusedShapeToTldrawShape(
 			shapeId: partial.shapeId ?? ('streaming-shape' as any),
 			note: partial.note ?? '',
 			color: partial.color ?? 'black',
+			// Ensure textAlign is either valid or undefined (not empty string)
+			textAlign: partial.textAlign && partial.textAlign.trim() ? partial.textAlign : undefined,
 		} as FocusedGeoShape
 		const result = convertGeoShapeToTldrawShape(editor, fullShape, { defaultShape })
 		return { shape: result.shape, bindings: null, position: { x: partial.x, y: partial.y } }


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

This PR fixes a validation error that occurred when streaming partial shapes, specifically when the `textAlign` property was an empty string or an invalid value. Previously, this could lead to an invalid `align` property on the resulting geo shape, causing runtime errors.

The fix introduces a `getValidAlign` helper function to ensure that the `align` property always receives a valid value, falling back to a default if the provided `textAlign` is invalid or empty. It also updates the partial shape conversion to properly handle empty `textAlign` strings.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1.  Create a shape (e.g., an octagon) with streaming partial updates.
2.  Observe that shapes with empty or invalid `textAlign` values no longer trigger validation errors.
3.  Verify that valid `textAlign` values are correctly applied.

- [x] Unit tests (a test script was created and run to verify valid, empty, and invalid `textAlign` values)
- [ ] End to end tests

### Release notes

- Fixed a bug where streaming partial shapes with empty or invalid `textAlign` values could cause a validation error due to an invalid `align` property. The `align` property now always defaults to a valid value.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3298079-fd24-4d52-9038-031d6ce768ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3298079-fd24-4d52-9038-031d6ce768ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

