### PR TITLE
fix(sync-core): handle U+2028/U+2029 line separators in chunked messages

### DIFF
--- a/packages/sync-core/src/lib/chunk.ts
+++ b/packages/sync-core/src/lib/chunk.ts
@@ -47,7 +47,9 @@ export function chunk(msg: string, maxSafeMessageSize = MAX_SAFE_MESSAGE_SIZE) {
 	}
 }
 
-const chunkRe = /^(\d+)_(.*)$/
+// The 's' flag (dotAll) makes '.' match any character including line terminators
+// like U+2028 and U+2029, which are commonly introduced via copy/paste from Word
+const chunkRe = /^(\d+)_(.*)$/s
 
 /**
  * Assembles chunked JSON messages back into complete objects.

--- a/packages/sync-core/src/test/chunk.test.ts
+++ b/packages/sync-core/src/test/chunk.test.ts
@@ -260,6 +260,25 @@ describe('json unchunker', () => {
 		expect(unchunker.handleMessage('{"ok": true}')).toMatchObject({ data: { ok: true } })
 	})
 
+	it('handles unicode line separators U+2028 and U+2029 in chunks', () => {
+		// These characters are common when copy/pasting from Microsoft Word
+		// and are valid JSON string content but act as line terminators in JS
+		const unchunker = new JsonChunkAssembler()
+
+		// Test U+2028 (Line Separator) and U+2029 (Paragraph Separator)
+		const jsonWithLineSeparators = '{"text": "hello\u2028world\u2029end"}'
+		const chunks = chunk(jsonWithLineSeparators, 10)
+
+		for (const c of chunks.slice(0, -1)) {
+			expect(unchunker.handleMessage(c)).toBeNull()
+		}
+
+		const result = unchunker.handleMessage(chunks[chunks.length - 1])
+		expect(result).toMatchObject({
+			data: { text: 'hello\u2028world\u2029end' },
+		})
+	})
+
 	it('handles duplicate or out-of-order chunk numbers', () => {
 		const unchunker = new JsonChunkAssembler()
 


### PR DESCRIPTION
## Summary
- Fixes WebSocket message chunking failing when text contains Unicode line separator characters (U+2028, U+2029)
- These characters are commonly introduced via copy/paste from Microsoft Word and act as line terminators in JavaScript
- Added the `s` (dotAll) flag to the chunk regex so `.` matches all characters including line terminators

Fixes #7848

### Change type

- [x] `bugfix`

## Test plan
- [x] Added test case for U+2028 and U+2029 handling in chunked messages
- [x] All existing chunk tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to chunk parsing plus a targeted test; low risk aside from potential edge-case behavior changes in regex matching.
> 
> **Overview**
> Fixes chunk reassembly for messages containing Unicode line/paragraph separators by updating the chunk-parsing regex (`chunkRe`) to use dotAll so chunk payloads can include JS line terminators.
> 
> Adds a regression test that chunks and reassembles JSON containing U+2028/U+2029 to ensure `JsonChunkAssembler.handleMessage` successfully reconstructs and parses the full message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b30d58f4ef7d1ce07f73e93666bc68cf753d745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->