### PR TITLE
fix(editor): fix memory leak from shared throttled updateHoveredShapeId

### DIFF
--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -1,9 +1,12 @@
 import { Editor } from '@tldraw/editor'
-import { updateHoveredShapeId } from './tools/selection-logic/updateHoveredShapeId'
+import {
+	cancelUpdateHoveredShapeId,
+	updateHoveredShapeId,
+} from './tools/selection-logic/updateHoveredShapeId'
 
 /** @public */
 export function registerDefaultSideEffects(editor: Editor) {
-	return editor.sideEffects.register({
+	const unsub = editor.sideEffects.register({
 		instance: {
 			afterChange: (prev, next) => {
 				if (prev.cameraState !== next.cameraState && next.cameraState === 'idle') {
@@ -62,4 +65,8 @@ export function registerDefaultSideEffects(editor: Editor) {
 			},
 		},
 	})
+	return () => {
+		unsub()
+		cancelUpdateHoveredShapeId(editor)
+	}
 }

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -1,5 +1,8 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
-import { updateHoveredShapeId } from '../../../tools/selection-logic/updateHoveredShapeId'
+import {
+	cancelUpdateHoveredShapeId,
+	updateHoveredShapeId,
+} from '../../../tools/selection-logic/updateHoveredShapeId'
 import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
 
 export class Idle extends StateNode {
@@ -23,7 +26,7 @@ export class Idle extends StateNode {
 	}
 
 	override onExit() {
-		updateHoveredShapeId.cancel()
+		cancelUpdateHoveredShapeId(this.editor)
 	}
 
 	override onKeyDown(info: TLKeyboardEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -10,7 +10,10 @@ import {
 import { getTextLabels } from '../../../utils/shapes/shapes'
 import { renderPlaintextFromRichText } from '../../../utils/text/richText'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
-import { updateHoveredShapeId } from '../../selection-logic/updateHoveredShapeId'
+import {
+	cancelUpdateHoveredShapeId,
+	updateHoveredShapeId,
+} from '../../selection-logic/updateHoveredShapeId'
 
 interface EditingShapeInfo {
 	isCreatingTextWhileToolLocked?: boolean
@@ -48,7 +51,7 @@ export class EditingShape extends StateNode {
 		const hadEditingShape = !!this.editor.getEditingShapeId()
 		this.editor.setEditingShape(null)
 
-		updateHoveredShapeId.cancel()
+		cancelUpdateHoveredShapeId(this.editor)
 
 		if (this.info.isCreatingTextWhileToolLocked && hadEditingShape) {
 			this.parent.setCurrentToolIdMask(undefined)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -17,7 +17,10 @@ import {
 import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { selectOnCanvasPointerUp } from '../../selection-logic/selectOnCanvasPointerUp'
-import { updateHoveredShapeId } from '../../selection-logic/updateHoveredShapeId'
+import {
+	cancelUpdateHoveredShapeId,
+	updateHoveredShapeId,
+} from '../../selection-logic/updateHoveredShapeId'
 import { hasRichText, startEditingShapeWithRichText } from '../selectHelpers'
 
 const SKIPPED_KEYS_FOR_AUTO_EDITING = [
@@ -44,7 +47,7 @@ export class Idle extends StateNode {
 	}
 
 	override onExit() {
-		updateHoveredShapeId.cancel()
+		cancelUpdateHoveredShapeId(this.editor)
 	}
 
 	override onPointerMove() {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -52,6 +52,8 @@ function getShapeToHover(editor: Editor): TLShapeId | null {
 }
 
 function _updateHoveredShapeId(editor: Editor) {
+	if (editor.isDisposed) return
+
 	const cameraMoving = editor.getCameraState() === 'moving'
 
 	if (!cameraMoving) {
@@ -81,8 +83,27 @@ function _updateHoveredShapeId(editor: Editor) {
 	return undefined
 }
 
+const THROTTLE_MS = process.env.NODE_ENV === 'test' ? 0 : 32
+const editorThrottles = new WeakMap<
+	Editor,
+	ReturnType<typeof throttle<typeof _updateHoveredShapeId>>
+>()
+
+function getThrottled(editor: Editor) {
+	let throttled = editorThrottles.get(editor)
+	if (!throttled) {
+		throttled = throttle(_updateHoveredShapeId, THROTTLE_MS)
+		editorThrottles.set(editor, throttled)
+	}
+	return throttled
+}
+
 /** @internal */
-export const updateHoveredShapeId = throttle(
-	_updateHoveredShapeId,
-	process.env.NODE_ENV === 'test' ? 0 : 32
-)
+export function updateHoveredShapeId(editor: Editor) {
+	getThrottled(editor)(editor)
+}
+
+/** @internal */
+export function cancelUpdateHoveredShapeId(editor: Editor) {
+	editorThrottles.get(editor)?.cancel()
+}


### PR DESCRIPTION
Cherry-pick of #8439 onto `v4.5.x` for SDK patch release.

Fixes a memory leak where `updateHoveredShapeId` was shared across all editor instances via a module-level throttled function, causing disposed editors to be retained in memory.