### PR TITLE
Fix a zh-cn translation

### DIFF
--- a/assets/translations/zh-cn.json
+++ b/assets/translations/zh-cn.json
@@ -244,7 +244,7 @@
 	"fill-style.solid": "实心",
 	"focus-mode.toggle-focus-mode": "切换专注模式",
 	"font-style.draw": "画笔",
-	"font-style.mono": "黑白",
+	"font-style.mono": "等宽",
 	"font-style.sans": "无衬线",
 	"font-style.serif": "衬线",
 	"geo-style.arrow-down": "向下箭头",


### PR DESCRIPTION
mono here means a monospace font, not "no color".

Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with zh-cn translation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only change limited to a single `zh-cn.json` translation string.
> 
> **Overview**
> Fixes a mislabeled Simplified Chinese translation by changing `font-style.mono` from “黑白” (black/white) to the correct “等宽” (monospace).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6469ebb4d4622046321115111b23b1e81bd4c275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->