### PR TITLE
embeds: update example to use latest

### DIFF
--- a/apps/examples/src/examples/configuration/custom-embed/CustomEmbedExample.tsx
+++ b/apps/examples/src/examples/configuration/custom-embed/CustomEmbedExample.tsx
@@ -2,6 +2,7 @@ import {
 	CustomEmbedDefinition,
 	DEFAULT_EMBED_DEFINITIONS,
 	DefaultEmbedDefinitionType,
+	EmbedShapeUtil,
 	Tldraw,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
@@ -45,12 +46,13 @@ const customEmbed: CustomEmbedDefinition = {
 
 // [3]
 const embeds = [...defaultEmbedsToKeep, customEmbed]
+const shapeUtils = [EmbedShapeUtil.configure({ embedDefinitions: embeds })]
 
 export default function CustomEmbedExample() {
 	return (
 		<div className="tldraw__editor">
 			{/* [4] */}
-			<Tldraw embeds={embeds} />
+			<Tldraw shapeUtils={shapeUtils} />
 		</div>
 	)
 }
@@ -67,6 +69,6 @@ We will also add support for embedding JSFiddles. Please note that you have to s
 We concatenate the filtered embed definitions with our custom JSFiddle one. 
 
 [4]
-We now pass the custom embed definitions to the `Tldraw` component. 
+We configure `EmbedShapeUtil` with our custom embed definitions and pass the configured util via `shapeUtils`.
 
 */


### PR DESCRIPTION
followup to https://github.com/tldraw/tldraw/pull/8034
not sure how this passed merge queue

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates an examples-only integration to the new embed configuration API; no core logic changes, but the sample could break if the util is misconfigured.
> 
> **Overview**
> Updates the `CustomEmbedExample` to use the latest embed configuration approach by configuring `EmbedShapeUtil` with the custom `embedDefinitions` and passing it to `Tldraw` via `shapeUtils`.
> 
> Removes usage of the `embeds` prop on `Tldraw` and adjusts the example’s imports/docs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d6fa554fdda5687973e77dcc93280b5daacd70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->