### PR TITLE
perf(shapes): skip CSS transform when dynamic size is not active

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -858,7 +858,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 						padding={0}
 						showTextOutline={this.options.showTextOutline}
 						style={{
-							transform: `translate(${labelPosition.box.center.x}px, ${labelPosition.box.center.y}px) scale(${shape.props.scale})`,
+							transform: `translate(${labelPosition.box.center.x}px, ${labelPosition.box.center.y}px)${shape.props.scale !== 1 ? ` scale(${shape.props.scale})` : ''}`,
 						}}
 					/>
 				)}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -367,12 +367,16 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 							labelColor={dv.labelColor}
 							wrap
 							showTextOutline={this.options.showTextOutline}
-							style={{
-								transform: `scale(${shape.props.scale})`,
-								transformOrigin: 'top left',
-								width: shape.props.w / shape.props.scale,
-								height: (shape.props.h + props.growY) / shape.props.scale,
-							}}
+							style={
+								shape.props.scale !== 1
+									? {
+											transform: `scale(${shape.props.scale})`,
+											transformOrigin: 'top left',
+											width: shape.props.w / shape.props.scale,
+											height: (shape.props.h + props.growY) / shape.props.scale,
+										}
+									: undefined
+							}
 						/>
 					</HTMLContainer>
 				)}

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -402,12 +402,16 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 							hasCustomTabBehavior
 							showTextOutline={false}
 							onKeyDown={handleKeyDown}
-							style={{
-								transform: `scale(${scale})`,
-								transformOrigin: 'top left',
-								width: dv.noteWidth,
-								height: dv.noteHeight + shape.props.growY,
-							}}
+							style={
+								scale !== 1
+									? {
+											transform: `scale(${scale})`,
+											transformOrigin: 'top left',
+											width: dv.noteWidth,
+											height: dv.noteHeight + shape.props.growY,
+										}
+									: undefined
+							}
 						/>
 					)}
 				</div>


### PR DESCRIPTION
In order to fix a rotation performance regression introduced by #8378 and #8451, this PR conditionally applies CSS `transform: scale()` on shape label containers only when dynamic size is active (`scale !== 1`). Closes #8562.

PR #8378 changed geo and note shapes to use CSS `transform: scale()` on label containers instead of multiplying `fontSize` and `padding` directly, fixing shadow artifacts and oversized carets at high zoom in dynamic size mode. However, this transform was applied unconditionally — even when `scale === 1` (the default), which forces an unnecessary compositing layer on every shape label, causing a measurable rotation performance regression.

The fix skips the `style` prop entirely when `scale === 1`, avoiding the extra composite layer during rotation while preserving the shadow/caret fix when dynamic sizing is active.

### Change type

- [x] `bugfix`

### Test plan

1. Create a canvas with many geo and note shapes (no dynamic sizing)
2. Select all and rotate — rotation should be smooth without the compositing overhead
3. Enable dynamic size on some shapes (scale !== 1) and verify labels still render correctly at high zoom (no shadow artifacts, no oversized carets)
4. Add arrow labels with dynamic size and verify positioning and scaling still work

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix rotation performance regression caused by unconditional CSS transforms on shape labels

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +21 / -13  |