### PR TITLE
fix(dotcom): Wrong FR translation for pin/unpin

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/fr.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/fr.json
@@ -96,7 +96,7 @@
   "12a6766ba1": [
     {
       "type": 0,
-      "value": "Détacher le fichier"
+      "value": "Désépingler le fichier"
     }
   ],
   "12c8a9838c": [
@@ -288,7 +288,7 @@
   "47f493a590": [
     {
       "type": 0,
-      "value": "Fichier d'épingles"
+      "value": "Épingler le fichier"
     }
   ],
   "49049467ff": [

--- a/apps/dotcom/client/public/tla/locales/fr.json
+++ b/apps/dotcom/client/public/tla/locales/fr.json
@@ -45,7 +45,7 @@
     "translation": "Quitter le groupe"
   },
   "12a6766ba1": {
-    "translation": "Détacher le fichier"
+    "translation": "Désépingler le fichier"
   },
   "12c8a9838c": {
     "translation": "Essayez le SDK tldraw"
@@ -141,7 +141,7 @@
     "translation": "tldraw"
   },
   "47f493a590": {
-    "translation": "Fichier d'épingles"
+    "translation": "Épingler le fichier"
   },
   "49049467ff": {
     "translation": "Collez l'URL du fichier tldraw..."


### PR DESCRIPTION
I may be the only one using tldraw in french. 
Anyhoo, found quite the weird translation for pin/unpin and HAD to correct it!

However, it's probably worth asking ourselves how these look in other languages as well. I've done some checks with chatGPT + Claude and "Épingler" and "Désépingler" are canonical in french UIs in various softwares. 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- Fixed translation of FR "Pin/Unpin"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization-only string changes with no functional or behavioral impact beyond displayed text.
> 
> **Overview**
> Corrects French translations for file pinning actions in `apps/dotcom/client/public/tla/locales/fr.json` and the compiled `locales-compiled/fr.json`, replacing the incorrect “Fichier d'épingles”/“Détacher le fichier” wording with “Épingler le fichier” and “Désépingler le fichier.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dfc59ec4abe9043eed6376917760d9fb41a2ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->