### PR TITLE
fix(tests): update vitest-canvas-mock to fix Path2D.roundRect

### DIFF
--- a/internal/config/package.json
+++ b/internal/config/package.json
@@ -9,6 +9,6 @@
 		"@peculiar/webcrypto": "^1.5.0",
 		"jest-matcher-utils": "^30.0.5",
 		"lazyrepo": "0.0.0-alpha.27",
-		"vitest-canvas-mock": "^0.3.3"
+		"vitest-canvas-mock": "^1.1.3"
 	}
 }

--- a/internal/config/vitest/setup.ts
+++ b/internal/config/vitest/setup.ts
@@ -8,10 +8,6 @@ import {
 	stringify,
 } from 'jest-matcher-utils'
 import { TextDecoder, TextEncoder } from 'util'
-import { beforeAll } from 'vitest'
-
-// Capture real setTimeout before any test file can install fake timers.
-const realSetTimeout = globalThis.setTimeout
 
 if (typeof window !== 'undefined') {
 	await import('vitest-canvas-mock')
@@ -54,18 +50,12 @@ if (typeof HTMLImageElement !== 'undefined') {
 	}
 }
 
-// Path2D polyfills — must run in beforeAll so that vitest-canvas-mock's
-// unwaited async importMockWindow() has resolved and the real mock Path2D
-// is in place before we polyfill roundRect onto it. The async yield
-// guarantees the un-awaited dynamic import has settled.
-beforeAll(async () => {
-	await new Promise((resolve) => realSetTimeout(resolve, 0))
-	if (typeof Path2D !== 'undefined' && typeof Path2D.prototype.roundRect !== 'function') {
-		Path2D.prototype.roundRect = function (x: number, y: number, w: number, h: number, _: any) {
-			this.rect(x, y, w, h)
-		}
+// Path2D polyfills
+if (typeof Path2D !== 'undefined' && typeof Path2D.prototype.roundRect !== 'function') {
+	Path2D.prototype.roundRect = function (x, y, w, h, _) {
+		this.rect(x, y, w, h)
 	}
-})
+}
 
 // CSS.supports polyfill for tests that use color spaces (e.g., highlight shapes)
 if (typeof CSS === 'undefined') {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 		"typescript": "^5.8.3",
 		"vercel": "^34.4.0",
 		"vitest": "^3.2.4",
-		"vitest-canvas-mock": "^0.3.3"
+		"vitest-canvas-mock": "^1.1.3"
 	},
 	"// resolutions.canvas": [
 		"our examples app depenends on pdf.js which pulls in canvas as an optional dependency.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9697,7 +9697,7 @@ __metadata:
     typescript: "npm:^5.8.3"
     vercel: "npm:^34.4.0"
     vitest: "npm:^3.2.4"
-    vitest-canvas-mock: "npm:^0.3.3"
+    vitest-canvas-mock: "npm:^1.1.3"
   languageName: unknown
   linkType: soft
 
@@ -14228,7 +14228,7 @@ __metadata:
     "@peculiar/webcrypto": "npm:^1.5.0"
     jest-matcher-utils: "npm:^30.0.5"
     lazyrepo: "npm:0.0.0-alpha.27"
-    vitest-canvas-mock: "npm:^0.3.3"
+    vitest-canvas-mock: "npm:^1.1.3"
   languageName: unknown
   linkType: soft
 
@@ -19618,16 +19618,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-canvas-mock@npm:~2.5.2":
-  version: 2.5.2
-  resolution: "jest-canvas-mock@npm:2.5.2"
-  dependencies:
-    cssfontparser: "npm:^1.2.1"
-    moo-color: "npm:^1.0.2"
-  checksum: 10/094e2e1c773c658fab7e91e9279027fc38a55060865b5b6a3c9acc47fc912fb9d3451ab4fdf544d016578f77b975626707c3a62e396575aa878f46d939c7ca5e
-  languageName: node
-  linkType: hard
-
 "jest-diff@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-diff@npm:30.0.5"
@@ -22073,7 +22063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moo-color@npm:^1.0.2":
+"moo-color@npm:^1.0.3":
   version: 1.0.3
   resolution: "moo-color@npm:1.0.3"
   dependencies:
@@ -29676,14 +29666,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest-canvas-mock@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "vitest-canvas-mock@npm:0.3.3"
+"vitest-canvas-mock@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "vitest-canvas-mock@npm:1.1.3"
   dependencies:
-    jest-canvas-mock: "npm:~2.5.2"
+    cssfontparser: "npm:^1.2.1"
+    moo-color: "npm:^1.0.3"
   peerDependencies:
-    vitest: "*"
-  checksum: 10/bf564fe0cb701f228eb20cacdbd3abb9eb83c948bebbbea7fe907082ef830b2f8d7865277eade77fd84806bd1ddccdf1426c85ad716b8da8a977ae6b82e4f85f
+    vitest: ^3.0.0 || ^4.0.0
+  checksum: 10/0885142f98d543dca70993e36d63664ca8585a0d8533933b19bf28c5819c8419760462b017f9372ae0050f351625cabfb0ffecdcb8e6997f2bde5324396c8222
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades `vitest-canvas-mock` from 0.3.3 to 1.x.

v0.3.3 called `importMockWindow()` without `await` ([source](https://github.com/wobsoriano/vitest-canvas-mock/blob/v0.3.3/src/index.ts)), creating a race where `global.Path2D` got replaced *after* our setup polyfill ran — so `roundRect` was patched onto the old, discarded prototype. v1.x rewrote this to be synchronous, eliminating the race.

### Change type

- [x] `bugfix`

### Test plan

1. `cd packages/tldraw && yarn test run -t "Renders the canvas and shapes"` — previously failed with `TypeError: path.roundRect is not a function`, now passes
2. Full `packages/tldraw` test suite passes (129 files, 2020 tests)

- [x] Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile + devDependency bump limited to test environment behavior; low blast radius outside of Vitest canvas mocking.
> 
> **Overview**
> Updates the test tooling dependency `vitest-canvas-mock` from `^0.3.3` to `^1.1.3` in both the root `package.json` and `internal/config/package.json`.
> 
> Refreshes `yarn.lock` accordingly, dropping the old `jest-canvas-mock` transitive entry and aligning peer/dependency metadata for the new `vitest-canvas-mock` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6fe55289570656e1364062a663a6541334876f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->