### PR TITLE
chore: Store/Restore lazyrepo and eslint cache 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,16 +35,19 @@ jobs:
       - name: Check packages
         run: yarn check-packages
 
-      - name: Restore Lazy and ESLint cache
+      - name: Restore build tool caches
         uses: actions/cache@v3
         with:
           path: |
             .lazy
             **/.lazy
             .eslintcache
-          key: lint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.mjs', 'lazy.config.ts') }}-${{ github.sha }}
+            **/.tsbuild
+            **/*.tsbuildinfo
+            node_modules/.cache/prettier
+          key: test-tools-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.mjs', 'lazy.config.ts') }}-${{ github.sha }}
           restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.mjs', 'lazy.config.ts') }}-
+            test-tools-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.mjs', 'lazy.config.ts') }}-
 
       - name: Typecheck
         run: yarn build-types
@@ -81,6 +84,18 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
+
+      - name: Restore build tool caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            .lazy
+            **/.lazy
+            **/.tsbuild
+            **/*.tsbuildinfo
+          key: build-tools-${{ runner.os }}-${{ hashFiles('yarn.lock', 'lazy.config.ts') }}-${{ github.sha }}
+          restore-keys: |
+            build-tools-${{ runner.os }}-${{ hashFiles('yarn.lock', 'lazy.config.ts') }}-
 
       - name: Build all projects
         # the sed pipe makes sure that github annotations come through without


### PR DESCRIPTION
Restore eslint and lazyrepo caches. 
fixes https://github.com/tldraw/tldraw/issues/7633
fixes https://github.com/tldraw/tldraw/issues/7632

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; risk is limited to potential cache misses/stale artifacts causing flaky builds, but keys are scoped to lock/config inputs.
> 
> **Overview**
> Speeds up CI by adding **restore-only** `actions/cache@v3` steps to the `test` and `build` jobs in `.github/workflows/checks.yml`.
> 
> The caches include `lazys` (`.lazy`), TypeScript incremental build artifacts (`**/*.tsbuildinfo`, `**/.tsbuild`), and in the test job also `.eslintcache` and Prettier’s cache. Cache keys are scoped by OS plus relevant config/lockfiles, with `restore-keys` to allow partial matches across commits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c6e52e546b81dad980d4d32f083b661e33c5863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->