### PR TITLE
chore(sync): disable rate limiting

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/rateLimit.ts
+++ b/apps/dotcom/sync-worker/src/utils/rateLimit.ts
@@ -1,6 +1,8 @@
 import { Environment } from '../types'
 
-export async function isRateLimited(env: Environment, key: string): Promise<boolean> {
-	const { success } = await env.RATE_LIMITER.limit({ key })
-	return !success
+export async function isRateLimited(_env: Environment, _key: string): Promise<boolean> {
+	// TODO: rate limiting is broken in cloudflare, disabled for now
+	// const { success } = await env.RATE_LIMITER.limit({ key })
+	// return !success
+	return false
 }


### PR DESCRIPTION
Cloudflare rate limiting is broken. This disables it temporarily by making `isRateLimited` always return `false`.

Original code is commented out for easy restoration.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging
2. Verify sync connections work without rate limit errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables rate limiting across sync-worker entry points, which can increase load and abuse risk until re-enabled. The change is simple and easy to revert, but impacts production traffic control.
> 
> **Overview**
> **Temporarily disables sync-worker rate limiting.** `isRateLimited` no longer calls `env.RATE_LIMITER.limit` and instead always returns `false`, with the original implementation commented out for later restoration.
> 
> This effectively bypasses rate-limit enforcement in call sites (e.g., websocket/session flows and `submitFeedback`) to avoid Cloudflare rate-limit failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 301450699961b239b0df8d6c33ff15934844ae39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->