### PR TITLE
fix(discord): stop redacting HTTP/HTTPS URLs in deploy notifications

### DIFF
--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -13,7 +13,7 @@ function sanitizeVariables(errorOutput: string): string {
 
 	// Sanitize connection strings (postgres://, redis://, etc.)
 	sanitized = sanitized.replace(
-		/\b(postgres|postgresql|mysql|redis|mongodb|amqp|https?):\/\/[^\s"']+/gi,
+		/\b(postgres|postgresql|mysql|redis|mongodb|amqp):\/\/[^\s"']+/gi,
 		'$1://`***`'
 	)
 


### PR DESCRIPTION
The `sanitizeVariables()` connection-string regex included `https?` alongside database protocols, causing all HTTP/HTTPS URLs (GitHub PR links, worker URLs) to be redacted to `https://***` in Discord deploy notifications. This PR removes `https?` from that regex so only actual database connection strings are sanitized.

Actual secrets (`postgres://` connection strings) are still covered by both the `KEY=VALUE` regex and the remaining connection-string protocols.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy a change and verify Discord notification contains clickable GitHub PR link

### Release notes

- Fix Discord deploy notifications redacting GitHub links

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +1 / -1    |