### PR TITLE
feat(examples): add category descriptions with tooltip on hover

### DIFF
--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -27,7 +27,7 @@ export function ExamplePage({
 	example: Example
 	children: React.ReactNode
 }) {
-	const categories = examples.map((e) => e.id)
+	const categories = examples
 	const [filterValue, setFilterValue] = useState('')
 	const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setFilterValue(e.target.value)
@@ -96,13 +96,20 @@ export function ExamplePage({
 						onChange={handleFilterChange}
 					/>
 					<ul className="example__sidebar__categories scroll-light">
-						{categories.map((currentCategory) => (
-							<li key={currentCategory} className="example__sidebar__category">
-								<h3 className="example__sidebar__category__header">{currentCategory}</h3>
+						{categories.map((category) => (
+							<li key={category.id} className="example__sidebar__category">
+								<h3 className="example__sidebar__category__header">
+									{category.id}
+									<span className="example__sidebar__category__info hoverable">
+										<InfoIcon />
+										<span className="example__sidebar__category__tooltip">
+											{category.description}
+										</span>
+									</span>
+								</h3>
 								<ul className="example__sidebar__category__items">
-									{examples
-										.find((category) => category.id === currentCategory)
-										?.value.filter((example) => {
+									{category.value
+										.filter((example) => {
 											const excludedWords = ['a', 'the', '', ' ']
 											const terms = filterValue
 												.toLowerCase()

--- a/apps/examples/src/examples.tsx
+++ b/apps/examples/src/examples.tsx
@@ -13,16 +13,28 @@ export interface Example {
 }
 
 const categories = [
-	['getting-started', 'Getting started'],
-	['configuration', 'Configuration'],
-	['editor-api', 'Editor API'],
-	['ui', 'UI & theming'],
-	['layout', 'Page layout'],
-	['events', 'Events & effects'],
-	['shapes/tools', 'Shapes & tools'],
-	['collaboration', 'Collaboration'],
-	['data/assets', 'Data & assets'],
-	['use-cases', 'Use cases'],
+	['getting-started', 'Getting started', 'Initial set up'],
+	[
+		'configuration',
+		'Configuration',
+		'Change tools, defaults, and behaviors to fit your application',
+	],
+	['editor-api', 'Editor API', 'Control the canvas engine programmatically'],
+	['ui', 'UI & theming', 'Replace interface components, add custom toolbars, and style the canvas'],
+	['layout', 'Page layout', 'Change the size and position of the canvas on the page'],
+	['events', 'Events & effects', 'React to changes on the canvas and add constraints'],
+	[
+		'shapes/tools',
+		'Shapes & tools',
+		'Create custom shapes and tools with their own behaviors and interactions',
+	],
+	[
+		'collaboration',
+		'Collaboration',
+		'Add multiplayer features, sync documents, and control content visibility per user',
+	],
+	['data/assets', 'Data & assets', 'Import, export, and manage document data'],
+	['use-cases', 'Use cases', 'Examples of custom canvas tools and experiences'],
 ] as const
 
 type Category = (typeof categories)[number][0]
@@ -60,7 +72,8 @@ const getExamplesForCategory = (category: Category) =>
 			return a.priority - b.priority
 		})
 
-export const examples = categories.map(([category, title]) => ({
+export const examples = categories.map(([category, title, description]) => ({
 	id: title,
+	description,
 	value: getExamplesForCategory(category as Category),
 }))

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -144,6 +144,37 @@ ul.example__sidebar__categories {
 	padding: 8px 12px;
 	margin: 0px;
 	font-size: 14px;
+	position: relative;
+}
+
+.example__sidebar__category__info {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	cursor: default;
+	color: var(--black-transparent-light);
+}
+
+.example__sidebar__category__tooltip {
+	display: none;
+	position: absolute;
+	left: 12px;
+	right: 12px;
+	top: calc(100% - 4px);
+	padding: 4px 8px;
+	border-radius: 4px;
+	background-color: var(--text);
+	color: var(--background);
+	font-size: 12px;
+	font-weight: 500;
+	z-index: 100;
+	pointer-events: none;
+}
+
+.example__sidebar__category__info:hover .example__sidebar__category__tooltip {
+	display: block;
 }
 
 /* Category */


### PR DESCRIPTION
## Summary
- Adds a short description string to each of the 10 example categories
- Shows the description as a tooltip when hovering the info icon next to each category header in the sidebar
- Extends the categories tuple in `examples.tsx` to include a third element for the description

Closes #7963

## Test plan
- [ ] Visit the examples app at localhost:5420
- [ ] Hover the info icon next to each category header in the sidebar
- [ ] Verify each tooltip shows a relevant description

🤖 Generated with [Claude Code](https://claude.com/claude-code)