### PR TITLE
chore(sync): increase rate limit from 300 to 600 requests per minute

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -486,7 +486,7 @@ export class TLDrawDurableObject extends DurableObject {
 
 				const rateLimitTimer = this.timer()
 				if (auth?.userId) {
-					const rateLimited = await isRateLimited(this.env, auth?.userId)
+					const rateLimited = await isRateLimited(this.env, auth.userId)
 					if (rateLimited) {
 						this.logEvent({
 							type: 'client',

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -346,25 +346,25 @@ binding = "CF_VERSION_METADATA"
 name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1001"
-simple = { limit = 300, period = 60 }
+simple = { limit = 600, period = 60 }
 
 [[env.preview.unsafe.bindings]]
 name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1002"
-simple = { limit = 300, period = 60 }
+simple = { limit = 600, period = 60 }
 
 [[env.staging.unsafe.bindings]]
 name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1003"
-simple = { limit = 300, period = 60 }
+simple = { limit = 600, period = 60 }
 
 [[env.production.unsafe.bindings]]
 name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1004"
-simple = { limit = 300, period = 60 }
+simple = { limit = 600, period = 60 }
 
 #################### Queues ####################
 [[env.dev.queues.producers]]


### PR DESCRIPTION
Increases the rate limit for the sync worker from 300 to 600 requests per 60-second period across all environments (dev, preview, staging, production).

Also removes an unnecessary optional chain in `TLDrawDurableObject.ts` where `auth.userId` is already confirmed to be truthy.

### Change type

- [x] `improvement`

### Test plan

1. Deploy to staging
2. Verify rate limiting still works but allows more requests

### Release notes

- Increased connection rate limit to reduce false positives for active users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts rate-limiting thresholds in a production-facing sync service, which can increase load and reduce abuse protection if mis-tuned. Code change is small but impacts traffic behavior across all environments.
> 
> **Overview**
> **Doubles the sync-worker rate limit** by updating the `RATE_LIMITER` binding in `wrangler.toml` from 300 to 600 requests per 60 seconds for `dev`, `preview`, `staging`, and `production`.
> 
> Also makes a tiny safety/clarity tweak in `TLDrawDurableObject.ts` by removing an unnecessary optional chain when calling `isRateLimited` after `auth.userId` is already confirmed present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3657bec1c52de36f92dff27520ab515fa1658d7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->