### PR TITLE
feat(examples): surface example descriptions on the canvas

### DIFF
--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -148,6 +148,7 @@ export function ExamplePage({
 				</nav>
 				<div className="example__content" role="main">
 					{children}
+					<ExampleDescriptionBar example={example} />
 					<Dialogs />
 				</div>
 			</div>
@@ -155,16 +156,59 @@ export function ExamplePage({
 	)
 }
 
-function ExampleSidebarListItem({
-	example,
-	isActive,
-}: {
-	example: Example
-	isActive?: boolean
-	showDescriptionWhenInactive?: boolean
-}) {
-	const ref = useRef<HTMLLIElement>(null)
+function stripHtml(html: string): string {
+	const doc = new DOMParser().parseFromString(html, 'text/html')
+	return doc.body.textContent?.trim() ?? ''
+}
+
+function getFirstParagraph(html: string): string {
+	const doc = new DOMParser().parseFromString(html, 'text/html')
+	const firstP = doc.querySelector('p')
+	return firstP?.textContent?.trim() ?? stripHtml(html)
+}
+
+function ExampleDescriptionBar({ example }: { example: Example }) {
 	const { setExampleDialog } = useContext(dialogContext)
+	const summaryText = getFirstParagraph(example.description)
+	if (!summaryText) return null
+
+	const hasDetails = !!stripHtml(example.details) || example.description.includes('</p>\n<')
+
+	return (
+		<div className="example__description-bar">
+			<span className="example__description-bar__title">{example.title}</span>
+			<span className="example__description-bar__text">{summaryText}</span>
+			<div className="example__description-bar__actions">
+				{hasDetails && (
+					<button
+						className="example__description-bar__button"
+						onClick={() => setExampleDialog(example)}
+					>
+						Learn more
+					</button>
+				)}
+				<a
+					className="example__description-bar__button"
+					href={example.codeUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					View source <ExternalLinkIcon />
+				</a>
+				<Link
+					className="example__description-bar__button"
+					to={`${example.path}/full`}
+					title="View standalone example"
+				>
+					Fullscreen <StandaloneIcon />
+				</Link>
+			</div>
+		</div>
+	)
+}
+
+function ExampleSidebarListItem({ example, isActive }: { example: Example; isActive?: boolean }) {
+	const ref = useRef<HTMLLIElement>(null)
 
 	useEffect(() => {
 		if (isActive) {
@@ -180,25 +224,6 @@ function ExampleSidebarListItem({
 		<li ref={ref} className="examples__sidebar__item" data-active={isActive}>
 			<Link to={example.path} className="examples__sidebar__item__link">
 				<span className="examples__sidebar__item__title">{example.title}</span>
-				{isActive && (
-					<div className="example__sidebar__item__buttons">
-						<button
-							className="example__sidebar__item__button hoverable"
-							onClick={() => setExampleDialog(example)}
-							aria-label="Info"
-						>
-							<InfoIcon />
-						</button>
-						<Link
-							to={`${example.path}/full`}
-							className="example__sidebar__item__button hoverable"
-							aria-label="Standalone"
-							title="View standalone example"
-						>
-							<StandaloneIcon />
-						</Link>
-					</div>
-				)}
 			</Link>
 		</li>
 	)

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -375,6 +375,69 @@ a.example__sidebar__header-link {
 	opacity: 1;
 }
 
+/* --------------- Description Bar --------------- */
+
+.example__description-bar {
+	position: absolute;
+	bottom: 52px;
+	left: 8px;
+	z-index: 99999;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 10px 14px;
+	background-color: white;
+	border-radius: 8px;
+	box-shadow:
+		0px 2px 4px rgba(0, 0, 0, 0.12),
+		0px 0px 0px 1px rgba(0, 0, 0, 0.08);
+	font-size: 13px;
+	width: 316px;
+	pointer-events: all;
+}
+
+.example__content:has(.tlui-debug-panel) .example__description-bar {
+	bottom: 92px;
+}
+
+.example__description-bar__title {
+	font-weight: 700;
+}
+
+.example__description-bar__text {
+	color: rgba(0, 0, 0, 0.6);
+	line-height: 1.5;
+	max-width: 300px;
+}
+
+.example__description-bar__actions {
+	display: flex;
+	gap: 6px;
+}
+
+.example__description-bar__button {
+	all: unset;
+	cursor: pointer;
+	font-size: 12px;
+	padding: 4px 8px;
+	border-radius: 4px;
+	background-color: var(--gray-light);
+	color: var(--text);
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	white-space: nowrap;
+}
+
+.example__description-bar__button:hover {
+	background-color: var(--gray-dark);
+}
+
+.example__description-bar__button svg {
+	width: 12px;
+	height: 12px;
+}
+
 /* --------------------- Dialog --------------------- */
 
 .example__dialog__overlay {


### PR DESCRIPTION
In order to make example descriptions immediately visible without requiring users to discover and click a tiny info button, this PR adds a floating description panel on the canvas. Closes #7961.

The panel sits in the bottom-left corner and shows:
- The example title
- A one-line summary (first paragraph from the README)
- Action buttons: "Learn more" (opens full details dialog), "View source", and "Fullscreen"

The panel automatically shifts up when debug mode is active to avoid overlapping the debug panel. The info and standalone buttons have been removed from the sidebar since their functionality now lives in the description bar.

### Change type

- [x] `improvement`

### Test plan

1. Open the examples app at localhost:5420
2. Navigate to any example — the description bar should appear in the bottom-left
3. Verify the title and one-line summary are shown
4. Click "Learn more" — the full details dialog should open
5. Click "View source" — should open the GitHub source
6. Click "Fullscreen" — should open the standalone example view
7. Toggle debug mode — the bar should shift up to avoid the debug panel
8. Navigate between examples — the bar should update with each example's info

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Show example descriptions directly on the canvas instead of hiding them behind an info button