### PR TITLE
Try and navigate to group files if already member of group

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -225,6 +225,14 @@ export class Sidebar {
 		return await this.page.evaluate(() => navigator.clipboard.readText())
 	}
 
+	@step
+	async copyFileLinkByName(name: string): Promise<string> {
+		const fileLink = this.getFileByName(name)
+		await this.openFileMenu(fileLink)
+		await this.copyFileLinkFromFileMenu()
+		return await this.page.evaluate(() => navigator.clipboard.readText())
+	}
+
 	async getAfterElementStyle(element: Locator, property: string): Promise<string> {
 		return element.evaluate((el, property) => {
 			return window.getComputedStyle(el, '::after').getPropertyValue(property)

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1232,11 +1232,20 @@ export class TldrawApp {
 
 		// Clear any existing ordering for this new group to get fresh ordering
 		this.lastGroupFileOrderings.delete(payload.groupId)
-		const files = this.getGroupFilesSorted(payload.groupId)
-		if (!files.length) {
+
+		if (!this.navigateToGroupFiles(payload.groupId)) {
 			this.navigate(routes.tlaRoot())
-			return
 		}
+	}
+
+	navigateToGroupFiles(groupId: string) {
+		const files = this.getGroupFilesSorted(groupId)
+
+		if (!files.length) {
+			return false
+		}
+
 		this.navigate(routes.tlaFile(files[0]!.fileId))
+		return true
 	}
 }

--- a/apps/dotcom/client/src/tla/components/GroupInviteHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/GroupInviteHandler.tsx
@@ -52,6 +52,7 @@ export function GroupInviteHandler() {
 							id: 'group-invite-already-member',
 							title: alreadyMemberMsg,
 						})
+						app.navigateToGroupFiles(data.groupId)
 						return
 					}
 


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8035 

Still draft, needs to write tests for it.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a group with AccountA, add two files, one named canvas 1, the other named canvas 2
2. Invite an AccountB to the group with a link
3. AccountB accepts invitation
4. AccountB clicks again on the invitation link
5. AccountB is directed to `canvas 2`
6. AccountA pin canvas 1
7. AccountB clicks again on the invitation link
8. AccountB is directed to `canvas`
9. AccountA removes all canvas 
10. …
11. AccountB stays on root (his files)

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fixed a bug on dotcom where members of a group clicking invitation to group are not redirected to the group file. We now redirect the user to the top pinned file or just the top file. If group has no files then the user stays on root.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side navigation behavior in the invite flow; risk is mainly regressions in routing/selection of the target file, mitigated by new E2E tests.
> 
> **Overview**
> Fixes the group invite flow so that **users who open an invite link for a group they already belong to are redirected into that group**.
> 
> Adds `TldrawApp.navigateToGroupFiles(groupId)` and uses it from `GroupInviteHandler` (and after invite acceptance) to navigate to the group’s top pinned file, or otherwise the first sorted file; if the group has no files it falls back to the root route.
> 
> Updates E2E coverage in `groups.spec.ts` to verify redirect behavior on repeated invite-link visits, including pinned-file precedence, and adds a `Sidebar.copyFileLinkByName` test helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e466aaa2dea3124c9f92aca8f2ec88c98ae7c03f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->