### PR TITLE
refactor(ui): extract useHasShapesOnPage hook from repeated menu item checks

### DIFF
--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -9,6 +9,7 @@ import {
 	useAnySelectedShapesCount,
 	useCanApplySelectionAction,
 	useHasLinkShapeSelected,
+	useHasShapesOnPage,
 	useOnlyFlippableShape,
 	useShowAutoSizeToggle,
 	useThreeStackableItems,
@@ -141,10 +142,7 @@ export function FitFrameToContentMenuItem() {
 
 /** @public @react */
 export function ToggleLockMenuItem() {
-	const editor = useEditor()
-	const shouldDisplay = useValue('selected shapes', () => editor.getSelectedShapes().length > 0, [
-		editor,
-	])
+	const shouldDisplay = useAnySelectedShapesCount(1)
 	if (!shouldDisplay) return null
 
 	return <TldrawUiMenuActionItem actionId="toggle-lock" />
@@ -170,12 +168,9 @@ export function ToggleTransparentBgMenuItem() {
 
 /** @public @react */
 export function UnlockAllMenuItem() {
-	const editor = useEditor()
-	const shouldDisplay = useValue('any shapes', () => editor.getCurrentPageShapeIds().size > 0, [
-		editor,
-	])
+	const hasShapes = useHasShapesOnPage()
 
-	return <TldrawUiMenuActionItem actionId="unlock-all" disabled={!shouldDisplay} />
+	return <TldrawUiMenuActionItem actionId="unlock-all" disabled={!hasShapes} />
 }
 
 /* ---------------------- Zoom ---------------------- */
@@ -192,8 +187,7 @@ export function ZoomTo100MenuItem() {
 
 /** @public @react */
 export function ZoomToFitMenuItem() {
-	const editor = useEditor()
-	const hasShapes = useValue('has shapes', () => editor.getCurrentPageShapeIds().size > 0, [editor])
+	const hasShapes = useHasShapesOnPage()
 
 	return (
 		<TldrawUiMenuActionItem
@@ -236,12 +230,7 @@ export function ClipboardMenuGroup() {
 
 /** @public @react */
 export function CopyAsMenuGroup() {
-	const editor = useEditor()
-	const atLeastOneShapeOnPage = useValue(
-		'atLeastOneShapeOnPage',
-		() => editor.getCurrentPageShapeIds().size > 0,
-		[editor]
-	)
+	const atLeastOneShapeOnPage = useHasShapesOnPage()
 
 	return (
 		<TldrawUiMenuSubmenu
@@ -294,12 +283,7 @@ export function PasteMenuItem() {
 
 /** @public @react */
 export function ConversionsMenuGroup() {
-	const editor = useEditor()
-	const atLeastOneShapeOnPage = useValue(
-		'atLeastOneShapeOnPage',
-		() => editor.getCurrentPageShapeIds().size > 0,
-		[editor]
-	)
+	const atLeastOneShapeOnPage = useHasShapesOnPage()
 
 	if (!atLeastOneShapeOnPage) return null
 
@@ -323,12 +307,7 @@ export function ConversionsMenuGroup() {
 /* ------------------ Set Selection ----------------- */
 /** @public @react */
 export function SelectAllMenuItem() {
-	const editor = useEditor()
-	const atLeastOneShapeOnPage = useValue(
-		'atLeastOneShapeOnPage',
-		() => editor.getCurrentPageShapeIds().size > 0,
-		[editor]
-	)
+	const atLeastOneShapeOnPage = useHasShapesOnPage()
 
 	return <TldrawUiMenuActionItem actionId="select-all" disabled={!atLeastOneShapeOnPage} />
 }
@@ -730,12 +709,9 @@ export function TogglePasteAtCursorItem() {
 
 /** @public @react */
 export function PrintItem() {
-	const editor = useEditor()
-	const emptyPage = useValue('emptyPage', () => editor.getCurrentPageShapeIds().size === 0, [
-		editor,
-	])
+	const hasShapes = useHasShapesOnPage()
 
-	return <TldrawUiMenuActionItem actionId="print" disabled={emptyPage} />
+	return <TldrawUiMenuActionItem actionId="print" disabled={!hasShapes} />
 }
 
 /* ---------------------- Multiplayer --------------------- */

--- a/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
+++ b/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
@@ -209,6 +209,12 @@ export function useCanUndo() {
 	return useValue('useCanUndo', () => editor.getCanUndo(), [editor])
 }
 
+/** Returns true if the current page has at least one shape. */
+export function useHasShapesOnPage() {
+	const editor = useEditor()
+	return useValue('hasShapesOnPage', () => editor.getCurrentPageShapeIds().size > 0, [editor])
+}
+
 /**
  * Returns true if the user is in the select tool and has at least one shape selected.
  * This corresponds to the `canApplySelectionAction()` check in actions.tsx.


### PR DESCRIPTION
In order to reduce code duplication and improve maintainability in menu-items.tsx, this PR extracts repeated `editor.getCurrentPageShapeIds().size > 0` checks into a reusable `useHasShapesOnPage()` hook in menu-hooks.ts. It also standardizes `ToggleLockMenuItem` to use the existing `useAnySelectedShapesCount(1)` hook instead of an inline `useValue` call.

https://github.com/user-attachments/assets/4dc94e9c-226a-4580-8ea6-4cc4f08db6ef

Closes #7812

### Change type

- [x] `improvement`

### Test plan

1. Open the editor with shapes on the canvas
2. Verify menu items that depend on "page has shapes" (Unlock All, Zoom to Fit, Copy As, Export As, Select All, Print) enable/disable correctly
3. Clear all shapes and verify those items become disabled
4. Select shapes and verify Toggle Lock menu item appears correctly

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reduce code duplication in menu item components by extracting shared `useHasShapesOnPage` hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI refactor that centralizes existing boolean checks; behavioral change risk is limited to menu item enable/disable/visibility conditions.
> 
> **Overview**
> Reduces duplicated “page has shapes” checks across `menu-items.tsx` by introducing a shared `useHasShapesOnPage()` hook in `menu-hooks.ts` and switching affected menu items (e.g. `UnlockAllMenuItem`, `ZoomToFitMenuItem`, `CopyAsMenuGroup`, `ConversionsMenuGroup`, `SelectAllMenuItem`, `PrintItem`) to use it.
> 
> Standardizes `ToggleLockMenuItem` to use the existing `useAnySelectedShapesCount(1)` hook for visibility instead of an inline `useValue` selection-length check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5bab6da3867f153ffd408b5f108e521b767eef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->