### PR TITLE
fix(editor): preserve pending diff when bailToMark target doesn't exist

### DIFF
--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
@@ -736,6 +736,22 @@ describe('HistoryManager error scenarios and edge cases', () => {
 			expect(store.get(ids.a)!.value).toBe(originalValue)
 		})
 
+		it('should preserve pending diff when mark is not found', () => {
+			manager._mark('real-mark')
+			store.update(ids.a, (s) => ({ ...s, value: 1 }))
+
+			// bail to a mark that doesn't exist
+			manager.bailToMark('non-existent-mark')
+
+			// the pending diff should still be intact
+			expect(store.get(ids.a)!.value).toBe(1)
+			expect(manager.getNumUndos()).toBeGreaterThan(0)
+
+			// a subsequent bail to the real mark should still work
+			manager.bailToMark('real-mark')
+			expect(store.get(ids.a)!.value).toBe(0)
+		})
+
 		it('should find mark correctly when it exists', () => {
 			manager._mark('existing-mark')
 			store.update(ids.a, (s) => ({ ...s, value: 1 }))

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -172,8 +172,8 @@ export class HistoryManager<R extends UnknownRecord> {
 			}
 
 			if (!didFindMark && toMark) {
-				// whoops, we didn't find the mark we were looking for
-				// don't do anything
+				// we didn't find the mark we were looking for — restore state and bail
+				this.pendingDiff.restore(pendingDiff)
 				return this
 			}
 
@@ -336,6 +336,11 @@ class PendingDiff<R extends UnknownRecord> {
 		this.diff = createEmptyRecordsDiff<R>()
 		this.isEmptyAtom.set(true)
 		return diff
+	}
+
+	restore(diff: RecordsDiff<R>) {
+		this.diff = diff
+		this.isEmptyAtom.set(isRecordsDiffEmpty(diff))
 	}
 
 	isEmpty() {


### PR DESCRIPTION
`bailToMark()` (and `_undo` with `toMark`) would silently discard the pending diff when the target mark didn't exist in the undo stack. The pending diff was cleared at the start of `_undo` but never restored on early return, causing accumulated changes to be lost. Now the pending diff is restored if the mark is not found.

Extracted from #8243.

### Change type

- [x] `bugfix`

### Test plan

1. Call `bailToMark` with a non-existent mark ID after making changes
2. Verify the pending changes are preserved (not silently discarded)
3. Verify a subsequent `bailToMark` with a valid mark still works correctly

- [x] Unit tests

### Release notes

- Fix a bug where calling `bailToMark` with a non-existent mark ID could silently discard pending history changes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -2    |
| Tests     | +16 / -0   |