### PR TITLE
fix(tldraw): allow data:image/svg+xml on <image> with recursive sanitization

### DIFF
--- a/packages/tldraw/src/lib/utils/svg/sanitizeSvg.test.ts
+++ b/packages/tldraw/src/lib/utils/svg/sanitizeSvg.test.ts
@@ -310,7 +310,7 @@ describe('sanitizeSvg', () => {
 		})
 
 		it('blocks fully-malicious data:image/svg+xml on <image>', () => {
-			// base64 of <svg><script>alert(1)</script></svg> — sanitizeSvg strips all children → returns null
+			// inner SVG has no safe content after sanitization, so href is removed
 			const result = sanitizeSvg(
 				wrap(
 					'<image href="data:image/svg+xml;base64,PHN2Zz48c2NyaXB0PmFsZXJ0KDEpPC9zY3JpcHQ+PC9zdmc+" width="10" height="10"/>'

--- a/packages/tldraw/src/lib/utils/svg/sanitizeSvg.ts
+++ b/packages/tldraw/src/lib/utils/svg/sanitizeSvg.ts
@@ -372,7 +372,7 @@ const SAFE_LINK_PROTOCOLS = /^(?:https?:|mailto:)/i
 // data: URI (for images, fonts)
 const DATA_URI = /^data:/i
 
-// data: URI restricted to raster image formats (no svg+xml — could embed unsanitized SVG)
+// data: URI for raster image formats (svg+xml handled separately below)
 const RASTER_DATA_URI =
 	/^data:image\/(?:png|jpeg|jpg|gif|webp|avif|bmp|tiff|x-icon|vnd\.microsoft\.icon)[;,]/i
 
@@ -460,44 +460,54 @@ const URL_BEARING_SVG_ATTRS = new Set([
 
 type SanitizeMode = 'svg' | 'html'
 
-// Guard against mutual recursion: sanitizeSvg → sanitizeNode → sanitizeEmbeddedSvgDataUri → sanitizeSvg
+// Guard against deep recursion: sanitizeSvgInner → ... → sanitizeUri → sanitizeEmbeddedSvgDataUri → sanitizeSvgInner
 const MAX_EMBED_DEPTH = 10
-let currentEmbedDepth = 0
 
-function sanitizeEmbeddedSvgDataUri(value: string): string | null {
-	if (currentEmbedDepth >= MAX_EMBED_DEPTH) return null
-	currentEmbedDepth++
-	try {
-		let svgText: string
-		if (/;base64,/i.test(value)) {
-			const base64 = value.split(/;base64,/i)[1]
-			const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
-			svgText = new TextDecoder().decode(bytes)
-		} else {
-			const idx = value.indexOf(',')
-			if (idx < 0) return null
-			svgText = decodeURIComponent(value.slice(idx + 1))
-		}
-		const sanitized = sanitizeSvg(svgText)
-		if (!sanitized) return null
-		const encoded = new TextEncoder().encode(sanitized)
-		const binaryStr = Array.from(encoded, (b) => String.fromCharCode(b)).join('')
-		return 'data:image/svg+xml;base64,' + btoa(binaryStr)
-	} catch {
-		return null
-	} finally {
-		currentEmbedDepth--
+function decodeDataUri(value: string): string | null {
+	const base64Idx = value.search(/;base64,/i)
+	if (base64Idx >= 0) {
+		const base64 = value.slice(base64Idx + 8) // 8 = ";base64,".length
+		const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+		return new TextDecoder().decode(bytes)
 	}
+	const commaIdx = value.indexOf(',')
+	if (commaIdx < 0) return null
+	return decodeURIComponent(value.slice(commaIdx + 1))
 }
 
-function sanitizeUri(el: Element, attrName: string, value: string): string | null {
+function encodeAsSvgDataUri(svgText: string): string {
+	const bytes = new TextEncoder().encode(svgText)
+	const binaryStr = Array.from(bytes, (b) => String.fromCharCode(b)).join('')
+	return 'data:image/svg+xml;base64,' + btoa(binaryStr)
+}
+
+function sanitizeEmbeddedSvgDataUri(value: string, depth: number): string | null {
+	if (depth >= MAX_EMBED_DEPTH) {
+		console.warn(`Embedded SVG data URI recursion depth limit (${MAX_EMBED_DEPTH}) reached`)
+		return null
+	}
+	let svgText: string
+	try {
+		const decoded = decodeDataUri(value)
+		if (decoded === null) return null
+		svgText = decoded
+	} catch {
+		// Invalid base64 or malformed percent-encoding — treat as unsafe
+		return null
+	}
+	const sanitized = sanitizeSvgInner(svgText, depth + 1)
+	if (!sanitized) return null
+	return encodeAsSvgDataUri(sanitized)
+}
+
+function sanitizeUri(el: Element, attrName: string, value: string, depth: number): string | null {
 	const stripped = value.replace(INVISIBLE_WHITESPACE, '')
 	const tagName = el.tagName.toLowerCase()
 
 	// <image> and <feImage>: raster data: or recursively-sanitized svg+xml data:
 	if (tagName === 'image' || tagName === 'feimage') {
 		if (RASTER_DATA_URI.test(stripped)) return value
-		if (SVG_DATA_URI.test(stripped)) return sanitizeEmbeddedSvgDataUri(value)
+		if (SVG_DATA_URI.test(stripped)) return sanitizeEmbeddedSvgDataUri(stripped, depth)
 		return null
 	}
 
@@ -518,7 +528,7 @@ function sanitizeUri(el: Element, attrName: string, value: string): string | nul
 	return null
 }
 
-function sanitizeSvgAttributes(el: Element): void {
+function sanitizeSvgAttributes(el: Element, depth: number): void {
 	for (let i = el.attributes.length - 1; i >= 0; i--) {
 		const attr = el.attributes[i]
 		const name = attr.name.toLowerCase()
@@ -542,7 +552,7 @@ function sanitizeSvgAttributes(el: Element): void {
 
 		// URI attributes need context-dependent sanitization
 		if (name === 'href' || name === 'xlink:href') {
-			const sanitized = sanitizeUri(el, name, attr.value)
+			const sanitized = sanitizeUri(el, name, attr.value, depth)
 			if (sanitized === null) {
 				el.removeAttribute(attr.name)
 			} else if (sanitized !== attr.value) {
@@ -609,7 +619,7 @@ function sanitizeHtmlAttributes(el: Element): void {
 	}
 }
 
-function sanitizeNode(node: Element, mode: SanitizeMode): void {
+function sanitizeNode(node: Element, mode: SanitizeMode, depth: number): void {
 	// Walk children in reverse so removals don't shift indices
 	for (let i = node.children.length - 1; i >= 0; i--) {
 		const child = node.children[i]
@@ -618,11 +628,11 @@ function sanitizeNode(node: Element, mode: SanitizeMode): void {
 		if (mode === 'svg') {
 			if (tag === 'foreignobject') {
 				// foreignObject: sanitize attrs as SVG, recurse children as HTML
-				sanitizeSvgAttributes(child)
-				sanitizeNode(child, 'html')
+				sanitizeSvgAttributes(child, depth)
+				sanitizeNode(child, 'html', depth)
 			} else if (tag === 'style') {
 				// <style>: sanitize attrs, sanitize text content as CSS
-				sanitizeSvgAttributes(child)
+				sanitizeSvgAttributes(child, depth)
 				if (child.textContent) {
 					child.textContent = sanitizeStyleElement(child.textContent)
 				}
@@ -630,8 +640,8 @@ function sanitizeNode(node: Element, mode: SanitizeMode): void {
 				// Animation targeting href/on* can inject javascript: URIs at runtime
 				child.remove()
 			} else if (ALLOWED_SVG_TAGS.has(tag)) {
-				sanitizeSvgAttributes(child)
-				sanitizeNode(child, 'svg')
+				sanitizeSvgAttributes(child, depth)
+				sanitizeNode(child, 'svg', depth)
 			} else {
 				child.remove()
 			}
@@ -641,7 +651,7 @@ function sanitizeNode(node: Element, mode: SanitizeMode): void {
 				child.remove()
 			} else if (ALLOWED_HTML_TAGS.has(tag)) {
 				sanitizeHtmlAttributes(child)
-				sanitizeNode(child, 'html')
+				sanitizeNode(child, 'html', depth)
 			} else {
 				child.remove()
 			}
@@ -649,10 +659,28 @@ function sanitizeNode(node: Element, mode: SanitizeMode): void {
 	}
 }
 
+function sanitizeSvgInner(svgText: string, depth: number): string {
+	const doc = new DOMParser().parseFromString(svgText, 'image/svg+xml')
+
+	const parseError = doc.querySelector('parsererror')
+	if (parseError) return ''
+
+	const svg = doc.documentElement
+	if (svg.tagName.toLowerCase() !== 'svg') return ''
+
+	sanitizeSvgAttributes(svg, depth)
+	sanitizeNode(svg, 'svg', depth)
+
+	if (svg.children.length === 0) return ''
+
+	return new XMLSerializer().serializeToString(svg)
+}
+
 /**
  * Sanitizes an SVG string by removing dangerous elements, attributes, and URIs
  * while preserving safe content including foreignObject (for text rendering),
  * style elements (for fonts with data: URLs), and animation elements.
+ * Embedded SVG data URIs on `<image>`/`<feImage>` are recursively sanitized.
  *
  * Returns the sanitized SVG string, or an empty string if the input was
  * malformed (parse error) or contained no safe content after sanitization.
@@ -660,20 +688,5 @@ function sanitizeNode(node: Element, mode: SanitizeMode): void {
  * @public
  */
 export function sanitizeSvg(svgText: string): string {
-	const doc = new DOMParser().parseFromString(svgText, 'image/svg+xml')
-
-	// Check for parse errors
-	const parseError = doc.querySelector('parsererror')
-	if (parseError) return ''
-
-	const svg = doc.documentElement
-	if (svg.tagName.toLowerCase() !== 'svg') return ''
-
-	sanitizeSvgAttributes(svg)
-	sanitizeNode(svg, 'svg')
-
-	// If sanitization stripped all children, the SVG has no safe content
-	if (svg.children.length === 0) return ''
-
-	return new XMLSerializer().serializeToString(svg)
+	return sanitizeSvgInner(svgText, 0)
 }


### PR DESCRIPTION
When you export shapes as SVG, paste back (creates image shape), then export again with other shapes — the second export wraps the first SVG as `<image href="data:image/svg+xml;base64,...">`. On paste, `sanitizeSvg()` strips this href because `sanitizeUri` only allows raster data URIs on `<image>` elements. Result: blank image.

This PR decodes the embedded SVG, runs `sanitizeSvg()` recursively (strips scripts/XSS), then re-encodes. Fully malicious embedded SVGs (no safe content left) are still blocked. Also adds a `MAX_NODE_DEPTH=100` cap on `sanitizeNode` recursion to prevent DoS from deeply nested elements.

### Change type

- [x] `bugfix`

### Test plan

1. Export a geo shape as SVG
2. Paste it back (creates image shape)
3. Select that image shape + another shape, export as SVG
4. Paste the resulting SVG — the image should render correctly, not be blank

- [x] Unit tests

### Release notes

- Fixed SVG sanitizer stripping embedded SVG data URIs on `<image>` elements. Nested SVGs (from re-exporting pasted SVG images) are now recursively sanitized instead of blocked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches XSS-sensitive SVG sanitization logic and introduces recursive decoding/encoding of data URIs, so subtle parsing/encoding or missed edge cases could create security or rendering regressions.
> 
> **Overview**
> Fixes a regression where exported SVGs containing nested `<image href="data:image/svg+xml;base64,...">` were being blanked by the sanitizer.
> 
> `sanitizeSvg` now allows `data:image/svg+xml` on `<image>`/`<feImage>` by decoding the embedded SVG, re-running sanitization recursively, and re-encoding the sanitized result (dropping the `href` entirely if the embedded SVG has no safe content). Adds an embed recursion depth limit and new unit tests covering safe embedded SVG preservation and script-stripping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8297037b1f0519b1aac90ea11d7f065a8d1b9f7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->