### PR TITLE
fix(editor): clear rich text editor when editing shape is deleted

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -49,11 +49,12 @@ export class EditingShape extends StateNode {
 	}
 
 	override onExit() {
+		const hadEditingShape = !!this.editor.getEditingShapeId()
 		this.editor.setEditingShape(null)
 
 		updateHoveredShapeId.cancel()
 
-		if (this.info.isCreatingTextWhileToolLocked) {
+		if (this.info.isCreatingTextWhileToolLocked && hadEditingShape) {
 			this.parent.setCurrentToolIdMask(undefined)
 			this.editor.setCurrentTool('text', {})
 		}


### PR DESCRIPTION
Closes #8049

See the issue for how to repro.

When a remote user deletes a shape that's being edited, `cleanupInstancePageState` sets `editingShapeId = null` directly. The `defaultSideEffects` handler then transitions to `select.idle`, which fires `EditingShape.onExit()`. But `onExit()` had an early return (`if (!editingShapeId) return`) that bailed because the id was already cleared — so `setEditingShape(null)` never ran and `_currentRichTextEditor` was never cleared. The rich text toolbar (and link editor) stayed visible.

### Fix

- **Remove the early return** in `EditingShape.onExit()`. The guard originally protected code that used `editingShapeId` after calling `setEditingShape(null)`, but that logic has since moved into `setEditingShape` itself. Now `setEditingShape(null)` always runs on exit, clearing `_currentRichTextEditor`.
- **Remove the `_currentRichTextEditor.set(null)`** added in the initial commit inside `cleanupInstancePageState` — it's no longer needed since the state machine exit path handles it.

### Change type

- [x] `bugfix`

### Test plan

1. Open the same tldraw room in two browser tabs
2. In tab A, create a text shape, enter edit mode, select text, open the link editor
3. In tab B, delete the text shape
4. Verify tab A's link editor disappears

### Release notes

- Fix rich text toolbar staying open when editing shape is deleted by another user

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to `EditingShape.onExit()` cleanup logic; primary risk is unintended tool switching when leaving edit mode, but the new `hadEditingShape` guard narrows that behavior.
> 
> **Overview**
> Fixes a state-machine edge case where leaving `select.editing_shape` could skip cleanup if `editingShapeId` had already been cleared externally (e.g. by collaborative deletion).
> 
> `EditingShape.onExit()` now **always** calls `editor.setEditingShape(null)` and only reverts the tool-lock-to-`text` flow when an editing shape actually existed, preventing stale rich-text UI (toolbar/link editor) from remaining visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30daedb304f192bab52a74930c46448b2f3b8e07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->