### PR TITLE
docs(routing): redirect /starter-kits to /starter-kits/overview

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -181,6 +181,11 @@ const nextConfig = {
 					'/?utm_source=mostlytechnical&utm_medium=paid_podcast&utm_campaign=ad_mostlytechnical_2025',
 				permanent: true,
 			},
+			{
+				source: '/starter-kits',
+				destination: '/starter-kits/overview',
+				permanent: true,
+			},
 		]
 	},
 	async rewrites() {
@@ -261,10 +266,6 @@ const nextConfig = {
 				{
 					source: '/showcase',
 					destination: `https://${REWRITE_DOMAIN}/showcase`,
-				},
-				{
-					source: '/starter-kits',
-					destination: `https://${REWRITE_DOMAIN}/starter-kits`,
 				},
 				{
 					source: '/thanks',


### PR DESCRIPTION
Now that starter kits content is served from the docs site, this removes the Framer rewrite and adds a permanent redirect from `/starter-kits` to `/starter-kits/overview`.

### Change type

- [x] `improvement`

### Test plan

1. Visit tldraw.dev/starter-kits
2. Verify it redirects to tldraw.dev/starter-kits/overview

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk routing-only change; main risk is unintended redirect behavior or SEO implications if other `/starter-kits` paths relied on the previous rewrite.
> 
> **Overview**
> Routes for `starter-kits` are now handled by the docs app: `/starter-kits` permanently redirects to `/starter-kits/overview`.
> 
> The previous Framer rewrite for `/starter-kits` has been removed so the path no longer proxies to `tldrawdotdev.framer.website`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e6f2ea9a10b54bdcbc9a70f787a8df7ab5223ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->