### PR TITLE
group-ui-fixes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarGroupItem.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarGroupItem.tsx
@@ -399,7 +399,6 @@ export function TlaSidebarGroupItem({ groupId, index }: { groupId: string; index
 									setIsExpanded(!isExpanded)
 								}
 							}}
-							style={{ cursor: 'default' }}
 							draggable={!isCoarsePointer}
 							onClick={() => setIsExpanded(!isExpanded)}
 							onDragStart={
@@ -432,7 +431,6 @@ export function TlaSidebarGroupItem({ groupId, index }: { groupId: string; index
 								onClick={(e) => e.stopPropagation()}
 								style={{ cursor: 'default' }}
 							>
-								<TlaSidebarGroupMenu groupId={groupId} />
 								<button
 									className={styles.sidebarGroupItemButton}
 									onClick={handleCreateFile}
@@ -441,6 +439,7 @@ export function TlaSidebarGroupItem({ groupId, index }: { groupId: string; index
 								>
 									<TlaIcon icon="edit" />
 								</button>
+								<TlaSidebarGroupMenu groupId={groupId} />
 							</div>
 						</div>
 					</Collapsible.Trigger>


### PR DESCRIPTION
move vertical ellipsis to the end of icon set, and make the header a pointer cursor

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to sidebar group header interactions (DOM order and inline cursor style) with minimal behavioral impact.
> 
> **Overview**
> Adjusts the sidebar group header UI by removing an inline `cursor: default` from the clickable header area and reordering the action controls so the “More options” (`TlaSidebarGroupMenu`) appears after the “New file” button (vertical ellipsis moved to the end of the icon set).
> 
> No logic changes to group expansion/drag handling; this is a presentation/layout tweak to improve interaction affordance and button placement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c7eb726ad0468e0eea32eb347684c443488c5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->