### PR TITLE
fix(ui): move debug mode toggle into preferences submenu

### DIFF
--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
@@ -16,6 +16,7 @@ import {
 	RemoveFrameMenuItem,
 	SelectAllMenuItem,
 	ToggleAutoSizeMenuItem,
+	ToggleDebugModeItem,
 	ToggleDynamicSizeModeItem,
 	ToggleEdgeScrollingItem,
 	ToggleFocusModeItem,
@@ -168,10 +169,12 @@ export function PreferencesGroup() {
 					<AccessibilityMenu />
 					<InputModeMenu />
 				</TldrawUiMenuGroup>
+				<TldrawUiMenuGroup id="debug">
+					<ToggleDebugModeItem />
+				</TldrawUiMenuGroup>
 			</TldrawUiMenuSubmenu>
 			<LanguageMenu />
 			<KeyboardShortcutsMenuItem />
-			<TldrawUiMenuActionItem actionId="toggle-debug-mode" />
 		</TldrawUiMenuGroup>
 	)
 }


### PR DESCRIPTION
The debug mode toggle was placed at the top level of the preferences group, outside the preferences submenu. This PR moves it inside the preferences submenu where it belongs, in its own "debug" group at the bottom.

### Change type

- [x] `improvement`

### Test plan

1. Open the main menu
2. Open the preferences submenu
3. Verify "Debug mode" toggle appears at the bottom of the submenu
4. Verify it no longer appears outside the submenu

### Release notes

- Move the debug mode toggle into the preferences submenu.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +4 / -1    |