### PR TITLE
refactor(editor): simplify putContentOntoCurrentPage paste-parent and positioning logic

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -133,7 +133,7 @@ import {
 } from '../utils/deepLinks'
 import { getIncrementedName } from '../utils/getIncrementedName'
 import { getReorderingShapesChanges } from '../utils/reorderShapes'
-import { getDroppedShapesToNewParents } from '../utils/reparenting'
+import { getDroppedShapesToNewParents, kickoutOccludedShapes } from '../utils/reparenting'
 import { TLTextOptions, TiptapEditor } from '../utils/richText'
 import { applyRotationToSnapshotShapes, getRotationSnapshot } from '../utils/rotation'
 import { BindingOnDeleteOptions, BindingUtil } from './bindings/BindingUtil'
@@ -9621,6 +9621,25 @@ export class Editor extends EventEmitter<TLEventMap> {
 						newParentId
 					)
 				})
+			}
+
+			// Kick out any pasted root shapes that ended up outside their parent container
+			const newShapeIdSet = new Set(newShapes.map((s) => s.id))
+			const shapesToKickout = rootShapes
+				.map((s) => s.id)
+				.filter((id) => {
+					const shape = this.getShape(id)
+					if (!shape) return false
+					// Only check shapes that are children of a shape (not page)
+					if (isPageId(shape.parentId)) return false
+					// Don't check containers with pasted children (preserves intentional
+					// parent-child relationships from the copied content)
+					const children = this.getSortedChildIdsForParent(id)
+					return !children.some((childId) => newShapeIdSet.has(childId))
+				})
+
+			if (shapesToKickout.length > 0) {
+				kickoutOccludedShapes(this, shapesToKickout)
 			}
 		})
 

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -610,4 +610,58 @@ describe('When pasting into frames...', () => {
 		const [pastedId] = editor.getSelectedShapeIds()
 		expect(editor.getShape(pastedId)?.parentId).toBe(ids.frame1)
 	})
+
+	it('Kicks out pasted shapes that do not overlap with the paste-parent frame', () => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+
+		// Create three 100x100 rectangles spaced 200px apart (200px gap between edges)
+		// rect1: x=0..100, rect2: x=300..400, rect3: x=600..700
+		// All at y=0, so selection bounds = 700x100, center = (350, 50)
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.box2, type: 'geo', x: 300, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.box3, type: 'geo', x: 600, y: 0, props: { w: 100, h: 100 } },
+		])
+
+		editor.select(ids.box1, ids.box2, ids.box3)
+		editor.copy()
+
+		// Delete the originals and create a 150x150 frame centered in the viewport
+		editor.deleteShapes([ids.box1, ids.box2, ids.box3])
+		const viewportCenter = editor.getViewportPageBounds().center
+		editor.createShapes([
+			{
+				id: ids.frame1,
+				type: 'frame',
+				x: viewportCenter.x - 75,
+				y: viewportCenter.y - 75,
+				props: { w: 150, h: 150 },
+			},
+		])
+
+		// Select the frame and paste
+		editor.select(ids.frame1)
+		editor.paste()
+
+		// Find the three pasted geo shapes (the new ones, not the originals which were deleted)
+		const pastedGeos = editor
+			.getCurrentPageShapes()
+			.filter((s) => s.type === 'geo')
+			.sort((a, b) => {
+				const aBounds = editor.getShapePageBounds(a)!
+				const bBounds = editor.getShapePageBounds(b)!
+				return aBounds.x - bBounds.x
+			})
+
+		expect(pastedGeos).toHaveLength(3)
+
+		const [left, middle, right] = pastedGeos
+
+		// The middle shape's center lands at the frame center → stays as child of the frame
+		expect(middle.parentId).toBe(ids.frame1)
+
+		// The left and right shapes are far outside the frame → kicked out to page
+		expect(left.parentId).toBe(editor.getCurrentPageId())
+		expect(right.parentId).toBe(editor.getCurrentPageId())
+	})
 })


### PR DESCRIPTION
In order to make the paste logic in `putContentOntoCurrentPage` easier to reason about and extend, this PR replaces the convoluted paste-parent selection and positioning code with clearer, well-separated logic paths.

### Change type

- [x] `improvement`

### Test plan

1. Copy shapes and paste them — they should appear at the viewport center or in-place if already visible
2. Select a frame, copy shapes, paste — they should land inside the selected frame
3. Right-click inside a frame and paste — shapes should land inside that frame at the cursor position
4. Copy a frame that is the same size as a selected frame and paste — the duplicate should not be reparented into the original (the "duplicating a frame" case)
5. Paste shapes that overlap multiple frames — only shapes whose center is inside a frame should be auto-reparented
6. Copy shapes inside a group, paste — they should land in the correct parent

- [x] Unit tests

### Release notes

- Simplify paste-parent selection to use `canReceiveNewChildrenOfType` instead of frame-specific checks
- Prevent edge-only overlap from auto-reparenting pasted shapes into adjacent frames

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paste/reparenting and positioning logic, which can subtly affect many copy/paste scenarios across containers and frames despite test coverage.
> 
> **Overview**
> Refactors `Editor.putContentOntoCurrentPage` paste behavior into clearer paths for *paste-at-cursor*, *standard paste*, and *preserve-position* pastes, using `canReceiveNewChildrenOfType` (with optional chaining) to choose a valid container from the selection/ancestors and avoiding pasting content into itself (duplicate-container case).
> 
> Updates positioning rules to center pastes within the chosen parent, keep coordinates for `preservePosition`, otherwise choose between original vs viewport center based on viewport overlap, and skips the `updateShapes` pass when the computed offset is zero.
> 
> Tightens page-level auto-reparenting into frames by filtering out source shapes and requiring the pasted shape’s bounds center to be inside the candidate parent (preventing reparenting on edge-only overlap); updates `paste.test.ts` expectations accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7e57192837506317a0f117407a267cce0a73353. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->