### PR TITLE
fix(utils): prevent false positive multiple instances warning in dev mode

### DIFF
--- a/packages/utils/src/lib/version.test.ts
+++ b/packages/utils/src/lib/version.test.ts
@@ -294,10 +294,13 @@ describe('version utilities', () => {
 			expect(mockConsoleLog).not.toHaveBeenCalled()
 		})
 
-		it('should ignore duplicate registrations of the same library', () => {
-			// Re-registering the same library with the same version and module type
-			// (e.g. due to module re-evaluation in Next.js dev mode) should not
-			// trigger a warning
+		it('should ignore duplicate registrations in Next.js dev mode', () => {
+			// In Next.js dev mode, Fast Refresh re-executes module-level code which causes
+			// the same library to register multiple times, producing a false positive warning.
+			vi.stubGlobal('__NEXT_DATA__', {})
+			const originalNodeEnv = process.env.NODE_ENV
+			process.env.NODE_ENV = 'development'
+
 			registerTldrawLibraryVersion('@tldraw/editor', '2.0.0', 'esm')
 			registerTldrawLibraryVersion('@tldraw/editor', '2.0.0', 'esm')
 			registerTldrawLibraryVersion('@tldraw/editor', '2.0.0', 'esm')
@@ -305,6 +308,21 @@ describe('version utilities', () => {
 			vi.runAllTimers()
 
 			expect(mockConsoleLog).not.toHaveBeenCalled()
+
+			process.env.NODE_ENV = originalNodeEnv
+		})
+
+		it('should detect duplicate registrations outside Next.js dev mode', () => {
+			// Outside Next.js dev, duplicate exact registrations should still be
+			// tracked and trigger the multiple instances warning
+			registerTldrawLibraryVersion('@tldraw/editor', '2.0.0', 'esm')
+			registerTldrawLibraryVersion('@tldraw/editor', '2.0.0', 'esm')
+
+			vi.runAllTimers()
+
+			expect(mockConsoleLog).toHaveBeenCalled()
+			const logMessage = mockConsoleLog.mock.calls[0][0]
+			expect(logMessage).toContain('multiple instances')
 		})
 
 		it('should handle bundler misconfiguration scenario', () => {

--- a/packages/utils/src/lib/version.ts
+++ b/packages/utils/src/lib/version.ts
@@ -93,10 +93,17 @@ export function registerTldrawLibraryVersion(name?: string, version?: string, mo
 	}
 
 	const info = getLibraryVersions()
-	const isDuplicate = info.versions.some(
-		(v) => v.name === name && v.version === version && v.modules === modules
-	)
-	if (isDuplicate) return
+
+	// In Next.js dev mode, Fast Refresh re-executes module-level code which causes
+	// the same library to register multiple times, producing a false positive warning.
+	// We skip exact duplicates only in Next.js dev to avoid hiding genuine issues.
+	if (isNextjsDev()) {
+		const isDuplicate = info.versions.some(
+			(v) => v.name === name && v.version === version && v.modules === modules
+		)
+		if (isDuplicate) return
+	}
+
 	info.versions.push({ name, version, modules })
 
 	if (!info.scheduledNotice) {
@@ -221,6 +228,14 @@ const formats = {
 } as const
 function format(value: string, formatters: (keyof typeof formats)[] = []) {
 	return `\x1B[${formatters.map((f) => formats[f]).join(';')}m${value}\x1B[m`
+}
+
+function isNextjsDev(): boolean {
+	try {
+		return process.env.NODE_ENV === 'development' && '__NEXT_DATA__' in globalThis
+	} catch {
+		return false
+	}
 }
 
 function entry<K, V>(map: Map<K, V>, key: K, defaultValue: V): V {


### PR DESCRIPTION
In order to fix a false positive "multiple instances" warning that fires in Next.js dev mode, this PR deduplicates registrations in `registerTldrawLibraryVersion()`.

When Next.js re-evaluates modules on page refresh, each tldraw package re-registers itself via `registerTldrawLibraryVersion()`. Since `globalThis.__TLDRAW_LIBRARY_VERSIONS__` persists across module re-evaluations, duplicate entries accumulate and trigger the "multiple instances" warning — even though only one copy of each library is loaded (all entries show the same version and same module type).

The fix skips registration when an identical entry (same name, version, and module type) already exists. Genuine conflicts (different versions or mixed ESM/CJS) are still detected correctly.

Closes #4614

### Change type

- [x] `bugfix`

### Test plan

1. Use tldraw in a Next.js app with dev mode
2. Refresh the page — the false "multiple instances" warning should no longer appear
3. Genuine version mismatches or ESM/CJS conflicts should still produce warnings

- [x] Unit tests

### Release notes

- Fixed false positive "multiple instances" warning in Next.js dev mode caused by module re-evaluation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to warning/dedup logic gated to Next.js dev mode with unit test coverage; main risk is inadvertently suppressing a real duplicate only under those conditions.
> 
> **Overview**
> Prevents false "multiple instances" warnings in Next.js *dev mode* by skipping re-registration when `registerTldrawLibraryVersion` sees an **exact duplicate** entry (same package, version, and module type) during Fast Refresh.
> 
> Adds `isNextjsDev()` gating (checks `NODE_ENV === 'development'` and presence of `__NEXT_DATA__`) so duplicate tracking and warnings still occur in non-Next.js environments, and updates tests to cover both the Next.js dev dedupe behavior and the unchanged non-dev duplicate warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc920c01d365539317e63c0fb542e6fc8d2d91fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->