### PR TITLE
fix(infra): add tldrawusercontent.com to CSP connect-src

### DIFF
--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -34,6 +34,9 @@ export const cspDirectives: { [key: string]: string[] } = {
 		'https://*.google-analytics.com',
 		'https://api.reo.dev',
 		'https://fonts.googleapis.com',
+		// asset uploads/serving
+		'https://tldrawusercontent.com',
+		'https://*.tldrawusercontent.com',
 	],
 	'font-src': [`'self'`, `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, 'data:'],
 	'frame-src': [`'self'`, `https:`],


### PR DESCRIPTION
Asset uploads/fetches to the new `tldrawusercontent.com` domain were being blocked by the Content Security Policy after #7875. This adds `tldrawusercontent.com` and `*.tldrawusercontent.com` to `connect-src` to unblock staging and production.

### Change type

- [x] `bugfix`

### Test plan

1. Upload an image on staging
2. Verify the asset loads without CSP errors in the console

### Release notes

- Fix asset uploads being blocked by Content Security Policy on the new asset domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted CSP allowlist change; risk is limited to slightly expanding permitted outbound connections to the specified asset domain.
> 
> **Overview**
> Fixes asset upload/fetch requests being blocked by CSP by **adding `tldrawusercontent.com` and `*.tldrawusercontent.com` to the `connect-src` directive** in `apps/dotcom/client/src/utils/csp.ts` (affecting both header-generated `csp` and dev `cspDev`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44b9706c4c4dc6778ca0cfbf6b95982c1d46a44c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->