### PR TITLE
fix(mcp-app): safe analytics when logging exec/search code

### DIFF
--- a/apps/mcp-app/src/shared/utils.ts
+++ b/apps/mcp-app/src/shared/utils.ts
@@ -64,7 +64,69 @@ export function resolveMcpAppHostNameFromClientInfo(
 }
 
 const CODE_EDITOR_HOST_NAMES: MCP_APP_HOST_NAMES[] = ['cursor', 'vscode']
+const ANALYTICS_ENGINE_MAX_BLOB_BYTES = 16 * 1024
+const TRUNCATED_ANALYTICS_SUFFIX = '...[truncated]'
 
 export function isHostCodeEditor(hostName: MCP_APP_HOST_NAMES): boolean {
 	return CODE_EDITOR_HOST_NAMES.includes(hostName)
+}
+
+function truncateUtf8String(value: string, maxBytes: number): string {
+	const encoder = new TextEncoder()
+	if (maxBytes <= 0) return ''
+	if (encoder.encode(value).byteLength <= maxBytes) return value
+
+	const suffixByteLength = encoder.encode(TRUNCATED_ANALYTICS_SUFFIX).byteLength
+	if (suffixByteLength >= maxBytes) {
+		let low = 0
+		let high = TRUNCATED_ANALYTICS_SUFFIX.length
+
+		while (low < high) {
+			const mid = Math.ceil((low + high) / 2)
+			if (encoder.encode(TRUNCATED_ANALYTICS_SUFFIX.slice(0, mid)).byteLength <= maxBytes) {
+				low = mid
+			} else {
+				high = mid - 1
+			}
+		}
+
+		return TRUNCATED_ANALYTICS_SUFFIX.slice(0, low)
+	}
+
+	const maxValueBytes = maxBytes - suffixByteLength
+	let low = 0
+	let high = value.length
+
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2)
+		if (encoder.encode(value.slice(0, mid)).byteLength <= maxValueBytes) {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+
+	return `${value.slice(0, low)}${TRUNCATED_ANALYTICS_SUFFIX}`
+}
+
+export function writeToolAnalytics(
+	analytics: AnalyticsEngineDataset | undefined,
+	toolName: string,
+	code: string
+) {
+	if (!analytics) return
+
+	const encoder = new TextEncoder()
+	const baseBlobs = ['tool_called', toolName]
+	const maxCodeBytes =
+		ANALYTICS_ENGINE_MAX_BLOB_BYTES -
+		baseBlobs.reduce((total, blob) => total + encoder.encode(blob).byteLength, 0)
+
+	try {
+		analytics.writeDataPoint({
+			blobs: [...baseBlobs, truncateUtf8String(code, maxCodeBytes)],
+		})
+	} catch {
+		// Best-effort analytics should never break a tool call.
+	}
 }

--- a/apps/mcp-app/src/shared/utils.ts
+++ b/apps/mcp-app/src/shared/utils.ts
@@ -127,6 +127,6 @@ export function writeToolAnalytics(
 			blobs: [...baseBlobs, truncateUtf8String(code, maxCodeBytes)],
 		})
 	} catch {
-		// Best-effort analytics should never break a tool call.
+		// writeDataPoint returns immediately and never throws, so we won't know if it failed
 	}
 }

--- a/apps/mcp-app/src/tools/exec.ts
+++ b/apps/mcp-app/src/tools/exec.ts
@@ -4,7 +4,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import type { PendingRequests } from '../shared/pending-requests'
 import { CANVAS_RESOURCE_URI } from '../shared/types'
-import { generateCanvasId } from '../shared/utils'
+import { generateCanvasId, writeToolAnalytics } from '../shared/utils'
 
 const EXEC_CALLBACK_TIMEOUT_MS = 30_000
 
@@ -58,15 +58,13 @@ Examples:
 			_meta: { ui: { resourceUri: CANVAS_RESOURCE_URI } },
 		},
 		async ({
-			code: _code,
+			code,
 			canvasId: inputCanvasId,
 		}: {
 			code: string
 			canvasId?: string
 		}): Promise<CallToolResult> => {
-			opts.analytics?.writeDataPoint({
-				blobs: ['tool_called', 'exec'],
-			})
+			writeToolAnalytics(opts.analytics, 'exec', code)
 
 			const canvasId = inputCanvasId || generateCanvasId()
 			opts.setCurrentExecCanvasId(canvasId)

--- a/apps/mcp-app/src/tools/search.ts
+++ b/apps/mcp-app/src/tools/search.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import type { EditorApiSpec } from '../shared/generated-data'
 import { WORKER_COMPATIBILITY_DATE } from '../shared/types'
 import type { DynamicWorkerLoader } from '../shared/types'
+import { writeToolAnalytics } from '../shared/utils'
 
 const SEARCH_TIMEOUT_MS = 5_000
 const SEARCH_RUNNER_MODULE = 'search-runner.js'
@@ -121,9 +122,7 @@ Examples:
 			},
 		},
 		async ({ code }: { code: string }): Promise<CallToolResult> => {
-			opts.analytics?.writeDataPoint({
-				blobs: ['tool_called', 'search'],
-			})
+			writeToolAnalytics(opts.analytics, 'search', code)
 			opts.log('[tldraw-mcp] search called')
 
 			try {


### PR DESCRIPTION
In order to trace which code runs in `exec` and `search` without risking tool failures or oversized Analytics Engine payloads, this PR logs tool code via a shared helper that UTF-8–truncates the `code` blob to stay under the 16 KB per-datapoint blob limit and wraps `writeDataPoint` in try/catch so analytics never breaks a tool call.

### Change type

- [x] `bugfix`
- [ ] `improvement` | `feature` | `api` | `other`

### Test plan

1. Call `exec` with a short script and confirm normal behavior.
2. Call `exec` with a script whose UTF-8 length would exceed the remaining blob budget after the fixed `tool_called` / tool name prefixes; confirm the tool still succeeds and analytics receives a truncated payload ending in `...[truncated]` if inspected.
3. Call `search` similarly with a long query script.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +67 / -8   |
| Core code      | +0 / -0    |
| Tests          | +0 / -0    |
| Automated files | +0 / -0   |
| Documentation  | +0 / -0    |
| Templates      | +0 / -0    |
| Config/tooling | +0 / -0    |