### PR TITLE
Add z-order manipulation example

### DIFF
--- a/apps/examples/src/examples/editor-api/z-order/README.md
+++ b/apps/examples/src/examples/editor-api/z-order/README.md
@@ -1,0 +1,12 @@
+---
+title: Z-order
+component: ./ZOrderExample.tsx
+priority: 3
+keywords: [z-order, stacking, reorder, bring to front, send to back, layer, depth]
+---
+
+Manipulate shape z-order (stacking) using the editor's reordering methods.
+
+---
+
+This example demonstrates how to use the four reordering methods to programmatically change the stacking order of shapes on the canvas: `sendToBack`, `sendBackward`, `bringForward`, and `bringToFront`. Create or select overlapping shapes, then use the buttons to change their z-order. The `sendBackward` and `bringForward` methods move shapes one position relative to overlapping shapes, while `sendToBack` and `bringToFront` move shapes to the absolute bottom or top of the stack.

--- a/apps/examples/src/examples/editor-api/z-order/ZOrderExample.tsx
+++ b/apps/examples/src/examples/editor-api/z-order/ZOrderExample.tsx
@@ -1,0 +1,106 @@
+import { createShapeId, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './z-order.css'
+
+// [1]
+const REORDER_OPERATIONS = [
+	{ label: 'Send to back', action: 'sendToBack' },
+	{ label: 'Send backward', action: 'sendBackward' },
+	{ label: 'Bring forward', action: 'bringForward' },
+	{ label: 'Bring to front', action: 'bringToFront' },
+] as const
+
+function ControlPanel() {
+	const editor = useEditor()
+
+	return (
+		<div className="tlui-menu control-panel">
+			{REORDER_OPERATIONS.map(({ label, action }) => (
+				<TldrawUiButton
+					type="normal"
+					key={action}
+					onClick={() => {
+						// [2]
+						const selectedIds = editor.getSelectedShapeIds()
+						if (selectedIds.length === 0) return
+
+						switch (action) {
+							case 'sendToBack':
+								editor.sendToBack(selectedIds)
+								break
+							case 'sendBackward':
+								editor.sendBackward(selectedIds)
+								break
+							case 'bringForward':
+								editor.bringForward(selectedIds)
+								break
+							case 'bringToFront':
+								editor.bringToFront(selectedIds)
+								break
+						}
+					}}
+				>
+					{label}
+				</TldrawUiButton>
+			))}
+		</div>
+	)
+}
+
+export default function ZOrderExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				onMount={(editor) => {
+					// [3]
+					const shapes = [
+						{
+							id: createShapeId(),
+							type: 'geo' as const,
+							x: 100,
+							y: 100,
+							props: { w: 200, h: 200, color: 'blue' as const },
+						},
+						{
+							id: createShapeId(),
+							type: 'geo' as const,
+							x: 200,
+							y: 150,
+							props: { w: 200, h: 200, color: 'red' as const },
+						},
+						{
+							id: createShapeId(),
+							type: 'geo' as const,
+							x: 300,
+							y: 200,
+							props: { w: 200, h: 200, color: 'green' as const },
+						},
+					]
+
+					editor.createShapes(shapes)
+					editor.selectAll()
+				}}
+				components={{
+					TopPanel: ControlPanel,
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+[1]
+Define the four reordering operations. sendToBack and bringToFront move shapes to the absolute
+bottom or top of the stacking order. sendBackward and bringForward move shapes one position
+relative to overlapping shapes.
+
+[2]
+Each method accepts an array of shape IDs. When multiple shapes are selected, their relative
+order is preserved during the reordering operation. sendBackward and bringForward only consider
+overlapping shapes by default — pass { considerAllShapes: true } to reorder relative to all
+shapes on the page instead.
+
+[3]
+Create three overlapping shapes so the z-order changes are immediately visible. Each shape is
+offset slightly so they stack visually.
+*/

--- a/apps/examples/src/examples/editor-api/z-order/z-order.css
+++ b/apps/examples/src/examples/editor-api/z-order/z-order.css
@@ -1,0 +1,5 @@
+.control-panel {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 8px;
+}


### PR DESCRIPTION
Closes #7460

Adds a focused example demonstrating programmatic shape z-order (stacking) manipulation using the editor's reordering methods.

The example creates three overlapping colored shapes and provides buttons for all four reordering operations:
- `sendToBack` — move shapes to the bottom of the stack
- `sendBackward` — move shapes one position down
- `bringForward` — move shapes one position up
- `bringToFront` — move shapes to the top of the stack

Comments explain the difference between relative reordering (backward/forward with overlapping shapes) vs absolute reordering (to back/to front), and mention the `considerAllShapes` option.

Follows the [writing examples guide](https://github.com/tldraw/tldraw/blob/main/apps/examples/writing-examples.md) — tight example, minimal styling, footnote-style comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained example and styling in the examples app with no changes to core editor logic or data handling.
> 
> **Overview**
> Adds a new `editor-api/z-order` example that demonstrates changing shape stacking order using `sendToBack`, `sendBackward`, `bringForward`, and `bringToFront` via a simple top-panel button UI.
> 
> The example pre-creates three overlapping geo shapes on mount for immediate visual feedback, includes short doc text in `README.md`, and adds minimal CSS for the control panel layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ba102159b061872898318819995dbce0b3eecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->