### PR TITLE
feat(dotcom): add RUM via editor.performance + PostHog

### DIFF
--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -24,22 +24,17 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		max_frame_time: r2(event.maxFrameTime),
 		shape_count: event.shapeCount,
 		zoom_level: r2(event.zoomLevel),
-		has_loaf: !!loafs && loafs.length > 0,
+		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
 	}
 }
 
 function handleInteractionEnd(event: TLInteractionEndPerfEvent) {
-	if (event.duration < 50) return
-
 	trackEvent('rum', {
 		type: 'interaction',
 		interaction_name: event.name,
 		interaction_path: event.path,
-		selected_shape_count: (Object.values(event.selectedShapeTypes) as number[]).reduce(
-			(a, b) => a + b,
-			0
-		),
+		selected_shape_count: Object.values(event.selectedShapeTypes).reduce((a, b) => a + b, 0),
 		selected_shape_types: event.selectedShapeTypes,
 		...commonStats(event),
 	})

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -54,15 +54,17 @@ export function usePerformanceTracking() {
 	return useCallback((editor: Editor) => {
 		let unsubInteraction: (() => void) | undefined
 		let unsubCamera: (() => void) | undefined
+		let disposed = false
 
 		fetchFeatureFlags().then((flags) => {
-			if (!flags.rum_enabled?.enabled) return
+			if (disposed || !flags.rum_enabled?.enabled) return
 
 			unsubInteraction = editor.performance.on('interaction-end', handleInteractionEnd)
 			unsubCamera = editor.performance.on('camera-end', handleCameraEnd)
 		})
 
 		return () => {
+			disposed = true
 			unsubInteraction?.()
 			unsubCamera?.()
 		}

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -1,0 +1,75 @@
+import { useCallback } from 'react'
+import {
+	Editor,
+	TLCameraEndPerfEvent,
+	TLInteractionEndPerfEvent,
+	TLPerfFrameTimeStats,
+} from 'tldraw'
+import { fetchFeatureFlags } from '../tla/utils/FeatureFlagPoller'
+import { trackEvent } from '../utils/analytics'
+
+const r2 = (n: number) => Math.round(n * 100) / 100
+
+function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLevel: number }) {
+	const loafs = event.longAnimationFrames
+	return {
+		duration_ms: Math.round(event.duration),
+		fps: Math.round(event.fps * 10) / 10,
+		frame_count: event.frameCount,
+		avg_frame_time: r2(event.avgFrameTime),
+		median_frame_time: r2(event.medianFrameTime),
+		p95_frame_time: r2(event.p95FrameTime),
+		p99_frame_time: r2(event.p99FrameTime),
+		min_frame_time: r2(event.minFrameTime),
+		max_frame_time: r2(event.maxFrameTime),
+		shape_count: event.shapeCount,
+		zoom_level: r2(event.zoomLevel),
+		has_loaf: !!loafs && loafs.length > 0,
+		loaf_count: loafs?.length ?? 0,
+	}
+}
+
+function handleInteractionEnd(event: TLInteractionEndPerfEvent) {
+	if (event.duration < 50) return
+
+	trackEvent('rum', {
+		type: 'interaction',
+		interaction_name: event.name,
+		interaction_path: event.path,
+		selected_shape_count: (Object.values(event.selectedShapeTypes) as number[]).reduce(
+			(a, b) => a + b,
+			0
+		),
+		selected_shape_types: event.selectedShapeTypes,
+		...commonStats(event),
+	})
+}
+
+function handleCameraEnd(event: TLCameraEndPerfEvent) {
+	trackEvent('rum', {
+		type: 'camera',
+		camera_type: event.type,
+		visible_shape_count: event.visibleShapeCount,
+		culled_shape_count: event.culledShapeCount,
+		...commonStats(event),
+	})
+}
+
+export function usePerformanceTracking() {
+	return useCallback((editor: Editor) => {
+		let unsubInteraction: (() => void) | undefined
+		let unsubCamera: (() => void) | undefined
+
+		fetchFeatureFlags().then((flags) => {
+			if (!flags.rum_enabled?.enabled) return
+
+			unsubInteraction = editor.performance.on('interaction-end', handleInteractionEnd)
+			unsubCamera = editor.performance.on('camera-end', handleCameraEnd)
+		})
+
+		return () => {
+			unsubInteraction?.()
+			unsubCamera?.()
+		}
+	}, [])
+}

--- a/apps/dotcom/client/src/tla/app/shouldUseProperZero.test.ts
+++ b/apps/dotcom/client/src/tla/app/shouldUseProperZero.test.ts
@@ -24,6 +24,7 @@ afterEach(() => {
 const FLAGS_OFF: FeatureFlags = {
 	zero_enabled: { enabled: false },
 	zero_kill_switch: { enabled: false },
+	rum_enabled: { enabled: false },
 }
 
 describe('shouldUseProperZero', () => {
@@ -140,6 +141,7 @@ describe('shouldUseProperZero', () => {
 			const flags: FeatureFlags = {
 				zero_enabled: { enabled: true },
 				zero_kill_switch: { enabled: true },
+				rum_enabled: { enabled: false },
 			}
 			// Kill switch wins over everything
 			const result = shouldUseProperZero(flags, 'dev@tldraw.com')

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -28,6 +28,7 @@ import {
 import { SneakyMermaidHandler } from '../../../components/SneakyMermaidHandler/SneakyMermaidHandler'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
 import { useOpenUrlAndTrack } from '../../../hooks/useOpenUrlAndTrack'
+import { usePerformanceTracking } from '../../../hooks/usePerformanceTracking'
 import { useRoomLoadTracking } from '../../../hooks/useRoomLoadTracking'
 import { trackEvent, useHandleUiEvents } from '../../../utils/analytics'
 import { assetUrls } from '../../../utils/assetUrls'
@@ -117,11 +118,13 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 
 	const trackRoomLoaded = useRoomLoadTracking()
 	const trackNewRoomCreation = useNewRoomCreationTracking()
+	const trackPerformance = usePerformanceTracking()
 
 	const handleMount = useCallback(
 		(editor: Editor) => {
 			trackRoomLoaded(editor)
 			trackNewRoomCreation(app, fileId)
+			const cleanupPerf = trackPerformance(editor)
 			;(window as any).app = app
 			;(window as any).editor = editor
 			// Register the editor globally
@@ -167,11 +170,21 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			}).then(setIsReady)
 
 			return () => {
+				cleanupPerf?.()
 				fileStateUpdater.dispose()
 				abortController.abort()
 			}
 		},
-		[addDialog, trackRoomLoaded, trackNewRoomCreation, app, fileId, remountImageShapes, setIsReady]
+		[
+			addDialog,
+			trackRoomLoaded,
+			trackNewRoomCreation,
+			trackPerformance,
+			app,
+			fileId,
+			remountImageShapes,
+			setIsReady,
+		]
 	)
 
 	const user = useTldrawCurrentUser()

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -170,7 +170,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			}).then(setIsReady)
 
 			return () => {
-				cleanupPerf?.()
+				cleanupPerf()
 				fileStateUpdater.dispose()
 				abortController.abort()
 			}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
@@ -56,8 +56,7 @@ export function TlaPublishEditor({ schema, records }: TlaPublishEditorProps) {
 					;(window as any).editor = editor
 					editor.updateInstanceState({ isReadonly: true })
 					globalEditor.set(editor)
-					const cleanupPerf = trackPerformance(editor)
-					return () => cleanupPerf?.()
+					return trackPerformance(editor)
 				}}
 				components={components}
 				options={{ deepLinks: true }}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPublishEditor.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { SerializedSchema, TLComponents, TLRecord, Tldraw } from 'tldraw'
 import { ThemeUpdater } from '../../../components/ThemeUpdater/ThemeUpdater'
 import { useLegacyUrlParams } from '../../../hooks/useLegacyUrlParams'
+import { usePerformanceTracking } from '../../../hooks/usePerformanceTracking'
 import { useHandleUiEvents } from '../../../utils/analytics'
 import { assetUrls } from '../../../utils/assetUrls'
 import { globalEditor } from '../../../utils/globalEditor'
@@ -29,6 +30,7 @@ export function TlaPublishEditor({ schema, records }: TlaPublishEditorProps) {
 	useLegacyUrlParams()
 
 	const handleUiEvent = useHandleUiEvents()
+	const trackPerformance = usePerformanceTracking()
 	const fileEditorOverrides = useFileEditorOverrides({
 		fileSlug: undefined,
 	})
@@ -54,6 +56,8 @@ export function TlaPublishEditor({ schema, records }: TlaPublishEditorProps) {
 					;(window as any).editor = editor
 					editor.updateInstanceState({ isReadonly: true })
 					globalEditor.set(editor)
+					const cleanupPerf = trackPerformance(editor)
+					return () => cleanupPerf?.()
 				}}
 				components={components}
 				options={{ deepLinks: true }}

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
@@ -14,6 +14,7 @@ function makeFlags(overrides: Partial<FeatureFlags> = {}): FeatureFlags {
 	return {
 		zero_enabled: { enabled: false },
 		zero_kill_switch: { enabled: false },
+		rum_enabled: { enabled: false },
 		...overrides,
 	}
 }

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
@@ -7,6 +7,7 @@ export type FeatureFlags = Record<FeatureFlagKey, EvaluatedFeatureFlag>
 export const DEFAULT_FLAGS: FeatureFlags = {
 	zero_enabled: { enabled: false },
 	zero_kill_switch: { enabled: false },
+	rum_enabled: { enabled: false },
 }
 
 let flagsPromise: Promise<FeatureFlags> | null = null

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
@@ -283,6 +283,6 @@ describe('getFeatureFlagsAdmin (route handler)', () => {
 		const response = await getFeatureFlagsAdmin({} as any, env as any)
 		const body: any = await response.json()
 
-		expect(Object.keys(body).sort()).toEqual(['zero_enabled', 'zero_kill_switch'].sort())
+		expect(Object.keys(body).sort()).toEqual(['rum_enabled', 'zero_enabled', 'zero_kill_switch'])
 	})
 })

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.ts
@@ -21,6 +21,12 @@ function getFlagDefaults(_env: Environment): Record<FeatureFlagKey, FeatureFlagV
 			enabled: false,
 			description: 'Emergency kill switch — when enabled, forces all users off Zero immediately',
 		},
+		rum_enabled: {
+			type: 'percentage',
+			percentage: 0,
+			enabled: false,
+			description: 'Real User Monitoring for editor performance metrics',
+		},
 	}
 }
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -219,7 +219,7 @@ export type TLCustomServerEvent = { type: 'persistence_good' } | { type: 'persis
 
 /* ----------------------- Feature Flags ---------------------- */
 
-export const FEATURE_FLAG_KEYS = ['zero_enabled', 'zero_kill_switch'] as const
+export const FEATURE_FLAG_KEYS = ['zero_enabled', 'zero_kill_switch', 'rum_enabled'] as const
 export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[number]
 
 export type FeatureFlagValue = BooleanFeatureFlag | PercentageFeatureFlag


### PR DESCRIPTION
Adds Real User Monitoring to dotcom by subscribing to `editor.performance` events (from #8421) and sending aggregated frame time metrics to PostHog, gated behind a percentage feature flag.

Decided to go with a percentage based rollout.

### How it works

- New `rum_enabled` percentage feature flag (defaults to off)
- `usePerformanceTracking` hook subscribes to `interaction-end` and `camera-end` perf events
- Sends a single `rum` PostHog event with `type: 'interaction' | 'camera'` discriminator
- Flag checked once at editor mount via `fetchFeatureFlags()` — zero overhead when off
- No extra consent handling needed — `trackEvent` → `posthog.capture` already respects opt-in/out

### Properties sent

**Common** (both types): `duration_ms`, `fps`, `frame_count`, `avg/median/p95/p99/min/max_frame_time`, `shape_count`, `zoom_level`, `has_loaf`, `loaf_count`

**Interaction-only**: `interaction_name`, `interaction_path`, `selected_shape_count`, `selected_shape_types`

**Camera-only**: `camera_type` (panning/zooming), `visible_shape_count`, `culled_shape_count`

### Change type

- [x] `feature`

### Test plan

1. Run `yarn dev-app`, open editor
2. Enable flag (admin panel or bypass check locally)
3. Draw, translate, resize, pan, zoom
4. Check PostHog debugger or console for `rum` events with correct properties
5. Verify no events fire when flag is off

### Release notes

- Add real user monitoring for editor performance metrics on tldraw.com

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps | +100 / -2 |