### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -302,4 +302,5 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix NaN propagation from zero-length labeled arrows causing all shapes to disappear. ([#8329](https://github.com/tldraw/tldraw/pull/8329))
 - Fix crash when isolating curved arrows with degenerate geometry. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix camera state stuck at 'moving' on dispose, blocking shape interactions on the next editor instance. ([#8396](https://github.com/tldraw/tldraw/pull/8396))
+- Fix opacity slider drag broken on Safari due to `stopPropagation` interfering with Radix UI Slider's pointer capture handling. ([#8519](https://github.com/tldraw/tldraw/pull/8519))
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))


### PR DESCRIPTION
In order to keep the release notes current during freeze week (source: `production`), this PR adds one new bug fix entry for PR #8519 (opacity slider drag broken on Safari).

All existing entries were verified against the `production` branch — no stale entries were found.

### Change type

- [ ] `major` — Breaking change
- [ ] `minor` — New feature
- [ ] `patch` — Bug fix
- [ ] `dependencies` — Updating dependencies
- [ ] `documentation` — Changes to the documentation only
- [ ] `tests` — Changes to any test code only
- [ ] `internal` — Any other changes that don't affect the published package
- [x] `other`

### Code changes

| Change                                 | Details          |
| -------------------------------------- | ---------------- |
| Documentation                          | Release notes    |

### Test plan

- [ ] Unit tests
- [ ] End to end tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)