### PR TITLE
fix(sync): sanitize malformed wal2json output before parsing

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -47,18 +47,24 @@ class SafeWal2JsonPlugin extends Wal2JsonPlugin {
 	// Wal2JsonPlugin.parse() does a bare JSON.parse(buffer.toString()) which throws
 	// on malformed output before our code can catch it. We try parsing first and only
 	// apply fixups on failure to avoid corrupting valid JSON string values that might
-	// contain comma patterns like "items: [, ]" or "a,,b".
+	// contain comma patterns like "a,,b".
+	// If fixups also fail, we deliberately let the error propagate — a crash loop is
+	// preferable to silently skipping (and acknowledging) unprocessable changes.
 	override parse(buffer: Buffer): any {
 		const raw = buffer.toString()
 		try {
 			return JSON.parse(raw)
-		} catch {
+		} catch (e) {
 			const fixed = raw
-				.replace(/"change"\s*:\s*\[,+/g, '"change":[') // leading commas: [,{ → [{
+				.replace(/"change":\[,+/g, '"change":[') // leading commas: [,{ → [{
 				.replace(/,+]/g, ']') // trailing commas: ,] → ]
 				.replace(/,,+/g, ',') // consecutive commas: ,, → ,
-			console.warn('SafeWal2JsonPlugin: fixed malformed wal2json output (eulerto/wal2json#266)')
-			return JSON.parse(fixed)
+			const result = JSON.parse(fixed)
+			console.warn(
+				`SafeWal2JsonPlugin: fixed malformed wal2json output (eulerto/wal2json#266). ` +
+					`Original error: ${e}. Payload sample: ${raw.slice(0, 200)}`
+			)
+			return result
 		}
 	}
 }

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -44,9 +44,22 @@ import {
 // Subclass to work around wal2json bug (eulerto/wal2json#266) where
 // concurrent pg_logical_emit_message produces malformed JSON with leading commas.
 class SafeWal2JsonPlugin extends Wal2JsonPlugin {
+	// Wal2JsonPlugin.parse() does a bare JSON.parse(buffer.toString()) which throws
+	// on malformed output before our code can catch it. We try parsing first and only
+	// apply fixups on failure to avoid corrupting valid JSON string values that might
+	// contain comma patterns like "items: [, ]" or "a,,b".
 	override parse(buffer: Buffer): any {
-		const str = buffer.toString().replace(/\[,/g, '[').replace(/,]/g, ']').replace(/,,+/g, ',')
-		return JSON.parse(str)
+		const raw = buffer.toString()
+		try {
+			return JSON.parse(raw)
+		} catch {
+			const fixed = raw
+				.replace(/"change"\s*:\s*\[,+/g, '"change":[') // leading commas: [,{ → [{
+				.replace(/,+]/g, ']') // trailing commas: ,] → ]
+				.replace(/,,+/g, ',') // consecutive commas: ,, → ,
+			console.warn('SafeWal2JsonPlugin: fixed malformed wal2json output (eulerto/wal2json#266)')
+			return JSON.parse(fixed)
+		}
 	}
 }
 

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -41,6 +41,15 @@ import {
 	getUserDurableObject,
 } from './utils/durableObjects'
 
+// Subclass to work around wal2json bug (eulerto/wal2json#266) where
+// concurrent pg_logical_emit_message produces malformed JSON with leading commas.
+class SafeWal2JsonPlugin extends Wal2JsonPlugin {
+	override parse(buffer: Buffer): any {
+		const str = buffer.toString().replace(/\[,/g, '[').replace(/,]/g, ']').replace(/,,+/g, ',')
+		return JSON.parse(str)
+	}
+}
+
 const ONE_MINUTE = 60 * 1000
 // IMPORTANT prune interval needs to be at least twice as big as the lsn update request timeout
 // otherwise we might prune users who are still connected.
@@ -104,7 +113,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		return slotNamePrefix + durableObjectId.slice(0, slotNameMaxLength - slotNamePrefix.length)
 	}
 
-	private readonly wal2jsonPlugin = new Wal2JsonPlugin({
+	private readonly wal2jsonPlugin = new SafeWal2JsonPlugin({
 		addTables:
 			'public.user,public.file,public.file_state,public.user_mutation_number,public.replicator_boot_id,public.group,public.group_user,public.group_file',
 	})

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -41,6 +41,7 @@ import {
 	getUserDurableObject,
 } from './utils/durableObjects'
 
+// TODO: remove this workaround after upgrading wal2json to a version with eulerto/wal2json#266 fixed.
 // Subclass to work around wal2json bug (eulerto/wal2json#266) where
 // concurrent pg_logical_emit_message produces malformed JSON with leading commas.
 class SafeWal2JsonPlugin extends Wal2JsonPlugin {


### PR DESCRIPTION
Workaround for a known wal2json bug ([eulerto/wal2json#266](https://github.com/eulerto/wal2json/issues/266)) that produces invalid JSON with spurious commas in the `change` array. This happens when a non-transactional `pg_logical_emit_message` (like `requestLsnUpdate`) arrives while a concurrent transaction is in progress. The bug is fixed in wal2json 2.6 but our production Postgres runs an older version.

The [`Wal2JsonPlugin.parse()`](https://github.com/kibae/pg-logical-replication/blob/master/src/output-plugins/wal2json/wal2json-plugin.ts#L31-L34) method in `pg-logical-replication` does a bare `JSON.parse(buffer.toString())`, so the malformed JSON throws before our code can catch it.

Subclasses `Wal2JsonPlugin` with a `SafeWal2JsonPlugin` that overrides `parse()`. It tries `JSON.parse` first and only applies regex fixups on failure — this avoids corrupting valid JSON string values that might contain comma patterns. The fixups handle leading commas (`"change":[,`), trailing commas (`,]`), and consecutive commas (`,,`). A warning is logged when the fixup path fires so we can track frequency and know when it's safe to remove.

> **Note:** The proper fix is to update wal2json to ≥2.6 on our production Postgres. This PR is a stopgap until then.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging
2. Monitor Sentry for `SyntaxError: Unexpected token ','` errors from TLPostgresReplicator — should stop occurring
3. Monitor logs for `SafeWal2JsonPlugin: fixed malformed wal2json output` warnings to track frequency

### Release notes

- Fix crash in sync worker caused by malformed wal2json output during concurrent replication events

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +22 / -1   |