### PR TITLE
docs(examples): expand and refine keywords in example READMEs

### DIFF
--- a/apps/examples/src/examples/action-overrides/README.md
+++ b/apps/examples/src/examples/action-overrides/README.md
@@ -3,7 +3,18 @@ title: Custom actions
 component: ./ActionOverridesExample.tsx
 category: ui
 priority: 3
-keywords: [keyboard, shortcut, copy, paste, group, align]
+keywords:
+  [
+    actions,
+    overrides,
+    keyboard shortcuts,
+    kbd,
+    custom actions,
+    useactions,
+    helpers,
+    addtoast,
+    tluiactionitem,
+  ]
 ---
 
 Customize and override tldraw's actions.

--- a/apps/examples/src/examples/add-tool-to-toolbar/README.md
+++ b/apps/examples/src/examples/add-tool-to-toolbar/README.md
@@ -3,7 +3,19 @@ title: Add a tool to the toolbar
 component: ./ToolInToolbarExample.tsx
 category: ui
 priority: 0
-keyword: [override, custom, icon]
+keywords:
+  [
+    custom tool,
+    toolbar,
+    icon,
+    asset urls,
+    keyboard shortcuts dialog,
+    defaulttoolbar,
+    tldrawuimenuitem,
+    useistoolselected,
+    usetools,
+    components,
+  ]
 ---
 
 Add your custom tool to the toolbar.

--- a/apps/examples/src/examples/after-create-update-shape/README.md
+++ b/apps/examples/src/examples/after-create-update-shape/README.md
@@ -3,7 +3,16 @@ title: After create/update shape
 component: ./AfterCreateUpdateShapeExample.tsx
 category: events
 priority: 5
-keywords: [handler, register, side effects, records]
+keywords:
+  [
+    side effects,
+    registeraftercreatehandler,
+    registerafterchangehandler,
+    lifecycle,
+    hooks,
+    shape creation,
+    shape update,
+  ]
 ---
 
 Register a handler to run after shapes are created or updated.

--- a/apps/examples/src/examples/after-delete-shape/README.md
+++ b/apps/examples/src/examples/after-delete-shape/README.md
@@ -3,7 +3,16 @@ title: After delete shape
 component: ./AfterDeleteShapeExample.tsx
 category: events
 priority: 5
-keywords: [handler, register, side effects, records]
+keywords:
+  [
+    side effects,
+    registerafterdeletehandler,
+    lifecycle,
+    hooks,
+    shape deletion,
+    frames,
+    parent shapes,
+  ]
 ---
 
 Register a handler to run after shapes are deleted.

--- a/apps/examples/src/examples/ag-grid-shape/README.md
+++ b/apps/examples/src/examples/ag-grid-shape/README.md
@@ -2,7 +2,19 @@
 title: Data grid shape
 component: ./DataGridExample.tsx
 category: shapes/tools
-keywords: [data grid ag grid]
+keywords:
+  [
+    custom shape,
+    shapeutil,
+    baseboxshapeutil,
+    ag grid,
+    data grid,
+    table,
+    spreadsheet,
+    canedit,
+    canscroll,
+    usedelaysvgexport,
+  ]
 priority: 5
 ---
 

--- a/apps/examples/src/examples/align-and-distribute-shapes/README.md
+++ b/apps/examples/src/examples/align-and-distribute-shapes/README.md
@@ -3,7 +3,18 @@ title: Align and distribute shapes
 component: ./AlignAndDistributeShapesExample.tsx
 category: editor-api
 priority: 3
-keywords: [align, distribute, layout, position, arrange]
+keywords:
+  [
+    align,
+    distribute,
+    alignshapes,
+    distributeshapes,
+    layout,
+    position,
+    arrange,
+    horizontal,
+    vertical,
+  ]
 ---
 
 Align and distribute shapes using the editor's built-in methods.

--- a/apps/examples/src/examples/api/README.md
+++ b/apps/examples/src/examples/api/README.md
@@ -3,7 +3,7 @@ title: Controlling the canvas
 component: ./APIExample.tsx
 category: editor-api
 priority: 0
-keywords: [api, create shape, update shape, mount, context]
+keywords: [editor api, createshapes, updateshape, rotateshapesby, zoomtofit, select, useeditor, onmount, setstyle, context]
 ---
 
 Manipulate the contents of the canvas using the editor API.

--- a/apps/examples/src/examples/arrow-binding-options/README.md
+++ b/apps/examples/src/examples/arrow-binding-options/README.md
@@ -3,7 +3,17 @@ title: Arrow binding options
 component: ./ArrowBindingOptionsExample.tsx
 category: shapes/tools
 priority: 3
-keywords: [arrow, binding, precise, exact, anchor, snap]
+keywords:
+  [
+    arrow,
+    binding,
+    isprecise,
+    isexact,
+    normalizedanchor,
+    anchor point,
+    arrow connections,
+    technical diagrams,
+  ]
 ---
 
 Demonstrate arrow binding options for precise positioning.

--- a/apps/examples/src/examples/arrows-precise-exact/README.md
+++ b/apps/examples/src/examples/arrows-precise-exact/README.md
@@ -3,7 +3,8 @@ title: Precise exact arrows
 component: ./ArrowsPreciseExactExample.tsx
 category: configuration
 priority: 5
-keywords: [arrow, configure, isPrecise, isExact]
+keywords:
+  [arrow, configure, isprecise, isexact, arrow behavior, arrowshapeutil, arrow tool, alt key]
 ---
 
 Make arrows adopt "isExact" behavior instead of "isPrecise".

--- a/apps/examples/src/examples/asset-props/README.md
+++ b/apps/examples/src/examples/asset-props/README.md
@@ -3,7 +3,18 @@ title: Asset options
 component: ./AssetPropsExample.tsx
 category: configuration
 priority: 1
-keywords: [images, videos, gif, dimensions, accepted image types]
+keywords:
+  [
+    assets,
+    images,
+    videos,
+    upload,
+    acceptedimagetypes,
+    acceptedvideotypes,
+    maxassetsize,
+    maximagesize,
+    maximagedimension,
+  ]
 ---
 
 Control the assets (images, videos, etc.) that can be added to the canvas.

--- a/apps/examples/src/examples/basic/README.md
+++ b/apps/examples/src/examples/basic/README.md
@@ -3,7 +3,18 @@ title: Tldraw component
 component: ./BasicExample.tsx
 category: getting-started
 priority: 0
-keywords: [basic, intro, simple, quick, start, hello world, installation]
+keywords:
+  [
+    basic,
+    getting started,
+    intro,
+    simple,
+    quick start,
+    hello world,
+    installation,
+    first app,
+    tldraw component,
+  ]
 ---
 
 The simplest way to use the `Tldraw` component.

--- a/apps/examples/src/examples/before-create-update-shape/README.md
+++ b/apps/examples/src/examples/before-create-update-shape/README.md
@@ -3,7 +3,17 @@ title: Before create/update shape
 component: ./BeforeCreateUpdateShapeExample.tsx
 category: events
 priority: 4
-keywords: [handler, register, side effects, records]
+keywords:
+  [
+    side effects,
+    registerbeforecreatehandler,
+    registerbeforechangehandler,
+    intercept,
+    validation,
+    lifecycle,
+    hooks,
+    shape creation,
+  ]
 ---
 
 Register a handler to run before shapes are created or updated.

--- a/apps/examples/src/examples/before-delete-shape/README.md
+++ b/apps/examples/src/examples/before-delete-shape/README.md
@@ -3,7 +3,16 @@ title: Before delete shape
 component: ./BeforeDeleteShapeExample.tsx
 category: events
 priority: 4
-keywords: [handler, register, side effects, records]
+keywords:
+  [
+    side effects,
+    registerbeforedeletehandler,
+    intercept,
+    prevent deletion,
+    lifecycle,
+    hooks,
+    validation,
+  ]
 ---
 
 Register a handler to run before shapes are deleted.

--- a/apps/examples/src/examples/bounds-snapping-shape/README.md
+++ b/apps/examples/src/examples/bounds-snapping-shape/README.md
@@ -3,7 +3,17 @@ title: Custom snapping
 component: ./BoundsSnappingShape.tsx
 category: shapes/tools
 priority: 3
-keywords: [geometry, custom]
+keywords:
+  [
+    snapping,
+    snap mode,
+    bounds snapping,
+    custom snapping,
+    getboundssnappinggeometry,
+    geometry,
+    custom shape,
+    playing cards,
+  ]
 ---
 
 Custom shapes with special bounds snapping behaviour.

--- a/apps/examples/src/examples/camera-options/README.md
+++ b/apps/examples/src/examples/camera-options/README.md
@@ -3,7 +3,18 @@ title: Camera options
 component: ./CameraOptionsExample.tsx
 category: configuration
 priority: 0.5
-keywords: [api, fixed, constraints, camera bounds, pan speed, zoom speed]
+keywords:
+  [
+    camera,
+    cameraoptions,
+    zoom constraints,
+    pan constraints,
+    camera bounds,
+    zoom speed,
+    pan speed,
+    viewport,
+    isfixed,
+  ]
 ---
 
 Configure the camera's options and constraints.

--- a/apps/examples/src/examples/canvas-events/README.md
+++ b/apps/examples/src/examples/canvas-events/README.md
@@ -3,7 +3,18 @@ title: Canvas events
 component: ./CanvasEventsExample.tsx
 category: events
 priority: 1
-keywords: [cursor, pointer, mouse, click, keyboard, handler, input]
+keywords:
+  [
+    events,
+    pointer events,
+    mouse events,
+    click,
+    keyboard events,
+    canvas events,
+    event listeners,
+    oncanvasmove,
+    oncanvasclick,
+  ]
 ---
 
 Listen to events from tldraw's canvas.

--- a/apps/examples/src/examples/changing-default-colors/README.md
+++ b/apps/examples/src/examples/changing-default-colors/README.md
@@ -3,7 +3,18 @@ title: Change default colors
 component: ./ChangingDefaultColorsExample.tsx
 category: ui
 priority: 0.5
-keywords: [colours, styles, palette, style panel]
+keywords:
+  [
+    colors,
+    colours,
+    theme,
+    palette,
+    style panel,
+    defaultcolorstyle,
+    color values,
+    theming,
+    customization,
+  ]
 ---
 
 Change the tldraw theme colors.

--- a/apps/examples/src/examples/changing-default-style/README.md
+++ b/apps/examples/src/examples/changing-default-style/README.md
@@ -3,7 +3,7 @@ title: Change default styles
 component: ./ChangingDefaultStyleExample.tsx
 category: ui
 priority: 0.5
-keywords: [size, styles, default]
+keywords: [styles, default style, style props, size, color, dash, fill, setdefaultvalue]
 ---
 
 Change the default value for a style prop.

--- a/apps/examples/src/examples/configure-shape-util/README.md
+++ b/apps/examples/src/examples/configure-shape-util/README.md
@@ -3,7 +3,16 @@ title: Shape options
 component: ./ConfigureShapeUtilExample.tsx
 category: configuration
 priority: 0
-keywords: [config, configure, shape, util, frame]
+keywords:
+  [
+    configure,
+    shapeutil,
+    shape options,
+    noteshapeoptions,
+    frameshapeoptions,
+    builtin shapes,
+    customization,
+  ]
 ---
 
 Change the behavior of built-in shapes by setting their options.

