### PR TITLE
Fix pasting at cursor near frames

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -134,7 +134,6 @@ import {
 } from '../utils/deepLinks'
 import { getIncrementedName } from '../utils/getIncrementedName'
 import { getReorderingShapesChanges } from '../utils/reorderShapes'
-import { getDroppedShapesToNewParents } from '../utils/reparenting'
 import { TLTextOptions, TiptapEditor } from '../utils/richText'
 import { applyRotationToSnapshotShapes, getRotationSnapshot } from '../utils/rotation'
 import { BindingOnDeleteOptions, BindingUtil } from './bindings/BindingUtil'
@@ -9446,10 +9445,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			isDuplicating = shapeIdMap.has(pasteParentId)
 		}
 
-		if (isDuplicating) {
-			pasteParentId = this.getShape(pasteParentId)!.parentId
-		}
-
 		let index = this.getHighestIndexForParent(pasteParentId) // todo: requires that the putting page is the current page
 
 		const rootShapes: TLShape[] = []
@@ -9633,20 +9628,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 					return { id: s.id, type: s.type, x: s.x + localDelta.x, y: s.y + localDelta.y }
 				})
 			)
-
-			// If shapes were pasted onto the page (not into a specific parent),
-			// check whether they landed inside a frame and reparent if so.
-			if (isPageId(pasteParentId)) {
-				const currentRootShapes = compact(rootShapes.map((s) => this.getShape(s.id)))
-				const { reparenting } = getDroppedShapesToNewParents(this, currentRootShapes)
-				reparenting.forEach((childrenToReparent, newParentId) => {
-					if (childrenToReparent.length === 0) return
-					this.reparentShapes(
-						childrenToReparent.map((s) => s.id),
-						newParentId
-					)
-				})
-			}
 		})
 
 		return this


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/7827

The part of the code that deals with checking wether or not we're on top of a frame works… but then auto correct to the parent element, then check shapes being pasted on the page if they are hovering a frame to put them back in the frame.

Anyhoo, the code works just by not trying to auto correct to the parent element and remove the part at the end that does the "reframing"

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paste/duplicate parenting behavior in `Editor.ts`, which can affect where shapes land across frames/groups; scope is localized but user-visible and easy to regress in edge cases.
> 
> **Overview**
> Fixes paste/duplicate parenting near frames by **preferring the shape under the cursor** as `pasteParentId` when a paste `point` is provided, instead of implicitly inheriting the original selection’s parent.
> 
> Removes special-case parent “auto-correction” during duplication and drops the post-paste pass that reparented page-level pasted shapes into frames via `getDroppedShapesToNewParents`, simplifying paste placement logic and avoiding incorrect reframing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc26d5b4fca153c333054a6a58e41dd29d7de92f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->