### PR TITLE
chore: update release notes skill to filter by base branch

### DIFF
--- a/.claude/skills/write-release-notes/SKILL.md
+++ b/.claude/skills/write-release-notes/SKILL.md
@@ -45,7 +45,7 @@ gh pr list --state merged --base main --search "merged:2024-01-01..2024-02-01"
 For each PR, get the full details:
 
 ```bash
-gh pr view <PR_NUMBER> --json title,body,labels,author
+gh pr view <PR_NUMBER> --json title,body,labels,author,baseRefName
 ```
 
 Look for:
@@ -54,6 +54,8 @@ Look for:
 - `### API changes` section in PR body
 - Labels indicating category (api, bugfix, improvement, etc.)
 - Whether "breaking" appears in the PR
+
+**Important:** Only include PRs whose `baseRefName` is `main`. PRs merged into feature branches (e.g. `default-shape-customization`) are not yet released — they will be included when the feature branch itself is merged to main.
 
 ### 4. Find patch releases
 


### PR DESCRIPTION
In order to prevent release notes from including PRs that were merged into feature branches (not main), this updates the write-release-notes skill to check `baseRefName` when fetching PR details.

### Change type

- [x] `other`

### Test plan

1. Run the write-release-notes skill and verify it skips PRs merged into non-main branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates guidance for how to collect PR metadata; no runtime or production code is affected.
> 
> **Overview**
> Updates the `write-release-notes` skill instructions to fetch `baseRefName` via `gh pr view` and explicitly **exclude PRs not targeting `main`** when compiling release notes, preventing feature-branch merges from being mistakenly included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0316bb84156630a5bcc23b8f1e8caf9bb6f4dca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->