### PR TITLE
fix(arrows): skip rendering empty label in SVG export

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -1080,22 +1080,26 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const theme = getDefaultColorTheme(ctx)
 		const scaleFactor = 1 / shape.props.scale
 
+		const showArrowLabel = !isEmptyRichText(shape.props.richText)
+
 		return (
 			<g transform={`scale(${scaleFactor})`}>
 				<ArrowSvg shape={shape} shouldDisplayHandles={false} />
-				<RichTextSVG
-					fontSize={getArrowLabelFontSize(shape)}
-					font={shape.props.font}
-					align="middle"
-					verticalAlign="middle"
-					labelColor={getColorValue(theme, shape.props.labelColor, 'solid')}
-					richText={shape.props.richText}
-					bounds={getArrowLabelPosition(this.editor, shape, false)
-						.box.clone()
-						.expandBy(-ARROW_LABEL_PADDING * shape.props.scale)}
-					padding={0}
-					showTextOutline={this.options.showTextOutline}
-				/>
+				{showArrowLabel && (
+					<RichTextSVG
+						fontSize={getArrowLabelFontSize(shape)}
+						font={shape.props.font}
+						align="middle"
+						verticalAlign="middle"
+						labelColor={getColorValue(theme, shape.props.labelColor, 'solid')}
+						richText={shape.props.richText}
+						bounds={getArrowLabelPosition(this.editor, shape, false)
+							.box.clone()
+							.expandBy(-ARROW_LABEL_PADDING * shape.props.scale)}
+						padding={0}
+						showTextOutline={this.options.showTextOutline}
+					/>
+				)}
 			</g>
 		)
 	}


### PR DESCRIPTION
Closes #7055. When exporting arrows without text labels via `getSvgElement()`, the `<foreignObject>` element receives negative width/height values (e.g. `-8.5`), causing browser console errors.

The root cause is in `ArrowShapeUtil.toSvg()`: it unconditionally renders a `RichTextSVG` for the arrow label and applies `.expandBy(-ARROW_LABEL_PADDING * scale)` to shrink the bounds by padding. For empty labels, `getArrowLabelPosition()` returns a zero-sized box, so subtracting `4.25 * 2 = 8.5` produces negative dimensions.

The fix skips rendering `RichTextSVG` entirely when the label is empty, matching the existing guard in the canvas rendering path.

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow with no text label
2. Export as SVG (File > Export as SVG)
3. Check the browser console — no more `<foreignObject> attribute width: A negative value is not valid` errors
4. Create an arrow with a text label and export — label renders correctly

### Release notes

- Fix arrow SVG export producing invalid negative `<foreignObject>` dimensions when arrows have no text label

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional render change limited to SVG export output, with no impact on arrow geometry or editing behavior beyond avoiding invalid `<foreignObject>` dimensions.
> 
> **Overview**
> Fixes arrow SVG export emitting invalid `<foreignObject>` sizes when an arrow has no text label.
> 
> `ArrowShapeUtil.toSvg()` now conditionally renders `RichTextSVG` only when `richText` is non-empty, avoiding negative label bounds after padding is applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58fb598da8baa65321da85d109f574e56eee3035. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->