### PR TITLE
fix(docs): exclude next.mdx from llms-releases.txt

### DIFF
--- a/apps/docs/scripts/lib/generateLllmsTxt.ts
+++ b/apps/docs/scripts/lib/generateLllmsTxt.ts
@@ -28,7 +28,7 @@ async function getMarkdownForOverview(db: DbType) {
 
 	const features = await db.all('SELECT * FROM articles WHERE sectionId = "sdk-features"')
 	const releases = await db.all(
-		'SELECT * FROM articles WHERE sectionId = "releases" ORDER BY id DESC'
+		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY id DESC`
 	)
 	const examples = await db.all('SELECT * FROM articles WHERE sectionId = "examples"')
 
@@ -71,7 +71,7 @@ async function getMarkdownForDocs(db: DbType) {
 async function getMarkdownForReleases(db: DbType) {
 	let result = `# tldraw SDK releases\n`
 	const releases = await db.all(
-		'SELECT * FROM articles WHERE sectionId = "releases" ORDER BY id DESC'
+		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY id DESC`
 	)
 
 	for (const release of releases) {


### PR DESCRIPTION
In order to prevent unreleased draft release notes from appearing in the LLM text files, this PR filters out the `next` article from the SQL queries in `getMarkdownForReleases()` and `getMarkdownForOverview()`. Closes #8365

### Change type

- [x] `bugfix`

### Test plan

1. Build the docs site and verify `llms-releases.txt` no longer contains the "Next release" article
2. Verify `llms.txt` overview no longer lists the "Next release" link
3. Verify `llms-full.txt` no longer contains the "Next release" content

### Release notes

- Fix llms-releases.txt including unreleased draft release notes from next.mdx

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +2 / -2    |