### PR TITLE
fix(style-panel): use markEventAsHandled instead of stopPropagation for pointermove

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanel.tsx
@@ -41,9 +41,11 @@ export const DefaultStylePanel = memo(function DefaultStylePanel({
 		if (!elm) return
 
 		function handlePointerMove(event: PointerEvent) {
-			// Prevent pointer move events from propagating to the
-			// canvas when the pointer is over the style panel.
-			event.stopPropagation()
+			// Mark the event as handled so the canvas's pointermove listener
+			// (on document.body) ignores it. We use markEventAsHandled instead
+			// of stopPropagation to avoid interfering with Radix UI's internal
+			// pointer capture handling, which breaks slider drags on Safari.
+			editor.markEventAsHandled(event)
 		}
 
 		function handleKeyDown(event: KeyboardEvent) {
@@ -56,10 +58,10 @@ export const DefaultStylePanel = memo(function DefaultStylePanel({
 			}
 		}
 
-		elm.addEventListener('pointermove', handlePointerMove, { capture: true })
+		elm.addEventListener('pointermove', handlePointerMove)
 		elm.addEventListener('keydown', handleKeyDown, { capture: true })
 		return () => {
-			elm.removeEventListener('pointermove', handlePointerMove, { capture: true })
+			elm.removeEventListener('pointermove', handlePointerMove)
 			elm.removeEventListener('keydown', handleKeyDown, { capture: true })
 		}
 	}, [editor])


### PR DESCRIPTION
Closes #8517

In order to fix the opacity slider drag being broken on Safari, this PR replaces the capturing-phase `stopPropagation()` on `pointermove` events in `DefaultStylePanel` with `editor.markEventAsHandled()`.

The style panel previously used a capturing-phase `pointermove` listener that called `event.stopPropagation()` to prevent the canvas from reacting to pointer moves over the style panel. This interfered with Radix UI Slider's internal pointer capture handling on Safari — Radix relies on `pointermove` events propagating to the element that called `setPointerCapture`, and Safari handles pointer capture event propagation differently from Chrome/Firefox when `stopPropagation` is called in the capture phase.

The canvas's `document.body` pointermove listener already checks `editor.wasEventAlreadyHandled(e)` and returns early, so `markEventAsHandled` achieves the same goal without breaking DOM event propagation.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw in **Safari**
2. Create or select a shape
3. Open the style panel
4. Drag the opacity slider — it should follow the pointer smoothly
5. Verify in **Chrome** and **Firefox** that the slider still works
6. Verify that moving the pointer over the style panel does not cause canvas reactions (e.g. hover states on shapes behind the panel)

### Release notes

- Fix opacity slider drag not working on Safari.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +7 / -5    |