### PR TITLE
fix early return on slurp max file failure

### DIFF
--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -38,12 +38,12 @@ export function Component() {
 						replace: true,
 						state: location.state,
 					})
+					return
 				} else {
 					// if the user has too many files we end up here.
 					// don't slurp the file and when they log out they'll
 					// be able to see the same content that was there before
 				}
-				return
 			}
 
 			const recentFiles = app.getMyFiles()


### PR DESCRIPTION
Before, if slurping failed bc the file limit was reached, we returned without navigating to the user's files, leaving them on a blank screen. 

Now, we don't return when slurping fails, instead continuing through to navigating to the most recent file. 

fixes #7653 

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Have max number of files on your account
2. Log out
3. Create at least one shape
4. Log in
5. You should be redirected to your most recent file and shown the max files toast

### Release notes

- Fixed bug where if your account has the maximum number of files, logging in while having shapes on your logged-out editor got you stuck on a blank screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk control-flow change in local login/navigation: only affects the fallback path when `slurpFile` fails (e.g., max file limit).
> 
> **Overview**
> Fixes a blank-screen edge case in `local.tsx` by only returning early after a *successful* `slurpFile` navigation.
> 
> When `slurpFile` fails (e.g., user hit the max file limit), the flow now continues to the normal fallback that selects/creates a file and navigates to it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee2baf74fd5119012970014b6a39535be7209f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->