--- a/apps/examples/src/examples/contextual-toolbar/README.md
+++ b/apps/examples/src/examples/contextual-toolbar/README.md
@@ -3,7 +3,16 @@ title: Contextual toolbar
 component: ./ContextualToolbarExample.tsx
 category: ui
 priority: 2
-keywords: [in front of the canvas, contextual]
+keywords:
+  [
+    contextual toolbar,
+    infrontofthecanvas,
+    selection,
+    ui overlay,
+    custom ui,
+    toolbar,
+    selected shapes,
+  ]
 ---
 
 Show a contextual toolbar above shapes when they are selected.

--- a/apps/examples/src/examples/coordinate-system/README.md
+++ b/apps/examples/src/examples/coordinate-system/README.md
@@ -13,6 +13,11 @@ keywords:
     getViewportPageBounds,
     viewport,
     transformation,
+    screen space,
+    page space,
+    dom positioning,
+    overlay,
+    camera,
   ]
 ---
 

--- a/apps/examples/src/examples/create-arrow/README.md
+++ b/apps/examples/src/examples/create-arrow/README.md
@@ -3,7 +3,19 @@ title: Create an arrow
 component: ./CreateArrowExample.tsx
 category: editor-api
 priority: 1
-keywords: [arrow, between]
+keywords:
+  [
+    arrow,
+    createShape,
+    createBindings,
+    binding,
+    connection,
+    normalizedAnchor,
+    isPrecise,
+    isExact,
+    terminal,
+    programmatic creation,
+  ]
 ---
 
 Create an arrow between two shapes.

--- a/apps/examples/src/examples/cubic-bezier-shape/README.md
+++ b/apps/examples/src/examples/cubic-bezier-shape/README.md
@@ -3,7 +3,20 @@ title: Cubic bezier curve shape
 component: ./CubicBezierShapeExample.tsx
 category: shapes/tools
 priority: 1
-keywords: [shape, util, handles, geometry, pen]
+keywords:
+  [
+    bezier,
+    curve,
+    handles,
+    control points,
+    shapeutil,
+    custom tool,
+    draggable,
+    editing mode,
+    statenode,
+    getHandles,
+    onHandleDrag,
+  ]
 ---
 
 A custom shape with interactive bezier curve editing.

--- a/apps/examples/src/examples/custom-clipping-shape/README.md
+++ b/apps/examples/src/examples/custom-clipping-shape/README.md
@@ -3,7 +3,18 @@ title: Custom clipping shape
 component: ./CustomClippingExample.tsx
 category: editor-api
 priority: 1
-keywords: [clipping, shape]
+keywords:
+  [
+    clipping,
+    clip path,
+    mask,
+    getClipPath,
+    shouldClipChild,
+    polygon,
+    children,
+    parent-child,
+    circular,
+  ]
 ---
 
 # Custom clipping shape example

--- a/apps/examples/src/examples/custom-components/README.md
+++ b/apps/examples/src/examples/custom-components/README.md
@@ -5,30 +5,22 @@ category: ui
 priority: 2
 keywords:
   [
-    custom,
+    components,
     Background,
-    SvgDefs,
     Brush,
-    ZoomBrush,
-    ShapeIndicator,
-    Cursor,
-    Canvas,
-    CollaboratorBrush,
-    CollaboratorCursor,
-    CollaboratorHint,
-    CollaboratorShapeIndicator,
-    Grid,
     Scribble,
-    CollaboratorScribble,
     SnapIndicator,
     Handles,
-    Handle,
-    Spinner,
+    Canvas,
+    Grid,
+    Cursor,
+    ShapeIndicator,
     SelectionForeground,
     SelectionBackground,
     OnTheCanvas,
     InFrontOfTheCanvas,
-    LoadingScreen,
+    custom ui,
+    override,
   ]
 ---
 

--- a/apps/examples/src/examples/custom-config/README.md
+++ b/apps/examples/src/examples/custom-config/README.md
@@ -2,7 +2,19 @@
 title: Custom shape and tool
 component: ./CustomConfigExample.tsx
 category: shapes/tools
-keywords: [toolbar, migrations, icon, util, ui overrides, card shape]
+keywords:
+  [
+    shapeutils,
+    tools,
+    toolbar,
+    custom tool,
+    custom shape,
+    icon,
+    overrides,
+    card,
+    statenode,
+    keyboard shortcut,
+  ]
 priority: 1
 ---
 

--- a/apps/examples/src/examples/custom-double-click-behavior/README.md
+++ b/apps/examples/src/examples/custom-double-click-behavior/README.md
@@ -3,7 +3,18 @@ title: Custom double-click behavior
 component: ./CustomDoubleClickBehaviorExample.tsx
 category: events
 priority: 4
-keywords: [double click, runtime override, state node, select tool, custom behavior]
+keywords:
+  [
+    double click,
+    override,
+    statenode,
+    select tool,
+    method replacement,
+    handleDoubleClickOnCanvas,
+    getStateDescendant,
+    runtime,
+    idle state,
+  ]
 ---
 
 Override the default double-click behavior by replacing the SelectTool's Idle state method at runtime.

--- a/apps/examples/src/examples/custom-embed/README.md
+++ b/apps/examples/src/examples/custom-embed/README.md
@@ -3,7 +3,17 @@ title: Custom embeds
 component: ./CustomEmbedExample.tsx
 category: configuration
 priority: 2
-keywords: [embed, custom]
+keywords:
+  [
+    embed,
+    iframe,
+    CustomEmbedDefinition,
+    DEFAULT_EMBED_DEFINITIONS,
+    toEmbedUrl,
+    fromEmbedUrl,
+    jsfiddle,
+    url parsing,
+  ]
 ---
 
 Allow custom embeds.

--- a/apps/examples/src/examples/custom-error-capture/README.md
+++ b/apps/examples/src/examples/custom-error-capture/README.md
@@ -3,7 +3,17 @@ title: Custom error capture
 component: ./CustomErrorCaptureExample.tsx
 category: ui
 priority: 3
-keywords: [error, fallback, capture, sentry, boundary, crash]
+keywords:
+  [
+    error,
+    ErrorFallback,
+    error boundary,
+    crash handling,
+    getErrorAnnotations,
+    sentry,
+    debugging,
+    error tracking,
+  ]
 ---
 
 Customize the error screen that appears when the editor crashes.

--- a/apps/examples/src/examples/custom-grid/README.md
+++ b/apps/examples/src/examples/custom-grid/README.md
@@ -3,7 +3,17 @@ title: Custom grid
 component: ./CustomGridExample.tsx
 category: ui
 priority: 2
-keywords: [grid, background, ui, layout]
+keywords:
+  [
+    grid,
+    canvas,
+    2d context,
+    Grid component,
+    getViewportPageBounds,
+    devicePixelRatio,
+    camera,
+    custom rendering,
+  ]
 ---
 
 Draw a custom grid on the canvas.

--- a/apps/examples/src/examples/custom-language-translations/README.md
+++ b/apps/examples/src/examples/custom-language-translations/README.md
@@ -3,7 +3,18 @@ title: Custom translations and overrides
 component: ./CustomLanguageTranslationExample.tsx
 category: ui
 priority: 70
-keywords: [translation, i18n, localization, language, custom, override, useTranslation]
+keywords:
+  [
+    translation,
+    i18n,
+    localization,
+    language,
+    useTranslation,
+    overrides,
+    multilingual,
+    custom text,
+    brand voice,
+  ]
 ---
 
 Customize tldraw's translation strings and use them in custom components.

--- a/apps/examples/src/examples/custom-menus/README.md
+++ b/apps/examples/src/examples/custom-menus/README.md
@@ -3,7 +3,22 @@ title: Changing menus
 component: ./CustomMenusExample.tsx
 category: ui
 priority: 0.5
-keywords: [menu, context menu, toolbar, main menu, page menu, panel]
+keywords:
+  [
+    menu,
+    toolbar,
+    context menu,
+    main menu,
+    page menu,
+    ActionsMenu,
+    DebugMenu,
+    HelpMenu,
+    StylePanel,
+    QuickActions,
+    ZoomMenu,
+    components,
+    TldrawUiMenuItem,
+  ]
 ---
 
 Customize tldraw's menus, including the toolbar, main menu, context menu, page menu, and more.

--- a/apps/examples/src/examples/custom-options/README.md
+++ b/apps/examples/src/examples/custom-options/README.md
@@ -3,6 +3,7 @@ title: Editor options
 component: ./CustomOptionsExample.tsx
 category: configuration
 priority: 0
+keywords: [options, configuration, pages, animation, camera]
 ---
 
 Override default editor options like max number of pages and animation speed.

--- a/apps/examples/src/examples/custom-paste/README.md
+++ b/apps/examples/src/examples/custom-paste/README.md
@@ -3,6 +3,7 @@ title: Custom paste behavior
 component: ./CustomPasteExample.tsx
 category: data/assets
 priority: 3
+keywords: [paste, clipboard, external content, handler]
 ---
 
 Change how pasting works by registering an external content handler.

--- a/apps/examples/src/examples/custom-relative-snapping/README.md
+++ b/apps/examples/src/examples/custom-relative-snapping/README.md
@@ -3,7 +3,18 @@ title: Custom handle snap reference
 component: ./CustomRelativeSnappingExample.tsx
 category: shapes/tools
 priority: 2
-keywords: [handles, snapping, snap reference]
+keywords:
+  [
+    handles,
+    snapping,
+    snapReferenceHandleId,
+    angle snapping,
+    shift modifier,
+    getHandles,
+    control points,
+    vertex,
+    reference point,
+  ]
 ---
 
 An example demonstrating `snapReferenceHandleId` for control point angle snapping.

--- a/apps/examples/src/examples/custom-renderer/README.md
+++ b/apps/examples/src/examples/custom-renderer/README.md
@@ -2,7 +2,16 @@
 title: Custom renderer
 component: ./CustomRendererExample.tsx
 category: ui
-keywords: [html, canvas, background, context]
+keywords:
+  [
+    renderer,
+    canvas,
+    Background component,
+    Canvas component,
+    custom rendering,
+    2d context,
+    alternative rendering,
+  ]
 priority: 100
 ---
 

--- a/apps/examples/src/examples/custom-shape-wrapper/README.md
+++ b/apps/examples/src/examples/custom-shape-wrapper/README.md
@@ -2,6 +2,20 @@
 title: Custom shape wrapper
 component: ./CustomShapeWrapperExample.tsx
 category: shapes/tools
+keywords:
+  [
+    ShapeWrapper,
+    DefaultShapeWrapper,
+    wrapper,
+    dom,
+    class names,
+    styling,
+    css,
+    atom,
+    useValue,
+    forwardRef,
+    components,
+  ]
 ---
 
 Customize the wrapper used for each shape in the DOM.

--- a/apps/examples/src/examples/custom-shape/README.md
+++ b/apps/examples/src/examples/custom-shape/README.md
@@ -3,7 +3,19 @@ title: Custom shape
 component: ./CustomShapeExample.tsx
 category: shapes/tools
 priority: 0
-keywords: [util]
+keywords:
+  [
+    shapeutil,
+    custom shape,
+    getGeometry,
+    component,
+    indicator,
+    HTMLContainer,
+    Rectangle2d,
+    getDefaultProps,
+    props,
+    validator,
+  ]
 ---
 
 A simple custom shape.

