### PR TITLE
fix: preserve sharp corners at shift+click segment junctions in freehand draw

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2829,6 +2829,8 @@ export interface StrokePoint {
     // (undocumented)
     input: Vec;
     // (undocumented)
+    isCorner?: boolean;
+    // (undocumented)
     point: Vec;
     // (undocumented)
     pressure: number;

--- a/packages/tldraw/src/lib/shapes/draw/getPath.ts
+++ b/packages/tldraw/src/lib/shapes/draw/getPath.ts
@@ -133,8 +133,16 @@ export function getPointsFromDrawSegment(
 export function getPointsFromDrawSegments(segments: TLDrawShapeSegment[], scaleX = 1, scaleY = 1) {
 	const points: Vec[] = []
 
-	for (const segment of segments) {
-		getPointsFromDrawSegment(segment, scaleX, scaleY, points)
+	for (let i = 0; i < segments.length; i++) {
+		getPointsFromDrawSegment(segments[i], scaleX, scaleY, points)
+		// Mark segment junction and a few preceding points as corners to prevent
+		// streamline lag from creating a curve/thinning at the junction
+		if (i < segments.length - 1 && points.length > 0) {
+			const count = Math.min(3, points.length)
+			for (let j = points.length - count; j < points.length; j++) {
+				;(points[j] as any).isCorner = true
+			}
+		}
 	}
 
 	return points

--- a/packages/tldraw/src/lib/shapes/shared/freehand/svgInk.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/svgInk.ts
@@ -55,6 +55,13 @@ function partitionAtElbows(points: StrokePoint[]): StrokePoint[][] {
 		}
 		currentPartition.push(thisPoint)
 
+		// Split at marked segment junctions with a meaningful angle change
+		if (thisPoint.isCorner && dpr < 0.7) {
+			result.push(cleanUpPartition(currentPartition))
+			currentPartition = [thisPoint]
+			continue
+		}
+
 		if (dpr > 0.7) {
 			// Not an elbow
 			continue

--- a/packages/tldraw/src/lib/shapes/shared/freehand/types.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/types.ts
@@ -46,4 +46,5 @@ export interface StrokePoint {
 	distance: number
 	runningLength: number
 	radius: number
+	isCorner?: boolean
 }


### PR DESCRIPTION
Closes #7867

When using the draw tool with shift+click to create straight line segments, corners between segments were excessively rounded by the freehand rendering pipeline. This fix propagates segment junction information through the rendering pipeline so corners stay sharp.

https://github.com/user-attachments/assets/39798ade-d590-4127-9801-a9663d76f620

The smoothing was caused by multiple stages in the freehand pipeline not knowing that certain points are intentional segment junctions:

1. **Streamline smoothing** pulled corner points toward previous positions, rounding them
2. **Elbow partitioning** in svgInk didn't split at segment junctions, so corners were rendered as smooth curves

The fix introduces an `isCorner` flag that flows through the pipeline:

- **`getPath.ts`** — Marks the last few points before each segment junction as corners
- **`getStrokePoints.ts`** — Skips streamline interpolation for corner points (and a short cooldown window after), preserving their exact position
- **`svgInk.ts`** — Splits stroke partitions at marked corners with meaningful angle changes (dpr < 0.7), so each segment renders independently with sharp joins
- **`types.ts`** — Adds optional `isCorner` field to the `StrokePoint` interface

### Change type

- [x] `bugfix`

 ### Release notes

- Fixed a bug where shift+click corners in freehand draw shapes were over-softened, producing rounded transitions instead of sharp angles at segment junctions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stroke-point generation and SVG partitioning logic; mistakes could subtly affect smoothing/appearance for non-segmented strokes, though changes are gated to flagged corner points.
> 
> **Overview**
> Fixes over-rounded corners when draw shapes are created as straight segments (e.g. shift+click) by propagating explicit *segment junction* metadata through the freehand rendering pipeline.
> 
> `getPointsFromDrawSegments` now marks the end of each segment (and a few preceding points) as corners, `getStrokePoints` preserves this flag and bypasses streamline interpolation for these points (with a short cooldown), and `svgInk` splits stroke partitions at flagged corners with a meaningful angle change. The public `StrokePoint` type (and API report) gains an optional `isCorner` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85bea995a0c16de14535a8643b4d7fbdcf578a39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->