### PR TITLE
docs: add drag and drop SDK documentation

### DIFF
--- a/apps/docs/content/sdk-features/drag-and-drop.mdx
+++ b/apps/docs/content/sdk-features/drag-and-drop.mdx
@@ -46,12 +46,12 @@ class MyContainerShapeUtil extends ShapeUtil<MyContainerShape> {
 
 When a user drags shapes across the canvas, the editor tracks which shape (if any) is under the cursor. Your shape util can implement these callbacks to respond:
 
-| Callback            | When it fires                                              |
-| ------------------- | ---------------------------------------------------------- |
-| `onDragShapesIn`    | Shapes are first dragged over this shape                   |
-| `onDragShapesOver`  | Shapes continue being dragged over this shape (every tick) |
-| `onDragShapesOut`   | Shapes are dragged away from this shape                    |
-| `onDropShapesOver`  | Shapes are dropped onto this shape                         |
+| Callback           | When it fires                                                                     |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `onDragShapesIn`   | Shapes are first dragged over this shape                                          |
+| `onDragShapesOver` | Shapes continue being dragged over this shape (on an interval, when cursor moves) |
+| `onDragShapesOut`  | Shapes are dragged away from this shape                                           |
+| `onDropShapesOver` | Shapes are dropped onto this shape                                                |
 
 The callbacks receive the target shape (the one being dragged over), an array of the shapes being dragged, and an info object with context about the drag operation.
 
@@ -71,7 +71,7 @@ override onDragShapesIn(shape: MyContainerShape, draggingShapes: TLShape[]) {
 
 ### onDragShapesOver
 
-Called continuously while shapes are being dragged over this shape. Use it for visual feedback or continuous updates like snapping to a grid:
+Called on an interval while shapes are being dragged over this shape, but only when the cursor moves. Use it for visual feedback or grid snapping:
 
 ```typescript
 override onDragShapesOver(shape: MyGridShape, draggingShapes: TLShape[]) {
@@ -146,20 +146,20 @@ All drag callbacks receive an info object with context about the drag operation.
 
 All info types share these common properties:
 
-| Property                     | Description                                              |
-| ---------------------------- | -------------------------------------------------------- |
-| `initialDraggingOverShapeId` | The shape that was under the cursor when drag started    |
-| `initialParentIds`           | Map of each shape's parent ID at drag start              |
-| `initialIndices`             | Map of each shape's z-index at drag start                |
+| Property                     | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `initialDraggingOverShapeId` | The shape that was under the cursor when drag started |
+| `initialParentIds`           | Map of each shape's parent ID at drag start           |
+| `initialIndices`             | Map of each shape's z-index at drag start             |
 
 Some callbacks have additional properties:
 
-| Property                  | Available in       | Description                              |
-| ------------------------- | ------------------ | ---------------------------------------- |
-| `prevDraggingOverShapeId` | `onDragShapesIn`   | The previous shape that was dragged over |
-| `nextDraggingOverShapeId` | `onDragShapesOut`  | The next shape being dragged into        |
+| Property                  | Available in      | Description                              |
+| ------------------------- | ----------------- | ---------------------------------------- |
+| `prevDraggingOverShapeId` | `onDragShapesIn`  | The previous shape that was dragged over |
+| `nextDraggingOverShapeId` | `onDragShapesOut` | The next shape being dragged into        |
 
-The `initialParentIds` and `initialIndices` maps let you restore shapes to their original positions if needed. Frames use this to preserve z-ordering when shapes are dragged back to their original parent.
+The `initialParentIds` and `initialIndices` maps let you restore shapes to their original positions. Frames use this to preserve z-ordering when shapes are dragged back to their original parent.
 
 ## Determining what's under the cursor
 
@@ -178,7 +178,7 @@ override canReceiveNewChildrenOfType(shape: MyContainerShape, type: TLShape['typ
 }
 ```
 
-The editor checks this before calling your drag callbacks.
+You must check this yourself in your drag callbacks. The editor does not call it automatically.
 
 ## Example: slot container
 


### PR DESCRIPTION
Adds new documentation for the shape-to-shape drag and drop system in tldraw. This covers the `ShapeUtil` callbacks (`onDragShapesIn`, `onDragShapesOver`, `onDragShapesOut`, `onDropShapesOver`) that shapes can implement to respond to other shapes being dragged over them.

This is distinct from the existing "External content handling" documentation which covers content dragged from outside the browser (files, URLs, etc.).

### Change type

- [x] `docs`

### Test plan

1. Run `yarn dev-docs`
2. Navigate to SDK Features > Drag and drop
3. Verify the article renders correctly with all code examples and tables

### Release notes

- Add documentation for the shape-to-shape drag and drop system

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new MDX documentation page only, with no runtime code or behavior changes.
> 
> **Overview**
> Adds a new `sdk-features/drag-and-drop.mdx` article documenting the shape-to-shape drag-and-drop system for custom shapes.
> 
> Covers `ShapeUtil` drag/drop callbacks (`onDragShapesIn`, `onDragShapesOver`, `onDragShapesOut`, `onDropShapesOver`), the associated info objects, guidance for determining drop targets and filtering acceptable child types via `canReceiveNewChildrenOfType`, plus a complete slot-container example and links to related docs/examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55eb4b25cfc50bde0c2d836d29ed848defb7ffe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->