### PR TITLE
fix: richText needs a better equality check with new msg squashing

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -9,6 +9,7 @@ import {
 	Editor,
 	TLRichText,
 	TLShapeId,
+	isEqual,
 	preventDefault,
 	useEditor,
 	useEvent,
@@ -71,7 +72,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 	useLayoutEffect(() => {
 		if (!rTextEditor.current) {
 			rInitialRichText.current = richText
-		} else if (rInitialRichText.current !== richText) {
+		} else if (!isEqual(rInitialRichText.current, richText)) {
 			rTextEditor.current.commands.setContent(richText as JSONContent)
 		}
 	}, [richText])


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/7724
the richText object in the new squashed world is different than what's in the ref.
this is a better equality check in general to have.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- fix: richText needs a better equality check with new msg squashing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves change detection for rich text updates in `RichTextArea.tsx`.
> 
> - Replaces reference comparison with `isEqual` when checking `richText` before calling `editor.commands.setContent`, ensuring correct content synchronization with TipTap
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee874ea562eb4d70ba0b6fc7e975dcd7f1f767a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->