### PR TITLE
fix(sync): exclude self-presence from connect response to prevent duplicates

### DIFF
--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -910,7 +910,15 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				sessionSchema,
 				requiresDownMigrations,
 				{
-					puts: Object.fromEntries([...this.presenceStore.values()].map((p) => [p.id, p])),
+					// Exclude the connecting session's own presence — it will push fresh
+					// data immediately after connecting. Sending the stale record back
+					// would leave an orphaned presence in the client's local store (the
+					// server never echoes a session's own updates back to it).
+					puts: Object.fromEntries(
+						[...this.presenceStore.values()]
+							.filter((p) => p.id !== session.presenceId)
+							.map((p) => [p.id, p])
+					),
 					deletes: [],
 				}
 			)


### PR DESCRIPTION
In order to fix duplicate presence cursors appearing after login/logout, this PR excludes the connecting session's own stale presence record from the connect handshake response.

Closes #7756

### Root cause

When a session reconnects (e.g. after auth state changes), the server sends all presence records in the connect response — including the connecting client's own stale record from the previous session. Because the server never echoes a session's own presence updates back to it (`broadcastPatch` skips `sourceSessionId`), this stale record permanently remains in the client's local store. If the `userId` changed between sessions (e.g. anonymous → authenticated), the stale record renders as a ghost cursor for "another person."

### Fix

Filter out the connecting session's `presenceId` from the initial presence dump sent in the connect response. The client always pushes fresh presence data immediately after connecting, so it never needs its own record back from the server.

### Change type

- [x] `bugfix`

### Test plan

1. Open a shared file while logged out
2. Log in
3. Verify only one presence cursor appears (not two)
4. Log out and back in — still only one cursor

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix duplicate presence cursors appearing after login or logout in multiplayer sessions.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +8 / -1    |