### PR TITLE
ci: try to address flakiness in e2e test or sidebar link

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Editor.ts
+++ b/apps/dotcom/client/e2e/fixtures/Editor.ts
@@ -65,6 +65,7 @@ export class Editor {
 		await this.fileName.click()
 		await this.page.getByRole('textbox').fill(newName)
 		await this.page.keyboard.press('Enter')
+		await this.sidebar.mutationResolution()
 	}
 
 	@step

--- a/apps/dotcom/client/e2e/tests/homepage.spec.ts
+++ b/apps/dotcom/client/e2e/tests/homepage.spec.ts
@@ -113,6 +113,7 @@ test.describe('sidebar actions', () => {
 			const input = page.getByRole('textbox')
 			await input?.fill(newName)
 			await page.keyboard.press('Enter')
+			await sidebar.mutationResolution()
 		})
 
 		await test.step('verify the name change', async () => {

--- a/apps/dotcom/client/e2e/tests/sidebar-dotdev-link.spec.ts
+++ b/apps/dotcom/client/e2e/tests/sidebar-dotdev-link.spec.ts
@@ -26,13 +26,24 @@ test.describe('sidebar dot dev link', () => {
 		await expect(dismissButton).toBeVisible()
 	})
 
-	test('clicking opens tldraw.dev in a new tab', async ({ page }) => {
+	test('clicking opens tldraw.dev in a new tab and hides the link', async ({ page }) => {
 		const link = page.getByTestId('tla-sidebar-dotdev-link')
 
-		const [popup] = await Promise.all([page.waitForEvent('popup'), link.click()])
-		await popup.waitForURL(/https:\/\/tldraw\.dev/, { timeout: 15000 })
-		expect(popup.url()).toContain('https://tldraw.dev')
-		await popup.close()
+		// Verify the link would open in a new tab
+		await expect(link).toHaveAttribute('target', '_blank')
+
+		// Click the link (the onClick handler sets localStorage to hide it)
+		await link.click()
+
+		// Verify the localStorage was set to hide the link
+		await expect(async () => {
+			const storedValue = await page.evaluate(
+				// eslint-disable-next-line no-restricted-syntax
+				(key) => window.localStorage.getItem(key),
+				DOT_DEV_LOCAL_STORAGE_KEY
+			)
+			expect(storedValue).toBe('false')
+		}).toPass()
 	})
 
 	test('can be dismissed and stays hidden after reload', async ({ page, homePage, editor }) => {


### PR DESCRIPTION
testing 123

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust synchronization and assertions; low product risk, with the main risk being altered test coverage/expectations for link-opening behavior.
> 
> **Overview**
> Reduces E2E flakiness around file renaming by waiting for `sidebar.mutationResolution()` after committing a rename in both the `Editor.rename` fixture and the homepage rename-via-double-click test.
> 
> Updates the sidebar dotdev link E2E test to avoid `popup`/URL waiting; it now asserts the link targets a new tab and verifies the click sets `showDotDevLink` in localStorage to hide the link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb184b48a3b60008d4b0b3d37532a5a75024e716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->