### PR TITLE
chore: run oxlint --fix-dangerously in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,11 @@
 	},
 	"packageManager": "yarn@4.12.0",
 	"lint-staged": {
-		"*.{js,jsx,ts,tsx,cjs,mjs,css,md,mdx,html,yml,yaml}": [
+		"*.{js,jsx,ts,tsx}": [
+			"oxlint --fix-dangerously --no-error-on-unmatched-pattern",
+			"oxfmt --write --no-error-on-unmatched-pattern"
+		],
+		"*.{cjs,mjs,css,md,mdx,html,yml,yaml}": [
 			"oxfmt --no-error-on-unmatched-pattern"
 		]
 	},


### PR DESCRIPTION
In order to catch unused imports and formatting issues before they reach CI, this PR adds `oxlint --fix-dangerously` to the lint-staged pre-commit config for JS/TS files. It runs before `oxfmt --write` so formatting stays clean after auto-fixes.

### Change type

- [x] `improvement`

### Test plan

1. Stage a file with an unused import
2. Commit — the pre-commit hook should remove the unused import and reformat
3. Verify the committed file has no unused import and is properly formatted

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +5 / -1    |