### PR TITLE
refactor(editor): move createShape from AssetUtil to ShapeUtil

### DIFF
--- a/apps/examples/src/examples/data/assets/custom-asset-type/CustomAssetTypeExample.tsx
+++ b/apps/examples/src/examples/data/assets/custom-asset-type/CustomAssetTypeExample.tsx
@@ -3,6 +3,7 @@ import {
 	BaseBoxShapeUtil,
 	HTMLContainer,
 	T,
+	TLAsset,
 	TLAssetId,
 	TLBaseAsset,
 	TLShape,
@@ -89,26 +90,10 @@ class FileAssetUtil extends AssetUtil<TLFileAsset> {
 			meta: {},
 		}
 	}
-
-	// [6]
-	override createShape(asset: TLFileAsset, position: VecModel): TLShapePartial {
-		return {
-			id: createShapeId(),
-			type: FILE_CARD_TYPE,
-			x: position.x,
-			y: position.y,
-			props: {
-				assetId: asset.id,
-				w: 200,
-				h: 64,
-			},
-		}
-	}
 }
 
 // --- Custom shape to display file assets ---
 
-// [7]
 const FILE_CARD_TYPE = 'file-card' as const
 
 declare module 'tldraw' {
@@ -131,15 +116,31 @@ function formatFileSize(bytes: number): string {
 	return `${value % 1 === 0 ? value : value.toFixed(1)} ${units[i]}`
 }
 
-// [8]
+// [6]
 class FileCardShapeUtil extends BaseBoxShapeUtil<FileCardShape> {
 	static override type = FILE_CARD_TYPE
+	static override handledAssetTypes = [FILE_ASSET_TYPE] as const
 
 	override getDefaultProps() {
 		return {
 			assetId: null as TLAssetId | null,
 			w: 200,
 			h: 64,
+		}
+	}
+
+	// [7]
+	override createShapeForAsset(asset: TLAsset, position: VecModel): TLShapePartial {
+		return {
+			id: createShapeId(),
+			type: FILE_CARD_TYPE,
+			x: position.x,
+			y: position.y,
+			props: {
+				assetId: asset.id,
+				w: 200,
+				h: 64,
+			},
 		}
 	}
 
@@ -181,7 +182,7 @@ class FileCardShapeUtil extends BaseBoxShapeUtil<FileCardShape> {
 								color: 'var(--color-text-1)',
 							}}
 						>
-							{/* [9] */}
+							{/* [8] */}
 							{src ? (
 								<a
 									href={src}
@@ -209,7 +210,7 @@ class FileCardShapeUtil extends BaseBoxShapeUtil<FileCardShape> {
 	}
 }
 
-// [10]
+// [9]
 export default function CustomAssetTypeExample() {
 	const instructionText = `Drag a file with these supported extensions ${FileAssetUtil.supportedExtensions.join(', ')} onto the board`
 
@@ -240,10 +241,10 @@ export default function CustomAssetTypeExample() {
 }
 
 /*
-This example shows how to use the AssetUtil API to add support for non-media file types.
-By default, tldraw supports images, videos, and bookmarks. With a custom AssetUtil, you
-can handle any file type—like PDFs, CSVs, or text files—and display them on the canvas
-with a custom shape.
+This example shows how to use AssetUtil and ShapeUtil together to add support for
+non-media file types. By default, tldraw supports images, videos, and bookmarks.
+With a custom AssetUtil and ShapeUtil, you can handle any file type—like PDFs, CSVs,
+or text files—and display them on the canvas with a custom shape.
 
 [1]
 Define a custom asset type using TLBaseAsset. The props describe what information we
@@ -252,6 +253,7 @@ We augment TLGlobalAssetPropsMap so that TLAsset includes our custom type.
 
 [2]
 FileAssetUtil extends AssetUtil and tells the editor how to handle our custom asset type.
+It handles file-to-asset conversion and MIME type matching.
 
 [3]
 Static props define the schema validators for the asset's properties. These use
@@ -268,21 +270,18 @@ file-handling pipeline to extract metadata before upload. The src is left as nul
 because TLAssetStore.upload will provide the URL after the file is stored.
 
 [6]
-createShape returns a shape partial that the editor places on the canvas when this
-asset is created. Here we create a file-card shape that references the asset.
+FileCardShapeUtil declares handledAssetTypes to tell the editor that this shape can be
+created from file assets. It renders files as cards on the canvas.
 
 [7]
-We define a custom shape type to display file assets on the canvas. The shape has an
-assetId prop that references the file asset, plus width and height for layout.
+createShapeForAsset returns a shape partial that the editor places on the canvas when
+this asset is created. The shape util declares which asset types it handles, and the
+editor calls this method to produce the shape.
 
 [8]
-FileCardShapeUtil renders the file as a card showing the filename, size, and a download
-link. It reads the asset from the editor's store to get the file metadata.
-
-[9]
 If the asset has a src URL, the filename becomes a clickable download link.
 
-[10]
+[9]
 We pass both the custom AssetUtil and ShapeUtil to the Tldraw component. The assetUtils
 prop registers our FileAssetUtil alongside the default image, video, and bookmark utils.
 No custom file handler is needed — the default handler automatically uses our AssetUtil

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -145,7 +145,6 @@ export abstract class AssetUtil<Asset extends TLAsset = TLAsset> {
     static configure<T extends TLAssetUtilConstructor<any, any>>(this: T, options: T extends new (...args: any[]) => {
         options: infer Options;
     } ? Partial<Options> : never): T;
-    createShape(_asset: Asset, _position: VecModel): null | TLShapePartial;
     // (undocumented)
     editor: Editor;
     getAssetFromFile(_file: File, _assetId: TLAssetId): Promise<Asset | null>;
@@ -1383,6 +1382,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getShapeUtil<S extends TLShape>(shape: S | S['type'] | TLShapePartial<S>): ShapeUtil<S>;
     // (undocumented)
     getShapeUtil<T extends ShapeUtil>(type: T extends ShapeUtil<infer R> ? R['type'] : string): T;
+    getShapeUtilForAssetType(assetType: string): ShapeUtil | undefined;
     getSharedOpacity(): SharedStyle<number>;
     getSharedStyles(): ReadonlySharedStyleMap;
     // (undocumented)
@@ -2874,6 +2874,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     static configure<T extends TLShapeUtilConstructor<any, any>>(this: T, options: T extends new (...args: any[]) => {
         options: infer Options;
     } ? Partial<Options> : never): T;
+    createShapeForAsset?(asset: TLAsset, position: VecModel): null | TLShapePartial;
     // (undocumented)
     editor: Editor;
     // @internal (undocumented)
@@ -2893,6 +2894,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     getReferencedUserIds(shape: Shape): string[];
     // (undocumented)
     getText(shape: Shape): string | undefined;
+    static handledAssetTypes?: readonly string[];
     hideInMinimap?(shape: Shape): boolean;
     hideResizeHandles(shape: Shape): boolean;
     hideRotateHandle(shape: Shape): boolean;
@@ -4545,6 +4547,8 @@ export interface TLShapeUtilCanvasSvgDef {
 export interface TLShapeUtilConstructor<T extends TLShape, U extends ShapeUtil<T> = ShapeUtil<T>> {
     // (undocumented)
     new (editor: Editor): U;
+    // (undocumented)
+    handledAssetTypes?: readonly string[];
     // (undocumented)
     migrations?: LegacyMigrations | MigrationSequence | TLPropsMigrations;
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -407,6 +407,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.shapeUtils = _shapeUtils
 		this.styleProps = _styleProps
 
+		const _shapeUtilsByAssetType = {} as Record<string, ShapeUtil<any>>
+		for (const Util of allShapeUtils) {
+			const assetTypes = Util.handledAssetTypes
+			if (assetTypes) {
+				for (const assetType of assetTypes) {
+					_shapeUtilsByAssetType[assetType] = _shapeUtils[Util.type]
+				}
+			}
+		}
+		this._shapeUtilsByAssetType = _shapeUtilsByAssetType
+
 		const allBindingUtils = checkBindings(bindingUtils)
 		const _bindingUtils = {} as Record<string, BindingUtil<any>>
 		for (const Util of allBindingUtils) {
@@ -1073,6 +1084,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	shapeUtils: { readonly [K in string]?: ShapeUtil<TLShape> }
 
+	/** @internal */
+	private _shapeUtilsByAssetType: { readonly [K in string]?: ShapeUtil<TLShape> } = {}
+
 	styleProps: { [key: string]: Map<StyleProp<any>, string> }
 
 	/**
@@ -1113,6 +1127,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 	hasShapeUtil(arg: string | { type: string }): boolean {
 		const type = typeof arg === 'string' ? arg : arg.type
 		return hasOwnProperty(this.shapeUtils, type)
+	}
+
+	/**
+	 * Get the shape util that handles the given asset type.
+	 * Returns the shape util whose {@link ShapeUtil.handledAssetTypes} includes
+	 * the given asset type, or undefined if none matches.
+	 *
+	 * @param assetType - The asset type string.
+	 * @public
+	 */
+	getShapeUtilForAssetType(assetType: string): ShapeUtil | undefined {
+		return getOwnProperty(this._shapeUtilsByAssetType, assetType)
 	}
 
 	/* ------------------- Binding Utils ------------------ */

--- a/packages/editor/src/lib/editor/assets/AssetUtil.ts
+++ b/packages/editor/src/lib/editor/assets/AssetUtil.ts
@@ -4,9 +4,7 @@ import {
 	TLAsset,
 	TLAssetId,
 	TLPropsMigrations,
-	TLShapePartial,
 	TLUnknownAsset,
-	VecModel,
 } from '@tldraw/tlschema'
 import type { Editor } from '../Editor'
 
@@ -25,8 +23,7 @@ export interface TLAssetUtilConstructor<
  * Abstract base class for defining asset-type-specific behavior.
  *
  * Each asset type (image, video, bookmark, etc.) has a corresponding AssetUtil that handles
- * type-specific operations like determining supported MIME types, creating assets from files,
- * and creating shapes from assets.
+ * type-specific operations like determining supported MIME types and creating assets from files.
  *
  * @public
  */
@@ -83,14 +80,6 @@ export abstract class AssetUtil<Asset extends TLAsset = TLAsset> {
 	 * Create an asset from a file. Return null if this asset type can't handle the file.
 	 */
 	async getAssetFromFile(_file: File, _assetId: TLAssetId): Promise<Asset | null> {
-		return null
-	}
-
-	/**
-	 * Create a shape partial for placing this asset on the canvas.
-	 * Return null if this asset type doesn't create shapes.
-	 */
-	createShape(_asset: Asset, _position: VecModel): TLShapePartial | null {
 		return null
 	}
 }

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -3,6 +3,7 @@ import { EMPTY_ARRAY } from '@tldraw/state'
 import { LegacyMigrations, MigrationSequence } from '@tldraw/store'
 import {
 	RecordProps,
+	TLAsset,
 	TLHandle,
 	TLParentId,
 	TLPropsMigrations,
@@ -11,6 +12,7 @@ import {
 	TLShapeId,
 	TLShapePartial,
 	TLUnknownShape,
+	VecModel,
 } from '@tldraw/tlschema'
 import { IndexKey } from '@tldraw/utils'
 import { ReactElement } from 'react'
@@ -31,6 +33,7 @@ export interface TLShapeUtilConstructor<T extends TLShape, U extends ShapeUtil<T
 	type: T['type']
 	props?: RecordProps<T>
 	migrations?: LegacyMigrations | TLPropsMigrations | MigrationSequence
+	handledAssetTypes?: readonly string[]
 }
 
 /**
@@ -169,11 +172,33 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	static type: string
 
 	/**
+	 * The asset types that this shape can be created from.
+	 * When a file is dropped on the canvas, the editor finds the shape util
+	 * whose `handledAssetTypes` includes the asset's type and calls
+	 * {@link ShapeUtil.createShapeForAsset} to produce the shape.
+	 *
+	 * @public
+	 */
+	static handledAssetTypes?: readonly string[]
+
+	/**
 	 * Get the default props for a shape.
 	 *
 	 * @public
 	 */
 	abstract getDefaultProps(): Shape['props']
+
+	/**
+	 * Create a shape partial for placing an asset on the canvas.
+	 * Only called for shapes whose constructor declares matching
+	 * {@link ShapeUtil.handledAssetTypes | `handledAssetTypes`}.
+	 *
+	 * @param asset - The asset to create a shape for.
+	 * @param position - Where to place the shape.
+	 * @returns A shape partial, or null if this shape can't be created for the asset.
+	 * @public
+	 */
+	createShapeForAsset?(asset: TLAsset, position: VecModel): TLShapePartial | null
 
 	/**
 	 * Get the shape's geometry.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2013,8 +2013,6 @@ export const iconTypes: readonly ["align-bottom", "align-center-horizontal", "al
 // @public (undocumented)
 export class ImageAssetUtil extends AssetUtil<TLImageAsset> {
     // (undocumented)
-    createShape(asset: TLImageAsset, position: VecLike): null | TLShapePartial;
-    // (undocumented)
     getAssetFromFile(file: File, assetId: TLAssetId): Promise<null | TLImageAsset>;
     // (undocumented)
     getDefaultProps(): TLImageAsset['props'];
@@ -2049,6 +2047,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     component(shape: TLImageShape): JSX.Element;
     // (undocumented)
+    createShapeForAsset(asset: TLAsset, position: VecModel): null | TLShapePartial;
+    // (undocumented)
     getAriaDescriptor(shape: TLImageShape): string;
     // (undocumented)
     getDefaultProps(): TLImageShape['props'];
@@ -2058,6 +2058,8 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     getIndicatorPath(shape: TLImageShape): Path2D | undefined;
     // (undocumented)
     getInterpolatedProps(startShape: TLImageShape, endShape: TLImageShape, t: number): TLImageShapeProps;
+    // (undocumented)
+    static handledAssetTypes: readonly ["image"];
     // (undocumented)
     indicator(shape: TLImageShape): JSX.Element | null;
     // (undocumented)
@@ -5732,8 +5734,6 @@ export function useUnlockedSelectedShapesCount(min?: number, max?: number): bool
 // @public (undocumented)
 export class VideoAssetUtil extends AssetUtil<TLVideoAsset> {
     // (undocumented)
-    createShape(asset: TLVideoAsset, position: VecLike): null | TLShapePartial;
-    // (undocumented)
     getAssetFromFile(file: File, assetId: TLAssetId): Promise<null | TLVideoAsset>;
     // (undocumented)
     getDefaultProps(): TLVideoAsset['props'];
@@ -5771,11 +5771,15 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
     component(shape: TLVideoShape): JSX.Element;
     // (undocumented)
+    createShapeForAsset(asset: TLAsset, position: VecModel): null | TLShapePartial;
+    // (undocumented)
     getAriaDescriptor(shape: TLVideoShape): string;
     // (undocumented)
     getDefaultProps(): TLVideoShape['props'];
     // (undocumented)
     getIndicatorPath(shape: TLVideoShape): Path2D;
+    // (undocumented)
+    static handledAssetTypes: readonly ["video"];
     // (undocumented)
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)

--- a/packages/tldraw/src/lib/assets/ImageAssetUtil.ts
+++ b/packages/tldraw/src/lib/assets/ImageAssetUtil.ts
@@ -4,9 +4,6 @@ import {
 	MediaHelpers,
 	TLAssetId,
 	TLImageAsset,
-	TLShapePartial,
-	VecLike,
-	createShapeId,
 	imageAssetMigrations,
 	imageAssetProps,
 } from '@tldraw/editor'
@@ -73,20 +70,5 @@ export class ImageAssetUtil extends AssetUtil<TLImageAsset> {
 		}
 
 		return assetInfo
-	}
-
-	override createShape(asset: TLImageAsset, position: VecLike): TLShapePartial | null {
-		return {
-			id: createShapeId(),
-			type: 'image',
-			x: position.x,
-			y: position.y,
-			opacity: 1,
-			props: {
-				assetId: asset.id,
-				w: asset.props.w,
-				h: asset.props.h,
-			},
-		}
 	}
 }

--- a/packages/tldraw/src/lib/assets/VideoAssetUtil.ts
+++ b/packages/tldraw/src/lib/assets/VideoAssetUtil.ts
@@ -3,10 +3,7 @@ import {
 	DEFAULT_SUPPORT_VIDEO_TYPES,
 	MediaHelpers,
 	TLAssetId,
-	TLShapePartial,
 	TLVideoAsset,
-	VecLike,
-	createShapeId,
 	videoAssetMigrations,
 	videoAssetProps,
 } from '@tldraw/editor'
@@ -61,21 +58,6 @@ export class VideoAssetUtil extends AssetUtil<TLVideoAsset> {
 				isAnimated: true,
 			},
 			meta: {},
-		}
-	}
-
-	override createShape(asset: TLVideoAsset, position: VecLike): TLShapePartial | null {
-		return {
-			id: createShapeId(),
-			type: 'video',
-			x: position.x,
-			y: position.y,
-			opacity: 1,
-			props: {
-				assetId: asset.id,
-				w: asset.props.w,
-				h: asset.props.h,
-			},
 		}
 	}
 }

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -667,12 +667,10 @@ export async function createShapesForAssets(
 
 	for (let i = 0; i < assets.length; i++) {
 		const asset = assets[i]
-		if (!editor.hasAssetUtil(asset)) continue
-		const assetUtil = editor.getAssetUtil(asset)
-		const partial = assetUtil.createShape(asset, currentPoint)
+		const shapeUtil = editor.getShapeUtilForAssetType(asset.type)
+		const partial = shapeUtil?.createShapeForAsset?.(asset, currentPoint) ?? null
 		if (partial) {
 			partials.push(partial)
-			// Advance x position based on asset width if available
 			if ('w' in asset.props && typeof asset.props.w === 'number') {
 				currentPoint.x += asset.props.w
 			}

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -11,12 +11,15 @@ import {
 	SvgExportContext,
 	TLAsset,
 	TLAssetId,
+	TLImageAsset,
 	TLImageShape,
 	TLImageShapeProps,
 	TLResizeInfo,
 	TLShapePartial,
 	Vec,
+	VecModel,
 	WeakCache,
+	createShapeId,
 	fetch,
 	getGlobalDocument,
 	imageShapeMigrations,
@@ -53,6 +56,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	static override type = 'image' as const
 	static override props = imageShapeProps
 	static override migrations = imageShapeMigrations
+	static override handledAssetTypes = ['image'] as const
 
 	override isAspectRatioLocked() {
 		return true
@@ -75,6 +79,22 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 			flipX: false,
 			flipY: false,
 			altText: '',
+		}
+	}
+
+	override createShapeForAsset(asset: TLAsset, position: VecModel): TLShapePartial | null {
+		const imageAsset = asset as TLImageAsset
+		return {
+			id: createShapeId(),
+			type: 'image',
+			x: position.x,
+			y: position.y,
+			opacity: 1,
+			props: {
+				assetId: imageAsset.id,
+				w: imageAsset.props.w,
+				h: imageAsset.props.h,
+			},
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -4,8 +4,12 @@ import {
 	MediaHelpers,
 	SvgExportContext,
 	TLAsset,
+	TLShapePartial,
+	TLVideoAsset,
 	TLVideoShape,
+	VecModel,
 	WeakCache,
+	createShapeId,
 	toDomPrecision,
 	useEditor,
 	useEditorComponents,
@@ -35,6 +39,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	static override type = 'video' as const
 	static override props = videoShapeProps
 	static override migrations = videoShapeMigrations
+	static override handledAssetTypes = ['video'] as const
 
 	override options: VideoShapeOptions = {
 		autoplay: true,
@@ -58,6 +63,22 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 			// Not used, but once upon a time were used to sync video state between users
 			time: 0,
 			playing: true,
+		}
+	}
+
+	override createShapeForAsset(asset: TLAsset, position: VecModel): TLShapePartial | null {
+		const videoAsset = asset as TLVideoAsset
+		return {
+			id: createShapeId(),
+			type: 'video',
+			x: position.x,
+			y: position.y,
+			opacity: 1,
+			props: {
+				assetId: videoAsset.id,
+				w: videoAsset.props.w,
+				h: videoAsset.props.h,
+			},
 		}
 	}
 


### PR DESCRIPTION
Based on [Mitja's review feedback](https://github.com/tldraw/tldraw/pull/8031#pullrequestreview-2860095803), this PR inverts the asset-to-shape creation responsibility. Instead of `AssetUtil` knowing which shape to create (`AssetUtil.createShape`), the `ShapeUtil` now declares which asset types it can be created from and handles its own creation from an asset.

Closes the feedback on #8031 regarding `createShape` direction.

### Change type

- [x] `improvement`

### What changed

**`@tldraw/editor` — `ShapeUtil` additions**
- `static handledAssetTypes?: readonly string[]` — declares which asset types a shape can be created from
- `createShapeForAsset?(asset, position)` — produces a shape partial from a matching asset
- `Editor.getShapeUtilForAssetType(assetType)` — O(1) lookup via a map built at init time

**`@tldraw/editor` — `AssetUtil` cleanup**
- Removed `createShape()` method — `AssetUtil` now focuses purely on file-to-asset conversion and MIME type handling

**`@tldraw/tldraw` — shape utils gain asset handling**
- `ImageShapeUtil` declares `handledAssetTypes = ['image']` and implements `createShapeForAsset`
- `VideoShapeUtil` declares `handledAssetTypes = ['video']` and implements `createShapeForAsset`
- `createShapesForAssets` uses `editor.getShapeUtilForAssetType()` instead of `assetUtil.createShape()`

**Example update**
- Custom asset type example moves `createShape` from `FileAssetUtil` to `FileCardShapeUtil`

### Test plan

1. `yarn typecheck` passes
2. Drop images and videos on the canvas — shapes created as before
3. Custom asset type example still works with file drops
4. Bookmark creation (via URL paste) unaffected (uses separate handler, no `createShape`)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Move shape-creation-from-asset responsibility from `AssetUtil.createShape` to `ShapeUtil.createShapeForAsset`, so shapes declare which asset types they handle rather than assets knowing which shapes they produce.

### API changes

- Added `ShapeUtil.handledAssetTypes` static property for declaring handled asset types
- Added `ShapeUtil.createShapeForAsset()` optional method for creating shapes from assets
- Added `Editor.getShapeUtilForAssetType()` for looking up shape utils by asset type
- Breaking: Removed `AssetUtil.createShape()` — use `ShapeUtil.createShapeForAsset()` instead

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +95 / -52  |
| Automated files | +13 / -5   |
| Documentation   | +31 / -32  |

Made with [Cursor](https://cursor.com)