### PR TITLE
fix(editor): handle duplicate index keys in kickoutOccludedShapes

### DIFF
--- a/packages/editor/src/lib/utils/reparenting.ts
+++ b/packages/editor/src/lib/utils/reparenting.ts
@@ -103,9 +103,13 @@ export function kickoutOccludedShapes(
 					if (oldParentIndex > -1) {
 						// If the old parent is a direct child of the new parent, then we'll add them above the old parent but below the next sibling.
 						const siblingsIndexAbove = oldParentSiblingIds[oldParentIndex + 1]
-						const indexKeyAbove = siblingsIndexAbove
+						const siblingAboveIndex = siblingsIndexAbove
 							? editor.getShape(siblingsIndexAbove)!.index
-							: getIndexAbove(prevParent.index)
+							: undefined
+						const indexKeyAbove =
+							siblingAboveIndex && siblingAboveIndex > prevParent.index
+								? siblingAboveIndex
+								: getIndexAbove(prevParent.index)
 						insertIndexKey = getIndexBetween(prevParent.index, indexKeyAbove)
 					} else {
 						// If the old parent is not a direct child of the new parent, then we'll add them to the "top" of the new parent's children.

--- a/packages/sync-core/src/test/syncFuzz.test.ts
+++ b/packages/sync-core/src/test/syncFuzz.test.ts
@@ -290,6 +290,10 @@ test('seed 5279266392988747 - undo/redo page integrity regression', () => {
 	runTest(5279266392988747)
 })
 
+test('seed 8090628137862085 - duplicate index key regression', () => {
+	runTest(8090628137862085)
+})
+
 for (let i = 0; i < NUM_TESTS; i++) {
 	const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
 	test(`seed ${seed}`, () => {


### PR DESCRIPTION
Discovered via a failing sync fuzz test at seed `8090628137862085`. The test hit a crash in `kickoutOccludedShapes` where `getIndexBetween` was called with equal index keys (`a >= a`).

During multiplayer sync, two clients can independently assign the same fractional index to sibling shapes. When `kickoutOccludedShapes` later tries to compute an insertion index between the old parent and its next sibling, `getIndexBetween` throws if the sibling's index is equal to or less than the parent's. The fix falls back to `getIndexAbove` in that case, which always produces a valid higher index.

Relates to tldraw/tldraw#6141

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

Added seed `8090628137862085` as a regression test in `syncFuzz.test.ts`.

### Release notes

- Fix a crash in `kickoutOccludedShapes` when shapes have duplicate fractional indices from sync conflicts.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Core code | +6 / -2 |
| Tests | +4 / -0 |