### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -302,4 +302,5 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix NaN propagation from zero-length labeled arrows causing all shapes to disappear. ([#8329](https://github.com/tldraw/tldraw/pull/8329))
 - Fix crash when isolating curved arrows with degenerate geometry. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix camera state stuck at 'moving' on dispose, blocking shape interactions on the next editor instance. ([#8396](https://github.com/tldraw/tldraw/pull/8396))
+- Fix opacity slider drag broken on Safari due to style panel's `stopPropagation` on pointermove interfering with Radix UI Slider's pointer capture. ([#8519](https://github.com/tldraw/tldraw/pull/8519))
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))


### PR DESCRIPTION
In order to keep the release notes current during the production freeze week, this PR adds one new bug fix entry to `next.mdx` from the production branch.

**Source**: `production` (freeze week, 3+ weeks since v4.5.0)

**Changes**:
- Added bug fix entry for #8519 (Safari opacity slider drag fix via hotfix)
- Verified all existing entries are still on production — no stale entries to prune
- No archival needed (`last_version` matches latest release v4.5.8)

### Code changes

| Change | Files |
|--------|-------|
| Documentation | `apps/docs/content/releases/next.mdx` |

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests