### PR TITLE
fix(dotcom): preserve user preferences when using deep links

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -134,17 +134,18 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			const deepLink = new URLSearchParams(window.location.search).get('d')
 			if (fileState?.lastSessionState) {
 				const sessionState = JSON.parse(fileState.lastSessionState.trim() || 'null')
-				if (deepLink) {
-					// When using a deep link, only load preferences (not camera/page states)
-					// since the deep link will control navigation
-					const { pageStates: _, currentPageId: _cpid, ...preferencesOnly } = sessionState
-					editor.loadSnapshot({ session: preferencesOnly }, { forceOverwriteSessionState: true })
-					editor.navigateToDeepLink(parseDeepLinkString(deepLink))
-				} else {
-					// No deep link - load the full session state including camera position
-					editor.loadSnapshot({ session: sessionState }, { forceOverwriteSessionState: true })
+				if (sessionState) {
+					if (deepLink) {
+						// When using a deep link, only load preferences (not camera/page states)
+						// since the deep link will control navigation
+						const { pageStates: _, currentPageId: _cpid, ...preferencesOnly } = sessionState
+						editor.loadSnapshot({ session: preferencesOnly }, { forceOverwriteSessionState: true })
+					} else {
+						editor.loadSnapshot({ session: sessionState }, { forceOverwriteSessionState: true })
+					}
 				}
-			} else if (deepLink) {
+			}
+			if (deepLink) {
 				editor.navigateToDeepLink(parseDeepLinkString(deepLink))
 			}
 			const fileStateUpdater = new FileStateUpdater(app, fileId, editor)


### PR DESCRIPTION
When a URL contains a deep link parameter (`?d=...`), the session state (including grid mode, tool lock, etc.) was being skipped entirely. This caused user preferences to be lost on page refresh when a deep link was present.

The previous logic was:
```typescript
if (fileState?.lastSessionState && !deepLink) {
    // Load session state - but ONLY if no deep link!
}
```

Now we load session preferences separately from camera/page states, allowing deep links to control navigation while preserving user settings like grid mode.

Closes #4391

### Change type

- [x] `bugfix`

### Test plan

1. Open a file on tldraw.com
2. Toggle grid mode ON (Cmd+' or menu)
3. Wait 10 seconds for auto-save, or refresh to trigger save
4. Refresh the page (note: URL will have `?d=` parameter)
5. Grid should now be preserved

### Release notes

- Fixed a bug where grid mode and other user preferences were lost on page refresh when a deep link was present in the URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client-side session restore behavior; main risk is subtle regressions in which parts of session state are restored when deep links are present.
> 
> **Overview**
> Fixes editor initialization so saved `lastSessionState` is no longer skipped when a `?d=` deep link is present.
> 
> When deep linking, it now loads only preference-related session fields (excluding `pageStates` and `currentPageId`) before calling `navigateToDeepLink`, preserving settings like grid/tool preferences without overriding deep-link navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 582aa7f2c891196af691249e8346cd35ce781192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->