### PR TITLE
chore: make our ts-lib config consistent

### DIFF
--- a/apps/analytics/tsconfig.json
+++ b/apps/analytics/tsconfig.json
@@ -9,7 +9,7 @@
 		"emitDeclarationOnly": false,
 		"incremental": false,
 		"types": ["vite/client", "vitest/globals"],
-		"lib": ["dom", "DOM.Iterable", "esnext"]
+		"lib": ["DOM", "DOM.Iterable", "ESNext"]
 	},
 	"exclude": ["node_modules", "public", ".tsbuild*", "worker"],
 	"include": ["src", "./vite.config.ts", "./vitest.config.ts"],

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "../../internal/config/tsconfig.base.json",
 	"compilerOptions": {
 		"paths": { "@/*": ["./*"] },
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"plugins": [{ "name": "next" }],
 		"allowJs": true,
 		"emitDeclarationOnly": false,

--- a/apps/dotcom/client/tsconfig.json
+++ b/apps/dotcom/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES5",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/apps/dotcom/zero-cache/tsconfig.json
+++ b/apps/dotcom/zero-cache/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ESNext",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/internal/apps-script/tsconfig.json
+++ b/internal/apps-script/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "es5",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/internal/config/tsconfig.base.json
+++ b/internal/config/tsconfig.base.json
@@ -14,7 +14,7 @@
 		"incremental": true,
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
-		"lib": ["dom", "DOM.Iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "esnext",
 		"target": "esnext",
 		"moduleResolution": "node",

--- a/templates/agent/tsconfig.json
+++ b/templates/agent/tsconfig.json
@@ -13,7 +13,7 @@
 		"resolveJsonModule": true,
 		"incremental": true,
 		"jsx": "react-jsx",
-		"lib": ["dom", "DOM.Iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "esnext",
 		"target": "esnext",
 		"moduleResolution": "node",

--- a/templates/branching-chat/tsconfig.json
+++ b/templates/branching-chat/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/chat/tsconfig.json
+++ b/templates/chat/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "es5",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/templates/image-pipeline/tsconfig.json
+++ b/templates/image-pipeline/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/nextjs/tsconfig.json
+++ b/templates/nextjs/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "es5",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,

--- a/templates/shader/tsconfig.json
+++ b/templates/shader/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/sync-cloudflare/tsconfig.json
+++ b/templates/sync-cloudflare/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["DOM", "DOM.Iterable", "ES2022"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/vite/tsconfig.json
+++ b/templates/vite/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/vue/tsconfig.json
+++ b/templates/vue/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",

--- a/templates/workflow/tsconfig.json
+++ b/templates/workflow/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2020",
 		"useDefineForClassFields": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 		"moduleResolution": "bundler",


### PR DESCRIPTION
Probably these can all be consistent. Any reason they shouldn't be?

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Release notes

- chore: make our ts-lib config consistent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that should be functionally equivalent; main risk is unexpected TypeScript type-checking differences where `ESNext` replaces `ES2020`/`ES2022`.
> 
> **Overview**
> Standardizes TypeScript `compilerOptions.lib` across multiple apps and templates to use consistent casing: `DOM`, `DOM.Iterable`, and `ESNext`.
> 
> A few templates also shift from versioned `ES2020`/`ES2022` entries to `ESNext` to match the base config, reducing tsconfig drift across the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50a7aadcde1c2c12aef3d4d47fd88c10badeca66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->