### PR TITLE
fix(tldraw): use DOMParser in stripHtml to prevent XSS via innerHTML

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -7,7 +7,6 @@ import {
 	activeElementShouldCaptureKeys,
 	assert,
 	compact,
-	getGlobalDocument,
 	isDefined,
 	preventDefault,
 	uniq,
@@ -39,9 +38,7 @@ const expectedPasteFileMimeTypes = [
  * @internal
  */
 function stripHtml(html: string) {
-	// See <https://github.com/developit/preact-markup/blob/4788b8d61b4e24f83688710746ee36e7464f7bbc/src/parse-markup.js#L60-L69>
-	const doc = getGlobalDocument().implementation.createHTMLDocument('')
-	doc.documentElement.innerHTML = html.trim()
+	const doc = new DOMParser().parseFromString(html.trim(), 'text/html')
 	return doc.body.textContent || doc.body.innerText || ''
 }
 


### PR DESCRIPTION
The previous implementation used createHTMLDocument + innerHTML which can trigger side effects like <img onerror=...> during parsing. DOMParser produces an inert document with no script execution.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Fixed a security issue within our tldraw stripHtml method by relying on DOMParser.