### PR TITLE
fix(deploy): sanitize secrets in Discord error messages

### DIFF
--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -1,12 +1,19 @@
 function sanitizeVariables(errorOutput: string): string {
-	const regex = /(--var\s+(\w+):[^ \n]+)/g
+	let sanitized = errorOutput
 
-	const sanitizedOutput = errorOutput.replace(regex, (_, match) => {
-		const [variable] = match.split(':')
-		return `${variable}:*`
-	})
+	// Sanitize wrangler --var KEY:VALUE patterns
+	sanitized = sanitized.replace(/(--var\s+)(\w+):[^ \n]+/g, '$1$2:***')
 
-	return sanitizedOutput
+	// Sanitize KEY=VALUE patterns where KEY looks like an env var (e.g. flyctl secrets set)
+	sanitized = sanitized.replace(/\b([A-Z][A-Z_0-9]{2,})=[^ \n]+/g, '$1=***')
+
+	// Sanitize connection strings (postgres://, redis://, etc.)
+	sanitized = sanitized.replace(
+		/\b(postgres|postgresql|mysql|redis|mongodb|amqp|https?):\/\/[^\s"']+/gi,
+		'$1://***'
+	)
+
+	return sanitized
 }
 
 export class Discord {


### PR DESCRIPTION
Deploy failure messages posted to Discord included raw error stacks, which could contain secrets passed as CLI arguments (e.g. `flyctl secrets set KEY=VALUE`). This expands the `sanitizeVariables` function to also redact:

- `KEY=VALUE` patterns where KEY looks like an env var name
- Connection strings (`postgres://`, `redis://`, etc.)

### Change type

- [x] `bugfix`

### Test plan

1. Paste the `sanitizeVariables` function into a browser console
2. Test with strings containing `flyctl secrets set ZERO_UPSTREAM_DB=postgres://user:pass@host/db`
3. Verify values are replaced with `***`

### Release notes

- Sanitize secrets from deploy error messages posted to Discord

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string-sanitization change limited to deploy/notification output; main risk is over/under-redaction due to regex behavior.
> 
> **Overview**
> Deploy failure messages sent via `Discord.message()` are now more aggressively scrubbed for secrets by expanding `sanitizeVariables()`.
> 
> In addition to existing `wrangler --var KEY:VALUE` redaction, it now masks `KEY=VALUE` env-var style assignments and replaces URL-like connection strings (e.g., `postgres://...`, `redis://...`, `https://...`) with `***` before posting to Discord.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355c17e994c832d651ee2be127753721b9969275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->