### PR TITLE
i18n: add warning if falling back to default translation, pt 2

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -112,9 +112,12 @@ export function TldrawUiTranslationProvider({
 export function useTranslation() {
 	const translation = React.useContext(TranslationsContext)
 	const messages = translation?.messages ?? DEFAULT_TRANSLATION
-	if (!translation?.messages) {
-		console.warn('No translation messages found, falling back to default translation.')
-	}
+
+	React.useEffect(() => {
+		if (!translation?.messages) {
+			console.warn('No translation messages found, falling back to default translation.')
+		}
+	}, [translation?.messages])
 
 	return React.useCallback(
 		function msg(id?: Exclude<string, TLUiTranslationKey> | string) {


### PR DESCRIPTION
bah, whoops, followup again https://github.com/tldraw/tldraw/pull/8164#pullrequestreview-3897476527

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes when the fallback `console.warn` fires, moving it out of render and preventing repeated warnings on re-renders.
> 
> **Overview**
> Moves the "falling back to default translation" warning in `useTranslation` from render-time to a `useEffect` keyed on `translation?.messages`, so the warning only emits when messages are missing (or change to missing) rather than on every render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ae187f3276044b3fdbce099dafbd1fcb00271e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->