### PR TITLE
fix(scripts): prevent secret leaks in deploy Discord messages

### DIFF
--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -7,6 +7,9 @@ function sanitizeVariables(errorOutput: string): string {
 	// Sanitize KEY=VALUE patterns where KEY looks like an env var (e.g. flyctl secrets set)
 	sanitized = sanitized.replace(/\b([A-Z][A-Z_0-9]{2,})=[^ \n]+/g, '$1=***')
 
+	// Sanitize --token VALUE patterns (e.g. vercel --token xxx)
+	sanitized = sanitized.replace(/(--token\s+)\S+/g, '$1***')
+
 	// Sanitize connection strings (postgres://, redis://, etc.)
 	sanitized = sanitized.replace(
 		/\b(postgres|postgresql|mysql|redis|mongodb|amqp|https?):\/\/[^\s"']+/gi,

--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -7,8 +7,8 @@ function sanitizeVariables(errorOutput: string): string {
 	// Sanitize KEY=VALUE patterns where KEY looks like an env var (e.g. flyctl secrets set)
 	sanitized = sanitized.replace(/\b([A-Z][A-Z_0-9]{2,})=[^ \n]+/g, '$1=***')
 
-	// Sanitize --token VALUE patterns (e.g. vercel --token xxx)
-	sanitized = sanitized.replace(/(--token\s+)\S+/g, '$1***')
+	// Sanitize --token VALUE and --token=VALUE patterns (e.g. vercel --token xxx)
+	sanitized = sanitized.replace(/(--token[\s=])\S+/g, '$1***')
 
 	// Sanitize connection strings (postgres://, redis://, etc.)
 	sanitized = sanitized.replace(


### PR DESCRIPTION
Adds a regex pattern to sanitize `--token VALUE` and `--token=VALUE` patterns (e.g. `vercel --token xxx`) in Discord error messages, preventing token leaks.

### Change type

- [x] `bugfix`

### Test plan

1. Error output containing `--token <value>` or `--token=<value>` is masked before reaching Discord