### PR TITLE
prettier - silly fix

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -215,6 +215,7 @@ export function Tldraw(props: TldrawProps) {
 
 	const embedShapeUtil = shapeUtilsWithDefaults.find((util) => util.type === 'embed')
 	if (embedShapeUtil && embeds) {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		EmbedShapeUtil.setEmbedDefinitions(embeds)
 	}
 


### PR DESCRIPTION
omg

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a lint suppression for an intentionally deprecated API call and adjusts comment formatting, with no runtime behavior changes expected.
> 
> **Overview**
> Keeps backward compatibility for the deprecated `embeds` prop by explicitly suppressing the `@typescript-eslint/no-deprecated` warning before calling `EmbedShapeUtil.setEmbedDefinitions(embeds)`.
> 
> Also applies a tiny formatting cleanup in the `embeds` prop JSDoc comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71d460acee4390a2ce97635f1fb2d7e85d1d414e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->