### PR TITLE
perf(zero): use performance CPUs for production replication manager

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -22,7 +22,7 @@ policy = "always"
 
 [[vm]]
 memory = "__VM_MEMORY"
-cpu_kind = "shared"
+cpu_kind = "__CPU_KIND"
 cpus = __VM_CPUS
 
 [mounts]

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -284,8 +284,8 @@ const zeroQueryUrl = `${env.MULTIPLAYER_SERVER.replace(/^ws/, 'http')}/app/zero/
 // Preview: Supabase branch instance (~60 max_connections per branch, isolated)
 // Production: higher limits but sync worker also connects, so ~30% of capacity for Zero
 // TODO(production): tune these once we know prod Postgres limits
-// Fly.io shared-cpu VM sizes per environment.
-// Max shared-cpu is 8x (8 CPUs, 16 GB RAM).
+// Fly.io VM sizes per environment.
+// Production RM uses performance (dedicated) CPUs; everything else uses shared.
 const zeroVmSizes = {
 	staging: {
 		rm: { cpus: 1, memory: '2gb', cpuKind: 'shared' },

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -287,9 +287,13 @@ const zeroQueryUrl = `${env.MULTIPLAYER_SERVER.replace(/^ws/, 'http')}/app/zero/
 // Fly.io shared-cpu VM sizes per environment.
 // Max shared-cpu is 8x (8 CPUs, 16 GB RAM).
 const zeroVmSizes = {
-	staging: { rm: { cpus: 1, memory: '2gb' }, vs: { cpus: 2, memory: '4gb' }, volumeSize: '1gb' },
+	staging: {
+		rm: { cpus: 1, memory: '2gb', cpuKind: 'shared' },
+		vs: { cpus: 2, memory: '4gb' },
+		volumeSize: '1gb',
+	},
 	production: {
-		rm: { cpus: 4, memory: '8gb' },
+		rm: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		vs: { cpus: 8, memory: '16gb' },
 		volumeSize: '8gb',
 	},
@@ -328,6 +332,7 @@ const zeroConns = zeroConnectionLimits[env.TLDRAW_ENV as keyof typeof zeroConnec
 interface VmSize {
 	cpus: number
 	memory: string
+	cpuKind?: 'shared' | 'performance'
 }
 interface SingleNodeVmSizes {
 	single: VmSize
@@ -737,6 +742,7 @@ function updateFlyioReplicationManagerToml(appName: string, backupPath: string):
 		.replaceAll('__RM_UPSTREAM_MAX_CONNS', String(zeroConns.rm.upstream))
 		.replaceAll('__RM_CVR_MAX_CONNS', String(zeroConns.rm.cvr))
 		.replaceAll('__RM_CHANGE_MAX_CONNS', String(zeroConns.rm.change))
+		.replaceAll('__CPU_KIND', zeroVm.rm.cpuKind ?? 'shared')
 		.replaceAll('__VM_CPUS', String(zeroVm.rm.cpus))
 		.replaceAll('__VM_MEMORY', zeroVm.rm.memory)
 		.replaceAll('__VOLUME_SIZE', zeroVm.volumeSize)


### PR DESCRIPTION
Zero RM is stuck in a restart loop due to CPU starvation on shared CPUs. Fly.io throttles shared CPUs under sustained load, preventing the RM from catching up on WAL backlog after restarts. This PR switches the production RM to dedicated performance CPUs.

- Adds `cpuKind` field to `VmSize` interface and `zeroVmSizes` config
- Templatizes `cpu_kind` in RM fly.toml template
- Production RM: `performance` (dedicated), staging RM: `shared`, VS: unchanged

### Investigation timeline (2026-04-15, UTC)

| Time | Event |
|------|-------|
| 15:33 | zero-change-streamer opens Postgres connection #1 |
| 15:41 | zero-change-streamer opens Postgres connection #2 |
| 15:42 | Postgres kills connection #1 — idle-in-transaction ~9.5 min |
| 15:43 | Postgres kills connection #2 — idle-in-transaction ~2 min |
| 15:43:51 | change-streamer: "last heartbeat received 93.606 seconds ago. draining." |
| 15:43:55 | Process exits (code 0) |
| 15:43:58 | Fly kernel: "reboot: Restarting system" |
| 16:04 | Fly restarts RM (restart #1) |
| 16:21 | Fly restarts RM again (restart #2 — heartbeat timeout during catchup) |

After restart #1, RM was catching up (transactions 400-900ms, 278 MB WAL lag). During catchup the heartbeat timed out again, triggering restart #2. Shared-cpu-4x only provides 50% baseline CPU (4 × 12.5%), insufficient for sustained catchup. Performance CPUs are dedicated and don't throttle.

### Change type

- [x] `improvement`

### Test plan

1. Verify `yarn typecheck` passes
2. Grep for `__CPU_KIND` — only in template and substitution
3. Deploy to staging (shared CPUs, no behavior change) then production

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +1 / -1    |
| Config/tooling | +8 / -2    |