### PR TITLE
fix(editor): remove window.__tldraw__hardReset global to fix memory leak

### DIFF
--- a/apps/vscode/editor/src/app.tsx
+++ b/apps/vscode/editor/src/app.tsx
@@ -12,6 +12,7 @@ import {
 	TLComponents,
 	Tldraw,
 	ViewSubmenu,
+	hardReset,
 	setRuntimeOverrides,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
@@ -44,7 +45,7 @@ setRuntimeOverrides({
 		})
 	},
 	hardReset: async () => {
-		await (window as any).__tldraw__hardReset?.()
+		await hardReset({ shouldReload: false })
 		vscode.postMessage({
 			type: 'vscode:hard-reset',
 		})

--- a/packages/editor/src/lib/utils/runtime.ts
+++ b/packages/editor/src/lib/utils/runtime.ts
@@ -1,3 +1,5 @@
+import { hardReset } from './sync/hardReset'
+
 /** @public */
 export const runtime: {
 	openWindow(url: string, target: string, allowReferrer?: boolean): void
@@ -11,7 +13,7 @@ export const runtime: {
 		window.location.reload()
 	},
 	async hardReset() {
-		return await (window as any).__tldraw__hardReset?.()
+		return await hardReset({ shouldReload: true })
 	},
 }
 

--- a/packages/editor/src/lib/utils/sync/hardReset.ts
+++ b/packages/editor/src/lib/utils/sync/hardReset.ts
@@ -19,11 +19,3 @@ export async function hardReset({ shouldReload = true } = {}) {
 		window.location.reload()
 	}
 }
-
-if (typeof window !== 'undefined') {
-	if (process.env.NODE_ENV === 'development') {
-		;(window as any).hardReset = hardReset
-	}
-	// window.__tldraw__hardReset is used to inject the logic into the tldraw library
-	;(window as any).__tldraw__hardReset = hardReset
-}


### PR DESCRIPTION
In order to fix a memory leak where unmounted `Editor` instances were retained via `window.__tldraw__hardReset`, this PR removes the global window assignments from `hardReset.ts` and has `runtime.hardReset()` call `hardReset` directly instead of dispatching through `window.__tldraw__hardReset`. The global was capturing the module scope (including a debounced `updateHoveredShapeId` closure that held `getContainer` → `Editor`), causing ~5.9 MB to be retained per editor after unmount.

Closes #8430.

### Change type

- [x] `bugfix`

### Test plan

1. Mount a tldraw editor, then unmount it.
2. Take a heap snapshot and confirm the `Editor` instance is no longer retained via `Window.__tldraw__hardReset`.
3. Verify `editor.hardReset()` (via `runtime.hardReset()`) still clears local data and reloads.

### Release notes

- Fix a memory leak where `Editor` instances were retained after unmount via the `window.__tldraw__hardReset` global.