--- a/apps/examples/src/examples/custom-stroke-and-font-sizes/README.md
+++ b/apps/examples/src/examples/custom-stroke-and-font-sizes/README.md
@@ -3,7 +3,8 @@ title: Custom stroke and font sizes
 component: ./CustomStrokeAndFontSizes.tsx
 category: configuration
 priority: 2
-keywords: [stroke, font, size, style]
+keywords:
+  [stroke, font, size, STROKE_SIZES, FONT_SIZES, style, configuration, constants, global settings]
 ---
 
 Customize the available stroke and font sizes in tldraw.

--- a/apps/examples/src/examples/custom-text-outline/README.md
+++ b/apps/examples/src/examples/custom-text-outline/README.md
@@ -3,6 +3,19 @@ title: Custom text outline
 component: ./CustomTextOutlineExample.tsx
 category: configuration
 priority: 1
+keywords:
+  [
+    text,
+    outline,
+    showTextOutline,
+    configure,
+    TextShapeUtil,
+    ArrowShapeUtil,
+    GeoShapeUtil,
+    label,
+    performance,
+    styling,
+  ]
 ---
 
 Disable text outlines on text and arrow labels.

--- a/apps/examples/src/examples/custom-tool/README.md
+++ b/apps/examples/src/examples/custom-tool/README.md
@@ -3,7 +3,8 @@ title: Custom tool (sticker)
 component: ./CustomToolExample.tsx
 category: shapes/tools
 priority: 0
-keywords: [state, machine, chart, node, sticker]
+keywords:
+  [statenode, tool, pointer events, onpointerdown, onenter, cursor, createshape, state machine]
 ---
 
 A simple custom tool.

--- a/apps/examples/src/examples/custom-ui/README.md
+++ b/apps/examples/src/examples/custom-ui/README.md
@@ -3,7 +3,8 @@ title: Replace the entire UI
 component: ./CustomUiExample.tsx
 category: ui
 priority: 1.5
-keywords: [hide, ui, event listener]
+keywords:
+  [hideui, custom ui, keyboard shortcuts, setcurrenttool, track, useeditor, toolbar, buttons]
 ---
 
 Replace tldraw's UI with your own.

--- a/apps/examples/src/examples/custom-validators/README.md
+++ b/apps/examples/src/examples/custom-validators/README.md
@@ -3,7 +3,18 @@ title: Custom validators for shape props
 component: ./CustomValidatorsExample.tsx
 category: shapes/tools
 priority: 4
-keywords: [validation, validators, check, refine, constraints, props, custom, shape]
+keywords:
+  [
+    validation,
+    validators,
+    check,
+    refine,
+    constraints,
+    props,
+    shapeutil,
+    recordprops,
+    error handling,
+  ]
 ---
 
 Demonstrates using custom validators with `.check()` and `.refine()` methods to add validation constraints to shape props.

--- a/apps/examples/src/examples/dark-mode-toggle/README.md
+++ b/apps/examples/src/examples/dark-mode-toggle/README.md
@@ -3,7 +3,16 @@ title: Toggle dark mode
 component: ./DarkModeToggleExample.tsx
 category: ui
 priority: 4
-keywords: [theme, dark mode]
+keywords:
+  [
+    theme,
+    dark mode,
+    light mode,
+    colorscheme,
+    user preferences,
+    updateuserpreferences,
+    getisdarkmode,
+  ]
 ---
 
 Toggle dark mode.

--- a/apps/examples/src/examples/deep-links/README.md
+++ b/apps/examples/src/examples/deep-links/README.md
@@ -3,7 +3,17 @@ title: Deep links
 component: ./DeepLinksExample.tsx
 category: configuration
 priority: 4
-keywords: [basic, intro, simple, quick, start]
+keywords:
+  [
+    deep links,
+    url,
+    navigation,
+    viewport,
+    search params,
+    createdeeplink,
+    navigatetodeeplink,
+    routing,
+  ]
 ---
 
 Allow linking to specific parts of a tldraw canvas.

--- a/apps/examples/src/examples/derived-view/README.md
+++ b/apps/examples/src/examples/derived-view/README.md
@@ -3,7 +3,8 @@ title: Derived view
 component: ./DerivedViewExample.tsx
 category: events
 priority: 6
-keywords: [basic, intro, simple, quick, start]
+keywords:
+  [computed, incremental, derivation, performance, store history, diffsince, reactive, usevalue]
 ---
 
 Derive data from the editor's document in an efficient way.

--- a/apps/examples/src/examples/disable-pages/README.md
+++ b/apps/examples/src/examples/disable-pages/README.md
@@ -3,7 +3,7 @@ title: Disable pages
 component: ./DisablePagesExample.tsx
 category: configuration
 priority: 10
-keywords: [basic, intro, simple, quick, start, page]
+keywords: [maxpages, single page, options, page selector, configuration]
 ---
 
 Disabling page-related UI for single-page use cases.

--- a/apps/examples/src/examples/drag-and-drop-tray/README.md
+++ b/apps/examples/src/examples/drag-and-drop-tray/README.md
@@ -3,6 +3,7 @@ title: Drag and drop tray
 component: ./DragAndDropTrayExample.tsx
 category: ui
 priority: 2
+keywords: [drag, drop, tray, shapes, InFrontOfTheCanvas]
 ---
 
 Create a drag and drop tray to create shapes on the canvas.

--- a/apps/examples/src/examples/drag-and-drop/README.md
+++ b/apps/examples/src/examples/drag-and-drop/README.md
@@ -3,7 +3,8 @@ title: Drag and drop shape
 component: ./DragAndDropExample.tsx
 category: shapes/tools
 priority: 5
-keywords: [reparent, shapes, grid, counter]
+keywords:
+  [reparent, ondragshapesin, ondragshapesout, parent, children, shape hierarchy, reparentshapes]
 ---
 
 Custom shapes that can be dragged and dropped onto each other.

--- a/apps/examples/src/examples/dynamic-tools/README.md
+++ b/apps/examples/src/examples/dynamic-tools/README.md
@@ -3,7 +3,8 @@ title: Dynamic tools with setTool and removeTool
 component: ./DynamicToolsExample.tsx
 category: editor-api
 priority: 2
-keywords: [setTool, removeTool, dynamic, tools, state chart, toolbar]
+keywords:
+  [settool, removetool, dynamic tools, runtime, conditional, permissions, feature flags, toolbar]
 ---
 
 Dynamically add and remove tools from the editor and toolbar after initialization.

--- a/apps/examples/src/examples/easter-egg-styles/README.md
+++ b/apps/examples/src/examples/easter-egg-styles/README.md
@@ -3,7 +3,8 @@ title: Easter egg styles
 component: ./EasterEggStylesExample.tsx
 category: editor-api
 priority: 5
-keywords: [easter egg, white color, fill styles, labelColor, hidden features]
+keywords:
+  [easter egg, white color, fill, lined-fill, labelcolor, scale, hidden styles, keyboard shortcuts]
 ---
 
 Use tldraw's collection of easter egg styles programmatically.

--- a/apps/examples/src/examples/editable-shape/README.md
+++ b/apps/examples/src/examples/editable-shape/README.md
@@ -3,7 +3,7 @@ title: Editable custom shape
 component: ./EditableShapeExample.tsx
 category: shapes/tools
 priority: 2
-keywords: [custom]
+keywords: [editing, canedit, double click, interactive, emoji picker, shape state, editing state]
 ---
 
 A custom shape that you can edit by double-clicking it.

--- a/apps/examples/src/examples/editor-focus/README.md
+++ b/apps/examples/src/examples/editor-focus/README.md
@@ -3,7 +3,7 @@ title: Focus the editor
 component: ./EditorFocusExample.tsx
 category: editor-api
 priority: 2
-keywords: [instance, state, keyboard shortcuts]
+keywords: [focus, blur, autofocus, keyboard shortcuts, multiple editors, scrolling, instance state]
 ---
 
 Manually manage the editor's focus to enable or disable keyboard shortcuts.

--- a/apps/examples/src/examples/education-canvas/README.md
+++ b/apps/examples/src/examples/education-canvas/README.md
@@ -3,7 +3,19 @@ title: Education canvas
 component: ./EducationCanvasExample.tsx
 category: use-cases
 priority: 1
-keywords: [education, math, geometry, GCSE, teaching, learning, canvas, fixed camera]
+keywords:
+  [
+    education,
+    math,
+    geometry,
+    gcse,
+    teaching,
+    learning,
+    camera constraints,
+    grid,
+    split layout,
+    worksheet,
+  ]
 ---
 
 An educational application template with a math question on the left and a drawing canvas on the right.

--- a/apps/examples/src/examples/environment-detection/README.md
+++ b/apps/examples/src/examples/environment-detection/README.md
@@ -3,7 +3,18 @@ title: Environment detection with tlenv and tlenvReactive
 component: ./EnvironmentDetectionExample.tsx
 category: configuration
 priority: 2
-keywords: [tlenv, tlenvReactive, environment, platform, browser, pointer, touch, mobile]
+keywords:
+  [
+    tlenv,
+    tlenvreactive,
+    platform detection,
+    browser,
+    iscoarsepointer,
+    touch,
+    mobile,
+    adaptive ui,
+    usevalue,
+  ]
 ---
 
 Detect platform, browser, and input device type.

--- a/apps/examples/src/examples/error-boundary/README.md
+++ b/apps/examples/src/examples/error-boundary/README.md
@@ -3,7 +3,8 @@ title: Error boundary
 component: ./ErrorBoundaryExample.tsx
 category: ui
 priority: 2
-keywords: [shape]
+keywords:
+  [error handling, shapeerrorfallback, error boundary, components, crash recovery, fallback ui]
 ---
 
 Customize the error fallback that appears when a shape throws an error.

--- a/apps/examples/src/examples/event-blocker/README.md
+++ b/apps/examples/src/examples/event-blocker/README.md
@@ -3,14 +3,7 @@ title: Block events
 component: ./EventBlockerExample.tsx
 category: events
 priority: 2
-keywords:
-  - event
-  - block
-  - propagation
-  - stop
-  - no
-  - select
-  - user-select
+keywords: [event, block, propagation, stop, select, user-select]
 ---
 
 Stop events from reaching the canvas.

--- a/apps/examples/src/examples/exam-marking/README.md
+++ b/apps/examples/src/examples/exam-marking/README.md
@@ -3,7 +3,7 @@ title: Mark exams
 component: ./ExamMarkingExample.tsx
 category: use-cases
 priority: 4
-keywords: [education, pdf, annotation, toolbar, util, ui overrides]
+keywords: [education, pdf, annotation, marking, scoring, grading, toolbar, ui overrides, widget]
 ---
 
 A tool for marking exams. It includes common pdf annotation tools, as well as a built in tool for marking individual questions and tallying the total score of the exam.

--- a/apps/examples/src/examples/exploded/README.md
+++ b/apps/examples/src/examples/exploded/README.md
@@ -3,7 +3,17 @@ title: Sublibraries
 component: ./ExplodedExample.tsx
 category: configuration
 priority: 100
-keywords: [ui, components, utils]
+keywords:
+  [
+    tldraweditor,
+    tldrawui,
+    sublibraries,
+    modular,
+    architecture,
+    defaultshapeutils,
+    defaulttools,
+    components,
+  ]
 ---
 
 Tldraw is built from several sublibraries - like the editor, default shapes & tools, and UI.

