### PR TITLE
chore: revert oxlint --fix-dangerously in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,11 +83,7 @@
 	},
 	"packageManager": "yarn@4.12.0",
 	"lint-staged": {
-		"*.{js,jsx,ts,tsx}": [
-			"oxlint --fix-dangerously --no-error-on-unmatched-pattern",
-			"oxfmt --write --no-error-on-unmatched-pattern"
-		],
-		"*.{cjs,mjs,css,md,mdx,html,yml,yaml}": [
+		"*.{js,jsx,ts,tsx,cjs,mjs,css,md,mdx,html,yml,yaml}": [
 			"oxfmt --no-error-on-unmatched-pattern"
 		]
 	},


### PR DESCRIPTION
Reverts #8414 which added `oxlint --fix-dangerously` to the lint-staged pre-commit hook.

### Change type

- [x] `other`

### Test plan

- [x] Pre-commit hook runs without `--fix-dangerously`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +1 / -5    |