### PR TITLE
fix(worker-shared): allow apex origin https://tldraw.com in CORS

### DIFF
--- a/packages/worker-shared/src/origins.ts
+++ b/packages/worker-shared/src/origins.ts
@@ -22,6 +22,7 @@ export function isAllowedOrigin(origin: string) {
 	if (origin === 'http://localhost:5420') return origin
 	if (origin === 'https://meet.google.com') return origin
 	if (origin === 'https://tldraw.dev') return origin
+	if (origin === 'https://tldraw.com') return origin
 	if (origin.endsWith('.tldraw.com')) return origin
 	if (origin.endsWith('.tldraw.dev')) return origin
 	if (origin.endsWith('.tldraw.club')) return origin


### PR DESCRIPTION
In order to allow cross-origin requests from the apex domain `https://tldraw.com`, this PR adds an explicit check for that origin in `isAllowedOrigin`. Previously only `origin.endsWith('.tldraw.com')` was used, which matches subdomains (e.g. `www.tldraw.com`, `staging.tldraw.com`) but not the exact apex `https://tldraw.com` (the string does not end with `.tldraw.com`). Workers using `worker-shared` (sync-worker, asset-upload-worker, tldrawusercontent-worker, image-resize-worker) would have rejected CORS preflight or requests from the apex.

### Change type

- [x] `bugfix`
- [ ] `improvement` | `feature` | `api` | `other`

### Test plan

1. Deploy to staging and confirm API requests from `https://tldraw.com` (apex) are accepted (e.g. open app at apex, trigger sync or asset upload).
2. Confirm subdomains (e.g. `www.tldraw.com`, `staging.tldraw.com`) still work.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Allow CORS requests from the apex domain `https://tldraw.com` so the main site can call API workers when loaded from that origin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line expansion of the CORS allowlist that should only broaden access to the intended apex domain without altering broader request handling.
> 
> **Overview**
> Allows CORS requests from the apex origin `https://tldraw.com` by adding an explicit allowlist check in `isAllowedOrigin`, fixing cases where only `*.tldraw.com` subdomains were previously permitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dff92050460d9543cb8f4f0fb1c2aea83cab4df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->