### PR TITLE
perf(editor): improve history system performance and fix pending diff loss bug

### DIFF
--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
@@ -1,7 +1,7 @@
 import { BaseRecord, RecordId, Store, StoreSchema, createRecordType } from '@tldraw/store'
 import { vi } from 'vitest'
 import { TLHistoryBatchOptions } from '../../types/history-types'
-import { HistoryManager } from './HistoryManager'
+import { HistoryManager, MAX_UNDO_STACK_SIZE } from './HistoryManager'
 
 interface TestRecord extends BaseRecord<'test', TestRecordId> {
 	value: number | string
@@ -736,6 +736,22 @@ describe('HistoryManager error scenarios and edge cases', () => {
 			expect(store.get(ids.a)!.value).toBe(originalValue)
 		})
 
+		it('should preserve pending diff when mark is not found', () => {
+			manager._mark('real-mark')
+			store.update(ids.a, (s) => ({ ...s, value: 1 }))
+
+			// bail to a mark that doesn't exist
+			manager.bailToMark('non-existent-mark')
+
+			// the pending diff should still be intact
+			expect(store.get(ids.a)!.value).toBe(1)
+			expect(manager.getNumUndos()).toBeGreaterThan(0)
+
+			// a subsequent bail to the real mark should still work
+			manager.bailToMark('real-mark')
+			expect(store.get(ids.a)!.value).toBe(0)
+		})
+
 		it('should find mark correctly when it exists', () => {
 			manager._mark('existing-mark')
 			store.update(ids.a, (s) => ({ ...s, value: 1 }))
@@ -858,5 +874,41 @@ describe('HistoryManager error scenarios and edge cases', () => {
 			manager.undo()
 			expect(store.get(ids.a)!.value).toBe(initialValue)
 		})
+	})
+})
+
+describe('undo stack trimming', () => {
+	it('should trim the undo stack when it exceeds MAX_UNDO_STACK_SIZE', () => {
+		const store = new Store({ schema: testSchema, props: null })
+		store.put([testSchema.types.test.create({ id: ids.a, value: 0 })])
+		const manager = new HistoryManager<TestRecord>({ store })
+
+		// push entries well beyond the limit
+		for (let i = 1; i <= MAX_UNDO_STACK_SIZE + 500; i++) {
+			store.update(ids.a, (s) => ({ ...s, value: i }))
+			manager._mark(`mark-${i}`)
+		}
+
+		// the undo stack should have been trimmed
+		expect(manager.getNumUndos()).toBeLessThanOrEqual(MAX_UNDO_STACK_SIZE)
+	})
+
+	it('should still allow undo/redo after trimming', () => {
+		const store = new Store({ schema: testSchema, props: null })
+		store.put([testSchema.types.test.create({ id: ids.a, value: 0 })])
+		const manager = new HistoryManager<TestRecord>({ store })
+
+		for (let i = 1; i <= 20; i++) {
+			store.update(ids.a, (s) => ({ ...s, value: i }))
+			manager._mark(`mark-${i}`)
+		}
+
+		// undo should still work normally
+		manager.undo()
+		const afterUndo = store.get(ids.a)!.value as number
+		expect(afterUndo).toBeLessThan(20)
+
+		manager.redo()
+		expect(store.get(ids.a)!.value).toBe(20)
 	})
 })

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -1,5 +1,6 @@
 import { atom, EMPTY_ARRAY, transact } from '@tldraw/state'
 import {
+	applyDiffToTarget,
 	createEmptyRecordsDiff,
 	isRecordsDiffEmpty,
 	RecordsDiff,
@@ -17,6 +18,9 @@ const HistoryRecorderState = {
 	Paused: 'paused',
 } as const
 type HistoryRecorderState = (typeof HistoryRecorderState)[keyof typeof HistoryRecorderState]
+
+/** @internal */
+export const MAX_UNDO_STACK_SIZE = 10_000
 
 /** @public */
 export class HistoryManager<R extends UnknownRecord> {
@@ -48,7 +52,9 @@ export class HistoryManager<R extends UnknownRecord> {
 			switch (this.state) {
 				case HistoryRecorderState.Recording:
 					this.pendingDiff.apply(entry.changes)
-					this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					if (this.stacks.get().redos.length > 0) {
+						this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					}
 					break
 				case HistoryRecorderState.RecordingPreserveRedoStack:
 					this.pendingDiff.apply(entry.changes)
@@ -156,7 +162,7 @@ export class HistoryManager<R extends UnknownRecord> {
 
 					switch (undo.type) {
 						case 'diff':
-							squashRecordDiffsMutable(diffToUndo, [reverseRecordsDiff(undo.diff)])
+							applyDiffToTarget(diffToUndo, reverseRecordsDiff(undo.diff))
 							break
 						case 'stop':
 							if (!toMark) break loop
@@ -172,14 +178,15 @@ export class HistoryManager<R extends UnknownRecord> {
 			}
 
 			if (!didFindMark && toMark) {
-				// whoops, we didn't find the mark we were looking for
-				// don't do anything
+				// we didn't find the mark we were looking for — restore state and bail
+				this.pendingDiff.restore(pendingDiff)
 				return this
 			}
 
 			this.store.applyDiff(diffToUndo, { ignoreEphemeralKeys: true })
 			this.store.ensureStoreIsUsable()
 			this.stacks.set({ undos, redos })
+			this.trimUndoStack()
 		} finally {
 			this.state = previousState
 		}
@@ -219,7 +226,7 @@ export class HistoryManager<R extends UnknownRecord> {
 				redos = redos.tail
 
 				if (redo.type === 'diff') {
-					squashRecordDiffsMutable(diffToRedo, [redo.diff])
+					applyDiffToTarget(diffToRedo, redo.diff)
 				} else {
 					break
 				}
@@ -228,6 +235,7 @@ export class HistoryManager<R extends UnknownRecord> {
 			this.store.applyDiff(diffToRedo, { ignoreEphemeralKeys: true })
 			this.store.ensureStoreIsUsable()
 			this.stacks.set({ undos, redos })
+			this.trimUndoStack()
 		} finally {
 			this.state = previousState
 		}
@@ -290,6 +298,7 @@ export class HistoryManager<R extends UnknownRecord> {
 			this.flushPendingDiff()
 			this.stacks.update(({ undos, redos }) => ({ undos: undos.push({ type: 'stop', id }), redos }))
 		})
+		this.trimUndoStack()
 	}
 
 	clear() {
@@ -307,6 +316,27 @@ export class HistoryManager<R extends UnknownRecord> {
 			top = top.tail
 		}
 		return null
+	}
+
+	private trimUndoStack() {
+		const { undos } = this.stacks.get()
+		if (undos.length <= MAX_UNDO_STACK_SIZE) return
+
+		// walk to the limit and truncate by creating a new stack from the kept entries
+		const kept: TLHistoryEntry<R>[] = []
+		let current: Stack<TLHistoryEntry<R>> = undos
+		for (let i = 0; i < MAX_UNDO_STACK_SIZE && current.head; i++) {
+			kept.push(current.head)
+			current = current.tail
+		}
+
+		// rebuild from bottom to top
+		let trimmed: Stack<TLHistoryEntry<R>> = stack()
+		for (let i = kept.length - 1; i >= 0; i--) {
+			trimmed = trimmed.push(kept[i])
+		}
+
+		this.stacks.update(({ redos }) => ({ undos: trimmed, redos }))
 	}
 
 	/** @internal */
@@ -338,12 +368,17 @@ class PendingDiff<R extends UnknownRecord> {
 		return diff
 	}
 
+	restore(diff: RecordsDiff<R>) {
+		this.diff = diff
+		this.isEmptyAtom.set(isRecordsDiffEmpty(diff))
+	}
+
 	isEmpty() {
 		return this.isEmptyAtom.get()
 	}
 
 	apply(diff: RecordsDiff<R>) {
-		squashRecordDiffsMutable(this.diff, [diff])
+		applyDiffToTarget(this.diff, diff)
 		this.isEmptyAtom.set(isRecordsDiffEmpty(this.diff))
 	}
 

--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -11,6 +11,9 @@ import { Result } from '@tldraw/utils';
 import { Signal } from '@tldraw/state';
 import { UNINITIALIZED } from '@tldraw/state';
 
+// @internal
+export function applyDiffToTarget<T extends UnknownRecord>(target: RecordsDiff<T>, diff: RecordsDiff<T>): void;
+
 // @public
 export function assertIdType<R extends UnknownRecord>(id: string | undefined, type: RecordType<R, any>): asserts id is IdOf<R>;
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -23,6 +23,7 @@ export {
 	type SynchronousStorage,
 } from './lib/migrate'
 export {
+	applyDiffToTarget,
 	createEmptyRecordsDiff,
 	isRecordsDiffEmpty,
 	reverseRecordsDiff,

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -107,11 +107,13 @@ export function reverseRecordsDiff(diff: RecordsDiff<any>) {
  * @public
  */
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>) {
-	return (
-		Object.keys(diff.added).length === 0 &&
-		Object.keys(diff.updated).length === 0 &&
-		Object.keys(diff.removed).length === 0
-	)
+	// eslint-disable-next-line no-unreachable-loop
+	for (const _ in diff.added) return false
+	// eslint-disable-next-line no-unreachable-loop
+	for (const _ in diff.updated) return false
+	// eslint-disable-next-line no-unreachable-loop
+	for (const _ in diff.removed) return false
+	return true
 }
 
 /**
@@ -204,45 +206,60 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	diffs: RecordsDiff<T>[]
 ): void {
 	for (const diff of diffs) {
-		for (const [id, value] of objectMapEntries(diff.added)) {
-			if (target.removed[id]) {
-				const original = target.removed[id]
-				delete target.removed[id]
-				if (original !== value) {
-					target.updated[id] = [original, value]
-				}
-			} else {
-				target.added[id] = value
-			}
-		}
+		applyDiffToTarget(target, diff)
+	}
+}
 
-		for (const [id, [_from, to]] of objectMapEntries(diff.updated)) {
-			if (target.added[id]) {
-				target.added[id] = to
-				delete target.updated[id]
-				delete target.removed[id]
-				continue
-			}
-			if (target.updated[id]) {
-				target.updated[id] = [target.updated[id][0], to]
-				delete target.removed[id]
-				continue
-			}
-
-			target.updated[id] = diff.updated[id]
+/**
+ * Applies a single diff to a target diff by mutating the target in-place.
+ * This avoids the need to wrap a single diff in an array when only one diff is being applied.
+ *
+ * @param target - The diff to modify in-place (will be mutated)
+ * @param diff - The diff to apply to the target
+ * @internal
+ */
+export function applyDiffToTarget<T extends UnknownRecord>(
+	target: RecordsDiff<T>,
+	diff: RecordsDiff<T>
+): void {
+	for (const [id, value] of objectMapEntries(diff.added)) {
+		if (target.removed[id]) {
+			const original = target.removed[id]
 			delete target.removed[id]
+			if (original !== value) {
+				target.updated[id] = [original, value]
+			}
+		} else {
+			target.added[id] = value
+		}
+	}
+
+	for (const [id, [_from, to]] of objectMapEntries(diff.updated)) {
+		if (target.added[id]) {
+			target.added[id] = to
+			delete target.updated[id]
+			delete target.removed[id]
+			continue
+		}
+		if (target.updated[id]) {
+			target.updated[id] = [target.updated[id][0], to]
+			delete target.removed[id]
+			continue
 		}
 
-		for (const [id, value] of objectMapEntries(diff.removed)) {
-			// the same record was added in this diff sequence, just drop it
-			if (target.added[id]) {
-				delete target.added[id]
-			} else if (target.updated[id]) {
-				target.removed[id] = target.updated[id][0]
-				delete target.updated[id]
-			} else {
-				target.removed[id] = value
-			}
+		target.updated[id] = diff.updated[id]
+		delete target.removed[id]
+	}
+
+	for (const [id, value] of objectMapEntries(diff.removed)) {
+		// the same record was added in this diff sequence, just drop it
+		if (target.added[id]) {
+			delete target.added[id]
+		} else if (target.updated[id]) {
+			target.removed[id] = target.updated[id][0]
+			delete target.updated[id]
+		} else {
+			target.removed[id] = value
 		}
 	}
 }


### PR DESCRIPTION
In order to reduce allocations on hot paths and fix a data-loss bug in the history system, this PR makes several targeted improvements to the undo/redo infrastructure in `@tldraw/store` and `@tldraw/editor`.

**Bug fix:** `bailToMark()` (and `_undo` with `toMark`) would silently discard the pending diff when the target mark didn't exist in the undo stack. The pending diff was cleared at the start of `_undo` but never restored on early return, causing accumulated changes to be lost. Now the pending diff is restored if the mark is not found.

👨‍🦰 not sure if this is a real problem, it might be adding complexity to protecting against a problem that doesn't really come up in practice

**Allocation reductions:** `isRecordsDiffEmpty` previously allocated 3 arrays per call via `Object.keys().length` — replaced with zero-allocation `for...in` early returns. `PendingDiff.apply()` no longer wraps a single diff in an array to call `squashRecordDiffsMutable` — a new `applyDiffToTarget` function handles single diffs directly. Redo stack clearing now short-circuits when the redo stack is already empty, avoiding closure + object allocation on every user change.

👨‍🦰 good bot

**Undo stack limit:** Added a `MAX_UNDO_STACK_SIZE` of 10,000 entries. When the stack exceeds this limit, oldest entries are trimmed. This prevents unbounded memory growth in long editing sessions.

👨‍🦰 good bot

### Change type

- [x] `improvement`

### Test plan

1. Open a tldraw editor and perform various draw/undo/redo operations
2. Verify undo/redo works correctly after many operations
3. Verify that `bailToMark` with an invalid mark ID does not lose pending changes

- [x] Unit tests

### Release notes

- Fix a bug where calling `bailToMark` with a non-existent mark ID could silently discard pending history changes.
- Reduce allocations on the history system hot path (every user change).
- Add an undo stack size limit (10,000 entries) to prevent unbounded memory growth in long sessions.

### API changes

- Added `applyDiffToTarget()` (`@internal`) for applying a single diff without array wrapping
- Added `MAX_UNDO_STACK_SIZE` (`@internal`) constant export from `HistoryManager`

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +100 / -44 |
| Tests           | +53 / -1   |
| Automated files | +3 / -0    |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core undo/redo logic and diff squashing, so regressions could impact history correctness despite being internal/perf-focused changes.
> 
> **Overview**
> Improves history performance and robustness by reducing allocations in diff handling (`isRecordsDiffEmpty` no longer uses `Object.keys`, and new internal `applyDiffToTarget` replaces single-item `squashRecordDiffsMutable` usage).
> 
> Fixes a bug where `bailToMark`/`_undo` would clear and lose the pending diff when the requested mark didn’t exist (now restored via `PendingDiff.restore`).
> 
> Adds an internal `MAX_UNDO_STACK_SIZE` (10,000) and trims the undo stack after marks/undo/redo to prevent unbounded memory growth, with new unit tests covering trimming and the pending-diff preservation case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 865e097de79cc9202cddf15db0469346b3051d6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->