### PR TITLE
chore(zero): add fly metrics script and extract shared utilities

### DIFF
--- a/internal/scripts/fetch-fly-logs.ts
+++ b/internal/scripts/fetch-fly-logs.ts
@@ -4,13 +4,6 @@
  * Usage:
  *   npx tsx internal/scripts/fetch-fly-logs.ts [options]
  *
- * App names:
- *   production-zero-rm    Production replication manager
- *   production-zero-vs    Production view syncer
- *   staging-zero-rm       Staging replication manager
- *   staging-zero-vs       Staging view syncer
- *   pr-NNNN-zero-cache    PR preview (single zero-cache process)
- *
  * Examples:
  *   npx tsx internal/scripts/fetch-fly-logs.ts --app production-zero-rm --last 2h
  *   npx tsx internal/scripts/fetch-fly-logs.ts --app production-zero-rm --last 30m --filter "Purged"
@@ -19,31 +12,13 @@
  *   npx tsx internal/scripts/fetch-fly-logs.ts --app production-zero-rm --last 6h --filter "Purged" --pretty
  *   FLY_TOKEN=fo1_xxx npx tsx internal/scripts/fetch-fly-logs.ts --app production-zero-rm --last 1h
  *   npx tsx internal/scripts/fetch-fly-logs.ts --token fo1_xxx --app production-zero-rm --last 1h
+ *
+ * See fly-common.ts for app names and token configuration.
  */
 
-const ORG_SLUG = 'tldraw-gb-ltd'
-const BASE_URL = `https://api.fly.io/victorialogs/${ORG_SLUG}/select/logsql/query`
+import { FLY_ORG_SLUG, getFlyToken, parseDuration } from './fly-common'
 
