### PR TITLE
fix: export of defaultHandleExternalFileReplaceContent

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -104,6 +104,7 @@ import { TLEmbedShapeProps } from '@tldraw/editor';
 import { TLEventInfo } from '@tldraw/editor';
 import { TLExportType } from '@tldraw/editor';
 import { TLFileExternalAsset } from '@tldraw/editor';
+import { TLFileReplaceExternalContent } from '@tldraw/editor';
 import { TLFontFace } from '@tldraw/tlschema';
 import { TLFontFace as TLFontFace_2 } from '@tldraw/editor';
 import { TLFrameShape } from '@tldraw/editor';
@@ -1004,6 +1005,9 @@ export function defaultHandleExternalFileContent(editor: Editor, { point, files 
     files: File[];
     point?: VecLike;
 }, options: TLDefaultExternalContentHandlerOpts): Promise<void>;
+
+// @public (undocumented)
+export function defaultHandleExternalFileReplaceContent(editor: Editor, { file, shapeId }: TLFileReplaceExternalContent, options: TLDefaultExternalContentHandlerOpts): Promise<TLAsset | undefined>;
 
 // @public (undocumented)
 export function defaultHandleExternalSvgTextContent(editor: Editor, { point, text }: {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -88,6 +88,7 @@ export {
 	defaultHandleExternalExcalidrawContent,
 	defaultHandleExternalFileAsset,
 	defaultHandleExternalFileContent,
+	defaultHandleExternalFileReplaceContent,
 	defaultHandleExternalSvgTextContent,
 	defaultHandleExternalTextContent,
 	defaultHandleExternalTldrawContent,


### PR DESCRIPTION
This function was added in PR #6276 but was never added to the package's public exports, despite being listed in the documentation alongside the other defaultHandleExternal* functions which are all exported.

### API changes
- Adds `defaultHandleExternalFileReplaceContent` to exports