### PR TITLE
docs(releases): update release notes for v4.3.2

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -5,7 +5,7 @@ author: tldraw
 date: 01/31/2025
 order: 0
 status: published
-last_version: v4.3.1
+last_version: v4.3.2
 ---
 
 This release adds a consolidated `options` prop, quick zoom navigation, a fill styles dropdown, a new `TldrawUiSelect` component, shape-aware binding checks, and an experimental canvas drop handler. It also includes 2D canvas rendering for shape indicators, R-tree spatial indexing, telestrator-style laser behavior, significant performance improvements for large canvases, and various bug fixes.
@@ -209,4 +209,6 @@ New options in `TldrawOptions`:
 - Fix keyboard shortcut menu item labels to use consistent ellipsis formatting. ([#7757](https://github.com/tldraw/tldraw/pull/7757))
 - Fix spatial index not removing shapes when moved to a different page. ([#7700](https://github.com/tldraw/tldraw/pull/7700))
 - Fix tldraw failing to load in CJS environments (tsx, ts-node, Jest) due to ESM-only rbush dependency. ([#7905](https://github.com/tldraw/tldraw/pull/7905))
+- Fix shapes pasted with Ctrl+V not being parented to a frame when they land inside one. ([#7938](https://github.com/tldraw/tldraw/pull/7938))
+- Fix crash when cropping custom shapes that don't include `isCircle` in their crop schema. ([#7931](https://github.com/tldraw/tldraw/pull/7931))
 - Fix draw shapes not rendering correctly on tablets that report zero pen pressure. ([#5693](https://github.com/tldraw/tldraw/pull/5693))

--- a/apps/docs/content/releases/v4.3.0.mdx
+++ b/apps/docs/content/releases/v4.3.0.mdx
@@ -254,3 +254,21 @@ Refactored `editor.inputs` to use reactive atoms via the new `InputsManager` cla
 - Fix "Back to content" button not appearing when selected shapes are off-screen. ([#7649](https://github.com/tldraw/tldraw/pull/7649))
 - Fix dotted freehand lines becoming invisible at minimum zoom on Chrome. ([#7650](https://github.com/tldraw/tldraw/pull/7650))
 - Fix menu bar stretching to full width on mobile viewports instead of fitting content. ([#7568](https://github.com/tldraw/tldraw/pull/7568))
+
+[View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.3.0)
+
+---
+
+## Patch releases
+
+### v4.3.1
+
+- Fix draw shape precision issues at high canvas coordinates by switching to delta encoding with a Float32 anchor point. ([#7710](https://github.com/tldraw/tldraw/pull/7710))
+
+[View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.3.1)
+
+### v4.3.2
+
+- Fix crash when cropping custom shapes that don't include `isCircle` in their crop schema. ([#7931](https://github.com/tldraw/tldraw/pull/7931))
+
+[View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.3.2)


### PR DESCRIPTION
In order to keep release documentation current after the v4.3.2 patch release, this PR updates both the archived and next release notes.

### Changes

**v4.3.0.mdx:**
- Add GitHub release link for v4.3.0
- Add v4.3.1 patch section (draw shape delta encoding precision fix)
- Add v4.3.2 patch section (custom shape crop fix)

**next.mdx:**
- Update `last_version` from v4.3.1 to v4.3.2
- Add bug fix entries for #7938 (paste-into-frame) and #7931 (crop isCircle)

### Change type

- [x] `docs`

### Test plan

- [ ] Verify release notes render correctly on the docs site

### Release notes

- Update release notes with v4.3.1 and v4.3.2 patch entries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to markdown release notes; no runtime code changes, with minimal risk beyond potential formatting/rendering issues.
> 
> **Overview**
> Updates release documentation to reflect the `v4.3.2` patch.
> 
> Bumps `apps/docs/content/releases/next.mdx` `last_version` to `v4.3.2` and adds two new bug-fix entries (paste-into-frame parenting and a custom-shape cropping crash).
> 
> Extends `apps/docs/content/releases/v4.3.0.mdx` with GitHub release links and a new **Patch releases** section covering `v4.3.1` and `v4.3.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee7dc07f4c7189dbb1318f60eb383dfdacf7b13f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->