### PR TITLE
fix(docs): fix duplicated path segments in API reference links

### DIFF
--- a/apps/docs/utils/autoLinkDocs.ts
+++ b/apps/docs/utils/autoLinkDocs.ts
@@ -31,7 +31,7 @@ export async function autoLinkDocsForArticle(
 		const [hit, _title] = match
 		const [title, heading] = _title.split('#')
 		const article = await db.get(
-			'SELECT id, sectionId, categoryId FROM articles WHERE title = ? AND sectionId = ?',
+			'SELECT id FROM articles WHERE title = ? AND sectionId = ?',
 			title,
 			'reference'
 		)
@@ -53,9 +53,9 @@ export async function autoLinkDocsForArticle(
 		if (heading) {
 			const headingRow = await db.get('SELECT slug FROM headings WHERE slug = ?', heading)
 			if (!headingRow) throw Error(`Could not find heading for ${_title} (${heading}) in ${id}`)
-			str = `[\`${title}.${heading}\`](/${article.sectionId}/${article.categoryId}/${article.id}#${headingRow.slug})`
+			str = `[\`${title}.${heading}\`](/${article.id}#${headingRow.slug})`
 		} else {
-			str = `[\`${title}\`](/${article.sectionId}/${article.categoryId}/${article.id})`
+			str = `[\`${title}\`](/${article.id})`
 		}
 
 		result = result.replaceAll(hit, str)


### PR DESCRIPTION
Closes #7958

Auto-generated API reference links on docs pages (e.g. `Editor.toImage`) produce broken URLs with duplicated path segments like `/reference/editor/reference/editor/Editor#toImage` instead of `/reference/editor/Editor#toImage`.

This happened because `article.id` now stores the full key path (`reference/editor/Editor`) but `autoLinkDocs.ts` was still prepending `/${sectionId}/${categoryId}/` to it.

### Change type

- [x] `bugfix`

### Test plan

1. Build docs and verify auto-linked API references point to correct URLs (e.g. `/reference/editor/Editor#toImage`)

### Release notes

- Fix broken API reference links on docs pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to docs link generation and a DB query shape; risk is limited to potential mismatches if `articles.id` is not a valid path for some reference entries.
> 
> **Overview**
> Fix.finalizes auto-link generation for API reference docs so links no longer prepend `sectionId/categoryId` onto reference article paths.
> 
> `autoLinkDocsForArticle` now queries only the reference `articles.id` and constructs links as `/${article.id}` (plus optional `#slug`), preventing broken URLs with duplicated path segments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d274b4793a3f58ddb43debcfb9ecb6d7e89c6938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->