### PR TITLE
feat(examples): improve UX in examples app

### DIFF
--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -49,6 +49,9 @@ export function ExamplePage({
 
 	useArrowKeyNavigation(filterValue, example.path)
 
+	const hasFilterResults =
+		!filterValue || examples.some((cat) => cat.value.some((ex) => matchesFilter(ex, filterValue)))
+
 	return (
 		<DialogContextProvider>
 			<div className="example">
@@ -98,25 +101,38 @@ export function ExamplePage({
 						value={filterValue}
 						onChange={handleFilterChange}
 					/>
-					<ul className="example__sidebar__categories scroll-light">
-						{categories.map((currentCategory) => (
-							<li key={currentCategory} className="example__sidebar__category">
-								<h3 className="example__sidebar__category__header">{currentCategory}</h3>
-								<ul className="example__sidebar__category__items">
-									{examples
-										.find((category) => category.id === currentCategory)
-										?.value.filter((ex) => matchesFilter(ex, filterValue))
-										.map((sidebarExample) => (
-											<ExampleSidebarListItem
-												key={sidebarExample.path}
-												example={sidebarExample}
-												isActive={sidebarExample.path === example.path}
-											/>
-										))}
-								</ul>
-							</li>
-						))}
-					</ul>
+					{hasFilterResults ? (
+						<ul className="example__sidebar__categories scroll-light">
+							{categories.map((currentCategory) => (
+								<li key={currentCategory} className="example__sidebar__category">
+									<h3 className="example__sidebar__category__header">{currentCategory}</h3>
+									<ul className="example__sidebar__category__items">
+										{examples
+											.find((category) => category.id === currentCategory)
+											?.value.filter((ex) => matchesFilter(ex, filterValue))
+											.map((sidebarExample) => (
+												<ExampleSidebarListItem
+													key={sidebarExample.path}
+													example={sidebarExample}
+													isActive={sidebarExample.path === example.path}
+												/>
+											))}
+									</ul>
+								</li>
+							))}
+						</ul>
+					) : (
+						<p className="example__sidebar__no-results">
+							No examples match your filter —{' '}
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								href="https://github.com/tldraw/tldraw/issues/new?assignees=&labels=Example%20Request&projects=&template=example_request.yml&title=%5BExample Request%5D%3A+"
+							>
+								request an example
+							</a>
+						</p>
+					)}
 					<div className="example__sidebar__footer-links">
 						<a
 							className="example__sidebar__footer-link example__sidebar__footer-link--grey"

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -300,6 +300,23 @@ a.example__sidebar__header-link {
 	font-size: 14px;
 }
 
+.example__sidebar__no-results {
+	padding: 16px;
+	color: black;
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.example__sidebar__no-results a {
+	color: black;
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.example__sidebar__no-results a:hover {
+	text-decoration: underline;
+}
+
 /* ------------------ Social Links ------------------ */
 
 .example__sidebar__header__socials {


### PR DESCRIPTION
## Summary

Closes [7967](https://github.com/tldraw/tldraw/issues/7967).

- Fix filter URL to preserve current example path instead of resetting to root
- Add arrow key navigation (up/down) to move between sidebar examples
- Show empty state message with "request an example" link when filter has no results

## Test plan
- [ ] Navigate to an example, type in the filter box, verify URL stays on current example path
- [ ] Press ArrowUp/ArrowDown to navigate between examples in the sidebar
- [ ] Type a filter that matches no examples, verify "No examples match your filter — request an example" appears
- [ ] Verify arrow keys don't interfere when typing in the filter input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the examples app (routing/query string updates and a global keydown handler) with limited blast radius.
> 
> **Overview**
> Improves examples sidebar navigation and filtering behavior.
> 
> The filter now updates the URL query while **preserving the current example path** (instead of resetting to `/`), refactors matching logic into a shared `matchesFilter`, and adds **ArrowUp/ArrowDown navigation** that routes through the current filtered list while ignoring keypresses in form fields.
> 
> When a filter yields no matches, the sidebar shows a new **"no results" empty state** with a link to request an example, along with new CSS styles for that message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2453420ca5a370d534ff19cc75c783b096fe283e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->