### PR TITLE
fix: geo shapes with text could not be resized to a smaller size

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -1,4 +1,4 @@
-import { Group2d, IndexKey, TLShapeId } from '@tldraw/editor'
+import { Group2d, IndexKey, TLGeoShape, TLShapeId, createShapeId, toRichText } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
 import { TL } from '../../../test/test-jsx'
 
@@ -7,6 +7,10 @@ let ids: Record<string, TLShapeId>
 
 beforeEach(() => {
 	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
 })
 
 describe('Handle snapping', () => {
@@ -74,5 +78,91 @@ describe('Handle snapping', () => {
 		editor.pointerMove(labelVertex.x + 2, labelVertex.y + 2, undefined, { ctrlKey: true })
 		expect(editor.snaps.getIndicators()).toHaveLength(0)
 		expect(lineHandles()[0]).toMatchObject({ x: labelVertex.x + 2, y: labelVertex.y + 2 })
+	})
+})
+
+describe('Resizing geo shapes with labels', () => {
+	const geoId = createShapeId('geo')
+
+	function getGeo() {
+		return editor.getShape<TLGeoShape>(geoId)!
+	}
+
+	test('can be resized narrower than the initial label width', () => {
+		// Create a wide shape with a short label
+		editor.createShapes([
+			{
+				id: geoId,
+				type: 'geo',
+				props: { w: 300, h: 100, richText: toRichText('Hi'), geo: 'rectangle' },
+			},
+		])
+		const initialW = getGeo().props.w
+
+		// Resize to half width
+		editor.resizeShape(geoId, { x: 0.5, y: 1 })
+
+		// Should be narrower than initial — not locked to the initial label measurement width
+		const afterW = getGeo().props.w
+		expect(afterW).toBeLessThan(initialW)
+	})
+
+	test('height grows to accommodate wrapped text when resized narrower', () => {
+		// Create a shape where the label fits without wrapping.
+		// "Hello World" (11 chars) at medium size has raw text width = 121,
+		// so min label width = 153. At initial w=300 the text is one line.
+		editor.createShapes([
+			{
+				id: geoId,
+				type: 'geo',
+				props: { w: 300, h: 100, richText: toRichText('Hello World'), geo: 'rectangle' },
+			},
+		])
+
+		// Resize to a narrow width AND short height — text must wrap at the narrower width,
+		// and the height should grow to fit the taller wrapped text.
+		editor.resizeShape(geoId, { x: 0.2, y: 0.3 })
+
+		const geo = getGeo()
+		// The height should be greater than the naive 100 * 0.3 = 30 target,
+		// because the text wraps at the narrower width and needs more vertical space.
+		expect(geo.props.h).toBeGreaterThan(30)
+	})
+
+	test('width is constrained to at least the minimum label width', () => {
+		// "Hello World" has a minimum label width of 153 (text raw width 121 + padding 32)
+		editor.createShapes([
+			{
+				id: geoId,
+				type: 'geo',
+				props: { w: 300, h: 100, richText: toRichText('Hello World'), geo: 'rectangle' },
+			},
+		])
+
+		// Try to resize to something very small
+		editor.resizeShape(geoId, { x: 0.1, y: 1 })
+
+		const geo = getGeo()
+		// The width should be at least MIN_SIZE_WITH_LABEL (51) — the text's minimum width
+		// is actually larger (153), so the shape should be constrained to the label width
+		expect(geo.props.w).toBeGreaterThanOrEqual(51)
+		// And specifically, it should be at least the label's minimum width
+		expect(geo.props.w).toBeGreaterThan(100)
+	})
+
+	test('shape without label can be resized freely', () => {
+		editor.createShapes([
+			{
+				id: geoId,
+				type: 'geo',
+				props: { w: 300, h: 200, geo: 'rectangle' },
+			},
+		])
+
+		editor.resizeShape(geoId, { x: 0.1, y: 0.1 })
+
+		const geo = getGeo()
+		expect(geo.props.w).toBeLessThan(50)
+		expect(geo.props.h).toBeLessThan(50)
 	})
 })


### PR DESCRIPTION
this regressed in https://github.com/tldraw/tldraw/pull/7412 and we didn't notice til now, oops.

before:

https://github.com/user-attachments/assets/1d02cfdb-5f6b-4b1c-bdc6-f4c7122863ba

after:

https://github.com/user-attachments/assets/3c34687c-3ff9-4839-87c0-574b2873581a





### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- fix: geo shapes with text could not be resized to a smaller size

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `GeoShapeUtil.onResize` sizing constraints and bypasses the label-size cache during drag-resize, which could affect resize behavior/perf for all labeled geo shapes; changes are covered by new unit tests.
> 
> **Overview**
> Fixes geo-shape resizing when a label is present by **re-measuring label size at the in-progress resize dimensions** (via `measureUnscaledLabelSize` on a temp shape) so constraints reflect text wrapping, rather than being locked to the initial cached measurement.
> 
> Adds unit tests covering resizing labeled geo shapes narrower than the initial label width, enforcing minimum width/height based on wrapped label size, and ensuring unlabeled shapes still resize freely; also disposes the `TestEditor` after each test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e326b65e4b31b4e706b749f608d79162ee77c6ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->