### PR TITLE
i18n: add warning if falling back to default translation

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -112,6 +112,10 @@ export function TldrawUiTranslationProvider({
 export function useTranslation() {
 	const translation = React.useContext(TranslationsContext)
 	const messages = translation?.messages ?? DEFAULT_TRANSLATION
+	if (!translation?.messages) {
+		console.warn('No translation messages found, falling back to default translation.')
+	}
+
 	return React.useCallback(
 		function msg(id?: Exclude<string, TLUiTranslationKey> | string) {
 			return messages[id as TLUiTranslationKey] ?? id


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/8011
tiny nit feedback from @MitjaBezensek 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `console.warn` when `useTranslation` cannot find translation messages, which may increase log noise but does not change translation lookup behavior.
> 
> **Overview**
> `useTranslation` now emits a `console.warn` when no translation messages are present and it falls back to `DEFAULT_TRANSLATION`, making missing/incorrect translation provider setup more visible during development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd95cda02a7b0fe75a86d0cfb98ab3e628f49d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->