### PR TITLE
fix(scripts): unify Fly.io auth header handling

### DIFF
--- a/internal/scripts/fetch-fly-logs.ts
+++ b/internal/scripts/fetch-fly-logs.ts
@@ -86,7 +86,7 @@ async function main() {
 	const token = getFlyToken(opts.token)
 	const url = `${BASE_URL}?${params}`
 
-	const res = await fetch(url, { headers: { Authorization: token } })
+	const res = await fetch(url, { headers: { Authorization: `FlyV1 ${token}` } })
 	if (!res.ok) {
 		console.error(`HTTP ${res.status}: ${await res.text()}`)
 		process.exit(1)

--- a/internal/scripts/fly-common.ts
+++ b/internal/scripts/fly-common.ts
@@ -12,12 +12,16 @@
 export const FLY_ORG_SLUG = process.env.FLY_ORG_SLUG ?? 'tldraw-gb-ltd'
 
 export function getFlyToken(explicit?: string): string {
-	if (explicit) return explicit
-	if (process.env.FLY_TOKEN) return process.env.FLY_TOKEN
-	console.error(
-		'No token provided. Use --token, FLY_TOKEN env var, or create one with: fly tokens create readonly'
-	)
-	process.exit(1)
+	let token = explicit ?? process.env.FLY_TOKEN
+	if (!token) {
+		console.error(
+			'No token provided. Use --token, FLY_TOKEN env var, or create one with: fly tokens create readonly'
+		)
+		process.exit(1)
+	}
+	// Strip "FlyV1 " prefix if present — callers add it themselves
+	if (token.startsWith('FlyV1 ')) token = token.slice(6)
+	return token
 }
 
 export function parseDuration(s: string, unit: 'ms' | 's' = 's'): number {


### PR DESCRIPTION
`fetch-fly-logs.ts` was sending the raw token as the `Authorization` header, while `fetch-fly-metrics.ts` correctly used the `FlyV1 <token>` format. Additionally, if a user passed a token that already included the `FlyV1 ` prefix (e.g. copied from a password manager), the metrics script would double-prefix it.

This PR fixes both issues:
- `getFlyToken()` now strips any existing `FlyV1 ` prefix, so callers always get a raw token
- `fetch-fly-logs.ts` now uses `FlyV1 ${token}` like `fetch-fly-metrics.ts`

### Change type

- [x] `bugfix`

### Test plan

1. Run `fetch-fly-logs.ts` with a token that includes the `FlyV1 ` prefix — should work
2. Run `fetch-fly-logs.ts` with a raw token — should work
3. Run `fetch-fly-metrics.ts` with both token formats — should still work

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +11 / -7   |