### PR TITLE
fix(sync): fix SQLite migration for multiplayer template

### DIFF
--- a/templates/sync-cloudflare/wrangler.toml
+++ b/templates/sync-cloudflare/wrangler.toml
@@ -24,10 +24,13 @@ bindings = [
 ]
 
 # Durable objects require migrations to create/modify/delete them
-# Using new_sqlite_classes for SQLite-backed storage
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["TldrawDurableObject"]
+new_classes = ["TldrawDurableObject"]
+
+[[migrations]]
+tag = "v2"
+classes_with_sqlite = ["TldrawDurableObject"]
 
 # We store asset uploads (images, videos) in an R2 bucket.
 # Room data is stored in Durable Object SQLite storage.


### PR DESCRIPTION
The multiplayer template's wrangler.toml was using `new_sqlite_classes` in its v1 migration, which doesn't work for existing deployments that were originally created with `new_classes` (KV-backed Durable Objects). Cloudflare skips already-applied migration tags, so the SQLite switch was silently ignored on redeploy.

This fixes the migrations to be append-only: v1 creates the DO with `new_classes`, and v2 enables SQLite via `classes_with_sqlite`.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy the multiplayer template to an existing Cloudflare worker that was previously using KV-backed DOs
2. Verify the v2 migration applies and SQLite storage works

### Release notes

- Fixed SQLite migration for the multiplayer Cloudflare template to work with existing deployments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Cloudflare Durable Object migration configuration; misconfiguration could affect deploy/upgrade behavior for existing rooms, but change is limited to `wrangler.toml` and is straightforward.
> 
> **Overview**
> Fixes `templates/sync-cloudflare/wrangler.toml` Durable Object migrations to be *append-only* and compatible with existing deployments.
> 
> `v1` now uses `new_classes` (matching original KV-backed creation), and a new `v2` migration enables SQLite via `classes_with_sqlite` so redeploys actually apply the storage switch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d908f6a5ec4c23d0e1705412fbd46b337282f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->