### PR TITLE
fix(editor): remove double viewport offset subtraction in quick zoom mode

### DIFF
--- a/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
@@ -40,8 +40,8 @@ export class ZoomQuick extends StateNode {
 		// We need each side to reach the common bounds edge.
 		const vsb = editor.getViewportScreenBounds()
 		const sp = editor.inputs.getCurrentScreenPoint()
-		const sx = sp.x - vsb.x
-		const sy = sp.y - vsb.y
+		const sx = sp.x
+		const sy = sp.y
 		const { x: px, y: py } = this.initialPp
 
 		const dLeft = px - commonBounds.minX
@@ -173,7 +173,7 @@ export class ZoomQuick extends StateNode {
 		// Normalize the offset on the current screen point within the current viewport screen bounds
 		const vsb = editor.getViewportScreenBounds()
 		const vsp = editor.inputs.getCurrentScreenPoint()
-		const { x: nx, y: ny } = new Vec((vsp.x - vsb.x) / vsb.w, (vsp.y - vsb.y) / vsb.h)
+		const { x: nx, y: ny } = new Vec(vsp.x / vsb.w, vsp.y / vsb.h)
 
 		return new Box(x - nx * w, y - ny * h, w, h)
 	}

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -530,6 +530,47 @@ describe('ZoomQuick', () => {
 	})
 })
 
+describe('ZoomQuick with non-zero screen bounds offset', () => {
+	beforeEach(() => {
+		editor = new TestEditor()
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		// Simulate a container offset from the top-left of the window (e.g. a header/sidebar)
+		editor.setScreenBounds({ x: 200, y: 100, w: 1080, h: 720 })
+	})
+
+	it('anchor point is not double-offset by the viewport screen bounds', () => {
+		// Position cursor at center of the viewport
+		editor.pointerMove(540, 360)
+		const cursorPagePoint = editor.inputs.getCurrentPagePoint()
+
+		editor.setCurrentTool('zoom.zoom_quick', { onInteractionEnd: 'select' })
+
+		// The page point under the cursor should remain the same after zooming,
+		// regardless of where the container sits on the page.
+		const newCursorPagePoint = editor.inputs.getCurrentPagePoint()
+		expect(newCursorPagePoint.x).toBeCloseTo(cursorPagePoint.x)
+		expect(newCursorPagePoint.y).toBeCloseTo(cursorPagePoint.y)
+	})
+
+	it('brush follows cursor correctly when container is offset', () => {
+		editor.pointerMove(540, 360) // center of viewport
+		editor.setCurrentTool('zoom.zoom_quick', { onInteractionEnd: 'select' })
+
+		// Move beyond threshold to enter moving state
+		editor.pointerMove(600, 400)
+		vi.advanceTimersByTime(16)
+
+		const brush = editor.getInstanceState().zoomBrush!
+		const cursorPage = editor.inputs.getCurrentPagePoint()
+
+		// The cursor should land inside the brush rectangle
+		expect(cursorPage.x).toBeGreaterThanOrEqual(brush.x)
+		expect(cursorPage.x).toBeLessThanOrEqual(brush.x + brush.w)
+		expect(cursorPage.y).toBeGreaterThanOrEqual(brush.y)
+		expect(cursorPage.y).toBeLessThanOrEqual(brush.y + brush.h)
+	})
+})
+
 describe('ZoomTool edge cases', () => {
 	beforeEach(() => {
 		editor = new TestEditor()


### PR DESCRIPTION
Closes #8500

`editor.inputs.getCurrentScreenPoint()` already returns coordinates relative to the viewport screen bounds (the subtraction happens in `InputsManager.updateFromEvent`). However, `ZoomQuick` was subtracting `vsb.x`/`vsb.y` a second time in both `onEnter` (anchor calculation) and `getNextVpb` (brush positioning). This caused the zoom anchor and brush rectangle to be offset by the container's page position when the tldraw container wasn't at `(0, 0)` of the window.

### Change type

- [x] `bugfix`

### Test plan

1. Embed tldraw in a page where the container is offset from `(0, 0)` (e.g. with a header or sidebar above it)
2. Activate the zoom tool (Z) and hold Shift to enter quick zoom mode
3. Verify the cursor stays fixed on screen during the overview zoom-out
4. Drag to reposition — the brush rectangle should follow the cursor exactly

- [x] Unit tests

### Release notes

- Fix quick zoom mode (Z + Shift) cursor anchor and brush misalignment when the tldraw container is offset from the top-left of the window.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +2 / -3    |
| Tests      | +41 / -0   |