### PR TITLE
fix(ci): fix Neon create-branch-action v6 breaking changes

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -81,14 +81,14 @@ jobs:
         uses: neondatabase/create-branch-action@v6
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
-          username: 'dotcom_owner'
+          role: 'dotcom_owner'
           database: 'dotcom'
           branch_name: pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }} # Generate an API key in your Neon account settings
 
       - run: |
           echo "NEON_PREVIEW_DB_CONNECTION_STRING=${{ steps.create-branch.outputs.db_url }}" >> "$GITHUB_ENV"
-          echo "NEON_PREVIEW_DB_POOLED_CONNECTION_STRING=${{ steps.create-branch.outputs.db_url_with_pooler }}" >> "$GITHUB_ENV"
+          echo "NEON_PREVIEW_DB_POOLED_CONNECTION_STRING=${{ steps.create-branch.outputs.db_url_pooled }}" >> "$GITHUB_ENV"
         if: github.event_name == 'pull_request'
 
       - name: Build types


### PR DESCRIPTION
#7904 bumped `neondatabase/create-branch-action` from v5 to v6 but didn't apply the [v6 breaking changes](https://github.com/neondatabase/create-branch-action/releases/tag/v6.0.0), which broke preview deploys.

- `username` → `role` (renamed in v6)
- `db_url_with_pooler` → `db_url_pooled` output (renamed in v6)

### Change type

- [x] `bugfix`

### Test plan

1. Create a preview deploy and verify Neon branch creation succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only workflow change limited to Neon action parameter/output renames; main risk is misnaming keys causing preview DB provisioning to fail.
> 
> **Overview**
> Fixes the dotcom preview deploy GitHub Actions workflow after upgrading to `neondatabase/create-branch-action@v6`.
> 
> Updates the Neon branch creation step to use `role` instead of `username`, and switches the pooled connection string export to the renamed output `db_url_pooled` (from `db_url_with_pooler`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e57ce71780147df80e1baf9caa98597e76f968e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->