### PR TITLE
fix(dotcom): preserve user preferences when using deep links, pt 2

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -134,18 +134,19 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			const deepLink = new URLSearchParams(window.location.search).get('d')
 			if (fileState?.lastSessionState) {
 				const sessionState = JSON.parse(fileState.lastSessionState.trim() || 'null')
-				if (sessionState) {
-					if (deepLink) {
-						// When using a deep link, only load preferences (not camera/page states)
-						// since the deep link will control navigation
-						const { pageStates: _, currentPageId: _cpid, ...preferencesOnly } = sessionState
-						editor.loadSnapshot({ session: preferencesOnly }, { forceOverwriteSessionState: true })
-					} else {
-						editor.loadSnapshot({ session: sessionState }, { forceOverwriteSessionState: true })
-					}
+				if (sessionState && deepLink) {
+					// When using a deep link, only load preferences (not camera/page states)
+					// since the deep link will control navigation
+					const { pageStates: _, currentPageId: _cpid, ...preferencesOnly } = sessionState
+					editor.loadSnapshot({ session: preferencesOnly }, { forceOverwriteSessionState: true })
+					editor.navigateToDeepLink(parseDeepLinkString(deepLink))
+				} else if (sessionState) {
+					// No deep link - load the full session state including camera position
+					editor.loadSnapshot({ session: sessionState }, { forceOverwriteSessionState: true })
+				} else if (deepLink) {
+					editor.navigateToDeepLink(parseDeepLinkString(deepLink))
 				}
-			}
-			if (deepLink) {
+			} else if (deepLink) {
 				editor.navigateToDeepLink(parseDeepLinkString(deepLink))
 			}
 			const fileStateUpdater = new FileStateUpdater(app, fileId, editor)


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/7917
it was fixed and then i accidentally commited a "cleanup" commit that undid the work 🤦 

closes https://github.com/tldraw/tldraw/issues/4391#issuecomment-3942483648

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to editor mount logic affecting deep-link/session-state restoration; low risk but could impact initial navigation/camera state on load.
> 
> **Overview**
> Fixes deep-link initialization so opening a URL with `?d=` preserves user *preferences* while letting the deep link control navigation.
> 
> `TlaEditor` now (1) loads only preference fields from `lastSessionState` when a deep link is present and navigates immediately, (2) otherwise loads the full session snapshot, and (3) still navigates to the deep link even when no saved session state exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e0ef182d842e3dc6746424b5165e69970733058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->