### PR TITLE
fix(dotcom): add missing React keys in manage cookies dialog

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
@@ -36,7 +36,7 @@ export function TlaManageCookiesDialog() {
 							defaultMessage="We use cookies to keep you logged in, to sync your files, and to collect analytics to help us improve tldraw."
 							values={{
 								a: (chunks) => (
-									<a href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
+									<a key="a" href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
 										{chunks}
 									</a>
 								),
@@ -72,7 +72,7 @@ export function TlaManageCookiesDialog() {
 							defaultMessage="Read our <a>cookie policy</a> to learn more."
 							values={{
 								a: (chunks) => (
-									<a href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
+									<a key="a" href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
 										{chunks}
 									</a>
 								),


### PR DESCRIPTION
When opening the manage cookies dialog, React warns about missing keys in the `FormattedMessage` rich text output. The `values` callbacks for `<a>` tags return elements that end up in an array rendered by `FormattedMessage`, so they need `key` props.

Adds `key="a"` to both anchor elements in `TlaManageCookiesDialog`.

```ts
installHook.js:1 Each child in a list should have a unique "key" prop.

Check the top-level render call using <FormattedMessage>. It was passed a child from FormattedMessage. See https://react.dev/link/warning-keys for more information.
```

### Change type

- [x] `bugfix`

### Test plan

1. Open the manage cookies dialog
2. Verify no "Each child in a list should have a unique key prop" warning in console

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix React key warning in manage cookies dialog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8f298f82266be041b37713c8e5664208dc7e4382. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->