### PR TITLE
chore: improve update-release-notes skill and add v4.5 to releases index

### DIFF
--- a/.claude/skills/update-release-notes/SKILL.md
+++ b/.claude/skills/update-release-notes/SKILL.md
@@ -153,12 +153,21 @@ After editing `next.mdx` (and any archive files), commit and push from the tldra
 
 ```bash
 cd /tmp/tldraw
-git checkout -b update-release-notes
+BRANCH="update-release-notes-$(date -u +%Y%m%d-%H%M)"
+git checkout -b "$BRANCH"
 git add apps/docs/content/releases/
 git commit -m "docs: update release notes"
-git push -u origin update-release-notes
-gh pr create -R tldraw/tldraw --title "docs: update release notes" --body "Update next.mdx with entries from $(source)."
+git push -u origin "$BRANCH"
 ```
+
+Then create the PR following the standards in `@.claude/skills/write-pr/SKILL.md`:
+
+- **Title**: `docs(releases): update release notes`
+- **Change type**: `other`
+- **Test plan**: Remove the numbered list (no manual testing steps). Untick both unit tests and end to end tests.
+- **Release notes**: Omit this section (internal docs work with no user-facing impact)
+- **Description paragraph**: Start with "In order to..." and mention the source (`main` or `production`) and what was updated (new entries added, stale entries pruned, archival performed, etc.)
+- Include a **Code changes** table with a `Documentation` row
 
 ## The `last_version` field
 


### PR DESCRIPTION
In order to improve the update-release-notes skill workflow and ensure the releases index page stays current, this PR updates the skill's push step to use timestamped branch names (avoiding collisions) and create PRs following write-pr skill standards, and adds the v4.5.0 entry to the releases index page.

### Change type

- [x] `other`

### Test plan

- Run the update-release-notes skill and verify it creates a timestamped branch and properly formatted PR

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Documentation  | +1 / -0   |
| Config/tooling | +12 / -3   |