### PR TITLE
fix(docs): statically generate all docs pages at build time

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -15,6 +15,13 @@ import { cn } from '@/utils/cn'
 import { db } from '@/utils/ContentDatabase'
 import { parseMarkdown } from '@/utils/parse-markdown'
 
+export async function generateStaticParams() {
+	const paths = await db.getAllPaths()
+	return paths.map((path) => ({ slug: path.replace(/^\//, '').split('/') }))
+}
+
+export const dynamicParams = false
+
 export async function generateMetadata(props: {
 	params: Promise<{ slug: string | string[] }>
 }): Promise<Metadata> {
@@ -32,7 +39,6 @@ export async function generateMetadata(props: {
 	}
 	return metadata
 }
-export const dynamicParams = true
 
 export default async function Page(props: { params: Promise<{ slug: string | string[] }> }) {
 	const params = await props.params


### PR DESCRIPTION
In order to fix production timeouts on reference and other docs pages, this PR switches from on-demand SSR to static generation at build time.

The docs site was using `dynamicParams = true` with no `generateStaticParams`, meaning every page was rendered server-side on each request by querying a SQLite database. This caused timeouts in production, particularly on reference pages. This PR adds `generateStaticParams()` to pre-render all pages at build time and sets `dynamicParams = false` so unknown paths return 404 instead of attempting runtime SSR.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn build-docs` and verify all pages are statically generated
2. Visit reference pages and confirm they load without timeouts

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix docs site timeouts by statically generating all pages at build time.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +7 / -1    |