### PR TITLE
fix(sync): handle invalidated replication slots in TLPostgresReplicator

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -94,7 +94,8 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private log
 
 	private readonly replicationService
-	private readonly slotName
+	private readonly slotNameBase
+	private slotName
 	private readonly wal2jsonPlugin = new Wal2JsonPlugin({
 		addTables:
 			'public.user,public.file,public.file_state,public.user_mutation_number,public.replicator_boot_id,public.group,public.group_user,public.group_file',
@@ -114,8 +115,9 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		const slotNameMaxLength = 63 // max postgres identifier length
 		const slotNamePrefix = 'tlpr_' // pick something short so we can get more of the durable object id
 		const durableObjectId = this.ctx.id.toString()
-		this.slotName =
+		this.slotNameBase =
 			slotNamePrefix + durableObjectId.slice(0, slotNameMaxLength - slotNamePrefix.length)
+		this.slotName = this.slotNameBase
 
 		this.log = new Logger(env, 'TLPostgresReplicator', this.sentry)
 		this.db = createPostgresConnectionPool(env, 'TLPostgresReplicator', 100)
@@ -149,13 +151,19 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 					this.captureException(e)
 					throw e
 				})
+				// incorporate generation into slot name (generation > 0 means slot was recreated after invalidation)
+				const { slotGeneration } = this.sqlite
+					.exec<{ slotGeneration: number }>('SELECT slotGeneration FROM meta')
+					.one()
+				if (slotGeneration > 0) {
+					const suffix = '_' + slotGeneration
+					this.slotName = this.slotNameBase.slice(0, 63 - suffix.length) + suffix
+				}
 				// if the slot name changed, we set the lsn to null, which will trigger a mass user DO reboot
 				if (this.sqlite.exec('select slotName from meta').one().slotName !== this.slotName) {
 					this.sqlite.exec('UPDATE meta SET slotName = ?, lsn = null', this.slotName)
 				}
-				await sql`SELECT pg_create_logical_replication_slot(${this.slotName}, 'wal2json') WHERE NOT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = ${this.slotName})`.execute(
-					this.db
-				)
+				await this.ensureValidSlot()
 				this.pruneHistory()
 			})
 			.then(() => {
@@ -301,6 +309,38 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		})
 	}
 
+	private async ensureValidSlot(): Promise<void> {
+		const result = await sql<{ wal_status: string }>`
+			SELECT wal_status FROM pg_replication_slots
+			WHERE slot_name = ${this.slotName}
+		`.execute(this.db)
+
+		const slotInfo = result.rows[0]
+
+		if (!slotInfo) {
+			this.log.debug('creating replication slot', this.slotName)
+			await sql`SELECT pg_create_logical_replication_slot(${this.slotName}, 'wal2json')`.execute(
+				this.db
+			)
+		} else if (slotInfo.wal_status === 'lost') {
+			this.captureException(new Error(`replication slot invalidated: ${this.slotName}`))
+			await sql`SELECT pg_drop_replication_slot(${this.slotName})`.execute(this.db)
+			// increment generation to get a new slot name, which changes all sequenceIds
+			// and guarantees downstream user DOs hard reset
+			this.sqlite.exec('UPDATE meta SET slotGeneration = slotGeneration + 1')
+			const { slotGeneration } = this.sqlite
+				.exec<{ slotGeneration: number }>('SELECT slotGeneration FROM meta')
+				.one()
+			const suffix = '_' + slotGeneration
+			this.slotName = this.slotNameBase.slice(0, 63 - suffix.length) + suffix
+			this.sqlite.exec('UPDATE meta SET slotName = ?, lsn = null', this.slotName)
+			this.log.debug('creating replication slot', this.slotName)
+			await sql`SELECT pg_create_logical_replication_slot(${this.slotName}, 'wal2json')`.execute(
+				this.db
+			)
+		}
+	}
+
 	private async boot() {
 		this.log.debug('booting')
 		this.lastPostgresMessageTime = Date.now()
@@ -315,6 +355,8 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			this.db
 		)
 		this.log.debug('done')
+
+		await this.ensureValidSlot()
 
 		const promise = 'promise' in this.state ? this.state.promise : promiseWithResolve()
 		this.state = {

--- a/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.test.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.test.ts
@@ -142,7 +142,7 @@ describe('replicatorMigrations', () => {
 			await migrate(sqlStorage as any, logger as any)
 
 			migrations = sqlStorage.exec('SELECT id FROM migrations ORDER BY id').toArray()
-			expect(migrations).toHaveLength(8) // All migrations should be applied
+			expect(migrations).toHaveLength(9) // All migrations should be applied
 
 			// Should not duplicate existing migrations
 			const migrationCounts = sqlStorage

--- a/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.ts
@@ -169,6 +169,10 @@ const migrations: Migration[] = [
 		// so we need to regenerate the subscription changes for all existing history rows
 		fn: _updateHistorySubscriptions,
 	},
+	{
+		id: '008_add_slot_generation',
+		sql: `ALTER TABLE meta ADD COLUMN slotGeneration INTEGER NOT NULL DEFAULT 0;`,
+	},
 ]
 
 function _updateHistorySubscriptions(sqlite: SqlStorage) {


### PR DESCRIPTION
In order to let TLPostgresReplicator self-heal from invalidated replication slots, this PR replaces the `WHERE NOT EXISTS` slot creation SQL with an `ensureValidSlot()` method that checks `pg_replication_slots.wal_status`.

During the April 7 incident, PG invalidated tlpr's replication slot during crash recovery. tlpr entered an infinite retry loop for 2+ hours because `WHERE NOT EXISTS` only checks slot *existence*, not *validity*. Zero's replicator self-healed in ~2 minutes.

When `wal_status = 'lost'` (invalidated), `ensureValidSlot()`:
1. Fires a Sentry alert
2. Drops the dead slot
3. Increments a `slotGeneration` counter in SQLite
4. Derives a new slot name from `slotNameBase` + generation suffix (e.g. `tlpr_abc...xy_1`)
5. Updates `meta.slotName` and nulls `meta.lsn`, which triggers a sequence break → all user DOs reboot
6. Creates the new slot

The new slot name changes all `sequenceId`s sent to user DOs, guaranteeing they detect the break and hard reset. This uses the same mechanism as the existing "force reboot by changing slot name" escape hatch described in migration 003.

Called in two places:
- **Constructor's `blockConcurrencyWhile`** — catches invalidation that happened while the DO was down
- **`boot()`** — the critical fix, catches invalidation during runtime (replication errors out → retry → `ensureValidSlot()` recovers)

On normal deploys (generation 0), the slot name is unchanged — no existing DOs are affected.

### Change type

- [x] `bugfix`

### Test plan

1. Next time a slot gets invalidated, tlpr should self-heal within one reboot cycle (~2-4s) instead of looping forever
2. Can verify manually: invalidate a slot, check that tlpr drops it, creates a new one with `_1` suffix, and all user DOs reboot
3. Verify normal deploys (generation 0) don't change slot name or trigger reboots

### Release notes

- Fix TLPostgresReplicator infinite retry loop when PostgreSQL invalidates a replication slot

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +45 / -3   |