### PR TITLE
perf(sync-worker): stream Pierre history snapshot to avoid OOM

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/getPierreHistorySnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/getPierreHistorySnapshot.ts
@@ -2,7 +2,7 @@ import { notFound } from '@tldraw/worker-shared'
 import { IRequest } from 'itty-router'
 import { Environment } from '../types'
 import { createPierreClient } from '../utils/createPierreClient'
-import { reconstructSnapshotFromPierre } from '../utils/pierreSnapshot'
+import { streamPierreSnapshotAsJson } from '../utils/pierreSnapshot'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { requireWriteAccessToFile } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
@@ -44,9 +44,9 @@ export async function getPierreHistorySnapshot(
 			return new Response('Not found', { status: 404 })
 		}
 
-		const snapshot = await reconstructSnapshotFromPierre(repo, commitHash)
+		const stream = streamPierreSnapshotAsJson(repo, commitHash)
 
-		return new Response(JSON.stringify(snapshot), {
+		return new Response(stream, {
 			headers: {
 				'content-type': 'application/json',
 				'Cache-Control': 'public, max-age=31536000, immutable',

--- a/apps/dotcom/sync-worker/src/utils/pierreSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/utils/pierreSnapshot.ts
@@ -1,5 +1,5 @@
 import type { Repo } from '@pierre/storage'
-import { RoomSnapshot } from '@tldraw/sync-core'
+import type { RoomSnapshot } from '@tldraw/sync-core'
 import { createTarDecoder } from 'modern-tar'
 import type { PierreMeta } from '../TLDrawDurableObject'
 
@@ -13,14 +13,22 @@ function isRecordFile(name: string) {
 	return /^records\/[^/]+\.json$/.test(name)
 }
 
+type DocEntry = RoomSnapshot['documents'][number]
+
+export interface PierreArchiveHandlers {
+	onMeta(meta: PierreMeta): void | Promise<void>
+	onDocument(doc: DocEntry): void | Promise<void>
+}
+
 /**
- * Reconstruct a RoomSnapshot from a Pierre repo at a given ref.
- * Streams the tar archive — only the parsed JSON values are held in memory.
+ * Iterate over a Pierre repo archive at a given ref. Calls onMeta when meta.json is read,
+ * onDocument for each record file, in tar order. Throws if the archive is empty or has no meta.json.
  */
-export async function reconstructSnapshotFromPierre(
+export async function iteratePierreArchive(
 	repo: Repo,
-	ref: string
-): Promise<RoomSnapshot> {
+	ref: string,
+	handlers: PierreArchiveHandlers
+): Promise<void> {
 	const resp = await repo.getArchiveStream({ ref })
 	if (!resp.body) {
 		throw new Error(`Empty archive body from Pierre at ref ${ref}`)
@@ -29,9 +37,7 @@ export async function reconstructSnapshotFromPierre(
 		.pipeThrough(new DecompressionStream('gzip'))
 		.pipeThrough(createTarDecoder())
 
-	let meta: PierreMeta | null = null
-	const documents: RoomSnapshot['documents'] = []
-
+	let metaSeen = false
 	const reader = entries.getReader()
 	try {
 		while (true) {
@@ -39,12 +45,12 @@ export async function reconstructSnapshotFromPierre(
 			if (done) break
 			const name = entry.header.name
 			if (isMetaJson(name)) {
-				meta = JSON.parse(await new Response(entry.body).text()) as PierreMeta
+				const meta = JSON.parse(await new Response(entry.body).text()) as PierreMeta
+				metaSeen = true
+				await handlers.onMeta(meta)
 			} else if (isRecordFile(name)) {
-				const state = JSON.parse(
-					await new Response(entry.body).text()
-				) as RoomSnapshot['documents'][number]['state']
-				documents.push({ state, lastChangedClock: 0 })
+				const state = JSON.parse(await new Response(entry.body).text()) as DocEntry['state']
+				await handlers.onDocument({ state, lastChangedClock: 0 })
 			} else {
 				await entry.body.cancel()
 			}
@@ -53,13 +59,97 @@ export async function reconstructSnapshotFromPierre(
 		reader.releaseLock()
 	}
 
-	if (!meta) {
+	if (!metaSeen) {
 		throw new Error(`No meta.json found in Pierre archive at ref ${ref}`)
 	}
+}
+
+/**
+ * Stream a RoomSnapshot as JSON from a Pierre repo at a given ref.
+ * Does not hold the full documents array in memory; streams each document as it is read from the tar.
+ * Use this for large files to avoid OOM.
+ */
+export function streamPierreSnapshotAsJson(repo: Repo, ref: string): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder()
+	return new ReadableStream<Uint8Array>({
+		async start(controller) {
+			let meta: PierreMeta | null = null
+			const documentBuffer: DocEntry[] = []
+			let headerSent = false
+			let isFirstDoc = true
+
+			const sendHeader = (m: PierreMeta) => {
+				if (headerSent) return
+				headerSent = true
+				controller.enqueue(
+					encoder.encode(
+						`{"documentClock":${m.documentClock},"schema":${JSON.stringify(m.schema ?? null)},"documents":[`
+					)
+				)
+			}
+
+			const flushDoc = (doc: DocEntry) => {
+				const chunk = isFirstDoc ? JSON.stringify(doc) : ',' + JSON.stringify(doc)
+				isFirstDoc = false
+				controller.enqueue(encoder.encode(chunk))
+			}
+
+			try {
+				await iteratePierreArchive(repo, ref, {
+					onMeta(m) {
+						meta = m
+						sendHeader(m)
+						for (const doc of documentBuffer) flushDoc(doc)
+						documentBuffer.length = 0
+					},
+					onDocument(doc) {
+						if (meta) {
+							sendHeader(meta)
+							flushDoc(doc)
+						} else {
+							documentBuffer.push(doc)
+						}
+					},
+				})
+				// Meta might have appeared after some or all records
+				if (meta) {
+					sendHeader(meta)
+					for (const doc of documentBuffer) flushDoc(doc)
+				}
+				controller.enqueue(encoder.encode(']}'))
+			} catch (err) {
+				controller.error(err)
+			} finally {
+				controller.close()
+			}
+		},
+	})
+}
+
+/**
+ * Reconstruct a RoomSnapshot from a Pierre repo at a given ref.
+ * Streams the tar archive — only the parsed JSON values are held in memory.
+ * For large files, use streamPierreSnapshotAsJson() and stream the response instead to avoid OOM.
+ */
+export async function reconstructSnapshotFromPierre(
+	repo: Repo,
+	ref: string
+): Promise<RoomSnapshot> {
+	let meta: PierreMeta | null = null
+	const documents: RoomSnapshot['documents'] = []
+
+	await iteratePierreArchive(repo, ref, {
+		onMeta(m) {
+			meta = m
+		},
+		onDocument(doc) {
+			documents.push(doc)
+		},
+	})
 
 	return {
-		documentClock: meta.documentClock,
-		schema: meta.schema,
+		documentClock: meta!.documentClock,
+		schema: meta!.schema,
 		documents,
 	}
 }


### PR DESCRIPTION
In order to avoid loading the full Pierre history snapshot into memory for large files (which could cause OOM in the sync-worker), this PR streams the snapshot as JSON from the Pierre archive. It extracts a generic `iteratePierreArchive` with `onMeta`/`onDocument` handlers, adds `streamPierreSnapshotAsJson` that streams the same RoomSnapshot JSON shape without buffering the full documents array, and switches the getPierreHistorySnapshot route to return that stream. Relates to #7742.

### Change type

- [x] `improvement`
- [ ] `bugfix` | `feature` | `api` | `other`

### Test plan

1. Deploy sync-worker and open a file that has Pierre history.
2. Request a history snapshot at a valid commit (e.g. from the revision history UI or direct API call).
3. Confirm response is valid JSON with `documentClock`, `schema`, and `documents` array; large files should not cause worker OOM.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- No user-facing change; internal sync-worker improvement for history snapshot endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the response construction for the Pierre history snapshot endpoint to incremental JSON streaming, where any formatting/ordering bug could break snapshot consumers or caching behavior.
> 
> **Overview**
> `getPierreHistorySnapshot` now returns a `ReadableStream` from Pierre instead of building the full snapshot in memory and `JSON.stringify`-ing it.
> 
> `pierreSnapshot.ts` factors tar parsing into a new `iteratePierreArchive` callback API and adds `streamPierreSnapshotAsJson` to emit the same `RoomSnapshot` JSON shape while reading records, avoiding OOM for large archives; `reconstructSnapshotFromPierre` is rebuilt on top of the iterator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0deb0adfde7dbb196968c47e19378d9bc6cb1a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->