### PR TITLE
fix(ci): fix publish-templates git credential handling for checkout v6

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 
@@ -45,7 +47,6 @@ jobs:
         run: |
           git config --global user.name 'huppy-bot[bot]'
           git config --global user.email '128400622+huppy-bot[bot]@users.noreply.github.com'
-          git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Export templates
         env:


### PR DESCRIPTION
The publish-templates workflow was failing at the "Configure git" step because `git config --unset-all http.https://github.com/.extraheader` returns exit code 5 when the key doesn't exist. With `actions/checkout@v6`, persisted credentials are stored in a separate temp file rather than `.git/config`, so the unset command can't find the key.

This PR fixes the issue by adding `persist-credentials: false` to the checkout step, which prevents the checkout token from being persisted at all. The `--unset-all` workaround is then removed since there's nothing to unset. This ensures the huppy-bot token is the only credential available for subsequent git operations.

### Change type

- [x] `bugfix`

### Test plan

1. Run the publish-templates workflow and verify the "Configure git" step succeeds
2. Verify template export still pushes using huppy-bot credentials

### Release notes

- Fix publish-templates CI workflow failing on git credential configuration

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +2 / -1    |