### PR TITLE
chore(skills): add releases index update and SDK release workflow to update-release-notes skill

### DIFF
--- a/.claude/skills/update-release-notes/SKILL.md
+++ b/.claude/skills/update-release-notes/SKILL.md
@@ -56,7 +56,12 @@ If a new release was published since `last_version` in `next.mdx`:
    - Set `title` to the version
    - Update dates
    - Add the GitHub release link after frontmatter
-3. Reset `next.mdx`:
+3. Add the new version to the releases index at `apps/docs/content/getting-started/releases.mdx`:
+   - Add a line at the top of the appropriate `## v{major}.x` section
+   - Format: `- [vX.Y](/releases/vX.Y.0) - Brief description`
+   - The description should be a short summary of the release highlights from the intro paragraph (3-5 key features, comma-separated)
+   - If a new major version section is needed, create it above the previous one
+4. Reset `next.mdx`:
    - Update `last_version` field to the new release
    - Clear the content sections
    - Keep the file structure for accumulating new changes
@@ -172,6 +177,20 @@ Then create the PR following the standards in `@.claude/skills/write-pr/SKILL.md
 ## The `last_version` field
 
 The `next.mdx` frontmatter includes a `last_version` field that tracks the most recent published release. This determines which PRs are "new" and need to be added.
+
+## SDK release workflow
+
+During an SDK release, this skill is run **twice** to get the docs site into its post-release state:
+
+1. **First run** — update `next.mdx` with all PRs that will ship in the release (source is `"production"` during freeze week). This ensures the release notes are complete before publishing.
+2. **Publish the release to NPM** — this happens outside of this skill.
+3. **Second run** — now that the release is published, the status script will detect `needs_archive: true`. This run:
+   - Archives `next.mdx` to a versioned file (e.g., `v4.5.0.mdx`)
+   - Adds the new version to the releases index (`releases.mdx`)
+   - Resets `next.mdx` with the new `last_version`
+   - Finds PRs that landed on `main` during the freeze (since the release tag) and adds them to the fresh `next.mdx`
+
+After the second run, the docs site reflects the published release and `next.mdx` already has a head start on the next cycle's changes.
 
 ## References
 


### PR DESCRIPTION
In order to automate the full SDK release docs workflow, this PR updates the `update-release-notes` skill with two additions:

1. **Releases index update during archival** — when archiving `next.mdx` to a versioned file, the skill now also adds the new version to `apps/docs/content/getting-started/releases.mdx` with a brief description derived from the release intro paragraph.

2. **SDK release workflow documentation** — documents the two-pass pattern used during SDK releases: first run finalizes `next.mdx` before NPM publish, second run archives, updates the index, resets `next.mdx`, and backfills PRs that landed during the freeze.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| --- | --- |
| Config/tooling | +20 / -1 |