### PR TITLE
fix(editor): reparent pasted shapes into frame when they land inside one

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -134,6 +134,7 @@ import {
 } from '../utils/deepLinks'
 import { getIncrementedName } from '../utils/getIncrementedName'
 import { getReorderingShapesChanges } from '../utils/reorderShapes'
+import { getDroppedShapesToNewParents } from '../utils/reparenting'
 import { TLTextOptions, TiptapEditor } from '../utils/richText'
 import { applyRotationToSnapshotShapes, getRotationSnapshot } from '../utils/rotation'
 import { BindingOnDeleteOptions, BindingUtil } from './bindings/BindingUtil'
@@ -9599,6 +9600,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 					return { id: s.id, type: s.type, x: s.x + localDelta.x, y: s.y + localDelta.y }
 				})
 			)
+
+			// If shapes were pasted onto the page (not into a specific parent),
+			// check whether they landed inside a frame and reparent if so.
+			if (isPageId(pasteParentId)) {
+				const currentRootShapes = compact(rootShapes.map((s) => this.getShape(s.id)))
+				const { reparenting } = getDroppedShapesToNewParents(this, currentRootShapes)
+				reparenting.forEach((childrenToReparent, newParentId) => {
+					if (childrenToReparent.length === 0) return
+					this.reparentShapes(
+						childrenToReparent.map((s) => s.id),
+						newParentId
+					)
+				})
+			}
 		})
 
 		return this

--- a/packages/tldraw/src/test/commands/putContent.test.ts
+++ b/packages/tldraw/src/test/commands/putContent.test.ts
@@ -39,6 +39,45 @@ describe('Migrations', () => {
 	})
 })
 
+describe('Post-positioning reparent into frame', () => {
+	it('reparents shapes into a frame when they land inside it without an explicit point', () => {
+		const frameId = createShapeId('frame')
+		const childId = createShapeId('child')
+
+		// Create a frame centered at the viewport center
+		const viewportCenter = editor.getViewportPageBounds().center
+		const frameW = 400
+		const frameH = 400
+		editor.createShapes([
+			{
+				id: frameId,
+				type: 'frame',
+				x: viewportCenter.x - frameW / 2,
+				y: viewportCenter.y - frameH / 2,
+				props: { w: frameW, h: frameH },
+			},
+			{
+				id: childId,
+				type: 'geo',
+				x: -500,
+				y: -500,
+				props: { w: 10, h: 10 },
+			},
+		])
+
+		editor.select(childId)
+		editor.copy()
+		editor.deleteShapes([childId])
+		editor.selectNone()
+
+		// Paste without a point — shapes should land at viewport center, inside the frame
+		editor.putContentOntoCurrentPage(editor.clipboard!, { select: true })
+
+		const [pastedId] = editor.getSelectedShapeIds()
+		expect(editor.getShape(pastedId)?.parentId).toBe(frameId)
+	})
+})
+
 describe('Paste parent selection with explicit point', () => {
 	it('falls back to the page when the cursor is outside the original parent', () => {
 		const frameId = createShapeId('frame')


### PR DESCRIPTION
Closes #5918

When shapes are pasted (Ctrl+V) and `pasteParentId` resolves to the current page (e.g. nothing is selected, or selected shapes share the page as their common ancestor), shapes are positioned at the viewport center or their original position but no check is made for whether they landed inside a frame. This causes z-ordering confusion: notes added to the frame stay behind the misparented shapes, and sending those shapes to back hides them behind the frame.

This PR adds a post-positioning reparent check in `putContentOntoCurrentPage`. After shapes are positioned, if the paste parent is the page, we compute the center of all pasted root shapes and use `getShapeAtPoint` to find a frame at that center — the same approach already used for paste-at-point. If a frame is found, the root shapes are reparented into it. The pasted shapes themselves are excluded from being considered as parents to prevent frame-into-self reparenting.

https://github.com/user-attachments/assets/a19e2bc2-d04d-42ca-9e20-8bcf89f8fcdf

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame on the canvas
2. Create a shape outside the frame, select it, copy it (Ctrl+C)
3. Deselect all shapes
4. Pan so the viewport is centered on the frame
5. Paste (Ctrl+V) — the shape should become a child of the frame

- [x] Unit tests

### Release notes

- Fixed shapes pasted with Ctrl+V not being parented to a frame when they land inside one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paste parenting behavior by auto-reparenting shapes after they’re positioned, which can affect hierarchy/z-order outcomes in edge cases with overlapping frames or groups; covered by new unit tests.
> 
> **Overview**
> Fixes paste behavior so that when content is pasted onto the page (i.e. no explicit paste parent), the editor **post-processes the newly positioned root shapes** and automatically reparents any that ended up inside a frame using `getDroppedShapesToNewParents` + `reparentShapes`.
> 
> Adds unit tests covering reparenting when pasting at viewport center and with `preservePosition`, and updates an ordering expectation in `paste.test.ts` to reflect the new frame-overlap reparenting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 491d54e3dced83b87256ccde4e466dbeab8900db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->