### PR TITLE
Fix Events link in footer navigation

### DIFF
--- a/apps/docs/components/navigation/footer.tsx
+++ b/apps/docs/components/navigation/footer.tsx
@@ -40,7 +40,7 @@ const menus = [
 	{
 		heading: 'Company',
 		items: [
-			{ caption: 'Events', href: '/blog/events' },
+			{ caption: 'Videos', href: '/blog/events' },
 			{ caption: 'Careers', href: '/careers' },
 			{ caption: 'License', href: '/legal/tldraw-license' },
 			{ caption: 'Trademarks', href: '/legal/trademark-guidelines' },


### PR DESCRIPTION
Events link in the docs footer currently 404s. Should go to /blog/events instead of just /events

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single docs UI link change; minimal surface area and no impact to runtime logic beyond navigation.
> 
> **Overview**
> Fixes a broken docs footer navigation item by replacing the `Company` menu link from `/events` to `/blog/events` and renaming the caption from *Events* to *Videos* to match the target page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc6ca9e195f55de37554f8e543b887b4da36c42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->