### PR TITLE
chore(sync): re-enable rate limiting

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/rateLimit.ts
+++ b/apps/dotcom/sync-worker/src/utils/rateLimit.ts
@@ -1,8 +1,6 @@
 import { Environment } from '../types'
 
-export async function isRateLimited(_env: Environment, _key: string): Promise<boolean> {
-	// TODO: rate limiting is broken in cloudflare, disabled for now
-	// const { success } = await env.RATE_LIMITER.limit({ key })
-	// return !success
-	return false
+export async function isRateLimited(env: Environment, key: string): Promise<boolean> {
+	const { success } = await env.RATE_LIMITER.limit({ key })
+	return !success
 }


### PR DESCRIPTION
The Cloudflare rate limiting issue from #7780 has been resolved. This PR re-enables rate limiting by restoring the original `isRateLimited` implementation that calls `env.RATE_LIMITER.limit()`.

https://www.cloudflarestatus.com/incidents/dk0d6pjt9vjx

### Change type

- [x] `improvement`

### Test plan

1. Deploy to staging
2. Verify sync connections work normally
3. Verify rate limiting kicks in under heavy load

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables enforcement of request limits in the sync worker; misconfigured limiter settings or unexpected limiter behavior could cause elevated 429s and disrupt sync/feedback flows under load.
> 
> **Overview**
> Re-enables rate limiting in the sync worker by restoring `isRateLimited` to call `env.RATE_LIMITER.limit({ key })` and returning `!success`, instead of always allowing requests.
> 
> This changes runtime behavior for all call sites (e.g., websocket connections/mutations and `submitFeedback`) to actively enforce limits again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17f882a626978fe85314d047634da4fb90db205c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->