### PR TITLE
fix: zoomToFit and getCurrentPageBounds now ignore hidden shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3072,7 +3072,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	zoomToFit(opts?: TLCameraMoveOptions): this {
-		const ids = [...this.getCurrentPageShapeIds()]
+		const ids = [...this.getCurrentPageShapeIds()].filter((id) => !this.isShapeHidden(id))
 		if (ids.length <= 0) return this
 		const pageBounds = Box.Common(compact(ids.map((id) => this.getShapePageBounds(id))))
 		this.zoomToBounds(pageBounds, opts)
@@ -5010,6 +5010,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let commonBounds: Box | undefined
 
 		this.getCurrentPageShapeIdsSorted().forEach((shapeId) => {
+			if (this.isShapeHidden(shapeId)) return
 			const bounds = this.getShapeMaskedPageBounds(shapeId)
 			if (!bounds) return
 			if (!commonBounds) {

--- a/packages/tldraw/src/test/commands/zoomToFit.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToFit.test.ts
@@ -1,3 +1,4 @@
+import { createShapeId } from '@tldraw/editor'
 import { TestEditor, createDefaultShapes } from '../TestEditor'
 
 let editor: TestEditor
@@ -25,4 +26,60 @@ it('is ignored by undo/redo', () => {
 	const camera = editor.getCamera()
 	editor.undo()
 	expect(editor.getCamera()).toBe(camera)
+})
+
+it('ignores hidden shapes', () => {
+	// Create a new editor with getShapeVisibility
+	const editorWithHidden = new TestEditor({
+		getShapeVisibility: (shape) => {
+			return shape.meta.hidden ? 'hidden' : 'inherit'
+		},
+	})
+
+	// Create three shapes: two visible and one hidden
+	const visibleShape1 = createShapeId('visible1')
+	const hiddenShape = createShapeId('hidden')
+	const visibleShape2 = createShapeId('visible2')
+
+	editorWithHidden.createShapes([
+		{
+			id: visibleShape1,
+			type: 'geo',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+		{
+			id: hiddenShape,
+			type: 'geo',
+			x: 1000,
+			y: 1000,
+			props: { w: 100, h: 100 },
+			meta: { hidden: true },
+		},
+		{
+			id: visibleShape2,
+			type: 'geo',
+			x: 200,
+			y: 200,
+			props: { w: 100, h: 100 },
+		},
+	])
+
+	// Verify the hidden shape is actually hidden
+	expect(editorWithHidden.isShapeHidden(hiddenShape)).toBe(true)
+	expect(editorWithHidden.isShapeHidden(visibleShape1)).toBe(false)
+	expect(editorWithHidden.isShapeHidden(visibleShape2)).toBe(false)
+
+	// Zoom to fit should only consider visible shapes
+	editorWithHidden.zoomToFit()
+
+	// Get the current page bounds - it should only include visible shapes
+	const pageBounds = editorWithHidden.getCurrentPageBounds()
+	expect(pageBounds).toBeDefined()
+
+	// The bounds should not include the hidden shape at (1000, 1000)
+	// It should only include shapes at (0, 0) and (200, 200)
+	expect(pageBounds!.maxX).toBeLessThan(1000)
+	expect(pageBounds!.maxY).toBeLessThan(1000)
 })


### PR DESCRIPTION
- Filter out hidden shapes in zoomToFit before computing bounds
- Skip hidden shapes when computing getCurrentPageBounds
- Add test to verify hidden shapes are properly ignored

Fixes #6818

🤖 Generated with [Claude Code](https://claude.ai/code)

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized logic changes to bounds calculations plus a targeted unit test; behavior only changes when shapes are marked hidden.
> 
> **Overview**
> **Hidden shapes no longer affect camera fitting or page bounds.** `zoomToFit` now filters out hidden shape ids before computing bounds, and `getCurrentPageBounds` skips hidden shapes when expanding the common bounds.
> 
> Adds a unit test ensuring `zoomToFit`/`getCurrentPageBounds` ignore a shape reported as hidden via `getShapeVisibility`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b03d950e764040a766002c38c5422df7b2c8ab1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->