### PR TITLE
fix(editor): Fix context menu flashing when right-clicking with one open

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -35,6 +35,9 @@ export function MenuClickCapture() {
 
 	const handlePointerDown = useCallback(
 		(e: PointerEvent) => {
+			const isCoarsePointer = editor.getInstanceState().isCoarsePointer || e.pointerType === 'touch'
+			const isPrimaryPointer =
+				e.button === LEFT_MOUSE_BUTTON || (isCoarsePointer && e.button === -1)
 			// On macOS, ctrl+left-click fires as button 0 with ctrlKey but triggers a
 			// contextmenu event just like a real right-click (button 2). We dispatch
 			// right_click directly so the editor updates state (selection, hovered shape)
@@ -49,17 +52,30 @@ export function MenuClickCapture() {
 					name: 'right_click',
 					...getPointerInfo(editor, e),
 				})
-			} else if (e.button === LEFT_MOUSE_BUTTON) {
+			} else if (isPrimaryPointer) {
+				// Dismiss open menus on primary pointer interactions. Keep this out of the
+				// right-click path to avoid racing with Radix contextmenu open handling.
+				editor.menus.clearOpenMenus()
 				setIsPointing(true)
 				rPointerState.current = {
 					isDown: true,
 					isDragging: false,
 					start: new Vec(e.clientX, e.clientY),
 				}
-				rDidAPointerDownAndDragWhileMenuWasOpen.current = false
+				// On coarse pointers, forward pointer_down immediately so long-press can
+				// retarget/open context menus while one is already open.
+				if (isCoarsePointer) {
+					canvasEvents.onPointerDown?.({
+						...e,
+						button: LEFT_MOUSE_BUTTON,
+					})
+					rDidAPointerDownAndDragWhileMenuWasOpen.current = true
+				} else {
+					rDidAPointerDownAndDragWhileMenuWasOpen.current = false
+				}
 			}
 		},
-		[editor]
+		[canvasEvents, editor]
 	)
 
 	const rDidAPointerDownAndDragWhileMenuWasOpen = useRef(false)

--- a/packages/editor/src/lib/hooks/useGlobalMenuIsOpen.ts
+++ b/packages/editor/src/lib/hooks/useGlobalMenuIsOpen.ts
@@ -19,7 +19,6 @@ export function useGlobalMenuIsOpen(
 			} else {
 				tlmenus.deleteOpenMenu(id)
 			}
-
 			onChange?.(isOpen)
 		},
 		[id, onChange]

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
@@ -50,7 +50,13 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 			if (!isOpen) {
 				const onlySelectedShape = editor.getOnlySelectedShape()
 
-				if (onlySelectedShape && editor.isShapeOrAncestorLocked(onlySelectedShape)) {
+				// Locked-shape selection on menu open is a coarse-pointer-only route (long press).
+				// Keep desktop right-click selection stable when re-targeting an already-open menu.
+				if (
+					editor.getInstanceState().isCoarsePointer &&
+					onlySelectedShape &&
+					editor.isShapeOrAncestorLocked(onlySelectedShape)
+				) {
 					editor.setSelectedShapes([])
 				}
 

--- a/packages/tldraw/src/test/ui/ContextMenu.test.tsx
+++ b/packages/tldraw/src/test/ui/ContextMenu.test.tsx
@@ -1,8 +1,11 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { createShapeId } from '@tldraw/editor'
 import { TLComponents, Tldraw } from '../../lib/Tldraw'
 import { DefaultContextMenu } from '../../lib/ui/components/ContextMenu/DefaultContextMenu'
-import { renderTldrawComponent } from '../testutils/renderTldrawComponent'
+import {
+	renderTldrawComponent,
+	renderTldrawComponentWithEditor,
+} from '../testutils/renderTldrawComponent'
 
 it('opens on right-click', async () => {
 	await renderTldrawComponent(
@@ -49,4 +52,90 @@ it('tunnels context menu', async () => {
 	await screen.findByTestId('context-menu')
 	const elm = await screen.findByTestId('abc123')
 	expect(elm).toBeDefined()
+})
+
+it('does not clear locked selection when closing context menu on desktop', async () => {
+	const lockedShapeId = createShapeId()
+
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => (
+			<Tldraw
+				onMount={(editor) => {
+					onMount(editor)
+					editor.createShape({
+						id: lockedShapeId,
+						type: 'geo',
+						isLocked: true,
+						x: 100,
+						y: 100,
+					})
+					editor.select(lockedShapeId)
+				}}
+			/>
+		),
+		{ waitForPatterns: false }
+	)
+
+	const canvas = await screen.findByTestId('canvas')
+	fireEvent.contextMenu(canvas)
+	await screen.findByTestId('context-menu')
+
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('context-menu')).toBeNull()
+	expect(editor.getOnlySelectedShape()?.id).toBe(lockedShapeId)
+})
+
+it('closes context menu on primary pointer down in menu click capture', async () => {
+	await renderTldrawComponent(
+		<Tldraw
+			onMount={(editor) => {
+				editor.createShape({ id: createShapeId(), type: 'geo' })
+			}}
+		/>,
+		{ waitForPatterns: false }
+	)
+
+	const canvas = await screen.findByTestId('canvas')
+	fireEvent.contextMenu(canvas)
+	await screen.findByTestId('context-menu')
+
+	const capture = await screen.findByTestId('menu-click-capture.content')
+	fireEvent.pointerDown(capture, {
+		button: 0,
+		clientX: 20,
+		clientY: 20,
+		pointerId: 1,
+		pointerType: 'mouse',
+	})
+
+	await waitFor(() => {
+		expect(screen.queryByTestId('context-menu')).toBeNull()
+	})
+})
+
+it('closes context menu on touch-style pointer down in menu click capture', async () => {
+	await renderTldrawComponent(
+		<Tldraw
+			onMount={(editor) => {
+				editor.createShape({ id: createShapeId(), type: 'geo' })
+			}}
+		/>,
+		{ waitForPatterns: false }
+	)
+	const canvas = await screen.findByTestId('canvas')
+	fireEvent.contextMenu(canvas)
+	await screen.findByTestId('context-menu')
+
+	const capture = await screen.findByTestId('menu-click-capture.content')
+	fireEvent.pointerDown(capture, {
+		button: -1,
+		clientX: 20,
+		clientY: 20,
+		pointerId: 1,
+		pointerType: 'touch',
+	})
+
+	await waitFor(() => {
+		expect(screen.queryByTestId('context-menu')).toBeNull()
+	})
 })


### PR DESCRIPTION

1. The MenuClickCapture overlay's clearOpenMenus() call raced with Radix's contextmenu handling, causing a close→reopen→close sequence. Removing it is safe because Radix's DismissableLayer already handles menu dismissal on outside clicks, and Editor.dispatch clears menus on pointer_down for drag interactions.

2. Make sure that right clicks are correctly handled (with platform quirks - macOS mostly) and dispatched as right click to the editor

Fixes https://github.com/tldraw/tldraw/issues/8251
(Potentially) fixes https://github.com/tldraw/tldraw/issues/8277?

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On canvas, right click to open a context menu
2. Right click again real quick 
3. First context menu is closed and new context menu opens
4. keep moving and right clicking, no blinking and closing of the newly opened context menu should be observed.
4. Left click anywhere else, it closes the context menu

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where right clicking on canvas quickly runs into a race condition and automatically close the newly open context menu resulting in a non-savoury blinking