### PR TITLE
fix(dotcom): match mermaid fences with balanced backticks

### DIFF
--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
@@ -95,6 +95,20 @@ describe('simpleMermaidStringTest', () => {
 			const text = '```mermaid\n%%{init: {"theme":"dark"}}%%\nflowchart LR\n  A --> B\n```'
 			expect(simpleMermaidStringTest(text)).toBe(true)
 		})
+
+		it('does not consume later non-mermaid fences in the same paste', () => {
+			const text = [
+				'```mermaid',
+				'flowchart TD',
+				'  A --> B',
+				'```',
+				'',
+				'```javascript',
+				'const x = 1',
+				'```',
+			].join('\n')
+			expect(simpleMermaidStringTest(text)).toBe(true)
+		})
 	})
 
 	describe('negative cases', () => {
@@ -127,6 +141,11 @@ describe('simpleMermaidStringTest', () => {
 			const text = '```javascript\nconst x = 1\n```'
 			expect(simpleMermaidStringTest(text)).toBe(false)
 		})
+
+		it('rejects a fence label that is not lowercase mermaid', () => {
+			const text = '```MERMAID\npie\n  "A" : 1\n```'
+			expect(simpleMermaidStringTest(text)).toBe(false)
+		})
 	})
 })
 
@@ -149,5 +168,35 @@ describe('stripMarkdownMermaidFence', () => {
 	it('handles extra backticks', () => {
 		const text = '````mermaid\ngantt\n  title Plan\n````'
 		expect(stripMarkdownMermaidFence(text)).toBe('gantt\n  title Plan')
+	})
+
+	it('stops at the first closing fence when more blocks follow', () => {
+		const text = [
+			'```mermaid',
+			'flowchart TD',
+			'  A --> B',
+			'```',
+			'',
+			'# More',
+			'',
+			'```js',
+			'x',
+			'```',
+		].join('\n')
+		expect(stripMarkdownMermaidFence(text)).toBe('flowchart TD\n  A --> B')
+	})
+
+	it('does not close on a shorter inner fence than the opening run', () => {
+		const text = ['````mermaid', 'flowchart TD', '  A --> B', '```', '  note text', '````'].join(
+			'\n'
+		)
+		expect(stripMarkdownMermaidFence(text)).toBe(
+			['flowchart TD', '  A --> B', '```', '  note text'].join('\n')
+		)
+	})
+
+	it('handles CRLF line endings in the fence', () => {
+		const text = '```mermaid\r\nflowchart TD\r\n  A --> B\r\n```'
+		expect(stripMarkdownMermaidFence(text)).toBe('flowchart TD\r\n  A --> B')
 	})
 })

--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
@@ -16,9 +16,13 @@ const DIAGRAM_KEYWORD_REGEX =
 	/^\s*(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|gitGraph|mindmap|timeline|sankey|xychart|block|quadrantChart|requirement|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|packet|kanban|architecture|treemap|radar|info)/
 
 /**
- * Captures the inner content of a mermaid code blog marked by ```mermaid
+ * Leading ```mermaid (or longer run) fence, closed by the first line that ends
+ * the same run length (CommonMark-style: inner shorter ``` lines do not close a
+ * longer fence). Trailing markdown after the block is allowed so multi-block
+ * pastes do not pull in later fences. Group 1 = fence run, group 2 = diagram body.
  */
-const MARKDOWN_MERMAID_FENCE_REGEX = /^\s*```+\s*mermaid\s*\n([\s\S]*?)\n\s*```+\s*$/
+const MARKDOWN_MERMAID_FENCE_REGEX =
+	/^\s*(```+)\s*mermaid\s*\r?\n([\s\S]*?)\r?\n\s*\1\s*(?:[\s\S]*)$/
 
 /**
  * Strip mermaid boilerplate (frontmatter, directives, comments) so only the
@@ -34,7 +38,7 @@ function stripMermaidBoilerplate(text: string): string {
 
 export function stripMarkdownMermaidFence(text: string): string {
 	const match = text.match(MARKDOWN_MERMAID_FENCE_REGEX)
-	return match ? match[1] : text
+	return match ? match[2] : text
 }
 
 export function simpleMermaidStringTest(text: string): boolean {


### PR DESCRIPTION
Use the same fence length for open and close (via a backreference) so inner ``` lines do not end a longer fence. Allow trailing markdown after the first closed block so multi-fence pastes are not merged into one body. Support CRLF and a case-insensitive mermaid info string; add tests.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests