### PR TITLE
[HOTFIX] fix(arrows): prevent NaN propagation from zero-length labeled arrows

### DIFF
--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -74,7 +74,7 @@ export class SpatialIndexManager {
 		// Collect all shape elements for bulk loading
 		for (const shape of shapes) {
 			const bounds = this.editor.getShapePageBounds(shape.id)
-			if (bounds) {
+			if (bounds && bounds.isValid()) {
 				elements.push({
 					minX: bounds.minX,
 					minY: bounds.minY,
@@ -101,7 +101,7 @@ export class SpatialIndexManager {
 			for (const shape of objectMapValues(changes.added) as TLShape[]) {
 				if (isShape(shape) && this.editor.getAncestorPageId(shape) === this.lastPageId) {
 					const bounds = this.editor.getShapePageBounds(shape.id)
-					if (bounds) {
+					if (bounds && bounds.isValid()) {
 						this.rbush.upsert(shape.id, bounds)
 					}
 					processedShapeIds.add(shape.id)
@@ -125,7 +125,7 @@ export class SpatialIndexManager {
 
 				if (isOnPage) {
 					const bounds = this.editor.getShapePageBounds(to.id)
-					if (bounds) {
+					if (bounds && bounds.isValid()) {
 						this.rbush.upsert(to.id, bounds)
 					}
 				} else {
@@ -145,7 +145,7 @@ export class SpatialIndexManager {
 			const indexedBounds = this.rbush.getBounds(shapeId)
 
 			if (!this.areBoundsEqual(currentBounds, indexedBounds)) {
-				if (currentBounds) {
+				if (currentBounds && currentBounds.isValid()) {
 					this.rbush.upsert(shapeId, currentBounds)
 				} else {
 					this.rbush.remove(shapeId)

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -191,6 +191,7 @@ export abstract class Geometry2d {
 			const dist = Vec.Dist(curr, next)
 			const newDistanceTraveled = distanceTraveled + dist
 			if (newDistanceTraveled >= distanceToTravel) {
+				if (dist === 0) return curr
 				const p = Vec.Lrp(
 					curr,
 					next,
@@ -241,7 +242,7 @@ export abstract class Geometry2d {
 		const distanceAlongRoute =
 			closestSegment.distanceToStart + Vec.Dist(closestSegment.start, closestSegment.nearestPoint)
 
-		return distanceAlongRoute / length
+		return length === 0 ? 0 : distanceAlongRoute / length
 	}
 
 	isPointInBounds(point: VecLike, margin = 0) {

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -221,7 +221,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 					: new Polyline2d({ points: info.route.points })
 
 		let labelGeom
-		if (isEditing || !isEmptyRichText(shape.props.richText)) {
+		if (info.isValid && (isEditing || !isEmptyRichText(shape.props.richText))) {
 			const labelPosition = getArrowLabelPosition(this.editor, shape, isEditing)
 			if (debugFlags.debugGeometry.get()) {
 				debugGeom.push(...labelPosition.debugGeom)


### PR DESCRIPTION
Cherry-pick of #8329 to `hotfixes` for dotcom deployment.

When arrow endpoints overlap exactly (same position), the arrow has zero length. If that arrow has a label, NaN values propagate through geometry → spatial index → culling, causing all shapes on the canvas to disappear.

### Change type

- [x] `bugfix`

### Test plan

1. Enable "always snap" in user preferences
2. Create an arrow and add a label to it
3. Drag one endpoint to overlap the other (snap to same grid point)
4. Verify other shapes on canvas remain visible

### Release notes

- Fix all shapes disappearing when a labeled arrow has zero length (e.g. when both endpoints overlap)

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -4    |