### PR TITLE
Fix mcp app cf build

### DIFF
--- a/apps/mcp-app/wrangler.toml
+++ b/apps/mcp-app/wrangler.toml
@@ -1,4 +1,4 @@
-name = "mcp-app"
+name = "tldraw-mcp-app"
 main = "src/cloudflare-worker.ts"
 compatibility_date = "2025-03-10"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
Describe what your pull request does. If you can, add GIFs or images showing the before and after of your change.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the build script to pre-generate a combined CSS file before running Vite, affecting build output but not runtime logic.
> 
> **Overview**
> Fixes the `mcp-app` Cloudflare/widget build by updating `build:widget` to run `packages/tldraw/scripts/copy-css-files.mjs` before `vite build`.
> 
> This ensures the generated `tldraw.css` (combined editor + UI CSS) exists when the app bundles, then continues to rename `dist/index.html` to `dist/mcp-app.html` as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c383cac71bbfa6087ba54a64f6a2181f0ba2a6ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->