### PR TITLE
chore: add minimum release age gate for supply chain defense

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,4 @@ enableInlineBuilds: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: "7d"
+npmMinimalAgeGate: '7d'

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ enableGlobalCache: false
 enableInlineBuilds: true
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: "7d"


### PR DESCRIPTION
Configure Yarn's `npmMinimalAgeGate` to `"7d"`, refusing to install any package version published less than 7 days ago. In order to defend against supply chain attacks where malicious versions are typically detected and removed within hours, this PR adds a single line to `.yarnrc.yml` that leverages community scrutiny time as a safety buffer.

Reference: https://daniakash.com/posts/simplest-supply-chain-defense/

### Change type

- [x] `improvement`

### Test plan

1. Run `yarn install` — should succeed (all current deps are older than 7 days)
2. Try adding a just-published package — Yarn should refuse with an age gate error

### Release notes

- Add 7-day minimum release age gate to Yarn config for supply chain defense

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +2 / -0    |