### PR TITLE
test(arrows): add tests for NaN propagation fix in zero-length arrows

### DIFF
--- a/packages/editor/src/lib/primitives/Box.test.ts
+++ b/packages/editor/src/lib/primitives/Box.test.ts
@@ -728,4 +728,34 @@ describe('Box', () => {
 			expect(result).not.toBe(zeroBox) // different object
 		})
 	})
+
+	describe('Box.isValid', () => {
+		it('returns true for normal box', () => {
+			expect(new Box(10, 20, 100, 200).isValid()).toBe(true)
+		})
+
+		it('returns false when x is NaN', () => {
+			expect(new Box(NaN, 0, 100, 100).isValid()).toBe(false)
+		})
+
+		it('returns false when y is NaN', () => {
+			expect(new Box(0, NaN, 100, 100).isValid()).toBe(false)
+		})
+
+		it('returns false when w is NaN', () => {
+			expect(new Box(0, 0, NaN, 100).isValid()).toBe(false)
+		})
+
+		it('returns false when h is NaN', () => {
+			expect(new Box(0, 0, 100, NaN).isValid()).toBe(false)
+		})
+
+		it('returns false for Infinity', () => {
+			expect(new Box(Infinity, 0, 100, 100).isValid()).toBe(false)
+		})
+
+		it('returns true for zero-sized box', () => {
+			expect(new Box(0, 0, 0, 0).isValid()).toBe(true)
+		})
+	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.test.ts
@@ -1,5 +1,6 @@
 import { Mat } from '../Mat'
 import { Vec, VecLike } from '../Vec'
+import { Edge2d } from './Edge2d'
 import { Geometry2dFilters } from './Geometry2d'
 import { Group2d } from './Group2d'
 import { Rectangle2d } from './Rectangle2d'
@@ -453,6 +454,26 @@ describe('Group2d getBoundsVertices', () => {
 
 		const boundsVertices = group.getBoundsVertices()
 		expect(boundsVertices).toEqual([])
+	})
+})
+
+describe('interpolateAlongEdge', () => {
+	it('returns vertex when segment has zero length', () => {
+		const edge = new Edge2d({ start: new Vec(5, 5), end: new Vec(5, 5) })
+		const result = edge.interpolateAlongEdge(0.5)
+		expect(result.x).toBe(5)
+		expect(result.y).toBe(5)
+		expect(Number.isFinite(result.x)).toBe(true)
+		expect(Number.isFinite(result.y)).toBe(true)
+	})
+})
+
+describe('uninterpolateAlongEdge', () => {
+	it('returns 0 when geometry has zero length', () => {
+		const edge = new Edge2d({ start: new Vec(5, 5), end: new Vec(5, 5) })
+		const result = edge.uninterpolateAlongEdge(new Vec(5, 5))
+		expect(result).toBe(0)
+		expect(Number.isFinite(result)).toBe(true)
 	})
 })
 

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -925,3 +925,66 @@ describe('When a bound shape is clipped by a frame', () => {
 		expect(endPagePoint.x).toBeGreaterThan(190)
 	})
 })
+
+describe('Zero-length arrows', () => {
+	it('reports isValid false', () => {
+		const id = createShapeId('zero-arrow')
+		editor.createShapes([
+			{
+				id,
+				type: 'arrow',
+				x: 0,
+				y: 0,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 0, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(id) as TLArrowShape
+		const info = getArrowInfo(editor, shape)
+		expect(info!.isValid).toBe(false)
+	})
+
+	it('with label does not produce NaN page bounds', () => {
+		const id = createShapeId('zero-label-arrow')
+		editor.createShapes([
+			{
+				id,
+				type: 'arrow',
+				x: 0,
+				y: 0,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 0, y: 0 },
+					richText: toRichText('Label'),
+				},
+			},
+		])
+		const bounds = editor.getShapePageBounds(id)
+		if (bounds) {
+			expect(bounds.isValid()).toBe(true)
+		}
+	})
+
+	it('with label does not corrupt spatial index', () => {
+		const geoId = createShapeId('geo-for-spatial')
+		const arrowId = createShapeId('zero-spatial-arrow')
+		editor.createShapes([
+			{ id: geoId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{
+				id: arrowId,
+				type: 'arrow',
+				x: 200,
+				y: 200,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 0, y: 0 },
+					richText: toRichText('Label'),
+				},
+			},
+		])
+		const shapesAtPoint = editor.getShapesAtPoint({ x: 50, y: 50 }, { hitInside: true })
+		expect(shapesAtPoint.some((s) => s.id === geoId)).toBe(true)
+	})
+})


### PR DESCRIPTION
Adds unit tests for the zero-length labeled arrow NaN propagation fix from #8329. Tests cover the three guard areas: geometry interpolation, spatial index insertion (via `Box.isValid`), and arrow label computation.

Relates to #8329

### Change type

- [x] `other`

### Test plan

1. Run `cd packages/editor && yarn test run -t "interpolateAlongEdge|uninterpolateAlongEdge|Box.isValid"`
2. Run `cd packages/tldraw && yarn test run -t "Zero-length"`

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +114 / -0  |