### PR TITLE
custom styles: riff on shape style config

### DIFF
--- a/apps/examples/src/examples/custom-styles/CustomStylesExample.tsx
+++ b/apps/examples/src/examples/custom-styles/CustomStylesExample.tsx
@@ -54,6 +54,26 @@ const styles: TLStylesConfig = {
 		sans: "'Inter', sans-serif",
 		mono: "'JetBrains Mono', monospace",
 	},
+	// [9]
+	shapes: {
+		geo: {
+			colors: {
+				coral: {
+					light: {
+						solid: '#9b2c2c',
+						fill: '#9b2c2c',
+					},
+					dark: {
+						solid: '#fca5a5',
+						fill: '#fca5a5',
+					},
+				},
+			},
+			sizes: {
+				m: { stroke: 5, labelFont: 20 },
+			},
+		},
+	},
 }
 
 // [5]
@@ -144,6 +164,18 @@ export default function CustomStylesExample() {
 						},
 					})
 
+					editor.createShape({
+						id: createShapeId(),
+						type: 'text',
+						x: 100,
+						y: 570,
+						props: {
+							richText: toRichText('Global coral text token'),
+							color: 'coral',
+							size: 'm',
+						},
+					})
+
 					editor.zoomToFit({ animation: { duration: 0 } })
 				}}
 			/>
@@ -187,4 +219,9 @@ font sizes produced by our custom size tokens.
 
 [8]
 Create text shapes using the overridden `sans` and `mono` font families.
+
+[9]
+Use `styles.shapes` for shape-specific overrides. Here we override the `coral`
+color and `m` size token only for `geo` shapes. Text shapes still use the
+global token values.
 */

--- a/apps/examples/src/examples/per-shape-styles/PerShapeStylesExample.tsx
+++ b/apps/examples/src/examples/per-shape-styles/PerShapeStylesExample.tsx
@@ -1,12 +1,20 @@
-import { GeoShapeUtil, Tldraw, createShapeId, toRichText } from 'tldraw'
+import { TLStylesConfig, Tldraw, createShapeId, toRichText } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file!
 
 // [1]
