### PR TITLE
fix(context-menu): prevent right-click release from selecting menu items

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -149,6 +149,15 @@ export function TldrawUiMenuItem<
 					draggable={false}
 					className="tlui-button tlui-button__menu"
 					data-testid={`${sourceId}.${id}`}
+					onPointerUp={(e) => {
+						// Prevent right-click pointerup from triggering item selection.
+						// Radix calls click() on pointerup when the pointer wasn't pressed
+						// on the item, but doesn't check the button — so a right-click
+						// release while moving across the menu selects the item under the cursor.
+						if (e.button !== 0) {
+							preventDefault(e)
+						}
+					}}
 					onSelect={(e) => {
 						if (noClose) preventDefault(e)
 						if (disableClicks) {


### PR DESCRIPTION
When right-clicking to open a context menu and moving the mouse quickly, the `pointerup` (button 2) from the right-click can land on a menu item and trigger selection without the user intending to click it.

Closes #8480

**Root cause:** Radix's `MenuItem` calls `event.currentTarget.click()` on `pointerup` when `isPointerDownRef` is false (i.e. the pointer wasn't pressed down on that item). This is intentional for drag-to-select behavior, but it doesn't check the pointer button — so a right-click release (button 2) triggers the same path as a left-click release.

**Fix:** Add an `onPointerUp` handler to `_ContextMenu.Item` that calls `preventDefault()` for non-left-click buttons. Radix's `composeEventHandlers` runs the user handler first and skips its internal handler when `defaultPrevented` is true, so the synthetic `click()` never fires.

### Change type

- [x] `bugfix`

### Test plan

1. Right-click on empty canvas — context menu appears
2. Move mouse quickly across menu items — no item should activate
3. Right-click on a shape, move fast across items — no item should activate
4. Left-click a menu item normally — should still work
5. Drag from outside the menu onto an item and release (left button) — should still select

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix context menu items being accidentally selected when right-clicking and quickly moving the mouse.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +9 / -0    |