### PR TITLE
Fix serving of svg assets

### DIFF
--- a/packages/worker-shared/src/userAssetUploads.ts
+++ b/packages/worker-shared/src/userAssetUploads.ts
@@ -120,6 +120,11 @@ export async function handleUserAssetGet({
 	// cache, which isn't allowed by cloudflare.
 	headers.set('access-control-allow-origin', '*')
 
+	// Prevent XSS from user-uploaded SVGs (or any file served with an executable content-type).
+	// This is critical when assets are served from the same origin as the app.
+	headers.set('content-security-policy', "default-src 'none'")
+	headers.set('x-content-type-options', 'nosniff')
+
 	// cloudflare doesn't set the content-range header automatically in writeHttpMetadata, so we
 	// need to do it ourselves.
 	let contentRange

--- a/templates/simple-server-example/src/server/server.ts
+++ b/templates/simple-server-example/src/server/server.ts
@@ -60,6 +60,9 @@ app.register(async (app) => {
 	app.get('/uploads/:id', async (req, res) => {
 		const id = (req.params as any).id as string
 		const data = await loadAsset(id)
+		// Prevent XSS from user-uploaded SVGs
+		res.header('Content-Security-Policy', "default-src 'none'")
+		res.header('X-Content-Type-Options', 'nosniff')
 		res.send(data)
 	})
 

--- a/templates/socketio-server-example/src/server/server.ts
+++ b/templates/socketio-server-example/src/server/server.ts
@@ -111,6 +111,9 @@ app.get('/uploads/:id', async (req, res) => {
 	try {
 		const id = req.params.id
 		const data = await loadAsset(id)
+		// Prevent XSS from user-uploaded SVGs
+		res.header('Content-Security-Policy', "default-src 'none'")
+		res.header('X-Content-Type-Options', 'nosniff')
 		res.send(data)
 	} catch (error) {
 		console.error('Asset download error:', error)

--- a/templates/sync-cloudflare/worker/assetUploads.ts
+++ b/templates/sync-cloudflare/worker/assetUploads.ts
@@ -65,6 +65,10 @@ export async function handleAssetDownload(request: IRequest, env: Env, ctx: Exec
 	// cache, which isn't allowed by cloudflare.
 	headers.set('access-control-allow-origin', '*')
 
+	// Prevent XSS from user-uploaded SVGs (or any file served with an executable content-type).
+	headers.set('content-security-policy', "default-src 'none'")
+	headers.set('x-content-type-options', 'nosniff')
+
 	// cloudflare doesn't set the content-range header automatically in writeHttpMetadata, so we
 	// need to do it ourselves.
 	let contentRange


### PR DESCRIPTION
### Change type

- [x] `bugfix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes response security headers for all served uploads, which could affect client rendering/embedding behavior, but is scoped to asset download endpoints and reduces XSS risk.
> 
> **Overview**
> Adds defense-in-depth headers when serving user-uploaded assets to prevent SVG/executable content from running when accessed from the app origin.
> 
> Cloudflare R2-backed download handlers and the Fastify/Express template `/uploads/:id` routes now set `Content-Security-Policy: default-src 'none'` and `X-Content-Type-Options: nosniff` on asset responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ac8fe3c453fe39c2024a6c202c59639fbc4016e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->