### PR TITLE
fix(zero): increase production view syncer upstream connections

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -297,7 +297,7 @@ const zeroConnectionLimits = {
 	},
 	production: {
 		rm: { upstream: 1, cvr: 3, change: 5 },
-		vs: { upstream: 5, cvr: 10, change: 3 },
+		vs: { upstream: 8, cvr: 10, change: 3 },
 	},
 	// Previews use Supabase branch DB
 	preview: {


### PR DESCRIPTION
Increases production view syncer `ZERO_UPSTREAM_MAX_CONNS` from 5 to 8 to match the 8-CPU VM. Without this, zero-cache crashes on startup: `Insufficient upstream connections (5) for 7 syncers`.

### Change type

- [x] `bugfix`

### Test plan

- Deploy to production and verify view syncer starts without connection errors

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +1 / -1    |