### PR TITLE
fix(vscode): retry publish on marketplace version conflict

### DIFF
--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -46,10 +46,6 @@ jobs:
       - name: Build types
         run: yarn build-types
 
-      - name: Get extension info from the marketplace
-        working-directory: 'apps/vscode/extension'
-        run: yarn get-info
-
       - name: Publish extension
         run: yarn tsx ./internal/scripts/publish-editor-extensions.ts
         env:

--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -11,8 +11,17 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
+const MAX_RETRIES = 5
+const RETRY_DELAY_MS = 60_000
 
-async function updateExtensionVersion() {
+function isVersionConflictError(err: unknown): boolean {
+	const message = err instanceof Error ? err.message : ''
+	const stderr = typeof (err as any)?.stderr === 'string' ? (err as any).stderr : ''
+	return message.includes('already exists') || stderr.includes('already exists')
+}
+
+async function fetchMarketplaceVersion(): Promise<string> {
+	await exec('yarn', ['get-info'], { pwd: EXTENSION_DIR })
 	const extensionInfoJsonPath = path.join(EXTENSION_DIR, 'extension.json')
 	if (!existsSync(extensionInfoJsonPath)) {
 		throw new Error('Published extension info not found.')
@@ -22,13 +31,18 @@ async function updateExtensionVersion() {
 	if (!version) {
 		throw new Error('Could not get the version of the published extension.')
 	}
-	const semVer = parse(version)
+	return version
+}
+
+async function bumpVersion(): Promise<string> {
+	const currentVersion = await fetchMarketplaceVersion()
+	const semVer = parse(currentVersion)
 	if (!semVer) {
-		throw new Error('Could not parse the published version.')
+		throw new Error(`Could not parse the published version: ${currentVersion}`)
 	}
 	const release = env.TLDRAW_ENV === 'production' ? 'minor' : 'patch'
 	const nextVersion = semVer.inc(release).version
-	nicelog(`Updating extension version from ${version} to ${nextVersion}`)
+	nicelog(`Bumping extension version from ${currentVersion} to ${nextVersion}`)
 
 	const packageJsonPath = path.join(EXTENSION_DIR, 'package.json')
 	if (!existsSync(packageJsonPath)) {
@@ -36,7 +50,6 @@ async function updateExtensionVersion() {
 	}
 	const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 	packageJson.version = nextVersion
-
 	writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, '\t') + '\n')
 	return nextVersion
 }
@@ -76,28 +89,44 @@ async function copyExtensionToReleaseFolder(version: string) {
 	await exec('git', ['push'])
 }
 
-async function packageAndPublish(version: string) {
+async function main() {
+	if (env.TLDRAW_ENV !== 'production' && env.TLDRAW_ENV !== 'staging') {
+		throw new Error('Workflow triggered from a branch other than main or production.')
+	}
+
 	await exec('yarn', ['lazy', 'run', 'build', '--filter=packages/*'])
-	switch (env.TLDRAW_ENV) {
-		case 'production':
-			await exec('yarn', ['package'], { pwd: EXTENSION_DIR })
-			await exec('yarn', ['publish'], { pwd: EXTENSION_DIR })
-			// commit vsix AFTER successful publish to avoid partial state on failure
-			await copyExtensionToReleaseFolder(version)
-			return
-		case 'staging':
-			await exec('yarn', ['package', '--pre-release'], { pwd: EXTENSION_DIR })
-			await exec('yarn', ['publish', '--pre-release'], { pwd: EXTENSION_DIR })
-			return
-		default:
-			throw new Error('Workflow triggered from a branch other than main or production.')
+
+	// When two pushes to main happen in quick succession, the concurrency group serializes
+	// the runs but the marketplace API has propagation delay — both runs can compute the same
+	// next version. If publish fails with "already exists", re-fetch and retry.
+	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+		const version = await bumpVersion()
+
+		try {
+			switch (env.TLDRAW_ENV) {
+				case 'production':
+					await exec('yarn', ['package'], { pwd: EXTENSION_DIR })
+					await exec('yarn', ['publish'], { pwd: EXTENSION_DIR })
+					await copyExtensionToReleaseFolder(version)
+					return
+				case 'staging':
+					await exec('yarn', ['package', '--pre-release'], { pwd: EXTENSION_DIR })
+					await exec('yarn', ['publish', '--pre-release'], { pwd: EXTENSION_DIR })
+					return
+			}
+		} catch (err) {
+			if (isVersionConflictError(err) && attempt < MAX_RETRIES) {
+				nicelog(
+					`Version conflict detected (attempt ${attempt}/${MAX_RETRIES}), retrying in ${RETRY_DELAY_MS / 1000}s...`
+				)
+				await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+				continue
+			}
+			throw err
+		}
 	}
 }
 
-async function main() {
-	const version = await updateExtensionVersion()
-	await packageAndPublish(version)
-}
 main().catch(async (err) => {
 	console.error(err)
 	process.exit(1)


### PR DESCRIPTION
When two pushes to `main` happen in quick succession, the `publish-editor-extensions` workflow fails with "already exists". The concurrency group serializes job execution, but the marketplace API has propagation delay — both runs fetch the same stale version and compute the same next version.

This PR wraps the version-bump → package → publish cycle in a retry loop. If `vsce publish` fails with "already exists", the script waits 60s, re-fetches the marketplace version, re-computes the next version, re-packages, and retries (up to 5 attempts).

Also moves the `vsce show` marketplace fetch (previously a separate workflow step) into the script so it can be re-run on retry.

### Change type

- [x] `bugfix`

### Test plan

1. Review the retry logic in `publish-editor-extensions.ts`
2. Verify the "already exists" error string matches what vsce actually outputs (confirmed from CI logs: `::error::tldraw-org.tldraw-vscode v2.216.1 already exists.`)

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +52 / -27  |