### PR TITLE
fix: correct efficient zoom threshold for scaled shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -953,7 +953,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		}
 
 		// Get arrow body path
-		const isForceSolid = this.editor.getEfficientZoomLevel() < shape.props.scale * 0.25
+		const isForceSolid = this.editor.getEfficientZoomLevel() < 0.25 / shape.props.scale
 		const bodyPathBuilder = getArrowBodyPathBuilder(info)
 		const bodyPath2D = bodyPathBuilder.toPath2D(
 			shape.props.dash === 'draw' && !isForceSolid
@@ -1136,7 +1136,7 @@ const ArrowSvg = track(function ArrowSvg({
 	const editor = useEditor()
 	const theme = useDefaultColorTheme()
 	const info = getArrowInfo(editor, shape)
-	const isForceSolid = useEfficientZoomThreshold(shape.props.scale * 0.25)
+	const isForceSolid = useEfficientZoomThreshold(0.25 / shape.props.scale)
 	const clipPathId = useSharedSafeId(shape.id + '_clip')
 	const arrowheadDotId = useSharedSafeId('arrowhead-dot')
 	const arrowheadCrossId = useSharedSafeId('arrowhead-cross')

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -188,7 +188,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const isReadyForEditing = useIsReadyForEditing(editor, shape.id)
 		const isEmpty = isEmptyRichText(shape.props.richText)
 		const showHtmlContainer = isReadyForEditing || !isEmpty
-		const isForceSolid = useEfficientZoomThreshold(shape.props.scale * 0.25)
+		const isForceSolid = useEfficientZoomThreshold(0.25 / shape.props.scale)
 
 		return (
 			<>
@@ -227,7 +227,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	}
 
 	indicator(shape: TLGeoShape) {
-		const isZoomedOut = useEfficientZoomThreshold(shape.props.scale * 0.25)
+		const isZoomedOut = useEfficientZoomThreshold(0.25 / shape.props.scale)
 
 		const { size, dash, scale } = shape.props
 		const strokeWidth = STROKE_SIZES[size]
@@ -251,7 +251,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	}
 
 	override getIndicatorPath(shape: TLGeoShape): Path2D | undefined {
-		const isForceSolid = this.editor.getEfficientZoomLevel() < shape.props.scale * 0.25
+		const isForceSolid = this.editor.getEfficientZoomLevel() < 0.25 / shape.props.scale
 
 		const { size, dash, scale } = shape.props
 		const strokeWidth = STROKE_SIZES[size]

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -272,7 +272,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const isDarkMode = useValue('dark mode', () => this.editor.user.getIsDarkMode(), [this.editor])
 
 		// Shadows are hidden when zoomed out far enough or in dark mode
-		let hideShadows = useEfficientZoomThreshold(scale * 0.25)
+		let hideShadows = useEfficientZoomThreshold(0.25 / scale)
 		if (isDarkMode) hideShadows = true
 
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()


### PR DESCRIPTION
In order to fix dynamic-size shapes losing their visual detail (shadows, dashes) too aggressively when zoomed out, this PR corrects the efficient zoom threshold formula for scaled shapes.

The threshold was using `scale * 0.25`, which made detail disappear *sooner* for larger-scale shapes — the opposite of what's correct. A note created at 5% zoom with scale 20 looks the same on screen as a scale-1 note at 100% zoom, so it should keep its shadow and dashes. Changed to `0.25 / scale` so the threshold accounts for the shape's visual size.

Closes #7999

### Change type

- [x] `bugfix`

### Test plan

1. Enable dynamic size mode
2. Create a sticky note while zoomed out (e.g. 5-10%) — verify it keeps its shadow, not a grey line
3. Create a dashed arrow while zoomed out — verify it stays dashed, not solid
4. Create a dashed geo shape while zoomed out — verify it stays dashed
5. Verify normal (scale: 1) shapes still behave the same at all zoom levels

### Release notes

- Fix dynamic-size shapes losing shadows and dashes too early when zoomed out