-function getToken(explicit?: string): string {
-	if (explicit) return explicit
-	if (process.env.FLY_TOKEN) return process.env.FLY_TOKEN
-	console.error(
-		'No token provided. Use --token, FLY_TOKEN env var, or create one with: fly tokens create readonly'
-	)
-	process.exit(1)
-}
-
-function parseDuration(s: string): number {
-	const match = s.match(/^(\d+)(m|h|d)$/)
-	if (!match) {
-		console.error(`Invalid duration: ${s}. Use e.g. 30m, 2h, 1d`)
-		process.exit(1)
-	}
-	const n = parseInt(match[1])
-	const unit = match[2]
-	const multipliers: Record<string, number> = { m: 60_000, h: 3_600_000, d: 86_400_000 }
-	return n * multipliers[unit]
-}
+const BASE_URL = `https://api.fly.io/victorialogs/${FLY_ORG_SLUG}/select/logsql/query`
 
 function parseArgs() {
 	const args = process.argv.slice(2)
@@ -98,7 +73,7 @@ async function main() {
 	if (opts.start) {
 		start = opts.start
 	} else {
-		const ms = parseDuration(opts.last ?? '1h')
+		const ms = parseDuration(opts.last ?? '1h', 'ms')
 		start = new Date(now.getTime() - ms).toISOString()
 	}
 
@@ -108,7 +83,7 @@ async function main() {
 	const params = new URLSearchParams({ query, start, end })
 	if (opts.limit) params.set('limit', opts.limit)
 
-	const token = getToken(opts.token)
+	const token = getFlyToken(opts.token)
 	const url = `${BASE_URL}?${params}`
 
 	const res = await fetch(url, { headers: { Authorization: token } })

--- a/internal/scripts/fetch-fly-metrics.ts
+++ b/internal/scripts/fetch-fly-metrics.ts
@@ -1,0 +1,201 @@
+/**
+ * Fetch CPU and memory metrics from Fly.io's Prometheus API.
+ *
+ * Usage:
+ *   npx tsx internal/scripts/fetch-fly-metrics.ts [options]
+ *
+ * Examples:
+ *   npx tsx internal/scripts/fetch-fly-metrics.ts --app production-zero-rm --last 1h
+ *   npx tsx internal/scripts/fetch-fly-metrics.ts --app production-zero-rm --last 6h --step 5m
+ *   npx tsx internal/scripts/fetch-fly-metrics.ts --token fo1_xxx --app production-zero-rm --last 2h
+ *   FLY_TOKEN=fo1_xxx npx tsx internal/scripts/fetch-fly-metrics.ts --app production-zero-rm --last 1h
+ *
+ * See fly-common.ts for app names and token configuration.
+ */
+
+import { FLY_ORG_SLUG, getFlyToken, parseDuration } from './fly-common'
+
+const PROM_URL = `https://api.fly.io/prometheus/${FLY_ORG_SLUG}/api/v1/query_range`
+
+function parseArgs() {
+	const args = process.argv.slice(2)
+	const opts: Record<string, string> = {}
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === '--token' || args[i] === '-t') opts.token = args[++i]
+		else if (args[i] === '--app' || args[i] === '-a') opts.app = args[++i]
+		else if (args[i] === '--last' || args[i] === '-l') opts.last = args[++i]
+		else if (args[i] === '--step' || args[i] === '-s') opts.step = args[++i]
+		else if (args[i] === '--output' || args[i] === '-o') opts.output = args[++i]
+		else if (args[i] === '--help' || args[i] === '-h') {
+			console.log(
+				[
+					'Usage: npx tsx internal/scripts/fetch-fly-metrics.ts [options]',
+					'',
+					'Options:',
+					'  --token, -t    Fly API token (falls back to FLY_TOKEN env var)',
+					'  --app, -a      Fly app name (required)',
+					'  --last, -l     Duration to look back, e.g. 30m, 2h, 1d (default: 1h)',
+					'  --step, -s     Query resolution step, e.g. 1m, 5m (default: 1m)',
+					'  --output, -o   Write to file instead of stdout',
+					'  --help, -h     Show this help',
+				].join('\n')
+			)
+			process.exit(0)
+		} else {
+			console.error(`Unknown option: ${args[i]}`)
+			process.exit(1)
+		}
+	}
+	if (!opts.app) {
+		console.error('--app is required')
+		process.exit(1)
+	}
+	return opts
+}
+
+interface PromResult {
+	metric: Record<string, string>
+	values: [number, string][]
+}
+
+async function queryRange(
+	token: string,
+	query: string,
+	start: number,
+	end: number,
+	step: string
+): Promise<PromResult[]> {
+	const params = new URLSearchParams({
+		query,
+		start: start.toString(),
+		end: end.toString(),
+		step,
+	})
+	const res = await fetch(`${PROM_URL}?${params}`, {
+		headers: { Authorization: `FlyV1 ${token}` },
+	})
+	if (!res.ok) {
+		console.error(`HTTP ${res.status}: ${await res.text()}`)
+		process.exit(1)
+	}
+	const json = (await res.json()) as { data: { result: PromResult[] } }
+	return json.data.result
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)}GB`
+	if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(1)}MB`
+	return `${(bytes / 1e3).toFixed(1)}KB`
+}
+
+function formatTime(epoch: number): string {
+	return new Date(epoch * 1000)
+		.toISOString()
+		.replace('T', ' ')
+		.replace(/\.\d+Z/, 'Z')
+}
+
+function seriesLabel(metric: Record<string, string>): string {
+	const instance = metric.instance ?? 'unknown'
+	const region = metric.region ?? ''
+	return region ? `${instance} (${region})` : instance
+}
+
+async function main() {
+	const opts = parseArgs()
+	const token = getFlyToken(opts.token)
+	const step = opts.step ?? '1m'
+
+	const now = Math.floor(Date.now() / 1000)
+	const rangeSec = parseDuration(opts.last ?? '1h')
+	const start = now - rangeSec
+	const app = opts.app
+
+	// Query A: CPU usage % (excludes idle + steal, normalized by core count)
+	const cpuQuery = `sum(increase(fly_instance_cpu{app="${app}", mode!="idle", mode!="steal"}[60s]))by(instance, region)/60 / sum(count(fly_instance_cpu{app="${app}", mode="idle"})without(cpu))by(instance, region)`
+	// Query B: CPU baseline (shared CPU fraction)
+	const baselineQuery = `mode(fly_instance_cpu_baseline{app="${app}"}) / mode(count(fly_instance_cpu{app="${app}", mode="idle"})without(cpu_id, mode)) * 100`
+	// Query C: CPU throttle indicator
+	const throttleQuery = `avg(rate(fly_instance_cpu_throttle{app="${app}"}[60s])) / count(fly_instance_cpu{app="${app}", mode="idle"})without(cpu_id, mode)`
+	// Memory used
+	const memQuery = `fly_instance_memory_mem_total{app="${app}"} - fly_instance_memory_mem_available{app="${app}"}`
+	const memTotalQuery = `fly_instance_memory_mem_total{app="${app}"}`
+
+	const [cpuResults, baselineResults, throttleResults, memResults, memTotalResults] =
+		await Promise.all([
+			queryRange(token, cpuQuery, start, now, step),
+			queryRange(token, baselineQuery, start, now, step),
+			queryRange(token, throttleQuery, start, now, step),
+			queryRange(token, memQuery, start, now, step),
+			queryRange(token, memTotalQuery, start, now, step),
+		])
+
+	if (!cpuResults.length && !memResults.length) {
+		console.error('No metrics found.')
+		process.exit(0)
+	}
+
+	const lines: string[] = []
+	lines.push(`Metrics for ${app} (last ${opts.last ?? '1h'}, step ${step})`)
+
+	// CPU time series
+	for (const series of cpuResults) {
+		const label = seriesLabel(series.metric)
+		const values = series.values.map((v) => parseFloat(v[1]))
+		const avg = values.reduce((a, b) => a + b, 0) / values.length
+		const max = Math.max(...values)
+		lines.push('')
+		lines.push(`--- CPU [${label}] avg=${avg.toFixed(1)}% max=${max.toFixed(1)}% ---`)
+		for (const [ts, val] of series.values) {
+			lines.push(`  ${formatTime(ts)}  ${parseFloat(val).toFixed(1)}%`)
+		}
+	}
+
+	// CPU baseline
+	for (const series of baselineResults) {
+		const label = seriesLabel(series.metric)
+		const values = series.values.map((v) => parseFloat(v[1]))
+		const avg = values.reduce((a, b) => a + b, 0) / values.length
+		lines.push('')
+		lines.push(`--- CPU baseline [${label}] avg=${avg.toFixed(1)}% ---`)
+	}
+
+	// CPU throttle
+	for (const series of throttleResults) {
+		const values = series.values.map((v) => parseFloat(v[1]))
+		const throttled = values.filter((v) => v > 1).length
+		if (throttled > 0) {
+			lines.push('')
+			lines.push(`--- CPU throttled: ${throttled}/${values.length} samples ---`)
+		}
+	}
+
+	// Memory time series
+	for (const series of memResults) {
+		const label = seriesLabel(series.metric)
+		const values = series.values.map((v) => parseFloat(v[1]))
+		const avg = values.reduce((a, b) => a + b, 0) / values.length
+		const max = Math.max(...values)
+		const totalSeries = memTotalResults.find((t) => t.metric.instance === series.metric.instance)
+		const total = totalSeries?.values[0] ? parseFloat(totalSeries.values[0][1]) : 0
+		const totalStr = total ? ` / ${formatBytes(total)}` : ''
+		lines.push('')
+		lines.push(`--- MEM [${label}] avg=${formatBytes(avg)} max=${formatBytes(max)}${totalStr} ---`)
+		for (const [ts, val] of series.values) {
+			const pct = total ? ` (${((parseFloat(val) / total) * 100).toFixed(1)}%)` : ''
+			lines.push(`  ${formatTime(ts)}  ${formatBytes(parseFloat(val))}${pct}`)
+		}
+	}
+
+	const output = lines.join('\n')
+
+	if (opts.output) {
+		const fs = await import('fs')
+		fs.writeFileSync(opts.output, output + '\n')
+		console.error(`Wrote to ${opts.output}`)
+	} else {
+		process.stdout.write(output + '\n')
+	}
+}
+
+main()

