### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -303,3 +303,4 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix crash when isolating curved arrows with degenerate geometry. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix camera state stuck at 'moving' on dispose, blocking shape interactions on the next editor instance. ([#8396](https://github.com/tldraw/tldraw/pull/8396))
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))
+- Fix opacity slider drag not working on Safari due to `stopPropagation` interfering with Radix UI Slider's pointer capture handling. ([#8519](https://github.com/tldraw/tldraw/pull/8519))


### PR DESCRIPTION
In order to keep release notes current during the production freeze week, this PR adds one new bug fix entry from the production branch that was missing from `next.mdx`.

Source: `production` (freeze week, 3+ weeks since v4.5.0)

**Added:**
- #8519 — Fix opacity slider drag not working on Safari

**Skipped (not SDK-relevant):** docs, chore, CI, dotcom, zero, and internal PRs. #8490 was skipped as it fixes a bug introduced by #8347 in the same release cycle. #8344 was skipped (dotcom label).

**Pruned:** None — all existing entries are on the production branch.

### Change type

- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `bugfix`
- [x] `other`

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -0    |

### Test plan

- [x] Verified all PR links are correct
- [x] Verified all entries reference PRs on production branch