### PR TITLE
fix(docs): correct example embed URLs to use slug instead of full article ID

### DIFF
--- a/apps/docs/components/content/example.tsx
+++ b/apps/docs/components/content/example.tsx
@@ -10,9 +10,12 @@ export function Example({ article }: { article: Article }) {
 		...Object.keys(additionalFiles).map((key) => ({ name: key, content: additionalFiles[key] })),
 	]
 
+	// article.id is in format "sectionId/categoryId/articleId", we need just the articleId
+	const slug = article.id.split('/').pop()
+
 	return (
 		<div className="w-full mt-8">
-			<Embed src={`${server}/${article.id}/full?utm_source=docs-embed`} />
+			<Embed src={`${server}/${slug}/full?utm_source=docs-embed`} />
 			<CodeFiles files={files} />
 		</div>
 	)


### PR DESCRIPTION
The example embeds on the docs site were generating broken URLs like `https://examples.tldraw.com/examples/events/derived-view/full` instead of the correct `https://examples.tldraw.com/derived-view/full`.

The issue was that `article.id` contains a composite key in the format `sectionId/categoryId/articleId`, but the examples server expects just the example slug. This PR extracts the slug (last segment) from the article ID before constructing the embed URL.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-docs`
2. Navigate to any example page (e.g., `/examples/events/derived-view`)
3. Verify the embedded iframe loads correctly from `examples.tldraw.com/derived-view/full`

### Release notes

- Fix example embeds on docs site generating incorrect URLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small docs-only URL construction change; main risk is `slug` being undefined if `article.id` is malformed, which would still produce a bad embed URL.
> 
> **Overview**
> Fixes docs example embeds to generate URLs using only the example slug (last segment of `article.id`) instead of the full composite `section/category/article` ID.
> 
> Updates `Example` to extract `slug` from `article.id` and uses it when building the `Embed` `src`, preventing broken `examples.tldraw.com` iframe links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5862549b190fb1f5382dbc5ffe093a41c06f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->