### PR TITLE
docs(skills): add code changes table to write-pr skill

### DIFF
--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -97,6 +97,32 @@ Include when changes affect `api-report.md`:
 - Changed `Editor.method()` to accept optional `options` parameter
 ```
 
+## Code changes table
+
+Create a table that includes net LOC changes for each of the following sections. The sum of all rows must match the total PR diff. Omit rows with no changes.
+
+- Core code — SDK packages (`packages/`) source, excluding tests and API reports
+- Tests — unit tests, e2e tests (`*.test.*`, `e2e/`)
+- Automated files — generated files (e.g. `api-report.api.md`, snapshots)
+- Documentation — docs site and examples (`apps/docs/`, `apps/examples/`)
+- Apps — application code (`apps/dotcom/`, `apps/mcp-app/`, `apps/vscode/`, etc.), excluding e2e tests
+- Templates — starter templates (`templates/`)
+- Config/tooling — config files, lock files, lint config, CI, build scripts (`eslint.config.*`, `yarn.lock`, etc.)
+
+```md
+### Code changes
+
+| Section         | LOC change |
+| --------------- | ---------- |
+| Core code       | +10 / -2   |
+| Tests           | +5 / -0    |
+| Automated files | +0 / -1    |
+| Documentation   | +2 / -0    |
+| Apps            | +3 / -1    |
+| Templates       | +0 / -0    |
+| Config/tooling  | +1 / -0    |
+```
+
 ## Related issues
 
 Search for and link relevant issues that this PR addresses.


### PR DESCRIPTION
In order to provide consistent LOC breakdowns in pull request descriptions, this PR adds a "Code changes table" section to the write-pr skill template.

The new section defines seven categories for classifying code changes:
- Core code (SDK packages source)
- Tests (unit tests, e2e tests)
- Automated files (generated files like API reports)
- Documentation (docs site and examples)
- Apps (application code)
- Templates (starter templates)
- Config/tooling (config files, CI, build scripts)

Each PR description should include a table showing net LOC changes per category, with all rows summing to the total diff.

### Change type

- [x] `improvement`

### Test plan

- [ ] Verify the skill template renders correctly by reviewing the raw markdown
- [ ] Create a test PR using the `/pr` command and confirm the code changes table is included

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +26 / -0   |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts PR-writing guidance; no runtime or production code is affected.
> 
> **Overview**
> Updates the `write-pr` skill template (`.claude/skills/write-pr/SKILL.md`) to require a new **Code changes** section in PR bodies.
> 
> The new section defines standard change categories (core code, tests, automated files, documentation, apps, templates, config/tooling) and provides a markdown table format for reporting net `+/-` LOC per category, with rows omitted when unchanged and totals matching the PR diff.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95bda3094f449e1e697e7c6aa2ccda2b9bb6912d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->