### PR TITLE
feat: add padding option to zoomToFit and zoomToSelection

### DIFF
--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -106,6 +106,14 @@ describe('zoomToFit', () => {
 		editor.zoomToFit({ force: true })
 		expect(editor.setCamera).toHaveBeenCalled()
 	})
+
+	it('passes padding as inset to zoomToBounds', () => {
+		editor.getCurrentPageShapeIds = vi.fn(() => new Set([createShapeId('box1')]))
+		editor.getShapePageBounds = vi.fn(() => Box.From({ x: 0, y: 0, w: 100, h: 100 }))
+		const spy = vi.spyOn(editor, 'zoomToBounds')
+		editor.zoomToFit({ padding: 40 })
+		expect(spy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ inset: 40 }))
+	})
 })
 
 describe('resetZoom', () => {
@@ -155,6 +163,13 @@ describe('zoomToSelection', () => {
 		editor.getSelectionPageBounds = vi.fn(() => Box.From({ x: 0, y: 0, w: 100, h: 100 }))
 		editor.zoomToSelection({ force: true })
 		expect(editor.setCamera).toHaveBeenCalled()
+	})
+
+	it('passes padding as inset to zoomToBounds', () => {
+		editor.getSelectionPageBounds = vi.fn(() => Box.From({ x: 0, y: 0, w: 100, h: 100 }))
+		const spy = vi.spyOn(editor, 'zoomToBounds')
+		editor.zoomToSelection({ padding: 40 })
+		expect(spy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ inset: 40 }))
 	})
 })
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3246,17 +3246,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```ts
 	 * editor.zoomToFit()
 	 * editor.zoomToFit({ animation: { duration: 200 } })
+	 * editor.zoomToFit({ padding: 40 })
 	 * ```
 	 *
 	 * @param opts - The camera move options.
 	 *
 	 * @public
 	 */
-	zoomToFit(opts?: TLCameraMoveOptions): this {
+	zoomToFit(
+		opts?: TLCameraMoveOptions & {
+			padding?: number
+			inset?: number
+			targetZoom?: number
+		}
+	): this {
 		const ids = [...this.getCurrentPageShapeIds()].filter((id) => !this.isShapeHidden(id))
 		if (ids.length <= 0) return this
 		const pageBounds = Box.Common(compact(ids.map((id) => this.getShapePageBounds(id))))
-		this.zoomToBounds(pageBounds, opts)
+		this.zoomToBounds(pageBounds, { inset: opts?.padding ?? opts?.inset, ...opts })
 		return this
 	}
 
@@ -3398,13 +3405,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * ```ts
 	 * editor.zoomToSelection()
 	 * editor.zoomToSelection({ animation: { duration: 200 } })
+	 * editor.zoomToSelection({ padding: 40 })
 	 * ```
 	 *
 	 * @param opts - The camera move options.
 	 *
 	 * @public
 	 */
-	zoomToSelection(opts?: TLCameraMoveOptions): this {
+	zoomToSelection(
+		opts?: TLCameraMoveOptions & {
+			padding?: number
+			inset?: number
+			targetZoom?: number
+		}
+	): this {
 		const { isLocked } = this.getCameraOptions()
 		if (isLocked && !opts?.force) return this
 
@@ -3414,10 +3428,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// If already at 100%, zoom to fit the selection in the viewport
 			// Otherwise, zoom to 100% centered on the selection
 			if (Math.abs(currentZoom - 1) < 0.01) {
-				this.zoomToBounds(selectionPageBounds, opts)
+				this.zoomToBounds(selectionPageBounds, { inset: opts?.padding ?? opts?.inset, ...opts })
 			} else {
 				this.zoomToBounds(selectionPageBounds, {
 					targetZoom: 1,
+					inset: opts?.padding ?? opts?.inset,
 					...opts,
 				})
 			}


### PR DESCRIPTION
## Description

This PR adds an optional `padding` parameter to the `zoomToFit` and `zoomToSelection` methods, as requested in #7515.

This allows developers to control the spacing around the zoomed content, which is useful for better visual balance and avoiding shapes being positioned at the very edge of the viewport.

## Changes

- Updated `zoomToFit` signature to accept `padding`, `inset`, and `targetZoom`.
- Updated `zoomToSelection` signature to accept `padding`, `inset`, and `targetZoom`.
- Mapped `padding` to the internal `inset` option used by `zoomToBounds`.
- Added unit tests in `Editor.test.ts` to verify the padding is correctly passed to `zoomToBounds`.

## Example Usage

```typescript
editor.zoomToFit({ padding: 40 })
editor.zoomToSelection({ padding: 40 })
```

## Checklist

- [x] I have tested these changes locally (via new unit tests)
- [x] I have updated the documentation (JSDoc examples)
- [x] My code follows the project's coding style

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive camera API change that only adjusts how options are forwarded to `zoomToBounds`, with tests covering the new `padding` mapping.
> 
> **Overview**
> Adds an optional `padding` option to `Editor.zoomToFit` and `Editor.zoomToSelection`, implemented as an alias for `zoomToBounds`’s `inset` parameter (while still allowing explicit `inset`/`targetZoom` overrides).
> 
> Updates JSDoc examples and extends `Editor.test.ts` to assert that providing `padding` results in `zoomToBounds` being called with the corresponding `inset` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7858ba958e6c27918869c40226cb642ca038506e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->