### PR TITLE
fix(dotcom): provide compiled messages to ErrorPage IntlProvider

### DIFF
--- a/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
 import { F, IntlProvider } from '../../tla/utils/i18n'
 import { isInIframe } from '../../utils/iFrame'
 
@@ -48,7 +49,7 @@ export function ErrorPage({
 }) {
 	return (
 		// This sits outside the regular providers, it needs to be able to have the intl object in the app context.
-		<IntlProvider defaultLocale="en" locale="en" messages={{}}>
+		<IntlProvider defaultLocale="en" locale="en" messages={translationsEnJson}>
 			<div className="error-page">
 				<div className="error-page__container">
 					{icon}


### PR DESCRIPTION
Fixes #7799

The `ErrorPage` component was passing an empty messages object (`messages={{}}`) to its `IntlProvider`, causing react-intl `FORMAT_ERROR` when rendering translated strings in `GoBackLink`:

```
[@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "324a0f3182", rendering default message verbatim
```

This imports the compiled English translations (same file used by `TlaRootProviders`) and passes them to the `IntlProvider`.

### Change type

- [x] `bugfix`

### Test plan

1. Navigate to an error page (e.g., invalid file URL)
2. Open browser console
3. Verify no FORMAT_ERROR is logged

### Release notes

- Fixed react-intl console errors on error pages

---

Co-authored-by: Kai Gritun <kai@kaigritun.com>