### PR TITLE
fix(tldraw): skip to main content to keep its z-index on hover

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1021,6 +1021,10 @@
 	left: 8px;
 }
 
+/* 
+ * focusing skip-to-main-content hide top ui buttons to make sure we avoid
+ * z-index clashes on hover (see issue #8328)
+ */
 .tl-skip-to-main-content:focus + .tlui-layout__top .tlui-helper-buttons {
 	display: none;
 }


### PR DESCRIPTION
Just a spike that shows what it takes to get rid of issues #8328 as this is basically a CSS UI caused by an UX/UI problem.

If the button is shown on focus, we should make sure that the following ui helper buttons are not showing.

### Before

Example of problem in issue: https://github.com/tldraw/tldraw/issues/8328

### After

https://github.com/user-attachments/assets/70bd5f89-63b3-4e7e-a5a9-8ce13d09ac62

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. go to canvas, draw some shapes 
2. move canvas until no shapes are visible
3. the "back to content" button should be visible 
4. press `tab` key
5. the "move focus to canvas" button is visible
6. hovering the "move focus to canvas" button does not display the "back to content" button

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed the flickering "back to content" button occuring when both the "back to content" + "move focus" are visible