### PR TITLE
fix(ci): add persist-credentials: false to remaining checkout v6 workflows

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Check branch
         run: |

--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -51,7 +51,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Check branch
         run: |

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Prepare repository
         # Fetch full git history and tags for auto

--- a/.github/workflows/trigger-dotcom-hotfix.yml
+++ b/.github/workflows/trigger-dotcom-hotfix.yml
@@ -38,8 +38,12 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/trigger-production-build.yml
+++ b/.github/workflows/trigger-production-build.yml
@@ -34,9 +34,13 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
           ref: refs/heads/production
           fetch-depth: 0
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Get target commit hash (manual dispatch)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/trigger-sdk-hotfix.yml
+++ b/.github/workflows/trigger-sdk-hotfix.yml
@@ -33,8 +33,12 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -27,8 +27,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Run our setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
In order to prevent potential credential conflicts with `actions/checkout@v6` across all workflows that use huppy-bot tokens, this PR extends the fix from #8267 to the remaining affected workflows. With checkout v6, persisted credentials are stored in a temp file that can take precedence over custom token auth configured later. Setting `persist-credentials: false` and explicitly configuring credentials via `url.insteadOf` ensures the huppy-bot token is used consistently for git operations.

Relates to #8267

### Affected workflows

- `publish-new.yml`
- `publish-patch.yml`
- `bump-versions.yml`
- `trigger-sdk-hotfix.yml`
- `trigger-dotcom-hotfix.yml`
- `trigger-production-build.yml`
- `update-release-notes.yml`
- `publish-editor-extensions.yml`

### Change type

- [x] `other`

### Test plan

- [ ] Verify publish workflows still authenticate correctly when triggered

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +32 / -0   |