### PR TITLE
docs(locked-shapes): fix incorrect claim about lock indicator on hover

### DIFF
--- a/apps/docs/content/sdk-features/locked-shapes.mdx
+++ b/apps/docs/content/sdk-features/locked-shapes.mdx
@@ -115,4 +115,4 @@ When this returns `true`, double-clicking the locked shape enters edit mode, let
 
 ## Locking in the UI
 
-In the default tldraw UI, users can lock shapes through the context menu or the keyboard shortcut (`Shift+L`). Locked shapes display a lock indicator when hovered, and the context menu shows an unlock option.
+In the default tldraw UI, users can lock shapes through the context menu or the keyboard shortcut (`Shift+L`). Users can right-click on a locked shape to access the context menu, which shows an unlock option.


### PR DESCRIPTION
The locked shapes documentation incorrectly stated that locked shapes display a lock indicator when hovered. This is not the case. This PR corrects the text to accurately describe the actual behavior: users can right-click a locked shape to access the context menu, which shows an unlock option.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Read the updated documentation and confirm the description matches actual locked shape behavior

### Release notes

- Fix incorrect documentation claiming locked shapes show a lock indicator on hover

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -1    |