### PR TITLE
fix(scripts): improve discord message sanitization formatting

### DIFF
--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -2,18 +2,19 @@ function sanitizeVariables(errorOutput: string): string {
 	let sanitized = errorOutput
 
 	// Sanitize wrangler --var KEY:VALUE patterns
-	sanitized = sanitized.replace(/(--var\s+)(\w+):[^ \n]+/g, '$1$2:***')
+	sanitized = sanitized.replace(/(--var\s+)(\w+):[^ \n]+/g, '$1$2:`***`')
 
-	// Sanitize KEY=VALUE patterns where KEY looks like an env var (e.g. flyctl secrets set)
-	sanitized = sanitized.replace(/\b([A-Z][A-Z_0-9]{2,})=[^ \n]+/g, '$1=***')
+	// Sanitize KEY=VALUE patterns where KEY looks like an env var and value is long enough
+	// to be a secret (e.g. flyctl secrets set). Short values like =debug are left alone.
+	sanitized = sanitized.replace(/\b([A-Z][A-Z_0-9]{2,})=([^ \n]{8,})/g, '$1=`***`')
 
 	// Sanitize --token VALUE and --token=VALUE patterns (e.g. vercel --token xxx)
-	sanitized = sanitized.replace(/(--token[\s=])\S+/g, '$1***')
+	sanitized = sanitized.replace(/(--token[\s=])\S+/g, '$1`***`')
 
 	// Sanitize connection strings (postgres://, redis://, etc.)
 	sanitized = sanitized.replace(
 		/\b(postgres|postgresql|mysql|redis|mongodb|amqp|https?):\/\/[^\s"']+/gi,
-		'$1://***'
+		'$1://`***`'
 	)
 
 	return sanitized


### PR DESCRIPTION
Improves the `sanitizeVariables` function in the Discord notification helper so that redacted values render as inline code in Discord, and short `KEY=VALUE` pairs (like `NODE_ENV=debug`) are no longer incorrectly redacted.

Follows up on #8287.

### Change type

- [x] `improvement`

### Test plan

1. Trigger a deploy that includes secret env vars in error output
2. Verify Discord messages show `` `***` `` as inline code blocks instead of bare `***` (which Discord renders as bold)
3. Verify short env assignments like `LOG_LEVEL=debug` are not redacted

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +6 / -5    |