### PR TITLE
license: fix console message colors for warnings/errors

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -431,25 +431,25 @@ export class LicenseManager {
 	private outputMessages(messages: string[], type: 'warning' | 'error' = 'error') {
 		if (this.isTest) return
 		if (this.verbose) {
-			this.outputDelimiter()
+			this.outputDelimiter(type)
 			for (const message of messages) {
-				const color = type === 'warning' ? 'orange' : 'crimson'
 				const bgColor = type === 'warning' ? 'orange' : 'crimson'
 				// eslint-disable-next-line no-console
 				console.log(
 					`%c${message}`,
-					`color: ${color}; background: ${bgColor}; padding: 2px; border-radius: 3px;`
+					`color: white; background: ${bgColor}; padding: 2px; border-radius: 3px;`
 				)
 			}
-			this.outputDelimiter()
+			this.outputDelimiter(type)
 		}
 	}
 
-	private outputDelimiter() {
+	private outputDelimiter(type: 'warning' | 'error' = 'error') {
+		const bgColor = type === 'warning' ? 'orange' : 'crimson'
 		// eslint-disable-next-line no-console
 		console.log(
 			'%c-------------------------------------------------------------------',
-			`color: white; background: crimson; padding: 2px; border-radius: 3px;`
+			`color: white; background: ${bgColor}; padding: 2px; border-radius: 3px;`
 		)
 	}
 


### PR DESCRIPTION
oof, i had messed this up in https://github.com/tldraw/tldraw/pull/6844 🤦 
i'll have to backport this to the 3.x branch as well, doh


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- license: fix console message colors for warnings/errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects verbose console logging styles for license warnings/errors; no licensing logic or data handling changes.
> 
> **Overview**
> Fixes console output styling for license validation messages so *warnings* and *errors* render with consistent, type-appropriate colors.
> 
> `outputDelimiter` now accepts the message `type` and uses the same background color as the message output, and message text is standardized to white for readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d83c190585f9ea3a2f8d488a6e4ec7bd97f0ea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->