### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -302,3 +302,4 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix NaN propagation from zero-length labeled arrows causing all shapes to disappear. ([#8329](https://github.com/tldraw/tldraw/pull/8329))
 - Fix crash when isolating curved arrows with degenerate geometry. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix camera state stuck at 'moving' on dispose, blocking shape interactions on the next editor instance. ([#8396](https://github.com/tldraw/tldraw/pull/8396))
+- Fix spiky artifacts on draw-style geometric shapes caused by square random offset distribution. ([#8466](https://github.com/tldraw/tldraw/pull/8466))


### PR DESCRIPTION
In order to keep the next release notes up to date with recent changes on `main`, this PR adds one new bug fix entry for #8466 (draw-style geo shape artifacts).

Source: `main` (development week 3 of 4). No archival needed — `last_version` matches the latest published release (`v4.5.7`). No stale entries found.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
- [x] `other`

### Code changes

| Category | File(s) |
|---|---|
| Documentation | `apps/docs/content/releases/next.mdx` |

### Test plan

- [ ] Unit tests
- [ ] End to end tests