--- a/apps/examples/src/examples/export-canvas-as-image/README.md
+++ b/apps/examples/src/examples/export-canvas-as-image/README.md
@@ -3,7 +3,7 @@ title: Export canvas as image
 component: ./ExportCanvasImageExample.tsx
 category: data/assets
 priority: 2
-keywords: [basic, assets, svg, png, blob]
+keywords: [export, toimage, download, png, svg, blob, screenshot, canvas export, sharepanel]
 ---
 
 Export the entire canvas as an image file.

--- a/apps/examples/src/examples/export-canvas-settings/README.md
+++ b/apps/examples/src/examples/export-canvas-settings/README.md
@@ -3,7 +3,22 @@ title: Export canvas as image (with settings)
 component: ./ExportCanvasImageSettingsExample.tsx
 category: data/assets
 priority: 2
-keywords: [basic, assets, svg, png, blob, image, settings]
+keywords:
+  [
+    toimage,
+    export,
+    download,
+    png,
+    svg,
+    blob,
+    background,
+    padding,
+    scale,
+    darkmode,
+    bounds,
+    box,
+    tlimageexportoptions,
+  ]
 ---
 
 Export the entire canvas as an image file, with configurable settings.

--- a/apps/examples/src/examples/external-content-sources/README.md
+++ b/apps/examples/src/examples/external-content-sources/README.md
@@ -3,7 +3,19 @@ title: External content sources
 component: ./ExternalContentSourcesExample.tsx
 category: data/assets
 priority: 3
-keywords: [copy, paste, html]
+keywords:
+  [
+    paste,
+    copy,
+    clipboard,
+    html,
+    registerexternalcontenthandler,
+    text content,
+    custom shape,
+    baseboxshapeutil,
+    htmlcontainer,
+    dangerouslysetinnerhtml,
+  ]
 ---
 
 Handle different types of content when pasting into tldraw.

--- a/apps/examples/src/examples/external-dialog/README.md
+++ b/apps/examples/src/examples/external-dialog/README.md
@@ -3,7 +3,7 @@ title: External dialog
 component: ./ExternalDialog.tsx
 category: layout
 priority: 20
-keywords: [css]
+keywords: [dialog, modal, css, styling, custom styles, embed, insert]
 ---
 
 Make dialogs open outside of the `Tldraw` component.

--- a/apps/examples/src/examples/external-ui-context/README.md
+++ b/apps/examples/src/examples/external-ui-context/README.md
@@ -3,7 +3,20 @@ title: External UI (using context)
 component: ./ExternalUiContextExample.tsx
 category: layout
 priority: 20
-keywords: [outside, editor, context]
+keywords:
+  [
+    custom ui,
+    toolbar,
+    buttons,
+    context,
+    createcontext,
+    usecontext,
+    onmount,
+    getcurrenttoolid,
+    setcurrenttool,
+    getstylefornextshape,
+    setstylefornextshapes,
+  ]
 ---
 
 This example shows how to control the tldraw editor from an external UI, using React context.

--- a/apps/examples/src/examples/external-ui/README.md
+++ b/apps/examples/src/examples/external-ui/README.md
@@ -3,7 +3,20 @@ title: External UI (using state)
 component: ./ExternalUiExample.tsx
 category: layout
 priority: 20
-keywords: [outside, editor]
+keywords:
+  [
+    custom ui,
+    toolbar,
+    buttons,
+    state,
+    usestate,
+    onmount,
+    getcurrenttoolid,
+    setcurrenttool,
+    getstylefornextshape,
+    setstylefornextshapes,
+    usevalue,
+  ]
 ---
 
 This example shows how to control the tldraw editor from an external UI, using state.

--- a/apps/examples/src/examples/floaty-window/README.md
+++ b/apps/examples/src/examples/floaty-window/README.md
@@ -4,6 +4,19 @@ hide: true
 component: ./FloatyExample.tsx
 category: ui
 priority: 30
+keywords:
+  [
+    camera,
+    setcamera,
+    window position,
+    screenx,
+    screeny,
+    screenleft,
+    screentop,
+    tick event,
+    vec,
+    usecontainer,
+  ]
 ---
 
 Create an illusion of a floating window.

--- a/apps/examples/src/examples/focus-mode/README.md
+++ b/apps/examples/src/examples/focus-mode/README.md
@@ -3,7 +3,7 @@ title: Toggle focus mode
 component: ./FocusModeExample.tsx
 category: editor-api
 priority: 3
-keywords: [focus, mode, editor, state, instance]
+keywords: [focus mode, isfocusmode, updateinstancestate, distraction free, hide ui, onmount]
 ---
 
 How to enable focus mode by using the editor API.

--- a/apps/examples/src/examples/fog-of-war/README.md
+++ b/apps/examples/src/examples/fog-of-war/README.md
@@ -2,7 +2,18 @@
 title: Fog of war
 component: ./FogOfWarExample.tsx
 category: use-cases
-keywords: [ui, fog, overlay]
+keywords:
+  [
+    canvas,
+    overlay,
+    infrontofthecanvas,
+    html canvas,
+    usereactor,
+    getcurrentpageshapes,
+    getshapepagebounds,
+    getshapegeometry,
+    collision detection,
+  ]
 priority: 3
 ---
 

--- a/apps/examples/src/examples/force-mobile/README.md
+++ b/apps/examples/src/examples/force-mobile/README.md
@@ -3,7 +3,7 @@ title: Force mobile layout
 component: ./ForceBreakpointExample
 category: ui
 priority: 4
-keywords: [force, mobile, breakpoint]
+keywords: [mobile, responsive, breakpoint, forcemobile, layout, ui layout]
 ---
 
 Force the editor UI to render as if it were on a mobile device.

--- a/apps/examples/src/examples/frame-colors/README.md
+++ b/apps/examples/src/examples/frame-colors/README.md
@@ -3,9 +3,7 @@ title: Frame colors
 component: ./FrameColorsExample.tsx
 category: configuration
 priority: 5
-keywords:
-  - frame
-  - color
+keywords: [frame, colors, configure, frameshapeutil, showcolors, shapeutils]
 ---
 
 Use the `showColors` option to display colored fills and headings on frame shapes.

--- a/apps/examples/src/examples/globs-editor/README.md
+++ b/apps/examples/src/examples/globs-editor/README.md
@@ -2,7 +2,19 @@
 title: Globs
 component: ./GlobsExample.tsx
 category: shapes/tools
-keywords: []
+keywords:
+  [
+    custom shape,
+    custom tool,
+    bindings,
+    bindingutil,
+    handles,
+    custom handles,
+    statenode,
+    vector editor,
+    bezier,
+    tension handles,
+  ]
 ---
 
 A globs based vector editor, based on the https://jcgt.org/published/0004/03/01/paper-lowres.pdf paper.

--- a/apps/examples/src/examples/hide-ui/README.md
+++ b/apps/examples/src/examples/hide-ui/README.md
@@ -3,7 +3,7 @@ title: Hide the entire UI
 component: ./HideUiExample.tsx
 category: ui
 priority: 1.5
-keywords: []
+keywords: [hideui, bare editor, minimal, custom ui, headless]
 ---
 
 Hide tldraw's UI with the `hideUi` prop.

--- a/apps/examples/src/examples/hosted-images/README.md
+++ b/apps/examples/src/examples/hosted-images/README.md
@@ -3,7 +3,19 @@ title: Hosted images
 component: ./HostedImagesExample.tsx
 category: data/assets
 priority: 2
-keywords: [assets, video, image, png, jpg, file]
+keywords:
+  [
+    upload,
+    images,
+    assets,
+    tlassetstore,
+    file upload,
+    asset handling,
+    resolve,
+    fetch,
+    storage,
+    hosting,
+  ]
 ---
 
 How to handle images uploaded by the user.

--- a/apps/examples/src/examples/image-annotator/README.md
+++ b/apps/examples/src/examples/image-annotator/README.md
@@ -3,7 +3,20 @@ title: Image annotator
 component: ./ImageAnnotatorExample.tsx
 category: use-cases
 priority: 1
-keywords: [annotation, camera options, constraints, zoom, pan, camera bounds, pan speed, zoom speed]
+keywords:
+  [
+    annotation,
+    image annotation,
+    cameraoptions,
+    constraints,
+    zoom,
+    pan,
+    bounds,
+    panspeed,
+    zoomspeed,
+    zoomsteps,
+    image editor,
+  ]
 ---
 
 An image annotator built with tldraw.

--- a/apps/examples/src/examples/image-component/README.md
+++ b/apps/examples/src/examples/image-component/README.md
@@ -3,7 +3,19 @@ title: Snapshot image component
 component: ./TldrawImageExample.tsx
 category: layout
 priority: 20
-keywords: [snapshot, export]
+keywords:
+  [
+    tldrawimage,
+    snapshot,
+    display snapshot,
+    read only,
+    getsnapshot,
+    store snapshot,
+    tlstoresnapshot,
+    format,
+    svg,
+    png,
+  ]
 ---
 
 Display a tldraw snapshot as an image by using the `TldrawImage` component.

--- a/apps/examples/src/examples/indicators-logic/README.md
+++ b/apps/examples/src/examples/indicators-logic/README.md
@@ -3,7 +3,17 @@ title: Custom indicators
 component: ./IndicatorsLogicExample.tsx
 category: ui
 priority: 3
-keywords: [indicators]
+keywords:
+  [
+    indicators,
+    shapeindicator,
+    onthecanvas,
+    getrenderingshapes,
+    useeditorcomponents,
+    defaultshapeindicators,
+    showall,
+    hideall,
+  ]
 ---
 
 Change when indicators are shown and how they appear.

--- a/apps/examples/src/examples/infer-dark-mode/README.md
+++ b/apps/examples/src/examples/infer-dark-mode/README.md
@@ -3,7 +3,7 @@ title: Infer dark mode
 component: ./InferDarkModeExample.tsx
 category: ui
 priority: 4
-keywords: [props]
+keywords: [dark mode, theme, inferdarkmode, system preferences, color scheme]
 ---
 
 Infer dark mode based on system preferences.

--- a/apps/examples/src/examples/inline-behavior/README.md
+++ b/apps/examples/src/examples/inline-behavior/README.md
@@ -3,7 +3,20 @@ title: Inset editor (common practices)
 component: ./InlineBehavior.tsx
 category: layout
 priority: 0.5
-keywords: [focus, blur, multiple]
+keywords:
+  [
+    inline,
+    embedded,
+    focus,
+    blur,
+    multiple editors,
+    autofocus,
+    hand tool,
+    edge scrolling,
+    edgescrollspeed,
+    maxpages,
+    context,
+  ]
 ---
 
 Common practices for using the `Tldraw` component as a block within a larger page.

--- a/apps/examples/src/examples/inline/README.md
+++ b/apps/examples/src/examples/inline/README.md
@@ -3,7 +3,7 @@ title: Inset editor (fixed sizes)
 component: ./InlineExample.tsx
 category: layout
 priority: 0
-keywords: [focus, auto, focus, multiple, editors]
+keywords: [inline, embedded, fixed size, width, height, responsive, multiple editors]
 ---
 
 Use the `Tldraw` component with a set height and width.

--- a/apps/examples/src/examples/inset-canvas/README.md
+++ b/apps/examples/src/examples/inset-canvas/README.md
@@ -3,7 +3,7 @@ title: Inset canvas
 component: ./InsetCanvasExample.tsx
 category: layout
 priority: 1
-keywords: []
+keywords: [canvas position, inset, css, custom layout, canvas offset]
 ---
 
 Handling events when the canvas is inset within the editor.

