### PR TITLE
refactor(editor): use @beta TSDoc tag for onDropOnCanvas instead of experimental_ prefix

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -695,7 +695,6 @@ export const defaultTldrawOptions: {
     readonly edgeScrollEaseDuration: 200;
     readonly edgeScrollSpeed: 25;
     readonly enableToolbarKeyboardShortcuts: true;
-    readonly experimental__onDropOnCanvas: undefined;
     readonly exportProvider: ExoticComponent<FragmentProps>;
     readonly flattenImageBoundsExpand: 64;
     readonly flattenImageBoundsPadding: 16;
@@ -729,6 +728,7 @@ export const defaultTldrawOptions: {
     readonly maxShapesPerPage: 4000;
     readonly multiClickDurationMs: 200;
     readonly nonce: undefined;
+    readonly onDropOnCanvas: undefined;
     readonly quickZoomPreservesScreenBounds: true;
     readonly snapThreshold: 8;
     readonly spacebarPanning: true;
@@ -3506,10 +3506,6 @@ export interface TldrawOptions {
     // (undocumented)
     readonly edgeScrollSpeed: number;
     readonly enableToolbarKeyboardShortcuts: boolean;
-    experimental__onDropOnCanvas?(options: {
-        event: React.DragEvent<Element>;
-        point: VecLike;
-    }): boolean;
     readonly exportProvider: ComponentType<{
         children: React.ReactNode;
     }>;
@@ -3546,6 +3542,11 @@ export interface TldrawOptions {
     // (undocumented)
     readonly multiClickDurationMs: number;
     readonly nonce: string | undefined;
+    // @beta
+    onDropOnCanvas?(options: {
+        event: React.DragEvent<Element>;
+        point: VecLike;
+    }): boolean;
     readonly quickZoomPreservesScreenBounds: boolean;
     readonly snapThreshold: number;
     readonly spacebarPanning: boolean;

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -105,8 +105,8 @@ export function useCanvasEvents() {
 				const pagePoint = editor.screenToPage({ x: e.clientX, y: e.clientY })
 
 				// Call the custom onDropOnCanvas callback if provided
-				if (editor.options.experimental__onDropOnCanvas) {
-					const handled = editor.options.experimental__onDropOnCanvas({
+				if (editor.options.onDropOnCanvas) {
+					const handled = editor.options.onDropOnCanvas({
 						point: pagePoint,
 						event: e,
 					})

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -160,11 +160,10 @@ export interface TldrawOptions {
 	 * Called when content is dropped on the canvas. Provides the page position
 	 * where the drop occurred and the underlying drag event object.
 	 * Return true to prevent default drop handling (files, URLs, etc.)
+	 *
+	 * @beta
 	 */
-	experimental__onDropOnCanvas?(options: {
-		point: VecLike
-		event: React.DragEvent<Element>
-	}): boolean
+	onDropOnCanvas?(options: { point: VecLike; event: React.DragEvent<Element> }): boolean
 }
 
 /** @public */
@@ -227,5 +226,5 @@ export const defaultTldrawOptions = {
 	text: {},
 	deepLinks: undefined,
 	quickZoomPreservesScreenBounds: true,
-	experimental__onDropOnCanvas: undefined,
+	onDropOnCanvas: undefined,
 } as const satisfies TldrawOptions


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/7911

In order to follow proper API Extractor conventions for marking experimental APIs, this PR replaces the `experimental__` prefix on `onDropOnCanvas` with the `@beta` TSDoc release tag. This ensures the API is properly annotated in the generated api-report (`// @beta`) and excluded from the public `.d.ts` rollup until promoted.

### Change type

- [x] `api`

### Test plan

1. Run `yarn typecheck` — passes
2. Run `yarn build-api` in `packages/editor` — api-report correctly shows `// @beta` annotation on `onDropOnCanvas`
3. Verify `onDropOnCanvas` is excluded from `api/public.d.ts`

### Release notes

- Rename `experimental__onDropOnCanvas` option to `onDropOnCanvas` with `@beta` TSDoc tag

### API changes

- Renamed `experimental__onDropOnCanvas` to `onDropOnCanvas` (marked `@beta`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API rename and doc-tag change; primary risk is downstream breakage for consumers still using `experimental__onDropOnCanvas`.
> 
> **Overview**
> Renames the editor options hook for canvas drop handling from `experimental__onDropOnCanvas` to `onDropOnCanvas`, updating `useCanvasEvents` to invoke the new option and `defaultTldrawOptions` to expose the renamed field.
> 
> Marks `onDropOnCanvas` as **`@beta`** in the `TldrawOptions` API and updates the generated `api-report.api.md` to reflect the beta release tag (and remove the experimental-prefixed API).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b50328715ca7b2ef692e3dc6aad70df8a6e73de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->