### PR TITLE
fix(tooltips): correct positioning when containing block is offset from viewport

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiTooltip.tsx
@@ -273,8 +273,13 @@ function TooltipSingleton() {
 			const trigger = triggerRef.current
 
 			trigger.style.position = 'fixed'
-			trigger.style.left = `${activeRect.left}px`
-			trigger.style.top = `${activeRect.top}px`
+			trigger.style.left = '0px'
+			trigger.style.top = '0px'
+			const cbOffset = trigger.getBoundingClientRect()
+
+			trigger.style.left = `${activeRect.left - cbOffset.left}px`
+			trigger.style.top = `${activeRect.top - cbOffset.top}px`
+
 			trigger.style.width = `${activeRect.width}px`
 			trigger.style.height = `${activeRect.height}px`
 			trigger.style.pointerEvents = 'none'


### PR DESCRIPTION
When the tooltip singleton's trigger element has an ancestor with a CSS `transform` (e.g. `transform3d`), `position: fixed` positions relative to that ancestor's containing block rather than the viewport. Since `getBoundingClientRect()` always returns viewport-relative coordinates, directly using those values as `left`/`top` produces incorrect positioning.

This PR fixes the issue by first placing the trigger at `(0, 0)`, reading back the containing block's offset via `getBoundingClientRect()`, and then subtracting that offset to compute the correct CSS position.

### Change type

- [x] `bugfix`

### Test plan

1. Embed tldraw inside a container that uses `transform: translate3d(...)` or similar CSS transform
2. Hover over toolbar buttons and other tooltip-bearing elements
3. Verify tooltips appear correctly positioned next to their target elements

### Release notes

- Fixed tooltip positioning when tldraw is rendered inside a container with CSS transforms.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how tooltip trigger `left`/`top` are computed; main risk is minor regressions in edge-case layout/positioning.
> 
> **Overview**
> Fixes incorrect tooltip placement when `tldraw` is rendered inside a transformed/offset containing block by adjusting the singleton trigger’s `position: fixed` coordinates.
> 
> The trigger is now temporarily placed at `(0,0)`, its containing-block offset is read via `getBoundingClientRect()`, and that offset is subtracted from the target element’s viewport rect to compute the correct `left`/`top`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d38447081c9acea7d8f62611702abc6db2378186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->