### PR TITLE
Use a different formulation of `TLShape` and `TLBinding`

### DIFF
--- a/packages/tldraw/src/test/test-jsx.tsx
+++ b/packages/tldraw/src/test/test-jsx.tsx
@@ -65,18 +65,17 @@ interface CommonBindingReactProps extends BindingReactConnections {
 type ReactPropsForBinding<Type extends TLBinding['type']> = CommonBindingReactProps &
 	Partial<TLBinding<Type>['props']>
 
-type BindingToCreate = TLBinding extends infer E
-	? E extends TLBinding
-		? {
-				type: E['type']
-				props: Partial<TLBinding<E['type']>['props']>
-				id: TLBindingId | undefined
-				parentId: TLShapeId | undefined
-				ref: string | undefined
-				connections: BindingReactConnections
-			}
-		: never
+type _BindingToCreate<E extends TLBinding = TLBinding> = E extends E
+	? {
+			type: E['type']
+			props: Partial<TLBinding<E['type']>['props']>
+			id: TLBindingId | undefined
+			parentId: TLShapeId | undefined
+			ref: string | undefined
+			connections: BindingReactConnections
+		}
 	: never
+type BindingToCreate = _BindingToCreate
 
 const createElement = (
 	type: typeof shapeTypeSymbol | typeof assetTypeSymbol | typeof bindingTypeSymbol,

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -23,6 +23,7 @@ import { StoreSnapshot } from '@tldraw/store';
 import { StoreValidator } from '@tldraw/store';
 import { T } from '@tldraw/validate';
 import { UnknownRecord } from '@tldraw/store';
+import { Values } from '@tldraw/utils';
 
 // @public
 export const arrowBindingMigrations: TLPropsMigrations;
@@ -853,7 +854,9 @@ export interface TLBaseShape<Type extends string, Props extends object> {
 }
 
 // @public
-export type TLBinding<K extends keyof TLIndexedBindings = keyof TLIndexedBindings> = TLIndexedBindings[K];
+export type TLBinding<K extends TLUnionizedBindings['type'] = TLUnionizedBindings['type']> = Extract<TLUnionizedBindings, {
+    type: K;
+}>;
 
 // @public
 export type TLBindingCreate<T extends TLBinding = TLBinding> = T extends T ? {
@@ -1154,22 +1157,6 @@ export interface TLImageShapeProps {
     w: number;
 }
 
-// @public (undocumented)
-export type TLIndexedBindings = {
-    [K in keyof TLGlobalBindingPropsMap | TLDefaultBinding['type'] as K extends TLDefaultBinding['type'] ? K extends keyof TLGlobalBindingPropsMap ? TLGlobalBindingPropsMap[K] extends null | undefined ? never : K : K : K]: K extends TLDefaultBinding['type'] ? K extends keyof TLGlobalBindingPropsMap ? TLBaseBinding<K, TLGlobalBindingPropsMap[K]> : Extract<TLDefaultBinding, {
-        type: K;
-    }> : TLBaseBinding<K, TLGlobalBindingPropsMap[K & keyof TLGlobalBindingPropsMap]>;
-};
-
-// @public (undocumented)
-export type TLIndexedShapes = {
-    [K in keyof TLGlobalShapePropsMap | TLDefaultShape['type'] as K extends TLDefaultShape['type'] ? K extends 'group' ? K : K extends keyof TLGlobalShapePropsMap ? TLGlobalShapePropsMap[K] extends null | undefined ? never : K : K : K]: K extends 'group' ? Extract<TLDefaultShape, {
-        type: K;
-    }> : K extends TLDefaultShape['type'] ? K extends keyof TLGlobalShapePropsMap ? TLBaseShape<K, TLGlobalShapePropsMap[K]> : Extract<TLDefaultShape, {
-        type: K;
-    }> : TLBaseShape<K, TLGlobalShapePropsMap[K & keyof TLGlobalShapePropsMap]>;
-};
-
 // @public
 export interface TLInstance extends BaseRecord<'instance', TLInstanceId> {
     // (undocumented)
@@ -1445,7 +1432,9 @@ export interface TLScribble {
 export type TLSerializedStore = SerializedStore<TLRecord>;
 
 // @public
-export type TLShape<K extends keyof TLIndexedShapes = keyof TLIndexedShapes> = TLIndexedShapes[K];
+export type TLShape<K extends TLUnionizedShapes['type'] = TLUnionizedShapes['type']> = Extract<TLUnionizedShapes, {
+    type: K;
+}>;
 
 // @public
 export interface TLShapeCrop {
@@ -1510,6 +1499,22 @@ export interface TLTextShapeProps {
     // (undocumented)
     w: number;
 }
+
+// @public (undocumented)
+export type TLUnionizedBindings = Values<{
+    [K in keyof TLGlobalBindingPropsMap | TLDefaultBinding['type'] as K extends TLDefaultBinding['type'] ? K extends keyof TLGlobalBindingPropsMap ? TLGlobalBindingPropsMap[K] extends null | undefined ? never : K : K : K]: K extends TLDefaultBinding['type'] ? K extends keyof TLGlobalBindingPropsMap ? TLBaseBinding<K, TLGlobalBindingPropsMap[K]> : Extract<TLDefaultBinding, {
+        type: K;
+    }> : TLBaseBinding<K, TLGlobalBindingPropsMap[K & keyof TLGlobalBindingPropsMap]>;
+}>;
+
+// @public (undocumented)
+export type TLUnionizedShapes = Values<{
+    [K in keyof TLGlobalShapePropsMap | TLDefaultShape['type'] as K extends TLDefaultShape['type'] ? K extends 'group' ? K : K extends keyof TLGlobalShapePropsMap ? TLGlobalShapePropsMap[K] extends null | undefined ? never : K : K : K]: K extends 'group' ? Extract<TLDefaultShape, {
+        type: K;
+    }> : K extends TLDefaultShape['type'] ? K extends keyof TLGlobalShapePropsMap ? TLBaseShape<K, TLGlobalShapePropsMap[K]> : Extract<TLDefaultShape, {
+        type: K;
+    }> : TLBaseShape<K, TLGlobalShapePropsMap[K & keyof TLGlobalShapePropsMap]>;
+}>;
 
 // @public
 export type TLUnknownBinding = TLBaseBinding<string, object>;

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -100,7 +100,7 @@ export {
 	type TLBindingUpdate,
 	type TLDefaultBinding,
 	type TLGlobalBindingPropsMap,
-	type TLIndexedBindings,
+	type TLUnionizedBindings,
 	type TLUnknownBinding,
 } from './records/TLBinding'
 export { CameraRecordType, type TLCamera, type TLCameraId } from './records/TLCamera'
@@ -152,11 +152,11 @@ export {
 	type TLCreateShapePartial,
 	type TLDefaultShape,
 	type TLGlobalShapePropsMap,
-	type TLIndexedShapes,
 	type TLParentId,
 	type TLShape,
 	type TLShapeId,
 	type TLShapePartial,
+	type TLUnionizedShapes,
 	type TLUnknownShape,
 } from './records/TLShape'
 export {

--- a/packages/tlschema/src/records/TLBinding.ts
+++ b/packages/tlschema/src/records/TLBinding.ts
@@ -5,7 +5,7 @@ import {
 	createRecordMigrationSequence,
 	createRecordType,
 } from '@tldraw/store'
-import { mapObjectMapValues, uniqueId } from '@tldraw/utils'
+import { Values, mapObjectMapValues, uniqueId } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
 import { TLArrowBinding } from '../bindings/TLArrowBinding'
 import { TLBaseBinding, createBindingValidator } from '../bindings/TLBaseBinding'
@@ -62,7 +62,7 @@ export interface TLGlobalBindingPropsMap {}
 
 /** @public */
 // prettier-ignore
-export type TLIndexedBindings = {
+export type TLUnionizedBindings = Values<{
 	// We iterate over a union of augmented keys and default binding types.
 	// This allows us to include (or conditionally exclude or override) the default bindings in one go.
 	//
@@ -83,7 +83,7 @@ export type TLIndexedBindings = {
 					Extract<TLDefaultBinding, { type: K }>
 			: // use the custom binding definition
 				TLBaseBinding<K, TLGlobalBindingPropsMap[K & keyof TLGlobalBindingPropsMap]>
-}
+}>
 
 /**
  * The set of all bindings that are available in the editor.
@@ -114,8 +114,8 @@ export type TLIndexedBindings = {
  *
  * @public
  */
-export type TLBinding<K extends keyof TLIndexedBindings = keyof TLIndexedBindings> =
-	TLIndexedBindings[K]
+export type TLBinding<K extends TLUnionizedBindings['type'] = TLUnionizedBindings['type']> =
+	Extract<TLUnionizedBindings, { type: K }>
 
 /**
  * Type for updating existing bindings with partial properties.

--- a/packages/tlschema/src/records/TLShape.ts
+++ b/packages/tlschema/src/records/TLShape.ts
@@ -5,7 +5,7 @@ import {
 	createRecordMigrationSequence,
 	createRecordType,
 } from '@tldraw/store'
-import { mapObjectMapValues, uniqueId } from '@tldraw/utils'
+import { Values, mapObjectMapValues, uniqueId } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
 import { SchemaPropsInfo } from '../createTLSchema'
 import { TLPropsMigrations } from '../recordsWithProps'
@@ -85,7 +85,7 @@ export interface TLGlobalShapePropsMap {}
 
 /** @public */
 // prettier-ignore
-export type TLIndexedShapes = {
+export type TLUnionizedShapes = Values<{
 	// We iterate over a union of augmented keys and default shape types.
 	// This allows us to include (or conditionally exclude or override) the default shapes in one go.
 	//
@@ -112,7 +112,7 @@ export type TLIndexedShapes = {
 					Extract<TLDefaultShape, { type: K }>
 			: // use the custom shape definition
 				TLBaseShape<K, TLGlobalShapePropsMap[K & keyof TLGlobalShapePropsMap]>
-}
+}>
 
 /**
  * The set of all shapes that are available in the editor.
@@ -143,7 +143,10 @@ export type TLIndexedShapes = {
  *
  * @public
  */
-export type TLShape<K extends keyof TLIndexedShapes = keyof TLIndexedShapes> = TLIndexedShapes[K]
+export type TLShape<K extends TLUnionizedShapes['type'] = TLUnionizedShapes['type']> = Extract<
+	TLUnionizedShapes,
+	{ type: K }
+>
 
 /**
  * A partial version of a shape, useful for updates and patches.

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -522,6 +522,9 @@ export function uniqueId(size?: number): string;
 // @internal
 export function validateIndexKey(index: string): asserts index is IndexKey;
 
+// @public
+export type Values<T> = T[keyof T];
+
 // @internal
 export function warnDeprecatedGetter(name: string): void;
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -98,6 +98,7 @@ export {
 	type MakeUndefinedOptional,
 	type RecursivePartial,
 	type Required,
+	type Values,
 } from './lib/types'
 export { safeParseUrl } from './lib/url'
 export {

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -139,3 +139,21 @@ export type MakeUndefinedOptional<T extends object> = Expand<
 		[P in { [K in keyof T]: undefined extends T[K] ? K : never }[keyof T]]?: T[P]
 	}
 >
+
+/**
+ * Extracts the union of all value types from an object type.
+ *
+ * @example
+ * ```ts
+ * type Colors = {
+ *   red: '#ff0000',
+ *   green: '#00ff00',
+ *   blue: '#0000ff'
+ * }
+ *
+ * type ColorValues = Values<Colors> // '#ff0000' | '#00ff00' | '#0000ff'
+ * ```
+ *
+ * @public
+ */
+export type Values<T> = T[keyof T]


### PR DESCRIPTION
### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

I do believe the provided repro case hits a TS issue (I'll be reporting it) but in the meanime we can use a different formulation of those types to fix the reported issue. 

### Test plan

- [x] manual tests in the provided repro

### Release notes

_placeholder_

fixes https://github.com/tldraw/tldraw/issues/7755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Type-level refactor in exported schema types (`TLShape`, `TLBinding`) and removal/rename of the underlying indexed-map aliases may break downstream TypeScript builds that relied on the old (undocumented) types, though there are no runtime behavior changes.
> 
> **Overview**
> Refactors the `@tldraw/tlschema` type model for `TLShape` and `TLBinding` to avoid a TypeScript inference issue by switching from indexed-map aliases (`TLIndexedShapes`/`TLIndexedBindings`) to value-union aliases (`TLUnionizedShapes`/`TLUnionizedBindings`) and defining `TLShape`/`TLBinding` via `Extract<...,{type: K}>`.
> 
> Adds a new shared utility type `Values<T> = T[keyof T]` (exported from `@tldraw/utils`) and updates the public exports/API reports accordingly; test JSX helpers update their binding creation conditional type to a distributive `_BindingToCreate` helper to match the new formulation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b577f0e38679377934df4717305124898ac6d6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->