### PR TITLE
fix: provide compiled messages to ErrorPage IntlProvider

### DIFF
--- a/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
 import { F, IntlProvider } from '../../tla/utils/i18n'
 import { isInIframe } from '../../utils/iFrame'
 
@@ -48,7 +49,7 @@ export function ErrorPage({
 }) {
 	return (
 		// This sits outside the regular providers, it needs to be able to have the intl object in the app context.
-		<IntlProvider defaultLocale="en" locale="en" messages={{}}>
+		<IntlProvider defaultLocale="en" locale="en" messages={translationsEnJson}>
 			<div className="error-page">
 				<div className="error-page__container">
 					{icon}


### PR DESCRIPTION
## Summary

Fixes #7799

The `ErrorPage` component was passing an empty messages object (`messages={{}}`) to its `IntlProvider`, causing react-intl `FORMAT_ERROR` when rendering translated strings in `GoBackLink`:

```
[@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "324a0f3182", rendering default message verbatim
```

## Solution

Import the compiled English translations (same file used by `TlaRootProviders`) and pass them to the `IntlProvider` in `ErrorPage`.

## Changes

- Import `translationsEnJson` from the compiled locales directory
- Pass `translationsEnJson` to the `IntlProvider` instead of empty object

This mirrors the pattern already used in `TlaRootProviders.tsx` at line 134.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to error-page rendering and only changes which i18n message bundle is passed to `IntlProvider` to avoid runtime `react-intl` format errors.
> 
> **Overview**
> `ErrorPage` now imports the compiled English locale bundle (`public/tla/locales-compiled/en.json`) and passes it to `IntlProvider` instead of `messages={{}}`, preventing `react-intl` `FORMAT_ERROR` when `F`-based strings render (e.g., the go-back CTA).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf007a61d221fbecb380a1770166b39bd8b8a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->