### PR TITLE
embed: add sandbox attr to gist

### DIFF
--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -186,14 +186,28 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			typeof window !== 'undefined' && (window !== window.top || window.self !== window.parent)
 		if (isIframe && embedInfo?.definition.type === 'tldraw') return null
 
+		const sandbox = getSandboxPermissions({
+			...embedShapePermissionDefaults,
+			...(embedInfo?.definition?.overridePermissions ?? {}),
+		})
+
 		if (embedInfo?.definition.type === 'github_gist') {
 			const idFromGistUrl = embedInfo.url.split('/').pop()
 			if (!idFromGistUrl) throw Error('No gist id!')
+
+			// Gist embeds use srcDoc, so we must disable allow-same-origin. Otherwise
+			// the embedded script shares the parent's origin and can escape the sandbox.
+			const gistSandbox = getSandboxPermissions({
+				...embedShapePermissionDefaults,
+				...(embedInfo?.definition?.overridePermissions ?? {}),
+				'allow-same-origin': false,
+			})
 
 			return (
 				<HTMLContainer className="tl-embed-container" id={shape.id}>
 					<Gist
 						id={idFromGistUrl}
+						sandbox={gistSandbox}
 						width={toDomPrecision(w)!}
 						height={toDomPrecision(h)!}
 						isInteractive={isInteractive}
@@ -202,11 +216,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 				</HTMLContainer>
 			)
 		}
-
-		const sandbox = getSandboxPermissions({
-			...embedShapePermissionDefaults,
-			...(embedInfo?.definition?.overridePermissions ?? {}),
-		})
 
 		const iframeSrc = embedInfo?.embedUrl ?? url
 
@@ -289,6 +298,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 function Gist({
 	id,
+	sandbox,
 	isInteractive,
 	width,
 	height,
@@ -296,6 +306,7 @@ function Gist({
 	pageRotation,
 }: {
 	id: string
+	sandbox: string
 	isInteractive: boolean
 	width: number
 	height: number
@@ -315,6 +326,7 @@ function Gist({
 	return (
 		<iframe
 			className="tl-embed"
+			sandbox={sandbox}
 			draggable={false}
 			width={toDomPrecision(width)}
 			height={toDomPrecision(height)}


### PR DESCRIPTION
We were missing the `sandbox` attribute on Gists.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- embed: add sandbox attr to gist