### PR TITLE
fix(editor): downgrade rbush to v3 for CJS compatibility

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -61,7 +61,7 @@
 		"eventemitter3": "^4.0.7",
 		"idb": "^7.1.1",
 		"is-plain-object": "^5.0.0",
-		"rbush": "^4.0.1"
+		"rbush": "^3.0.1"
 	},
 	"peerDependencies": {
 		"react": "^18.2.0 || ^19.2.1",
@@ -72,7 +72,7 @@
 		"@testing-library/dom": "^10.0.0",
 		"@testing-library/react": "^16.0.0",
 		"@types/benchmark": "^2.1.5",
-		"@types/rbush": "^4.0.0",
+		"@types/rbush": "^3.0.0",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
 		"@types/wicg-file-system-access": "^2020.9.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9619,7 +9619,7 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     "@tldraw/validate": "workspace:*"
     "@types/benchmark": "npm:^2.1.5"
-    "@types/rbush": "npm:^4.0.0"
+    "@types/rbush": "npm:^3.0.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/wicg-file-system-access": "npm:^2020.9.8"
@@ -9631,7 +9631,7 @@ __metadata:
     idb: "npm:^7.1.1"
     is-plain-object: "npm:^5.0.0"
     lazyrepo: "npm:0.0.0-alpha.27"
-    rbush: "npm:^4.0.1"
+    rbush: "npm:^3.0.1"
     react: "npm:^19.2.1"
     react-dom: "npm:^19.2.1"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -10693,10 +10693,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/rbush@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@types/rbush@npm:4.0.0"
-  checksum: 10/ee37c7fa322a83af4e754180022253b7e2bbbb853c9a6d8ffce1ea1e59bbb0eef3a347e2f37934bb1afa4d40ea2ea44409d7cee751cb8ac8dbded13dc9160a64
+"@types/rbush@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@types/rbush@npm:3.0.4"
+  checksum: 10/3f3b723f0f2542c7e2d493286c81177f3f2850c944c2f5d3296c86e02d4c206a447be7c982b23b82b95da9a2adc210d07cf870c1564f68b58eaa46d43073e013
   languageName: node
   linkType: hard
 
@@ -24628,10 +24628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quickselect@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "quickselect@npm:3.0.0"
-  checksum: 10/8f72bedb8bb14bce5c3767c55f567bc296fa3ca9d98ba385e3867e434463bc633feee1eddf3dfec17914b7e88feeb08c7b313cf47114a8ff11bf964f77f51cfc
+"quickselect@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "quickselect@npm:2.0.0"
+  checksum: 10/ed2e78431050d223fb75da20ee98011aef1a03f7cb04e1a32ee893402e640be3cfb76d72e9dbe01edf3bb457ff6a62e5c2d85748424d1aa531f6ba50daef098c
   languageName: node
   linkType: hard
 
@@ -24757,12 +24757,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rbush@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "rbush@npm:4.0.1"
+"rbush@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "rbush@npm:3.0.1"
   dependencies:
-    quickselect: "npm:^3.0.0"
-  checksum: 10/8db2f9b464ee31cbb13237e762140c27f4de517a470d1639f840cc606b1f917f64f6273178b2f07c93d95c44cc068cc0c25c84ad40c4a483404e60d17c054eec
+    quickselect: "npm:^2.0.0"
+  checksum: 10/489e2e7d9889888ad533518f194e3ab7cc19b1f1365a38ee99fbdda542a47f41cda7dc89870180050f4d04ea402e9ff294e1d767d03c0f1694e0028b7609eec9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Downgrade `rbush` from v4 (ESM-only) to v3 (CJS-compatible) to fix CJS environments (tsx, ts-node, Jest). v3→v4 only changed the module format with no API changes, so downgrading is safe.

[Context](https://discord.com/channels/859816885297741824/1471626494022389810).

### Change type

- [x] `bugfix`

### Test plan

1. All existing editor tests pass
2. Build output (CJS + ESM) works correctly
3. `node --import tsx -e "const { RBushIndex } = require('./packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts'); new RBushIndex()"` now works

### Release notes

- Fix tldraw failing to load in CJS environments (tsx, ts-node, Jest) due to ESM-only rbush dependency