### PR TITLE
fix(toolbar): avoid hover-triggered overflow recalculations causing ResizeObserver loop warnings

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -240,8 +240,6 @@ export function OverflowingToolbar({
 		mutationObserver.observe(mainToolsRef.current, {
 			childList: true,
 			subtree: true,
-			attributes: true,
-			characterData: true,
 		})
 
 		const sizingParent = findParentWithClassName(mainToolsRef.current, sizingParentClassName)


### PR DESCRIPTION
In order to fix intermittent `ResizeObserver loop completed with undelivered notifications` browser warnings when hovering over toolbar buttons, this PR removes the `attributes` and `characterData` options from the `MutationObserver` in `OverflowingToolbar`.

The overflow recalculation (`onDomUpdate`) only needs to respond to DOM structure changes (`childList`) and container resizes (`ResizeObserver`). Observing `attributes` caused a feedback loop: hovering triggered attribute changes → `onDomUpdate` set `data-toolbar-visible` attributes → mutation observer fired again → ResizeObserver loop warning. React-driven attribute changes (like tool selection) already trigger recalculation via the `useLayoutEffect` that runs after every render.

Closes #8528

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app with the default toolbar
2. Move the pointer quickly across toolbar buttons
3. Verify no `ResizeObserver loop` warnings appear in the browser console
4. Verify toolbar overflow still works correctly when resizing the window

### Release notes

- Fix intermittent `ResizeObserver loop` browser warnings when hovering over toolbar buttons.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +0 / -2    |