### PR TITLE
fix(crop): prevent isCircle from leaking onto custom shape crops

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -337,7 +337,9 @@ export function getCropBox<T extends ShapeWithCrop>(
 	const newCrop: TLShapeCrop = {
 		topLeft: { x: tempBox.x / w, y: tempBox.y / h },
 		bottomRight: { x: tempBox.maxX / w, y: tempBox.maxY / h },
-		isCircle: crop.isCircle,
+	}
+	if (crop.isCircle != null) {
+		newCrop.isCircle = crop.isCircle
 	}
 
 	// If the crop hasn't changed, we can return early


### PR DESCRIPTION
In order to fix custom croppable shapes crashing when cropped (#7927), this PR prevents `getCropBox` from adding `isCircle: undefined` to the result crop object.

The `isCircle` property was introduced for circle crops on image shapes. However, `getCropBox` was unconditionally copying it onto every result crop via `isCircle: crop.isCircle`. When the input crop didn't have `isCircle` set, this produced `{ isCircle: undefined }` — and `Object.keys()` includes keys with `undefined` values. Custom shapes with their own crop validators (without an `isCircle` field) would then fail with `ValidationError: Unexpected property` at `isCircle`.

The fix only copies `isCircle` when it was explicitly set on the input crop (`!= null`).

Closes #7927
Based on the fix from #7926 by @jamesbvaughan.

### Change type

- [x] `bugfix`

### Test plan

1. Create a custom croppable shape without `isCircle` in its crop validator
2. Crop the shape — should no longer crash

- [x] Unit tests

### Release notes

- Fixed a crash when cropping custom shapes that don't include `isCircle` in their crop schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to crop serialization plus added tests; main risk is minor behavior change for callers that implicitly relied on `isCircle` always being present.
> 
> **Overview**
> Fixes a cropping regression where `getCropBox` would always copy `crop.isCircle` into the returned crop object, causing `isCircle: undefined` to appear and break custom shape crop validators.
> 
> `getCropBox` now only includes `isCircle` in the output when it’s explicitly set (non-null/undefined) on the input crop, and new unit tests cover absence/undefined cases plus validation against a custom crop schema without `isCircle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c716452e5ad12204c501342b5e7341690455a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->