### PR TITLE
chore(zero): increase staging Zero machine memory

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -21,7 +21,7 @@ path = "/keepalive"
 policy = "always"
 
 [[vm]]
-memory = "1gb"
+memory = "4gb"
 cpu_kind = "shared"
 cpus = 1
 

--- a/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
+++ b/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
@@ -24,7 +24,7 @@ timeout = "5s"
 path = "/"
 
 [[vm]]
-memory = "2gb"
+memory = "4gb"
 cpu_kind = "shared"
 cpus = 2
 


### PR DESCRIPTION
Increase memory for staging Zero RM and VS Fly.io machines as a precautionary measure while debugging staging crash-loops.

- RM: 1GB → 4GB
- VS: 2GB → 4GB

Preview (single-node) unchanged — it's been stable.

### Change type

- [x] `improvement`

### Test plan

1. Deploy to staging
2. Monitor RM/VS logs for stability