### PR TITLE
fix(editor): fix FocusManager.dispose() to actually remove event listeners

### DIFF
--- a/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
@@ -11,6 +11,8 @@ import type { Editor } from '../../Editor'
  */
 export class FocusManager {
 	private disposeSideEffectListener?: () => void
+	private readonly boundHandleKeyDown: (e: KeyboardEvent) => void
+	private readonly boundHandleMouseDown: () => void
 
 	constructor(
 		public editor: Editor,
@@ -31,8 +33,10 @@ export class FocusManager {
 		}
 		this.updateContainerClass()
 
-		document.body.addEventListener('keydown', this.handleKeyDown.bind(this))
-		document.body.addEventListener('mousedown', this.handleMouseDown.bind(this))
+		this.boundHandleKeyDown = this.handleKeyDown.bind(this)
+		this.boundHandleMouseDown = this.handleMouseDown.bind(this)
+		document.body.addEventListener('keydown', this.boundHandleKeyDown)
+		document.body.addEventListener('mousedown', this.boundHandleMouseDown)
 	}
 
 	/**
@@ -84,8 +88,8 @@ export class FocusManager {
 	}
 
 	dispose() {
-		document.body.removeEventListener('keydown', this.handleKeyDown.bind(this))
-		document.body.removeEventListener('mousedown', this.handleMouseDown.bind(this))
+		document.body.removeEventListener('keydown', this.boundHandleKeyDown)
+		document.body.removeEventListener('mousedown', this.boundHandleMouseDown)
 		this.disposeSideEffectListener?.()
 	}
 }


### PR DESCRIPTION
The `dispose()` method was calling `.bind(this)` again when removing event listeners, which creates new function references that don't match the ones passed to `addEventListener`. This meant the listeners were never actually removed.

This fix stores the bound handler references in the constructor and reuses them for both `addEventListener` and `removeEventListener`.

### Change type

- [x] `bugfix`

### Test plan

1. Mount and unmount an editor instance
2. Verify that keydown/mousedown listeners on `document.body` are cleaned up after dispose

### Release notes

- Fix FocusManager.dispose() to correctly remove document event listeners

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +6 / -4    |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to focus event listener lifecycle; main risk is unintended changes to focus-ring behavior if handlers are mis-bound.
> 
> **Overview**
> Fixes a cleanup bug in `FocusManager` where `dispose()` previously failed to remove `document.body` `keydown`/`mousedown` listeners due to rebinding functions.
> 
> The constructor now stores bound handler references (`boundHandleKeyDown`/`boundHandleMouseDown`) and reuses them for both `addEventListener` and `removeEventListener`, preventing listener leaks across editor mount/unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fc16c355360d76f88d274fb4cf9690c0794d0c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->