### PR TITLE
perf(editor): replace lodash isEqual with optimized Set comparisons

### DIFF
--- a/packages/editor/src/lib/hooks/usePeerIds.ts
+++ b/packages/editor/src/lib/hooks/usePeerIds.ts
@@ -1,5 +1,4 @@
 import { useAtom, useComputed, useValue } from '@tldraw/state-react'
-import { isEqual } from '@tldraw/utils'
 import { useEffect } from 'react'
 import {
 	getCollaboratorStateFromElapsedTime,
@@ -7,6 +6,14 @@ import {
 } from '../utils/collaboratorState'
 import { uniq } from '../utils/uniq'
 import { useEditor } from './useEditor'
+
+function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+	if (a.size !== b.size) return false
+	for (const item of a) {
+		if (!b.has(item)) return false
+	}
+	return true
+}
 
 // TODO: maybe move this to a computed property on the App class?
 /**
@@ -60,7 +67,7 @@ export function useActivePeerIds$() {
 					.map((p) => p.userId)
 			)
 		},
-		{ isEqual },
+		{ isEqual: setsEqual },
 		[editor]
 	)
 }


### PR DESCRIPTION
In order to fix a major performance bottleneck in large multiplayer rooms, this PR replaces expensive lodash deep equality checks with custom equality functions optimized for Sets.

lodash's `isEqual` doesn't handle Sets efficiently - it likely converts them to arrays for deep comparison. With thousands of shapes in large multiplayer rooms, this was causing significant performance overhead on every frame during the equality checks in computed signals.

### Change type

- [x] `improvement`

### Test plan

1. Open a large multiplayer room with many shapes
2. Check flame graph - `isEqual` should no longer appear in hot paths

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve performance in large multiplayer rooms by replacing lodash deep equality with optimized Set comparisons