### PR TITLE
Examples app button styles

### DIFF
--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -244,9 +244,18 @@ li.examples__sidebar__item {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: 1.2;
+	appearance: none;
+	-webkit-appearance: none;
 }
 .example__sidebar__item__button:hover {
 	z-index: 20;
+}
+.example__sidebar__item__button:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: -1px;
 }
 .example__sidebar__item__button:nth-of-type(n + 1) {
 	margin-left: -4px;
@@ -284,9 +293,22 @@ li.examples__sidebar__item {
 	justify-content: center;
 	color: #fff;
 	text-decoration: none;
+	border: 1px solid transparent;
 	box-shadow:
 		0px 1px 2px rgba(0, 0, 0, 0.12),
 		0px 1px 3px rgba(0, 0, 0, 0.04);
+	transition:
+		background-color 120ms ease,
+		border-color 120ms ease,
+		box-shadow 120ms ease;
+}
+
+.example__sidebar__header-link:hover {
+	background-color: hsl(214, 92%, 46%);
+}
+
+.example__sidebar__header-link:active {
+	background-color: hsl(214, 92%, 42%);
 }
 
 a.example__sidebar__header-link {
@@ -298,6 +320,14 @@ a.example__sidebar__header-link {
 	color: black;
 	border: 1px solid var(--gray-dark);
 	font-size: 14px;
+}
+
+.example__sidebar__footer-link--grey:hover {
+	background-color: #efefef;
+}
+
+.example__sidebar__footer-link--grey:active {
+	background-color: #e4e4e4;
 }
 
 /* ------------------ Social Links ------------------ */
@@ -445,6 +475,24 @@ a.example__sidebar__header-link {
 	color: black;
 	border: 1px solid var(--gray-dark);
 	font-size: 14px;
+	font-family: inherit;
+	line-height: 1.2;
+	appearance: none;
+	-webkit-appearance: none;
+	transition:
+		background-color 120ms ease,
+		border-color 120ms ease;
+}
+
+.example__dialog__actions a:hover,
+.example__dialog__actions button:hover {
+	background-color: #efefef;
+	border-color: #dcdcdc;
+}
+
+.example__dialog__actions a:active,
+.example__dialog__actions button:active {
+	background-color: #e4e4e4;
 }
 
 .example__dialog__content p > code {
@@ -501,6 +549,14 @@ a.example__sidebar__header-link {
 	cursor: pointer;
 	position: relative;
 	text-align: center;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: 1.2;
+	appearance: none;
+	-webkit-appearance: none;
+	transition:
+		background-color 120ms ease,
+		border-color 120ms ease;
 }
 .MultiplayerExampleWrapper-copy:has(.MultiplayerExampleWrapper-copied) {
 	color: transparent;
@@ -515,9 +571,23 @@ a.example__sidebar__header-link {
 }
 
 .MultiplayerExampleWrapper-copy:hover {
-	border: 1px solid var(--black-transparent-lighter);
+	background: var(--gray-light);
+	border-color: var(--black-transparent-light);
+}
+
+.MultiplayerExampleWrapper-copy:active {
+	background: var(--gray-dark);
 }
 .MultiplayerExampleWrapper-example {
 	position: relative;
 	flex: 1;
+}
+
+.example__sidebar__header-link:focus-visible,
+.example__sidebar__footer-link:focus-visible,
+.example__dialog__actions a:focus-visible,
+.example__dialog__actions button:focus-visible,
+.MultiplayerExampleWrapper-copy:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 1px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR refines the button styles within the examples app shell to ensure consistent typography, appearance, and interactive states (hover, active, focus-visible). This addresses inconsistencies across sidebar buttons, dialog action buttons, sidebar item icon buttons, and the multiplayer 'Copy link' button.

### Walkthrough
<video src="/opt/cursor/artifacts/examples_app_button_styles_walkthrough.mp4" controls></video>
Examples app buttons now render and interact consistently (hover/active/focus + copy-link feedback) across sidebar, dialog, and multiplayer UI.

<img src="/opt/cursor/artifacts/examples_app_button_styles_sidebar.webp" alt="examples app sidebar buttons" />

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Run the examples app locally.
2. Verify consistent hover, active, and focus-visible states for:
    *   Sidebar buttons
    *   Dialog action buttons
    *   Sidebar item icon buttons
    *   The multiplayer "Copy link" button (including the "Copied!" state).
3. Ensure `yarn prettier --check "apps/examples/src/styles.css"` passes.

- [ ] Unit tests
- [x] End to end tests (manual UI verification)

### Release notes

- Improved button styles in the examples app for consistent appearance and interactive states.

---
<p><a href="https://cursor.com/agents/bc-be03b85e-bbf7-4f5c-99d5-7232e57986bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be03b85e-bbf7-4f5c-99d5-7232e57986bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->