--- a/apps/examples/src/examples/inset/README.md
+++ b/apps/examples/src/examples/inset/README.md
@@ -3,7 +3,7 @@ title: Inset editor
 component: ./InsetExample.tsx
 category: layout
 priority: 0
-keywords: [inline]
+keywords: [inline, embedded, non-fullscreen, layout, container, positioning, inset, wrapper]
 ---
 
 Using the tldraw component in a non-fullscreen layout.

--- a/apps/examples/src/examples/inspector-panel/README.md
+++ b/apps/examples/src/examples/inspector-panel/README.md
@@ -2,7 +2,20 @@
 title: Inspector panel
 component: ./InspectorPanelExample.tsx
 category: ui
-keywords: [inspector, properties, props, selection, panel]
+keywords:
+  [
+    inspector,
+    properties,
+    props,
+    selection,
+    panel,
+    debug,
+    usevalue,
+    bindings,
+    shared styles,
+    getselectedshapes,
+    getbindingsinvolvingshape,
+  ]
 ---
 
 Display an inspector panel that shows the properties of the currently selected shape.

--- a/apps/examples/src/examples/interaction-end-callback/README.md
+++ b/apps/examples/src/examples/interaction-end-callback/README.md
@@ -3,7 +3,19 @@ title: Interaction end callback
 component: ./InteractionEndExample.tsx
 category: editor-api
 priority: 4
-keywords: [callback, interaction, drag, resize, rotate, tool]
+keywords:
+  [
+    callback,
+    interaction,
+    drag,
+    resize,
+    rotate,
+    tool,
+    oninteractionend,
+    translating,
+    setcurrenttool,
+    programmatic,
+  ]
 ---
 
 Control behavior after dragging, resizing, or rotating shapes.

--- a/apps/examples/src/examples/interactive-shape/README.md
+++ b/apps/examples/src/examples/interactive-shape/README.md
@@ -3,7 +3,20 @@ title: Clickable custom shape
 component: ./InteractiveShapeExample.tsx
 category: shapes/tools
 priority: 2
-keywords: [interaction, pointer events, stop propagation, click, input]
+keywords:
+  [
+    interaction,
+    pointer events,
+    stop propagation,
+    click,
+    input,
+    button,
+    checkbox,
+    todo,
+    html,
+    custom shape,
+    onclick,
+  ]
 ---
 
 A custom shape that has its own onClick interactions.

--- a/apps/examples/src/examples/keyboard-shortcuts/README.md
+++ b/apps/examples/src/examples/keyboard-shortcuts/README.md
@@ -3,7 +3,7 @@ title: Custom keyboard shortcuts
 component: ./KeyboardShortcutsExample.tsx
 category: ui
 priority: 3
-keywords: [dialog, overrides, actions, tools]
+keywords: [shortcuts, hotkeys, keybindings, kbd, overrides, actions, tools, customize]
 ---
 
 Replace tldraw's default keyboard shortcuts with your own.

--- a/apps/examples/src/examples/lasso-select-tool/README.md
+++ b/apps/examples/src/examples/lasso-select-tool/README.md
@@ -4,7 +4,19 @@ component: ./LassoSelectToolExample.tsx
 category: editor-api
 priority: 3
 keywords:
-  [tools, state machine, custom tool, selection, lasso, overlays, editor atom, freehand drawing]
+  [
+    lasso,
+    selection,
+    freehand,
+    overlays,
+    custom tool,
+    state machine,
+    atom,
+    statenode,
+    getstrokepoints,
+    getsupathfromstrokepoints,
+    usevalue,
+  ]
 ---
 
 Add a lasso select tool to tldraw.

--- a/apps/examples/src/examples/layer-panel/README.md
+++ b/apps/examples/src/examples/layer-panel/README.md
@@ -3,7 +3,20 @@ title: Layer panel
 component: ./LayerPanelExample.tsx
 category: ui
 priority: 5
-keywords: []
+keywords:
+  [
+    layers,
+    panel,
+    tree view,
+    hierarchy,
+    visibility,
+    show,
+    hide,
+    getsortedchildidsforparent,
+    getshapevisibility,
+    meta,
+    infrontofthecanvas,
+  ]
 ---
 
 Implementing a minimal layers panel for tldraw.

--- a/apps/examples/src/examples/layout-bindings/README.md
+++ b/apps/examples/src/examples/layout-bindings/README.md
@@ -2,7 +2,22 @@
 title: Layout constraints (bindings)
 component: ./LayoutExample.tsx
 category: shapes/tools
-keywords: [constraints, group, shape, custom, bindings, drag, drop, position]
+keywords:
+  [
+    bindings,
+    constraints,
+    layout,
+    position,
+    container,
+    drag,
+    drop,
+    bindingutil,
+    ontranslate,
+    ontranslatestart,
+    ontranslateend,
+    relationships,
+    custom binding,
+  ]
 priority: 10
 ---
 

--- a/apps/examples/src/examples/local-images/README.md
+++ b/apps/examples/src/examples/local-images/README.md
@@ -3,7 +3,7 @@ title: Create an image shape
 component: ./LocalImagesExample.tsx
 category: editor-api
 priority: 2
-keywords: [asset, record, create asset]
+keywords: [image, asset, assetrecordtype, createassets, local, static, png, jpg, imageshape]
 ---
 
 Create an image shape using a local asset.

--- a/apps/examples/src/examples/local-storage/README.md
+++ b/apps/examples/src/examples/local-storage/README.md
@@ -3,7 +3,19 @@ title: Persist to storage
 component: ./LocalStorageExample.tsx
 category: data/assets
 priority: 0
-keywords: [store, snapshot, debounce]
+keywords:
+  [
+    persistence,
+    localstorage,
+    save,
+    load,
+    snapshot,
+    getsnapshot,
+    loadsnapshot,
+    createtlstore,
+    store.listen,
+    throttle,
+  ]
 ---
 
 Manually persist the contents of the editor to storage.

--- a/apps/examples/src/examples/local-videos/README.md
+++ b/apps/examples/src/examples/local-videos/README.md
@@ -3,7 +3,7 @@ title: Create a video shape
 component: ./LocalVideosExample.tsx
 category: editor-api
 priority: 2
-keywords: [asset, video]
+keywords: [video, asset, assetrecordtype, createassets, local, static, mp4, videoshape]
 ---
 
 Create a video shape using a local asset.

--- a/apps/examples/src/examples/lock-camera-zoom/README.md
+++ b/apps/examples/src/examples/lock-camera-zoom/README.md
@@ -3,7 +3,18 @@ title: Lock camera zoom
 component: ./LockCameraZoomExample.tsx
 category: editor-api
 priority: 2
-keywords: [camera, lock, zoom]
+keywords:
+  [
+    camera,
+    zoom,
+    lock,
+    setcameraoptions,
+    zoomsteps,
+    getzoomlevel,
+    getcameraoptions,
+    viewport,
+    fixed zoom,
+  ]
 ---
 
 Lock the camera at a specific zoom level.

--- a/apps/examples/src/examples/locked-shapes/README.md
+++ b/apps/examples/src/examples/locked-shapes/README.md
@@ -3,7 +3,20 @@ title: Locked shapes
 component: ./LockedShapesExample.tsx
 category: editor-api
 priority: 3
-keywords: [lock, unlock, locked, isLocked, ignoreShapeLock, template, background]
+keywords:
+  [
+    lock,
+    unlock,
+    locked,
+    islocked,
+    ignoreshapelock,
+    template,
+    background,
+    togglelock,
+    editor.run,
+    programmatic,
+    read-only,
+  ]
 ---
 
 Lock shapes to prevent user editing, and use `ignoreShapeLock` to modify them programmatically.

--- a/apps/examples/src/examples/mask-window/README.md
+++ b/apps/examples/src/examples/mask-window/README.md
@@ -2,7 +2,18 @@
 title: Canvas mask
 component: ./MaskWindowExample.tsx
 category: use-cases
-keywords: [mask, window, clip]
+keywords:
+  [
+    mask,
+    clip,
+    clippath,
+    overlay,
+    selection bounds,
+    getselectionrotatedscreenbounds,
+    usequickreactor,
+    css,
+    viewport,
+  ]
 priority: 2
 ---
 

--- a/apps/examples/src/examples/menu-system-hover/README.md
+++ b/apps/examples/src/examples/menu-system-hover/README.md
@@ -3,7 +3,19 @@ title: Menu system hover
 component: ./MenuSystemHoverExample.tsx
 category: ui
 priority: 1
-keywords: [menu, hover, dropdown, programmatic, control]
+keywords:
+  [
+    menu,
+    hover,
+    dropdown,
+    programmatic,
+    control,
+    editor.menus,
+    addopenmenu,
+    deleteopenmenu,
+    usemenuisopen,
+    ui,
+  ]
 ---
 
 Programmatically control dropdown menus via hover interactions using the editor's menu tracking API.

--- a/apps/examples/src/examples/meta-migrations/README.md
+++ b/apps/examples/src/examples/meta-migrations/README.md
@@ -3,7 +3,17 @@ title: Meta migrations
 component: ./MetaMigrations.tsx
 category: data/assets
 priority: 6
-keywords: [records, snapshot, sequence]
+keywords:
+  [
+    migrations,
+    meta,
+    schema,
+    createmigrationids,
+    createmigrationsequence,
+    versioning,
+    upgrade,
+    snapshot,
+  ]
 ---
 
 Create custom migrations for `meta` properties.

--- a/apps/examples/src/examples/meta-on-change/README.md
+++ b/apps/examples/src/examples/meta-on-change/README.md
@@ -3,7 +3,18 @@ title: Shape meta (on change)
 component: ./OnChangeShapeMetaExample.tsx
 category: events
 priority: 7
-keywords: [side, effects, register, change, initial]
+keywords:
+  [
+    meta,
+    metadata,
+    side effects,
+    registerbeforechangehandler,
+    getinitialmeta,
+    onchange,
+    tracking,
+    audit,
+    custom data,
+  ]
 ---
 
 Add custom metadata to shapes when they're changed.

--- a/apps/examples/src/examples/meta-on-create/README.md
+++ b/apps/examples/src/examples/meta-on-create/README.md
@@ -3,7 +3,7 @@ title: Shape meta (on create)
 component: ./OnCreateShapeMetaExample.tsx
 category: events
 priority: 7
-keywords: [side, effects, initial, meta, register]
+keywords: [meta, metadata, getinitialmeta, getinitialmeta for shape, oncreate, custom data, track]
 ---
 
 Add custom metadata to shapes when they're created.

--- a/apps/examples/src/examples/multiple/README.md
+++ b/apps/examples/src/examples/multiple/README.md
@@ -3,7 +3,7 @@ title: Multiple editors
 component: ./MultipleExample.tsx
 category: layout
 priority: 2
-keywords: [multiple, focus]
+keywords: [multiple editors, focus, autofocus, blur, context, shared document, persistencekey, sync]
 ---
 
 Use multiple `<Tldraw/>` components on the same page.

--- a/apps/examples/src/examples/only-editor/README.md
+++ b/apps/examples/src/examples/only-editor/README.md
@@ -3,7 +3,8 @@ title: Minimal
 component: ./OnlyEditorExample.tsx
 category: configuration
 priority: 100
