### PR TITLE
fix(editor): fall back to existing currentPageId in loadSessionStateSnapshotIntoStore

### DIFF
--- a/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
+++ b/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
@@ -230,7 +230,8 @@ export function loadSessionStateSnapshotIntoStore(
 	const res = migrateAndValidateSessionStateSnapshot(snapshot)
 	if (!res) return
 
-	const preserved = pluckPreservingValues(store.get(TLINSTANCE_ID))
+	const existingInstance = store.get(TLINSTANCE_ID)
+	const preserved = pluckPreservingValues(existingInstance)
 	const primary = opts?.forceOverwrite ? res : preserved
 	const secondary = opts?.forceOverwrite ? preserved : res
 
@@ -238,7 +239,7 @@ export function loadSessionStateSnapshotIntoStore(
 		id: TLINSTANCE_ID,
 		...preserved,
 		// the integrity checker will ensure that the currentPageId is valid
-		currentPageId: res.currentPageId,
+		currentPageId: res.currentPageId ?? existingInstance?.currentPageId,
 		isDebugMode: primary?.isDebugMode ?? secondary?.isDebugMode,
 		isFocusMode: primary?.isFocusMode ?? secondary?.isFocusMode,
 		isToolLocked: primary?.isToolLocked ?? secondary?.isToolLocked,

--- a/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
+++ b/packages/tldraw/src/test/TLSessionStateSnapshot.test.ts
@@ -108,6 +108,21 @@ describe(loadSessionStateSnapshotIntoStore, () => {
 		})
 	})
 
+	it('does not crash when currentPageId is undefined', () => {
+		const snapshot = createSessionStateSnapshotSignal(editor.store).get()
+		if (!snapshot) throw new Error('snapshot is null')
+
+		const currentPageId = editor.getCurrentPageId()
+
+		// Strip currentPageId to simulate what TlaEditor does for deep links
+		const { currentPageId: _, ...snapshotWithoutPageId } = snapshot
+
+		loadSessionStateSnapshotIntoStore(editor.store, snapshotWithoutPageId as TLSessionStateSnapshot)
+
+		// Should preserve the existing currentPageId
+		expect(editor.getCurrentPageId()).toBe(currentPageId)
+	})
+
 	it('overrides existing UI flags if you say so', () => {
 		expect(editor.getInstanceState()).toMatchObject({
 			isGridMode: false,


### PR DESCRIPTION
Closes #7993

`loadSessionStateSnapshotIntoStore` crashes with a `ValidationError` when a session state snapshot without `currentPageId` is loaded (e.g. via deep links in dotcom). This happens because `currentPageId` is passed as `undefined` to the instance validator, which rejects it.

The fix falls back to the existing instance's `currentPageId` when the snapshot doesn't include one, consistent with how the other fields in the function already use `??` fallbacks. Note that `pluckPreservingValues` deliberately excludes `currentPageId` (since the page may no longer exist), so we read it directly from the existing instance record instead.

### Change type

- [x] `bugfix`

### Test plan

1. Open a file on tldraw.com with a `?d=` deep link parameter
2. Have a saved `lastSessionState` in the file state
3. Refresh the page — should no longer crash

- [x] Unit tests

### Release notes

- Fix a crash when loading session state without a `currentPageId` (e.g. when using deep links).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to snapshot-loading fallback behavior with a focused regression test; minimal impact outside this edge case.
> 
> **Overview**
> Prevents a crash when loading a `TLSessionStateSnapshot` that omits `currentPageId` (e.g. deep-link flows).
> 
> `loadSessionStateSnapshotIntoStore` now falls back to the existing instance record’s `currentPageId` when the snapshot doesn’t provide one, and a unit test was added to ensure the page id is preserved in this scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3599025ba980850e8c15e26d1bfd4127eb01add9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->