### PR TITLE
chore: add x-article-publisher Claude Code skill

### DIFF
--- a/.claude/skills/x-article-publisher/scripts/copy_to_clipboard.py
+++ b/.claude/skills/x-article-publisher/scripts/copy_to_clipboard.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Copy image or HTML to system clipboard for X Articles publishing.
+
+Supports:
+- Image files (jpg, png, gif, webp) - copies as image data
+- HTML content - copies as rich text for paste
+- Optional image compression before copying
+
+Usage:
+    # Copy image to clipboard
+    python copy_to_clipboard.py image /path/to/image.jpg
+
+    # Copy image with compression (quality 0-100)
+    python copy_to_clipboard.py image /path/to/image.jpg --quality 80
+
+    # Copy HTML to clipboard
+    python copy_to_clipboard.py html "<p>Hello</p>"
+
+    # Copy HTML from file
+    python copy_to_clipboard.py html --file /path/to/content.html
+
+Requirements:
+    macOS: pip install Pillow pyobjc-framework-Cocoa
+    Windows: pip install Pillow pywin32 clip-util
+"""
+
+import argparse
+import io
+import os
+import sys
+from pathlib import Path
+
+
+def compress_image(image_path: str, quality: int = 85, max_size: tuple = (2000, 2000)) -> bytes:
+    """Compress image and return as bytes."""
+    from PIL import Image
+
+    img = Image.open(image_path)
+
+    # Convert to RGB if necessary (for JPEG)
+    if img.mode in ('RGBA', 'P'):
+        img = img.convert('RGB')
+
+    # Resize if too large
+    img.thumbnail(max_size, Image.Resampling.LANCZOS)
+
+    # Save to bytes
+    buffer = io.BytesIO()
+    img.save(buffer, format='JPEG', quality=quality, optimize=True)
+    return buffer.getvalue()
+
+
+def copy_image_to_clipboard_macos(image_path: str, quality: int = None) -> bool:
+    """Copy image to macOS clipboard using AppKit."""
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypePNG, NSPasteboardTypeTIFF
+        from Foundation import NSData
+
+        # Compress if quality specified, otherwise use original
+        if quality:
+            image_data = compress_image(image_path, quality)
+        else:
+            with open(image_path, 'rb') as f:
+                image_data = f.read()
+
+        # Create NSData from image bytes
+        ns_data = NSData.dataWithBytes_length_(image_data, len(image_data))
+
+        # Get pasteboard and clear it
+        pasteboard = NSPasteboard.generalPasteboard()
+        pasteboard.clearContents()
+
+        # Determine type based on file extension
+        ext = Path(image_path).suffix.lower()
+        if ext in ('.png',):
+            pasteboard.setData_forType_(ns_data, NSPasteboardTypePNG)
+        else:
+            # For JPEG and others, use TIFF (more compatible)
+            from PIL import Image
+            img = Image.open(io.BytesIO(image_data))
+            tiff_buffer = io.BytesIO()
+            img.save(tiff_buffer, format='TIFF')
+            tiff_data = NSData.dataWithBytes_length_(tiff_buffer.getvalue(), len(tiff_buffer.getvalue()))
+            pasteboard.setData_forType_(tiff_data, NSPasteboardTypeTIFF)
+
+        return True
+
+    except ImportError as e:
+        print(f"Error: Missing dependency: {e}", file=sys.stderr)
+        print("Install with: pip install Pillow pyobjc-framework-Cocoa", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error copying image: {e}", file=sys.stderr)
+        return False
+
+
+def copy_html_to_clipboard_macos(html: str) -> bool:
+    """Copy HTML to macOS clipboard as rich text."""
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypeHTML, NSPasteboardTypeString
+        from Foundation import NSData
+
+        # Get pasteboard and clear it
+        pasteboard = NSPasteboard.generalPasteboard()
+        pasteboard.clearContents()
+
+        # Set HTML content
+        html_data = html.encode('utf-8')
+        ns_data = NSData.dataWithBytes_length_(html_data, len(html_data))
+        pasteboard.setData_forType_(ns_data, NSPasteboardTypeHTML)
+
+        # Also set plain text version
+        pasteboard.setString_forType_(html, NSPasteboardTypeString)
+
+        return True
+
+    except ImportError as e:
+        print(f"Error: Missing dependency: {e}", file=sys.stderr)
+        print("Install with: pip install pyobjc-framework-Cocoa", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error copying HTML: {e}", file=sys.stderr)
+        return False
+
+
+# ============================================================================
+# Windows Implementation
+# ============================================================================
+
+def copy_image_to_clipboard_windows(image_path: str, quality: int = None) -> bool:
+    """Copy image to Windows clipboard using CF_DIB format."""
+    try:
+        import win32clipboard
+        from PIL import Image
+
+        # Load and optionally compress image
+        if quality:
+            image_data = compress_image(image_path, quality)
+            img = Image.open(io.BytesIO(image_data))
+        else:
+            img = Image.open(image_path)
+
+        # Convert to RGB (required for BMP format)
+        if img.mode in ('RGBA', 'P', 'LA'):
+            img = img.convert('RGB')
+
+        # Save as BMP to BytesIO, skip 14-byte BITMAPFILEHEADER
+        output = io.BytesIO()
+        img.save(output, format='BMP')
+        data = output.getvalue()[14:]  # Skip BITMAPFILEHEADER
+        output.close()
+
+        # Copy to clipboard
+        win32clipboard.OpenClipboard()
+        try:
+            win32clipboard.EmptyClipboard()
+            win32clipboard.SetClipboardData(win32clipboard.CF_DIB, data)
+        finally:
+            win32clipboard.CloseClipboard()
+
+        return True
+
+    except ImportError as e:
+        print(f"Error: Missing dependency: {e}", file=sys.stderr)
+        print("Install with: pip install Pillow pywin32", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error copying image: {e}", file=sys.stderr)
+        return False
+
+
+def copy_html_to_clipboard_windows(html: str) -> bool:
+    """Copy HTML to Windows clipboard using clip-util library."""
+    try:
+        from clipboard import Clipboard
+
+        with Clipboard() as clipboard:
+            clipboard["html"] = html
+
+        return True
+
+    except ImportError as e:
+        print(f"Error: Missing dependency: {e}", file=sys.stderr)
+        print("Install with: pip install clip-util", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error copying HTML: {e}", file=sys.stderr)
+        return False
+
+
+# ============================================================================
+# Platform Detection
+# ============================================================================
+
+def copy_image_to_clipboard(image_path: str, quality: int = None) -> bool:
+    """Copy image to clipboard (cross-platform)."""
+    if sys.platform == 'darwin':
+        return copy_image_to_clipboard_macos(image_path, quality)
+    elif sys.platform == 'win32':
+        return copy_image_to_clipboard_windows(image_path, quality)
+    else:
+        print(f"Error: Unsupported platform: {sys.platform}", file=sys.stderr)
+        return False
+
+
+def copy_html_to_clipboard(html: str) -> bool:
+    """Copy HTML to clipboard (cross-platform)."""
+    if sys.platform == 'darwin':
+        return copy_html_to_clipboard_macos(html)
+    elif sys.platform == 'win32':
+        return copy_html_to_clipboard_windows(html)
+    else:
+        print(f"Error: Unsupported platform: {sys.platform}", file=sys.stderr)
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Copy to clipboard for X Articles')
+    subparsers = parser.add_subparsers(dest='type', required=True)
+
+    # Image subcommand
+    img_parser = subparsers.add_parser('image', help='Copy image to clipboard')
+    img_parser.add_argument('path', help='Path to image file')
+    img_parser.add_argument('--quality', type=int, default=None,
+                           help='JPEG quality (1-100), enables compression')
+    img_parser.add_argument('--max-width', type=int, default=2000,
+                           help='Max width for resize')
+    img_parser.add_argument('--max-height', type=int, default=2000,
+                           help='Max height for resize')
+
+    # HTML subcommand
+    html_parser = subparsers.add_parser('html', help='Copy HTML to clipboard')
+    html_parser.add_argument('content', nargs='?', help='HTML content')
+    html_parser.add_argument('--file', '-f', help='Read HTML from file')
+
+    args = parser.parse_args()
+
+    if args.type == 'image':
+        if not os.path.exists(args.path):
+            print(f"Error: Image not found: {args.path}", file=sys.stderr)
+            sys.exit(1)
+
+        success = copy_image_to_clipboard(args.path, args.quality)
+        if success:
+            print(f"Image copied to clipboard: {args.path}")
+            if args.quality:
+                print(f"  (compressed with quality={args.quality})")
+        sys.exit(0 if success else 1)
+
+    elif args.type == 'html':
+        if args.file:
+            if not os.path.exists(args.file):
+                print(f"Error: File not found: {args.file}", file=sys.stderr)
+                sys.exit(1)
+            with open(args.file, 'r', encoding='utf-8') as f:
+                html = f.read()
+        elif args.content:
+            html = args.content
+        else:
+            # Read from stdin
+            html = sys.stdin.read()
+
+        success = copy_html_to_clipboard(html)
+        if success:
+            print(f"HTML copied to clipboard ({len(html)} chars)")
+        sys.exit(0 if success else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/x-article-publisher/scripts/parse_markdown.py
+++ b/.claude/skills/x-article-publisher/scripts/parse_markdown.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Parse Markdown for X Articles publishing.
+
+Extracts:
+- Title (from first H1/H2 or first line)
+- Cover image (first image)
+- Content images with block index for precise positioning
+- Dividers (---) with block index for menu insertion
+- HTML content (images and dividers stripped)
+
+Usage:
+    python parse_markdown.py <markdown_file> [--output json|html]
+
+Output (JSON):
+{
+    "title": "Article Title",
+    "cover_image": "/path/to/cover.jpg",
+    "content_images": [
+        {"path": "/path/to/img.jpg", "block_index": 3, "after_text": "context..."},
+        ...
+    ],
+    "dividers": [
+        {"block_index": 7, "after_text": "context..."},
+        ...
+    ],
+    "html": "<p>Content...</p><h2>Section</h2>...",
+    "total_blocks": 25
+}
+
+The block_index indicates which block element (0-indexed) the image/divider should follow.
+This allows precise positioning without relying on text matching.
+
+Note: Dividers must be inserted via X Articles' Insert > Divider menu, not HTML <hr> tags.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.parse
+from pathlib import Path
+
+
+# Common search directories for missing images
+SEARCH_DIRS = [
+    Path.home() / "Downloads",
+    Path.home() / "Desktop",
+    Path.home() / "Pictures",
+]
+
+
+def find_image_file(original_path: str, filename: str) -> tuple[str, bool]:
+    """Find an image file, searching common directories if not found at original path.
+    
+    Args:
+        original_path: The resolved absolute path from markdown
+        filename: Just the filename to search for
+    
+    Returns:
+        (found_path, exists): The path to use and whether file exists
+    """
+    if os.path.isfile(original_path):
+        return original_path, True
+    
+    for search_dir in SEARCH_DIRS:
+        candidate = search_dir / filename
+        if candidate.is_file():
+            print(f"[parse_markdown] Image not found at '{original_path}', using '{candidate}' instead", file=sys.stderr)
+            return str(candidate), True
+    
+    print(f"[parse_markdown] WARNING: Image not found: '{original_path}' (also searched {[str(d) for d in SEARCH_DIRS]})", file=sys.stderr)
+    return original_path, False
+
+
+def split_into_blocks(markdown: str) -> list[str]:
+    """Split markdown into logical blocks (paragraphs, headers, quotes, code blocks, etc.)."""
+    blocks = []
+    current_block = []
+    in_code_block = False
+    code_block_lines = []
+
+    lines = markdown.split('\n')
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Handle code block boundaries
+        if stripped.startswith('```'):
+            if in_code_block:
+                # End of code block
+                in_code_block = False
+                if code_block_lines:
+                    # Mark as code block with special prefix for later processing
+                    # Use ___CODE_BLOCK_START___ and ___CODE_BLOCK_END___ to preserve content
+                    blocks.append('___CODE_BLOCK_START___' + '\n'.join(code_block_lines) + '___CODE_BLOCK_END___')
+                code_block_lines = []
+            else:
+                # Start of code block
+                if current_block:
+                    blocks.append('\n'.join(current_block))
+                    current_block = []
+                in_code_block = True
+            continue
+
+        # If inside code block, collect ALL lines (including empty lines)
+        if in_code_block:
+            code_block_lines.append(line)
+            continue
+
+        # Empty line signals end of block
+        if not stripped:
+            if current_block:
+                blocks.append('\n'.join(current_block))
+                current_block = []
+            continue
+
+        # Horizontal rule (divider) is its own block
+        if re.match(r'^---+$', stripped):
+            if current_block:
+                blocks.append('\n'.join(current_block))
+                current_block = []
+            blocks.append('___DIVIDER___')
+            continue
+
+        # Headers, blockquotes are their own blocks
+        if stripped.startswith(('#', '>')):
+            if current_block:
+                blocks.append('\n'.join(current_block))
+                current_block = []
+            blocks.append(stripped)
+            continue
+
+        # Image on its own line is its own block
+        if re.match(r'^!\[.*\]\(.*\)$', stripped):
+            if current_block:
+                blocks.append('\n'.join(current_block))
+                current_block = []
+            blocks.append(stripped)
+            continue
+
+        current_block.append(line)
+
+    if current_block:
+        blocks.append('\n'.join(current_block))
+
+    # Handle unclosed code block
+    if code_block_lines:
+        blocks.append('___CODE_BLOCK_START___' + '\n'.join(code_block_lines) + '___CODE_BLOCK_END___')
+
+    return blocks
+
+
+def extract_images_and_dividers(markdown: str, base_path: Path) -> tuple[list[dict], list[dict], str, int]:
+    """Extract images and dividers with their block index positions.
+
+    Returns:
+        (image_list, divider_list, markdown_without_images_and_dividers, total_blocks)
+    """
+    blocks = split_into_blocks(markdown)
+    images = []
+    dividers = []
+    clean_blocks = []
+
+    img_pattern = re.compile(r'^!\[([^\]]*)\]\(([^)]+)\)$')
+
+    for i, block in enumerate(blocks):
+        block_stripped = block.strip()
+
+        # Check for divider
+        if block_stripped == '___DIVIDER___':
+            block_index = len(clean_blocks)
+            after_text = ""
+            if clean_blocks:
+                prev_block = clean_blocks[-1].strip()
+                lines = [l for l in prev_block.split('\n') if l.strip()]
+                after_text = lines[-1][:80] if lines else ""
+            dividers.append({
+                "block_index": block_index,
+                "after_text": after_text
+            })
+            continue
+
+        match = img_pattern.match(block_stripped)
+        if match:
+            alt_text = match.group(1)
+            img_path = match.group(2)
+
+            if not os.path.isabs(img_path):
+                resolved_path = str(base_path / img_path)
+            else:
+                resolved_path = img_path
+
+            filename = os.path.basename(urllib.parse.unquote(img_path))
+            full_path, exists = find_image_file(resolved_path, filename)
+
+            block_index = len(clean_blocks)
+
+            after_text = ""
+            if clean_blocks:
+                prev_block = clean_blocks[-1].strip()
+                lines = [l for l in prev_block.split('\n') if l.strip()]
+                after_text = lines[-1][:80] if lines else ""
+
+            images.append({
+                "path": full_path,
+                "original_path": resolved_path,
+                "exists": exists,
+                "alt": alt_text,
+                "block_index": block_index,
+                "after_text": after_text
+            })
+        else:
+            clean_blocks.append(block)
+
+    clean_markdown = '\n\n'.join(clean_blocks)
+    return images, dividers, clean_markdown, len(clean_blocks)
+
+
+def extract_title(markdown: str) -> tuple[str, str]:
+    """Extract title from first H1, H2, or first non-empty line.
+
+    Returns:
+        (title, markdown_without_title): Title string and markdown with H1 title removed.
+        If title is from H1, it's removed from markdown to avoid duplication.
+    """
+    lines = markdown.strip().split('\n')
+    title = "Untitled"
+    title_line_idx = None
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # H1 - use as title and mark for removal
+        if stripped.startswith('# '):
+            title = stripped[2:].strip()
+            title_line_idx = idx
+            break
+        # H2 - use as title but don't remove (it's a section header)
+        if stripped.startswith('## '):
+            title = stripped[3:].strip()
+            break
+        # First non-empty, non-image line
+        if not stripped.startswith('!['):
+            title = stripped[:100]
+            break
+
+    # Remove H1 title line from markdown to avoid duplication
+    if title_line_idx is not None:
+        lines.pop(title_line_idx)
+        markdown = '\n'.join(lines)
+
+    return title, markdown
+
+
+def markdown_to_html(markdown: str) -> str:
+    """Convert markdown to HTML for X Articles rich text paste."""
+    html = markdown
+
+    # Process code blocks first (marked with ___CODE_BLOCK_START___ and ___CODE_BLOCK_END___)
+    # Convert to blockquote format since X Articles doesn't support <pre><code>
+    def convert_code_block(match):
+        code_content = match.group(1)
+        lines = code_content.strip().split('\n')
+        # Join non-empty lines with <br> for display
+        formatted = '<br>'.join(line for line in lines if line.strip())
+        return f'<blockquote>{formatted}</blockquote>'
+
+    html = re.sub(r'___CODE_BLOCK_START___(.*?)___CODE_BLOCK_END___', convert_code_block, html, flags=re.DOTALL)
+
+    # Headers (H2 only, H1 is title)
+    html = re.sub(r'^## (.+)$', r'<h2>\1</h2>', html, flags=re.MULTILINE)
+    html = re.sub(r'^### (.+)$', r'<h3>\1</h3>', html, flags=re.MULTILINE)
+
+    # Bold
+    html = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', html)
+
+    # Italic
+    html = re.sub(r'\*([^*]+)\*', r'<em>\1</em>', html)
+
+    # Links
+    html = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', html)
+
+    # Blockquotes (regular markdown blockquotes, not code blocks)
+    html = re.sub(r'^> (.+)$', r'<blockquote>\1</blockquote>', html, flags=re.MULTILINE)
+
+    # Unordered lists
+    html = re.sub(r'^- (.+)$', r'<li>\1</li>', html, flags=re.MULTILINE)
+
+    # Ordered lists
+    html = re.sub(r'^\d+\. (.+)$', r'<li>\1</li>', html, flags=re.MULTILINE)
+
+    # Wrap consecutive <li> in <ul>
+    html = re.sub(r'((?:<li>.*?</li>\n?)+)', r'<ul>\1</ul>', html)
+
+    # Paragraphs - split by double newlines
+    parts = html.split('\n\n')
+    processed_parts = []
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        # Skip if already a block element
+        if part.startswith(('<h2>', '<h3>', '<blockquote>', '<ul>', '<ol>')):
+            processed_parts.append(part)
+        else:
+            # Wrap in paragraph, convert single newlines to <br>
+            part = part.replace('\n', '<br>')
+            processed_parts.append(f'<p>{part}</p>')
+
+    return ''.join(processed_parts)
+
+
+def parse_markdown_file(filepath: str) -> dict:
+    """Parse a markdown file and return structured data."""
+    path = Path(filepath)
+    base_path = path.parent
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Skip YAML frontmatter if present
+    if content.startswith('---'):
+        end_marker = content.find('---', 3)
+        if end_marker != -1:
+            content = content[end_marker + 3:].strip()
+
+    # Extract title first (and remove H1 from markdown)
+    title, content = extract_title(content)
+
+    # Extract images and dividers with block indices
+    images, dividers, clean_markdown, total_blocks = extract_images_and_dividers(content, base_path)
+
+    # Convert to HTML
+    html = markdown_to_html(clean_markdown)
+
+    cover_image = images[0]["path"] if images else None
+    cover_exists = images[0]["exists"] if images else True
+    content_images = images[1:] if len(images) > 1 else []
+
+    missing = [img for img in images if not img["exists"]]
+    if missing:
+        print(f"[parse_markdown] WARNING: {len(missing)} image(s) not found", file=sys.stderr)
+
+    return {
+        "title": title,
+        "cover_image": cover_image,
+        "cover_exists": cover_exists,
+        "content_images": content_images,
+        "dividers": dividers,
+        "html": html,
+        "total_blocks": total_blocks,
+        "source_file": str(path.absolute()),
+        "missing_images": len(missing)
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Parse Markdown for X Articles')
+    parser.add_argument('file', help='Markdown file to parse')
+    parser.add_argument('--output', choices=['json', 'html'], default='json',
+                       help='Output format (default: json)')
+    parser.add_argument('--html-only', action='store_true',
+                       help='Output only HTML content')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.file):
+        print(f"Error: File not found: {args.file}", file=sys.stderr)
+        sys.exit(1)
+
+    result = parse_markdown_file(args.file)
+
+    if args.html_only:
+        print(result['html'])
+    elif args.output == 'json':
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(result['html'])
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/x-article-publisher/scripts/table_to_image.py
+++ b/.claude/skills/x-article-publisher/scripts/table_to_image.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Convert Markdown table to PNG image.
+
+For X Articles publishing when native table rendering is not supported
+(X Premium tier) or when you want consistent visual styling.
+
+Usage:
+    python3 table_to_image.py <input.md> <output.png> [--scale 2]
+
+Arguments:
+    input.md    - Markdown file containing a table
+    output.png  - Output PNG file path
+    --scale N   - Scale factor for high-DPI displays (default: 2)
+
+Requirements:
+    pip install pillow
+"""
+
+import sys
+import re
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    print("Error: Pillow not installed. Run: pip install pillow")
+    sys.exit(1)
+
+
+def parse_markdown_table(content: str) -> tuple[list[str], list[list[str]], list[str]]:
+    """Parse markdown table into headers, rows, and alignments."""
+    lines = [line.strip() for line in content.strip().split('\n') if line.strip()]
+
+    if len(lines) < 2:
+        raise ValueError("Table must have at least 2 rows")
+
+    def parse_cells(line: str) -> list[str]:
+        line = line.strip()
+        if line.startswith('|'):
+            line = line[1:]
+        if line.endswith('|'):
+            line = line[:-1]
+        return [cell.strip() for cell in line.split('|')]
+
+    # Find separator line
+    separator_idx = -1
+    for i, line in enumerate(lines):
+        if re.match(r'^\|?[\s]*:?-{2,}:?[\s]*(\|[\s]*:?-{2,}:?[\s]*)*\|?$', line):
+            separator_idx = i
+            break
+
+    if separator_idx > 0:
+        # Has headers
+        headers = parse_cells(lines[separator_idx - 1])
+        sep_cells = parse_cells(lines[separator_idx])
+        alignments = []
+        for cell in sep_cells:
+            cell = cell.strip()
+            if cell.startswith(':') and cell.endswith(':'):
+                alignments.append('center')
+            elif cell.endswith(':'):
+                alignments.append('right')
+            else:
+                alignments.append('left')
+        rows = [parse_cells(line) for line in lines[separator_idx + 1:]]
+    else:
+        # No headers - all data rows
+        headers = []
+        rows = [parse_cells(line) for line in lines]
+        alignments = ['left'] * (len(rows[0]) if rows else 0)
+
+    return headers, rows, alignments
+
+
+def get_font(size: int, bold: bool = False):
+    """Get a font, falling back to default if system fonts unavailable."""
+    font_paths = [
+        # macOS
+        "/System/Library/Fonts/SFNSMono.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf",
+        # macOS Chinese fonts
+        "/System/Library/Fonts/PingFang.ttc",
+        "/System/Library/Fonts/STHeiti Light.ttc",
+        # Linux
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/TTF/DejaVuSans.ttf",
+        # Windows
+        "C:/Windows/Fonts/arial.ttf",
+        "C:/Windows/Fonts/msyh.ttc",  # Microsoft YaHei
+    ]
+
+    for path in font_paths:
+        try:
+            return ImageFont.truetype(path, size)
+        except (OSError, IOError):
+            continue
+
+    # Fallback to default
+    return ImageFont.load_default()
+
+
+def render_table_to_image(
+    headers: list[str],
+    rows: list[list[str]],
+    alignments: list[str],
+    scale: int = 2
+) -> Image.Image:
+    """Render table data to a PIL Image."""
+
+    # Configuration
+    base_font_size = 14
+    font_size = base_font_size * scale
+    padding_x = 16 * scale
+    padding_y = 12 * scale
+    border_radius = 8 * scale
+    margin = 20 * scale
+
+    # Colors
+    bg_color = (255, 255, 255)
+    header_bg = (249, 250, 251)
+    text_color = (55, 65, 81)
+    header_text_color = (17, 24, 39)
+    border_color = (229, 231, 235)
+
+    # Fonts
+    regular_font = get_font(font_size)
+    bold_font = get_font(font_size, bold=True)
+
+    # Calculate column widths
+    col_count = len(headers) if headers else (len(rows[0]) if rows else 0)
+    col_widths = [0] * col_count
+
+    # Create temp image for text measurement
+    temp_img = Image.new('RGB', (1, 1))
+    temp_draw = ImageDraw.Draw(temp_img)
+
+    # Measure headers
+    for i, header in enumerate(headers):
+        bbox = temp_draw.textbbox((0, 0), header, font=bold_font)
+        col_widths[i] = max(col_widths[i], bbox[2] - bbox[0])
+
+    # Measure data cells
+    for row in rows:
+        for i, cell in enumerate(row):
+            if i < col_count:
+                bbox = temp_draw.textbbox((0, 0), cell, font=regular_font)
+                col_widths[i] = max(col_widths[i], bbox[2] - bbox[0])
+
+    # Add padding to widths
+    col_widths = [w + padding_x * 2 for w in col_widths]
+
+    # Calculate dimensions
+    row_height = font_size + padding_y * 2
+    header_height = row_height if headers else 0
+    table_width = sum(col_widths)
+    table_height = header_height + len(rows) * row_height
+
+    img_width = table_width + margin * 2
+    img_height = table_height + margin * 2
+
+    # Create image
+    img = Image.new('RGB', (img_width, img_height), bg_color)
+    draw = ImageDraw.Draw(img)
+
+    # Draw table border (rounded rectangle)
+    x0, y0 = margin, margin
+    x1, y1 = margin + table_width, margin + table_height
+    draw.rounded_rectangle([x0, y0, x1, y1], radius=border_radius, outline=border_color, width=scale)
+
+    y = margin
+
+    # Draw header
+    if headers:
+        # Header background
+        draw.rounded_rectangle(
+            [x0, y0, x1, y0 + row_height],
+            radius=border_radius,
+            fill=header_bg
+        )
+        # Cover bottom corners of header (they should be square)
+        draw.rectangle([x0, y0 + row_height - border_radius, x1, y0 + row_height], fill=header_bg)
+
+        # Header border
+        draw.line([(x0, y + row_height), (x1, y + row_height)], fill=border_color, width=scale)
+
+        # Header text
+        x = margin
+        for i, header in enumerate(headers):
+            bbox = draw.textbbox((0, 0), header, font=bold_font)
+            text_width = bbox[2] - bbox[0]
+
+            if alignments[i] == 'center':
+                text_x = x + (col_widths[i] - text_width) // 2
+            elif alignments[i] == 'right':
+                text_x = x + col_widths[i] - text_width - padding_x
+            else:
+                text_x = x + padding_x
+
+            text_y = y + padding_y
+            draw.text((text_x, text_y), header, fill=header_text_color, font=bold_font)
+            x += col_widths[i]
+
+        y += row_height
+
+    # Draw data rows
+    for row_idx, row in enumerate(rows):
+        # Row border (except last row)
+        if row_idx < len(rows) - 1:
+            draw.line([(x0, y + row_height), (x1, y + row_height)], fill=border_color, width=scale)
+
+        # Cell text
+        x = margin
+        for i, cell in enumerate(row):
+            if i >= col_count:
+                break
+
+            bbox = draw.textbbox((0, 0), cell, font=regular_font)
+            text_width = bbox[2] - bbox[0]
+
+            if i < len(alignments):
+                if alignments[i] == 'center':
+                    text_x = x + (col_widths[i] - text_width) // 2
+                elif alignments[i] == 'right':
+                    text_x = x + col_widths[i] - text_width - padding_x
+                else:
+                    text_x = x + padding_x
+            else:
+                text_x = x + padding_x
+
+            text_y = y + padding_y
+            draw.text((text_x, text_y), cell, fill=text_color, font=regular_font)
+            x += col_widths[i]
+
+        y += row_height
+
+    return img
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 table_to_image.py <input.md> <output.png> [--scale N]")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    # Parse optional scale argument
+    scale = 2
+    if '--scale' in sys.argv:
+        scale_idx = sys.argv.index('--scale')
+        if scale_idx + 1 < len(sys.argv):
+            try:
+                scale = int(sys.argv[scale_idx + 1])
+            except ValueError:
+                pass
+
+    # Read input
+    content = Path(input_path).read_text()
+
+    # Parse table
+    try:
+        headers, rows, alignments = parse_markdown_table(content)
+    except Exception as e:
+        print(f"Error parsing table: {e}")
+        sys.exit(1)
+
+    if not rows:
+        print("Error: No data rows found in table")
+        sys.exit(1)
+
+    # Render image
+    img = render_table_to_image(headers, rows, alignments, scale)
+
+    # Save
+    output = Path(output_path)
+    img.save(output, 'PNG')
+    print(f"Saved: {output} ({img.width}x{img.height})")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/x-article-publisher/skill.md
+++ b/.claude/skills/x-article-publisher/skill.md
@@ -1,0 +1,174 @@
+# X Article Publisher
+
+Prepare Markdown content for publishing to X (Twitter) Articles with rich text formatting.
+
+## Overview
+
+This skill extracts content from Markdown files or URLs and prepares it for manual publishing to X Articles. It does NOT automate the browser—you'll copy the prepared content to X Articles yourself.
+
+## Prerequisites
+
+- Python 3.9+ with dependencies:
+  - macOS: `pip install Pillow pyobjc-framework-Cocoa markdown`
+  - Windows: `pip install Pillow pywin32 clip-util markdown`
+
+## Workflow
+
+### Step 1: Generate article ID and fetch content
+
+Generate a short article ID from the title or URL slug (e.g., `redesigning-lasers`, `my-article`). Use kebab-case, max 30 characters. Create the directory `.x-article-temp/<article-id>/`.
+
+If the user provides a URL instead of a local file, use WebFetch or browser tools to extract the article content and save it as a Markdown file in `.x-article-temp/<article-id>/`.
+
+### Step 2: Download media
+
+Download all images and videos referenced in the article to `.x-article-temp/<article-id>/`. Use parallel downloads for efficiency.
+
+### Step 3: Parse Markdown
+
+```bash
+python3 .claude/skills/x-article-publisher/scripts/parse_markdown.py .x-article-temp/<article-id>/article.md
+```
+
+This outputs JSON with:
+
+- `title`: Article title (from H1)
+- `cover_image`: Path to first image/video (use as cover)
+- `content_images`: Array of media with `path`, `block_index`, `after_text`
+- `html`: Rich text HTML content
+- `total_blocks`: Number of block elements
+
+Save HTML to file:
+
+```bash
+python3 .claude/skills/x-article-publisher/scripts/parse_markdown.py .x-article-temp/<article-id>/article.md --html-only > .x-article-temp/<article-id>/article.html
+```
+
+### Step 4: Report to user
+
+After all preparation is complete, report to the user:
+
+1. **Title** of the article
+2. **Cover media** file path
+3. **Number of content images/videos** and their file paths
+
+### Step 5: Prompt for clipboard copy
+
+**IMPORTANT**: Ask the user for confirmation before running the clipboard command.
+
+Use AskUserQuestion to ask:
+
+> "Ready to copy the rich text content to your clipboard. After copying, paste (Cmd+V) into the X Articles editor body. Copy now?"
+
+Only after user confirms, run:
+
+```bash
+python3 .claude/skills/x-article-publisher/scripts/copy_to_clipboard.py html --file .x-article-temp/<article-id>/article.html
+```
+
+Then tell the user: "Content copied! Paste into the X Articles editor now."
+
+### Step 6: Guide media insertion
+
+After the user pastes the text, guide them to insert media at the correct positions:
+
+For each content image/video (in order of appearance):
+
+1. Tell them the `after_text` context so they know where to place cursor
+2. Provide the file path to upload
+3. They can drag-drop or use Insert > Media
+
+## File structure
+
+All temporary files go in `.x-article-temp/<article-id>/` in the current working directory:
+
+```
+.x-article-temp/<article-id>/
+├── article.md      # Source markdown
+├── article.html    # Generated HTML for clipboard
+├── video1.mp4      # Downloaded media
+├── video2.mp4
+├── image1.png
+└── ...
+```
+
+## Scripts
+
+### parse_markdown.py
+
+Parse Markdown and extract structured data:
+
+```bash
+python3 scripts/parse_markdown.py <markdown_file> [--output json|html] [--html-only]
+```
+
+### copy_to_clipboard.py
+
+Copy HTML to system clipboard as rich text:
+
+```bash
+python3 scripts/copy_to_clipboard.py html --file <html_file>
+```
+
+Copy image to clipboard:
+
+```bash
+python3 scripts/copy_to_clipboard.py image <image_path> [--quality 85]
+```
+
+## Supported formatting
+
+| Element           | Support   | Notes              |
+| ----------------- | --------- | ------------------ |
+| H2 (`##`)         | Native    | Section headers    |
+| Bold (`**`)       | Native    | Strong emphasis    |
+| Italic (`*`)      | Native    | Emphasis           |
+| Links (`[](url)`) | Native    | Hyperlinks         |
+| Ordered lists     | Native    | 1. 2. 3.           |
+| Unordered lists   | Native    | - bullets          |
+| Blockquotes (`>`) | Native    | Quoted text        |
+| Code blocks       | Converted | → Blockquotes      |
+| Images            | Manual    | Upload after paste |
+| Videos            | Manual    | Upload after paste |
+
+## Example session
+
+**User**: "Publish https://example.com/blog/my-article to X"
+
+**Claude**:
+
+1. Generates article ID: `my-article`
+2. Fetches article content from URL
+3. Saves markdown to `.x-article-temp/my-article/article.md`
+4. Downloads all media to `.x-article-temp/my-article/`
+5. Parses markdown, generates HTML
+6. Reports:
+
+   ```
+   Article prepared for X publishing:
+
+   Title: "My Article Title"
+   Cover: .x-article-temp/my-article/hero.jpg
+   Content media: 3 images
+
+   To publish:
+   1. Go to https://x.com/compose/articles
+   2. Click "create"
+   3. Upload cover image: .x-article-temp/my-article/hero.jpg
+   4. Enter title: "My Article Title"
+   5. Click in the editor body
+   ```
+
+6. Asks: "Ready to copy rich text to clipboard?"
+7. User confirms
+8. Runs clipboard copy command
+9. Says: "Content copied! Paste (Cmd+V) into the editor now."
+10. Guides media insertion with file paths and placement hints
+
+## Critical rules
+
+1. **NEVER attempt browser login** - This skill prepares content only
+2. **Always use `.x-article-temp/<article-id>/`** - Keep all temp files in article-specific subdirectories
+3. **Always ask before clipboard copy** - User must confirm
+4. **H1 = title only** - First H1 becomes article title, not body content
+5. **Guide media insertion** - Provide clear file paths and context for placement

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lerna-debug.log*
 
 # Temporary files
 *.tmp.ts
