### PR TITLE
fix(embeds): tighten iframe referrer policy to avoid leaking document URLs

### DIFF
--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -234,7 +234,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 						draggable={false}
 						// eslint-disable-next-line @typescript-eslint/no-deprecated
 						frameBorder="0"
-						referrerPolicy="no-referrer-when-downgrade"
+						referrerPolicy="strict-origin-when-cross-origin"
 						tabIndex={isEditing ? 0 : -1}
 						allowFullScreen
 						style={{
@@ -337,7 +337,7 @@ function Gist({
 			frameBorder="0"
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			scrolling="no"
-			referrerPolicy="no-referrer-when-downgrade"
+			referrerPolicy="strict-origin-when-cross-origin"
 			tabIndex={isInteractive ? 0 : -1}
 			style={{
 				...style,


### PR DESCRIPTION
In order to prevent leaking document paths (e.g. room IDs, query params) to third-party embed providers, this PR switches the `referrerPolicy` on embed iframes from `no-referrer-when-downgrade` to `strict-origin-when-cross-origin`.

Despite its name, `no-referrer-when-downgrade` sends the **full URL** (including path and query string) to any HTTPS destination. `strict-origin-when-cross-origin` sends only the **origin** (e.g. `https://tldraw.com`) for cross-origin requests, which is all embed providers need for domain allowlisting and analytics. This is also the modern browser default.

Relates to #8306, #8404

### Change type

- [x] `improvement`

### Test plan

1. Paste a known embed (YouTube, Figma, Google Maps, etc.) — should render and function normally
2. Paste an arbitrary `<iframe>` embed code — should render normally
3. Verify in DevTools Network tab that the `Referer` header sent to embed hosts contains only the origin, not the full path

### Release notes

- Tighten iframe referrer policy for embeds to avoid leaking document URLs to third-party embed providers.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -2    |

Made with [Cursor](https://cursor.com)