### PR TITLE
add tldraw-y claude verbs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,6 @@
 			"selecting",
 			"deselecting",
 			"duplicating",
-			"deleting",
 			"nudging",
 			"resizing",
 			"rotating",
@@ -24,15 +23,9 @@
 			"packing",
 			"grouping",
 			"ungrouping",
-			"reordering",
 			"editing",
 			"cropping",
 			"styling",
-			"locking",
-			"undoing",
-			"redoing",
-			"sharing",
-			"exporting",
 			"embedding"
 		]
 	},


### PR DESCRIPTION
Replaces bad claude verbs with good tldraw claude verbs

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change affecting Claude UI spinner wording; no runtime application logic is modified.
> 
> **Overview**
> Updates `.claude/settings.json` to **replace** the Claude `spinnerVerbs` list with a new set of tldraw-style verbs (e.g., panning/zooming/drawing/etc.), leaving existing permissions/hooks unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 645b99ca4b9d1931f8486d49ac0225e77c135d5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->