### PR TITLE
Add 10% production pierre load test

### DIFF
--- a/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLDrawDurableObject.ts
@@ -59,7 +59,7 @@ import { getPublishedRoomSnapshot } from './routes/tla/getPublishedFile'
 import { generateSnapshotChunks } from './snapshotUtils'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
-import { createPierreClient } from './utils/createPierreClient'
+import { createPierreClient, isSlugInPierreRollout } from './utils/createPierreClient'
 import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getRoomDurableObject } from './utils/durableObjects'
 import { reconstructSnapshotFromPierre } from './utils/pierreSnapshot'
@@ -1368,7 +1368,7 @@ export class TLFileDurableObject extends DurableObject {
 			!this.pierreClient ||
 			!this.documentInfo.isApp ||
 			!this.env.TLDRAW_ENV ||
-			this.env.TLDRAW_ENV === 'production'
+			!isSlugInPierreRollout(this.env, this.documentInfo.slug)
 		) {
 			return null
 		}
@@ -1450,11 +1450,15 @@ export class TLFileDurableObject extends DurableObject {
 					documentClock,
 					schema: snapshot.schema,
 				}
-				commitBuilder.addFileFromString('meta.json', JSON.stringify(meta))
+				const metaJson = JSON.stringify(meta)
+				let incrementalCommitPayloadLength = metaJson.length
+				commitBuilder.addFileFromString('meta.json', metaJson)
 
 				for (const [id, put] of Object.entries(diff.puts)) {
 					const state = Array.isArray(put) ? put[1] : put
-					commitBuilder.addFileFromString(`records/${id}.json`, JSON.stringify(state))
+					const recordJson = JSON.stringify(state)
+					incrementalCommitPayloadLength += recordJson.length
+					commitBuilder.addFileFromString(`records/${id}.json`, recordJson)
 				}
 
 				// Only apply diff.deletes when we have a parent commit and we're not in wipeAll.
@@ -1492,6 +1496,12 @@ export class TLFileDurableObject extends DurableObject {
 					this.pierreState = {
 						headSha: result ? result.refUpdate.newSha : headSha,
 						documentClock,
+					}
+					// Incremental commits only (not the first commit to an empty repo); combined JSON string lengths (meta + record payloads).
+					if (headSha && result) {
+						this.writeEvent('pierre_incremental_write_chars', {
+							doubles: [incrementalCommitPayloadLength],
+						})
 					}
 					return
 				} catch (error) {

--- a/apps/dotcom/sync-worker/src/utils/createPierreClient.ts
+++ b/apps/dotcom/sync-worker/src/utils/createPierreClient.ts
@@ -1,12 +1,24 @@
 import { GitStorage } from '@pierre/storage'
 import { Environment } from '../types'
 
-export function createPierreClient(env: Environment): GitStorage | undefined {
-	// Only enable Pierre in non-production environments
-	if (env.TLDRAW_ENV === 'production') {
-		return undefined
+/** Stable 0–99 bucket for staggered Pierre rollout (same slug always maps to the same bucket). */
+export function hashSlugToBucket(slug: string): number {
+	let h = 0
+	for (let i = 0; i < slug.length; i++) {
+		h = (Math.imul(h, 31) + slug.charCodeAt(i)) | 0
 	}
+	return (h >>> 0) % 100
+}
 
+/** In production, Pierre snapshots are enabled for 10% of app file slugs (bucket < 10). Elsewhere, all slugs. */
+export function isSlugInPierreRollout(env: Environment, slug: string): boolean {
+	if (env.TLDRAW_ENV !== 'production') {
+		return true
+	}
+	return hashSlugToBucket(slug) < 10
+}
+
+export function createPierreClient(env: Environment): GitStorage | undefined {
 	if (!env.PIERRE_KEY) {
 		return undefined
 	}


### PR DESCRIPTION
I spoke with @fat from pierre and agreed to a 10% trial of production traffic so we could get a sense of how much space we'd consume as well as what kind of write throughput we'd expect to see.

For throughput I added a workers analytics event to track the number of bytes written in incremental writes. Then we can sum all the events in grafana and multiply by 10 to get a realistic view of write throughput.

For disk space consumption I'll be running some separate tests using staging R2 snapshot data to 'migrate' existing rooms to pierre to get a sense of what kind of compression factor it offers (i think it'll be logarithmic and dependent on usage patterns), and then we can try to apply that to the production R2 bucket to get a good sense of how much space we'd be using.

### Change type

- [x] `other`