-keywords: [select, tool, editor, bare, bones]
+keywords:
+  [tldraweditor, minimal, bare bones, custom ui, no ui, headless, shapeutils, tools, statenodeonly]
 ---
 
 Use the `<TldrawEditor/>` component to render a bare-bones editor with minimal built-in shapes and tools.

--- a/apps/examples/src/examples/outlined-text/README.md
+++ b/apps/examples/src/examples/outlined-text/README.md
@@ -3,7 +3,17 @@ title: Outlined text example
 component: ./OutlinedTextExample.tsx
 category: shapes/tools
 priority: 21
-keywords: [text, outline, stroke, extension, toolbar, styling]
+keywords:
+  [
+    tiptap,
+    text styling,
+    text stroke,
+    custom extension,
+    rich text toolbar,
+    mark,
+    css styling,
+    text effects,
+  ]
 ---
 
 Add outlined text styling to the TipTap text editor with a custom extension.

--- a/apps/examples/src/examples/pdf-editor/README.md
+++ b/apps/examples/src/examples/pdf-editor/README.md
@@ -4,7 +4,19 @@ component: ./PdfEditorExample.tsx
 category: use-cases
 priority: 1
 keywords:
-  [annotation, camera options, constraints, zoom, pan, camera bounds, pan speed, zoom speed, scroll]
+  [
+    pdf,
+    annotation,
+    camera options,
+    constraints,
+    zoom,
+    pan,
+    camera bounds,
+    pan speed,
+    zoom speed,
+    scroll,
+    document viewer,
+  ]
 ---
 
 A very basic PDF editor built with tldraw.

--- a/apps/examples/src/examples/permissions-2/README.md
+++ b/apps/examples/src/examples/permissions-2/README.md
@@ -3,7 +3,19 @@ title: Permissions 2
 component: ./PermissionsExample2.tsx
 category: events
 priority: 5
-keywords: [constraints, bounds, side effects, permissions, clamping]
+keywords:
+  [
+    constraints,
+    bounds,
+    side effects,
+    permissions,
+    clamping,
+    registerbeforechangehandler,
+    movement restriction,
+    bounded region,
+    shape geometry,
+    resize constraint,
+  ]
 ---
 
 A second example of how to use side effect APIs to constrain shape movement within a bounding box.

--- a/apps/examples/src/examples/permissions/README.md
+++ b/apps/examples/src/examples/permissions/README.md
@@ -3,7 +3,19 @@ title: Permissions
 component: ./PermissionsExample.tsx
 category: events
 priority: 5
-keywords: [constraints, bounds, side effects, permissions, clamping]
+keywords:
+  [
+    constraints,
+    bounds,
+    side effects,
+    permissions,
+    clamping,
+    registerbeforechangehandler,
+    movement restriction,
+    bounded region,
+    shape geometry,
+    svgcontainer,
+  ]
 ---
 
 Use side effect APIs to constrain shape movement within a bounding box.

--- a/apps/examples/src/examples/persistence-key/README.md
+++ b/apps/examples/src/examples/persistence-key/README.md
@@ -3,7 +3,8 @@ title: Persistence key
 component: ./PersistenceKeyExample.tsx
 category: configuration
 priority: 1
-keywords: [local storage]
+keywords:
+  [persistence, local storage, save state, persistencekey, indexeddb, session storage, auto save]
 ---
 
 Persist the editor's content between sessions by using a persistence key.

--- a/apps/examples/src/examples/pin-bindings/README.md
+++ b/apps/examples/src/examples/pin-bindings/README.md
@@ -2,7 +2,20 @@
 title: Pin (bindings)
 component: ./PinExample.tsx
 category: shapes/tools
-keywords: []
+keywords:
+  [
+    bindings,
+    bindingutil,
+    custom binding,
+    relationships,
+    connections,
+    network,
+    custom tool,
+    statenode,
+    onafterchangetoshape,
+    shape relationships,
+    pin together,
+  ]
 priority: 10
 ---
 

--- a/apps/examples/src/examples/popup-shape/README.md
+++ b/apps/examples/src/examples/popup-shape/README.md
@@ -2,7 +2,19 @@
 title: Popup shape
 component: ./PopupShapeExample.tsx
 category: shapes/tools
-keywords: [dynamic shadows, css]
+keywords:
+  [
+    3d effect,
+    css transform,
+    perspective,
+    shadows,
+    animation,
+    interaction,
+    double click,
+    htmlcontainer,
+    transform origin,
+    visual effects,
+  ]
 priority: 100
 ---
 

--- a/apps/examples/src/examples/prevent-instance-change/README.md
+++ b/apps/examples/src/examples/prevent-instance-change/README.md
@@ -3,7 +3,17 @@ title: Prevent instance changes
 component: ./PreventInstanceChangeExample.tsx
 category: events
 priority: 2
-keywords: [side, effect, instance, grid, mode, prevent]
+keywords:
+  [
+    instance state,
+    prevent change,
+    registerbeforechangehandler,
+    side effects,
+    grid mode,
+    isgridmode,
+    validation,
+    state protection,
+  ]
 ---
 
 Prevent a change to the "instance" record that would turn off grid mode.

--- a/apps/examples/src/examples/prevent-multi-shape-selection/README.md
+++ b/apps/examples/src/examples/prevent-multi-shape-selection/README.md
@@ -3,7 +3,16 @@ title: Prevent multi-shape selection
 component: ./PreventMultiShapeSelectionExample.tsx
 category: events
 priority: 3
-keywords: [selection, editor, instance, state]
+keywords:
+  [
+    selection,
+    single selection,
+    prevent multi-select,
+    instance page state,
+    registerbeforechangehandler,
+    selectedshapeids,
+    selection control,
+  ]
 ---
 
 This example demonstrates how to prevent users from selecting multiple shapes at once in tldraw.

--- a/apps/examples/src/examples/prevent-shape-change/README.md
+++ b/apps/examples/src/examples/prevent-shape-change/README.md
@@ -3,7 +3,18 @@ title: Prevent shape changes
 component: ./PreventShapeChangeExample.tsx
 category: events
 priority: 2
-keywords: [side, effect, move, prevent]
+keywords:
+  [
+    prevent transform,
+    lock shape,
+    registerbeforechangehandler,
+    side effects,
+    immutable shape,
+    disable move,
+    disable resize,
+    disable rotate,
+    shape protection,
+  ]
 ---
 
 Prevent changes to a shape's properties.

--- a/apps/examples/src/examples/reactive-inputs/README.md
+++ b/apps/examples/src/examples/reactive-inputs/README.md
@@ -3,7 +3,20 @@ title: Reactive inputs
 component: ./ReactiveInputsExample.tsx
 category: editor-api
 priority: 3
-keywords: ['input', 'mouse', 'pointer', 'position', 'velocity', 'reactive', 'state']
+keywords:
+  [
+    inputs manager,
+    pointer tracking,
+    mouse position,
+    velocity,
+    usevalue,
+    reactive state,
+    screen point,
+    page point,
+    origin point,
+    pointer events,
+    atom,
+  ]
 ---
 
 Reactively track mouse positions and velocities using the editor's inputs manager.

--- a/apps/examples/src/examples/readonly/README.md
+++ b/apps/examples/src/examples/readonly/README.md
@@ -3,7 +3,16 @@ title: Read-only
 component: ./ReadOnlyExample
 category: configuration
 priority: 1
-keywords: [read, only mode]
+keywords:
+  [
+    readonly,
+    read-only mode,
+    isreadonly,
+    view only,
+    disable editing,
+    presentation mode,
+    locked editor,
+  ]
 ---
 
 Use the editor in read-only mode.

--- a/apps/examples/src/examples/reduced-motion/README.md
+++ b/apps/examples/src/examples/reduced-motion/README.md
@@ -3,7 +3,20 @@ title: Reduced motion preferences
 component: ./ReducedMotionExample.tsx
 category: configuration
 priority: 1
-keywords: [accessibility, a11y, reduced motion, animation, prefers-reduced-motion, custom shape]
+keywords:
+  [
+    accessibility,
+    a11y,
+    reduced motion,
+    animation,
+    prefers-reduced-motion,
+    useprefersreducedmotion,
+    animationspeed,
+    user preferences,
+    custom shape,
+    css animation,
+    vestibular,
+  ]
 ---
 
 Respecting user motion preferences in custom shapes.

--- a/apps/examples/src/examples/remove-tool/README.md
+++ b/apps/examples/src/examples/remove-tool/README.md
@@ -3,7 +3,16 @@ title: Remove a tool from the toolbar
 component: ./RemoveToolExample.tsx
 category: ui
 priority: 0
-keywords: [remove, tool]
+keywords:
+  [
+    hide tool,
+    remove tool,
+    overrides,
+    customization,
+    toolbar customization,
+    disable tool,
+    tool visibility,
+  ]
 ---
 
 You can remove a tool from the user interface.

--- a/apps/examples/src/examples/resize-note/README.md
+++ b/apps/examples/src/examples/resize-note/README.md
@@ -2,7 +2,17 @@
 title: Note resizing
 component: ./ResizeNoteExample.tsx
 category: configuration
-keywords: [note, resize, sticky]
+keywords:
+  [
+    note shape,
+    resize,
+    sticky note,
+    resizemode,
+    scale,
+    configure,
+    shapeutil configuration,
+    note scaling,
+  ]
 priority: 5
 ---
 

--- a/apps/examples/src/examples/rich-text-custom-extension/README.md
+++ b/apps/examples/src/examples/rich-text-custom-extension/README.md
@@ -3,7 +3,19 @@ title: Rich text with custom extension and toolbar
 component: ./RichTextCustomExtension.tsx
 category: shapes/tools
 priority: 20
-keywords: [text, tip, tap, extension, toolbar]
+keywords:
+  [
+    tiptap,
+    rich text,
+    custom extension,
+    text editor,
+    mark,
+    toolbar button,
+    textoptions,
+    wavy text,
+    text effects,
+    defaultrichtexttoolbar,
+  ]
 ---
 
 Extend the TipTap text editor by adding a custom extension and toolbar.

--- a/apps/examples/src/examples/rich-text-font-extensions/README.md
+++ b/apps/examples/src/examples/rich-text-font-extensions/README.md
@@ -3,7 +3,20 @@ title: Rich text with font options
 component: ./RichTextFontExtension.tsx
 category: shapes/tools
 priority: 20
-keywords: [text, tip, tap, extension, toolbar, font]
+keywords:
+  [
+    tiptap,
+    rich text,
+    font family,
+    font size,
+    text editor,
+    custom fonts,
+    textoptions,
+    google fonts,
+    fontface,
+    addfontsfromnode,
+    typography,
+  ]
 ---
 
 Extend the TipTap text editor by adding font-family and font-size options.

--- a/apps/examples/src/examples/rich-text-on-multiple-shapes/README.md
+++ b/apps/examples/src/examples/rich-text-on-multiple-shapes/README.md
@@ -3,7 +3,19 @@ title: Format rich text on multiple shapes
 component: ./RichTextFormatOnMultipleShapesExample.tsx
 category: ui
 priority: 0.5
-keywords: [rich text, format, tiptap, multiple]
+keywords:
+  [
+    rich text,
+    formatting,
+    batch edit,
+    multiple shapes,
+    style panel,
+    bold,
+    marks,
+    programmatic formatting,
+    tlrichtext,
+    document traversal,
+  ]
 ---
 
 Add a toggle button to the style panel that allows you to make all text bold (or remove bold) from multiple selected shapes at once.

