### PR TITLE
fix(ci): run refresh-assets before package diff check in publish-patch

### DIFF
--- a/internal/scripts/publish-patch.ts
+++ b/internal/scripts/publish-patch.ts
@@ -46,6 +46,10 @@ async function main() {
 		await publishProductionDocsAndExamplesAndBemo()
 	}
 
+	// Ensure asset directories exist before comparing package contents.
+	// CI may skip postinstall (and thus refresh-assets) when install-state.gz is cached.
+	await exec('yarn', ['refresh-assets', '--force'])
+
 	// Skip releasing a new version if the package contents are identical.
 	// This may happen when cherry-picking docs-only changes.
 	if (!(await getAnyPackageDiff())) {


### PR DESCRIPTION
In order to stop docs-only hotfixes from triggering unwanted npm patch releases, this PR adds `yarn refresh-assets --force` before the `getAnyPackageDiff()` check in `publish-patch.ts`.

### Root cause

PR #8204 added `.yarn/install-state.gz` to the CI cache. When Yarn determines that the install state hasn't changed (e.g. `node_modules` is already populated and no dependencies changed), it [skips lifecycle scripts](https://yarnpkg.com/advanced/lifecycle-scripts) including `postinstall` ([related discussion](https://github.com/yarnpkg/berry/discussions/5924)). This means the `postinstall` hook (`husky install && yarn refresh-assets`) never runs.

Without `refresh-assets`, the gitignored asset directories in `@tldraw/assets` (`embed-icons/`, `fonts/`, `icons/`, `translations/`) don't exist on disk. The `getAnyPackageDiff()` guard runs `yarn pack` which produces a tarball missing these dirs (14 files), while the npm-published tarball has them (265 files) — always finding a diff, always publishing.

**Before #8204 (working):** PR #8102 docs hotfix cherry-picked to v4.4.x — publish-patch skipped correctly, no version bump.

**After #8204 (broken):** PRs #8263 and #8270 docs hotfixes cherry-picked to v4.5.x — both triggered unwanted npm publishes (v4.5.1 and v4.5.2).

### Why this approach

Considered three options:
1. **Remove `install-state.gz` from cache** — doesn't actually help; Yarn skips postinstall based on dependency changes, not just the state file
2. **Add `refresh-assets` to the setup action** — overkill; lazyrepo already auto-runs it as a dependency of `build`, `build-types`, and `dev`
3. **Add `refresh-assets` to `publish-patch.ts`** — targeted fix matching what `trigger-sdk-hotfix.ts` already does (line 98)

Option 3 is the right call. `publish-patch.ts` is the only workflow confirmed broken — everything else is protected by either lazyrepo's dependency graph or explicit `refresh-assets` calls in the workflow YAML.

### Change type

- [x] `bugfix`

### Test plan

Verified locally:
1. Removed asset dirs to simulate CI with warm cache (no postinstall)
2. `yarn pack` on `@tldraw/assets` → 14 files
3. Ran `yarn refresh-assets --force`
4. `yarn pack` again → 265 files

On a release branch with only docs changes, `getAnyPackageDiff()` should now return `null` → "No packages have changed, skipping release" → no publish.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +4 / -0    |