### PR TITLE
fix(editor): clean up active animations, following, and menus on dispose

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1045,8 +1045,19 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	dispose() {
+		// Stop any in-progress camera animations and following before
+		// running disposables, so their cleanup listeners fire first
+		this.stopCameraAnimation()
+		if (this.getInstanceState().followingUserId) {
+			this.stopFollowingUser()
+		}
+
 		this.disposables.forEach((dispose) => dispose())
 		this.disposables.clear()
+
+		// Clear any open menus for this editor's context
+		this.menus.clearOpenMenus()
+
 		this.store.dispose()
 		this.isDisposed = true
 		this.emit('dispose')


### PR DESCRIPTION
In order to prevent stale state and leaked reactive subscriptions when editors are remounted (e.g. React strict mode, deep links), this PR adds cleanup for in-progress camera animations, user following, and open menus to `Editor.dispose()`. Relates to #8396.

Previously, if the editor was disposed while a camera animation was running, a user was being followed, or menus were open, these resources would leak:

- **Camera animations**: `stopCameraAnimation()` was never called, leaving tick listeners and `once('stop-camera-animation')` handlers attached to the EventEmitter.
- **Following user**: The `react('update current page')` reactive subscription would continue running after dispose since `stopFollowingUser()` was never called — the most significant leak, as this is a live `EffectScheduler` that keeps reacting to store changes.
- **Open menus**: Entries in the global `tlmenus` atom scoped to the disposed editor's context would persist indefinitely.

### Change type

- [x] `bugfix`

### Test plan

1. In `apps/examples/src/index.tsx`, set `ENABLE_STRICT_MODE = true`
2. Run `yarn dev`, open any example
3. Start a camera animation (e.g. zoom to fit), then quickly navigate away and back
4. Verify the editor works correctly after remount
5. Follow a user in a multiplayer room, then dispose the editor — verify no console errors from stale reactive subscriptions

- [x] Unit tests (existing tests pass — 774 editor + 2208 tldraw)

### Release notes

- Fixed leaked camera animations, following subscriptions, and stale menu state when the editor is disposed during active operations.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +11 / -0   |