### PR TITLE
feat(editor): add BaseFrameLikeShapeUtil for custom frame-like shapes

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -194,6 +194,22 @@ export abstract class BaseBoxShapeUtil<Shape extends TLBaseBoxShape> extends Sha
     onResize(shape: any, info: TLResizeInfo<any>): any;
 }
 
+// @public
+export abstract class BaseFrameLikeShapeUtil<Shape extends TLBaseBoxShape> extends BaseBoxShapeUtil<Shape> {
+    // (undocumented)
+    canReceiveNewChildrenOfType(shape: TLShape): boolean;
+    // (undocumented)
+    getClipPath(shape: Shape): undefined | Vec[];
+    // (undocumented)
+    isFrameLike(): boolean;
+    // (undocumented)
+    onDragShapesIn(shape: Shape, draggingShapes: TLShape[], { initialParentIds, initialIndices }: TLDragShapesOverInfo): void;
+    // (undocumented)
+    onDragShapesOut(shape: Shape, draggingShapes: TLShape[], info: TLDragShapesOutInfo): void;
+    // (undocumented)
+    providesBackgroundForChildren(): boolean;
+}
+
 // @public (undocumented)
 export interface BatchMeasurementRequest {
     // (undocumented)
@@ -2954,6 +2970,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     abstract indicator(shape: Shape): any;
     isAspectRatioLocked(shape: Shape): boolean;
     isExportBoundsContainer(shape: Shape): boolean;
+    isFrameLike(_shape: Shape): boolean;
     static migrations?: LegacyMigrations | MigrationSequence | TLPropsMigrations;
     onBeforeCreate?(next: Shape): Shape | void;
     onBeforeUpdate?(prev: Shape, next: Shape): Shape | void;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -191,6 +191,7 @@ export {
 } from './lib/editor/managers/PerformanceManager/perf-types'
 export { UserPreferencesManager } from './lib/editor/managers/UserPreferencesManager/UserPreferencesManager'
 export { BaseBoxShapeUtil, type TLBaseBoxShape } from './lib/editor/shapes/BaseBoxShapeUtil'
+export { BaseFrameLikeShapeUtil } from './lib/editor/shapes/BaseFrameLikeShapeUtil'
 export { GroupShapeUtil } from './lib/editor/shapes/group/GroupShapeUtil'
 export {
 	ShapeUtil,

--- a/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
@@ -1,0 +1,125 @@
+import { TLShape, TLShapeId } from '@tldraw/tlschema'
+import { compact, IndexKey } from '@tldraw/utils'
+import { Vec } from '../../primitives/Vec'
+import { TLBaseBoxShape } from './BaseBoxShapeUtil'
+import { BaseBoxShapeUtil } from './BaseBoxShapeUtil'
+import { TLDragShapesOutInfo, TLDragShapesOverInfo } from './ShapeUtil'
+
+/**
+ * A base class for frame-like shapes — containers that clip their children,
+ * require full-brush selection, block erasure from inside, and support
+ * drag-and-drop reparenting.
+ *
+ * Extending this class is the easiest way to create a custom frame-like shape.
+ * It provides sensible defaults for all frame-like behaviors:
+ *
+ * - `isFrameLike()` returns `true`
+ * - `providesBackgroundForChildren()` returns `true`
+ * - `canReceiveNewChildrenOfType()` returns `true` unless the shape is locked
+ * - `getClipPath()` returns the shape geometry's vertices
+ * - `onDragShapesIn()` reparents shapes into the frame (with index restoration)
+ * - `onDragShapesOut()` reparents shapes back to the page
+ *
+ * All methods can be overridden for custom behavior.
+ *
+ * @example
+ * ```ts
+ * class MyContainerUtil extends BaseFrameLikeShapeUtil<MyContainerShape> {
+ *   static override type = 'my-container' as const
+ *   static override props = myContainerShapeProps
+ *
+ *   override getDefaultProps() {
+ *     return { w: 300, h: 200 }
+ *   }
+ *
+ *   override component(shape: MyContainerShape) {
+ *     return <SVGContainer>...</SVGContainer>
+ *   }
+ *
+ *   override indicator(shape: MyContainerShape) {
+ *     return <rect width={shape.props.w} height={shape.props.h} />
+ *   }
+ * }
+ * ```
+ *
+ * @public
+ */
+export abstract class BaseFrameLikeShapeUtil<
+	Shape extends TLBaseBoxShape,
+> extends BaseBoxShapeUtil<Shape> {
+	override isFrameLike(): boolean {
+		return true
+	}
+
+	override providesBackgroundForChildren(): boolean {
+		return true
+	}
+
+	override canReceiveNewChildrenOfType(shape: TLShape): boolean {
+		return !shape.isLocked
+	}
+
+	override getClipPath(shape: Shape): Vec[] | undefined {
+		return this.editor.getShapeGeometry(shape.id).vertices
+	}
+
+	override onDragShapesIn(
+		shape: Shape,
+		draggingShapes: TLShape[],
+		{ initialParentIds, initialIndices }: TLDragShapesOverInfo
+	): void {
+		const { editor } = this
+
+		if (draggingShapes.every((s) => s.parentId === shape.id)) return
+
+		// Check to see whether any of the shapes can have their old index restored
+		let canRestoreOriginalIndices = false
+		const previousChildren = draggingShapes.filter(
+			(s) => shape.id === (initialParentIds.get(s.id) as TLShapeId)
+		)
+
+		if (previousChildren.length > 0) {
+			const currentChildren = compact(
+				editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))
+			)
+			if (previousChildren.every((s) => !currentChildren.find((c) => c.index === s.index))) {
+				canRestoreOriginalIndices = true
+			}
+		}
+
+		// If any of the children are the ancestor of the frame, quit here
+		if (draggingShapes.some((s) => editor.hasAncestor(shape, s.id))) return
+
+		// Reparent the shapes to the new parent
+		editor.reparentShapes(draggingShapes, shape.id)
+
+		// If we can restore the original indices, then do so
+		if (canRestoreOriginalIndices) {
+			for (const s of previousChildren) {
+				editor.updateShape({
+					id: s.id,
+					type: s.type,
+					index: initialIndices.get(s.id) as IndexKey,
+				})
+			}
+		}
+	}
+
+	override onDragShapesOut(
+		shape: Shape,
+		draggingShapes: TLShape[],
+		info: TLDragShapesOutInfo
+	): void {
+		const { editor } = this
+		// When a user drags shapes out and we're not dragging into a new shape,
+		// reparent the dragging shapes onto the current page instead
+		if (!info.nextDraggingOverShapeId) {
+			editor.reparentShapes(
+				draggingShapes.filter(
+					(s) => s.parentId === shape.id && this.canReceiveNewChildrenOfType(s)
+				),
+				editor.getCurrentPageId()
+			)
+		}
+	}
+}

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -493,6 +493,17 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	}
 
 	/**
+	 * Whether the shape behaves like a frame — a container that clips children,
+	 * requires full-brush selection, blocks erasure from inside, etc.
+	 *
+	 * @param shape - The shape.
+	 * @public
+	 */
+	isFrameLike(_shape: Shape): boolean {
+		return false
+	}
+
+	/**
 	 * By default, the bounds of an image export are the bounds of all the shapes it contains, plus
 	 * some padding. If an export includes a shape where `isExportBoundsContainer` is true, then the
 	 * padding is skipped _if the bounds of that shape contains all the other shapes_. This is

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -8,6 +8,7 @@ import { AssetUtil } from '@tldraw/editor';
 import { Atom } from '@tldraw/editor';
 import { BaseBoxShapeTool } from '@tldraw/editor';
 import { BaseBoxShapeUtil } from '@tldraw/editor';
+import { BaseFrameLikeShapeUtil } from '@tldraw/editor';
 import { BindingOnChangeOptions } from '@tldraw/editor';
 import { BindingOnCreateOptions } from '@tldraw/editor';
 import { BindingOnShapeChangeOptions } from '@tldraw/editor';
@@ -88,8 +89,6 @@ import { TLCropInfo } from '@tldraw/editor';
 import { TLDefaultColorStyle } from '@tldraw/tlschema';
 import { TLDefaultFontStyle } from '@tldraw/tlschema';
 import { TLDefaultSizeStyle } from '@tldraw/editor';
-import { TLDragShapesOutInfo } from '@tldraw/editor';
-import { TLDragShapesOverInfo } from '@tldraw/editor';
 import { TldrawEditorBaseProps } from '@tldraw/editor';
 import { TldrawEditorStoreProps } from '@tldraw/editor';
 import { TldrawOptions } from '@tldraw/editor';
@@ -1680,11 +1679,9 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 }
 
 // @public (undocumented)
-export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
+export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
     // (undocumented)
     canEdit(shape: TLFrameShape, info: TLEditStartInfo): boolean;
-    // (undocumented)
-    canReceiveNewChildrenOfType(shape: TLShape): boolean;
     // (undocumented)
     canResize(shape: TLFrameShape): boolean;
     // (undocumented)
@@ -1697,8 +1694,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
     } ? Partial<Options> : never): T;
     // (undocumented)
     getAriaDescriptor(shape: TLFrameShape): string;
-    // (undocumented)
-    getClipPath(shape: TLFrameShape): Vec[];
     // (undocumented)
     getDefaultProps(): TLFrameShape['props'];
     // (undocumented)
@@ -1730,17 +1725,9 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
         type: "frame";
     } | undefined;
     // (undocumented)
-    onDragShapesIn(shape: TLFrameShape, draggingShapes: TLShape[], { initialParentIds, initialIndices }: TLDragShapesOverInfo): void;
-    // (undocumented)
-    onDragShapesOut(shape: TLFrameShape, draggingShapes: TLShape[], info: TLDragShapesOutInfo): void;
-    // (undocumented)
-    onResize(shape: any, info: TLResizeInfo<any>): any;
-    // (undocumented)
     options: FrameShapeOptions;
     // (undocumented)
     static props: RecordProps<TLFrameShape>;
-    // (undocumented)
-    providesBackgroundForChildren(): boolean;
     // (undocumented)
     toSvg(shape: TLFrameShape, ctx: SvgExportContext): JSX.Element;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -1,5 +1,5 @@
 import {
-	BaseBoxShapeUtil,
+	BaseFrameLikeShapeUtil,
 	DefaultColorStyle,
 	Geometry2d,
 	Group2d,
@@ -7,13 +7,9 @@ import {
 	SVGContainer,
 	SvgExportContext,
 	TLClickEventInfo,
-	TLDragShapesOutInfo,
-	TLDragShapesOverInfo,
 	TLEditStartInfo,
 	TLFrameShape,
 	TLFrameShapeProps,
-	TLResizeInfo,
-	TLShape,
 	TLShapePartial,
 	TLShapeUtilConstructor,
 	clamp,
@@ -22,7 +18,6 @@ import {
 	frameShapeProps,
 	getColorValue,
 	lerp,
-	resizeBox,
 	toDomPrecision,
 	useColorMode,
 	useValue,
@@ -79,7 +74,7 @@ export interface FrameShapeOptions extends ShapeOptionsWithDisplayValues<
 }
 
 /** @public */
