### PR TITLE
fix(images): guard OffscreenCanvas usage for unsupported browsers

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageAlphaCache.ts
+++ b/packages/tldraw/src/lib/shapes/image/ImageAlphaCache.ts
@@ -98,6 +98,7 @@ function extractAlphas(ctx: OffscreenCanvasRenderingContext2D, w: number, h: num
  *   finds data that was preloaded from a resolved URL.
  */
 export function preloadAlphaData(url: string, cacheKey?: string): void {
+	if (typeof OffscreenCanvas === 'undefined') return
 	const key = cacheKey ?? url
 	if (alphaCache.has(key) || pending.has(key)) return
 	pending.add(key)


### PR DESCRIPTION
In order to prevent `ReferenceError: Can't find variable: OffscreenCanvas` in browsers without `OffscreenCanvas` support (older Safari, some iOS — 2.2K events / 344 users in 90d), this PR adds an early return in `preloadAlphaData`.

The degradation is already graceful — when alpha data isn't loaded, `isImagePointTransparent` returns `false` (treats all pixels as opaque), so no further changes are needed.

### Change type

- [x] `bugfix`

### Test plan

- Open tldraw in a browser without `OffscreenCanvas` support (e.g. older Safari/iOS)
- Verify no console errors related to `OffscreenCanvas`
- Verify image shapes still work (clicking transparent areas selects the shape, which is the expected fallback)

### Release notes

- Fix crash in browsers without `OffscreenCanvas` support (e.g. older Safari)

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -0    |