### PR TITLE
docs: update README with missing starter kit and Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ npx create-tldraw@latest
 - **Agent** — AI agents that read, interpret, and modify canvas content
 - **Workflow** — drag-and-drop node builder for automation pipelines, visual programming, and no-code platforms
 - **Chat** — canvas-powered AI chat where users sketch, annotate, and mark up images alongside conversations
+- **Image pipeline** — node-based builder for image generation pipelines
 - **Branching chat** — AI chat with visual branching, letting users explore and compare different conversation paths
 - **Shader** — WebGL shaders that respond to canvas interactions
 
 ## Local development
 
-The development server runs the examples app at `localhost:5420`. Clone the repo, then enable [corepack](https://nodejs.org/api/corepack.html) for the correct yarn version:
+The development server runs the examples app at `localhost:5420`. You'll need [Node.js](https://nodejs.org) `^20.0.0`. Clone the repo, then enable [corepack](https://nodejs.org/api/corepack.html) for the correct yarn version:
 
 ```bash
 npm i -g corepack


### PR DESCRIPTION
In order to keep the top-level README accurate against the current repo state, this PR adds the `Image pipeline` starter kit (which is already shipped via `npm create tldraw` in `packages/create-tldraw/src/templates.ts`) to the starter kits list, and notes the required Node.js version (`^20.0.0`, per the `engines` field in `package.json`) in the Local development section.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +2 / -1    |
