### PR TITLE
Rename plugin from 'tldraw-mcp' to 'tldraw'

### DIFF
--- a/apps/mcp-app/plugins/tldraw-mcp/.cursor-plugin/plugin.json
+++ b/apps/mcp-app/plugins/tldraw-mcp/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-	"name": "tldraw-mcp",
+	"name": "tldraw",
 	"displayName": "tldraw",
 	"version": "0.1.0",
 	"description": "Draw and visually collaborate with your agents inside Cursor",


### PR DESCRIPTION
Correctly fixing the name
### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple metadata-only change to the Cursor plugin identifier; low risk aside from potential downstream references expecting the old name.
> 
> **Overview**
> Updates the Cursor plugin manifest (`plugin.json`) to rename the plugin `name` from `tldraw-mcp` to `tldraw`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9edc8952aa396bb770e8397cf207c847cbfdbff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->