### PR TITLE
move cmd+shift+v paste default shortcut from svg to png

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -287,7 +287,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					menu: 'action.copy-as-svg.short',
 					['context-menu']: 'action.copy-as-svg.short',
 				},
-				kbd: 'cmd+shift+c,ctrl+shift+c',
 				readonlyOk: true,
 				onSelect(source) {
 					let ids = editor.getSelectedShapeIds()
@@ -305,6 +304,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					['context-menu']: 'action.copy-as-png.short',
 				},
 				readonlyOk: true,
+				kbd: 'cmd+shift+c,ctrl+shift+c',
 				onSelect(source) {
 					let ids = editor.getSelectedShapeIds()
 					if (ids.length === 0) ids = Array.from(editor.getCurrentPageShapeIds().values())


### PR DESCRIPTION
it is more common to copy png then it is svg, lets make the shortcut apply to pngs instead of svgs! Note this is a breaking change.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- Changed the default "Copy as" keyboard shortcut from SVG to PNG. 💥 This is a breaking change.