### PR TITLE
Add inset (padding) option to zoomToFit and zoomToSelection

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3247,13 +3247,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```ts
 	 * editor.zoomToFit()
 	 * editor.zoomToFit({ animation: { duration: 200 } })
+	 * editor.zoomToFit({ inset: 100 })
 	 * ```
 	 *
-	 * @param opts - The camera move options.
+	 * @param opts - The camera move options, and optional inset (padding) amount.
 	 *
 	 * @public
 	 */
-	zoomToFit(opts?: TLCameraMoveOptions): this {
+	zoomToFit(opts?: { inset?: number } & TLCameraMoveOptions): this {
 		const ids = [...this.getCurrentPageShapeIds()].filter((id) => !this.isShapeHidden(id))
 		if (ids.length <= 0) return this
 		const pageBounds = Box.Common(compact(ids.map((id) => this.getShapePageBounds(id))))
@@ -3399,13 +3400,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```ts
 	 * editor.zoomToSelection()
 	 * editor.zoomToSelection({ animation: { duration: 200 } })
+	 * editor.zoomToSelection({ inset: 100 })
 	 * ```
 	 *
-	 * @param opts - The camera move options.
+	 * @param opts - The camera move options, and optional inset (padding) amount.
 	 *
 	 * @public
 	 */
-	zoomToSelection(opts?: TLCameraMoveOptions): this {
+	zoomToSelection(opts?: { inset?: number } & TLCameraMoveOptions): this {
 		const { isLocked } = this.getCameraOptions()
 		if (isLocked && !opts?.force) return this
 

--- a/packages/tldraw/src/test/commands/zoomToFit.test.ts
+++ b/packages/tldraw/src/test/commands/zoomToFit.test.ts
@@ -28,6 +28,28 @@ it('is ignored by undo/redo', () => {
 	expect(editor.getCamera()).toBe(camera)
 })
 
+it('respects inset option', () => {
+	editor.zoomToFit()
+	const cameraWithoutInset = { ...editor.getCamera() }
+
+	editor.zoomToFit({ inset: 200 })
+	const cameraWithInset = { ...editor.getCamera() }
+
+	// With more inset, the zoom should be smaller (more padding means more zoomed out)
+	expect(cameraWithInset.z).toBeLessThan(cameraWithoutInset.z)
+})
+
+it('respects inset of zero', () => {
+	editor.zoomToFit({ inset: 0 })
+	const cameraNoInset = { ...editor.getCamera() }
+
+	editor.zoomToFit()
+	const cameraDefault = { ...editor.getCamera() }
+
+	// Zero inset should produce a higher zoom than the default padding
+	expect(cameraNoInset.z).toBeGreaterThanOrEqual(cameraDefault.z)
+})
+
 it('ignores hidden shapes', () => {
 	// Create a new editor with getShapeVisibility
 	const editorWithHidden = new TestEditor({


### PR DESCRIPTION
Adds an optional `inset` parameter to `zoomToFit()` and `zoomToSelection()` that controls the padding around the zoomed content.

`zoomToBounds` already supported an `inset` option, but it wasn't exposed through `zoomToFit` or `zoomToSelection`. This change passes it through so users can control spacing without calling `zoomToBounds` directly.

```ts
editor.zoomToFit({ inset: 100 })
editor.zoomToSelection({ inset: 50 })
```

Also adds tests for the new option.

Fixes #7515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API surface expansion that forwards an already-supported `zoomToBounds` option; behavior changes are limited to camera framing when callers opt into the new `inset` parameter.
> 
> **Overview**
> `editor.zoomToFit()` and `editor.zoomToSelection()` now accept an optional `inset` value (in addition to existing `TLCameraMoveOptions`) and pass it through to `zoomToBounds`, allowing callers to control padding around the fitted content.
> 
> Adds `zoomToFit` tests to assert larger `inset` results in a more zoomed-out camera and that `inset: 0` behaves distinctly from the default padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b724bad1bd495420c2a6f07d84937773f5b95f83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->