### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -5,7 +5,7 @@ author: tldraw
 date: 03/18/2026
 order: 0
 status: published
-last_version: v4.5.8
+last_version: v4.5.9
 ---
 
 This release adds a first-class theme system with display values for customizing default shapes, extensible asset types via a new `AssetUtil` system, shape attribution with a new `TLUserStore` provider and extensible user records, clipboard hooks for intercepting copy, cut, and paste, custom record types to the store, a new `@tldraw/mermaid` package for converting Mermaid diagrams to native shapes, WebSocket hibernation support for tlsync, a new `@tldraw/editor-controller` package for scripting and automation, RTL language support in the UI, cross-window embedding support, arbitrary iframe embed pasting, a paste-as-plain-text keyboard shortcut, and smarter export trimming. It also includes various other improvements and bug fixes.
@@ -302,4 +302,5 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix NaN propagation from zero-length labeled arrows causing all shapes to disappear. ([#8329](https://github.com/tldraw/tldraw/pull/8329))
 - Fix crash when isolating curved arrows with degenerate geometry. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix camera state stuck at 'moving' on dispose, blocking shape interactions on the next editor instance. ([#8396](https://github.com/tldraw/tldraw/pull/8396))
+- Fix opacity slider drag broken on Safari due to `stopPropagation` interfering with Radix UI Slider's pointer capture handling. ([#8519](https://github.com/tldraw/tldraw/pull/8519))
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))

--- a/apps/docs/content/releases/v4.5.0.mdx
+++ b/apps/docs/content/releases/v4.5.0.mdx
@@ -14,6 +14,8 @@ keywords:
   - v4.5.4
   - v4.5.5
   - v4.5.6
+  - v4.5.7
+  - v4.5.8
   - transparent-pixels
   - embed-definitions
   - high-dpi
@@ -167,3 +169,15 @@ const cleanSvg = sanitizeSvg(untrustedSvgText)
 - Fix crash when isolating curved arrows with degenerate binding geometry. ([#8390](https://github.com/tldraw/tldraw/pull/8390))
 
 [View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.5.6)
+
+### v4.5.7
+
+- Fix VSCode extension bundle incorrectly including `hotkeys-js` as a bundled dependency. ([#8444](https://github.com/tldraw/tldraw/pull/8444))
+
+[View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.5.7)
+
+### v4.5.8
+
+- Fix memory leak where the Editor was retained after unmount via a shared throttled `updateHoveredShapeId` closure. ([#8474](https://github.com/tldraw/tldraw/pull/8474))
+
+[View release on GitHub](https://github.com/tldraw/tldraw/releases/tag/v4.5.8)


### PR DESCRIPTION
In order to keep the release notes current with the latest production patches and new SDK changes, this PR updates both `next.mdx` and `v4.5.0.mdx`. Source is `production` (4 weeks since v4.5.0). One new SDK bug fix entry was added (#8519 — Safari style panel opacity slider fix), `last_version` was bumped from v4.5.8 to v4.5.9, and patch release sections for v4.5.7 and v4.5.8 were added to the archived v4.5.0 release notes.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +16 / -1   |