### PR TITLE
fix(text): paste plain text instead of blocking paste in editable shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -156,6 +156,7 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 						const plainText = e.clipboardData.getData('text/plain')
 						preventDefault(e)
 						if (plainText) {
+							// eslint-disable-next-line @typescript-eslint/no-deprecated -- best way to insert text with undo support
 							document.execCommand('insertText', false, plainText)
 						}
 					}


### PR DESCRIPTION
When pasting tldraw clipboard data into an editable text shape (e.g. a geo shape label or note), the paste was silently blocked. This PR fixes it to extract and insert the plain text content from the clipboard instead.

fixes https://github.com/tldraw/tldraw/issues/8187

### Change type

- [x] `bugfix`

### Test plan

1. Create two shapes with text (e.g. geo shapes with labels)
2. Select and copy one shape (Cmd+C)
3. Double-click the other shape to edit its text
4. Paste (Cmd+V) — the plain text from the copied shape should be inserted

### Release notes

- Fix pasting into editable text shapes when clipboard contains tldraw data


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to paste handling for editable text, with minimal impact outside the specific tldraw-clipboard paste path.
> 
> **Overview**
> Fixes paste into editable text shapes when the clipboard contains tldraw HTML data. Instead of silently blocking the paste, `useEditablePlainText` now prevents the default and inserts the clipboard’s `text/plain` content via `document.execCommand('insertText')` to preserve undo support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa808bd71217aeff4e82fa428b37533fac210fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->