### PR TITLE
chore(ci): add vouch trust system for contributor gating

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,19 @@
+# Vouched contributors for the tldraw repository.
+#
+# Vouched users can open issues and pull requests.
+# Denounced users (prefixed with -) are blocked.
+#
+# Maintainers can vouch for users by commenting "vouch" or "vouch @user"
+# on any issue or PR. To denounce: "denounce" or "denounce @user".
+#
+# One handle per line (without @), sorted alphabetically.
+
+AniKrisn
+angrycaptain19
+ds300
+kaneel
+kostyafarber
+max-drake
+mimecuvalo
+MitjaBezensek
+steveruizok

--- a/.github/workflows/issue-vouch.yml
+++ b/.github/workflows/issue-vouch.yml
@@ -1,0 +1,20 @@
+name: Issue Vouch
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-issue@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -1,0 +1,73 @@
+name: PR Vouch
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+  push:
+    branches: [main]
+    paths:
+      - .github/VOUCHED.td
+      - .github/workflows/pr-vouch.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  collect-targets:
+    name: Collect PR targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.collect.outputs.targets }}
+    steps:
+      - id: collect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === "pull_request_target") {
+              const pr = context.payload.pull_request;
+              core.setOutput("targets", JSON.stringify([{ number: pr.number }]));
+              return;
+            }
+
+            if (context.eventName === "issue_comment") {
+              const issue = context.payload.issue;
+              const body = context.payload.comment?.body ?? "";
+              if (!issue?.pull_request || !body.includes("/recheck-vouch")) {
+                core.setOutput("targets", "[]");
+                return;
+              }
+              core.setOutput("targets", JSON.stringify([{ number: issue.number }]));
+              return;
+            }
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const targets = pulls.map((pull) => ({ number: pull.number }));
+            core.setOutput("targets", JSON.stringify(targets));
+
+  check:
+    name: Check PR ${{ matrix.target.number }}
+    needs: collect-targets
+    if: ${{ needs.collect-targets.outputs.targets != '[]' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-vouch-${{ matrix.target.number }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.collect-targets.outputs.targets) }}
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ matrix.target.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -1,0 +1,28 @@
+name: Vouch Management
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-issue@v1
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Integrate [mitchellh/vouch](https://github.com/mitchellh/vouch) to manage contributor trust via a `VOUCHED.td` file and GitHub Actions. PRs and issues from unvouched or denounced users are auto-closed. Maintainers can vouch for or denounce users by commenting on any issue or PR.

related to https://github.com/tldraw/tldraw/issues/7695

### Change type

- [x] `other`

### Test plan

- These are CI workflows that can only be fully tested once merged and triggered by real GitHub events.
- Verify workflows parse correctly by reviewing the YAML.
- After merge, test by having an unvouched user open a test issue or PR and confirming it is auto-closed.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +140 / -0  |
