### PR TITLE
fix(tldraw): allow TldrawSelectionForeground without TldrawUiContextProvider

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -110,12 +110,13 @@ export function TldrawUiTranslationProvider({
  * @public
  */
 export function useTranslation() {
-	const translation = useCurrentTranslation()
+	const translation = React.useContext(TranslationsContext)
+	const messages = translation?.messages ?? DEFAULT_TRANSLATION
 	return React.useCallback(
 		function msg(id?: Exclude<string, TLUiTranslationKey> | string) {
-			return translation.messages[id as TLUiTranslationKey] ?? id
+			return messages[id as TLUiTranslationKey] ?? id
 		},
-		[translation]
+		[messages]
 	)
 }
 


### PR DESCRIPTION
In order to allow SDK users to use `TldrawSelectionForeground` with `TldrawEditor` directly (without wrapping in `TldrawUiContextProvider`), this PR makes `useTranslation()` gracefully fall back to default English translations when `TranslationsContext` is not available.

Closes #6236

PR #7053 partially addressed this for `NoteShapeUtil` but missed `TldrawSelectionForeground` and its child components (`RotateCornerHandle`, `MobileRotateHandle`, `TldrawCropHandles`), which all call `useTranslation()`. Rather than patching each component individually, this fixes `useTranslation()` itself so all current and future consumers are covered.

### Change type

- [x] `bugfix`

### Test plan

1. Use `TldrawEditor` with `components={{ SelectionForeground: TldrawSelectionForeground }}` but without `TldrawUiContextProvider`
2. Create and select a shape
3. Verify the selection foreground renders correctly with resize/rotate handles

- [x] Unit tests

### Release notes

- Fix `TldrawSelectionForeground` crashing when used without `TldrawUiContextProvider`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a hook to avoid throwing when context is missing, plus a targeted regression test; minimal behavioral impact beyond preventing crashes.
> 
> **Overview**
> Fixes a crash when rendering `TldrawSelectionForeground` (and other UI pieces calling `useTranslation`) without `TldrawUiContextProvider` by making `useTranslation()` fall back to `DEFAULT_TRANSLATION` when `TranslationsContext` is absent.
> 
> Adds a unit test that mounts `TldrawEditor` with `SelectionForeground: TldrawSelectionForeground` and asserts selecting a shape renders the selection foreground without triggering the error boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95d5ef82a02d26a62d947768e9254efa9ec91107. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->