### PR TITLE
zero: update the dev command

### DIFF
--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -11,8 +11,7 @@
 		"defaults"
 	],
 	"scripts": {
-		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success'",
-		"dev-zero": "concurrently 'yarn docker-up' 'yarn migrate --signal-success' 'yarn bundle-schema:watch' 'yarn zero-server'",
+		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success' 'yarn bundle-schema:watch' 'yarn zero-server'",
 		"bundle-schema": "esbuild --bundle --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
 		"bundle-schema:watch": "esbuild --bundle --watch --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
 		"zero-server": "nodemon --watch ./.schema.js --exec 'zero-cache-dev -p ./.schema.js' --signal SIGINT",


### PR DESCRIPTION
followup from https://github.com/tldraw/tldraw/pull/7358/changes#r2800063784

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change affecting local developer workflow; no runtime or production logic is modified.
> 
> **Overview**
> **Simplifies local development for `@tldraw/zero-cache`.** The `package.json` scripts remove the separate `dev-zero` entry and update `dev` to also watch/bundle the schema and run the Zero server alongside Docker and migrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfd6db893ef7bd788d2c71d74e6f9ce43f98d702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->