### PR TITLE
docs: render docs pages dynamically instead of statically

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -32,13 +32,7 @@ export async function generateMetadata(props: {
 	}
 	return metadata
 }
-const nonDocsPaths = ['/blog/', '/legal/']
-export async function generateStaticParams() {
-	const paths = await db.getAllPaths()
-	return paths
-		.filter((path) => !nonDocsPaths.some((nonDocsPath) => path.startsWith(nonDocsPath)))
-		.map((path) => ({ slug: path.slice(1).split('/') }))
-}
+export const dynamicParams = true
 
 export default async function Page(props: { params: Promise<{ slug: string | string[] }> }) {
 	const params = await props.params


### PR DESCRIPTION
In order to avoid pre-rendering all ~1300 docs pages at build time, this PR switches the docs catch-all route to render pages dynamically on first request.

Removes `generateStaticParams` and sets `dynamicParams = true` so that Next.js server-renders each page when it's first visited rather than generating them all upfront during deploy.

### Change type

- [x] `improvement`

### Test plan

1. Deploy the docs site
2. Visit a reference page (e.g. `/reference/editor/Editor`)
3. Confirm it renders correctly on first load

### Release notes

- Switch docs site to render reference pages on demand instead of statically at build time

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -7    |