### PR TITLE
perf(editor): avoid unnecessary Set allocations in notVisibleShapes

### DIFF
--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -9,34 +9,78 @@ import { Editor } from '../Editor'
  * @returns Incremental derivation of non visible shapes.
  */
 export function notVisibleShapes(editor: Editor) {
+	const emptySet = new Set<TLShapeId>()
+
 	return computed<Set<TLShapeId>>('notVisibleShapes', function (prevValue) {
 		const allShapeIds = editor.getCurrentPageShapeIds()
 		const viewportPageBounds = editor.getViewportPageBounds()
 		const visibleIds = editor.getShapeIdsInsideBounds(viewportPageBounds)
 
-		const nextValue = new Set<TLShapeId>()
+		// Fast path: if all shapes are visible, return empty set
+		if (visibleIds.size === allShapeIds.size) {
+			if (isUninitialized(prevValue) || prevValue.size > 0) {
+				return emptySet
+			}
+			return prevValue
+		}
 
-		// Non-visible shapes are all shapes minus visible shapes
-		for (const id of allShapeIds) {
-			if (!visibleIds.has(id)) {
+		// First run: compute from scratch
+		if (isUninitialized(prevValue)) {
+			const nextValue = new Set<TLShapeId>()
+			for (const id of allShapeIds) {
+				if (visibleIds.has(id)) continue
+
 				const shape = editor.getShape(id)
 				if (!shape) continue
 
-				const canCull = editor.getShapeUtil(shape.type).canCull(shape)
-				if (!canCull) continue
+				if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
 
 				nextValue.add(id)
 			}
-		}
-
-		if (isUninitialized(prevValue) || prevValue.size !== nextValue.size) {
 			return nextValue
 		}
 
-		for (const prev of prevValue) {
-			if (!nextValue.has(prev)) return nextValue
+		// Subsequent runs: check if result differs before creating new Set
+		let count = 0
+		let hasDiff = false
+
+		for (const id of allShapeIds) {
+			if (visibleIds.has(id)) continue
+
+			const shape = editor.getShape(id)
+			if (!shape) continue
+
+			if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
+
+			count++
+			if (!hasDiff && !prevValue.has(id)) {
+				hasDiff = true
+			}
 		}
 
-		return prevValue
+		// Check if size changed
+		if (!hasDiff && prevValue.size !== count) {
+			hasDiff = true
+		}
+
+		// If nothing changed, return the previous value
+		if (!hasDiff) {
+			return prevValue
+		}
+
+		// Build the new Set (only when needed)
+		const nextValue = new Set<TLShapeId>()
+		for (const id of allShapeIds) {
+			if (visibleIds.has(id)) continue
+
+			const shape = editor.getShape(id)
+			if (!shape) continue
+
+			if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
+
+			nextValue.add(id)
+		}
+
+		return nextValue
 	})
 }


### PR DESCRIPTION
## Summary
- Add fast path when all shapes are visible (return cached empty set)
- On first run, compute from scratch
- On subsequent runs, check if result differs before creating new Set
- Only allocate new Set when contents actually changed

This reduces GC pressure by avoiding unnecessary Set allocations on every frame.

## Test plan
- [x] Typecheck passes
- [ ] Manual testing with many shapes on canvas

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor limited to `notVisibleShapes` derivation; main risk is subtle cache/identity behavior affecting downstream consumers if the computed value no longer updates when expected.
> 
> **Overview**
> Optimizes `notVisibleShapes` to reduce GC pressure by **reusing Set instances** instead of allocating a new `Set` every recompute.
> 
> Adds a fast path that returns a cached empty `Set` when all shapes are visible, computes from scratch on the first run, and on subsequent runs scans to detect changes before building a new `Set` (returning `prevValue` when contents are unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e74207fbe4ba185c21c5b0d0756fcbbd82cecdd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->