### PR TITLE
bugfix(mcp) correctly slice claude url hash

### DIFF
--- a/apps/mcp-app/src/register-tools.ts
+++ b/apps/mcp-app/src/register-tools.ts
@@ -65,13 +65,13 @@ function injectBootstrapData(html: string, bootstrap: Record<string, unknown>): 
  * Returns the widget domain for the given host, or `undefined` in dev mode.
  *
  * - ChatGPT: https://developers.openai.com/apps-sdk/build/mcp-server#widget-domains
- *   "Set `_meta.ui.domain` on the widget resource template. This is required for app
+ *   Set `_meta.ui.domain` on the widget resource template. This is required for app
  *   submission and must be unique per app. ChatGPT renders the widget under
- *   `<domain>.web-sandbox.oaiusercontent.com`"
+ *   `<domain>.web-sandbox.oaiusercontent.com`
  *
  * - Claude: https://claude.com/docs/connectors/building/mcp-apps/cross-compatibility#domain-handling
- *   "Compute the value by running:
- *   `node -e 'const yourServerUrl = "https://example.com/mcp"; console.log(require("crypto").createHash("sha256").update(yourServerUrl).digest("hex").slice(0,32) + ".claudemcpcontent.com")'`"
+ *   Compute the value by running:
+ *   `node -e 'const yourServerUrl = "https://example.com/mcp"; console.log(require("crypto").createHash("sha256").update(yourServerUrl).digest("hex").slice(0,32) + ".claudemcpcontent.com")'`
 "
  */
 async function getWidgetDomain(


### PR DESCRIPTION
Bring the url of the domain anthropic will be hosting its widget on in line with the [docs](https://claude.com/docs/connectors/building/mcp-apps/cross-compatibility#domain-handling)

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to Claude widget domain computation; main risk is miscomputing the domain and breaking widget loading in Claude.
> 
> **Overview**
> Fixes Claude widget domain generation to match Anthropic’s docs by truncating the SHA-256 hex digest to the first 32 characters before appending `.claudemcpcontent.com`.
> 
> Also updates the inline documentation/example command in `getWidgetDomain` and slightly refactors the hash string construction for readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9638410d52294f13ea9d380c231144ee65201619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->