### PR TITLE
fix(vscode): exclude hotkeys-js from extension bundle

### DIFF
--- a/apps/vscode/extension/scripts/build.ts
+++ b/apps/vscode/extension/scripts/build.ts
@@ -24,6 +24,22 @@ async function build() {
 			},
 			tsconfig: './tsconfig.json',
 			external: ['vscode'],
+			plugins: [
+				{
+					name: 'exclude-hotkeys',
+					setup(build) {
+						build.onResolve({ filter: /^hotkeys-js$/ }, () => ({
+							path: 'hotkeys-js',
+							namespace: 'exclude',
+						}))
+						build.onLoad({ filter: /.*/, namespace: 'exclude' }, () => ({
+							contents:
+								'module.exports = function hotkeys() {}; module.exports.default = module.exports;',
+							loader: 'js',
+						}))
+					},
+				},
+			],
 			loader: {
 				'.woff2': 'dataurl',
 				'.woff': 'dataurl',

--- a/apps/vscode/extension/scripts/dev.ts
+++ b/apps/vscode/extension/scripts/dev.ts
@@ -30,6 +30,24 @@ async function dev() {
 			external: ['vscode'],
 			plugins: [
 				{
+					// hotkeys-js uses `module.exports = hotkeys` which clobbers the
+					// bundle's CJS exports, breaking the extension's activate export.
+					// Since it's only used by the tldraw UI (which runs in the webview,
+					// not the extension host), we replace it with an empty module.
+					name: 'exclude-hotkeys',
+					setup(build) {
+						build.onResolve({ filter: /^hotkeys-js$/ }, () => ({
+							path: 'hotkeys-js',
+							namespace: 'exclude',
+						}))
+						build.onLoad({ filter: /.*/, namespace: 'exclude' }, () => ({
+							contents:
+								'module.exports = function hotkeys() {}; module.exports.default = module.exports;',
+							loader: 'js',
+						}))
+					},
+				},
+				{
 					name: 'log-builds',
 					setup(build) {
 						build.onEnd((result) => {


### PR DESCRIPTION
Closes #8442, #8426

`hotkeys-js` uses a top-level `module.exports = hotkeys` assignment which clobbers the CJS bundle's exports object when bundled into the VS Code extension. This breaks the extension's `activate` export, preventing VS Code from activating it. Since `hotkeys-js` is only used by the tldraw UI running in the webview (not the extension host), this PR adds an esbuild plugin to replace it with a stub module during the extension build.

### Change type

- [x] `bugfix`

### Test plan

1. Open a `.tldr` file in VS Code
2. Verify the extension activates and the tldraw editor loads correctly

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix VS Code extension failing to activate due to `hotkeys-js` clobbering bundle exports

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +34 / -0   |