### PR TITLE
refactor(mcp-app): remove frontend analytics event tool

### DIFF
--- a/apps/mcp-app/src/register-tools.ts
+++ b/apps/mcp-app/src/register-tools.ts
@@ -568,40 +568,6 @@ export function registerTools(
 		}
 	)
 
-	// --- event (app-only) ---
-
-	server.registerTool(
-		'event',
-		{
-			inputSchema: z.object({
-				event: z.string().min(1),
-				value: z.number().optional(),
-			}),
-			annotations: {
-				readOnlyHint: false,
-				destructiveHint: false,
-				idempotentHint: false,
-				openWorldHint: true,
-			},
-			_meta: { ui: { visibility: ['app'] } },
-		},
-		async ({ event, value }: { event: string; value?: number }): Promise<CallToolResult> => {
-			analytics?.writeDataPoint(
-				typeof value === 'number'
-					? {
-							blobs: [event],
-							doubles: [value],
-						}
-					: {
-							blobs: [event],
-						}
-			)
-			return {
-				content: [{ type: 'text', text: 'Tracked widget event.' }],
-			}
-		}
-	)
-
 	// --- canvas resource ---
 
 	registerAppResource(

--- a/apps/mcp-app/src/widget/mcp-app.tsx
+++ b/apps/mcp-app/src/widget/mcp-app.tsx
@@ -69,24 +69,8 @@ function SharePanelContent() {
 		return isHostCodeEditor(hostName)
 	}, [hostName])
 
-	const trackWidgetEvent = useCallback(
-		(event: string) => {
-			if (!app) return
-			app
-				.callServerTool({
-					name: 'event',
-					arguments: { event },
-				})
-				.catch(() => {
-					// no-op best effort
-				})
-		},
-		[app]
-	)
-
 	const handleBuildItClick = useCallback(() => {
 		if (!app) return
-		trackWidgetEvent('build_it_clicked')
 		const messageText =
 			lastEditor === 'user'
 				? "Hey I've made some edits to the canvas. The new canvas state is attached. Take the changes and implement them in the codebase."
@@ -100,7 +84,7 @@ function SharePanelContent() {
 				},
 			],
 		})
-	}, [app, lastEditor, trackWidgetEvent])
+	}, [app, lastEditor])
 
 	return (
 		<div className="tlui-share-zone" draggable={false} style={{ display: 'flex', gap: 4 }}>


### PR DESCRIPTION
In order to simplify the MCP app and remove frontend analytics tracking, this PR removes the `event` MCP tool and the `trackWidgetEvent` callback that was used to report widget events (e.g. "build_it_clicked") to Cloudflare Analytics.

### Change type

- [x] `other`

### Test plan

1. Run the MCP app and verify the share panel "Build it" button still works
2. Confirm no errors in the console related to the event tool

- [ ] Unit tests
- [ ] End to end tests

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a best-effort analytics-only tool and its caller without affecting core canvas/checkpoint functionality. Main risk is any external dependency on the `event` tool name in clients.
> 
> **Overview**
> Removes the app-only MCP tool `event` (and its Cloudflare Analytics datapoint writes) from `register-tools.ts`.
> 
> Simplifies the widget share panel by deleting `trackWidgetEvent` and no longer emitting the `build_it_clicked` event when the **Build it** button is pressed; button behavior otherwise remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b0dcf36f4fd5bc342ac53122ddfdbcf57a9521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->