### PR TITLE
ci: fix caching miss with node 24 upgrade

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,6 +24,7 @@ runs:
           **/node_modules
           .yarn/cache
           .yarn/unplugged
+          .yarn/install-state.gz
         key: ${{ runner.os }}-node-24.13.1-yarn-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/patches/*') }}
         restore-keys: |
           ${{ runner.os }}-node-24.13.1-yarn-


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/7920

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that expands cache contents; minimal risk beyond potentially stale/invalid caches causing occasional reinstall.
> 
> **Overview**
> Improves CI dependency caching by adding Yarn’s `.yarn/install-state.gz` file to the `actions/cache` paths in the `setup` composite action, reducing cache misses after the Node 24 upgrade.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5f7f2825d74ed057ebbb064d24d1995ab5014b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->