### PR TITLE
Fix cropping issue with shapes that do not set `isCircle`

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -337,7 +337,9 @@ export function getCropBox<T extends ShapeWithCrop>(
 	const newCrop: TLShapeCrop = {
 		topLeft: { x: tempBox.x / w, y: tempBox.y / h },
 		bottomRight: { x: tempBox.maxX / w, y: tempBox.maxY / h },
-		isCircle: crop.isCircle,
+	}
+	if (crop.isCircle != null) {
+		newCrop.isCircle = crop.isCircle
 	}
 
 	// If the crop hasn't changed, we can return early


### PR DESCRIPTION
Closes #7927

This fixes a bug where custom shapes that are croppable end up with invalid props when cropped, causing the application to crash.

If I understand the problem correctly, this started happening with the introduction of the `isCircle` property on `TLShapeCrop`. This specific code path made it possible for that property to end up `undefined`, which causes record validation to fail.

This branch fixes that by making `getCropBox` only set `isCircle` if it was set already.

I know that this PR will get auto-closed with the new contribution policy. I'll also create an issue to start a discussion about this.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed a bug where custom croppable shapes end up with invalid data