### PR TITLE
fix(mcp-app): make the Build it button clickable

### DIFF
--- a/apps/mcp-app/src/widget/mcp-app.tsx
+++ b/apps/mcp-app/src/widget/mcp-app.tsx
@@ -111,6 +111,7 @@ function SharePanelContent() {
 						borderRadius: 'var(--tl-radius-2)',
 						margin: 'var(--tl-space-2)',
 						cursor: hasShapes ? 'pointer' : 'not-allowed',
+						pointerEvents: 'all',
 					}}
 				>
 					Build it


### PR DESCRIPTION
In order to allow users to trigger app generation from the widget share panel, this PR ensures the `Build it` button can receive pointer input by explicitly enabling pointer events on the button element.

### Change type

- [x] `bugfix`

### Test plan

1. Run the MCP app and open the widget share panel.
2. Confirm the `Build it` button is clickable when shapes are present.
3. Confirm the button remains visually disabled (`not-allowed` cursor) when no shapes are present.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix `Build it` button interaction in the MCP app share panel so clicks are registered.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line style change to restore button clickability; minimal chance of unintended UI interaction changes outside the share panel.
> 
> **Overview**
> Fixes the MCP app share panel’s **`Build it`** button not registering clicks by explicitly enabling `pointerEvents: 'all'` on the button’s inline styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e135db74c109ed6551d513eb6e73a3f8a23a7c11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->