### PR TITLE
ci: see if we can reduce deploy-dotcom timing

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process'
 import * as fs from 'fs'
 import { existsSync, readdirSync, writeFileSync } from 'fs'
 import path from 'path'
+import { performance } from 'perf_hooks'
 import { PassThrough } from 'stream'
 import * as tar from 'tar'
 import {
@@ -126,6 +127,45 @@ const discord = new Discord({
 
 const sentryReleaseName = `${env.TLDRAW_ENV}-${previewId ? previewId + '-' : ''}-${sha}`
 
+interface TimingEntry {
+	label: string
+	durationMs: number
+}
+
+const timings: TimingEntry[] = []
+
+function formatDurationMs(durationMs: number) {
+	if (durationMs >= 60_000) return `${(durationMs / 60_000).toFixed(2)}m`
+	if (durationMs >= 1_000) return `${(durationMs / 1_000).toFixed(2)}s`
+	return `${durationMs.toFixed(0)}ms`
+}
+
+async function withTiming<T>(label: string, fn: () => Promise<T> | T): Promise<T> {
+	const startedAt = performance.now()
+	try {
+		return await fn()
+	} finally {
+		const durationMs = performance.now() - startedAt
+		timings.push({ label, durationMs })
+		nicelog(`[timing] ${label}: ${formatDurationMs(durationMs)}`)
+	}
+}
+
+function logTimingSummary() {
+	if (!timings.length) return
+	nicelog('[timing] deploy breakdown (longest first):')
+	for (const [index, entry] of timings
+		.slice()
+		.sort((a, b) => b.durationMs - a.durationMs)
+		.entries()) {
+		nicelog(
+			`[timing] ${String(index + 1).padStart(2, '0')}. ${entry.label}: ${formatDurationMs(
+				entry.durationMs
+			)}`
+		)
+	}
+}
+
 if (previewId) {
 	env.ASSET_UPLOAD = `https://${previewId}-tldraw-assets.tldraw.workers.dev`
 	env.MULTIPLAYER_SERVER = `https://${previewId}-tldraw-multiplayer.tldraw.workers.dev`
@@ -173,6 +213,7 @@ const zeroConns = zeroConnectionLimits[env.TLDRAW_ENV as keyof typeof zeroConnec
 	| MultiNodeConnLimits
 
 async function main() {
+	const deployStart = performance.now()
 	assert(
 		env.TLDRAW_ENV === 'staging' || env.TLDRAW_ENV === 'production' || env.TLDRAW_ENV === 'preview',
 		'TLDRAW_ENV must be staging or production or preview'
@@ -182,77 +223,115 @@ async function main() {
 
 	await discord.step('setting up deploy', async () => {
 		// make sure the tldraw .css files are built:
-		await exec('yarn', ['lazy', 'prebuild'])
+		await withTiming('prebuild assets', () => exec('yarn', ['lazy', 'prebuild']))
 
 		// link to vercel and supabase projects:
-		await vercelCli('link', ['--project', env.VERCEL_PROJECT_ID])
+		await withTiming('vercel link', () => vercelCli('link', ['--project', env.VERCEL_PROJECT_ID]))
 	})
 
 	// deploy pre-flight steps:
 	// 1. get the dotcom app ready to go (env vars and pre-build)
-	await discord.step('building dotcom app', async () => {
-		await createSentryRelease()
-		await prepareDotcomApp()
-		await uploadSourceMaps()
-		await coalesceWithPreviousAssets(`${dotcom}/.vercel/output/static/assets`)
-	})
+	await withTiming('step: building dotcom app', () =>
+		discord.step('building dotcom app', async () => {
+			await withTiming('dotcom sentry release', () => createSentryRelease())
+			await withTiming('dotcom build', () => prepareDotcomApp())
+			await withTiming('dotcom sourcemap upload', () => uploadSourceMaps())
+			await withTiming('dotcom asset coalescing', () =>
+				coalesceWithPreviousAssets(`${dotcom}/.vercel/output/static/assets`)
+			)
+		})
+	)
 
-	await discord.step('cloudflare deploy dry run', async () => {
-		await deployAssetUploadWorker({ dryRun: true })
-		await deployHealthWorker({ dryRun: true })
-		await deployTlsyncWorker({ dryRun: true })
-		await deployTldrawUserContentWorker({ dryRun: true })
-		await deployImageResizeWorker({ dryRun: true })
-	})
+	await withTiming('step: cloudflare deploy dry run', () =>
+		discord.step('cloudflare deploy dry run', async () => {
+			await withTiming('worker dry run: asset-upload', () =>
+				deployAssetUploadWorker({ dryRun: true })
+			)
+			await withTiming('worker dry run: health', () => deployHealthWorker({ dryRun: true }))
+			await withTiming('worker dry run: multiplayer', () => deployTlsyncWorker({ dryRun: true }))
+			await withTiming('worker dry run: tldrawusercontent', () =>
+				deployTldrawUserContentWorker({ dryRun: true })
+			)
+			await withTiming('worker dry run: image-resize', () =>
+				deployImageResizeWorker({ dryRun: true })
+			)
+		})
+	)
 
 	// --- point of no return! do the deploy for real --- //
 
 	await discord.message(`--- **pre-flight complete, starting real dotcom deploy** ---`)
 
 	// 2. deploy the cloudflare workers:
-	await discord.step('deploying asset uploader to cloudflare', async () => {
-		await deployAssetUploadWorker({ dryRun: false })
-	})
-	await discord.step('deploying multiplayer worker to cloudflare', async () => {
-		await deployTlsyncWorker({ dryRun: false })
-	})
-	await discord.step('deploying tldrawusercontent worker to cloudflare', async () => {
-		await deployTldrawUserContentWorker({ dryRun: false })
-	})
-	await discord.step('deploying image resizer to cloudflare', async () => {
-		await deployImageResizeWorker({ dryRun: false })
-	})
-	await discord.step('deploying health worker to cloudflare', async () => {
-		await deployHealthWorker({ dryRun: false })
-	})
+	await withTiming('step: deploy asset uploader worker', () =>
+		discord.step('deploying asset uploader to cloudflare', async () => {
+			await withTiming('worker deploy: asset-upload', () =>
+				deployAssetUploadWorker({ dryRun: false })
+			)
+		})
+	)
+	await withTiming('step: deploy multiplayer worker', () =>
+		discord.step('deploying multiplayer worker to cloudflare', async () => {
+			await withTiming('worker deploy: multiplayer', () => deployTlsyncWorker({ dryRun: false }))
+		})
+	)
+	await withTiming('step: deploy tldrawusercontent worker', () =>
+		discord.step('deploying tldrawusercontent worker to cloudflare', async () => {
+			await withTiming('worker deploy: tldrawusercontent', () =>
+				deployTldrawUserContentWorker({ dryRun: false })
+			)
+		})
+	)
+	await withTiming('step: deploy image resizer worker', () =>
+		discord.step('deploying image resizer to cloudflare', async () => {
+			await withTiming('worker deploy: image-resize', () =>
+				deployImageResizeWorker({ dryRun: false })
+			)
+		})
+	)
+	await withTiming('step: deploy health worker', () =>
+		discord.step('deploying health worker to cloudflare', async () => {
+			await withTiming('worker deploy: health', () => deployHealthWorker({ dryRun: false }))
+		})
+	)
 
 	// 3. deploy the pre-build dotcom app:
-	const { deploymentUrl, inspectUrl } = await discord.step(
-		'deploying dotcom app to vercel',
-		async () => {
-			return await deploySpa()
-		}
+	const { deploymentUrl, inspectUrl } = await withTiming(
+		'step: deploy dotcom app to vercel',
+		async () =>
+			await discord.step('deploying dotcom app to vercel', async () => {
+				return await withTiming('vercel deploy --prebuilt', () => deploySpa())
+			})
 	)
 
 	let deploymentAlias = null as null | string
 
 	if (previewId) {
 		const aliasDomain = `${previewId}-preview-deploy.tldraw.com`
-		await discord.step('aliasing preview deployment', async () => {
-			await vercelCli('alias', ['set', deploymentUrl, aliasDomain])
-		})
+		await withTiming('step: alias preview deployment', () =>
+			discord.step('aliasing preview deployment', async () => {
+				await withTiming('vercel alias set', () =>
+					vercelCli('alias', ['set', deploymentUrl, aliasDomain])
+				)
+			})
+		)
 
 		deploymentAlias = `https://${aliasDomain}`
 	}
 
 	nicelog('Creating deployment for', deploymentUrl)
-	await createGithubDeployment(env, {
-		app: 'dotcom',
-		deploymentUrl: deploymentAlias ?? deploymentUrl,
-		inspectUrl,
-		sha,
-	})
+	await withTiming('github deployment status update', () =>
+		createGithubDeployment(env, {
+			app: 'dotcom',
+			deploymentUrl: deploymentAlias ?? deploymentUrl,
+			inspectUrl,
+			sha,
+		})
+	)
 
+	const totalDurationMs = performance.now() - deployStart
+	nicelog(`[timing] total deploy script runtime: ${formatDurationMs(totalDurationMs)}`)
+	logTimingSummary()
 	await discord.message(`**Deploy complete!**`)
 }
 


### PR DESCRIPTION
this adds timing to the deploy-dotcom action for future debugging

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change that wraps existing deploy steps with timing/logging; low risk beyond slightly noisier logs or minor overhead in the deploy script.
> 
> **Overview**
> Adds **runtime timing instrumentation** to `internal/scripts/deploy-dotcom.ts` to help identify slow parts of the dotcom deploy.
> 
> The deploy pipeline is wrapped in a new `withTiming` helper that logs per-step durations (prebuild, Vercel link/deploy/alias, Sentry release + sourcemaps, asset coalescing, Cloudflare worker dry runs and deploys, GitHub deployment update) and prints a sorted end-of-run breakdown plus total script runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2147426d287b0cef6369cf9dd82671f774282f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->