### PR TITLE
fix(vscode): hotfix exclude hotkeys-js from extension bundle

### DIFF
--- a/apps/vscode/extension/scripts/build.ts
+++ b/apps/vscode/extension/scripts/build.ts
@@ -24,6 +24,22 @@ async function build() {
 			},
 			tsconfig: './tsconfig.json',
 			external: ['vscode'],
+			plugins: [
+				{
+					name: 'exclude-hotkeys',
+					setup(build) {
+						build.onResolve({ filter: /^hotkeys-js$/ }, () => ({
+							path: 'hotkeys-js',
+							namespace: 'exclude',
+						}))
+						build.onLoad({ filter: /.*/, namespace: 'exclude' }, () => ({
+							contents:
+								'module.exports = function hotkeys() {}; module.exports.default = module.exports;',
+							loader: 'js',
+						}))
+					},
+				},
+			],
 			loader: {
 				'.woff2': 'dataurl',
 				'.woff': 'dataurl',

--- a/apps/vscode/extension/scripts/dev.ts
+++ b/apps/vscode/extension/scripts/dev.ts
@@ -30,6 +30,24 @@ async function dev() {
 			external: ['vscode'],
 			plugins: [
 				{
+					// hotkeys-js uses `module.exports = hotkeys` which clobbers the
+					// bundle's CJS exports, breaking the extension's activate export.
+					// Since it's only used by the tldraw UI (which runs in the webview,
+					// not the extension host), we replace it with an empty module.
+					name: 'exclude-hotkeys',
+					setup(build) {
+						build.onResolve({ filter: /^hotkeys-js$/ }, () => ({
+							path: 'hotkeys-js',
+							namespace: 'exclude',
+						}))
+						build.onLoad({ filter: /.*/, namespace: 'exclude' }, () => ({
+							contents:
+								'module.exports = function hotkeys() {}; module.exports.default = module.exports;',
+							loader: 'js',
+						}))
+					},
+				},
+				{
 					name: 'log-builds',
 					setup(build) {
 						build.onEnd((result) => {


### PR DESCRIPTION
In order to fix the VSCode extension activation failure caused by `hotkeys-js` clobbering the CJS bundle's `module.exports`, this PR cherry-picks #8443 onto the `v4.5.x` release branch.

The `hotkeys-js` package uses `module.exports = hotkeys` which overwrites the bundle's own CJS exports object, preventing the extension's `activate` function from being found by VS Code. The fix adds an esbuild plugin to both `build.ts` and `dev.ts` that replaces `hotkeys-js` with an empty stub module — this is safe because hotkeys-js is only used by the tldraw UI running in the webview, not the extension host.

The automated hotfix via `sdk-hotfix-please` label failed because `package.json` on `main` is missing its trailing newline (removed in #8347), which causes `yarn install` to re-add it, dirtying the working tree and blocking `git checkout v4.5.x`. This cherry-pick was done manually to work around that.

### Change type

- [x] `bugfix`

### Test plan

- [x] Cherry-pick applies cleanly
- [ ] CI passes on release branch
- [ ] VSCode extension activates correctly after publish

### Release notes

- Fix VSCode extension activation failure caused by hotkeys-js dependency

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +34 / -0   |
