### PR TITLE
perf(store): simplify string hash caching in ImmutableMap

### DIFF
--- a/packages/store/src/lib/ImmutableMap.ts
+++ b/packages/store/src/lib/ImmutableMap.ts
@@ -3,7 +3,6 @@
  * MIT License: https://github.com/immutable-js/immutable-js/blob/main/LICENSE
  * Copyright (c) 2014-present, Lee Byron and other contributors.
  */
-
 function smi(i32: number) {
 	return ((i32 >>> 1) & 0x40000000) | (i32 & 0xbfffffff)
 }
@@ -35,7 +34,7 @@ function hash(o: any) {
 		case 'number':
 			return hashNumber(v)
 		case 'string':
-			return v.length > STRING_HASH_CACHE_MIN_STRLEN ? cachedHashString(v) : hashString(v)
+			return cachedHashString(v)
 		case 'object':
 		case 'function':
 			return hashJSObj(v)
@@ -73,11 +72,6 @@ function cachedHashString(string: string) {
 	let hashed = stringHashCache[string]
 	if (hashed === undefined) {
 		hashed = hashString(string)
-		if (STRING_HASH_CACHE_SIZE === STRING_HASH_CACHE_MAX_SIZE) {
-			STRING_HASH_CACHE_SIZE = 0
-			stringHashCache = {}
-		}
-		STRING_HASH_CACHE_SIZE++
 		stringHashCache[string] = hashed
 	}
 	return hashed
@@ -145,10 +139,7 @@ const symbolMap = Object.create(null)
 
 let _objHashUID = 0
 
-const STRING_HASH_CACHE_MIN_STRLEN = 16
-const STRING_HASH_CACHE_MAX_SIZE = 255
-let STRING_HASH_CACHE_SIZE = 0
-let stringHashCache: Record<string, number> = {}
+const stringHashCache: Record<string, number> = {}
 
 // Constants describing the size of trie nodes.
 const SHIFT = 5 // Resulted in best performance after ______?


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/7833. Previously, once the number of shapes grew to 256, we were creating new hashes for all shapes on every frame.

## Summary

- Cache all strings regardless of length (removed 16-char minimum threshold)
- Remove cache eviction logic (no more 255 entry limit and reset)
- Simplify to unbounded cache since shape IDs are finite per document

The previous implementation avoided caching short strings and had an eviction policy. However, in tldraw's use case, the number of unique string keys is bounded by the document's shape/record count, so an unbounded cache is safe and reduces overhead.

## Test plan
- [x] Typecheck passes
- [ ] Manual testing with large documents

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hashing hot-path used by `ImmutableMap` to always cache string hashes and removes cache eviction, which could increase memory use or alter performance characteristics on workloads with many unique strings.
> 
> **Overview**
> **Simplifies string hash caching in `ImmutableMap`** by always routing string hashing through `cachedHashString` (removing the short-string threshold).
> 
> Removes the cache size/eviction logic and related constants, making `stringHashCache` an unbounded in-memory map that retains all hashed strings for the process lifetime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3fefe084b6378ab6bbed108da4bdf2be19d6e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->