### PR TITLE
feat(examples): add modifier keys to reactive inputs example

### DIFF
--- a/apps/examples/src/examples/editor-api/reactive-inputs/ReactiveInputsExample.tsx
+++ b/apps/examples/src/examples/editor-api/reactive-inputs/ReactiveInputsExample.tsx
@@ -17,6 +17,11 @@ export default function ReactiveInputsExample() {
 	)
 }
 
+function formatNum(n: number, decimals: number): string {
+	const s = n.toFixed(decimals)
+	return n >= 0 ? ` ${s}` : s
+}
+
 // [2]
 function ReactiveInputsPanel() {
 	const editor = useEditor()
@@ -68,42 +73,42 @@ function ReactiveInputsPanel() {
 				<div className="input-group">
 					<div className="input-label">Screen point</div>
 					<div className="input-value">
-						{currentScreenPoint.x.toFixed(0)}, {currentScreenPoint.y.toFixed(0)}
+						{formatNum(currentScreenPoint.x, 0)}, {formatNum(currentScreenPoint.y, 0)}
 					</div>
 				</div>
 
 				<div className="input-group">
 					<div className="input-label">Page point</div>
 					<div className="input-value">
-						{currentPagePoint.x.toFixed(0)}, {currentPagePoint.y.toFixed(0)}
+						{formatNum(currentPagePoint.x, 0)}, {formatNum(currentPagePoint.y, 0)}
 					</div>
 				</div>
 
 				<div className="input-group">
 					<div className="input-label">Prev screen</div>
 					<div className="input-value">
-						{previousScreenPoint.x.toFixed(0)}, {previousScreenPoint.y.toFixed(0)}
+						{formatNum(previousScreenPoint.x, 0)}, {formatNum(previousScreenPoint.y, 0)}
 					</div>
 				</div>
 
 				<div className="input-group">
 					<div className="input-label">Prev page</div>
 					<div className="input-value">
-						{previousPagePoint.x.toFixed(0)}, {previousPagePoint.y.toFixed(0)}
+						{formatNum(previousPagePoint.x, 0)}, {formatNum(previousPagePoint.y, 0)}
 					</div>
 				</div>
 
 				<div className="input-group">
 					<div className="input-label">Origin screen</div>
 					<div className="input-value">
-						{originScreenPoint.x.toFixed(0)}, {originScreenPoint.y.toFixed(0)}
+						{formatNum(originScreenPoint.x, 0)}, {formatNum(originScreenPoint.y, 0)}
 					</div>
 				</div>
 
 				<div className="input-group">
 					<div className="input-label">Origin page</div>
 					<div className="input-value">
-						{originPagePoint.x.toFixed(0)}, {originPagePoint.y.toFixed(0)}
+						{formatNum(originPagePoint.x, 0)}, {formatNum(originPagePoint.y, 0)}
 					</div>
 				</div>
 
@@ -111,7 +116,7 @@ function ReactiveInputsPanel() {
 				<div className="input-group">
 					<div className="input-label">Velocity</div>
 					<div className="input-value">
-						{pointerVelocity.x.toFixed(4)}, {pointerVelocity.y.toFixed(4)}
+						{formatNum(pointerVelocity.x, 2)}, {formatNum(pointerVelocity.y, 2)}
 						<span className="input-hint"> px/ms</span>
 					</div>
 				</div>

--- a/apps/examples/src/examples/editor-api/reactive-inputs/reactive-inputs.css
+++ b/apps/examples/src/examples/editor-api/reactive-inputs/reactive-inputs.css
@@ -1,19 +1,14 @@
 .reactive-inputs-panel {
-	padding: 8px 12px;
-	background: rgba(248, 249, 250, 0.95);
-	border-bottom: 1px solid #e0e0e0;
-	border-radius: 6px;
-	font-family:
-		system-ui,
-		-apple-system,
-		sans-serif;
+	padding: 6px;
+	border: 1px solid #ccc;
+	box-shadow: none;
 	pointer-events: all;
 }
 
 .reactive-inputs-content {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 6px;
 	align-items: center;
 }
 
@@ -22,32 +17,27 @@
 	align-items: baseline;
 	gap: 4px;
 	padding: 2px 8px;
-	background: white;
-	border: 1px solid #e0e0e0;
-	border-radius: 4px;
+	background: #fff;
+	border: 1px solid #ccc;
 }
 
 .input-label {
-	font-size: 10px;
-	font-weight: 600;
-	color: #666;
-	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	font-size: 12px;
+	color: #333;
 	white-space: nowrap;
 }
 
 .input-value {
-	font-family:
-		'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
-	font-size: 12px;
-	color: #1a1a1a;
+	font-size: 10px;
+	color: #111;
 	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+	min-width: 80px;
 }
 
 .input-hint {
-	font-size: 10px;
-	color: #999;
-	font-style: italic;
+	font-size: 11px;
+	color: #666;
 }
 
 .modifier-keys {
@@ -59,20 +49,14 @@
 .modifier-key {
 	display: inline-block;
 	padding: 2px 6px;
-	font-family:
-		'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
 	font-size: 11px;
-	border-radius: 4px;
-	background: #e8e8e8;
-	color: #999;
-	border: 1px solid #ddd;
-	transition:
-		background 0.1s,
-		color 0.1s;
+	background: #e0e0e0;
+	color: #666;
+	border: 1px solid #ccc;
 }
 
 .modifier-key[data-active='true'] {
-	background: #1a1a1a;
-	color: white;
-	border-color: #1a1a1a;
+	background: #333;
+	color: #fff;
+	border-color: #333;
 }


### PR DESCRIPTION
In order to demonstrate the full range of reactive inputs available in the editor's InputsManager (closes #7713), this PR adds modifier key indicators to the reactive inputs example and moves the panel into the canvas UI as a TopPanel component.

It also fixes a bug where modifier key state (particularly Meta/Cmd on macOS) could get stuck after key release, because on macOS the keyup event for Cmd can report `e.metaKey = true`. The fix force-clears a modifier key's state when its own explicit keyup event is received.

### Changes

- Add shift, alt, meta, and accel key indicators using `useValue` with the InputsManager's reactive getter methods
- Move the panel from a side panel layout to a `TopPanel` component inside the canvas UI, fixing the issue where the panel was below the fold and hidden
- Fix modifier key state getting stuck on macOS by immediately clearing state on explicit keyup events for Shift, Alt, and Meta keys
- Remove the `Ctrl` badge since `getCtrlKey()` is normalized to `e.metaKey || e.ctrlKey` (redundant with Accel)

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev` and open the "Reactive inputs" example
2. Verify the inputs panel renders in the top zone of the canvas
3. Press modifier keys (Shift, Alt, Cmd/Meta) and verify they light up
4. Release modifier keys and verify they immediately clear (no sticking)
5. Verify the "Accel" badge follows Cmd on Mac and Ctrl elsewhere

### Release notes

- Add modifier key indicators (Shift, Alt, Meta, Accel) to the reactive inputs example.
- Fix modifier key state getting stuck after key release on macOS.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only UI changes that rewire how the panel is rendered and add a few new reactive subscriptions; no production logic or data handling is affected.
> 
> **Overview**
> Updates the Reactive Inputs example to render its panel inside the canvas UI by wiring `ReactiveInputsPanel` as a `TopPanel` via `components`, switching from storing the `editor` in local state to using `useEditor()`.
> 
> Extends the panel to display reactive modifier key state (`Shift`, `Ctrl`, `Alt`, `Meta`, `Accel`) using `useValue`, and simplifies/compacts the coordinate and velocity readouts with a shared `formatNum` helper.
> 
> Restyles the panel from a fixed side layout to a compact, wrap-friendly top bar and adds new styles for modifier key badges (including active-state styling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67600563d9f5a08e05626b50e5b743a2597a8d0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->