### PR TITLE
i18n: fix lokalise project hitting size limit

### DIFF
--- a/internal/scripts/i18n-download-strings.ts
+++ b/internal/scripts/i18n-download-strings.ts
@@ -1,7 +1,106 @@
 import fs from 'fs'
 import path from 'path'
-import { LokaliseApi } from '@lokalise/node-api'
 import JSZip from 'jszip'
+
+const LOKALISE_API_BASE = 'https://api.lokalise.com/api2'
+const ASYNC_EXPORT_POLL_INTERVAL_MS = 2000
+const ASYNC_EXPORT_MAX_POLLS = 120
+
+function formatError(error: unknown) {
+	if (error instanceof Error) {
+		return error.stack ?? error.message
+	}
+
+	try {
+		return JSON.stringify(error, null, 2)
+	} catch {
+		return String(error)
+	}
+}
+
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function getEnv(name: string) {
+	const value = process.env[name]
+	if (!value) throw new Error(`Missing required env var: ${name}`)
+	return value
+}
+
+async function lokaliseRequest<T>(path: string, init: RequestInit, apiKey: string): Promise<T> {
+	const response = await fetch(`${LOKALISE_API_BASE}${path}`, {
+		...init,
+		headers: {
+			'Content-Type': 'application/json',
+			'X-Api-Token': apiKey,
+			...(init.headers ?? {}),
+		},
+	})
+
+	const body = (await response.json()) as unknown
+	if (!response.ok) {
+		throw new Error(
+			`Lokalise request failed (${response.status}): ${JSON.stringify(body, null, 2)}`
+		)
+	}
+
+	return body as T
+}
+
+async function getAsyncBundleUrl(
+	projectId: string,
+	options: Record<string, unknown>,
+	apiKey: string
+) {
+	const start = await lokaliseRequest<{ process_id?: string }>(
+		`/projects/${projectId}/files/async-download`,
+		{
+			method: 'POST',
+			body: JSON.stringify(options),
+		},
+		apiKey
+	)
+
+	if (!start.process_id) {
+		throw new Error(`Async export did not return process_id: ${JSON.stringify(start, null, 2)}`)
+	}
+
+	for (let i = 0; i < ASYNC_EXPORT_MAX_POLLS; i++) {
+		const processResult = await lokaliseRequest<{
+			process?: {
+				status?: string
+				message?: string
+				details?: { download_url?: string; bundle_url?: string }
+			}
+		}>(`/projects/${projectId}/processes/${start.process_id}`, { method: 'GET' }, apiKey)
+
+		const status = processResult.process?.status
+		const details = processResult.process?.details
+		const bundleUrl = details?.download_url ?? details?.bundle_url
+
+		if (status === 'finished') {
+			if (!bundleUrl) {
+				throw new Error(
+					`Async export finished but no bundle URL was returned: ${JSON.stringify(processResult, null, 2)}`
+				)
+			}
+			return bundleUrl
+		}
+
+		if (status === 'failed' || status === 'cancelled') {
+			throw new Error(
+				`Async export ${status}: ${processResult.process?.message ?? 'No message'}\n${JSON.stringify(processResult, null, 2)}`
+			)
+		}
+
+		await sleep(ASYNC_EXPORT_POLL_INTERVAL_MS)
+	}
+
+	throw new Error(
+		`Async export timed out after ${ASYNC_EXPORT_MAX_POLLS} polls for project ${projectId}`
+	)
+}
 
 async function fetchAndSave(
 	url: string,
@@ -55,25 +154,23 @@ async function i18nDownloadStrings() {
 }
 
 async function i18nDownloadTldrawStrings() {
-	const projectId = process.env.LOKALISE_TLDRAW_PROJECT_ID!
+	const projectId = getEnv('LOKALISE_TLDRAW_PROJECT_ID')
+	const apiKey = getEnv('LOKALISE_API_TOKEN')
 	const dirPath = path.resolve(__dirname, '../../assets/translations')
 	console.log('Downloading tldraw project files...')
 
-	const lokaliseApi = new LokaliseApi({ apiKey: process.env.LOKALISE_API_TOKEN })
-	const downloadResult = await lokaliseApi.files().download(projectId, {
-		format: 'json',
-		original_filenames: true,
-		export_empty_as: 'skip',
-	})
-
-	if (!downloadResult.bundle_url) {
-		console.error('Failed to download files:', downloadResult)
-		process.exit(1)
-		return
-	}
+	const bundleUrl = await getAsyncBundleUrl(
+		projectId,
+		{
+			format: 'json',
+			original_filenames: true,
+			export_empty_as: 'skip',
+		},
+		apiKey
+	)
 
 	await fetchAndSave(
-		downloadResult.bundle_url,
+		bundleUrl,
 		dirPath,
 		false /* sort json */,
 		(fileName) => fileName.split('/')[0].replace('_', '-').toLowerCase() + '.json',
@@ -85,29 +182,27 @@ async function i18nDownloadTldrawStrings() {
 }
 
 async function i18nDownloadDotcomStrings() {
-	const projectId = process.env.LOKALISE_PROJECT_ID!
+	const projectId = getEnv('LOKALISE_PROJECT_ID')
+	const apiKey = getEnv('LOKALISE_API_TOKEN')
 	const dirPath = path.resolve(__dirname, '../../apps/dotcom/client/public/tla/locales')
 	console.log('Downloading dotcom project files...')
 
-	const lokaliseApi = new LokaliseApi({ apiKey: process.env.LOKALISE_API_TOKEN })
-	const downloadResult = await lokaliseApi.files().download(projectId, {
-		format: 'json_structured',
-		original_filenames: true,
-		include_comments: true,
-		include_description: true,
-		export_empty_as: 'skip',
-		plural_format: 'icu',
-		placeholder_format: 'icu',
-	})
-
-	if (!downloadResult.bundle_url) {
-		console.error('Failed to download files:', downloadResult)
-		process.exit(1)
-		return
-	}
+	const bundleUrl = await getAsyncBundleUrl(
+		projectId,
+		{
+			format: 'json_structured',
+			original_filenames: true,
+			include_comments: true,
+			include_description: true,
+			export_empty_as: 'skip',
+			plural_format: 'icu',
+			placeholder_format: 'icu',
+		},
+		apiKey
+	)
 
 	await fetchAndSave(
-		downloadResult.bundle_url,
+		bundleUrl,
 		dirPath,
 		true /* sort json */,
 		(fileName) => fileName.split('/')[1].replace('_', '-').toLowerCase(),
@@ -117,4 +212,8 @@ async function i18nDownloadDotcomStrings() {
 	console.log('Downloaded files successfully!')
 }
 
-i18nDownloadStrings()
+i18nDownloadStrings().catch((error) => {
+	console.error('Failed to download i18n strings:')
+	console.error(formatError(error))
+	process.exit(1)
+})


### PR DESCRIPTION
was getting:
```
{
  "message": "Project too big for sync export. Please use our async export endpoint instead. (/files/async-download)",
  "code": 413
}
```

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
