### PR TITLE
fix(ci): generate namespaced-tldraw CSS from source files

### DIFF
--- a/packages/namespaced-tldraw/scripts/copy-css-files.mjs
+++ b/packages/namespaced-tldraw/scripts/copy-css-files.mjs
@@ -7,6 +7,24 @@ const __dirname = dirname(__filename)
 
 const packageDir = join(__dirname, '..')
 
-const content = readFileSync(join(packageDir, '..', 'tldraw', 'tldraw.css'), 'utf8')
+// Generate CSS from source files directly (same sources as packages/tldraw)
+// to avoid depending on tldraw's generated tldraw.css which may not exist
+// when lazyrepo caching skips the prebuild step.
+let combinedContent = [
+	join(packageDir, '..', 'editor', 'editor.css'),
+	join(packageDir, '..', 'tldraw', 'src', 'lib', 'ui.css'),
+].reduce(
+	(acc, path) => {
+		const content = readFileSync(path, 'utf8')
+		acc += content + '\n'
+		return acc
+	},
+	`/* THIS CSS FILE IS GENERATED! DO NOT EDIT. OR EDIT. I'M A COMMENT NOT A COP */
+/* This file is created by the copy-css-files.mjs script in packages/namespaced-tldraw. */
+/* It combines @tldraw/editor's editor.css and tldraw's ui.css */
+
+`
+)
+
 const destination = join(packageDir, 'tldraw.css')
-writeFileSync(destination, content)
+writeFileSync(destination, combinedContent)


### PR DESCRIPTION
In order to fix the CI build failure introduced by the recent lazyrepo cache changes (#7879), this PR updates the namespaced-tldraw CSS prebuild script to generate CSS from source files directly.

The script was reading from `packages/tldraw/tldraw.css`, a generated file. With lazyrepo cache restoration in CI, `prebuild::packages/tldraw` can be a cache hit (skipping execution) without the actual `tldraw.css` file existing on disk, causing `prebuild::packages/namespaced-tldraw` to fail with ENOENT.

The fix reads from the same source files (`editor.css` + `ui.css`) that `packages/tldraw`'s own prebuild script uses, eliminating the cross-package dependency on a generated artifact.

### Change type

- [x] `bugfix`

### Test plan

1. Run `node packages/namespaced-tldraw/scripts/copy-css-files.mjs` and verify it generates correct CSS
2. Verify CI build passes

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time-only change to how a CSS file is assembled; runtime behavior shouldn’t change aside from potential ordering/content differences in the generated CSS.
> 
> **Overview**
> Updates `packages/namespaced-tldraw/scripts/copy-css-files.mjs` to generate its `tldraw.css` by concatenating the source CSS files (`editor.css` + `tldraw/src/lib/ui.css`) instead of reading `packages/tldraw/tldraw.css`.
> 
> This removes a fragile dependency on `tldraw`’s generated artifact so `namespaced-tldraw` prebuild doesn’t fail when CI caching skips `tldraw`’s prebuild step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5ec154ee6347d0bc8f486d5df2bd1f882e23834. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->