### PR TITLE
chore: normalize formatting in wrangler.toml files

### DIFF
--- a/apps/bemo-worker/wrangler.toml
+++ b/apps/bemo-worker/wrangler.toml
@@ -9,7 +9,7 @@ ip = "0.0.0.0"
 # these migrations are append-only. you can't change them. if you do need to change something, do so
 # by creating new migrations
 [[migrations]]
-tag = "v1"               # Should be unique for each entry
+tag = "v1" # Should be unique for each entry
 new_classes = ["BemoDO"]
 
 

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -10,7 +10,7 @@ ip = "0.0.0.0"
 # these migrations are append-only. you can't change them. if you do need to change something, do so
 # by creating new migrations
 [[migrations]]
-tag = "v1"                            # Should be unique for each entry
+tag = "v1" # Should be unique for each entry
 new_classes = ["TLDrawDurableObject"]
 
 [[migrations]]
@@ -66,12 +66,12 @@ MULTIPLAYER_SERVER = "http://localhost:3000"
 # staging is the same as a preview on main:
 [env.staging]
 name = "main-tldraw-multiplayer"
-workers_dev = true               # todo: remove this once clients are updated
+workers_dev = true # todo: remove this once clients are updated
 
 # production gets the proper name
 [env.production]
 name = "tldraw-multiplayer"
-workers_dev = true          # todo: remove this once clients are updated
+workers_dev = true # todo: remove this once clients are updated
 
 #################### Routing ####################
 # no custom routes for previews and development

--- a/apps/mcp-app/wrangler.toml
+++ b/apps/mcp-app/wrangler.toml
@@ -33,9 +33,9 @@ dataset = "MCP_ANALYTICS"
 name = "RATE_LIMITER"
 namespace_id = "2001"
 
-  [ratelimits.simple]
-  limit = 30
-  period = 60
+[ratelimits.simple]
+limit = 30
+period = 60
 
 [observability]
 enabled = true

--- a/templates/agent/wrangler.toml
+++ b/templates/agent/wrangler.toml
@@ -13,9 +13,7 @@ custom_domain = true
 
 # Set up the durable object used for each tldraw room
 [durable_objects]
-bindings = [
-    { name = "AGENT_DURABLE_OBJECT", class_name = "AgentDurableObject" },
-]
+bindings = [{ name = "AGENT_DURABLE_OBJECT", class_name = "AgentDurableObject" }]
 
 # Durable objects require migrations to create/modify/delete them
 [[migrations]]
@@ -24,6 +22,4 @@ new_classes = ["TldrawAiDurableObject"]
 
 [[migrations]]
 tag = "v2"
-renamed_classes = [
-    { from = "TldrawAiDurableObject", to = "AgentDurableObject" },
-]
+renamed_classes = [{ from = "TldrawAiDurableObject", to = "AgentDurableObject" }]

--- a/templates/sync-cloudflare/wrangler.toml
+++ b/templates/sync-cloudflare/wrangler.toml
@@ -19,9 +19,7 @@ directory = "./dist/client"
 
 # Set up the durable object used for each tldraw room
 [durable_objects]
-bindings = [
-    { name = "TLDRAW_DURABLE_OBJECT", class_name = "TldrawDurableObject" },
-]
+bindings = [{ name = "TLDRAW_DURABLE_OBJECT", class_name = "TldrawDurableObject" }]
 
 # Durable objects require migrations to create/modify/delete them
 # Using new_sqlite_classes for SQLite-backed storage


### PR DESCRIPTION
In order to keep consistent formatting across wrangler.toml files, this PR normalizes whitespace and indentation.

Changes:
- Remove excessive inline comment alignment padding (e.g. `tag = "v1"               # Should be unique`)
- Fix incorrect indentation of `[ratelimits.simple]` block in mcp-app
- Collapse single-element inline arrays onto one line in templates

### Change type

- [x] `other`

### Test plan

No functional changes — formatting only.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +3 / -3    |
| Templates      | +2 / -6    |
| Config/tooling | +0 / -0    |