### PR TITLE
docs: add Lokalise partnership section to translations page

### DIFF
--- a/apps/docs/content/community/translations.mdx
+++ b/apps/docs/content/community/translations.mdx
@@ -11,3 +11,7 @@ The tldraw user interface (in [@tldraw/ui](/docs/user-interface)) is currently t
 ## Contributing translations
 
 We manage our translations through [Lokalise](https://www.lokalise.com), a long-time tldraw sponsor. If you would like to help by translating or reviewing translations, please let us know on [Discord](https://discord.tldraw.com/?utm_source=docs&utm_medium=organic&utm_campaign=sociallink) so that we can add you to the project.
+
+## Lokalise for universities
+
+tldraw is proud to partner with [Lokalise](https://lokalise.com) through their Innovation and Research Plan. This initiative provides our students and researchers with industry-leading localization technology, empowering the next generation of language professionals to master modern, AI-driven workflows.

--- a/apps/docs/content/community/translations.mdx
+++ b/apps/docs/content/community/translations.mdx
@@ -12,6 +12,6 @@ The tldraw user interface (in [@tldraw/ui](/docs/user-interface)) is currently t
 
 We manage our translations through [Lokalise](https://www.lokalise.com), a long-time tldraw sponsor. If you would like to help by translating or reviewing translations, please let us know on [Discord](https://discord.tldraw.com/?utm_source=docs&utm_medium=organic&utm_campaign=sociallink) so that we can add you to the project.
 
-## Lokalise for universities
+## Lokalise for open source
 
-tldraw is proud to partner with [Lokalise](https://lokalise.com) through their Innovation and Research Plan. This initiative provides our students and researchers with industry-leading localization technology, empowering the next generation of language professionals to master modern, AI-driven workflows.
+tldraw is proud to partner with [Lokalise](https://lokalise.com) through their Innovation and Research Plan. This initiative provides our developers with industry-leading localization technology, empowering the next generation of language professionals to master modern, AI-driven workflows.


### PR DESCRIPTION
In order to acknowledge the Lokalise Innovation and Research Plan partnership, this PR adds a new "Lokalise for universities" section to the translations documentation page.

### Change type

- [x] `other`

### Test plan

1. Visit the translations page in the docs app
2. Verify the new "Lokalise for universities" section appears below "Contributing translations"
3. Confirm the Lokalise link points to https://lokalise.com

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +4 / -0    |