### PR TITLE
test(editor): add tests for camera state reset on dispose

### DIFF
--- a/packages/tldraw/src/test/commands/cameraState.test.ts
+++ b/packages/tldraw/src/test/commands/cameraState.test.ts
@@ -406,3 +406,19 @@ describe('getEfficientZoomLevel', () => {
 		})
 	})
 })
+
+describe('camera state on dispose', () => {
+	it('resets to idle when disposed while camera is moving', () => {
+		editor.setCamera({ x: 100, y: 100, z: 1 })
+		expect(editor.getCameraState()).toBe('moving')
+
+		editor.dispose()
+		expect(editor.getCameraState()).toBe('idle')
+	})
+
+	it('is a no-op when disposed while camera is already idle', () => {
+		expect(editor.getCameraState()).toBe('idle')
+		editor.dispose()
+		expect(editor.getCameraState()).toBe('idle')
+	})
+})


### PR DESCRIPTION
Adds unit tests for the camera state reset on dispose behavior introduced in #8396. Verifies that disposing the editor while the camera is in `'moving'` state correctly resets it to `'idle'`, and that disposing while already idle is a no-op.

### Change type

- [x] `other`

### Test plan

```bash
cd packages/tldraw && yarn test run -t "camera state on dispose"
```

- [x] Unit tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +16 / -0  |