### PR TITLE
fix(editor): prevent sub-pixel rendering gaps at image boundaries

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -1421,7 +1421,9 @@ input,
 
 .tl-image {
 	position: absolute;
-	inset: 0;
+	inset: -0.5px;
+	width: calc(100% + 1px);
+	height: calc(100% + 1px);
 }
 
 .tl-video.tl-video-is-fullscreen {


### PR DESCRIPTION
Closes #8482

In order to fix grey vertical lines flickering at image boundaries during scroll/zoom, this PR extends `.tl-image` elements 0.5px beyond their container on each edge.

When the camera transform places shapes at sub-pixel coordinates, the browser anti-aliases the `overflow: hidden` clip boundary on the image container. This produces thin grey lines at image edges as the background bleeds through the anti-aliased clip. By oversizing the image by 1px on each axis (`inset: -0.5px` + `calc(100% + 1px)` dimensions), the image fully covers the clip boundary at any fractional position. The extra pixels are clipped away by the parent's `overflow: hidden`, so the visual result is identical — just without the seam.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw and add several PNG images to the canvas
2. Zoom in/out and pan around the canvas
3. Verify no grey vertical lines appear at image boundaries
4. Verify images render correctly at various zoom levels
5. Test with cropped images to ensure no visual regression
6. Test in Chrome, Firefox, and Safari

### Release notes

- Fix grey line artifacts appearing at image edges during scroll and zoom.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +3 / -1    |