### PR TITLE
chore: update release notes skills to handle reverts and same-cycle fixes

### DIFF
--- a/.claude/skills/shared/release-notes-guide.md
+++ b/.claude/skills/shared/release-notes-guide.md
@@ -61,6 +61,8 @@ Also skip:
 - Reverts, unless they fix something user-facing
 - Fixes for bugs introduced in the same release cycle (i.e., the bug was caused by a PR that is also in `next.mdx` and was not in the previous release)
 
+When a PR is reverted, also remove the original PR's entry from `next.mdx` if it is present.
+
 ## Team members (do not credit)
 
 angrycaptain19, AniKrisn, ds300, kostyafarber, max-dra, mimecuvalo, MitjaBezensek, profdl, Siobhantldraw, steveruizok, tldrawdaniel, huppy-bot, github-actions, Somehats, todepond, Taha-Hassan-Git, alex-mckenna-1, max-drake

--- a/.claude/skills/update-release-notes/SKILL.md
+++ b/.claude/skills/update-release-notes/SKILL.md
@@ -61,8 +61,9 @@ For each PR not already in `next.mdx`:
 1. Check PR labels and body against the style guide's categorization rules
 2. Skip PRs that should be omitted (see style guide)
 3. Skip PRs that fix bugs introduced in the same release cycle (i.e., bugs caused by other PRs already in `next.mdx` that were not in the previous release)
-4. Add entries to the appropriate section
-5. Promote significant changes to featured sections when warranted
+4. If a PR is a revert, also remove the original reverted PR's entry from `next.mdx` if present
+5. Add entries to the appropriate section
+6. Promote significant changes to featured sections when warranted
 
 ### 6. Verify
 


### PR DESCRIPTION
In order to improve the accuracy of automated release notes, this PR updates the release notes skills to:

- Skip PRs that fix bugs introduced in the same release cycle (bugs caused by other PRs already in `next.mdx` that weren't in the previous release)
- Remove entries from `next.mdx` when their corresponding PR is reverted

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/process-only changes that adjust release-notes curation rules, with no impact on product/runtime code.
> 
> **Overview**
> Updates the release-notes style guide and `update-release-notes` skill instructions to **exclude two additional PR types** from `next.mdx`: reverts (unless user-facing) and fixes for bugs introduced within the same release cycle.
> 
> Adds guidance that when processing a revert PR, the corresponding original PR entry should also be removed from `next.mdx` to avoid shipping reverted changes in release notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8579d85c6edf5e4ab5150a3757aee78884cafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->