### PR TITLE
Rename plugin from 'tldraw-mcp' to 'tldraw'

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"name": "tldraw-mcp",
+	"name": "tldraw",
 	"owner": {
 		"name": "tldraw",
 		"email": "tim@tldraw.com"
@@ -11,7 +11,7 @@
 	},
 	"plugins": [
 		{
-			"name": "tldraw-mcp",
+			"name": "tldraw",
 			"source": "tldraw-mcp",
 			"description": "Draw and visually collaborate with your agents inside Cursor"
 		}


### PR DESCRIPTION
### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that renames the plugin entry; no runtime logic is modified.
> 
> **Overview**
> Renames the Cursor marketplace plugin identifier from `tldraw-mcp` to `tldraw` in `.cursor-plugin/marketplace.json`, updating both the top-level package name and the plugin entry name while keeping the source (`tldraw-mcp`) and other metadata unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b18d124e202bb210274102ca7f8f4198da29327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->