### PR TITLE
fix build script

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -71,6 +71,7 @@
 		"@types/qrcode": "^1.5.5",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
+		"@types/regexgen": "^1",
 		"@vitejs/plugin-react": "^6.0.1",
 		"dotenv": "^16.4.7",
 		"fast-glob": "^3.3.3",
@@ -79,6 +80,7 @@
 		"kysely": "^0.28.12",
 		"lazyrepo": "0.0.0-alpha.27",
 		"pg": "^8.13.1",
+		"regexgen": "^1.3.0",
 		"vite": "^8.0.1",
 		"vitest": "^3.2.4",
 		"ws": "^8.18.0"

--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -3,6 +3,8 @@ import { T } from '@tldraw/validate'
 import { config } from 'dotenv'
 import glob from 'fast-glob'
 import json5 from 'json5'
+import _ from 'lodash'
+import regexgen from 'regexgen'
 import { exec } from '../../../../internal/scripts/lib/exec'
 import { nicelog } from '../../../../internal/scripts/lib/nicelog'
 import { csp } from '../src/utils/csp'
@@ -46,7 +48,7 @@ async function build() {
 	// make sure we have the latest routes
 	await exec('yarn', ['test', 'src/routes.test.tsx'])
 	const spaRoutes = loadSpaRoutes()
-	await exec('vite', ['build', '--emptyOutDir'])
+	await exec('../../../node_modules/.bin/vite', ['build', '--emptyOutDir'])
 	await exec('yarn', ['run', '-T', 'sentry-cli', 'sourcemaps', 'inject', 'dist/assets'])
 	// Clear output static folder (in case we are running locally and have already built the app once before)
 	await exec('rm', ['-rf', '.vercel/output'])
@@ -90,17 +92,10 @@ async function build() {
 	writeFileSync('.vercel/output/static/index.html', newIndex)
 
 	const multiplayerServerUrl = getMultiplayerServerURL() ?? 'http://localhost:8787'
-	const assetExtensions = [
-		...new Set(
-			assetsList
-				.filter((f) => !f.endsWith('.js.map') && f.includes('.'))
-				.map((f) => f.split('.').pop()!)
-		),
-	]
-	if (assetExtensions.length === 0) {
-		throw new Error('No asset extensions found in dist/assets')
-	}
-	const assetsToCacheRegex = `^\\/assets\\/.+\\.(${assetExtensions.join('|')})$`
+
+	const assetsToCache = assetsList.filter((f) => !f.endsWith('.js.map')).map((f) => `/assets/${f}`)
+	// need to batch these because Vercel's route limit is 4096 characters
+	const assetsBatches = _.chunk(assetsToCache, 50)
 
 	writeFileSync(
 		'.vercel/output/config.json',
@@ -125,12 +120,12 @@ async function build() {
 					},
 					// cache static assets immutably. we match by extension to avoid exceeding
 					// Vercel's 4096-char route limit (see #8286).
-					{
-						src: assetsToCacheRegex,
+					...assetsBatches.map((batch) => ({
+						src: `^${regexgen(batch).source}$`,
 						headers: {
 							'Cache-Control': 'public, max-age=31536000, immutable',
 						},
-					},
+					})),
 					// server up index.html specifically because we want to include
 					// security headers. otherwise, it goes to the handle: 'miss'
 					// part below (and _not_ to the spaRoutes as maybe expected!)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12618,6 +12618,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/regexgen@npm:^1":
+  version: 1.3.3
+  resolution: "@types/regexgen@npm:1.3.3"
+  checksum: 10/aa95eeb89adc724edc9babf5d2b68d512ae09f1c8fb633997ae03fedfc09c30a5ea00a4bba3919a5e3f1ba02ec379e2e1ca3e147d99d05f38858ff477cb87855
+  languageName: node
+  linkType: hard
+
 "@types/retry@npm:*":
   version: 0.12.5
   resolution: "@types/retry@npm:0.12.5"
@@ -17100,6 +17107,7 @@ __metadata:
     "@types/qrcode": "npm:^1.5.5"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
+    "@types/regexgen": "npm:^1"
     "@vitejs/plugin-react": "npm:^6.0.1"
     axe-core: "npm:^4.10.3"
     browser-fs-access: "npm:^0.35.0"
@@ -17124,6 +17132,7 @@ __metadata:
     react-intl: "npm:^8.1.3"
     react-markdown: "npm:^10.1.0"
     react-router-dom: "npm:^6.28.2"
+    regexgen: "npm:^1.3.0"
     tldraw: "workspace:*"
     vite: "npm:^8.0.1"
     vitest: "npm:^3.2.4"
@@ -21127,6 +21136,15 @@ __metadata:
     canvas:
       optional: true
   checksum: 10/e6bf7250ddd2fbcf68da0ea041a0dc63545dc4bf77fa3ff40a46ae45b1dac1ca55b87574ab904d1f8baeeb547c52cec493a22f545d7d413b320011f41150ec49
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^2.3.0":
+  version: 2.5.2
+  resolution: "jsesc@npm:2.5.2"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 10/d2096abdcdec56969764b40ffc91d4a23408aa2f351b4d1c13f736f25476643238c43fdbaf38a191c26b1b78fd856d965f5d4d0dde7b89459cd94025190cdf13
   languageName: node
   linkType: hard
 
@@ -26585,6 +26603,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerate@npm:^1.3.2":
+  version: 1.4.2
+  resolution: "regenerate@npm:1.4.2"
+  checksum: 10/dc6c95ae4b3ba6adbd7687cafac260eee4640318c7a95239d5ce847d9b9263979758389e862fe9c93d633b5792ea4ada5708df75885dc5aa05a309fa18140a87
+  languageName: node
+  linkType: hard
+
 "regex-recursion@npm:^5.1.1":
   version: 5.1.1
   resolution: "regex-recursion@npm:5.1.1"
@@ -26608,6 +26633,18 @@ __metadata:
   dependencies:
     regex-utilities: "npm:^2.3.0"
   checksum: 10/956d0f34afa8086551dc9a0e2c575cb6d7ed5122d6d440a72cfbcd1f9adb5a3dcce4dcb61ec69eaecfcbc508cfd25075ac60d011bab5f28f1b2a36220e09a245
+  languageName: node
+  linkType: hard
+
+"regexgen@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "regexgen@npm:1.3.0"
+  dependencies:
+    jsesc: "npm:^2.3.0"
+    regenerate: "npm:^1.3.2"
+  bin:
+    regexgen: bin/cli.js
+  checksum: 10/b23d4b743e8f7312db4622e3384b86dc0fac3a2dcc1f4a4daa70b678b4ee817e9a5cf22d2634576aca213306525b44ef23678d0b1d44cc42f95acdacc44b3c5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
we were compiling too many asset urls into a single pattern to match against for our assets caching rules. this splits them up into multiple rules

kudos @MitjaBezensek 

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
