### PR TITLE
chore(zero): downgrade @rocicorp/zero to 0.25.9 to test regression

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@clerk/clerk-react": "^5.53.3",
 		"@clerk/elements": "^0.23.74",
-		"@rocicorp/zero": "0.25.13-canary.9",
+		"@rocicorp/zero": "0.25.9",
 		"@sentry/integrations": "^7.120.3",
 		"@sentry/react": "^7.120.3",
 		"@tldraw/assets": "workspace:*",

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@clerk/backend": "^1.23.7",
 		"@pierre/storage": "^0.1.1",
-		"@rocicorp/zero": "0.25.13-canary.9",
+		"@rocicorp/zero": "0.25.9",
 		"@supabase/auth-helpers-remix": "^0.2.6",
 		"@supabase/supabase-js": "^2.48.1",
 		"@tldraw/dotcom-shared": "workspace:*",

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -26,7 +26,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "0.25.13-canary.9",
+		"@rocicorp/zero": "0.25.9",
 		"kysely": "^0.27.5",
 		"pg": "^8.13.1"
 	},

--- a/packages/dotcom-shared/package.json
+++ b/packages/dotcom-shared/package.json
@@ -9,7 +9,7 @@
 	"files": [],
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "0.25.13-canary.9",
+		"@rocicorp/zero": "0.25.9",
 		"@tldraw/state": "workspace:*",
 		"@tldraw/store": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7868,9 +7868,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocicorp/zero@npm:0.25.13-canary.9":
-  version: 0.25.13-canary.9
-  resolution: "@rocicorp/zero@npm:0.25.13-canary.9"
+"@rocicorp/zero@npm:0.25.9":
+  version: 0.25.9
+  resolution: "@rocicorp/zero@npm:0.25.9"
   dependencies:
     "@badrap/valita": "npm:0.3.11"
     "@databases/escape-identifier": "npm:^1.0.3"
@@ -7914,7 +7914,7 @@ __metadata:
     nanoid: "npm:^5.1.2"
     parse-prometheus-text-format: "npm:^1.1.1"
     pg-format: "npm:pg-format-fix@^1.0.5"
-    postgres: "npm:3.4.7"
+    postgres: "npm:^3.4.4"
     prettier: "npm:^3.5.3"
     semver: "npm:^7.5.4"
     tsx: "npm:^4.19.1"
@@ -7938,7 +7938,7 @@ __metadata:
     zero-cache-dev: out/zero/src/zero-cache-dev.js
     zero-deploy-permissions: out/zero/src/deploy-permissions.js
     zero-out: out/zero/src/zero-out.js
-  checksum: 10/9fbebe49a196ab69df302e3b9299c1e815fdecbb6a4bc1f07f00ce52626ee3628f3b503147f53cc211741cb6802ddab5e95a7f912a404d3a1c489845335119fe
+  checksum: 10/040d8444e0c3e7b657c859887cb76771d385c929e650654023ab2f97e92358861dd2184a61ef52f6a83542744426ff6f0b8608262c9b8ed2a42bf2a22c06e546
   languageName: node
   linkType: hard
 
@@ -10199,7 +10199,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/dotcom-shared@workspace:packages/dotcom-shared"
   dependencies:
-    "@rocicorp/zero": "npm:0.25.13-canary.9"
+    "@rocicorp/zero": "npm:0.25.9"
     "@tldraw/state": "workspace:*"
     "@tldraw/store": "workspace:*"
     "@tldraw/tlschema": "workspace:*"
@@ -10223,7 +10223,7 @@ __metadata:
     "@clerk/backend": "npm:^1.23.7"
     "@cloudflare/workers-types": "npm:^4.20250913.0"
     "@pierre/storage": "npm:^0.1.1"
-    "@rocicorp/zero": "npm:0.25.13-canary.9"
+    "@rocicorp/zero": "npm:0.25.9"
     "@supabase/auth-helpers-remix": "npm:^0.2.6"
     "@supabase/supabase-js": "npm:^2.48.1"
     "@tldraw/dotcom-shared": "workspace:*"
@@ -10657,7 +10657,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/zero-cache@workspace:apps/dotcom/zero-cache"
   dependencies:
-    "@rocicorp/zero": "npm:0.25.13-canary.9"
+    "@rocicorp/zero": "npm:0.25.9"
     concurrently: "npm:^9.1.2"
     dotenv: "npm:^16.4.7"
     esbuild: "npm:^0.25.6"
@@ -15785,7 +15785,7 @@ __metadata:
     "@clerk/testing": "npm:^1.4.15"
     "@formatjs/cli": "npm:^6.5.1"
     "@playwright/test": "npm:^1.58.2"
-    "@rocicorp/zero": "npm:0.25.13-canary.9"
+    "@rocicorp/zero": "npm:0.25.9"
     "@sentry/cli": "npm:^2.41.1"
     "@sentry/integrations": "npm:^7.120.3"
     "@sentry/react": "npm:^7.120.3"
@@ -24617,10 +24617,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postgres@npm:3.4.7":
-  version: 3.4.7
-  resolution: "postgres@npm:3.4.7"
-  checksum: 10/ef5b43b137412c13d907da0d37e7d4141653365fd371ffa000e124076119fe14ef95a27b1469f2ed6fb006f855746fc65087f326a124fe320a2b1f3bbec397f4
+"postgres@npm:^3.4.4":
+  version: 3.4.8
+  resolution: "postgres@npm:3.4.8"
+  checksum: 10/65bf20b4ada953926c05a83f3fb454f10f5db0f05bd1fd2d41ddba4ce16d2038b46a973fd04e0331fb43cb5b6028fda272db438e497bc7c947756790f8fadc52
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In order to test whether the staging zero-cache RM crash loop is a regression in 0.25.10+, this PR downgrades `@rocicorp/zero` from 0.25.12 to 0.25.9 across all packages

If RM stays stable for 15+ min on 0.25.9, the regression is confirmed in 0.25.10+.

### Change type

- [x] `other`

### Test plan

1. Deploy to staging
2. Watch `fly logs -a staging-zero-rm` for 15+ min
3. Check Supabase logs for `08P01` events
4. Stable = no `reboot: Restarting system` for 15+ min


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency downgrade affecting sync/cache infrastructure; behavior may change at runtime and could impact data replication or caching stability despite minimal code changes.
> 
> **Overview**
> Downgrades `@rocicorp/zero` from `0.25.13-canary.9` to `0.25.9` across dotcom packages (`client`, `sync-worker`, `zero-cache`, and `dotcom-shared`) to validate whether newer versions introduced a regression.
> 
> Updates `yarn.lock` accordingly, including `@rocicorp/zero`’s resolved transitive dependency on `postgres` (now `^3.4.4`, resolving to `3.4.8`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6de4576cb034678d55f6918d91f7e00dbbf3ae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->