### PR TITLE
feat(tldraw): add headless RoomSnapshot to .tldr conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ opencode.json
 .claude/skills/pr-walkthrough/video/dist
 .claude/skills/pr-walkthrough/video/public/audio-*
 .claude/skills/pr-walkthrough/video/public/manifest.json
+
+# Stray file created by git hooks
+/0

--- a/apps/dotcom/sync-worker/scripts/snapshot-to-tldr.ts
+++ b/apps/dotcom/sync-worker/scripts/snapshot-to-tldr.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env tsx
+/**
+ * Convert a `RoomSnapshot` JSON blob (as stored in the `rooms-history-ephemeral`
+ * R2 bucket) into a `.tldr` file that can be opened in the tldraw editor.
+ *
+ * Usage:
+ *   tsx scripts/snapshot-to-tldr.ts [--in <path>] [--out <path>]
+ *
+ * Reads from stdin by default, writes to stdout by default.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { RoomSnapshot } from '@tldraw/sync-core'
+// Import directly from the source file so we don't load the full `tldraw`
+// package (React, editor, etc.) just for a pure data transform.
+import { roomSnapshotToTldrawFile } from '../../../../packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile'
+
+interface CliArgs {
+	in?: string
+	out?: string
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: CliArgs = {}
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]
+		if (arg === '--in') {
+			args.in = argv[++i]
+		} else if (arg === '--out') {
+			args.out = argv[++i]
+		} else if (arg === '-h' || arg === '--help') {
+			process.stdout.write('Usage: tsx scripts/snapshot-to-tldr.ts [--in <path>] [--out <path>]\n')
+			process.exit(0)
+		} else {
+			process.stderr.write(`Unknown argument: ${arg}\n`)
+			process.exit(1)
+		}
+	}
+	return args
+}
+
+function readInput(path: string | undefined): string {
+	if (path) return readFileSync(path, 'utf-8')
+	return readFileSync(0, 'utf-8')
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2))
+	const input = readInput(args.in)
+	const snapshot = JSON.parse(input) as RoomSnapshot
+	const file = roomSnapshotToTldrawFile(snapshot)
+	const output = JSON.stringify(file)
+	if (args.out) {
+		writeFileSync(args.out, output)
+	} else {
+		process.stdout.write(output)
+	}
+}
+
+main()

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3031,6 +3031,28 @@ export interface RichTextSVGProps {
     wrap?: boolean;
 }
 
+// @public
+export interface RoomSnapshotLike {
+    // (undocumented)
+    clock?: number;
+    // (undocumented)
+    documentClock?: number;
+    // (undocumented)
+    documents: Array<{
+        lastChangedClock: number;
+        state: UnknownRecord;
+    }>;
+    // (undocumented)
+    schema?: SerializedSchema;
+    // (undocumented)
+    tombstoneHistoryStartsAtClock?: number;
+    // (undocumented)
+    tombstones?: Record<string, number>;
+}
+
+// @public
+export function roomSnapshotToTldrawFile(snapshot: RoomSnapshotLike): TldrawFile;
+
 // @public (undocumented)
 export function RotateCWMenuItem(): JSX.Element;
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -827,6 +827,10 @@ export {
 	type TldrawFile,
 	type TldrawFileParseError,
 } from './lib/utils/tldr/file'
+export {
+	roomSnapshotToTldrawFile,
+	type RoomSnapshotLike,
+} from './lib/utils/tldr/roomSnapshotToTldrawFile'
 
 registerTldrawLibraryVersion(
 	(globalThis as any).TLDRAW_LIBRARY_NAME,

--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -168,7 +168,8 @@ export function parseTldrawJsonFile({
 	}
 }
 
-function pruneUnusedAssets(records: TLRecord[]) {
+/** @internal */
+export function pruneUnusedAssets(records: TLRecord[]) {
 	const usedAssets = new Set<TLAssetId>()
 	for (const record of records) {
 		if (record.typeName === 'shape' && 'assetId' in record.props && record.props.assetId) {

--- a/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.test.ts
+++ b/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.test.ts
@@ -1,0 +1,159 @@
+import {
+	AssetRecordType,
+	InstancePresenceRecordType,
+	TLArrowBinding,
+	TLRecord,
+	UnknownRecord,
+	createShapeId,
+} from '@tldraw/editor'
+import { TestEditor } from '../../../test/TestEditor'
+import { parseTldrawJsonFile } from './file'
+import { RoomSnapshotLike, roomSnapshotToTldrawFile } from './roomSnapshotToTldrawFile'
+
+function buildSnapshot(editor: TestEditor, extra: UnknownRecord[] = []): RoomSnapshotLike {
+	const documents = [...editor.store.allRecords(), ...extra].map((state) => ({
+		state,
+		lastChangedClock: 0,
+	}))
+	return {
+		clock: documents.length,
+		documentClock: documents.length,
+		documents,
+		schema: editor.store.schema.serialize(),
+	}
+}
+
+describe('roomSnapshotToTldrawFile', () => {
+	const shapeId = createShapeId('shape1')
+	const arrowId = createShapeId('arrow1')
+	const usedAssetId = AssetRecordType.createId('used')
+	const orphanAssetId = AssetRecordType.createId('orphan')
+
+	let editor: TestEditor
+
+	beforeEach(() => {
+		editor = new TestEditor()
+		editor.createAssets([
+			{
+				type: 'image',
+				id: usedAssetId,
+				typeName: 'asset',
+				props: {
+					w: 100,
+					h: 100,
+					name: 'used.png',
+					isAnimated: false,
+					mimeType: 'image/png',
+					src: 'https://example.com/used.png',
+				},
+				meta: {},
+			},
+			{
+				type: 'image',
+				id: orphanAssetId,
+				typeName: 'asset',
+				props: {
+					w: 10,
+					h: 10,
+					name: 'orphan.png',
+					isAnimated: false,
+					mimeType: 'image/png',
+					src: 'https://example.com/orphan.png',
+				},
+				meta: {},
+			},
+		])
+		editor.createShapes([
+			{
+				id: shapeId,
+				type: 'image',
+				x: 0,
+				y: 0,
+				props: { w: 100, h: 100, assetId: usedAssetId },
+			},
+			{ id: arrowId, type: 'arrow', x: 200, y: 0 },
+		])
+	})
+
+	it('keeps only persistent record types and drops session-scoped ones', () => {
+		const presence = InstancePresenceRecordType.create({
+			id: InstancePresenceRecordType.createId('p1'),
+			currentPageId: editor.getCurrentPageId(),
+			userId: 'user-1',
+			userName: 'remote',
+		})
+		const snapshot = buildSnapshot(editor, [presence])
+
+		// sanity: the input contains all the session-scoped types we expect to be dropped
+		const inputTypeNames = new Set(snapshot.documents.map((d) => d.state.typeName))
+		for (const t of ['instance', 'instance_page_state', 'instance_presence', 'camera', 'pointer']) {
+			expect(inputTypeNames.has(t)).toBe(true)
+		}
+
+		const file = roomSnapshotToTldrawFile(snapshot)
+		const outTypeNames = new Set(file.records.map((r) => r.typeName))
+		const persistent = new Set(['document', 'page', 'shape', 'asset', 'binding'])
+
+		for (const t of outTypeNames) {
+			expect(persistent.has(t)).toBe(true)
+		}
+		for (const t of [
+			'instance',
+			'instance_page_state',
+			'instance_presence',
+			'camera',
+			'pointer',
+			'user',
+		]) {
+			expect(outTypeNames.has(t)).toBe(false)
+		}
+	})
+
+	it('prunes asset records not referenced by a surviving shape', () => {
+		const file = roomSnapshotToTldrawFile(buildSnapshot(editor))
+		const assetIds = file.records.filter((r) => r.typeName === 'asset').map((r) => r.id)
+
+		expect(assetIds).toContain(usedAssetId)
+		expect(assetIds).not.toContain(orphanAssetId)
+	})
+
+	it('keeps bindings on surviving records', () => {
+		editor.createBinding<TLArrowBinding>({
+			type: 'arrow',
+			fromId: arrowId,
+			toId: shapeId,
+			props: {
+				terminal: 'start',
+				isPrecise: false,
+				isExact: false,
+				normalizedAnchor: { x: 0.5, y: 0.5 },
+			},
+		})
+
+		const file = roomSnapshotToTldrawFile(buildSnapshot(editor))
+		const bindings = file.records.filter((r) => r.typeName === 'binding')
+		expect(bindings).toHaveLength(1)
+	})
+
+	it('round-trips through parseTldrawJsonFile without validation errors', () => {
+		const file = roomSnapshotToTldrawFile(buildSnapshot(editor))
+		const result = parseTldrawJsonFile({
+			json: JSON.stringify(file),
+			schema: editor.store.schema,
+		})
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+
+		const loaded = result.value.allRecords() as TLRecord[]
+		const loadedShapeIds = new Set(loaded.filter((r) => r.typeName === 'shape').map((r) => r.id))
+		expect(loadedShapeIds.has(shapeId)).toBe(true)
+		expect(loadedShapeIds.has(arrowId)).toBe(true)
+	})
+
+	it('throws when the snapshot is missing a schema', () => {
+		expect(() => roomSnapshotToTldrawFile({ documents: [], schema: undefined })).toThrow(
+			/missing a schema/
+		)
+	})
+})

--- a/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.ts
+++ b/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.ts
@@ -1,0 +1,61 @@
+import type { SerializedSchema, TLAssetId, TLRecord, UnknownRecord } from '@tldraw/editor'
+import type { TldrawFile } from './file'
+
+/**
+ * Mirrors the `RoomSnapshot` shape from `@tldraw/sync-core` without importing
+ * that package (the `tldraw` package does not depend on sync-core). Any real
+ * `RoomSnapshot` is structurally assignable to this.
+ *
+ * @public
+ */
+export interface RoomSnapshotLike {
+	clock?: number
+	documentClock?: number
+	documents: Array<{ state: UnknownRecord; lastChangedClock: number }>
+	tombstones?: Record<string, number>
+	tombstoneHistoryStartsAtClock?: number
+	schema?: SerializedSchema
+}
+
+const PERSISTENT_TYPE_NAMES = new Set(['document', 'page', 'shape', 'asset', 'binding'])
+
+/**
+ * Convert a `RoomSnapshot` JSON blob (as produced by the sync server) into a
+ * `TldrawFile` that can be serialized to a `.tldr` file.
+ *
+ * This is a pure function: it does not touch the DOM, fetch network resources,
+ * or rewrite asset URLs. Session-scoped records (`instance`, `instance_page_state`,
+ * `instance_presence`, `camera`, `pointer`, `user`) are dropped, and any asset
+ * records that are not referenced by a surviving shape are pruned.
+ *
+ * @param snapshot - The room snapshot to convert.
+ * @returns A `TldrawFile` ready to stringify and write to disk.
+ *
+ * @public
+ */
+export function roomSnapshotToTldrawFile(snapshot: RoomSnapshotLike): TldrawFile {
+	if (!snapshot.schema) {
+		throw new Error('roomSnapshotToTldrawFile: snapshot is missing a schema')
+	}
+
+	const persistent: TLRecord[] = []
+	for (const doc of snapshot.documents) {
+		if (PERSISTENT_TYPE_NAMES.has(doc.state.typeName)) {
+			persistent.push(doc.state as TLRecord)
+		}
+	}
+
+	const usedAssets = new Set<TLAssetId>()
+	for (const record of persistent) {
+		if (record.typeName === 'shape' && 'assetId' in record.props && record.props.assetId) {
+			usedAssets.add(record.props.assetId as TLAssetId)
+		}
+	}
+	const records = persistent.filter((r) => r.typeName !== 'asset' || usedAssets.has(r.id))
+
+	return {
+		tldrawFileFormatVersion: 1,
+		schema: snapshot.schema,
+		records,
+	}
+}

--- a/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.ts
+++ b/packages/tldraw/src/lib/utils/tldr/roomSnapshotToTldrawFile.ts
@@ -1,5 +1,6 @@
-import type { SerializedSchema, TLAssetId, TLRecord, UnknownRecord } from '@tldraw/editor'
+import type { SerializedSchema, TLRecord, UnknownRecord } from '@tldraw/editor'
 import type { TldrawFile } from './file'
+import { pruneUnusedAssets } from './file'
 
 /**
  * Mirrors the `RoomSnapshot` shape from `@tldraw/sync-core` without importing
@@ -45,13 +46,7 @@ export function roomSnapshotToTldrawFile(snapshot: RoomSnapshotLike): TldrawFile
 		}
 	}
 
-	const usedAssets = new Set<TLAssetId>()
-	for (const record of persistent) {
-		if (record.typeName === 'shape' && 'assetId' in record.props && record.props.assetId) {
-			usedAssets.add(record.props.assetId as TLAssetId)
-		}
-	}
-	const records = persistent.filter((r) => r.typeName !== 'asset' || usedAssets.has(r.id))
+	const records = pruneUnusedAssets(persistent)
 
 	return {
 		tldrawFileFormatVersion: 1,


### PR DESCRIPTION
In order to turn a sync-worker `RoomSnapshot` JSON blob (as written to the R2 `rooms-history-ephemeral` bucket) into a standard `.tldr` file without spinning up a live `Editor` or touching the DOM, this PR adds a pure `roomSnapshotToTldrawFile` helper in the `tldraw` package plus a small tsx-based CLI in the sync-worker. Closes #8589.

The helper:

- Keeps only document-persistent record types (`document`, `page`, `shape`, `asset`, `binding`) and drops session-scoped records (`instance`, `instance_page_state`, `instance_presence`, `camera`, `pointer`, `user`).
- Prunes asset records that aren't referenced by a surviving shape.
- Uses type-only imports so it stays a zero-side-effect pure function — usable from Node scripts, CFW debugging tools, or anything else that has a snapshot in hand.

The CLI (`apps/dotcom/sync-worker/scripts/snapshot-to-tldr.ts`) reads a `RoomSnapshot` JSON from stdin or `--in <path>`, runs it through the helper, and writes the result to stdout or `--out <path>`. It imports the helper directly from its source file so we don't load the full `tldraw` package (React, editor, styles) just to transform JSON.

Asset URL rewriting / data-URI inlining is explicitly out of scope, since that needs a DOM or network. Consumers that want inlined assets can re-import the file into an editor and use the existing `serializeTldrawJson` path.

### API changes

- Added `roomSnapshotToTldrawFile(snapshot)` — pure conversion from a `RoomSnapshot`-shaped input to a `TldrawFile`.
- Added `RoomSnapshotLike` interface — a structural mirror of `@tldraw/sync-core`'s `RoomSnapshot`, used as the helper's input type so that `tldraw` does not need to depend on `sync-core`. Any real `RoomSnapshot` is structurally assignable to it.

### Change type

- [x] `feature`

### Test plan

1. Pipe a real bucket snapshot JSON through the CLI:
   ```
   yarn tsx apps/dotcom/sync-worker/scripts/snapshot-to-tldr.ts --in snapshot.json --out room.tldr
   ```
2. Open the resulting `.tldr` in the tldraw editor (`yarn dev`, `File → Open`). Confirm shapes, pages, and bindings load with no parse errors.

- [x] Unit tests

### Release notes

- Add `roomSnapshotToTldrawFile`, a pure helper that converts a sync `RoomSnapshot` JSON blob into a `.tldr`-compatible `TldrawFile` without needing a live editor or DOM.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +65 / -0   |
| Tests           | +159 / -0  |
| Automated files | +22 / -0   |
| Apps            | +59 / -0   |