-export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
+export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 	static override type = 'frame' as const
 	static override props = frameShapeProps
 	static override migrations = frameShapeMigrations
@@ -362,22 +357,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return path
 	}
 
-	override providesBackgroundForChildren(): boolean {
-		return true
-	}
-
-	override getClipPath(shape: TLFrameShape) {
-		return this.editor.getShapeGeometry(shape.id).vertices
-	}
-
-	override canReceiveNewChildrenOfType(shape: TLShape) {
-		return !shape.isLocked
-	}
-
-	override onResize(shape: any, info: TLResizeInfo<any>) {
-		return resizeBox(shape, info)
-	}
-
 	override getInterpolatedProps(
 		startShape: TLFrameShape,
 		endShape: TLFrameShape,
@@ -435,64 +414,6 @@ export class FrameShapeUtil extends BaseBoxShapeUtil<TLFrameShape> {
 		return {
 			id: shape.id,
 			type: shape.type,
-		}
-	}
-
-	override onDragShapesIn(
-		shape: TLFrameShape,
-		draggingShapes: TLShape[],
-		{ initialParentIds, initialIndices }: TLDragShapesOverInfo
-	) {
-		const { editor } = this
-
-		if (draggingShapes.every((s) => s.parentId === shape.id)) return
-
-		// Check to see whether any of the shapes can have their old index restored
-		let canRestoreOriginalIndices = false
-		const previousChildren = draggingShapes.filter((s) => shape.id === initialParentIds.get(s.id))
-
-		if (previousChildren.length > 0) {
-			const currentChildren = compact(
-				editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))
-			)
-			if (previousChildren.every((s) => !currentChildren.find((c) => c.index === s.index))) {
-				canRestoreOriginalIndices = true
-			}
-		}
-
-		// I can't imagine this happening, but if any of the children are the ancestor of the frame, quit here
-		if (draggingShapes.some((s) => editor.hasAncestor(shape, s.id))) return
-
-		// Reparent the shapes to the new parent
-		editor.reparentShapes(draggingShapes, shape.id)
-
-		// If we can restore the original indices, then do so
-		if (canRestoreOriginalIndices) {
-			for (const shape of previousChildren) {
-				editor.updateShape({
-					id: shape.id,
-					type: shape.type,
-					index: initialIndices.get(shape.id),
-				})
-			}
-		}
-	}
-
-	override onDragShapesOut(
-		shape: TLFrameShape,
-		draggingShapes: TLShape[],
-		info: TLDragShapesOutInfo
-	): void {
-		const { editor } = this
-		// When a user drags shapes out of a frame, and if we're not dragging into a new shape, then reparent
-		// the dragging shapes (that are current children of the frame) onto the current page instead
-		if (!info.nextDraggingOverShapeId) {
-			editor.reparentShapes(
-				draggingShapes.filter(
-					(s) => s.parentId === shape.id && this.canReceiveNewChildrenOfType(s)
-				),
-				editor.getCurrentPageId()
-			)
 		}
 	}
 }


