### PR TITLE
chore(ci): reduce cache bloat by saving only on main

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,7 +39,7 @@ runs:
     # Only save the cache on pushes to main to avoid per-PR duplicates.
     # Runs after install so the cache is fully populated.
     - name: Save yarn cache
-      if: github.event_name == 'push' && steps.yarn-cache.outputs.cache-hit != 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.yarn-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
         path: |


### PR DESCRIPTION
In order to reduce GitHub Actions cache storage from ~1.1GB per PR to ~300MB shared, this PR changes the setup action to cache only `.yarn/cache` and `.yarn/install-state.gz` (dropping `node_modules` and `.yarn/unplugged`), use restore-only caching on PRs via `actions/cache/restore`, and save the cache only on pushes to main via `actions/cache/save`.

Relates to #7628

### Change type

- [x] `improvement`

### Test plan

1. Verify CI passes on this PR (cache restore still works from main's existing entry)
2. After merging, confirm new cache entries on main are ~300MB instead of ~1.1GB
3. Clean up old `Linux-node-24.13.1-yarn-*` cache entries from the Actions cache page

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +14 / -6   |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only caching behavior change; main risk is slower installs or cache misses if keys/paths are misconfigured, with no production/runtime impact.
> 
> **Overview**
> The CI `setup` composite action switches from caching `node_modules` to caching only Yarn’s `.yarn/cache` and `.yarn/install-state.gz`, reducing cache size and avoiding per-branch duplication.
> 
> It now uses `actions/cache/restore@v5` to restore caches for all runs, and conditionally saves the cache via `actions/cache/save@v5` only on `push` events to `refs/heads/main` (and only when the restore wasn’t a hit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45d80534ac2ee5a68d4818d022a02c8d6a88e39b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->