### PR TITLE
Try to split e2e multi and single player tests in CI

### DIFF
--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -69,7 +69,6 @@ jobs:
             e2e/tests/file-not-found.spec.ts
         working-directory: apps/dotcom/client
         env:
-          E2E_WORKERS: 6
           VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         if: ${{!contains(github.event.pull_request.labels.*.name, 'e2e-x10') }}

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -22,15 +22,14 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 2 : 0,
-	// For now we need to use 1 worker for dev as well, otherwise clearing the db fails since there might
-	// an open connection to the db when we are trying to clear it.
-	// E2E_WORKERS overrides for split runs (single-user vs multiplayer).
+	// E2E_WORKERS overrides worker count (used by CI to cap multiplayer tests at 2).
+	// Without it, Playwright auto-detects (half CPUs) in CI, or 3 locally.
 	workers: process.env.E2E_WORKERS
 		? parseInt(process.env.E2E_WORKERS, 10)
 		: process.env.STAGING_TESTS
 			? 6
 			: process.env.CI
-				? 2
+				? undefined
 				: 3,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: process.env.CI ? [['list'], ['github'], ['html', { open: 'never' }]] : 'list',


### PR DESCRIPTION
Quick one about splitting e2e multi and single player tests, running single player tests with MOAR WORKERZ! than with multiplayer ones. 


### Change type

- [x] `other`