-const shapeUtils = [
-	GeoShapeUtil.configure({
-		styles: {
+const styles: TLStylesConfig = {
+	// Global defaults for all shapes.
+	sizes: {
+		s: { stroke: 1, font: 14, labelFont: 14, arrowLabelFont: 14 },
+		m: { stroke: 2, font: 16, labelFont: 16, arrowLabelFont: 16 },
+		l: { stroke: 4, font: 20, labelFont: 20, arrowLabelFont: 20 },
+		xl: { stroke: 8, font: 24, labelFont: 24, arrowLabelFont: 24 },
+	},
+	// Shape-specific overrides now live under `styles.shapes`.
+	shapes: {
+		geo: {
 			sizes: {
 				s: { stroke: 1, labelFont: 14 },
 				m: { stroke: 3, labelFont: 18 },
@@ -14,14 +22,14 @@ const shapeUtils = [
 				xl: { stroke: 12, labelFont: 32 },
 			},
 		},
-	}),
-]
+	},
+}
 
 export default function PerShapeStylesExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				shapeUtils={shapeUtils}
+				styles={styles}
 				onMount={(editor) => {
 					// [2]
 					const sizes = ['s', 'm', 'l', 'xl'] as const
@@ -65,10 +73,9 @@ export default function PerShapeStylesExample() {
 
 /*
 [1]
-Use GeoShapeUtil.configure() to override style tokens just for geo shapes.
-The `styles` property uses the same format as the global `styles` prop on <Tldraw>.
-Here we make geo shapes use different stroke widths and label font sizes than
-the global defaults. Other shape types (draw, arrow, text, etc.) are unaffected.
+Set global token defaults at the top level (`sizes`) and put shape-specific
+overrides under `styles.shapes`. Here, geo shapes override their size tokens,
+while text shapes still use the global values.
 
 [2]
 Create geo shapes and text shapes at each size to compare. The geo shapes

--- a/apps/examples/src/examples/per-shape-styles/README.md
+++ b/apps/examples/src/examples/per-shape-styles/README.md
@@ -3,13 +3,13 @@ title: Per-shape-type styles
 component: ./PerShapeStylesExample.tsx
 category: configuration
 priority: 6
-keywords: [styles, per-shape, configure, sizes, stroke, override, shape-specific]
+keywords: [styles, per-shape, sizes, stroke, override, shape-specific, shapes]
 ---
 
-Override style tokens for a specific shape type using `ShapeUtil.configure()`.
+Override style tokens for a specific shape type using `styles.shapes`.
 
 ---
 
-Use `ShapeUtil.configure({ styles: { ... } })` to override size, color, or font tokens
-for a single shape type. This uses the same format as the global `styles` prop on `<Tldraw>`,
-but only affects shapes of that type. Other shapes continue using the global config.
+Set global style tokens on the top-level `styles` config, then add per-shape overrides
+under `styles.shapes.<shapeType>`. This uses the same token format (`colors`, `sizes`,
+`fonts`) and only affects the matching shape type. Other shapes continue using global values.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2473,7 +2473,7 @@ export function maybeSnapToGrid(point: Vec, editor: Editor): Vec;
 export function MenuClickCapture(): false | JSX.Element;
 
 // @public
-export function mergeStylesIntoContext(ctx: TLStyleContext, config: TLStylesConfig): TLStyleContext;
+export function mergeStylesIntoContext(ctx: TLStyleContext, config: TLStyleTokensConfig): TLStyleContext;
 
 // @internal (undocumented)
 export function normalizeWheel(event: React.WheelEvent<HTMLElement> | WheelEvent): {
@@ -4527,7 +4527,12 @@ export interface TLStylesColorDefinition {
 }
 
 // @public
-export interface TLStylesConfig {
+export interface TLStylesConfig extends TLStyleTokensConfig {
+    shapes?: Record<string, TLStyleTokensConfig>;
+}
+
+// @public
+export interface TLStyleTokensConfig {
     colors?: Record<string, null | Partial<TLStylesColorDefinition>>;
     fonts?: Record<string, null | string>;
     sizes?: Record<string, null | Partial<TLSizeTokenDefinition>>;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -204,6 +204,7 @@ export {
 	type TLStyleContext,
 	type TLStylesColorDefinition,
 	type TLStylesConfig,
+	type TLStyleTokensConfig,
 } from './lib/editor/TLShapeStyles'
 export { BaseBoxShapeTool } from './lib/editor/tools/BaseBoxShapeTool/BaseBoxShapeTool'
 export { maybeSnapToGrid } from './lib/editor/tools/BaseBoxShapeTool/children/Pointing'

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -145,6 +145,7 @@ import {
 	TLStyleContext,
 	TLStylesConfig,
 	extendStyleValidators,
+	mergeStylesIntoContext,
 } from './TLShapeStyles'
 import { BindingOnDeleteOptions, BindingUtil } from './bindings/BindingUtil'
 import { bindingsIndex } from './derivations/bindingsIndex'
@@ -921,7 +922,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getShapeStyles<T extends TLShape>(shape: T): TLResolvedStyles<T> {
 		const util = this.getShapeUtil(shape)
-		const ctx = this.getStyleContext()
+		let ctx = this.getStyleContext()
+		const shapeStylesConfig = this._stylesConfig?.shapes?.[shape.type]
+		if (shapeStylesConfig) {
+			ctx = mergeStylesIntoContext(ctx, shapeStylesConfig)
+		}
 		let styles: object = util.getDefaultStyles(shape, ctx) ?? {}
 
 		if (this._getShapeStyleOverrides) {

--- a/packages/editor/src/lib/editor/TLShapeStyles.ts
+++ b/packages/editor/src/lib/editor/TLShapeStyles.ts
@@ -75,11 +75,11 @@ export interface TLStyleContext {
 }
 
 /**
- * Configuration for customizing the style system. Passed as the `styles` prop on `<Tldraw>`.
+ * Token overrides for color, size, and font style systems.
  *
  * @public
  */
-export interface TLStylesConfig {
+export interface TLStyleTokensConfig {
 	/**
 	 * Override, add, or remove color tokens.
 	 * Set a color to `null` to remove it from the palette.
@@ -96,6 +96,19 @@ export interface TLStylesConfig {
 	 * Set a font to `null` to remove it from the font palette.
 	 */
 	fonts?: Record<string, string | null>
+}
+
+/**
+ * Configuration for customizing the style system. Passed as the `styles` prop on `<Tldraw>`.
+ *
+ * @public
+ */
+export interface TLStylesConfig extends TLStyleTokensConfig {
+	/**
+	 * Per-shape token overrides. These are merged onto the global token config
+	 * when resolving styles for a shape of the matching type.
+	 */
+	shapes?: Record<string, TLStyleTokensConfig>
 }
 
 /**
@@ -133,7 +146,7 @@ const STYLE_CONFIG_PROPS: Record<string, EnumStyleProp<any>[]> = {
  */
 export function mergeStylesIntoContext(
 	ctx: TLStyleContext,
-	config: TLStylesConfig
+	config: TLStyleTokensConfig
 ): TLStyleContext {
 	let { theme, sizes, fonts } = ctx
 
@@ -184,21 +197,39 @@ export function mergeStylesIntoContext(
  */
 export function extendStyleValidators(stylesConfig: TLStylesConfig | undefined) {
 	if (!stylesConfig) return
+	const shapeConfigs = Object.values(stylesConfig.shapes ?? {})
+
 	for (const [configKey, props] of Object.entries(STYLE_CONFIG_PROPS)) {
-		const config = (stylesConfig as any)[configKey] as Record<string, unknown> | undefined
-		if (!config) continue
-		const added: string[] = []
-		const removed: string[] = []
-		for (const [name, def] of Object.entries(config)) {
-			if (def === null) {
-				removed.push(name)
-			} else if (!props[0]._valuesSet.has(name as any)) {
-				added.push(name)
+		const globalConfig = (stylesConfig as any)[configKey] as Record<string, unknown> | undefined
+		const added = new Set<string>()
+		const removed = new Set<string>()
+
+		if (globalConfig) {
+			for (const [name, def] of Object.entries(globalConfig)) {
+				if (def === null) {
+					removed.add(name)
+				} else if (!props[0]._valuesSet.has(name as any)) {
+					added.add(name)
+				}
 			}
 		}
+
+		for (const shapeConfig of shapeConfigs) {
+			const config = (shapeConfig as any)[configKey] as Record<string, unknown> | undefined
+			if (!config) continue
+			for (const [name, def] of Object.entries(config)) {
+				if (def !== null && !props[0]._valuesSet.has(name as any)) {
+					added.add(name)
+				}
+			}
+		}
+
+		const addedValues = [...added]
+		const removedValues = [...removed].filter((name) => !added.has(name))
+
 		for (const prop of props) {
-			if (added.length) prop.addValues(added as any)
-			if (removed.length) prop.removeValues(removed as any)
+			if (addedValues.length) prop.addValues(addedValues as any)
+			if (removedValues.length) prop.removeValues(removedValues as any)
 		}
 	}
 }

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -243,7 +243,6 @@ export interface ArrowShapeOptions {
     shouldBeExact(editor: Editor, isPrecise: boolean): boolean;
     shouldIgnoreTargets(editor: Editor): boolean;
     readonly showTextOutline: boolean;
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -1156,7 +1155,6 @@ export interface DrawPathBuilderOpts extends BasePathBuilderOpts, DrawPathBuilde
 // @public (undocumented)
 export interface DrawShapeOptions {
     readonly maxPointsPerShape: number;
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -1556,7 +1554,6 @@ export const FONT_SIZES: Record<TLDefaultSizeStyle, number>;
 export interface FrameShapeOptions {
     resizeChildren: boolean;
     showColors: boolean;
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -1649,7 +1646,6 @@ export function FrameToolbarItem(): JSX.Element;
 // @public (undocumented)
 export interface GeoShapeOptions {
     showTextOutline: boolean;
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -1915,7 +1911,6 @@ export interface HighlightShapeOptions {
     readonly maxPointsPerShape: number;
     // (undocumented)
     readonly overlayOpacity: number;
-    styles?: TLStylesConfig;
     // (undocumented)
     readonly underlayOpacity: number;
 }
@@ -2065,7 +2060,6 @@ export function LaserToolbarItem(): JSX.Element;
 
 // @public (undocumented)
 export interface LineShapeOptions {
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -2231,7 +2225,6 @@ export interface MoveToPathBuilderCommand extends PathBuilderCommandBase {
 // @public (undocumented)
 export interface NoteShapeOptions {
     resizeMode: 'none' | 'scale';
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)
@@ -3086,7 +3079,6 @@ export interface TextAreaProps {
 export interface TextShapeOptions {
     extraArrowHorizontalPadding: number;
     showTextOutline: boolean;
-    styles?: TLStylesConfig;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -38,7 +38,6 @@ import {
 	lerp,
 	mapObjectMapValues,
 	maybeSnapToGrid,
-	mergeStylesIntoContext,
 	structuredClone,
 	toDomPrecision,
 	toRichText,
@@ -192,7 +191,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	}
 
 	override getDefaultStyles(shape: TLArrowShape, ctx: TLStyleContext): TLArrowShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			strokeWidth: ctx.sizes[shape.props.size].stroke,
 			strokeColor: getColorValue(ctx.theme, shape.props.color, 'solid'),

--- a/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrow-types.ts
@@ -1,10 +1,4 @@
-import {
-	Editor,
-	TLArrowShapeArrowheadStyle,
-	TLDefaultSizeStyle,
-	TLStylesConfig,
-	VecLike,
-} from '@tldraw/editor'
+import { Editor, TLArrowShapeArrowheadStyle, TLDefaultSizeStyle, VecLike } from '@tldraw/editor'
 import { ElbowArrowInfo, ElbowArrowRoute } from './elbow/definitions'
 import { TLArrowBindings } from './shared'
 
@@ -103,8 +97,6 @@ export interface ArrowShapeOptions {
 	shouldIgnoreTargets(editor: Editor): boolean
 	/** Whether to show the outline of the arrow shape's label (using the same color as the canvas). This helps with overlapping shapes. It does not show up on Safari, where text outline is a performance issues. */
 	readonly showTextOutline: boolean
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -11,14 +11,12 @@ import {
 	TLResizeInfo,
 	TLShapeUtilCanvasSvgDef,
 	TLStyleContext,
-	TLStylesConfig,
 	VecLike,
 	drawShapeMigrations,
 	drawShapeProps,
 	getColorValue,
 	last,
 	lerp,
-	mergeStylesIntoContext,
 	rng,
 	useEditor,
 	useValue,
@@ -44,8 +42,6 @@ export interface DrawShapeOptions {
 	 * A higher number will lead to poor performance while drawing very long lines.
 	 */
 	readonly maxPointsPerShape: number
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */
@@ -85,7 +81,6 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 	}
 
 	override getDefaultStyles(shape: TLDrawShape, ctx: TLStyleContext): TLDrawShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			strokeWidth: ctx.sizes[shape.props.size].stroke + 1,
 			strokeColor: getColorValue(ctx.theme, shape.props.color, 'solid'),

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -17,14 +17,12 @@ import {
 	TLShapePartial,
 	TLShapeUtilConstructor,
 	TLStyleContext,
-	TLStylesConfig,
 	clamp,
 	compact,
 	frameShapeMigrations,
 	frameShapeProps,
 	getColorValue,
 	lerp,
-	mergeStylesIntoContext,
 	resizeBox,
 	toDomPrecision,
 	useValue,
@@ -59,8 +57,6 @@ export interface FrameShapeOptions {
 	 * When true, the frame will resize its children when the frame itself is resized.
 	 */
 	resizeChildren: boolean
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 export function defaultEmptyAs(str: string, dflt: string) {
@@ -118,7 +114,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 	}
 
 	override getDefaultStyles(shape: TLFrameShape, ctx: TLStyleContext): TLFrameShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		const showColors = this.options.showColors
 		const colorToUse = showColors ? shape.props.color : 'black'
 		return {

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -15,7 +15,6 @@ import {
 	TLResizeInfo,
 	TLShapeUtilCanvasSvgDef,
 	TLStyleContext,
-	TLStylesConfig,
 	Vec,
 	WeakCache,
 	exhaustiveSwitchError,
@@ -25,7 +24,6 @@ import {
 	getFontsFromRichText,
 	isEqual,
 	lerp,
-	mergeStylesIntoContext,
 	toRichText,
 	useValue,
 } from '@tldraw/editor'
@@ -49,8 +47,6 @@ const MIN_SIZE_WITH_LABEL = 17 * 3
 export interface GeoShapeOptions {
 	/** Whether to show the outline of the text label (using the same color as the canvas). */
 	showTextOutline: boolean
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */
@@ -90,7 +86,6 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	}
 
 	override getDefaultStyles(shape: TLGeoShape, ctx: TLStyleContext): TLGeoShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			strokeWidth: ctx.sizes[shape.props.size].stroke,
 			strokeColor: getColorValue(ctx.theme, shape.props.color, 'solid'),

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -9,14 +9,12 @@ import {
 	TLHighlightShapeProps,
 	TLResizeInfo,
 	TLStyleContext,
-	TLStylesConfig,
 	VecLike,
 	getColorValue,
 	highlightShapeMigrations,
 	highlightShapeProps,
 	last,
 	lerp,
-	mergeStylesIntoContext,
 	rng,
 	useEditor,
 	useValue,
@@ -40,8 +38,6 @@ export interface HighlightShapeOptions {
 	readonly maxPointsPerShape: number
 	readonly underlayOpacity: number
 	readonly overlayOpacity: number
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */
@@ -83,7 +79,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 		shape: TLHighlightShape,
 		ctx: TLStyleContext
 	): TLHighlightShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			strokeWidth: ctx.sizes[shape.props.size].font * 1.12,
 			highlightColorSrgb: getColorValue(ctx.theme, shape.props.color, 'highlightSrgb'),

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -9,7 +9,6 @@ import {
 	TLLineShapePoint,
 	TLResizeInfo,
 	TLStyleContext,
-	TLStylesConfig,
 	Vec,
 	WeakCache,
 	ZERO_INDEX_KEY,
@@ -23,7 +22,6 @@ import {
 	lineShapeProps,
 	mapObjectMapValues,
 	maybeSnapToGrid,
-	mergeStylesIntoContext,
 	sortByIndex,
 	useEditor,
 } from '@tldraw/editor'
@@ -33,10 +31,7 @@ import { PathBuilder, PathBuilderGeometry2d } from '../shared/PathBuilder'
 const handlesCache = new WeakCache<TLLineShape['props'], TLHandle[]>()
 
 /** @public */
-export interface LineShapeOptions {
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
-}
+export interface LineShapeOptions {}
 
 /** @public */
 export class LineShapeUtil extends ShapeUtil<TLLineShape> {
@@ -78,7 +73,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	}
 
 	override getDefaultStyles(shape: TLLineShape, ctx: TLStyleContext): TLLineShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			strokeWidth: ctx.sizes[shape.props.size].stroke,
 			strokeColor: getColorValue(ctx.theme, shape.props.color, 'solid'),

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -15,7 +15,6 @@ import {
 	TLShape,
 	TLShapeId,
 	TLStyleContext,
-	TLStylesConfig,
 	Vec,
 	WeakCache,
 	exhaustiveSwitchError,
@@ -23,7 +22,6 @@ import {
 	getFontsFromRichText,
 	isEqual,
 	lerp,
-	mergeStylesIntoContext,
 	noteShapeMigrations,
 	noteShapeProps,
 	resizeScaled,
@@ -61,8 +59,6 @@ export interface NoteShapeOptions {
 	 * but you can set it to be user-resizable using scale.
 	 */
 	resizeMode: 'none' | 'scale'
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */
@@ -118,7 +114,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	}
 
 	override getDefaultStyles(shape: TLNoteShape, ctx: TLStyleContext): TLNoteShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		const labelColor =
 			shape.props.labelColor === 'black'
 				? getColorValue(ctx.theme, shape.props.color, 'noteText')

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -9,14 +9,12 @@ import {
 	TLResizeInfo,
 	TLShapeId,
 	TLStyleContext,
-	TLStylesConfig,
 	TLTextShape,
 	Vec,
 	createComputedCache,
 	getColorValue,
 	getFontsFromRichText,
 	isEqual,
-	mergeStylesIntoContext,
 	resizeScaled,
 	textShapeMigrations,
 	textShapeProps,
@@ -46,8 +44,6 @@ export interface TextShapeOptions {
 	extraArrowHorizontalPadding: number
 	/** Whether to show the outline of the text shape (using the same color as the canvas). This helps with overlapping shapes. It does not show up on Safari, where text outline is a performance issues. */
 	showTextOutline: boolean
-	/** Per-shape style overrides. Same format as the global `styles` prop on `<Tldraw>`. */
-	styles?: TLStylesConfig
 }
 
 /** @public */
@@ -75,7 +71,6 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	}
 
 	override getDefaultStyles(shape: TLTextShape, ctx: TLStyleContext): TLTextShapeResolvedStyles {
-		if (this.options.styles) ctx = mergeStylesIntoContext(ctx, this.options.styles)
 		return {
 			fontSize: ctx.sizes[shape.props.size].font,
 			textColor: getColorValue(ctx.theme, shape.props.color, 'solid'),


### PR DESCRIPTION
riff on https://github.com/tldraw/tldraw/pull/7916
we talked about the pseudo-MUI theme pattern of being able to override styles on a component/shape level in the same place to make the config easier to grok/setup.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [x] `feature`
- [ ] `api`
- [ ] `other`
