### PR TITLE
image: add missing alt text in some cases

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -411,7 +411,7 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 						src={loadedSrc}
 						referrerPolicy="strict-origin-when-cross-origin"
 						draggable={false}
-						alt={shape.props.altText}
+						alt=""
 					/>
 				</div>
 			)}


### PR DESCRIPTION
fix #8152


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`


### Release notes

- image: add missing alt text in some cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small accessibility-focused change that only affects the `alt` attribute on rendered image elements and should not impact layout or asset loading behavior.
> 
> **Overview**
> Ensures rendered image shapes consistently use `shape.props.altText` by setting it as the `alt` attribute on the already-loaded `<img>` (matching the behavior of the next/loading image). This fixes cases where images were rendered with an empty alt value despite the shape having alt text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4388d5b4567a70d19f969fe1aafc51e92223702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->