### PR TITLE
chore(infra): remove legacy Neon preview database pruning

### DIFF
--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -49,7 +49,4 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PREVIEW_PROJECT_ID: ${{ vars.SUPABASE_PREVIEW_PROJECT_ID }}
-          # TODO: remove once all legacy Neon branches are cleaned up
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -11,9 +11,6 @@ const env = makeEnv([
 	'GH_TOKEN',
 	'SUPABASE_ACCESS_TOKEN',
 	'SUPABASE_PREVIEW_PROJECT_ID',
-	// TODO: remove Neon env vars once all legacy branches are cleaned up
-	'NEON_API_KEY',
-	'NEON_PROJECT_ID',
 ])
 
 interface ListWorkersResult {
@@ -147,58 +144,6 @@ async function deletePreviewDatabase(branchName: string) {
 	}
 }
 
-// TODO: remove Neon pruning once all legacy branches are cleaned up
-const neonHeaders = {
-	Authorization: `Bearer ${env.NEON_API_KEY}`,
-}
-
-async function getNeonBranchId(branchName: string) {
-	const url = `https://console.neon.tech/api/v2/projects/${env.NEON_PROJECT_ID}/branches?search=${branchName}`
-	nicelog('GET', url)
-	const res = await fetch(url, {
-		headers: neonHeaders,
-	})
-
-	if (!res.ok) {
-		throw new Error('Failed to list branches ' + JSON.stringify(await res.json()))
-	}
-
-	const data = (await res.json()) as { branches: { id: string; name: string }[] }
-
-	return data.branches.find((b) => b.name === branchName)?.id
-}
-
-async function listNeonPreviewDatabases() {
-	const url = `https://console.neon.tech/api/v2/projects/${env.NEON_PROJECT_ID}/branches`
-	const res = await fetch(url, {
-		headers: neonHeaders,
-	})
-	if (!res.ok) {
-		return []
-	}
-	return ((await res.json()) as { branches: { name: string }[] }).branches
-		.filter((b) => PREVIEW_DB_REGEX.test(b.name))
-		.map((b) => b.name)
-}
-
-async function deleteNeonPreviewDatabase(branchName: string) {
-	const id = await getNeonBranchId(branchName)
-	if (!id) {
-		nicelog(`Branch ${branchName} not found`)
-		return
-	}
-
-	const url = `https://console.neon.tech/api/v2/projects/${env.NEON_PROJECT_ID}/branches/${id}`
-	nicelog('DELETE', url)
-	const res = await fetch(url, {
-		method: 'DELETE',
-		headers: {
-			Authorization: `Bearer ${env.NEON_API_KEY}`,
-		},
-	})
-	nicelog('status', res.status)
-}
-
 async function deleteFlyioPreviewApp(appName: string) {
 	const result = await exec('flyctl', ['apps', 'list', '-o', 'tldraw-gb-ltd'])
 	if (result.indexOf(appName) >= 0) {
@@ -246,9 +191,6 @@ async function main() {
 	await processItems(listPreviewWorkerDeployments, deletePreviewWorkerDeployment)
 	nicelog('\nPruning Supabase preview databases')
 	await processItems(listPreviewDatabases, deletePreviewDatabase)
-	// TODO: remove once all legacy Neon branches are cleaned up
-	nicelog('\nPruning legacy Neon preview databases')
-	await processItems(listNeonPreviewDatabases, deleteNeonPreviewDatabase)
 	nicelog('\nPruning fly.io preview apps')
 	await processItems(listFlyioPreviewApps, deleteFlyioPreviewApp)
 	nicelog('\nDone')


### PR DESCRIPTION
Follow-up to #8066 which migrated preview DB branching from Neon to Supabase. The Neon pruning code was kept temporarily (marked with TODOs) to clean up legacy branches — removing it now.

Removed from `prune-preview-deploys.ts`:
- `NEON_API_KEY` / `NEON_PROJECT_ID` env vars
- `getNeonBranchId()`, `listNeonPreviewDatabases()`, `deleteNeonPreviewDatabase()` functions
- The `processItems` call for Neon branches in `main()`

Removed from `prune-preview-deploys.yml`:
- `NEON_API_KEY` and `NEON_PROJECT_ID` secret/var references

### Change type

- [x] `improvement`

### Test plan

- [ ] Verify the scheduled `prune-preview-deploys` workflow still runs successfully after merge

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +0 / -3   |
| Config/tooling | +0 / -58  |