### PR TITLE
fix: make prettier pre-commit hook work from any directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "git diff --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx|js|jsx|json|md)$' | xargs -r yarn run -T prettier --write"
+						"command": "cd \"$(git rev-parse --show-toplevel)\" && git diff --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx|js|jsx|json|md)$' | xargs -r yarn run -T prettier --write || true"
 					}
 				]
 			}


### PR DESCRIPTION
In order to ensure the Claude Code pre-commit prettier hook works correctly regardless of which subdirectory it's invoked from, this PR updates the hook command to `cd` to the git repo root before running prettier. It also adds `|| true` to prevent hook failures from blocking commits.

### Change type

- [x] `bugfix`

### Test plan

1. Navigate to a subdirectory in the repo (e.g., `cd packages/editor`)
2. Make a change to a file and commit via Claude Code
3. Verify the prettier hook runs successfully and formats changed files

### Release notes

- Omitted (internal tooling change with no user-facing impact)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal tooling-only change; main risk is silently skipping formatting failures due to `|| true`.
> 
> **Overview**
> Updates the Claude Code `Stop` hook in `.claude/settings.json` to `cd` to the git repository root before running the prettier-on-changed-files command, so it works when invoked from subdirectories.
> 
> Also appends `|| true` so hook errors don’t block the workflow, while still attempting to format modified `ts/tsx/js/jsx/json/md` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a083069b2524b5c6e03a37406b4ef5985b176913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->