### PR TITLE
fix(arrows): use transform scale for arrow labels in dynamic size mode

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -969,8 +969,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 						y={toDomPrecision(labelBounds.y)}
 						width={labelBounds.w}
 						height={labelBounds.h}
-						rx={dv.labelBorderRadius}
-						ry={dv.labelBorderRadius}
+						rx={dv.labelBorderRadius * shape.props.scale}
+						ry={dv.labelBorderRadius * shape.props.scale}
 					/>
 				)}
 			</g>
@@ -1084,7 +1084,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 					labelBounds.y,
 					labelBounds.w,
 					labelBounds.h,
-					dv.labelBorderRadius
+					dv.labelBorderRadius * shape.props.scale
 				)
 				additionalPaths.push(labelPath)
 			}


### PR DESCRIPTION
In order to fix the oversized text caret when editing arrow labels at high zoom in dynamic size mode, this PR applies the same strategy from #8378 to arrow labels: render text at the base font size and use CSS `transform: scale()` instead of directly multiplying `fontSize` and `textWidth` by the shape scale.

Closes #8379

### Change type

- [x] `bugfix`

### Test plan

1. Enable dynamic size mode (View menu → Dynamic size mode)
2. Create an arrow with a text label
3. Zoom to 800%
4. Double-click to edit the arrow label — verify the caret is proportionally sized

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix oversized text caret when editing arrow labels at high zoom in dynamic size mode

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +5 / -3    |