### PR TITLE
fix(zero): lower staging machine memory to Fly shared CPU limit

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -21,7 +21,7 @@ path = "/keepalive"
 policy = "always"
 
 [[vm]]
-memory = "4gb"
+memory = "2gb"
 cpu_kind = "shared"
 cpus = 1
 

--- a/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
+++ b/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
@@ -24,7 +24,7 @@ timeout = "5s"
 path = "/"
 
 [[vm]]
-memory = "4gb"
+memory = "2gb"
 cpu_kind = "shared"
 cpus = 2
 


### PR DESCRIPTION
#8025 set RM and VS to 4GB but Fly shared CPUs cap at 2GB, causing deploy failures. This lowers both back to 2GB (the max for shared CPU).

Net effect from before #8025: RM doubles from 1GB → 2GB, VS stays at 2GB.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging
2. Verify machines start without memory limit errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change adjusting machine memory limits; low blast radius beyond potential performance/memory-pressure effects if workloads exceed 2GB.
> 
> **Overview**
> Lowers Fly VM `memory` from `4gb` to `2gb` in the `flyio-replication-manager.template.toml` and `flyio-view-syncer.template.toml` templates so shared-CPU machines can be provisioned successfully in staging.
> 
> No application logic changes; this is purely an infra config adjustment to avoid Fly memory limit errors during deploys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543e76f534e2cf149f89f2765f4327a299e9956b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->