### PR TITLE
fix(zero): increase RM connection limits to prevent storer back-pressure stalls

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -300,7 +300,7 @@ const zeroConnectionLimits = {
 		vs: { upstream: 2, cvr: 3, change: 1 },
 	},
 	production: {
-		rm: { upstream: 1, cvr: 3, change: 5 },
+		rm: { upstream: 5, cvr: 10, change: 15 },
 		vs: { upstream: 8, cvr: 10, change: 3 },
 	},
 	// Previews use Supabase branch DB


### PR DESCRIPTION
Zero's replication manager stalled in production after ~10 hours of normal operation. The Storer's back-pressure mechanism activated (83,500 queued changes, ~82MB) and never recovered, leaving the pipeline frozen with 16+ hours of replication lag.

Investigation showed the Storer's change DB writes couldn't keep up with the incoming replication stream, likely exacerbated by a transient Postgres rollback spike (5,124 rollbacks). With only 5 change DB connections and `statement_timeout=0`, the queue couldn't drain and `readyForMore()` never resolved.

This PR increases the RM's connection limits while keeping VS unchanged (was working fine):

| | Before | After | Zero default |
|---|---|---|---|
| RM upstream | 1 | 5 | 20 |
| RM cvr | 3 | 10 | 30 |
| RM change | 5 | **15** | 5 |
| VS (unchanged) | 8/10/3 | 8/10/3 | 20/30/5 |

Full investigation report: `zero-stall-investigation.md` (not committed, shared separately with Rocicorp).

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to production
2. Restart RM and monitor replication catches up
3. Watch for back-pressure warnings under load

### Release notes

- Increase Zero replication manager connection limits to prevent storer back-pressure stalls

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +1 / -1    |