--- a/internal/scripts/fly-common.ts
+++ b/internal/scripts/fly-common.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared utilities for Fly.io scripts.
+ *
+ * App names:
+ *   production-zero-rm    Production replication manager
+ *   production-zero-vs    Production view syncer
+ *   staging-zero-rm       Staging replication manager
+ *   staging-zero-vs       Staging view syncer
+ *   pr-NNNN-zero-cache    PR preview (single zero-cache process)
+ */
+
+export const FLY_ORG_SLUG = process.env.FLY_ORG_SLUG ?? 'tldraw-gb-ltd'
+
+export function getFlyToken(explicit?: string): string {
+	if (explicit) return explicit
+	if (process.env.FLY_TOKEN) return process.env.FLY_TOKEN
+	console.error(
+		'No token provided. Use --token, FLY_TOKEN env var, or create one with: fly tokens create readonly'
+	)
+	process.exit(1)
+}
+
+export function parseDuration(s: string, unit: 'ms' | 's' = 's'): number {
+	const match = s.match(/^(\d+)(m|h|d)$/)
+	if (!match) {
+		console.error(`Invalid duration: ${s}. Use e.g. 30m, 2h, 1d`)
+		process.exit(1)
+	}
+	const n = parseInt(match[1])
+	const u = match[2]
+	const multipliers: Record<string, number> = { m: 60, h: 3_600, d: 86_400 }
+	const sec = n * multipliers[u]
+	return unit === 'ms' ? sec * 1000 : sec
+}


### PR DESCRIPTION
In order to let Rocicorp pull zero-cache metrics without needing fly CLI auth, this PR adds a Prometheus metrics script and extracts shared utilities.

Changes:
- **`fly-common.ts`** (new): shared org slug (configurable via `FLY_ORG_SLUG`), token resolution (`--token` / `FLY_TOKEN`), duration parsing
- **`fetch-fly-logs.ts`**: refactored to use shared module, removed fly CLI fallback that silently minted new org deploy tokens on every run
- **`fetch-fly-metrics.ts`** (new): fetches CPU and memory time series from Fly's Prometheus API using the same queries as the Grafana dashboard (CPU usage, baseline, throttle, memory used/total)

### Change type

- [x] `improvement`

### Test plan

1. Run logs script with `--token` — should fetch logs
2. Run logs script without token — should error with helpful message
3. Run metrics script with `--token` — should show CPU/memory time series
4. Run metrics script with `FLY_TOKEN` env var — same result

### Code changes

| Section        | LOC change  |
| -------------- | ----------- |
| Config/tooling | +241 / -31  |