--- a/apps/examples/src/examples/screen-reader-accessibility/README.md
+++ b/apps/examples/src/examples/screen-reader-accessibility/README.md
@@ -3,7 +3,21 @@ title: Screen reader accessibility
 component: ./ScreenReaderAccessibilityExample.tsx
 category: ui
 priority: 1
-keywords: [accessibility, a11y, screen reader, aria]
+keywords:
+  [
+    accessibility,
+    a11y,
+    screen reader,
+    aria,
+    getariadescriptor,
+    gettext,
+    usea11y,
+    announcements,
+    aria live region,
+    polite,
+    assertive,
+    wcag,
+  ]
 ---
 
 Implement accessible custom shapes and custom screen reader announcements.

--- a/apps/examples/src/examples/screenshot-tool/README.md
+++ b/apps/examples/src/examples/screenshot-tool/README.md
@@ -3,7 +3,20 @@ title: Custom tool (screenshot)
 component: ./ScreenshotToolExample.tsx
 category: shapes/tools
 priority: 0.5
-keywords: [state chart, state machine, child states]
+keywords:
+  [
+    custom tool,
+    statenode,
+    screenshot,
+    export,
+    state machine,
+    child states,
+    brush selection,
+    dragging state,
+    overrides,
+    toolbar,
+    asset urls,
+  ]
 ---
 
 A custom tool that takes a screenshot of the canvas.

--- a/apps/examples/src/examples/scroll/README.md
+++ b/apps/examples/src/examples/scroll/README.md
@@ -3,7 +3,7 @@ title: Scrollable container
 component: ./ScrollExample.tsx
 category: layout
 priority: 1
-keywords: [focus, mouse wheel]
+keywords: [scrollable, container, layout, autofocus, focus, mousewheel, viewport, nested]
 ---
 
 Use the editor inside a scrollable container.

--- a/apps/examples/src/examples/selection-color-condition/README.md
+++ b/apps/examples/src/examples/selection-color-condition/README.md
@@ -3,7 +3,17 @@ title: Selection color condition
 component: ./SelectionColorConditionExample.tsx
 category: ui
 priority: 3
-keywords: [selection, color, condition, rectangle, geo shapes]
+keywords:
+  [
+    selection,
+    color,
+    conditional styling,
+    css variables,
+    react,
+    getselectedshapes,
+    isshapeoftype,
+    css class,
+  ]
 ---
 
 Change the selection color based on the types of shapes selected.

--- a/apps/examples/src/examples/selection-ui/README.md
+++ b/apps/examples/src/examples/selection-ui/README.md
@@ -3,7 +3,17 @@ title: Selection UI
 component: ./SelectionUiExample.tsx
 category: ui
 priority: 2
-keywords: [duplication controls, handles]
+keywords:
+  [
+    selection,
+    ui overlay,
+    infrontofthecanvas,
+    custom controls,
+    duplicate,
+    handles,
+    usevalue,
+    getselectionrotatedscreenbounds,
+  ]
 ---
 
 Add extra UI elements around the user's selection.

--- a/apps/examples/src/examples/shape-with-custom-styles/README.md
+++ b/apps/examples/src/examples/shape-with-custom-styles/README.md
@@ -3,7 +3,17 @@ title: Custom shape with custom styles
 component: ./ShapeWithCustomStylesExample.tsx
 category: shapes/tools
 priority: 1.5
-keywords: [style panel, rating]
+keywords:
+  [
+    custom styles,
+    styleprop,
+    defineenum,
+    style panel,
+    defaultstylepanel,
+    userelevantsstyles,
+    setstyleforselectedshapes,
+    shapeutil,
+  ]
 ---
 
 Use the custom styles API with your custom shapes.

--- a/apps/examples/src/examples/shape-with-geometry/README.md
+++ b/apps/examples/src/examples/shape-with-geometry/README.md
@@ -3,7 +3,18 @@ title: Custom shape geometry
 component: ./ShapeWithGeometry.tsx
 category: shapes/tools
 priority: 3
-keywords: [svg, path, house, door]
+keywords:
+  [
+    custom geometry,
+    getgeometry,
+    polygon2d,
+    rectangle2d,
+    group2d,
+    svg path,
+    vertices,
+    hit testing,
+    shapeutil,
+  ]
 ---
 
 A shape with custom geometry.

--- a/apps/examples/src/examples/shape-with-migrations/README.md
+++ b/apps/examples/src/examples/shape-with-migrations/README.md
@@ -3,7 +3,17 @@ title: Custom shape migrations
 component: ./ShapeWithMigrationsExample.tsx
 category: shapes/tools
 priority: 3
-keywords: [version, update]
+keywords:
+  [
+    migrations,
+    schema versioning,
+    createshapepropsmigrationids,
+    createshapepropsmigrationsequence,
+    up,
+    down,
+    backwards compatibility,
+    data migration,
+  ]
 ---
 
 Migrate your shapes and their data between versions

--- a/apps/examples/src/examples/shape-with-tldraw-styles/README.md
+++ b/apps/examples/src/examples/shape-with-tldraw-styles/README.md
@@ -3,7 +3,16 @@ title: Custom shape with tldraw styles
 component: ./ShapeWithTldrawStylesExample.tsx
 category: shapes/tools
 priority: 1.5
-keywords: [default styles, style panel]
+keywords:
+  [
+    default styles,
+    defaultsizestyle,
+    defaultcolorstyle,
+    style panel,
+    usedefaultcolortheme,
+    getcolorvalue,
+    shapeutil,
+  ]
 ---
 
 Use the tldraw style panel with your custom shapes.

--- a/apps/examples/src/examples/signals/README.md
+++ b/apps/examples/src/examples/signals/README.md
@@ -3,7 +3,8 @@ title: Signals
 component: ./StateStoreExample.tsx
 category: events
 priority: 0
-keywords: [signia, state, store, side, effects, subscribe, track]
+keywords:
+  [signals, reactive, track, usevalue, usereactor, state management, side effects, computed, atom]
 ---
 
 React to changes by using signals.

--- a/apps/examples/src/examples/size-from-dom/README.md
+++ b/apps/examples/src/examples/size-from-dom/README.md
@@ -3,7 +3,18 @@ title: DOM-based shape size
 component: ./SizeFromDomExample.tsx
 category: shapes/tools
 priority: 10
-keywords: [dom, size, custom, dynamic, shape]
+keywords:
+  [
+    dom sizing,
+    dynamic size,
+    resizeobserver,
+    editoratom,
+    atommap,
+    getgeometry,
+    measure,
+    htmlcontainer,
+    responsive,
+  ]
 ---
 
 A custom shape who's size is derived from it's rendered DOM.

--- a/apps/examples/src/examples/snapshots/README.md
+++ b/apps/examples/src/examples/snapshots/README.md
@@ -3,7 +3,20 @@ title: Save and load snapshots
 component: ./SnapshotExample.tsx
 category: editor-api
 priority: 0
-keywords: []
+keywords:
+  [
+    snapshot,
+    save,
+    load,
+    getsnapshot,
+    loadsnapshot,
+    persistence,
+    export,
+    import,
+    document,
+    session,
+    localstorage,
+  ]
 ---
 
 Sand and load a snapshot of the editor's contents.

--- a/apps/examples/src/examples/snowstorm/README.md
+++ b/apps/examples/src/examples/snowstorm/README.md
@@ -2,7 +2,7 @@
 title: Snowstorm
 component: ./SnowStormExample.tsx
 category: use-cases
-keywords: [snowstorm, front]
+keywords: [overlay, visual effects, animation, css, children, layering, infrontofthecanvas]
 priority: 10
 ---
 

--- a/apps/examples/src/examples/speech-bubble/README.md
+++ b/apps/examples/src/examples/speech-bubble/README.md
@@ -3,7 +3,8 @@ title: Custom shape with handles
 component: ./CustomShapeWithHandles.tsx
 category: shapes/tools
 priority: 2
-keywords: [handles, handle, geometry, interaction, text label]
+keywords:
+  [handles, custom handles, gethandles, onhandledrag, interaction, geometry, tail, shapeutil, tool]
 ---
 
 A speech bubble shape with custom handles.

--- a/apps/examples/src/examples/static-assets/README.md
+++ b/apps/examples/src/examples/static-assets/README.md
@@ -2,7 +2,7 @@
 title: Static assets
 component: ./StaticAssetsExample.tsx
 category: data/assets
-keywords: [icons, fonts, pre-load]
+keywords: [assets, asseturls, custom fonts, custom icons, cdn, static files, preload, configuration]
 priority: 0
 ---
 

--- a/apps/examples/src/examples/sticker-bindings/README.md
+++ b/apps/examples/src/examples/sticker-bindings/README.md
@@ -2,7 +2,19 @@
 title: Attach shapes together (bindings)
 component: ./StickerExample.tsx
 category: shapes/tools
-keywords: [attach]
+keywords:
+  [
+    bindings,
+    bindingutil,
+    relationships,
+    attach,
+    stick,
+    canbind,
+    createbinding,
+    onafterchangetoshape,
+    anchor,
+    relative position,
+  ]
 priority: 10
 ---
 

--- a/apps/examples/src/examples/store-events/README.md
+++ b/apps/examples/src/examples/store-events/README.md
@@ -3,7 +3,19 @@ title: Store events
 component: ./StoreEventsExample.tsx
 category: events
 priority: 1
-keywords: [listen, changes]
+keywords:
+  [
+    store,
+    events,
+    listen,
+    changes,
+    transactions,
+    added,
+    updated,
+    removed,
+    tleventmaphandler,
+    subscribe,
+  ]
 ---
 
 Listen to changes from tldraw's store.

--- a/apps/examples/src/examples/sync-custom-people-menu/README.md
+++ b/apps/examples/src/examples/sync-custom-people-menu/README.md
@@ -3,7 +3,18 @@ title: Multiplayer sync with custom people menu
 component: ./SyncCustomPeopleMenuExample.tsx
 category: collaboration
 priority: 3
-keywords: [multiplayer, sync, collaboration, custom shape, presence, people, ui, facepile]
+keywords:
+  [
+    multiplayer,
+    collaboration,
+    presence,
+    facepile,
+    people menu,
+    getcollaborators,
+    tlinstancepresence,
+    cursor position,
+    custom ui,
+  ]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/sync-custom-presence/README.md
+++ b/apps/examples/src/examples/sync-custom-presence/README.md
@@ -3,7 +3,17 @@ title: Multiplayer sync with custom presence
 component: ./SyncCustomPresence.tsx
 category: collaboration
 priority: 3
-keywords: [basic, intro, simple, quick, start, multiplayer, sync, collaboration, presence]
+keywords:
+  [
+    multiplayer,
+    collaboration,
+    presence,
+    custom data,
+    sync,
+    tlinstancepresence,
+    user state,
+    real-time,
+  ]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/sync-custom-shape/README.md
+++ b/apps/examples/src/examples/sync-custom-shape/README.md
@@ -3,7 +3,8 @@ title: Multiplayer sync with a custom shape
 component: ./SyncDemoShapeExample.tsx
 category: collaboration
 priority: 3
-keywords: [basic, intro, simple, quick, start, multiplayer, sync, collaboration, custom shape]
+keywords:
+  [multiplayer, sync, useSyncDemo, shapeUtils, custom shape, shapeutil, collaboration, real-time]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/sync-custom-user/README.md
+++ b/apps/examples/src/examples/sync-custom-user/README.md
@@ -3,7 +3,18 @@ title: Multiplayer sync with custom user data
 component: ./SyncCustomUser.tsx
 category: collaboration
 priority: 3
