### PR TITLE
perf(dotcom): upgrade Zero view syncer to performance machines

### DIFF
--- a/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
+++ b/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
@@ -25,7 +25,7 @@ path = "/"
 
 [[vm]]
 memory = "__VM_MEMORY"
-cpu_kind = "shared"
+cpu_kind = "__CPU_KIND"
 cpus = __VM_CPUS
 
 [mounts]

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -294,7 +294,7 @@ const zeroVmSizes = {
 	},
 	production: {
 		rm: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
-		vs: { cpus: 8, memory: '16gb' },
+		vs: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		volumeSize: '8gb',
 	},
 	preview: { single: { cpus: 2, memory: '2gb' } },
@@ -783,6 +783,7 @@ function updateFlyioViewSyncerToml(
 		.replaceAll('__VS_CHANGE_MAX_CONNS', String(zeroConns.vs.change))
 		.replaceAll('__VM_CPUS', String(zeroVm.vs.cpus))
 		.replaceAll('__VM_MEMORY', zeroVm.vs.memory)
+		.replaceAll('__CPU_KIND', zeroVm.vs.cpuKind ?? 'shared')
 		.replaceAll('__VOLUME_SIZE', zeroVm.volumeSize)
 		.replaceAll('__TLDRAW_ENV', env.TLDRAW_ENV)
 		.replaceAll('__ZERO_VERSION', zeroVersion)


### PR DESCRIPTION
Upgrade Zero view syncer from shared-cpu-8x/16GB to performance-4x/8GB dedicated CPUs. Shared CPUs are burstable and get throttled under sustained load. Dedicated CPUs will perform better as we roll out Zero to more users via feature flags. This matches the RM config (also performance-4x/8GB).

Changes:
- Production VS: `shared-cpu-8x` / 16GB → `performance-4x` / 8GB
- Templatize `cpu_kind` in VS toml (was hardcoded to `"shared"`)
- Add `__CPU_KIND` replacement in `updateFlyioViewSyncerToml()`
- Staging unchanged (shared CPUs, no `cpuKind` field → defaults to `'shared'`)

### Change type

- [x] `improvement`

### Test plan

- Trace template substitution: production VS gets `cpu_kind = "performance"`, staging gets `cpu_kind = "shared"`
- `yarn typecheck` passes

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Apps       | +1 / -1    |
| Config/tooling | +2 / -1 |