### PR TITLE
fix(deploy): replace regexgen with extension-based pattern for Vercel route limit

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -40,7 +40,6 @@
 		"@tldraw/sync": "workspace:*",
 		"@tldraw/sync-core": "workspace:*",
 		"@tldraw/utils": "workspace:*",
-		"@vercel/analytics": "^1.4.1",
 		"axe-core": "^4.10.3",
 		"browser-fs-access": "^0.35.0",
 		"classnames": "^2.5.1",

--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -93,11 +93,13 @@ async function build() {
 	const assetExtensions = [
 		...new Set(
 			assetsList
-				.filter((f) => !f.endsWith('.js.map'))
+				.filter((f) => !f.endsWith('.js.map') && f.includes('.'))
 				.map((f) => f.split('.').pop()!)
-				.filter(Boolean)
 		),
 	]
+	if (assetExtensions.length === 0) {
+		throw new Error('No asset extensions found in dist/assets')
+	}
 	const assetsToCacheRegex = `^\\/assets\\/.+\\.(${assetExtensions.join('|')})$`
 
 	writeFileSync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12401,36 +12401,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/analytics@npm:^1.4.1":
-  version: 1.6.1
-  resolution: "@vercel/analytics@npm:1.6.1"
-  peerDependencies:
-    "@remix-run/react": ^2
-    "@sveltejs/kit": ^1 || ^2
-    next: ">= 13"
-    react: ^18 || ^19 || ^19.0.0-rc
-    svelte: ">= 4"
-    vue: ^3
-    vue-router: ^4
-  peerDependenciesMeta:
-    "@remix-run/react":
-      optional: true
-    "@sveltejs/kit":
-      optional: true
-    next:
-      optional: true
-    react:
-      optional: true
-    svelte:
-      optional: true
-    vue:
-      optional: true
-    vue-router:
-      optional: true
-  checksum: 10/304c6cfef21cdec4c1a2c68c1664e323c1813d733972c9f3603b955ca899655b2a9a0084a34288548e6847ffb802c2916273e4b2bef70e5ce712254a18ae2f3c
-  languageName: node
-  linkType: hard
-
 "@vercel/build-utils@npm:8.3.2":
   version: 8.3.2
   resolution: "@vercel/build-utils@npm:8.3.2"
@@ -16776,7 +16746,6 @@ __metadata:
     "@types/qrcode": "npm:^1.5.5"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
-    "@vercel/analytics": "npm:^1.4.1"
     "@vitejs/plugin-react-swc": "npm:^3.10.2"
     axe-core: "npm:^4.10.3"
     browser-fs-access: "npm:^0.35.0"


### PR DESCRIPTION
Staging deploys to Vercel fail with:

```
Error: Builder returned invalid routes: should NOT be longer than 4096 characters
```

The `build.ts` script uses `regexgen` to create a trie-regex enumerating every asset filename for the immutable cache-control route. The Vite build now produces ~157 files, pushing this regex well over Vercel's 4096-char-per-route limit.

**When it started failing:** `feat(mermaid): add @tldraw/mermaid package` (#8194) — merged Mar 18. Last successful deploy was #8273.

**Root cause:** `regexgen` builds a trie-regex from all asset filenames. The exact-match approach was introduced in #4863 to prevent Cloudflare from caching 404 responses for `/assets/*` with immutable headers, which caused "Failed to fetch dynamically imported module" errors after deploys.

**Fix:** Replace the per-file trie regex with an extension-based pattern. Given 3 example assets:

```
assets/admin-D_Yk9J1y.js
assets/styles-BKwyi6c.css
assets/Inter-Medium-abc123.woff2
```

Old regex (regexgen): `^\/assets\/(?:admin\-D_Yk9J1y\.js|styles\-BKwyi6c\.css|Inter\-Medium\-abc123\.woff2)$`
New regex: `^\/assets\/.+\.(js|css|woff2)$`

| Request | Old regex | New regex |
|---|---|---|
| `/assets/admin-D_Yk9J1y.js` | Match (immutable cache) | Match (immutable cache) |
| `/assets/styles-BKwyi6c.css` | Match (immutable cache) | Match (immutable cache) |
| `/assets/nonexistent.js` | No match (no cache headers) | Match (immutable cache on 404) |
| `/assets/foo` | No match | No match |

### Possible cons

- **Slightly broader matching** — a request like `/assets/nonexistent.js` would get immutable headers on its 404 response. This could cause Cloudflare to cache the 404 at the edge, which was the original concern in #4863.
- **Not an exact match** — we lose the guarantee that only known files get immutable caching.

### Why the cons don't matter in practice

1. Asset URLs come from compiled JS bundles referencing real content-hashed filenames — no user or browser crafts random `/assets/*.js` URLs
2. `coalesceWithPreviousAssets()` copies 30 days of old assets into every deploy, so old URLs from stale tabs don't 404
3. The old exact-match regex only enumerated the *current* build's assets — it never protected against old assets from previous builds returning 404 either. For stale tabs >30 days old, both approaches fail identically.
4. Even if Cloudflare caches a 404 with immutable headers for a fabricated URL, it only affects that specific fake URL — real asset URLs with content hashes are unaffected

Also removes `regexgen` and `@types/regexgen` dependencies.

Closes #8286

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to Vercel staging and verify the deploy succeeds
2. Verify assets are served with `Cache-Control: public, max-age=31536000, immutable`
3. Verify non-existent asset paths without valid extensions don't get cache headers

### Release notes

- Fix Vercel deploy failure caused by asset cache route regex exceeding 4096-char limit

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +10 / -5   |
| Config/tooling | +33 / -39  |