### PR TITLE
fix(context-menu): prevent flash on consecutive right-clicks

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -42,6 +42,22 @@ export function MenuClickCapture() {
 				}
 				rDidAPointerDownAndDragWhileMenuWasOpen.current = false
 			}
+			if (e.button === 2) {
+				// Swallow the contextmenu event that follows this right-click pointerdown.
+				// clearOpenMenus() below triggers a synchronous render that unmounts this
+				// component, so our React onContextMenu handler won't be around to catch it.
+				// Without this, the contextmenu event reaches the Radix Trigger and briefly
+				// opens a new context menu (which then immediately dismisses — causing a flash).
+				const ownerDocument = editor.getContainerDocument()
+				ownerDocument.addEventListener(
+					'contextmenu',
+					(event) => {
+						event.preventDefault()
+						event.stopImmediatePropagation()
+					},
+					{ capture: true, once: true }
+				)
+			}
 			editor.menus.clearOpenMenus()
 		},
 		[editor]
@@ -117,6 +133,10 @@ export function MenuClickCapture() {
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}
+				onContextMenu={(e) => {
+					e.preventDefault()
+					e.stopPropagation()
+				}}
 			/>
 		)
 	)


### PR DESCRIPTION
In order to prevent a context menu from briefly flashing when right-clicking to dismiss an already-open context menu, this PR intercepts the browser's `contextmenu` event before it can reach the Radix Trigger.

Closes #8479
Closes #8251

**Root cause:** When a menu is open, `MenuClickCapture` overlays the canvas. On right-click, `handlePointerDown` calls `clearOpenMenus()`, which triggers a synchronous render that unmounts `MenuClickCapture` itself. The browser's `contextmenu` event — which fires after `pointerdown` — then passes through to the Radix `ContextMenu.Trigger` unopposed, briefly opening a new context menu. Radix's `DismissableLayer` immediately detects the pointer is outside and dismisses it, producing a visible flash.

**Fix:** Before calling `clearOpenMenus()`, register a one-shot capture-phase `contextmenu` listener on the document that swallows the event with `stopImmediatePropagation()`. This prevents the event from ever reaching Radix. The listener auto-removes via `{ once: true }`. A React `onContextMenu` handler is also added to `MenuClickCapture` as a belt-and-suspenders guard for cases where the component hasn't unmounted yet.

### Change type

- [x] `bugfix`

### Test plan

1. Right-click on the canvas — context menu appears
2. Right-click elsewhere on the canvas — context menu dismisses cleanly, no flash
3. Repeat rapidly — no flash on any consecutive right-click
4. Right-click on a shape — context menu shows shape actions
5. Open a dropdown/toolbar menu, then right-click on canvas — dropdown dismisses, no flash
6. Left-click or press Escape to dismiss context menu — still works as before
7. Long-press on touch device — context menu still works (fix only targets button 2)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix context menu briefly flashing when right-clicking to dismiss an already-open context menu.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +20 / -0   |