### PR TITLE
[HOTFIX] fix(zero): increase RM connection limits

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -300,7 +300,7 @@ const zeroConnectionLimits = {
 		vs: { upstream: 2, cvr: 3, change: 1 },
 	},
 	production: {
-		rm: { upstream: 1, cvr: 3, change: 5 },
+		rm: { upstream: 5, cvr: 10, change: 15 },
 		vs: { upstream: 8, cvr: 10, change: 3 },
 	},
 	// Previews use Supabase branch DB


### PR DESCRIPTION
Cherry-pick of #8435. Increases Zero replication manager connection limits to prevent storer back-pressure stalls in production.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to production
2. Restart RM and monitor replication catches up