### PR TITLE
fix(docs): update PeopleMenuProps auto-link to use canonical name

### DIFF
--- a/apps/docs/content/sdk-features/ui-components.mdx
+++ b/apps/docs/content/sdk-features/ui-components.mdx
@@ -80,39 +80,39 @@ Each slot is optional. Pass `null` as an override to hide a component entirely, 
 
 The UI portion of the `components` prop is shaped by [TLUiComponents](?). Every key is optional: use `null` to hide that slot, or pass a React component. When a slot has a documented props type in the table below, import that type from `tldraw` and type your replacement as `React.ComponentType<…>` (or implement the matching props). When the props column says **none**, the SDK does not declare extra props for that slot beyond what a plain `ComponentType` allows.
 
-| Slot                      | Props (import from `tldraw`)                                           |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `ContextMenu`             | [TLUiContextMenuProps](?)                                              |
-| `ActionsMenu`             | [TLUiActionsMenuProps](?)                                              |
-| `HelpMenu`                | [TLUiHelpMenuProps](?)                                                 |
-| `ZoomMenu`                | [TLUiZoomMenuProps](?)                                                 |
-| `MainMenu`                | [TLUiMainMenuProps](?)                                                 |
-| `Minimap`                 | none                                                                   |
-| `StylePanel`              | [TLUiStylePanelProps](?)                                               |
-| `PageMenu`                | none                                                                   |
-| `NavigationPanel`         | none                                                                   |
-| `Toolbar`                 | none                                                                   |
-| `RichTextToolbar`         | [TLUiRichTextToolbarProps](?)                                          |
-| `ImageToolbar`            | none                                                                   |
-| `VideoToolbar`            | none                                                                   |
-| `KeyboardShortcutsDialog` | [TLUiKeyboardShortcutsDialogProps](?)                                  |
-| `QuickActions`            | [TLUiQuickActionsProps](?)                                             |
-| `HelperButtons`           | [TLUiHelperButtonsProps](?)                                            |
-| `DebugPanel`              | none                                                                   |
-| `DebugMenu`               | none                                                                   |
-| `MenuPanel`               | none                                                                   |
-| `TopPanel`                | none                                                                   |
-| `SharePanel`              | none                                                                   |
-| `CursorChatBubble`        | none                                                                   |
-| `Dialogs`                 | none                                                                   |
-| `Toasts`                  | none                                                                   |
-| `A11y`                    | none                                                                   |
-| `FollowingIndicator`      | none                                                                   |
-| `PeopleMenu`              | none (default component: optional `children` via [PeopleMenuProps](?)) |
-| `PeopleMenuAvatar`        | [TLUiPeopleMenuAvatarProps](?)                                         |
-| `PeopleMenuFacePile`      | [TLUiPeopleMenuFacePileProps](?)                                       |
-| `PeopleMenuItem`          | [TLUiPeopleMenuItemProps](?)                                           |
-| `UserPresenceEditor`      | none                                                                   |
+| Slot                      | Props (import from `tldraw`)                                                  |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `ContextMenu`             | [TLUiContextMenuProps](?)                                                     |
+| `ActionsMenu`             | [TLUiActionsMenuProps](?)                                                     |
+| `HelpMenu`                | [TLUiHelpMenuProps](?)                                                        |
+| `ZoomMenu`                | [TLUiZoomMenuProps](?)                                                        |
+| `MainMenu`                | [TLUiMainMenuProps](?)                                                        |
+| `Minimap`                 | none                                                                          |
+| `StylePanel`              | [TLUiStylePanelProps](?)                                                      |
+| `PageMenu`                | none                                                                          |
+| `NavigationPanel`         | none                                                                          |
+| `Toolbar`                 | none                                                                          |
+| `RichTextToolbar`         | [TLUiRichTextToolbarProps](?)                                                 |
+| `ImageToolbar`            | none                                                                          |
+| `VideoToolbar`            | none                                                                          |
+| `KeyboardShortcutsDialog` | [TLUiKeyboardShortcutsDialogProps](?)                                         |
+| `QuickActions`            | [TLUiQuickActionsProps](?)                                                    |
+| `HelperButtons`           | [TLUiHelperButtonsProps](?)                                                   |
+| `DebugPanel`              | none                                                                          |
+| `DebugMenu`               | none                                                                          |
+| `MenuPanel`               | none                                                                          |
+| `TopPanel`                | none                                                                          |
+| `SharePanel`              | none                                                                          |
+| `CursorChatBubble`        | none                                                                          |
+| `Dialogs`                 | none                                                                          |
+| `Toasts`                  | none                                                                          |
+| `A11y`                    | none                                                                          |
+| `FollowingIndicator`      | none                                                                          |
+| `PeopleMenu`              | none (default component: optional `children` via [DefaultPeopleMenuProps](?)) |
+| `PeopleMenuAvatar`        | [TLUiPeopleMenuAvatarProps](?)                                                |
+| `PeopleMenuFacePile`      | [TLUiPeopleMenuFacePileProps](?)                                              |
+| `PeopleMenuItem`          | [TLUiPeopleMenuItemProps](?)                                                  |
+| `UserPresenceEditor`      | none                                                                          |
 
 This table is an index; the authoritative list and types remain [TLUiComponents](?) in the API reference and in the package typings.
 


### PR DESCRIPTION
In order to fix the docs deployment build failure, this PR updates the auto-link reference in `ui-components.mdx` from `PeopleMenuProps` to `DefaultPeopleMenuProps`.

PR #8346 renamed `PeopleMenu` to `DefaultPeopleMenu` and `PeopleMenuProps` to `DefaultPeopleMenuProps`, keeping the old names as legacy re-export aliases. API Extractor uses the canonical declaration name (`DefaultPeopleMenuProps`) when generating the doc model, so the reference article is now titled `DefaultPeopleMenuProps`. However, the doc page still referenced the old alias name `[PeopleMenuProps](?)`, which caused the auto-link resolution in `autoLinkDocs.ts` to fail with:

```
Error: 💥 Could not find article for PeopleMenuProps (PeopleMenuProps) in /sdk-features/ui-components at line 92
```

### Change type

- [x] `bugfix`

### Test plan

1. Run `cd apps/docs && yarn fetch-api-source && yarn create-api-markdown && yarn refresh-content` — should complete without errors

### Release notes

- Fix docs build failure caused by stale `PeopleMenuProps` auto-link reference

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -1    |