### PR TITLE
Fix mcp app cf build

### DIFF
--- a/apps/mcp-app/package.json
+++ b/apps/mcp-app/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build:widget": "vite build && mv dist/index.html dist/mcp-app.html",
+		"build:widget": "node ../../packages/tldraw/scripts/copy-css-files.mjs && vite build && mv dist/index.html dist/mcp-app.html",
 		"build": "yarn build:widget",
 		"dev": "tsx main.ts",
 		"dev:cf": "yarn build:widget && wrangler dev",

--- a/apps/mcp-app/wrangler.toml
+++ b/apps/mcp-app/wrangler.toml
@@ -1,4 +1,4 @@
-name = "tldraw-mcp-app"
+name = "mcp-app"
 main = "src/cloudflare-worker.ts"
 compatibility_date = "2025-03-10"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts build/deploy configuration (prebuild CSS generation and Cloudflare worker name) with no runtime logic changes.
> 
> **Overview**
> **Build pipeline update:** `apps/mcp-app` now runs `packages/tldraw/scripts/copy-css-files.mjs` before `vite build` in `build:widget`, ensuring the generated `tldraw.css` is up to date in widget builds.
> 
> **Cloudflare config tweak:** `wrangler.toml` renames the worker from `tldraw-mcp-app` to `mcp-app`, affecting deploy naming/URLs but not worker code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a1ff907cf9095956548fe7958a9713c617e36e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->