### PR TITLE
chore(ci): remove pack-tarball step from checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,6 +101,3 @@ jobs:
         # the sed pipe makes sure that github annotations come through without
         # turbo's prefix
         run: "yarn build-package | sed -E 's/^.*? ::/::/'"
-
-      - name: Pack public packages
-        run: "yarn lazy pack-tarball | sed -E 's/^.*? ::/::/'"


### PR DESCRIPTION
In order to speed up CI checks, this PR removes the `pack-tarball` step from the checks workflow since packing is unnecessary for PR validation.

### Change type

- [x] `other`

### Test plan

- CI checks should pass without the pack step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that removes an extra packaging step; low risk aside from potentially reducing coverage for release packaging issues.
> 
> **Overview**
> Removes the `Pack public packages` (`yarn lazy pack-tarball`) step from `.github/workflows/checks.yml`, leaving the workflow to build packages without producing tarballs during checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e15dfdcc26172939d6490df2790f993183b9d3b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->