+.x-article-temp/
 
 node_modules
 dist


### PR DESCRIPTION
Add a new Claude Code skill that prepares Markdown content for publishing to X (Twitter) Articles with rich text formatting. The skill provides a semi-automated workflow where Claude prepares the content and guides the user through the manual publishing process.

### Change type

- [x] `other`

### Test plan

1. Run `/x-article-publisher` with a Markdown file or URL
2. Verify the skill extracts the title and identifies images
3. Confirm the HTML generation produces valid rich text
4. Test the clipboard copy functionality (requires Python dependencies)
5. Follow the guided media insertion workflow

### Release notes

- Internal tooling for publishing articles to X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new, standalone Python tooling and documentation under `.claude/skills` plus a `.gitignore` entry, without touching application runtime paths.
> 
> **Overview**
> Adds a new `.claude/skills/x-article-publisher` skill that prepares Markdown for manual publishing to X Articles, including extracting a title/cover image, tracking image/divider placement via `block_index`, and generating rich-text HTML for paste.
> 
> Introduces helper scripts: `parse_markdown.py` (Markdown → structured JSON + HTML), `copy_to_clipboard.py` (cross-platform HTML/image clipboard copy with optional image compression), and `table_to_image.py` (render Markdown tables to PNG for upload). Updates `.gitignore` to exclude `.x-article-temp/` working directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc8b19e132ce1db99c4d1b68fc0fbf64fd21eaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->