### PR TITLE
docs: add v4.5 to releases index

### DIFF
--- a/apps/docs/content/getting-started/releases.mdx
+++ b/apps/docs/content/getting-started/releases.mdx
@@ -23,6 +23,7 @@ Unlike many JavaScript packages distributed on [NPM](https://www.npmjs.com/), th
 
 ## v4.x
 
+- [v4.5](/releases/v4.5.0) - Click-through on transparent pixels, SVG sanitization, configurable embed definitions
 - [v4.4](/releases/v4.4.0) - Image pipeline starter kit, performance improvements, quick zoom, canvas indicators
 - [v4.3](/releases/v4.3.0) - SQLite sync storage, improved custom shape types, reactive inputs, draw shape encoding
 - [v4.2](/releases/v4.2.0) - TipTap v3, dynamic tools, custom socket implementations


### PR DESCRIPTION
In order to add the missing v4.5 release to the docs releases index, this PR adds the v4.5.0 entry to the releases page. This was supposed to be included in #8271 but was missed.

### Change type

- [x] `other`

### Test plan

- Verify v4.5 appears on the releases index page at tldraw.dev

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -0    |