### PR TITLE
fix(arrows): cherry-pick crash fix for degenerate curved arrows

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -5003,6 +5003,8 @@ export class Vec {
     // (undocumented)
     static FromArray(v: number[]): Vec;
     // (undocumented)
+    static IsFinite(A: VecLike): boolean;
+    // (undocumented)
     static IsNaN(A: VecLike): boolean;
     // (undocumented)
     static Len(A: VecLike): number;

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -476,6 +476,10 @@ export class Vec {
 		return isNaN(A.x) || isNaN(A.y)
 	}
 
+	static IsFinite(A: VecLike): boolean {
+		return Number.isFinite(A.x) && Number.isFinite(A.y)
+	}
+
 	/**
 	 * Get the angle from position A to position B.
 	 */

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -17,7 +17,6 @@ import {
 	approximately,
 	arrowBindingMigrations,
 	arrowBindingProps,
-	assert,
 	getIndexAbove,
 	getIndexBetween,
 	intersectLineSegmentCircle,
@@ -235,8 +234,14 @@ export function updateArrowTerminal({
 		throw new Error('expected arrow info')
 	}
 
-	const startPoint = useHandle ? info.start.handle : info.start.point
-	const endPoint = useHandle ? info.end.handle : info.end.point
+	const startPoint = getValidTerminalPoint(
+		useHandle ? info.start.handle : info.start.point,
+		arrow.props.start
+	)
+	const endPoint = getValidTerminalPoint(
+		useHandle ? info.end.handle : info.end.point,
+		arrow.props.end
+	)
 	const point = terminal === 'start' ? startPoint : endPoint
 
 	const update = {
@@ -251,30 +256,58 @@ export function updateArrowTerminal({
 	// fix up the bend:
 	if (info.type === 'arc') {
 		// find the new start/end points of the resulting arrow
-		const newStart = terminal === 'start' ? startPoint : info.start.handle
-		const newEnd = terminal === 'end' ? endPoint : info.end.handle
+		const newStart =
+			terminal === 'start'
+				? startPoint
+				: getValidTerminalPoint(info.start.handle, arrow.props.start)
+		const newEnd =
+			terminal === 'end' ? endPoint : getValidTerminalPoint(info.end.handle, arrow.props.end)
 		const newMidPoint = Vec.Med(newStart, newEnd)
+		const arrowDirection = Vec.Sub(newStart, newEnd)
+		if (approximately(Vec.Len2(arrowDirection), 0)) {
+			editor.updateShape(update)
+			if (unbind) {
+				removeArrowBinding(editor, arrow, terminal)
+			}
+			return
+		}
 
 		// intersect a line segment perpendicular to the new arrow with the old arrow arc to
 		// find the new mid-point
-		const lineSegment = Vec.Sub(newStart, newEnd)
+		const lineSegment = arrowDirection
 			.per()
 			.uni()
 			.mul(info.handleArc.radius * 2 * Math.sign(arrow.props.bend))
+		const targetPoint = Vec.Add(newMidPoint, lineSegment)
+		if (
+			!Vec.IsFinite(info.handleArc.center) ||
+			!Number.isFinite(info.handleArc.radius) ||
+			!Vec.IsFinite(targetPoint)
+		) {
+			editor.updateShape(update)
+			if (unbind) {
+				removeArrowBinding(editor, arrow, terminal)
+			}
+			return
+		}
 
 		// find the intersections with the old arrow arc:
 		const intersections = intersectLineSegmentCircle(
 			info.handleArc.center,
-			Vec.Add(newMidPoint, lineSegment),
+			targetPoint,
 			info.handleArc.center,
 			info.handleArc.radius
 		)
 
-		assert(intersections?.length === 1)
-		const bend = Vec.Dist(newMidPoint, intersections[0]) * Math.sign(arrow.props.bend)
-		// use `approximately` to avoid endless update loops
-		if (!approximately(bend, update.props.bend)) {
-			update.props.bend = bend
+		if (intersections?.length) {
+			const intersection = intersections.reduce((closest, candidate) =>
+				Vec.Dist2(candidate, targetPoint) < Vec.Dist2(closest, targetPoint) ? candidate : closest
+			)
+			const bend = Vec.Dist(newMidPoint, intersection) * Math.sign(arrow.props.bend)
+			// use `approximately` to avoid endless update loops
+			if (!approximately(bend, update.props.bend)) {
+				update.props.bend = bend
+			}
 		}
 	}
 
@@ -282,4 +315,11 @@ export function updateArrowTerminal({
 	if (unbind) {
 		removeArrowBinding(editor, arrow, terminal)
 	}
+}
+
+function getValidTerminalPoint(
+	point: { x: number; y: number },
+	fallback: { x: number; y: number }
+) {
+	return Vec.From(Vec.IsFinite(point) ? point : fallback)
 }

--- a/packages/tldraw/src/test/commands/deleteShapes.test.ts
+++ b/packages/tldraw/src/test/commands/deleteShapes.test.ts
@@ -103,6 +103,57 @@ describe('Editor.deleteShapes', () => {
 		expect(editor.getShape(ids.box3)).toBeUndefined()
 		expect(editor.getShape(ids.box4)).toBeUndefined()
 	})
+
+	it('does not crash when deleting a bent arrow and two adjacent bound shapes', () => {
+		const leftId = createShapeId('left')
+		const rightId = createShapeId('right')
+		const bentArrowId = createShapeId('bent-arrow')
+
+		editor.createShapes([
+			{ id: leftId, type: 'geo', x: 500, y: 500, props: { w: 100, h: 100 } },
+			{ id: rightId, type: 'geo', x: 600, y: 500, props: { w: 100, h: 100 } },
+			{
+				id: bentArrowId,
+				type: 'arrow',
+				x: 550,
+				y: 550,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+					bend: -120,
+				},
+			},
+		])
+
+		editor.createBindings([
+			{
+				id: createBindingId(),
+				fromId: bentArrowId,
+				toId: leftId,
+				type: 'arrow',
+				props: {
+					terminal: 'start',
+					isExact: false,
+					normalizedAnchor: { x: 1, y: 0.5 },
+					isPrecise: false,
+				},
+			},
+			{
+				id: createBindingId(),
+				fromId: bentArrowId,
+				toId: rightId,
+				type: 'arrow',
+				props: {
+					terminal: 'end',
+					isExact: false,
+					normalizedAnchor: { x: 0, y: 0.5 },
+					isPrecise: false,
+				},
+			},
+		])
+
+		expect(() => editor.deleteShapes([leftId, bentArrowId, rightId])).not.toThrow()
+	})
 })
 
 describe('When deleting arrows', () => {


### PR DESCRIPTION
In order to prevent crashes in `tldraw@4.5.x` when curved arrows have degenerate geometry, this PR cherry-picks #8176 onto the `v4.5.x` release branch. Closes #8174.

The `ArrowBindingUtil` in 4.5.4 calls `assert(intersections?.length === 1)` which can crash when curved arrow geometry becomes degenerate (e.g. during shape deletion) or when the dynamic re-export of `assert` from `@tldraw/utils` through `@tldraw/editor` isn't resolved by webpack in Next.js bundled environments. This cherry-pick removes the strict assert and replaces it with safe guards, matching what's already on `main`.

### Change type

- [x] `bugfix`

### Test plan

1. Create two adjacent shapes and draw a bent (curved) arrow between them
2. Select all three shapes and delete them — should not crash
3. Verify curved arrows still render and update correctly during normal editing

- [x] Unit tests

### API changes

- Added `Vec.IsFinite()` static method for checking if a vector has finite coordinates

### Release notes

- Fix crash when isolating curved arrows with degenerate binding geometry

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +56 / -12  |
| Tests           | +51 / -0   |
| Automated files | +2 / -0    |