### PR TITLE
fix(arrows): clamp boundary anchors to avoid degenerate intersections

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -89,11 +89,7 @@ export function getArrowTerminalInArrowSpace(
 		// If the parent is the bound shape, then it's always treated as precise.
 		const shouldUsePreciseAnchor = binding.props.isPrecise || forceImprecise
 		const normalizedAnchor = shouldUsePreciseAnchor
-			? // Keep exact bindings untouched; only sanitize imprecise/precise anchors to avoid
-				// edge/corner degeneracies when anchors are exactly 0 or 1.
-				binding.props.isExact
-				? binding.props.normalizedAnchor
-				: clampNormalizedAnchor(binding.props.normalizedAnchor)
+			? clampNormalizedAnchor(binding.props.normalizedAnchor)
 			: { x: 0.5, y: 0.5 }
 
 		const shapePoint = Vec.Add(point, Vec.MulV(normalizedAnchor, size))


### PR DESCRIPTION
Closes #8125

https://github.com/user-attachments/assets/cf96fc2a-c7f2-4448-8ccf-42e0eaa5ba2b

Arrow endpoints flicker when `normalizedAnchor` coordinates are exactly 0 or 1 (shape edges/corners). At these exact values, the intersection math becomes numerically unstable — small floating-point errors cause intersections to toggle between found and not-found across frames.

**Solution:** if arrow is precise or forceImprecise, clamp each anchor coordinate from [0, 1] to [0.001, 0.999]. This clamping happens inside `getArrowTerminalInArrowSpace`, which runs every time the arrow info is recomputed (i.e. whenever the arrow or its bound shapes change). The binding record in the store is never modified — the nudge only exists ephemerally during computation, so the intersection math never sees an exact boundary value.

### Change type

- [x] `bugfix`

### Test plan

1. Create a shape and programmatically bind a self-referential arrow with anchors at exact boundary positions (e.g. `{x: 0, y: 0}`, `{x: 0.5, y: 0}`)
2. Verify arrows render without flickering
3. Resize and move the shape — arrows should remain stable

- [x] Unit tests

### Release notes

- Fix arrow endpoint flickering when anchors are at exact shape boundaries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core arrow terminal computation; clamping precise anchors near 0/1 can subtly shift endpoints (up to ~0.1% of shape size) and may affect arrow rendering/attachment in edge cases.
> 
> **Overview**
> Prevents arrow endpoint flicker when a bound terminal’s `normalizedAnchor` lands exactly on a shape edge/corner by clamping precise anchors away from `0`/`1` during `getArrowTerminalInArrowSpace` computations.
> 
> Adds a small epsilon-based `clampNormalizedAnchor` helper and refactors the terminal point calculation to use the clamped anchor without mutating stored binding data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4ecde2cf1bec7edadca0a0d18ecb7186a86e60f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->