### PR TITLE
[wip] feat(editor): add fromShape and toShape to TLShapeUtilCanBindOpts

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -4340,7 +4340,11 @@ export interface TLShapeUtilCanBeLaidOutOpts {
 // @public
 export interface TLShapeUtilCanBindOpts<Shape extends TLShape = TLShape> {
     bindingType: string;
+    fromShape: TLShape | undefined;
+    // @deprecated
     fromShapeType: TLShape['type'];
+    toShape: TLShape | undefined;
+    // @deprecated
     toShapeType: TLShape['type'];
 }
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -153,7 +153,13 @@ import { SpatialIndexManager } from './managers/SpatialIndexManager/SpatialIndex
 import { TextManager } from './managers/TextManager/TextManager'
 import { TickManager } from './managers/TickManager/TickManager'
 import { UserPreferencesManager } from './managers/UserPreferencesManager/UserPreferencesManager'
-import { ShapeUtil, TLEditStartInfo, TLGeometryOpts, TLResizeMode } from './shapes/ShapeUtil'
+import {
+	ShapeUtil,
+	TLEditStartInfo,
+	TLGeometryOpts,
+	TLResizeMode,
+	TLShapeUtilCanBindOpts,
+} from './shapes/ShapeUtil'
 import { RootState } from './tools/RootState'
 import { StateNode, TLStateNodeConstructor } from './tools/StateNode'
 import { TLContent } from './types/clipboard-types'
@@ -6245,7 +6251,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const toShapeType = typeof toShape === 'string' ? toShape : toShape.type
 		const bindingType = typeof binding === 'string' ? binding : binding.type
 
-		const canBindOpts = { fromShapeType, toShapeType, bindingType } as const
+		const fromShapeObj =
+			typeof fromShape === 'object' && 'id' in fromShape ? (fromShape as TLShape) : undefined
+		const toShapeObj =
+			typeof toShape === 'object' && 'id' in toShape ? (toShape as TLShape) : undefined
+
+		const canBindOpts: TLShapeUtilCanBindOpts = {
+			fromShape: fromShapeObj,
+			toShape: toShapeObj,
+			fromShapeType,
+			toShapeType,
+			bindingType,
+		}
 
 		if (fromShapeType === toShapeType) {
 			return this.getShapeUtil(fromShapeType).canBind(canBindOpts)

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -40,9 +40,23 @@ export interface TLShapeUtilConstructor<T extends TLShape, U extends ShapeUtil<T
  * @public
  */
 export interface TLShapeUtilCanBindOpts<Shape extends TLShape = TLShape> {
-	/** The type of shape referenced by the `fromId` of the binding. */
+	/**
+	 * The shape referenced by the `fromId` of the binding, if available.
+	 */
+	fromShape: TLShape | undefined
+	/**
+	 * The shape referenced by the `toId` of the binding, if available.
+	 */
+	toShape: TLShape | undefined
+	/**
+	 * The type of shape referenced by the `fromId` of the binding.
+	 * @deprecated Use `fromShape.type` instead when `fromShape` is available.
+	 */
 	fromShapeType: TLShape['type']
-	/** The type of shape referenced by the `toId` of the binding. */
+	/**
+	 * The type of shape referenced by the `toId` of the binding.
+	 * @deprecated Use `toShape.type` instead when `toShape` is available.
+	 */
 	toShapeType: TLShape['type']
 	/** The type of binding. */
 	bindingType: string


### PR DESCRIPTION
Closes #7748

Adds `fromShape` and `toShape` properties to `TLShapeUtilCanBindOpts`, allowing `ShapeUtil.canBind()` to access full shape objects for prop-based binding decisions. The existing `fromShapeType` and `toShapeType` properties are deprecated but preserved for backwards compatibility.

### Change type

- [x] `api`

### Test plan

1. Create a custom `ShapeUtil` with a `canBind()` override
2. Access `opts.fromShape` and `opts.toShape` to make binding decisions based on shape props
3. Verify existing code using `fromShapeType`/`toShapeType` continues to work

### API changes

- Added `TLShapeUtilCanBindOpts.fromShape: TLShape | undefined`
- Added `TLShapeUtilCanBindOpts.toShape: TLShape | undefined`
- Deprecated `TLShapeUtilCanBindOpts.fromShapeType` (use `fromShape.type` instead)
- Deprecated `TLShapeUtilCanBindOpts.toShapeType` (use `toShape.type` instead)

### Release notes

- Add `fromShape` and `toShape` to `ShapeUtil.canBind()` options, enabling prop-based binding logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API expansion: `canBind` call sites now optionally pass full `TLShape` objects, which could affect custom `canBind` overrides only if they assume the old opts shape. Core binding logic is otherwise unchanged and legacy `fromShapeType`/`toShapeType` remain for compatibility.
> 
> **Overview**
> Extends the public `TLShapeUtilCanBindOpts` passed to `ShapeUtil.canBind()` to include optional `fromShape` and `toShape` objects, enabling binding decisions based on shape props.
> 
> Updates `Editor.canBindShapes()` to populate these new fields when full shape objects are provided, while keeping `fromShapeType`/`toShapeType` (now deprecated) for backwards compatibility and updating the API report accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b1d76ab6cb48d7c54050864b2c1f173b9138797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->