### PR TITLE
fix(ci): tolerate Node 24 deprecation warnings in vscode packaging

### DIFF
--- a/apps/vscode/extension/scripts/package.ts
+++ b/apps/vscode/extension/scripts/package.ts
@@ -24,7 +24,7 @@ async function main() {
 				if (error) {
 					throw new Error(error.message)
 				}
-				if (stderr && stderr.search('warning') !== 0) {
+				if (stderr && !/^(warning|\(node:)/.test(stderr)) {
 					throw new Error(stderr)
 				}
 			}


### PR DESCRIPTION
The Node 24 upgrade introduced a `punycode` module deprecation warning that gets written to stderr. The vscode extension packaging script treats any stderr not starting with `"warning"` as a fatal error, which broke the publish workflow.

This updates the stderr check to also tolerate Node.js deprecation warnings (`(node:PID) [DEP...]`).

### Change type

- [x] `bugfix`

### Test plan

1. Run the publish-editor-extensions workflow on main.
2. Verify the packaging step no longer fails due to the punycode deprecation warning.

- [ ] Unit tests
- [ ] End to end tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI scripting change limited to stderr filtering during packaging; minimal functional impact beyond allowing benign warnings.
> 
> **Overview**
> Updates the VS Code extension packaging script to **not fail** when `vsce package` writes Node.js deprecation warnings to stderr (e.g., lines starting with `(node:)`), while still treating other stderr output as an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4f6133f6c532f129b7e862979f2710cb431d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->