### PR TITLE
fix(ui): fix fill dropdown testid ambiguity and missing translations

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2953,6 +2953,7 @@ export interface StylePanelDropdownPickerProps<T extends string> {
     style: StyleProp<T>;
     // (undocumented)
     stylePanelType: string;
+    testIdType?: string;
     // (undocumented)
     type: 'icon' | 'menu' | 'tool';
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -170,6 +170,7 @@ export function StylePanelFillPicker() {
 					type="icon"
 					id="fill-extra"
 					uiType="fill"
+					testIdType="fill-extra"
 					stylePanelType="fill"
 					style={DefaultFillStyle}
 					items={STYLES.fillExtra}

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -26,6 +26,8 @@ export interface StylePanelDropdownPickerProps<T extends string> {
 	items: StyleValuesForUi<T>
 	type: 'icon' | 'tool' | 'menu'
 	onValueChange?(style: StyleProp<T>, value: T): void
+	/** Override the test ID prefix. Defaults to uiType. */
+	testIdType?: string
 }
 
 function StylePanelDropdownPickerInner<T extends string>(props: StylePanelDropdownPickerProps<T>) {
@@ -54,6 +56,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 		type,
 		value,
 		onValueChange = ctx.onValueChange,
+		testIdType = uiType,
 	} = props
 	const msg = useTranslation()
 	const editor = useEditor()
@@ -84,7 +87,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 			<TldrawUiPopoverTrigger>
 				<TldrawUiToolbarButton
 					type={type}
-					data-testid={`style.${uiType}`}
+					data-testid={`style.${testIdType}`}
 					data-direction="left"
 					title={titleStr}
 				>
@@ -100,7 +103,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 								<TldrawUiToolbarButton
 									key={item.value}
 									type="icon"
-									data-testid={`style.${uiType}.${item.value}`}
+									data-testid={`style.${testIdType}.${item.value}`}
 									title={
 										stylePanelName +
 										' — ' +


### PR DESCRIPTION
In order to fix a Playwright test failure caused by duplicate `data-testid="style.fill"` elements and missing tooltip translations, this PR adds a `testIdType` prop to `StylePanelDropdownPickerProps` and applies it to the fill-extra dropdown.

The fill-extra dropdown introduced in #7885 originally used `uiType="fill-extra"`, which broke tooltip translations (keys like `fill-extra-style.none` don't exist). The first commit fixed this by changing `uiType` back to `"fill"`, but that caused both the button picker and dropdown picker to emit `data-testid="style.fill"`, breaking the Playwright strict mode selector. The second commit adds `testIdType` to decouple the test ID from the translation key, giving the dropdown `data-testid="style.fill-extra"` while keeping `uiType="fill"` for correct translations.

### Change type

- [x] `bugfix`

### Test plan

1. Select a geo shape
2. Hover over the fill dropdown button — verify tooltip shows "Fill — Pattern" (not raw keys)
3. Open the dropdown, hover each option — verify all tooltips are translated
4. Run the style panel e2e test — verify `getByTestId('style.fill')` resolves uniquely

- [ ] End to end tests

### Release notes

- Fixed duplicate test IDs and missing translations in the fill style dropdown.

### API changes

- Added optional `testIdType` to `StylePanelDropdownPickerProps` to override the test ID prefix independently of `uiType`