### PR TITLE
feature spike: add hotkey to create connected shapes

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -18,6 +18,7 @@ import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { selectOnCanvasPointerUp } from '../../selection-logic/selectOnCanvasPointerUp'
 import { updateHoveredShapeId } from '../../selection-logic/updateHoveredShapeId'
+import { createConnectedShape } from '../createConnectedShape'
 import { hasRichText, startEditingShapeWithRichText } from '../selectHelpers'
 
 const SKIPPED_KEYS_FOR_AUTO_EDITING = [
@@ -443,6 +444,13 @@ export class Idle extends StateNode {
 			case 'ArrowRight':
 			case 'ArrowUp':
 			case 'ArrowDown': {
+				if (info.shiftKey && this.editor.inputs.keys.has('KeyA')) {
+					createConnectedShape(
+						this.editor,
+						info.code.replace('Arrow', '').toLowerCase() as 'left' | 'right' | 'up' | 'down'
+					)
+					return
+				}
 				if (info.accelKey) {
 					if (info.shiftKey) {
 						if (info.code === 'ArrowDown') {
@@ -497,6 +505,7 @@ export class Idle extends StateNode {
 			case 'ArrowRight':
 			case 'ArrowUp':
 			case 'ArrowDown': {
+				if (info.shiftKey && this.editor.inputs.keys.has('KeyA')) return // don't repeat-fire connected shape creation
 				if (info.accelKey) {
 					this.editor.selectAdjacentShape(
 						info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection

--- a/packages/tldraw/src/lib/tools/SelectTool/createConnectedShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/createConnectedShape.ts
@@ -1,0 +1,106 @@
+import { Editor, Mat, TLShapePartial, createShapeId } from '@tldraw/editor'
+import { createOrUpdateArrowBinding } from '../../shapes/arrow/shared'
+
+const CONNECTED_SHAPE_MIN_GAP = 40
+const CONNECTED_SHAPE_GAP_RATIO = 0.4
+
+/**
+ * Create a new geo shape connected to the selected shape by an arrow.
+ *
+ * @param editor - The editor instance.
+ * @param direction - Direction to place the new shape.
+ *
+ * @internal
+ */
+export function createConnectedShape(editor: Editor, direction: 'left' | 'right' | 'up' | 'down') {
+	if (editor.getIsReadonly()) return
+
+	const sourceShape = editor.getOnlySelectedShape()
+	if (!sourceShape) return
+	if (!editor.isShapeOfType(sourceShape, 'geo')) return
+
+	const sourceBounds = editor.getShapePageBounds(sourceShape)
+	if (!sourceBounds) return
+
+	const newW = sourceShape.props.w
+	const newH = sourceShape.props.h + sourceShape.props.growY
+
+	const { geo, color, fill, dash, size, font, scale } = sourceShape.props
+
+	const geoStyleProps = { geo, color, fill, dash, size, font, scale }
+	const arrowStyleProps = { color, dash, size, scale }
+
+	const isHorizontal = direction === 'left' || direction === 'right'
+	const relevantDimension = isHorizontal ? sourceBounds.w : sourceBounds.h
+	const gap = Math.max(CONNECTED_SHAPE_MIN_GAP, relevantDimension * CONNECTED_SHAPE_GAP_RATIO)
+
+	let pageX: number
+	let pageY: number
+	switch (direction) {
+		case 'right':
+			pageX = sourceBounds.maxX + gap
+			pageY = sourceBounds.midY - newH / 2
+			break
+		case 'left':
+			pageX = sourceBounds.minX - gap - newW
+			pageY = sourceBounds.midY - newH / 2
+			break
+		case 'down':
+			pageX = sourceBounds.midX - newW / 2
+			pageY = sourceBounds.maxY + gap
+			break
+		case 'up':
+			pageX = sourceBounds.midX - newW / 2
+			pageY = sourceBounds.minY - gap - newH
+			break
+	}
+
+	const parentTransform = editor.getShapeParentTransform(sourceShape)
+	const localPoint = Mat.applyToPoint(Mat.Inverse(parentTransform), { x: pageX, y: pageY })
+
+	const newShapeId = createShapeId()
+	const arrowId = createShapeId()
+
+	const shapes: TLShapePartial[] = [
+		{
+			id: newShapeId,
+			type: 'geo',
+			x: localPoint.x,
+			y: localPoint.y,
+			parentId: sourceShape.parentId,
+			props: {
+				w: newW,
+				h: newH,
+				...geoStyleProps,
+			},
+		},
+		{
+			id: arrowId,
+			type: 'arrow',
+			parentId: sourceShape.parentId,
+			props: arrowStyleProps,
+		},
+	]
+
+	editor.markHistoryStoppingPoint('create connected shape')
+	editor.run(() => {
+		editor.createShapes(shapes)
+
+		createOrUpdateArrowBinding(editor, arrowId, sourceShape.id, {
+			terminal: 'start',
+			normalizedAnchor: { x: 0.5, y: 0.5 },
+			isExact: false,
+			isPrecise: false,
+			snap: 'none',
+		})
+		createOrUpdateArrowBinding(editor, arrowId, newShapeId, {
+			terminal: 'end',
+			normalizedAnchor: { x: 0.5, y: 0.5 },
+			isExact: false,
+			isPrecise: false,
+			snap: 'none',
+		})
+	})
+
+	editor.select(newShapeId)
+}

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -73,9 +73,12 @@ export function useKeyboardShortcuts() {
 			}
 
 			if (SKIP_KBDS.includes(tool.id)) continue
+			const toolHotkeys = getHotkeysStringFromKbd(tool.kbd)
 
-			hot(getHotkeysStringFromKbd(tool.kbd), (event) => {
+			hot(toolHotkeys, (event) => {
 				if (areShortcutsDisabled(editor)) return
+				// Reserve shifted key combos for interactions unless this tool shortcut explicitly uses shift.
+				if (event.shiftKey && !toolHotkeys.includes('shift+')) return
 				preventDefault(event)
 				tool.onSelect('kbd')
 			})


### PR DESCRIPTION
## Summary
- Adds a flowcharting keyboard shortcut: **Shift+A+Arrow** creates a new geo shape connected by an arrow in the chosen direction
- Works with dynamic sizing — the new shape accounts for `growY` so text-expanded shapes are duplicated at the correct height
- Arrow is automatically bound to both shapes; selection moves to the new shape

Closes #6595

## Test plan
- [ ] Select a geo shape, press Shift+A+Arrow in each direction — verify a connected shape + arrow is created
- [ ] Verify the new shape inherits style props from the source
- [ ] Verify the arrow is properly bound to both shapes
- [ ] Verify selection moves to the newly created shape
- [ ] Verify undo restores the previous state in one step
- [ ] Verify holding keys down doesn't repeat-fire the action
- [ ] Verify it does nothing when no shape is selected or a non-geo shape is selected
- [ ] Verify it does nothing in readonly mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)