### PR TITLE
fix(eraser): erase shapes inside groups when starting drag from within group bounds

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -149,7 +149,16 @@ export class Erasing extends StateNode {
 			}
 
 			if (geometry.hitTestLineSegment(A, B, minDist)) {
-				erasing.add(editor.getOutermostSelectableShape(shape).id)
+				const outermost = editor.getOutermostSelectableShape(shape)
+				if (excludedShapeIds.has(outermost.id)) {
+					// If the outermost shape is excluded (e.g. we started erasing inside a group),
+					// resolve to the deepest non-excluded ancestor so we erase the child shape instead
+					erasing.add(
+						editor.getOutermostSelectableShape(shape, (s) => !excludedShapeIds.has(s.id)).id
+					)
+				} else {
+					erasing.add(outermost.id)
+				}
 			}
 
 			this._erasingShapeIds = [...erasing]


### PR DESCRIPTION
In order to fix erasing shapes inside groups when the eraser drag starts from within the group bounds, this PR updates the hit-resolution logic in the Erasing state. Previously, `getOutermostSelectableShape` resolved every hit shape to the group, which was then filtered out by the exclusion set — so nothing got erased. Now, when the outermost shape is excluded (i.e. the group we started inside), we re-resolve using a filter that skips excluded shapes, targeting the child shape or nested group instead.

Closes #7684

### Change type

- [x] `bugfix`

### Test plan

1. Create a group with shapes inside it
2. Use the eraser tool, start dragging from inside the group bounds over a child shape
3. Verify the child shape is erased and the group is not
4. Verify erasing from outside the group still erases the entire group
5. Test with nested groups (Group A > Group B > Shape) — erasing from inside Group A should erase Group B or its children, not Group A

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix eraser not erasing shapes when starting drag from inside a group's bounds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to eraser hit-targeting logic; risk is limited to regressions in group/frame erasing edge cases.
> 
> **Overview**
> Fixes the eraser’s hit-resolution in `Erasing` so that when a line-segment hit resolves to an outermost selectable shape that’s in the initial exclusion set (e.g. the group/frame you started erasing inside), it re-resolves to the deepest non-excluded ancestor and erases that instead.
> 
> This prevents “no-op” erases when starting within group bounds while preserving the existing behavior of erasing the whole outer container when it isn’t excluded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef43ba8a080fa70c60bc4f075977abd321d0a838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->