### PR TITLE
fix(tldraw): fix download original for cross-origin assets

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1757,7 +1757,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						if (!url) continue
 
 						const name =
-							asset.type === 'video' || asset.type === 'image' ? asset.props.name : 'download'
+							(asset.type === 'video' || asset.type === 'image') &&
+							!asset.props.src.startsWith('asset:')
+								? asset.props.name
+								: 'download'
 
 						try {
 							const resp = await fetch(url)


### PR DESCRIPTION
"Download original" was broken in production because assets are hosted on `tldrawusercontent.com` (cross-origin from `tldraw.com`). Browsers ignore `<a download>` for cross-origin URLs and navigate instead of downloading.

This replaces the `<a>` link approach with fetch + blob. Blob URLs are always same-origin, so `<a download>` works correctly. Falls back to `window.open` if the fetch fails (e.g. CORS blocked).

This would also work for SDK user that also host images on a separate domain, which is why I feel that doing the fix in the SDK code is the right way to go.

### Change type

- [x] `bugfix`

### Test plan

1. Upload an image on tldraw.com
2. Select it → click download icon in toolbar → browser downloads with correct filename
3. Right-click → "Download original" → same behavior
4. Test with video asset

### Release notes

- Fixed "Download original" not triggering a download for cross-origin assets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the asset download flow to fetch and blob-create files, which can be affected by CORS/network failures and browser memory usage, but is scoped to a single UI action with a safe fallback.
> 
> **Overview**
> Fixes **`Download original`** for image/video shapes when the asset URL is cross-origin by replacing the `<a download>` navigation approach with `fetch` → `blob` → `File` and triggering download via the shared `downloadFile` helper.
> 
> Also makes multi-selection more robust by skipping shapes whose resolved URL is missing (instead of aborting the whole loop) and falling back to `openWindow(url, '_blank')` if the fetch/download path fails (e.g. CORS blocked).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6c3ced19077bd16b4c5fa6d45ffe8c9c05b167d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->