### PR TITLE
fix(dotcom): simplify Plain thread title for feedback submissions

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/submitFeedback.ts
+++ b/apps/dotcom/sync-worker/src/routes/submitFeedback.ts
@@ -193,7 +193,7 @@ async function createPlainThread(
 		{
 			input: {
 				customerIdentifier: { customerId },
-				title: `Dotcom feedback from ${email ?? 'anonymous'}`,
+				title: 'tldraw.com feedback',
 				description: description.length > 200 ? description.slice(0, 200) + '…' : description,
 				components: [{ componentText: { text: `${description}\n\nURL: ${url}` } }],
 				...(env.PLAIN_LABEL_TYPE_ID && { labelTypeIds: [env.PLAIN_LABEL_TYPE_ID] }),


### PR DESCRIPTION
In order to make feedback thread titles more consistent and avoid leaking user emails in Plain thread titles, this PR simplifies the title from `Dotcom feedback from <email>` to a static `tldraw.com feedback`.

### Change type

- [x] `improvement`

### Test plan

- Submit feedback via tldraw.com and verify the Plain thread title is "tldraw.com feedback"

### Release notes

- Simplify feedback thread title in support system

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +1 / -1    |