### PR TITLE
fix(shapes): add shape parameter to ShapeUtil base class methods

### DIFF
--- a/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
+++ b/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
@@ -56,7 +56,7 @@ export class PulseShapeUtil extends ShapeUtil<PulseShape> {
 		return { w: 200, h: 200 }
 	}
 
-	override canEdit(_shape: PulseShape) {
+	override canEdit() {
 		return false
 	}
 

--- a/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
+++ b/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
@@ -56,7 +56,7 @@ export class PulseShapeUtil extends ShapeUtil<PulseShape> {
 		return { w: 200, h: 200 }
 	}
 
-	override canEdit(_shape: PulseShape) {
+	override canEdit(shape: PulseShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
+++ b/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
@@ -56,7 +56,7 @@ export class PulseShapeUtil extends ShapeUtil<PulseShape> {
 		return { w: 200, h: 200 }
 	}
 
-	override canEdit() {
+	override canEdit(_shape: PulseShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/bounds-snapping-shape/PlayingCardShape/playing-card-util.tsx
+++ b/apps/examples/src/examples/shapes/tools/bounds-snapping-shape/PlayingCardShape/playing-card-util.tsx
@@ -36,7 +36,7 @@ export class PlayingCardUtil extends BaseBoxShapeUtil<IPlayingCard> {
 	}
 
 	// [4]
-	override isAspectRatioLocked(_shape: IPlayingCard) {
+	override isAspectRatioLocked(shape: IPlayingCard) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-config/CardShape/CardShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-config/CardShape/CardShapeUtil.tsx
@@ -33,10 +33,10 @@ export class CardShapeUtil extends ShapeUtil<ICardShape> {
 	static override migrations = cardShapeMigrations
 
 	// [3]
-	override isAspectRatioLocked(_shape: ICardShape) {
+	override isAspectRatioLocked(shape: ICardShape) {
 		return false
 	}
-	override canResize(_shape: ICardShape) {
+	override canResize(shape: ICardShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
@@ -52,7 +52,7 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
@@ -46,13 +46,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canEdit(_shape: ICustomShape) {
+	override canEdit(shape: ICustomShape) {
 		return false
 	}
-	override canResize(_shape: ICustomShape) {
+	override canResize(shape: ICustomShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ICustomShape) {
+	override isAspectRatioLocked(shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
@@ -46,13 +46,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canEdit() {
+	override canEdit(_shape: ICustomShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ICustomShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
@@ -46,13 +46,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canEdit(_shape: ICustomShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ICustomShape) {
+	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ICustomShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-shape/CustomShapeExample.tsx
@@ -46,10 +46,10 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	}
 
 	// [c]
-	override canEdit() {
+	override canEdit(_shape: ICustomShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ICustomShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: ICustomShape) {

--- a/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
@@ -30,10 +30,10 @@ const SLOT_SIZE = 100
 class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 	static override type = MY_COUNTER_SHAPE_TYPE
 
-	override canResize(_shape: MyCounterShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: MyCounterShape) {
+	override hideResizeHandles() {
 		return true
 	}
 
@@ -78,10 +78,10 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 		})
 	}
 
-	override canResize(_shape: MyGridShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: MyGridShape) {
+	override hideResizeHandles() {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
@@ -30,10 +30,10 @@ const SLOT_SIZE = 100
 class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 	static override type = MY_COUNTER_SHAPE_TYPE
 
-	override canResize() {
+	override canResize(_shape: MyCounterShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: MyCounterShape) {
 		return true
 	}
 
@@ -78,10 +78,10 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 		})
 	}
 
-	override canResize() {
+	override canResize(_shape: MyGridShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: MyGridShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/drag-and-drop/DragAndDropExample.tsx
@@ -30,10 +30,10 @@ const SLOT_SIZE = 100
 class MyCounterShapeUtil extends ShapeUtil<MyCounterShape> {
 	static override type = MY_COUNTER_SHAPE_TYPE
 
-	override canResize(_shape: MyCounterShape) {
+	override canResize(shape: MyCounterShape) {
 		return false
 	}
-	override hideResizeHandles(_shape: MyCounterShape) {
+	override hideResizeHandles(shape: MyCounterShape) {
 		return true
 	}
 
@@ -78,10 +78,10 @@ class MyGridShapeUtil extends ShapeUtil<MyGridShape> {
 		})
 	}
 
-	override canResize(_shape: MyGridShape) {
+	override canResize(shape: MyGridShape) {
 		return false
 	}
-	override hideResizeHandles(_shape: MyGridShape) {
+	override hideResizeHandles(shape: MyGridShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
@@ -27,12 +27,12 @@ export class EditableShapeUtil extends BaseBoxShapeUtil<IMyEditableShape> {
 	}
 
 	// [1]
-	override canEdit(_shape: IMyEditableShape) {
+	override canEdit(shape: IMyEditableShape) {
 		return true
 	}
 
 	// [1b]
-	override canEditWhileLocked(_shape: IMyEditableShape) {
+	override canEditWhileLocked(shape: IMyEditableShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
@@ -27,12 +27,12 @@ export class EditableShapeUtil extends BaseBoxShapeUtil<IMyEditableShape> {
 	}
 
 	// [1]
-	override canEdit() {
+	override canEdit(_shape: IMyEditableShape) {
 		return true
 	}
 
 	// [1b]
-	override canEditWhileLocked() {
+	override canEditWhileLocked(_shape: IMyEditableShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/editable-shape/EditableShapeUtil.tsx
@@ -27,12 +27,12 @@ export class EditableShapeUtil extends BaseBoxShapeUtil<IMyEditableShape> {
 	}
 
 	// [1]
-	override canEdit(_shape: IMyEditableShape) {
+	override canEdit() {
 		return true
 	}
 
 	// [1b]
-	override canEditWhileLocked(_shape: IMyEditableShape) {
+	override canEditWhileLocked() {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/globs-editor/GlobShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/globs-editor/GlobShapeUtil.tsx
@@ -224,23 +224,23 @@ export class GlobShapeUtil extends ShapeUtil<GlobShape> {
 		}
 	}
 
-	override hideSelectionBoundsBg(_shape: GlobShape): boolean {
+	override hideSelectionBoundsBg(shape: GlobShape): boolean {
 		return true
 	}
 
-	override hideResizeHandles(_shape: GlobShape): boolean {
+	override hideResizeHandles(shape: GlobShape): boolean {
 		return true
 	}
 
-	override hideRotateHandle(_shape: GlobShape): boolean {
+	override hideRotateHandle(shape: GlobShape): boolean {
 		return true
 	}
 
-	override hideSelectionBoundsFg(_shape: GlobShape): boolean {
+	override hideSelectionBoundsFg(shape: GlobShape): boolean {
 		return true
 	}
 
-	override onResize(_shape: GlobShape, info: TLResizeInfo<GlobShape>) {
+	override onResize(shape: GlobShape, info: TLResizeInfo<GlobShape>) {
 		const { scaleX, scaleY, initialShape } = info
 
 		const scaledEdgeA_d = {

--- a/apps/examples/src/examples/shapes/tools/globs-editor/NodeShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/globs-editor/NodeShapeUtil.tsx
@@ -45,19 +45,19 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override hideResizeHandles(_shape: NodeShape): boolean {
+	override hideResizeHandles(shape: NodeShape): boolean {
 		return true
 	}
 
-	override hideRotateHandle(_shape: NodeShape): boolean {
+	override hideRotateHandle(shape: NodeShape): boolean {
 		return true
 	}
 
-	override hideSelectionBoundsBg(_shape: NodeShape): boolean {
+	override hideSelectionBoundsBg(shape: NodeShape): boolean {
 		return true
 	}
 
-	override hideSelectionBoundsFg(_shape: NodeShape): boolean {
+	override hideSelectionBoundsFg(shape: NodeShape): boolean {
 		return true
 	}
 
@@ -70,7 +70,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		})
 	}
 
-	override onResize(_shape: NodeShape, info: TLResizeInfo<NodeShape>) {
+	override onResize(shape: NodeShape, info: TLResizeInfo<NodeShape>) {
 		const { scaleX, scaleY, initialShape } = info
 		const avgScale = (Math.abs(scaleX) + Math.abs(scaleY)) / 2
 

--- a/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
@@ -54,16 +54,16 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit(_shape: ContainerShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ContainerShape) {
+	override canResize() {
 		return false
 	}
-	override hideRotateHandle(_shape: ContainerShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ContainerShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 
@@ -113,16 +113,16 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit(_shape: ElementShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ElementShape) {
+	override canResize() {
 		return false
 	}
-	override hideRotateHandle(_shape: ElementShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ElementShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
@@ -54,16 +54,16 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit(_shape: ContainerShape) {
+	override canEdit(shape: ContainerShape) {
 		return false
 	}
-	override canResize(_shape: ContainerShape) {
+	override canResize(shape: ContainerShape) {
 		return false
 	}
-	override hideRotateHandle(_shape: ContainerShape) {
+	override hideRotateHandle(shape: ContainerShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ContainerShape) {
+	override isAspectRatioLocked(shape: ContainerShape) {
 		return true
 	}
 
@@ -113,16 +113,16 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit(_shape: ElementShape) {
+	override canEdit(shape: ElementShape) {
 		return false
 	}
-	override canResize(_shape: ElementShape) {
+	override canResize(shape: ElementShape) {
 		return false
 	}
-	override hideRotateHandle(_shape: ElementShape) {
+	override hideRotateHandle(shape: ElementShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: ElementShape) {
+	override isAspectRatioLocked(shape: ElementShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
@@ -54,13 +54,13 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit() {
+	override canEdit(_shape: ContainerShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ContainerShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ContainerShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: ContainerShape) {
@@ -113,13 +113,13 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit() {
+	override canEdit(_shape: ElementShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ElementShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ElementShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: ElementShape) {

--- a/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
@@ -63,7 +63,7 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ContainerShape) {
 		return true
 	}
 
@@ -122,7 +122,7 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ElementShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/layout-bindings/LayoutExample.tsx
@@ -54,16 +54,16 @@ class ContainerShapeUtil extends ShapeUtil<ContainerShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit() {
+	override canEdit(_shape: ContainerShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ContainerShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ContainerShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ContainerShape) {
 		return true
 	}
 
@@ -113,16 +113,16 @@ class ElementShapeUtil extends ShapeUtil<ElementShape> {
 			fromShape.type === 'container' && toShape.type === 'element' && bindingType === LAYOUT_TYPE
 		)
 	}
-	override canEdit() {
+	override canEdit(_shape: ElementShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ElementShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ElementShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ElementShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
@@ -59,13 +59,13 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 		// Allow pins to participate in other bindings, e.g. arrows
 		return true
 	}
-	override canEdit() {
+	override canEdit(_shape: PinShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: PinShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: PinShape) {
 		return true
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
@@ -59,13 +59,13 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 		// Allow pins to participate in other bindings, e.g. arrows
 		return true
 	}
-	override canEdit(_shape: PinShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: PinShape) {
+	override canResize() {
 		return false
 	}
-	override hideRotateHandle(_shape: PinShape) {
+	override hideRotateHandle() {
 		return true
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/pin-bindings/PinExample.tsx
@@ -59,13 +59,13 @@ class PinShapeUtil extends ShapeUtil<PinShape> {
 		// Allow pins to participate in other bindings, e.g. arrows
 		return true
 	}
-	override canEdit(_shape: PinShape) {
+	override canEdit(shape: PinShape) {
 		return false
 	}
-	override canResize(_shape: PinShape) {
+	override canResize(shape: PinShape) {
 		return false
 	}
-	override hideRotateHandle(_shape: PinShape) {
+	override hideRotateHandle(shape: PinShape) {
 		return true
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
@@ -33,7 +33,7 @@ class HouseShapeUtil extends ShapeUtil<HouseShape> {
 	static override type = HOUSE_TYPE
 	static override props = houseShapeProps
 
-	override canResize(_shape: HouseShape) {
+	override canResize(shape: HouseShape) {
 		return true
 	}
 	override getDefaultProps() {

--- a/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
@@ -33,7 +33,7 @@ class HouseShapeUtil extends ShapeUtil<HouseShape> {
 	static override type = HOUSE_TYPE
 	static override props = houseShapeProps
 
-	override canResize() {
+	override canResize(_shape: HouseShape) {
 		return true
 	}
 	override getDefaultProps() {

--- a/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-geometry/ShapeWithGeometry.tsx
@@ -33,7 +33,7 @@ class HouseShapeUtil extends ShapeUtil<HouseShape> {
 	static override type = HOUSE_TYPE
 	static override props = houseShapeProps
 
-	override canResize(_shape: HouseShape) {
+	override canResize() {
 		return true
 	}
 	override getDefaultProps() {

--- a/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
@@ -40,7 +40,7 @@ export class ClickableShapeUtil extends BaseBoxShapeUtil<ClickableShape> {
 		}
 	}
 
-	override canEdit(_shape: ClickableShape) {
+	override canEdit(shape: ClickableShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
@@ -40,7 +40,7 @@ export class ClickableShapeUtil extends BaseBoxShapeUtil<ClickableShape> {
 		}
 	}
 
-	override canEdit(_shape: ClickableShape) {
+	override canEdit() {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/shape-with-onClick/ClickableShapeUtil.tsx
@@ -40,7 +40,7 @@ export class ClickableShapeUtil extends BaseBoxShapeUtil<ClickableShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ClickableShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
@@ -97,15 +97,15 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 	}
 
 	// [c]
-	override canCull(_shape: DynamicSizeShape) {
+	override canCull(shape: DynamicSizeShape) {
 		return false
 	}
 
 	// [d]
-	override canEdit(_shape: DynamicSizeShape) {
+	override canEdit(shape: DynamicSizeShape) {
 		return false
 	}
-	override canResize(_shape: DynamicSizeShape) {
+	override canResize(shape: DynamicSizeShape) {
 		return false
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
@@ -97,15 +97,15 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 	}
 
 	// [c]
-	override canCull() {
+	override canCull(_shape: DynamicSizeShape) {
 		return false
 	}
 
 	// [d]
-	override canEdit() {
+	override canEdit(_shape: DynamicSizeShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: DynamicSizeShape) {
 		return false
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/size-from-dom/SizeFromDomExample.tsx
@@ -97,15 +97,15 @@ export class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
 	}
 
 	// [c]
-	override canCull(_shape: DynamicSizeShape) {
+	override canCull() {
 		return false
 	}
 
 	// [d]
-	override canEdit(_shape: DynamicSizeShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: DynamicSizeShape) {
+	override canResize() {
 		return false
 	}
 	override isAspectRatioLocked() {

--- a/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -82,15 +82,15 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	// [3]
 	static override props = speechBubbleShapeProps
 
-	override isAspectRatioLocked(_shape: SpeechBubbleShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
 
-	override canResize(_shape: SpeechBubbleShape) {
+	override canResize() {
 		return true
 	}
 
-	override canEdit(_shape: SpeechBubbleShape) {
+	override canEdit() {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -90,7 +90,7 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 		return true
 	}
 
-	override canEdit() {
+	override canEdit(_shape: SpeechBubbleShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -82,15 +82,15 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	// [3]
 	static override props = speechBubbleShapeProps
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: SpeechBubbleShape) {
 		return false
 	}
 
-	override canResize() {
+	override canResize(_shape: SpeechBubbleShape) {
 		return true
 	}
 
-	override canEdit() {
+	override canEdit(_shape: SpeechBubbleShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/SpeechBubbleUtil.tsx
@@ -82,15 +82,15 @@ export class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	// [3]
 	static override props = speechBubbleShapeProps
 
-	override isAspectRatioLocked(_shape: SpeechBubbleShape) {
+	override isAspectRatioLocked(shape: SpeechBubbleShape) {
 		return false
 	}
 
-	override canResize(_shape: SpeechBubbleShape) {
+	override canResize(shape: SpeechBubbleShape) {
 		return true
 	}
 
-	override canEdit(_shape: SpeechBubbleShape) {
+	override canEdit(shape: SpeechBubbleShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
@@ -49,19 +49,19 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		// stickers can bind to anything
 		return true
 	}
-	override canEdit(_shape: StickerShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: StickerShape) {
+	override canResize() {
 		return false
 	}
-	override canSnap(_shape: StickerShape) {
+	override canSnap() {
 		return false
 	}
-	override hideRotateHandle(_shape: StickerShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: StickerShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
@@ -49,19 +49,19 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		// stickers can bind to anything
 		return true
 	}
-	override canEdit(_shape: StickerShape) {
+	override canEdit(shape: StickerShape) {
 		return false
 	}
-	override canResize(_shape: StickerShape) {
+	override canResize(shape: StickerShape) {
 		return false
 	}
-	override canSnap(_shape: StickerShape) {
+	override canSnap(shape: StickerShape) {
 		return false
 	}
-	override hideRotateHandle(_shape: StickerShape) {
+	override hideRotateHandle(shape: StickerShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: StickerShape) {
+	override isAspectRatioLocked(shape: StickerShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
@@ -49,19 +49,19 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		// stickers can bind to anything
 		return true
 	}
-	override canEdit() {
+	override canEdit(_shape: StickerShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: StickerShape) {
 		return false
 	}
-	override canSnap() {
+	override canSnap(_shape: StickerShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: StickerShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: StickerShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
@@ -49,16 +49,16 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 		// stickers can bind to anything
 		return true
 	}
-	override canEdit() {
+	override canEdit(_shape: StickerShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: StickerShape) {
 		return false
 	}
-	override canSnap() {
+	override canSnap(_shape: StickerShape) {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: StickerShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: StickerShape) {

--- a/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/sticker-bindings/StickerExample.tsx
@@ -61,7 +61,7 @@ class StickerShapeUtil extends ShapeUtil<StickerShape> {
 	override hideRotateHandle() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: StickerShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -47,7 +47,7 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 	override canResize() {
 		return false
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -41,13 +41,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ICustomShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ICustomShape) {
 		return false
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -41,13 +41,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit(_shape: ICustomShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ICustomShape) {
+	override canResize() {
 		return false
 	}
-	override isAspectRatioLocked(_shape: ICustomShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
 

--- a/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -41,10 +41,10 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ICustomShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ICustomShape) {
 		return false
 	}
 	override isAspectRatioLocked(_shape: ICustomShape) {

--- a/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/toSvg-method-example/CustomShapeToSvgExample.tsx
@@ -41,13 +41,13 @@ export class MyShapeUtil extends ShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit(_shape: ICustomShape) {
+	override canEdit(shape: ICustomShape) {
 		return false
 	}
-	override canResize(_shape: ICustomShape) {
+	override canResize(shape: ICustomShape) {
 		return false
 	}
-	override isAspectRatioLocked(_shape: ICustomShape) {
+	override isAspectRatioLocked(shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
@@ -78,7 +78,7 @@ export class FlowchartShapeUtil extends BaseBoxShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit(_shape: ICustomShape) {
+	override canEdit() {
 		return false
 	}
 

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
@@ -78,7 +78,7 @@ export class FlowchartShapeUtil extends BaseBoxShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/customMermaidShapeUtil.tsx
@@ -78,7 +78,7 @@ export class FlowchartShapeUtil extends BaseBoxShapeUtil<ICustomShape> {
 		}
 	}
 
-	override canEdit(_shape: ICustomShape) {
+	override canEdit(shape: ICustomShape) {
 		return false
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
@@ -71,10 +71,10 @@ export class UsMapShapeUtil extends ShapeUtil<UsMapShape> {
 		return { w: MAP_WIDTH, h: MAP_HEIGHT }
 	}
 
-	override canResize(_shape: UsMapShape) {
+	override canResize(shape: UsMapShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: UsMapShape) {
+	override isAspectRatioLocked(shape: UsMapShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
@@ -71,10 +71,10 @@ export class UsMapShapeUtil extends ShapeUtil<UsMapShape> {
 		return { w: MAP_WIDTH, h: MAP_HEIGHT }
 	}
 
-	override canResize() {
+	override canResize(_shape: UsMapShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: UsMapShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
@@ -71,7 +71,7 @@ export class UsMapShapeUtil extends ShapeUtil<UsMapShape> {
 		return { w: MAP_WIDTH, h: MAP_HEIGHT }
 	}
 
-	override canResize() {
+	override canResize(_shape: UsMapShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: UsMapShape) {

--- a/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
@@ -71,10 +71,10 @@ export class UsMapShapeUtil extends ShapeUtil<UsMapShape> {
 		return { w: MAP_WIDTH, h: MAP_HEIGHT }
 	}
 
-	override canResize(_shape: UsMapShape) {
+	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: UsMapShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsMapShapeUtil.tsx
@@ -74,7 +74,7 @@ export class UsMapShapeUtil extends ShapeUtil<UsMapShape> {
 	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: UsMapShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
@@ -58,10 +58,10 @@ export class UsStateShapeUtil extends ShapeUtil<UsStateShape> {
 		}
 	}
 
-	override canResize() {
+	override canResize(_shape: UsStateShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: UsStateShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
@@ -61,7 +61,7 @@ export class UsStateShapeUtil extends ShapeUtil<UsStateShape> {
 	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: UsStateShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
@@ -58,10 +58,10 @@ export class UsStateShapeUtil extends ShapeUtil<UsStateShape> {
 		}
 	}
 
-	override canResize(_shape: UsStateShape) {
+	override canResize() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: UsStateShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
@@ -58,7 +58,7 @@ export class UsStateShapeUtil extends ShapeUtil<UsStateShape> {
 		}
 	}
 
-	override canResize() {
+	override canResize(_shape: UsStateShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: UsStateShape) {

--- a/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/d3-map/UsStateShapeUtil.tsx
@@ -58,10 +58,10 @@ export class UsStateShapeUtil extends ShapeUtil<UsStateShape> {
 		}
 	}
 
-	override canResize(_shape: UsStateShape) {
+	override canResize(shape: UsStateShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: UsStateShape) {
+	override isAspectRatioLocked(shape: UsStateShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
+++ b/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
@@ -31,7 +31,7 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 	}
 
 	// [1]
-	override canEdit(): boolean {
+	override canEdit(_shape: IExamMarkShape): boolean {
 		return true
 	}
 
@@ -124,14 +124,14 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 		})
 	}
 
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: IExamMarkShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: IExamMarkShape) {
 		return true
 	}
 
-	override canResize(): boolean {
+	override canResize(_shape: IExamMarkShape): boolean {
 		return false
 	}
 }

--- a/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
+++ b/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
@@ -124,10 +124,10 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 		})
 	}
 
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: IExamMarkShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: IExamMarkShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
+++ b/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
@@ -31,7 +31,7 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 	}
 
 	// [1]
-	override canEdit(_shape: IExamMarkShape): boolean {
+	override canEdit(shape: IExamMarkShape): boolean {
 		return true
 	}
 
@@ -124,14 +124,14 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 		})
 	}
 
-	override hideSelectionBoundsBg(_shape: IExamMarkShape) {
+	override hideSelectionBoundsBg(shape: IExamMarkShape) {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: IExamMarkShape) {
+	override hideSelectionBoundsFg(shape: IExamMarkShape) {
 		return true
 	}
 
-	override canResize(_shape: IExamMarkShape): boolean {
+	override canResize(shape: IExamMarkShape): boolean {
 		return false
 	}
 }

--- a/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
+++ b/apps/examples/src/examples/use-cases/exam-marking/add-mark-util.tsx
@@ -31,7 +31,7 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 	}
 
 	// [1]
-	override canEdit(_shape: IExamMarkShape): boolean {
+	override canEdit(): boolean {
 		return true
 	}
 
@@ -124,14 +124,14 @@ export class ExamMarkUtil extends ShapeUtil<IExamMarkShape> {
 		})
 	}
 
-	override hideSelectionBoundsBg(_shape: IExamMarkShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: IExamMarkShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
 
-	override canResize(_shape: IExamMarkShape): boolean {
+	override canResize(): boolean {
 		return false
 	}
 }

--- a/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
@@ -37,7 +37,7 @@ export class SlideShapeUtil extends ShapeUtil<SlideShape> {
 	override canBind() {
 		return false
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: SlideShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
@@ -37,7 +37,7 @@ export class SlideShapeUtil extends ShapeUtil<SlideShape> {
 	override canBind() {
 		return false
 	}
-	override hideRotateHandle(_shape: SlideShape) {
+	override hideRotateHandle(shape: SlideShape) {
 		return true
 	}
 

--- a/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/slides/SlideShapeUtil.tsx
@@ -37,7 +37,7 @@ export class SlideShapeUtil extends ShapeUtil<SlideShape> {
 	override canBind() {
 		return false
 	}
-	override hideRotateHandle(_shape: SlideShape) {
+	override hideRotateHandle() {
 		return true
 	}
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2065,7 +2065,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     getGeometry(shape: TLGroupShape): Geometry2d;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLGroupShape): boolean;
+    hideSelectionBoundsFg(shape: TLGroupShape): boolean;
     // (undocumented)
     indicator(shape: TLGroupShape): JSX.Element;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2065,7 +2065,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     getGeometry(shape: TLGroupShape): Geometry2d;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLGroupShape): boolean;
     // (undocumented)
     indicator(shape: TLGroupShape): JSX.Element;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2883,13 +2883,13 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     // @internal
     backgroundComponent?(shape: Shape): any;
     canBeLaidOut(shape: Shape, info: TLShapeUtilCanBeLaidOutOpts): boolean;
-    canBind(_opts: TLShapeUtilCanBindOpts): boolean;
+    canBind(opts: TLShapeUtilCanBindOpts): boolean;
     canCrop(shape: Shape): boolean;
     canCull(shape: Shape): boolean;
     canEdit(shape: Shape, info: TLEditStartInfo): boolean;
     canEditInReadonly(shape: Shape): boolean;
     canEditWhileLocked(shape: Shape): boolean;
-    canReceiveNewChildrenOfType(shape: Shape, _type: TLShape['type']): boolean;
+    canReceiveNewChildrenOfType(shape: Shape, type: TLShape['type']): boolean;
     canResize(shape: Shape): boolean;
     canResizeChildren(shape: Shape): boolean;
     canScroll(shape: Shape): boolean;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2065,7 +2065,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
     // (undocumented)
     getGeometry(shape: TLGroupShape): Geometry2d;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLGroupShape): boolean;
+    hideSelectionBoundsFg(): boolean;
     // (undocumented)
     indicator(shape: TLGroupShape): JSX.Element;
     // (undocumented)

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -301,7 +301,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 *
 	 * @public
 	 */
-	canBind(_opts: TLShapeUtilCanBindOpts): boolean {
+	canBind(opts: TLShapeUtilCanBindOpts): boolean {
 		return true
 	}
 
@@ -551,7 +551,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 * @param type - The shape type.
 	 * @public
 	 */
-	canReceiveNewChildrenOfType(shape: Shape, _type: TLShape['type']) {
+	canReceiveNewChildrenOfType(shape: Shape, type: TLShape['type']) {
 		return false
 	}
 

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -12,7 +12,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	static override props = groupShapeProps
 	static override migrations = groupShapeMigrations
 
-	override hideSelectionBoundsFg(_shape: TLGroupShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
 

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -12,7 +12,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	static override props = groupShapeProps
 	static override migrations = groupShapeMigrations
 
-	override hideSelectionBoundsFg(_shape: TLGroupShape) {
+	override hideSelectionBoundsFg(shape: TLGroupShape) {
 		return true
 	}
 

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -12,7 +12,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 	static override props = groupShapeProps
 	static override migrations = groupShapeMigrations
 
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLGroupShape) {
 		return true
 	}
 

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -262,9 +262,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean;
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLArrowShape): boolean;
     // (undocumented)
-    canSnap(): boolean;
+    canSnap(_shape: TLArrowShape): boolean;
     // (undocumented)
     component(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -290,13 +290,13 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideRotateHandle(): boolean;
+    hideRotateHandle(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(): boolean;
+    hideSelectionBoundsBg(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLArrowShape): boolean;
     // (undocumented)
     indicator(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -477,7 +477,7 @@ export interface BookmarkShapeOptions extends ShapeOptionsWithDisplayValues<TLBo
 // @public (undocumented)
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
-    canResize(): boolean;
+    canResize(_shape: TLBookmarkShape): boolean;
     // (undocumented)
     component(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -491,7 +491,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
     getText(shape: TLBookmarkShape): string;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLBookmarkShape): boolean;
     // (undocumented)
     indicator(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -1528,9 +1528,9 @@ export const embedShapePermissionDefaults: {
 // @public (undocumented)
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLEmbedShape): boolean;
     // (undocumented)
-    canEditInReadonly(): boolean;
+    canEditInReadonly(_shape: TLEmbedShape): boolean;
     // (undocumented)
     canEditWhileLocked(shape: TLEmbedShape): boolean;
     // (undocumented)
@@ -1686,9 +1686,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canReceiveNewChildrenOfType(shape: TLShape): boolean;
     // (undocumented)
-    canResize(): boolean;
+    canResize(_shape: TLFrameShape): boolean;
     // (undocumented)
-    canResizeChildren(): boolean;
+    canResizeChildren(_shape: TLFrameShape): boolean;
     // (undocumented)
     component(shape: TLFrameShape): JSX.Element;
     // (undocumented)
@@ -1797,7 +1797,7 @@ export class GeoShapeTool extends StateNode {
 // @public (undocumented)
 export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLGeoShape): boolean;
     // (undocumented)
     component(shape: TLGeoShape): JSX.Element;
     // (undocumented)
@@ -2226,7 +2226,7 @@ export interface ImageShapeOptions extends ShapeOptionsWithDisplayValues<TLImage
 // @public (undocumented)
 export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
-    canCrop(): boolean;
+    canCrop(_shape: TLImageShape): boolean;
     // (undocumented)
     component(shape: TLImageShape): JSX.Element;
     // (undocumented)
@@ -2246,7 +2246,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     indicator(shape: TLImageShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLImageShape): boolean;
     // (undocumented)
     isExportBoundsContainer(): boolean;
     // (undocumented)
@@ -2337,13 +2337,13 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideRotateHandle(): boolean;
+    hideRotateHandle(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(): boolean;
+    hideSelectionBoundsBg(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLLineShape): boolean;
     // (undocumented)
     indicator(shape: TLLineShape): JSX.Element;
     // (undocumented)
@@ -2492,7 +2492,7 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLNoteShape): boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -2512,13 +2512,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getText(shape: TLNoteShape): string;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLNoteShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLNoteShape): boolean;
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLNoteShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -3368,7 +3368,7 @@ export class TextShapeTool extends StateNode {
 // @public (undocumented)
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLTextShape): boolean;
     // (undocumented)
     component(shape: TLTextShape): JSX.Element;
     // (undocumented)
@@ -3389,7 +3389,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     indicator(shape: TLTextShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLTextShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -6020,7 +6020,7 @@ export interface VideoShapeOptions extends ShapeOptionsWithDisplayValues<TLVideo
 // @public (undocumented)
 export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLVideoShape): boolean;
     // (undocumented)
     component(shape: TLVideoShape): JSX.Element;
     // (undocumented)
@@ -6036,7 +6036,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLVideoShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -262,9 +262,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean;
     // (undocumented)
-    canEdit(_shape: TLArrowShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
-    canSnap(_shape: TLArrowShape): boolean;
+    canSnap(): boolean;
     // (undocumented)
     component(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -290,13 +290,13 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(_shape: TLArrowShape): boolean;
+    hideResizeHandles(): boolean;
     // (undocumented)
-    hideRotateHandle(_shape: TLArrowShape): boolean;
+    hideRotateHandle(): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(_shape: TLArrowShape): boolean;
+    hideSelectionBoundsBg(): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLArrowShape): boolean;
+    hideSelectionBoundsFg(): boolean;
     // (undocumented)
     indicator(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -477,7 +477,7 @@ export interface BookmarkShapeOptions extends ShapeOptionsWithDisplayValues<TLBo
 // @public (undocumented)
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
-    canResize(_shape: TLBookmarkShape): boolean;
+    canResize(): boolean;
     // (undocumented)
     component(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -491,7 +491,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
     getText(shape: TLBookmarkShape): string;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLBookmarkShape): boolean;
+    hideSelectionBoundsFg(): boolean;
     // (undocumented)
     indicator(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -1528,9 +1528,9 @@ export const embedShapePermissionDefaults: {
 // @public (undocumented)
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
-    canEdit(_shape: TLEmbedShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
-    canEditInReadonly(_shape: TLEmbedShape): boolean;
+    canEditInReadonly(): boolean;
     // (undocumented)
     canEditWhileLocked(shape: TLEmbedShape): boolean;
     // (undocumented)
@@ -1686,9 +1686,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canReceiveNewChildrenOfType(shape: TLShape): boolean;
     // (undocumented)
-    canResize(_shape: TLFrameShape): boolean;
+    canResize(): boolean;
     // (undocumented)
-    canResizeChildren(_shape: TLFrameShape): boolean;
+    canResizeChildren(): boolean;
     // (undocumented)
     component(shape: TLFrameShape): JSX.Element;
     // (undocumented)
@@ -1797,7 +1797,7 @@ export class GeoShapeTool extends StateNode {
 // @public (undocumented)
 export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     // (undocumented)
-    canEdit(_shape: TLGeoShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
     component(shape: TLGeoShape): JSX.Element;
     // (undocumented)
@@ -2226,7 +2226,7 @@ export interface ImageShapeOptions extends ShapeOptionsWithDisplayValues<TLImage
 // @public (undocumented)
 export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
-    canCrop(_shape: TLImageShape): boolean;
+    canCrop(): boolean;
     // (undocumented)
     component(shape: TLImageShape): JSX.Element;
     // (undocumented)
@@ -2246,7 +2246,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     indicator(shape: TLImageShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLImageShape): boolean;
+    isAspectRatioLocked(): boolean;
     // (undocumented)
     isExportBoundsContainer(): boolean;
     // (undocumented)
@@ -2337,13 +2337,13 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(_shape: TLLineShape): boolean;
+    hideResizeHandles(): boolean;
     // (undocumented)
-    hideRotateHandle(_shape: TLLineShape): boolean;
+    hideRotateHandle(): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(_shape: TLLineShape): boolean;
+    hideSelectionBoundsBg(): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLLineShape): boolean;
+    hideSelectionBoundsFg(): boolean;
     // (undocumented)
     indicator(shape: TLLineShape): JSX.Element;
     // (undocumented)
@@ -2492,7 +2492,7 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canEdit(_shape: TLNoteShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -2512,13 +2512,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getText(shape: TLNoteShape): string;
     // (undocumented)
-    hideResizeHandles(_shape: TLNoteShape): boolean;
+    hideResizeHandles(): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLNoteShape): boolean;
+    hideSelectionBoundsFg(): boolean;
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLNoteShape): boolean;
+    isAspectRatioLocked(): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -3368,7 +3368,7 @@ export class TextShapeTool extends StateNode {
 // @public (undocumented)
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
-    canEdit(_shape: TLTextShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
     component(shape: TLTextShape): JSX.Element;
     // (undocumented)
@@ -3389,7 +3389,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     indicator(shape: TLTextShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLTextShape): boolean;
+    isAspectRatioLocked(): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -6020,7 +6020,7 @@ export interface VideoShapeOptions extends ShapeOptionsWithDisplayValues<TLVideo
 // @public (undocumented)
 export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
-    canEdit(_shape: TLVideoShape): boolean;
+    canEdit(): boolean;
     // (undocumented)
     component(shape: TLVideoShape): JSX.Element;
     // (undocumented)
@@ -6036,7 +6036,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLVideoShape): boolean;
+    isAspectRatioLocked(): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -262,9 +262,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean;
     // (undocumented)
-    canEdit(_shape: TLArrowShape): boolean;
+    canEdit(shape: TLArrowShape): boolean;
     // (undocumented)
-    canSnap(_shape: TLArrowShape): boolean;
+    canSnap(shape: TLArrowShape): boolean;
     // (undocumented)
     component(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -290,13 +290,13 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(_shape: TLArrowShape): boolean;
+    hideResizeHandles(shape: TLArrowShape): boolean;
     // (undocumented)
-    hideRotateHandle(_shape: TLArrowShape): boolean;
+    hideRotateHandle(shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(_shape: TLArrowShape): boolean;
+    hideSelectionBoundsBg(shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLArrowShape): boolean;
+    hideSelectionBoundsFg(shape: TLArrowShape): boolean;
     // (undocumented)
     indicator(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -477,7 +477,7 @@ export interface BookmarkShapeOptions extends ShapeOptionsWithDisplayValues<TLBo
 // @public (undocumented)
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
-    canResize(_shape: TLBookmarkShape): boolean;
+    canResize(shape: TLBookmarkShape): boolean;
     // (undocumented)
     component(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -491,7 +491,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
     getText(shape: TLBookmarkShape): string;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLBookmarkShape): boolean;
+    hideSelectionBoundsFg(shape: TLBookmarkShape): boolean;
     // (undocumented)
     indicator(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -1528,9 +1528,9 @@ export const embedShapePermissionDefaults: {
 // @public (undocumented)
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
-    canEdit(_shape: TLEmbedShape): boolean;
+    canEdit(shape: TLEmbedShape): boolean;
     // (undocumented)
-    canEditInReadonly(_shape: TLEmbedShape): boolean;
+    canEditInReadonly(shape: TLEmbedShape): boolean;
     // (undocumented)
     canEditWhileLocked(shape: TLEmbedShape): boolean;
     // (undocumented)
@@ -1686,9 +1686,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canReceiveNewChildrenOfType(shape: TLShape): boolean;
     // (undocumented)
-    canResize(_shape: TLFrameShape): boolean;
+    canResize(shape: TLFrameShape): boolean;
     // (undocumented)
-    canResizeChildren(_shape: TLFrameShape): boolean;
+    canResizeChildren(shape: TLFrameShape): boolean;
     // (undocumented)
     component(shape: TLFrameShape): JSX.Element;
     // (undocumented)
@@ -1797,7 +1797,7 @@ export class GeoShapeTool extends StateNode {
 // @public (undocumented)
 export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     // (undocumented)
-    canEdit(_shape: TLGeoShape): boolean;
+    canEdit(shape: TLGeoShape): boolean;
     // (undocumented)
     component(shape: TLGeoShape): JSX.Element;
     // (undocumented)
@@ -2226,7 +2226,7 @@ export interface ImageShapeOptions extends ShapeOptionsWithDisplayValues<TLImage
 // @public (undocumented)
 export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
-    canCrop(_shape: TLImageShape): boolean;
+    canCrop(shape: TLImageShape): boolean;
     // (undocumented)
     component(shape: TLImageShape): JSX.Element;
     // (undocumented)
@@ -2246,7 +2246,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     indicator(shape: TLImageShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLImageShape): boolean;
+    isAspectRatioLocked(shape: TLImageShape): boolean;
     // (undocumented)
     isExportBoundsContainer(): boolean;
     // (undocumented)
@@ -2337,13 +2337,13 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(_shape: TLLineShape): boolean;
+    hideResizeHandles(shape: TLLineShape): boolean;
     // (undocumented)
-    hideRotateHandle(_shape: TLLineShape): boolean;
+    hideRotateHandle(shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(_shape: TLLineShape): boolean;
+    hideSelectionBoundsBg(shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLLineShape): boolean;
+    hideSelectionBoundsFg(shape: TLLineShape): boolean;
     // (undocumented)
     indicator(shape: TLLineShape): JSX.Element;
     // (undocumented)
@@ -2492,7 +2492,7 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canEdit(_shape: TLNoteShape): boolean;
+    canEdit(shape: TLNoteShape): boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -2512,13 +2512,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getText(shape: TLNoteShape): string;
     // (undocumented)
-    hideResizeHandles(_shape: TLNoteShape): boolean;
+    hideResizeHandles(shape: TLNoteShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(_shape: TLNoteShape): boolean;
+    hideSelectionBoundsFg(shape: TLNoteShape): boolean;
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLNoteShape): boolean;
+    isAspectRatioLocked(shape: TLNoteShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -3368,7 +3368,7 @@ export class TextShapeTool extends StateNode {
 // @public (undocumented)
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
-    canEdit(_shape: TLTextShape): boolean;
+    canEdit(shape: TLTextShape): boolean;
     // (undocumented)
     component(shape: TLTextShape): JSX.Element;
     // (undocumented)
@@ -3389,7 +3389,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     indicator(shape: TLTextShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLTextShape): boolean;
+    isAspectRatioLocked(shape: TLTextShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -6020,7 +6020,7 @@ export interface VideoShapeOptions extends ShapeOptionsWithDisplayValues<TLVideo
 // @public (undocumented)
 export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
-    canEdit(_shape: TLVideoShape): boolean;
+    canEdit(shape: TLVideoShape): boolean;
     // (undocumented)
     component(shape: TLVideoShape): JSX.Element;
     // (undocumented)
@@ -6036,7 +6036,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(_shape: TLVideoShape): boolean;
+    isAspectRatioLocked(shape: TLVideoShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2246,7 +2246,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
     indicator(shape: TLImageShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLImageShape): boolean;
     // (undocumented)
     isExportBoundsContainer(): boolean;
     // (undocumented)
@@ -2518,7 +2518,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLNoteShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -3389,7 +3389,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
     indicator(shape: TLTextShape): JSX.Element | null;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLTextShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)
@@ -6036,7 +6036,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
     indicator(shape: TLVideoShape): JSX.Element;
     // (undocumented)
-    isAspectRatioLocked(): boolean;
+    isAspectRatioLocked(_shape: TLVideoShape): boolean;
     // (undocumented)
     static migrations: TLPropsMigrations;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -262,9 +262,9 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean;
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLArrowShape): boolean;
     // (undocumented)
-    canSnap(): boolean;
+    canSnap(_shape: TLArrowShape): boolean;
     // (undocumented)
     component(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -290,13 +290,13 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideRotateHandle(): boolean;
+    hideRotateHandle(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(): boolean;
+    hideSelectionBoundsBg(_shape: TLArrowShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLArrowShape): boolean;
     // (undocumented)
     indicator(shape: TLArrowShape): JSX.Element | null;
     // (undocumented)
@@ -477,7 +477,7 @@ export interface BookmarkShapeOptions extends ShapeOptionsWithDisplayValues<TLBo
 // @public (undocumented)
 export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
-    canResize(): boolean;
+    canResize(_shape: TLBookmarkShape): boolean;
     // (undocumented)
     component(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -491,7 +491,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
     // (undocumented)
     getText(shape: TLBookmarkShape): string;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLBookmarkShape): boolean;
     // (undocumented)
     indicator(shape: TLBookmarkShape): JSX.Element;
     // (undocumented)
@@ -1528,9 +1528,9 @@ export const embedShapePermissionDefaults: {
 // @public (undocumented)
 export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLEmbedShape): boolean;
     // (undocumented)
-    canEditInReadonly(): boolean;
+    canEditInReadonly(_shape: TLEmbedShape): boolean;
     // (undocumented)
     canEditWhileLocked(shape: TLEmbedShape): boolean;
     // (undocumented)
@@ -1686,9 +1686,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     // (undocumented)
     canReceiveNewChildrenOfType(shape: TLShape): boolean;
     // (undocumented)
-    canResize(): boolean;
+    canResize(_shape: TLFrameShape): boolean;
     // (undocumented)
-    canResizeChildren(): boolean;
+    canResizeChildren(_shape: TLFrameShape): boolean;
     // (undocumented)
     component(shape: TLFrameShape): JSX.Element;
     // (undocumented)
@@ -1797,7 +1797,7 @@ export class GeoShapeTool extends StateNode {
 // @public (undocumented)
 export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLGeoShape): boolean;
     // (undocumented)
     component(shape: TLGeoShape): JSX.Element;
     // (undocumented)
@@ -2226,7 +2226,7 @@ export interface ImageShapeOptions extends ShapeOptionsWithDisplayValues<TLImage
 // @public (undocumented)
 export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
     // (undocumented)
-    canCrop(): boolean;
+    canCrop(_shape: TLImageShape): boolean;
     // (undocumented)
     component(shape: TLImageShape): JSX.Element;
     // (undocumented)
@@ -2337,13 +2337,13 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
     // (undocumented)
     hideInMinimap(): boolean;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideRotateHandle(): boolean;
+    hideRotateHandle(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsBg(): boolean;
+    hideSelectionBoundsBg(_shape: TLLineShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLLineShape): boolean;
     // (undocumented)
     indicator(shape: TLLineShape): JSX.Element;
     // (undocumented)
@@ -2492,7 +2492,7 @@ export class NoteShapeTool extends StateNode {
 // @public (undocumented)
 export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLNoteShape): boolean;
     // (undocumented)
     component(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -2512,9 +2512,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     getText(shape: TLNoteShape): string;
     // (undocumented)
-    hideResizeHandles(): boolean;
+    hideResizeHandles(_shape: TLNoteShape): boolean;
     // (undocumented)
-    hideSelectionBoundsFg(): boolean;
+    hideSelectionBoundsFg(_shape: TLNoteShape): boolean;
     // (undocumented)
     indicator(shape: TLNoteShape): JSX.Element;
     // (undocumented)
@@ -3368,7 +3368,7 @@ export class TextShapeTool extends StateNode {
 // @public (undocumented)
 export class TextShapeUtil extends ShapeUtil<TLTextShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLTextShape): boolean;
     // (undocumented)
     component(shape: TLTextShape): JSX.Element;
     // (undocumented)
@@ -6020,7 +6020,7 @@ export interface VideoShapeOptions extends ShapeOptionsWithDisplayValues<TLVideo
 // @public (undocumented)
 export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
     // (undocumented)
-    canEdit(): boolean;
+    canEdit(_shape: TLVideoShape): boolean;
     // (undocumented)
     component(shape: TLVideoShape): JSX.Element;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -155,26 +155,26 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLArrowShape) {
 		return true
 	}
 	override canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean {
 		// bindings can go from arrows to shapes, but not from shapes to arrows
 		return toShape.type !== 'arrow'
 	}
-	override canSnap() {
+	override canSnap(_shape: TLArrowShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: TLArrowShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: TLArrowShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: TLArrowShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLArrowShape) {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -155,26 +155,26 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		},
 	}
 
-	override canEdit(_shape: TLArrowShape) {
+	override canEdit() {
 		return true
 	}
 	override canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean {
 		// bindings can go from arrows to shapes, but not from shapes to arrows
 		return toShape.type !== 'arrow'
 	}
-	override canSnap(_shape: TLArrowShape) {
+	override canSnap() {
 		return false
 	}
-	override hideResizeHandles(_shape: TLArrowShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: TLArrowShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: TLArrowShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: TLArrowShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -155,26 +155,26 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		},
 	}
 
-	override canEdit(_shape: TLArrowShape) {
+	override canEdit(shape: TLArrowShape) {
 		return true
 	}
 	override canBind({ toShape }: TLShapeUtilCanBindOpts<TLArrowShape>): boolean {
 		// bindings can go from arrows to shapes, but not from shapes to arrows
 		return toShape.type !== 'arrow'
 	}
-	override canSnap(_shape: TLArrowShape) {
+	override canSnap(shape: TLArrowShape) {
 		return false
 	}
-	override hideResizeHandles(_shape: TLArrowShape) {
+	override hideResizeHandles(shape: TLArrowShape) {
 		return true
 	}
-	override hideRotateHandle(_shape: TLArrowShape) {
+	override hideRotateHandle(shape: TLArrowShape) {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: TLArrowShape) {
+	override hideSelectionBoundsBg(shape: TLArrowShape) {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: TLArrowShape) {
+	override hideSelectionBoundsFg(shape: TLArrowShape) {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -54,11 +54,11 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 		},
 	}
 
-	override canResize(_shape: TLBookmarkShape) {
+	override canResize(shape: TLBookmarkShape) {
 		return false
 	}
 
-	override hideSelectionBoundsFg(_shape: TLBookmarkShape) {
+	override hideSelectionBoundsFg(shape: TLBookmarkShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -54,11 +54,11 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 		},
 	}
 
-	override canResize() {
+	override canResize(_shape: TLBookmarkShape) {
 		return false
 	}
 
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLBookmarkShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -54,11 +54,11 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 		},
 	}
 
-	override canResize(_shape: TLBookmarkShape) {
+	override canResize() {
 		return false
 	}
 
-	override hideSelectionBoundsFg(_shape: TLBookmarkShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -105,13 +105,13 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	override hideSelectionBoundsFg(shape: TLEmbedShape) {
 		return !this.canResize(shape)
 	}
-	override canEdit() {
+	override canEdit(_shape: TLEmbedShape) {
 		return true
 	}
 	override canResize(shape: TLEmbedShape) {
 		return this.getEmbedDefinition(shape.props.url)?.definition?.doesResize ?? true
 	}
-	override canEditInReadonly() {
+	override canEditInReadonly(_shape: TLEmbedShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -105,13 +105,13 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	override hideSelectionBoundsFg(shape: TLEmbedShape) {
 		return !this.canResize(shape)
 	}
-	override canEdit(_shape: TLEmbedShape) {
+	override canEdit() {
 		return true
 	}
 	override canResize(shape: TLEmbedShape) {
 		return this.getEmbedDefinition(shape.props.url)?.definition?.doesResize ?? true
 	}
-	override canEditInReadonly(_shape: TLEmbedShape) {
+	override canEditInReadonly() {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -105,13 +105,13 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 	override hideSelectionBoundsFg(shape: TLEmbedShape) {
 		return !this.canResize(shape)
 	}
-	override canEdit(_shape: TLEmbedShape) {
+	override canEdit(shape: TLEmbedShape) {
 		return true
 	}
 	override canResize(shape: TLEmbedShape) {
 		return this.getEmbedDefinition(shape.props.url)?.definition?.doesResize ?? true
 	}
-	override canEditInReadonly(_shape: TLEmbedShape) {
+	override canEditInReadonly(shape: TLEmbedShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -128,11 +128,11 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return info.type === 'click-header' || info.type === 'unknown'
 	}
 
-	override canResize(_shape: TLFrameShape) {
+	override canResize() {
 		return true
 	}
 
-	override canResizeChildren(_shape: TLFrameShape) {
+	override canResizeChildren() {
 		return this.options.resizeChildren
 	}
 

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -128,11 +128,11 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return info.type === 'click-header' || info.type === 'unknown'
 	}
 
-	override canResize(_shape: TLFrameShape) {
+	override canResize(shape: TLFrameShape) {
 		return true
 	}
 
-	override canResizeChildren(_shape: TLFrameShape) {
+	override canResizeChildren(shape: TLFrameShape) {
 		return this.options.resizeChildren
 	}
 

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -128,11 +128,11 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return info.type === 'click-header' || info.type === 'unknown'
 	}
 
-	override canResize() {
+	override canResize(_shape: TLFrameShape) {
 		return true
 	}
 
-	override canResizeChildren() {
+	override canResizeChildren(_shape: TLFrameShape) {
 		return this.options.resizeChildren
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -161,7 +161,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		},
 	}
 
-	override canEdit(_shape: TLGeoShape) {
+	override canEdit(shape: TLGeoShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -161,7 +161,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		},
 	}
 
-	override canEdit(_shape: TLGeoShape) {
+	override canEdit() {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -161,7 +161,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLGeoShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -78,10 +78,10 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		},
 	}
 
-	override isAspectRatioLocked(_shape: TLImageShape) {
+	override isAspectRatioLocked(shape: TLImageShape) {
 		return true
 	}
-	override canCrop(_shape: TLImageShape) {
+	override canCrop(shape: TLImageShape) {
 		return true
 	}
 	override isExportBoundsContainer(): boolean {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -78,10 +78,10 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		},
 	}
 
-	override isAspectRatioLocked(_shape: TLImageShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
-	override canCrop(_shape: TLImageShape) {
+	override canCrop() {
 		return true
 	}
 	override isExportBoundsContainer(): boolean {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -81,7 +81,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	override isAspectRatioLocked(_shape: TLImageShape) {
 		return true
 	}
-	override canCrop() {
+	override canCrop(_shape: TLImageShape) {
 		return true
 	}
 	override isExportBoundsContainer(): boolean {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -78,10 +78,10 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		},
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLImageShape) {
 		return true
 	}
-	override canCrop() {
+	override canCrop(_shape: TLImageShape) {
 		return true
 	}
 	override isExportBoundsContainer(): boolean {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -78,7 +78,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		},
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLImageShape) {
 		return true
 	}
 	override canCrop() {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -63,16 +63,16 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		},
 	}
 
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: TLLineShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: TLLineShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLLineShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: TLLineShape) {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -63,16 +63,16 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		},
 	}
 
-	override hideResizeHandles(_shape: TLLineShape) {
+	override hideResizeHandles(shape: TLLineShape) {
 		return true
 	}
-	override hideRotateHandle(_shape: TLLineShape) {
+	override hideRotateHandle(shape: TLLineShape) {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: TLLineShape) {
+	override hideSelectionBoundsFg(shape: TLLineShape) {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: TLLineShape) {
+	override hideSelectionBoundsBg(shape: TLLineShape) {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -63,16 +63,16 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		},
 	}
 
-	override hideResizeHandles(_shape: TLLineShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: TLLineShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: TLLineShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: TLLineShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
 	override hideInMinimap() {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -139,10 +139,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		},
 	}
 
-	override canEdit(_shape: TLNoteShape) {
+	override canEdit() {
 		return true
 	}
-	override hideResizeHandles(_shape: TLNoteShape) {
+	override hideResizeHandles() {
 		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
@@ -157,11 +157,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		}
 	}
 
-	override isAspectRatioLocked(_shape: TLNoteShape) {
+	override isAspectRatioLocked() {
 		return this.options.resizeMode === 'scale'
 	}
 
-	override hideSelectionBoundsFg(_shape: TLNoteShape) {
+	override hideSelectionBoundsFg() {
 		return false
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -139,10 +139,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLNoteShape) {
 		return true
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: TLNoteShape) {
 		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
@@ -157,11 +157,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		}
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLNoteShape) {
 		return this.options.resizeMode === 'scale'
 	}
 
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLNoteShape) {
 		return false
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -157,7 +157,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		}
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLNoteShape) {
 		return this.options.resizeMode === 'scale'
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -139,10 +139,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLNoteShape) {
 		return true
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: TLNoteShape) {
 		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
@@ -161,7 +161,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		return this.options.resizeMode === 'scale'
 	}
 
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: TLNoteShape) {
 		return false
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -139,10 +139,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		},
 	}
 
-	override canEdit(_shape: TLNoteShape) {
+	override canEdit(shape: TLNoteShape) {
 		return true
 	}
-	override hideResizeHandles(_shape: TLNoteShape) {
+	override hideResizeHandles(shape: TLNoteShape) {
 		const { resizeMode } = this.options
 		switch (resizeMode) {
 			case 'none': {
@@ -157,11 +157,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		}
 	}
 
-	override isAspectRatioLocked(_shape: TLNoteShape) {
+	override isAspectRatioLocked(shape: TLNoteShape) {
 		return this.options.resizeMode === 'scale'
 	}
 
-	override hideSelectionBoundsFg(_shape: TLNoteShape) {
+	override hideSelectionBoundsFg(shape: TLNoteShape) {
 		return false
 	}
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -142,7 +142,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return renderPlaintextFromRichText(this.editor, shape.props.richText)
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLTextShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -142,11 +142,11 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return renderPlaintextFromRichText(this.editor, shape.props.richText)
 	}
 
-	override canEdit(_shape: TLTextShape) {
+	override canEdit() {
 		return true
 	}
 
-	override isAspectRatioLocked(_shape: TLTextShape) {
+	override isAspectRatioLocked() {
 		return true
 	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -142,11 +142,11 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return renderPlaintextFromRichText(this.editor, shape.props.richText)
 	}
 
-	override canEdit(_shape: TLTextShape) {
+	override canEdit(shape: TLTextShape) {
 		return true
 	}
 
-	override isAspectRatioLocked(_shape: TLTextShape) {
+	override isAspectRatioLocked(shape: TLTextShape) {
 		return true
 	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -146,7 +146,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return true
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLTextShape) {
 		return true
 	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -142,11 +142,11 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return renderPlaintextFromRichText(this.editor, shape.props.richText)
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLTextShape) {
 		return true
 	}
 
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLTextShape) {
 		return true
 	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -59,10 +59,10 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLVideoShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLVideoShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -59,10 +59,10 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		},
 	}
 
-	override canEdit(_shape: TLVideoShape) {
+	override canEdit() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: TLVideoShape) {
+	override isAspectRatioLocked() {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -62,7 +62,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 	override canEdit() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: TLVideoShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -59,10 +59,10 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		},
 	}
 
-	override canEdit(_shape: TLVideoShape) {
+	override canEdit(shape: TLVideoShape) {
 		return true
 	}
-	override isAspectRatioLocked(_shape: TLVideoShape) {
+	override isAspectRatioLocked(shape: TLVideoShape) {
 		return true
 	}
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -59,7 +59,7 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		},
 	}
 
-	override canEdit() {
+	override canEdit(_shape: TLVideoShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: TLVideoShape) {

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -537,10 +537,10 @@ describe('Custom shapes', () => {
 	class CardUtil extends BaseBoxShapeUtil<CardShape> {
 		static override type = CARD_TYPE
 
-		override isAspectRatioLocked(_shape: CardShape) {
+		override isAspectRatioLocked(shape: CardShape) {
 			return false
 		}
-		override canResize(_shape: CardShape) {
+		override canResize(shape: CardShape) {
 			return true
 		}
 

--- a/packages/tldraw/src/test/custom-clipping.test.ts
+++ b/packages/tldraw/src/test/custom-clipping.test.ts
@@ -92,13 +92,13 @@ export class CircleClipShapeUtil extends BaseBoxShapeUtil<CircleClipShape> {
 		return isClippingEnabled$.get()
 	}
 
-	override component(_shape: CircleClipShape) {
+	override component(shape: CircleClipShape) {
 		// For testing purposes, we'll just return null
 		// In a real implementation, this would return JSX
 		return null as any
 	}
 
-	override indicator(_shape: CircleClipShape) {
+	override indicator(shape: CircleClipShape) {
 		// For testing purposes, we'll just return null
 		// In a real implementation, this would return JSX
 		return null as any

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -860,21 +860,21 @@ describe('frame shapes', () => {
 		it('has default canResizeChildren behavior as false', () => {
 			const frameUtil = editor.getShapeUtil<TLFrameShape>('frame') as FrameShapeUtil
 			expect(frameUtil.options.resizeChildren).toBe(false)
-			expect(frameUtil.canResizeChildren()).toBe(false)
+			expect(frameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
 		})
 
 		it('can be configured to allow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: true })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(true)
-			expect(configuredFrameUtil.canResizeChildren()).toBe(true)
+			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(true)
 		})
 
 		it('can be configured to disallow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: false })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(false)
-			expect(configuredFrameUtil.canResizeChildren()).toBe(false)
+			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
 		})
 
 		it('maintains other options when configuring resizeChildren', () => {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -859,22 +859,24 @@ describe('frame shapes', () => {
 	describe('resizeChildren configuration option', () => {
 		it('has default canResizeChildren behavior as false', () => {
 			const frameUtil = editor.getShapeUtil<TLFrameShape>('frame') as FrameShapeUtil
+			const frameShape =
+				editor.getShape<TLFrameShape>(editor.getSelectedShapeIds()[0]) ?? ({} as TLFrameShape)
 			expect(frameUtil.options.resizeChildren).toBe(false)
-			expect(frameUtil.canResizeChildren()).toBe(false)
+			expect(frameUtil.canResizeChildren(frameShape)).toBe(false)
 		})
 
 		it('can be configured to allow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: true })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(true)
-			expect(configuredFrameUtil.canResizeChildren()).toBe(true)
+			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(true)
 		})
 
 		it('can be configured to disallow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: false })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(false)
-			expect(configuredFrameUtil.canResizeChildren()).toBe(false)
+			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
 		})
 
 		it('maintains other options when configuring resizeChildren', () => {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -860,21 +860,21 @@ describe('frame shapes', () => {
 		it('has default canResizeChildren behavior as false', () => {
 			const frameUtil = editor.getShapeUtil<TLFrameShape>('frame') as FrameShapeUtil
 			expect(frameUtil.options.resizeChildren).toBe(false)
-			expect(frameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
+			expect(frameUtil.canResizeChildren()).toBe(false)
 		})
 
 		it('can be configured to allow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: true })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(true)
-			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(true)
+			expect(configuredFrameUtil.canResizeChildren()).toBe(true)
 		})
 
 		it('can be configured to disallow resizing children', () => {
 			const ConfiguredFrameShapeUtil = FrameShapeUtil.configure({ resizeChildren: false })
 			const configuredFrameUtil = new ConfiguredFrameShapeUtil(editor)
 			expect(configuredFrameUtil.options.resizeChildren).toBe(false)
-			expect(configuredFrameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
+			expect(configuredFrameUtil.canResizeChildren()).toBe(false)
 		})
 
 		it('maintains other options when configuring resizeChildren', () => {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -859,10 +859,8 @@ describe('frame shapes', () => {
 	describe('resizeChildren configuration option', () => {
 		it('has default canResizeChildren behavior as false', () => {
 			const frameUtil = editor.getShapeUtil<TLFrameShape>('frame') as FrameShapeUtil
-			const frameShape =
-				editor.getShape<TLFrameShape>(editor.getSelectedShapeIds()[0]) ?? ({} as TLFrameShape)
 			expect(frameUtil.options.resizeChildren).toBe(false)
-			expect(frameUtil.canResizeChildren(frameShape)).toBe(false)
+			expect(frameUtil.canResizeChildren({} as TLFrameShape)).toBe(false)
 		})
 
 		it('can be configured to allow resizing children', () => {

--- a/packages/tldraw/src/test/getCulledShapes.test.tsx
+++ b/packages/tldraw/src/test/getCulledShapes.test.tsx
@@ -28,7 +28,7 @@ class UncullableShapeUtil extends BaseBoxShapeUtil<UncullableShape> {
 		h: T.number,
 	}
 
-	override canCull(_shape: UncullableShape) {
+	override canCull(shape: UncullableShape) {
 		return false
 	}
 

--- a/packages/tldraw/src/test/getCulledShapes.test.tsx
+++ b/packages/tldraw/src/test/getCulledShapes.test.tsx
@@ -28,7 +28,7 @@ class UncullableShapeUtil extends BaseBoxShapeUtil<UncullableShape> {
 		h: T.number,
 	}
 
-	override canCull() {
+	override canCull(_shape: UncullableShape) {
 		return false
 	}
 

--- a/packages/tldraw/src/test/getCulledShapes.test.tsx
+++ b/packages/tldraw/src/test/getCulledShapes.test.tsx
@@ -28,7 +28,7 @@ class UncullableShapeUtil extends BaseBoxShapeUtil<UncullableShape> {
 		h: T.number,
 	}
 
-	override canCull(_shape: UncullableShape) {
+	override canCull() {
 		return false
 	}
 

--- a/packages/tldraw/src/test/notVisibleShapes.test.ts
+++ b/packages/tldraw/src/test/notVisibleShapes.test.ts
@@ -52,7 +52,7 @@ class TestShape extends ShapeUtil<ITestShape> {
 	override canCull(shape: ITestShape): boolean {
 		return shape.props.canCull
 	}
-	override canEdit(_shape: ITestShape) {
+	override canEdit(shape: ITestShape) {
 		return true
 	}
 	indicator() {}

--- a/packages/tldraw/src/test/notVisibleShapes.test.ts
+++ b/packages/tldraw/src/test/notVisibleShapes.test.ts
@@ -52,7 +52,7 @@ class TestShape extends ShapeUtil<ITestShape> {
 	override canCull(shape: ITestShape): boolean {
 		return shape.props.canCull
 	}
-	override canEdit() {
+	override canEdit(_shape: ITestShape) {
 		return true
 	}
 	indicator() {}

--- a/packages/tldraw/src/test/notVisibleShapes.test.ts
+++ b/packages/tldraw/src/test/notVisibleShapes.test.ts
@@ -52,7 +52,7 @@ class TestShape extends ShapeUtil<ITestShape> {
 	override canCull(shape: ITestShape): boolean {
 		return shape.props.canCull
 	}
-	override canEdit(_shape: ITestShape) {
+	override canEdit() {
 		return true
 	}
 	indicator() {}

--- a/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
@@ -70,29 +70,29 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ConnectionShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ConnectionShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: ConnectionShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: ConnectionShape) {
 		return true
 	}
-	override canSnap() {
+	override canSnap(_shape: ConnectionShape) {
 		// disable snapping this shape to other shapes
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: ConnectionShape) {
 		return {
 			// disable snapping other shape to this shape
 			points: [],

--- a/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
@@ -70,29 +70,29 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit(_shape: ConnectionShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ConnectionShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: ConnectionShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: ConnectionShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: ConnectionShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: ConnectionShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override canSnap(_shape: ConnectionShape) {
+	override canSnap() {
 		// disable snapping this shape to other shapes
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: ConnectionShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			// disable snapping other shape to this shape
 			points: [],

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -67,7 +67,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideSelectionBoundsFg() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: NodeShape) {

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -49,22 +49,22 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: NodeShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: NodeShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: NodeShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: NodeShape) {

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -49,28 +49,28 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit(_shape: NodeShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: NodeShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: NodeShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: NodeShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: NodeShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: NodeShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: NodeShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: NodeShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -49,28 +49,28 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: NodeShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: NodeShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: NodeShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: NodeShape) {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}

--- a/templates/image-pipeline/src/connection/ConnectionShapeUtil.tsx
+++ b/templates/image-pipeline/src/connection/ConnectionShapeUtil.tsx
@@ -75,28 +75,28 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ConnectionShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ConnectionShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: ConnectionShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: ConnectionShape) {
 		return true
 	}
-	override canSnap() {
+	override canSnap(_shape: ConnectionShape) {
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: ConnectionShape) {
 		return {
 			points: [],
 		}

--- a/templates/image-pipeline/src/connection/ConnectionShapeUtil.tsx
+++ b/templates/image-pipeline/src/connection/ConnectionShapeUtil.tsx
@@ -75,28 +75,28 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit(_shape: ConnectionShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ConnectionShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: ConnectionShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: ConnectionShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: ConnectionShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: ConnectionShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override canSnap(_shape: ConnectionShape) {
+	override canSnap() {
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: ConnectionShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			points: [],
 		}

--- a/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
+++ b/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
@@ -81,7 +81,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideSelectionBoundsFg(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: NodeShape) {

--- a/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
+++ b/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
@@ -63,7 +63,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
 	override canResize(shape: NodeShape) {
@@ -72,7 +72,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideResizeHandles(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
 	override hideSelectionBoundsBg(shape: NodeShape) {

--- a/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
+++ b/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
@@ -63,7 +63,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
 	override canResize(shape: NodeShape) {
@@ -72,7 +72,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideResizeHandles(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
 	override hideSelectionBoundsBg(shape: NodeShape) {
@@ -81,10 +81,10 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideSelectionBoundsFg(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: NodeShape) {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}

--- a/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
+++ b/templates/image-pipeline/src/nodes/NodeShapeUtil.tsx
@@ -63,7 +63,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit(_shape: NodeShape) {
+	override canEdit() {
 		return false
 	}
 	override canResize(shape: NodeShape) {
@@ -72,7 +72,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideResizeHandles(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override hideRotateHandle(_shape: NodeShape) {
+	override hideRotateHandle() {
 		return true
 	}
 	override hideSelectionBoundsBg(shape: NodeShape) {
@@ -81,10 +81,10 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideSelectionBoundsFg(shape: NodeShape) {
 		return !this.canResize(shape)
 	}
-	override isAspectRatioLocked(_shape: NodeShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: NodeShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}

--- a/templates/workflow/src/connection/ConnectionShapeUtil.tsx
+++ b/templates/workflow/src/connection/ConnectionShapeUtil.tsx
@@ -72,29 +72,29 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: ConnectionShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: ConnectionShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: ConnectionShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: ConnectionShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: ConnectionShape) {
 		return true
 	}
-	override canSnap() {
+	override canSnap(_shape: ConnectionShape) {
 		// disable snapping this shape to other shapes
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: ConnectionShape) {
 		return {
 			// disable snapping other shape to this shape
 			points: [],

--- a/templates/workflow/src/connection/ConnectionShapeUtil.tsx
+++ b/templates/workflow/src/connection/ConnectionShapeUtil.tsx
@@ -72,29 +72,29 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		}
 	}
 
-	override canEdit(_shape: ConnectionShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: ConnectionShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: ConnectionShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: ConnectionShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: ConnectionShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: ConnectionShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override canSnap(_shape: ConnectionShape) {
+	override canSnap() {
 		// disable snapping this shape to other shapes
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: ConnectionShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			// disable snapping other shape to this shape
 			points: [],

--- a/templates/workflow/src/nodes/NodeShapeUtil.tsx
+++ b/templates/workflow/src/nodes/NodeShapeUtil.tsx
@@ -47,22 +47,22 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: NodeShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: NodeShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: NodeShape) {
 		return true
 	}
 	override isAspectRatioLocked(_shape: NodeShape) {

--- a/templates/workflow/src/nodes/NodeShapeUtil.tsx
+++ b/templates/workflow/src/nodes/NodeShapeUtil.tsx
@@ -47,28 +47,28 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit(_shape: NodeShape) {
+	override canEdit() {
 		return false
 	}
-	override canResize(_shape: NodeShape) {
+	override canResize() {
 		return false
 	}
-	override hideResizeHandles(_shape: NodeShape) {
+	override hideResizeHandles() {
 		return true
 	}
-	override hideRotateHandle(_shape: NodeShape) {
+	override hideRotateHandle() {
 		return true
 	}
-	override hideSelectionBoundsBg(_shape: NodeShape) {
+	override hideSelectionBoundsBg() {
 		return true
 	}
-	override hideSelectionBoundsFg(_shape: NodeShape) {
+	override hideSelectionBoundsFg() {
 		return true
 	}
-	override isAspectRatioLocked(_shape: NodeShape) {
+	override isAspectRatioLocked() {
 		return false
 	}
-	override getBoundsSnapGeometry(_shape: NodeShape) {
+	override getBoundsSnapGeometry() {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}

--- a/templates/workflow/src/nodes/NodeShapeUtil.tsx
+++ b/templates/workflow/src/nodes/NodeShapeUtil.tsx
@@ -65,7 +65,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	override hideSelectionBoundsFg() {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: NodeShape) {

--- a/templates/workflow/src/nodes/NodeShapeUtil.tsx
+++ b/templates/workflow/src/nodes/NodeShapeUtil.tsx
@@ -47,28 +47,28 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	override canEdit() {
+	override canEdit(_shape: NodeShape) {
 		return false
 	}
-	override canResize() {
+	override canResize(_shape: NodeShape) {
 		return false
 	}
-	override hideResizeHandles() {
+	override hideResizeHandles(_shape: NodeShape) {
 		return true
 	}
-	override hideRotateHandle() {
+	override hideRotateHandle(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsBg() {
+	override hideSelectionBoundsBg(_shape: NodeShape) {
 		return true
 	}
-	override hideSelectionBoundsFg() {
+	override hideSelectionBoundsFg(_shape: NodeShape) {
 		return true
 	}
-	override isAspectRatioLocked() {
+	override isAspectRatioLocked(_shape: NodeShape) {
 		return false
 	}
-	override getBoundsSnapGeometry() {
+	override getBoundsSnapGeometry(_shape: NodeShape) {
 		return {
 			points: [{ x: 0, y: 0 }],
 		}


### PR DESCRIPTION
Closes #8456

In order to fix the TypeScript signature mismatch where `ShapeUtil` base class methods declare a `shape` parameter that overrides omit, this PR cleans up both sides: the base class param names are tidied (removing unnecessary underscore prefixes on `canBind` and `canReceiveNewChildrenOfType`), and override implementations that had unused `_shape` params from an earlier pass now omit them entirely — TypeScript allows omitting trailing parameters in overrides, so they only need to appear in implementations that actually reference the shape.

### Change type

- [x] `bugfix`

### Test plan

1. Create image, video, note, text, geo, arrow, frame, embed, and line shapes
2. Verify resize, crop, and other interactions work as before

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed ShapeUtil method signatures so overrides that need the `shape` parameter can declare it without TypeScript errors.

### API changes

Changes to `packages/editor/api-report.api.md`:
- `ShapeUtil.canBind(_opts)` → `ShapeUtil.canBind(opts)` — removed underscore prefix
- `ShapeUtil.canReceiveNewChildrenOfType(shape, _type)` → `ShapeUtil.canReceiveNewChildrenOfType(shape, type)` — removed underscore prefix

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +2 / -2   |
| Automated files | +2 / -2   |
| Documentation   | +4 / -4   |
| Templates       | +3 / -3   |