### PR TITLE
fix(editor): change default pixelRatio from 2 to 1 for bitmap exports

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9695,7 +9695,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const withDefaults = {
 			format: 'png',
 			scale: 1,
-			pixelRatio: opts.format === 'svg' ? undefined : 2,
+			pixelRatio: opts.format === 'svg' ? undefined : 1,
 			...opts,
 		} satisfies TLImageExportOptions
 		const result = await this.getSvgString(shapes, withDefaults)

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -29,7 +29,7 @@ export interface TLSvgExportOptions {
 	 * by this number.
 	 *
 	 * For SVG exports, this defaults to undefined - which means we'll request original-quality
-	 * assets. For bitmap exports, this defaults to 2.
+	 * assets. For bitmap exports, this defaults to 1.
 	 */
 	pixelRatio?: number
 

--- a/packages/editor/src/lib/exports/getSvgAsImage.ts
+++ b/packages/editor/src/lib/exports/getSvgAsImage.ts
@@ -14,7 +14,7 @@ export async function getSvgAsImage(
 		pixelRatio?: number
 	}
 ) {
-	const { type, width, height, quality = 1, pixelRatio = 2 } = options
+	const { type, width, height, quality = 1, pixelRatio = 1 } = options
 
 	let [clampedWidth, clampedHeight] = clampToBrowserMaxCanvasSize(
 		width * pixelRatio,


### PR DESCRIPTION
In order to fix blurry exported/copied PNGs when raster images are on the canvas, this PR changes the default `pixelRatio` from `2` to `1` for bitmap exports.

When a user pastes an image (e.g. 600x400) and uses "Copy as PNG", the export pipeline was creating a canvas at 2x the logical dimensions (1200x800), upscaling the raster image data and causing blurriness. Vector content scales perfectly at 2x, but raster images cannot be upscaled without quality loss. Setting the default to 1 preserves original image dimensions and sharpness.

Closes #5139

### Change type

- [x] `bugfix`

### Test plan

1. Paste a raster image (e.g. a 600x400 PNG) onto the canvas
2. Right-click → Copy as → PNG
3. Paste into another app and verify the image is sharp and dimensions match the original

- [x] Unit tests

### Release notes

- Fix blurry PNG exports for raster images by changing default pixel ratio from 2 to 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-output behavior changes for image export sizing/quality, but limited to bitmap export paths and is easily verified visually.
> 
> **Overview**
> Fixes blurry bitmap exports/copy by changing the default `pixelRatio` for non-SVG `toImage` exports from `2` to `1`.
> 
> Aligns `TLImageExportOptions` docs and `getSvgAsImage` defaults with the new behavior, so bitmap rasterization no longer creates a 2× larger canvas unless explicitly requested.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0eebccaec71cc346b716f177c3fc753bf504d85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->