### PR TITLE
fix(dotcom): use hardcoded strings for Clerk error boundary messages

### DIFF
--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -94,9 +94,10 @@ if (!PUBLISHABLE_KEY) {
 const CLERK_LOAD_TIMEOUT_MS = 10_000
 
 const CLERK_ERROR_MESSAGES = {
-	header: appMessages.clerkUnavailable.defaultMessage,
-	para1: appMessages.clerkUnavailablePara.defaultMessage,
-	cta: appMessages.refresh.defaultMessage,
+	header: 'Unable to connect',
+	para1:
+		"We're having trouble connecting to our authentication service. This is usually temporary. Please try refreshing the page.",
+	cta: 'Refresh',
 }
 
 export function Component() {


### PR DESCRIPTION
`@formatjs/unplugin` with `ast: true` compiles `defineMessages()` output into AST arrays at build time, so `.defaultMessage` returns `{type, value}` objects instead of strings. `CLERK_ERROR_MESSAGES` was passing these objects directly to `<h1>`/`<p>`/`<button>` in `ErrorPage`, crashing React with "Objects are not valid as a React child". This replaces the `.defaultMessage` references with hardcoded English strings, matching the existing pattern in `main.tsx:13-18` (`TOP_LEVEL_ERROR_MESSAGES`) which also sits outside `IntlWrapper` and uses the same approach.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy and trigger the Clerk error boundary (e.g. block Clerk's domain)
2. Verify the error page renders correctly with "Unable to connect" header

### Release notes

- Fix crash when Clerk authentication service is unavailable

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +4 / -3    |