### PR TITLE
fix(build): add file extensions to dynamic import() paths

### DIFF
--- a/internal/scripts/lib/add-extensions.ts
+++ b/internal/scripts/lib/add-extensions.ts
@@ -20,7 +20,7 @@ function resolveRelativePath(importingFile: string, relativePath: string) {
 	}
 
 	// strip the file extension if applicable
-	relativePath.replace(/\.(m|c)?js$/, '')
+	relativePath = relativePath.replace(/\.(m|c)?js$/, '')
 
 	for (const extension of extensions) {
 		if (relativePath.endsWith(extension)) {
@@ -67,6 +67,13 @@ export function addJsExtensions(distDir: string) {
 					path.value.arguments[0]?.type === 'StringLiteral'
 				) {
 					path.value.arguments[0].value = resolveRelativePath(file, path.value.arguments[0].value)
+				}
+				this.traverse(path)
+			},
+			visitImportExpression(path) {
+				const source = path.value.source
+				if (source?.type === 'StringLiteral' || source?.type === 'Literal') {
+					source.value = resolveRelativePath(file, source.value)
 				}
 				this.traverse(path)
 			},


### PR DESCRIPTION
The build post-processor (`add-extensions.ts`) adds `.mjs`/`.cjs` extensions to relative import paths in the compiled output. However, it was not handling dynamic `import()` expressions — the TypeScript parser represents these as `ImportExpression` AST nodes, but only `CallExpression` with an `Import` callee was being checked. This caused runtime errors when consuming the SDK with bundlers like esbuild:

```
Could not resolve "./utils/svg/sanitizeSvg"
  node_modules/tldraw/dist-esm/lib/defaultExternalContentHandlers.mjs
```

This PR adds a `visitImportExpression` handler to properly resolve dynamic import paths, and fixes a latent bug where `String.replace()` result was not assigned back when stripping existing file extensions.

### Change type

- [x] `bugfix`

### Test plan

1. Build the SDK with `yarn build-package`
2. Verify that `dist-esm/lib/defaultExternalContentHandlers.mjs` contains `import("./utils/svg/sanitizeSvg.mjs")` instead of `import("./utils/svg/sanitizeSvg")`
3. Consume the built SDK in an esbuild-based project and confirm no resolution errors

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix dynamic `import()` paths missing file extensions in built SDK output, which caused resolution errors in esbuild and other bundlers

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +8 / -1    |