### PR TITLE
chore: setup node_modules cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,10 +11,9 @@ runs:
       shell: bash
 
     - name: Setup Node.js Environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22.16.0
-        cache: ''
 
     - name: Restore node_modules cache
       uses: actions/cache@v4


### PR DESCRIPTION
This PR to improve caching of node_modules, it drops setup from 1m20s to ~20-30s

fixes https://github.com/tldraw/tldraw/issues/7630

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that affects dependency installation behavior; main risk is stale/incorrect caches causing flaky builds if cache keys don’t fully capture dependency changes.
> 
> **Overview**
> Adds a dedicated `actions/cache@v4` step to persist and restore `node_modules` (including workspace `**/node_modules`) and Yarn artifacts (`.yarn/cache`, `.yarn/unplugged`) in the shared `.github/actions/setup` composite action.
> 
> Skips `yarn install --immutable` when the cache is a hit, aiming to reduce CI setup time while keying the cache off `yarn.lock`, `.yarnrc.yml`, and `.yarn/patches/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8036284fde80ef403314fb1457ab0032c0f61ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->