### PR TITLE
fix(sync-worker): read from SQLite storage instead of R2 for tldr download

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -665,12 +665,9 @@ export class TLFileDurableObject extends DurableObject {
 			return new Response('Forbidden', { status: 403 })
 		}
 
-		const key = getR2KeyForRoom({ slug: this.documentInfo.slug, isApp: true })
-		const roomR2 = await this.r2.rooms.get(key)
-		if (!roomR2) {
-			return new Response('Not found', { status: 404 })
-		}
-		const snapshot = (await roomR2.json()) as RoomSnapshot
+		const storage = await this.getStorage()
+		assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
+		const snapshot = storage.getSnapshot()
 		const records = pruneUnusedAssetsForTldr(snapshot.documents.map((d) => d.state) as TLRecord[])
 
 		const assetRows = await this.db


### PR DESCRIPTION
In order to ensure tldr downloads always reflect the latest state, this PR changes `onDownloadTldr` to read directly from the durable object's SQLite storage instead of fetching from R2. The R2 copy can lag behind when a persist hasn't been triggered yet, whereas the SQLite storage is the authoritative source of truth. Since the snapshot is fully loaded into memory either way (the R2 path parsed via `.json()`), there's no streaming advantage lost.

### Change type

- [x] `bugfix`

### Test plan

1. Open a tldraw file and make some edits
2. Immediately download the file as .tldr
3. Verify the downloaded file contains the latest edits

### Release notes

- Fixed tldr file downloads to always include the latest changes by reading from the authoritative storage instead of the R2 cache.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Apps            | +3 / -6    |

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change isolated to the download path that only alters the snapshot source from R2 to in-memory SQLite state. Main risk is unexpected behavior if SQLite storage isn’t initialized or `getSnapshot()` differs from the persisted R2 format.
> 
> **Overview**
> `.tldr` downloads (`onDownloadTldr`) now build the exported records from the Durable Object’s live SQLite-backed storage (`getStorage()` + `SQLiteSyncStorage.getSnapshot()`) instead of fetching/parsing the room snapshot from R2.
> 
> This prevents downloads from lagging behind recent edits when persistence to R2 hasn’t run yet, while keeping the rest of the export flow (asset pruning and asset inlining) the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 681bb75609c225f5c1bb49aef167f7a8c0559f1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->