### PR TITLE
fix(dotcom): mismatch between asset id and props.src when importing

### DIFF
--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -42,6 +42,8 @@ const localFileCache = new WeakMap<TLAsset, { file: File; url: string }>()
 // this is used by our multiplayer asset store to load slurped assets from indexedDb
 // temporarily while they are being uploaded to the server.
 export async function loadLocalFile(asset: TLAsset): Promise<{ file: File; url: string } | null> {
+	if (!asset.props.src) return null
+
 	const existing = localFileCache.get(asset)
 	if (existing) return existing
 	const slurpPersistenceKey = getGlobalSlurpPersistenceKey()
@@ -49,7 +51,7 @@ export async function loadLocalFile(asset: TLAsset): Promise<{ file: File; url: 
 
 	const db = new LocalIndexedDb(slurpPersistenceKey)
 	try {
-		const file = await db.getAsset(asset.props.src || asset.id)
+		const file = await db.getAsset(asset.props.src)
 		if (!file) {
 			console.error(
 				`Failed to find local file for asset ({id: ${asset.id}, src ${asset.props.src}})`


### PR DESCRIPTION
### Problem

When importing a file that contains assets into a local (unlogged) tldraw, slurping on signing in will fail 100% of the time.

### Findings

Exported files have base64 data url for props.src; once imported, the image is uploaded in the local database and the resulting entry in assets table has a different id than the shape "asset.id". Slurping retrieve the image data from the assets table using `asset.id`, which is not the same as `asset.props.src` and we end up lost in limbos for ever and ever.

### Solution

Rely on props.src when slurping. 

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Import a .tldr file with image assets into a local tldraw
2. Sign in
3. Slurp does not fail

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed slurping of imported tldraw files with image assets.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to asset lookup keys during slurping; main risk is missing/incorrect `props.src` values causing assets to fail to load until uploaded.
> 
> **Overview**
> Fixes slurping of imported assets by changing local blob retrieval to key off `asset.props.src` (and bailing early when it’s missing) instead of `asset.id`, avoiding mismatches between imported shape asset ids and IndexedDB asset entries.
> 
> Adds a targeted error log when the expected local file can’t be found to make slurp/upload failures easier to diagnose.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa29274d55bf79d8199d690dda51c20f1847b363. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->