### PR TITLE
Revert back to what we had.

### DIFF
--- a/templates/sync-cloudflare/worker-configuration.d.ts
+++ b/templates/sync-cloudflare/worker-configuration.d.ts
@@ -3,9 +3,7 @@
 // Runtime types generated with workerd@1.20250617.0 2025-05-08 nodejs_compat
 declare namespace Cloudflare {
 	interface Env {
-		TLDRAW_DURABLE_OBJECT: DurableObjectNamespace<
-			import('./worker/worker').TldrawDurableObjectSqlite
-		>
+		TLDRAW_DURABLE_OBJECT: DurableObjectNamespace<import('./worker/worker').TldrawDurableObject>
 		TLDRAW_BUCKET: R2Bucket
 	}
 }

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -19,7 +19,7 @@ const schema = createTLSchema({
 //
 // There's only ever one durable object instance per room. Room state is
 // persisted automatically to SQLite via ctx.storage.
-export class TldrawDurableObjectSqlite extends DurableObject {
+export class TldrawDurableObject extends DurableObject {
 	private room: TLSocketRoom<TLRecord, void>
 
 	constructor(ctx: DurableObjectState, env: Env) {

--- a/templates/sync-cloudflare/worker/worker.ts
+++ b/templates/sync-cloudflare/worker/worker.ts
@@ -3,7 +3,7 @@ import { AutoRouter, error, IRequest } from 'itty-router'
 import { handleAssetDownload, handleAssetUpload } from './assetUploads'
 
 // make sure our sync durable object is made available to cloudflare
-export { TldrawDurableObjectSqlite } from './TldrawDurableObjectSqlite'
+export { TldrawDurableObject } from './TldrawDurableObject'
 
 // we use itty-router (https://itty.dev/) to handle routing. in this example we turn on CORS because
 // we're hosting the worker separately to the client. you should restrict this to your own domain.

--- a/templates/sync-cloudflare/wrangler.toml
+++ b/templates/sync-cloudflare/wrangler.toml
@@ -20,22 +20,14 @@ directory = "./dist/client"
 # Set up the durable object used for each tldraw room
 [durable_objects]
 bindings = [
-    { name = "TLDRAW_DURABLE_OBJECT", class_name = "TldrawDurableObjectSqlite" },
+    { name = "TLDRAW_DURABLE_OBJECT", class_name = "TldrawDurableObject" },
 ]
 
 # Durable objects require migrations to create/modify/delete them
+# Using new_sqlite_classes for SQLite-backed storage
 [[migrations]]
 tag = "v1"
-new_classes = ["TldrawDurableObject"]
-
-# v2 was a no-op, kept because existing deployments already applied it
-[[migrations]]
-tag = "v2"
-
-# New SQLite-backed class to replace KV-backed TldrawDurableObject
-[[migrations]]
-tag = "v3"
-new_sqlite_classes = ["TldrawDurableObjectSqlite"]
+new_sqlite_classes = ["TldrawDurableObject"]
 
 # We store asset uploads (images, videos) in an R2 bucket.
 # Room data is stored in Durable Object SQLite storage.


### PR DESCRIPTION
We'll delete the worker and make it redeploy so it picks up the v1 again.

### Change type

- [x] `bugfix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Durable Object class name and wrangler migrations, which can affect existing deployments’ object class mapping and stored state if the migration history differs. Runtime logic is unchanged but misconfiguration could break room connectivity or data persistence.
> 
> **Overview**
> Reverts the Cloudflare sync template to use a single SQLite-backed Durable Object class named `TldrawDurableObject` (renaming from `TldrawDurableObjectSqlite`) and updates exports and generated env typings accordingly.
> 
> Adjusts `wrangler.toml` to bind `TLDRAW_DURABLE_OBJECT` to the reverted class and collapses migrations back to a single `v1` `new_sqlite_classes` entry, removing the prior `v2`/`v3` migration history.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9bf9529300e87ae9ce445db5a02fda7b951711a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->