### PR TITLE
hotfix(zero): add replicator health check and statement timeout

### DIFF
--- a/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
+++ b/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
@@ -1,4 +1,5 @@
 import { createRouter, notFound } from '@tldraw/worker-shared'
+import { sql } from 'kysely'
 import { createPostgresConnectionPool } from './postgres'
 import { isDebugLogging, type Environment } from './types'
 import { getStatsDurableObjct } from './utils/durableObjects'
@@ -48,8 +49,9 @@ export const healthCheckRoutes = createRouter<Environment>()
 		}
 	})
 	.get('/health-check/db', async (_, env) => {
+		const db = createPostgresConnectionPool(env, '/health-check/db')
 		try {
-			await createPostgresConnectionPool(env, '/health-check/db')
+			await db
 				.selectFrom('user')
 				.select('name')
 				.where('email', '=', 'mitja@tldraw.com')
@@ -58,6 +60,35 @@ export const healthCheckRoutes = createRouter<Environment>()
 			return new Response('ok', { status: 200 })
 		} catch (_e) {
 			return new Response('Could not reach the database', { status: 500 })
+		} finally {
+			await db.destroy()
+		}
+	})
+	.get('/health-check/zero-replicator', async (_, env) => {
+		const db = createPostgresConnectionPool(env, '/health-check/zero-replicator')
+		try {
+			const result = await sql<{ status: string }>`
+				SELECT
+					CASE
+						WHEN write_lsn IS NULL THEN 'STALLED'
+						WHEN write_lag > interval '1 minute' THEN 'LAGGING'
+						ELSE 'HEALTHY'
+					END AS status
+				FROM pg_stat_replication
+				WHERE application_name = 'zero-replicator'
+			`.execute(db)
+			if (result.rows.length === 0) {
+				return new Response('zero-replicator not connected', { status: 500 })
+			}
+			const status = result.rows[0].status
+			if (status !== 'HEALTHY') {
+				return new Response(`zero-replicator: ${status}`, { status: 500 })
+			}
+			return new Response('ok', { status: 200 })
+		} catch (_e) {
+			return new Response('Could not check zero-replicator status', { status: 500 })
+		} finally {
+			await db.destroy()
 		}
 	})
 	.all('*', notFound)

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -669,7 +669,7 @@ async function vercelCli(command: string, args: string[], opts?: ExecOpts) {
 
 function withStatementTimeout(connString: string): string {
 	const separator = connString.includes('?') ? '&' : '?'
-	return `${connString}${separator}statement_timeout=0`
+	return `${connString}${separator}statement_timeout=1800000`
 }
 
 function updateFlyioToml(appName: string): void {


### PR DESCRIPTION
## Summary

Cherry-pick of #8437 onto `hotfixes`.

- Adds `/health-check/zero-replicator` endpoint querying `pg_stat_replication`
- Adds statement timeout to health check DB connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)