### PR TITLE
fix(dotcom): validate userId param in connect route

### DIFF
--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -111,6 +111,7 @@ const router = createRouter<Environment>()
 			return notFound()
 		}
 
+		if (req.params.userId !== auth.userId) return notFound()
 		const stub = getUserDurableObject(env, auth.userId)
 		return stub.fetch(req)
 	})


### PR DESCRIPTION
Validates that the `:userId` URL parameter matches the authenticated user ID before forwarding the request to the user Durable Object.

The DO routing itself already uses `auth.userId` (so you always connect to the correct DO regardless of the URL param), but the forwarded request carried the untrusted URL param which the DO uses to set `this.userId` on cold start. This is an additional precaution to ensure the URL param and authenticated identity are consistent.

### Change type

- [x] `bugfix`

### Test plan

1. Connect to `/app/:userId/connect` with a mismatched userId — should get 404
2. Connect with correct userId — should work as before