### PR TITLE
chore(tldraw): update hotkeys-js from v3 to v4

### DIFF
--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -63,7 +63,7 @@
 		"@tldraw/editor": "workspace:*",
 		"@tldraw/store": "workspace:*",
 		"classnames": "^2.5.1",
-		"hotkeys-js": "^3.13.9",
+		"hotkeys-js": "^4.0.2",
 		"idb": "^7.1.1",
 		"lz-string": "^1.5.0",
 		"radix-ui": "^1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19914,10 +19914,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hotkeys-js@npm:^3.13.9":
-  version: 3.13.9
-  resolution: "hotkeys-js@npm:3.13.9"
-  checksum: 10/452bf1763276bca14fad0d61c9374896f69606998dcef685c68729486cc19a59090d7902785e78e75bbf002025f6e3c7ef18dd1c10b9c5bec6b930b2e0b6e4d2
+"hotkeys-js@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "hotkeys-js@npm:4.0.2"
+  checksum: 10/76fdcff36899d3bf7abc5d9431fa5d404daccd81159eb8efd112480f403ca328ec471c636893150072228d60683b893450784454624af6fb77b1f0da7b4f377b
   languageName: node
   linkType: hard
 
@@ -29340,7 +29340,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     chokidar-cli: "npm:^3.0.0"
     classnames: "npm:^2.5.1"
-    hotkeys-js: "npm:^3.13.9"
+    hotkeys-js: "npm:^4.0.2"
     idb: "npm:^7.1.1"
     lazyrepo: "npm:0.0.0-alpha.27"
     lz-string: "npm:^1.5.0"


### PR DESCRIPTION
In order to stay current with the hotkeys-js library and pick up improvements to keyboard layout handling, this PR updates hotkeys-js from ^3.13.9 to ^4.0.2.

The v4 release includes a TypeScript rewrite, layout-independent hotkey handling improvements, and a fix for stuck keys on fullscreen changes. No code changes were needed — the API is backwards compatible.

Relates to #8250

### Change type

- [x] `improvement`

### Test plan

- All existing tests pass (2186 in tldraw package)
- Typecheck passes with no errors

- [x] Unit tests

### Release notes

- Update hotkeys-js keyboard shortcut library from v3 to v4.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +1 / -1   |
| Config/tooling | +5 / -5   |