### PR TITLE
fix(editor): pass initialPageTransform when resizing unaligned shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7842,6 +7842,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			initialShape: options.initialShape,
 			initialBounds: options.initialBounds,
 			isAspectRatioLocked: options.isAspectRatioLocked,
+			initialPageTransform: options.initialPageTransform,
 		})
 
 		// then if the shape is flipped in one axis only, we need to apply an extra rotation


### PR DESCRIPTION
When resizing an unaligned shape (e.g. a rotated arrow), `_resizeUnalignedShape` calls `resizeShape` but was not forwarding the `initialPageTransform` option. This caused `resizeShape` to re-derive the page transform from the shape's current state instead of using the original transform from when the resize began. Since `_resizeUnalignedShape` modifies the shape's position/rotation during resize, using the stale current transform led to compounding errors that could cause shapes to "explode" (grow or move uncontrollably).

This PR passes `initialPageTransform` through to `resizeShape` so that the correct initial transform is used consistently throughout the resize operation.

fixes #7151 

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow between two shapes
2. Rotate one of the shapes so the arrow is not axis-aligned
3. Select the arrow and resize it by dragging a corner handle
4. Verify the arrow resizes smoothly without jumping or growing uncontrollably

### Release notes

- Fix shapes exploding when resizing unaligned arrows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to editor resize option plumbing; main risk is subtle regressions in edge-case resize behavior for rotated/flipped shapes.
> 
> **Overview**
> Fixes a resize bug for *unaligned/awkwardly rotated shapes* (e.g. rotated arrows) where `_resizeUnalignedShape` called `resizeShape` without forwarding `initialPageTransform`.
> 
> `_resizeUnalignedShape` now passes through `initialPageTransform` to keep the resize math anchored to the transform captured at resize start, preventing compounding transform errors that could cause shapes to jump/grow uncontrollably during the drag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eccd4a709fd7dd931f9d3da7517d924722bf49b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->