-keywords: [basic, intro, simple, quick, start, multiplayer, sync, collaboration, custom shape]
+keywords:
+  [
+    multiplayer,
+    sync,
+    useSyncDemo,
+    user preferences,
+    useTldrawUser,
+    user info,
+    userInfo,
+    collaboration,
+    presence,
+  ]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/sync-demo/README.md
+++ b/apps/examples/src/examples/sync-demo/README.md
@@ -3,7 +3,7 @@ title: Multiplayer sync
 component: ./SyncDemoExample.tsx
 category: collaboration
 priority: 1
-keywords: [basic, intro, simple, quick, start, multiplayer, sync, collaboration]
+keywords: [multiplayer, sync, useSyncDemo, collaboration, real-time, websocket, co-editing]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/sync-private-content/README.md
+++ b/apps/examples/src/examples/sync-private-content/README.md
@@ -3,7 +3,19 @@ title: Multiplayer sync with private content
 component: ./SyncPrivateContentExample.tsx
 category: collaboration
 priority: 4
-keywords: [basic, intro, simple, quick, start, multiplayer, sync, collaboration]
+keywords:
+  [
+    multiplayer,
+    sync,
+    private,
+    visibility,
+    getShapeVisibility,
+    permissions,
+    ownership,
+    meta,
+    side effects,
+    registerBeforeCreateHandler,
+  ]
 multiplayer: true
 ---
 

--- a/apps/examples/src/examples/text-search/README.md
+++ b/apps/examples/src/examples/text-search/README.md
@@ -3,7 +3,18 @@ title: Search text on the canvas
 component: ./TextSearchExample.tsx
 category: editor-api
 priority: 2
-keywords: [zoom, pan, camera bounds, search, text]
+keywords:
+  [
+    search,
+    text search,
+    find text,
+    keyboard shortcut,
+    helpers,
+    helperButtons,
+    filter shapes,
+    overrides,
+    actions,
+  ]
 ---
 
 Search through all the text on the canvas.

--- a/apps/examples/src/examples/text-shape-configuration/README.md
+++ b/apps/examples/src/examples/text-shape-configuration/README.md
@@ -3,7 +3,21 @@ title: Programmatic text shape creation
 component: ./TextShapeConfigurationExample.tsx
 category: shapes/tools
 priority: 4
-keywords: [text, create, programmatic, autoSize, font, textAlign, richText, toRichText, bold, marks]
+keywords:
+  [
+    text shape,
+    create text,
+    programmatic,
+    autoSize,
+    font,
+    textAlign,
+    richText,
+    toRichText,
+    bold,
+    marks,
+    formatting,
+    createShape,
+  ]
 ---
 
 Create and configure text shapes programmatically.

--- a/apps/examples/src/examples/things-on-the-canvas/README.md
+++ b/apps/examples/src/examples/things-on-the-canvas/README.md
@@ -3,7 +3,18 @@ title: Things on the canvas
 component: ./OnTheCanvasExample.tsx
 category: ui
 priority: 1
-keywords: [in front of the canvas, scale, zoom, ui]
+keywords:
+  [
+    canvas overlay,
+    OnTheCanvas,
+    InFrontOfTheCanvas,
+    components,
+    custom component,
+    camera,
+    page coordinates,
+    pageToViewport,
+    track,
+  ]
 ---
 
 Add custom components to the canvas.

--- a/apps/examples/src/examples/timeline-scrubber/README.md
+++ b/apps/examples/src/examples/timeline-scrubber/README.md
@@ -3,7 +3,21 @@ title: Timeline scrubber
 component: ./TimelineScrubberExample.tsx
 category: use-cases
 priority: 10
-keywords: [timeline, history, undo, redo, time travel, scrubber]
+keywords:
+  [
+    timeline,
+    history,
+    undo,
+    redo,
+    time travel,
+    scrubber,
+    store.listen,
+    RecordsDiff,
+    squashRecordDiffs,
+    reverseRecordsDiff,
+    applyDiff,
+    document changes,
+  ]
 ---
 
 A timeline scrubber that records document changes and allows time travel through editor history.

--- a/apps/examples/src/examples/toSvg-method-example/README.md
+++ b/apps/examples/src/examples/toSvg-method-example/README.md
@@ -3,7 +3,18 @@ title: Custom shape SVG export
 component: ./CustomShapeToSvgExample.tsx
 category: shapes/tools
 priority: 3
-keywords: [basic, svg, custom, export, copy]
+keywords:
+  [
+    svg export,
+    toSvg,
+    toBackgroundSvg,
+    custom shape export,
+    SvgExportContext,
+    export image,
+    copy as svg,
+    foreignObject,
+    shapeutil,
+  ]
 ---
 
 Determine how your custom shapes look when copied/exported as an image.

--- a/apps/examples/src/examples/toasts-and-dialogs/README.md
+++ b/apps/examples/src/examples/toasts-and-dialogs/README.md
@@ -3,7 +3,18 @@ title: Toasts and dialogs
 component: ./ToastsDialogsExample.tsx
 category: ui
 priority: 1
-keywords: [ui, components, dialogs, toasts]
+keywords:
+  [
+    toasts,
+    dialogs,
+    useToasts,
+    useDialogs,
+    addToast,
+    addDialog,
+    notifications,
+    modals,
+    TldrawUiDialog,
+  ]
 ---
 
 Add, remove and clear toasts and dialogs in your app using the `useToasts` and `useDialogs` hooks.

--- a/apps/examples/src/examples/tool-with-child-states/README.md
+++ b/apps/examples/src/examples/tool-with-child-states/README.md
@@ -3,7 +3,21 @@ title: Custom tool with child states
 component: ./ToolWithChildStatesExample.tsx
 category: shapes/tools
 priority: 2
-keywords: [state machine, custom tool, state node, interactions]
+keywords:
+  [
+    custom tool,
+    state machine,
+    StateNode,
+    child states,
+    tool states,
+    onPointerDown,
+    onPointerMove,
+    onEnter,
+    transitions,
+    pointing,
+    dragging,
+    idle,
+  ]
 ---
 
 You can implement more complex behaviour in a custom tool by using child states

--- a/apps/examples/src/examples/toolbar-groups/README.md
+++ b/apps/examples/src/examples/toolbar-groups/README.md
@@ -2,7 +2,17 @@
 title: Toolbar groups
 component: ./ToolbarGroupsExample.tsx
 category: ui
-keyword: [custom, vertical, toolbar, groups]
+keywords:
+  [
+    toolbar,
+    toolbar groups,
+    TldrawUiMenuGroup,
+    DefaultToolbar,
+    customize toolbar,
+    toolbar items,
+    toolbar layout,
+    orientation,
+  ]
 ---
 
 Create groups within the toolbar to separate related concepts.

--- a/apps/examples/src/examples/ui-components-hidden/README.md
+++ b/apps/examples/src/examples/ui-components-hidden/README.md
@@ -3,7 +3,8 @@ title: Hide UI components
 component: ./UiComponentsHiddenExample.tsx
 category: ui
 priority: 1
-keywords: [hide, ui, overrides]
+keywords:
+  [hide ui, components override, minimal ui, headless, remove ui, TLUiComponents, null components]
 ---
 
 Hide individual UI components.

--- a/apps/examples/src/examples/ui-events/README.md
+++ b/apps/examples/src/examples/ui-events/README.md
@@ -3,7 +3,17 @@ title: UI events
 component: ./UiEventsExample.tsx
 category: events
 priority: 1
-keywords: [ui, events, api, x-ray]
+keywords:
+  [
+    ui events,
+    onUiEvent,
+    TLUiEventHandler,
+    event logging,
+    keyboard shortcuts,
+    actions,
+    tools,
+    debugging,
+  ]
 ---
 
 Listen to UI events.

--- a/apps/examples/src/examples/unsaved-changes/README.md
+++ b/apps/examples/src/examples/unsaved-changes/README.md
@@ -2,7 +2,19 @@
 title: Unsaved changes
 component: ./UnsavedChangesExample.tsx
 category: events
-keywords: [save, unsaved, changes, document, listen, state]
+keywords:
+  [
+    save,
+    unsaved changes,
+    document changes,
+    store.listen,
+    document scope,
+    RecordsDiff,
+    squashRecordDiffs,
+    persistence,
+    dirty state,
+    getSnapshot,
+  ]
 ---
 
 Track unsaved changes and enable save functionality.

--- a/apps/examples/src/examples/user-presence/README.md
+++ b/apps/examples/src/examples/user-presence/README.md
@@ -2,7 +2,18 @@
 title: Manually update user presence
 component: ./UserPresenceExample.tsx
 category: collaboration
-keywords: [cursor]
+keywords:
+  [
+    presence,
+    cursors,
+    InstancePresenceRecordType,
+    collaboration cursors,
+    fake users,
+    cursor position,
+    chat message,
+    cursor animation,
+    mergeRemoteChanges,
+  ]
 priority: 5
 ---
 

--- a/apps/examples/src/examples/vertical-toolbar/README.md
+++ b/apps/examples/src/examples/vertical-toolbar/README.md
@@ -2,7 +2,7 @@
 title: Vertical toolbar
 component: ./VerticalToolbarExample.tsx
 category: ui
-keyword: [custom, vertical, toolbar]
+keywords: [vertical toolbar, toolbar orientation, DefaultToolbar, components override, layout]
 ---
 
 Switch from a horizontal toolbar at the bottom of the screen to a vertical one on the left.

--- a/apps/examples/src/examples/zones/README.md
+++ b/apps/examples/src/examples/zones/README.md
@@ -3,7 +3,8 @@ title: UI zones
 component: ./ZonesExample.tsx
 category: ui
 priority: 1
-keywords: [top zone, share zone]
+keywords:
+  [zones, TopPanel, SharePanel, ui zones, custom panels, components override, top zone, share zone]
 ---
 
 Inject custom components into tldraw's empty areas.

--- a/apps/examples/src/examples/zoom-to-bounds/README.md
+++ b/apps/examples/src/examples/zoom-to-bounds/README.md
@@ -3,7 +3,7 @@ title: Zoom to bounds
 component: ./ZoomToBoundsExample.tsx
 category: editor-api
 priority: 1
-keywords: [zoom, camera, bounds, inset]
+keywords: [zoom, zoomToBounds, camera, bounds, Box, inset, animation, viewport, programmatic zoom]
 ---
 
 Zoom the camera to specific bounds using the editor's `zoomToBounds` function.


### PR DESCRIPTION
Improves the discoverability of SDK examples by expanding and refining the keywords in each example's README.md frontmatter.

### Change type

- [x] `improvement`

### Test plan

1. Run `yarn dev` and verify the examples app loads
2. Use the search functionality to verify keywords help find relevant examples

### Release notes

- Improved search keywords across all SDK examples for better discoverability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that affects example search metadata; main risk is minor YAML/frontmatter formatting issues impacting parsing or search results.
> 
> **Overview**
> Improves examples discoverability by **expanding and normalizing `keywords` frontmatter** across many example `README.md` files (often converting single-line or inconsistent `keyword(s)` fields into richer `keywords` arrays).
> 
> No runtime logic changes were made; this primarily affects how the examples app’s sidebar filter matches against `example.keywords`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf2bdb3244a8bd1416f0b12a241b6d749c2493f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->