### PR TITLE
Remove deprecated downlevelIteration option

### DIFF
--- a/apps/dotcom/zero-cache/tsconfig.json
+++ b/apps/dotcom/zero-cache/tsconfig.json
@@ -15,7 +15,6 @@
 		"jsx": "preserve",
 		"jsxImportSource": "react",
 		"incremental": true,
-		"downlevelIteration": true,
 		"plugins": [{ "name": "next" }]
 	},
 	"include": ["**/*.ts", "**/*.tsx", "src/tla/layouts/TlaAnonLayout", "zero.config.ts"],


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when `target` is `esnext`, so can be safely removed from this config file.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config cleanup: removes a deprecated TypeScript compiler option that is a no-op when targeting `ESNext`, so it should not affect builds or runtime behavior.
> 
> **Overview**
> Removes the deprecated `downlevelIteration` setting from `apps/dotcom/zero-cache/tsconfig.json` (a no-op with `target: ESNext`) to keep the TypeScript config compatible with newer TypeScript versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac9912efaa9134d96eafac3b74eff9730d4a4985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->