### PR TITLE
revert(ci): restore full build in checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,10 +97,10 @@ jobs:
           restore-keys: |
             build-tools-${{ runner.os }}-${{ hashFiles('yarn.lock', 'lazy.config.ts') }}-
 
-      - name: Build packages
+      - name: Build all projects
         # the sed pipe makes sure that github annotations come through without
         # turbo's prefix
-        run: "yarn build-package | sed -E 's/^.*? ::/::/'"
+        run: "yarn build | sed -E 's/^.*? ::/::/'"
 
       - name: Pack public packages
         run: "yarn lazy pack-tarball | sed -E 's/^.*? ::/::/'"


### PR DESCRIPTION
Reverts #7909. The checks workflow should use `yarn build` to build all workspaces, not just packages, to catch integration and build failures in apps/docs that were previously covered.

### Change type

- [x] `improvement`

### Test plan

1. Open this PR and verify the checks workflow passes with the full build

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that increases build coverage; main risk is longer build times or newly surfaced build failures rather than production impact.
> 
> **Overview**
> The Checks GitHub Actions workflow’s build job now runs `yarn build` (renamed to **Build all projects**) instead of the previous package-only build command, so CI also compiles apps/docs and catches cross-workspace build issues.
> 
> Caching and subsequent packaging steps are unchanged; this primarily broadens build coverage in PR checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df7dddaed373f8bab6139a47f8e2b2c05a926bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->