### PR DESCRIPTION
In order to make it easier to create custom frame-like shapes without having to know about and manually implement each frame-related method (`isFrameLike`, `providesBackgroundForChildren`, `getClipPath`, `canReceiveNewChildrenOfType`, `onDragShapesIn`, `onDragShapesOut`), this PR introduces a `BaseFrameLikeShapeUtil` abstract class that bundles all of these behaviors with sensible defaults.

Relates to #7309, relates to #8331

### Change type

- [x] `api`

### Test plan

1. Existing frame tests still pass — no behavioral changes
2. Custom frame-like shapes can extend `BaseFrameLikeShapeUtil` and get all frame behaviors out of the box

- [x] Unit tests

### Release notes

- Add `BaseFrameLikeShapeUtil` abstract class that provides default implementations for all frame-like behaviors (clipping, drag-and-drop reparenting, background for children). Custom frame-like shapes can extend this instead of manually implementing each method.
- Add `ShapeUtil.isFrameLike()` capability method.

### API changes

- Added `BaseFrameLikeShapeUtil` abstract class (extends `BaseBoxShapeUtil`)
- Added `ShapeUtil.isFrameLike()` method (defaults to `false`)
- Changed `FrameShapeUtil` to extend `BaseFrameLikeShapeUtil` instead of `BaseBoxShapeUtil`
- Removed `FrameShapeUtil.providesBackgroundForChildren()` (now inherited)
- Removed `FrameShapeUtil.getClipPath()` (now inherited)
- Removed `FrameShapeUtil.canReceiveNewChildrenOfType()` (now inherited)
- Removed `FrameShapeUtil.onDragShapesIn()` (now inherited)
- Removed `FrameShapeUtil.onDragShapesOut()` (now inherited)
- Removed `FrameShapeUtil.onResize()` (now inherited from `BaseBoxShapeUtil`)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +138 / -83 |
| Automated files | +20 / -13  |