### PR TITLE
fix(ci): skip S3 upload when Playwright report is missing

### DIFF
--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -110,7 +110,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/dotcom/client/playwright-report/**') != ''
         name: Upload S3
         id: s3
         with:

--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -110,7 +110,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/dotcom/client/playwright-report/**') != ''
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/dotcom/client/playwright-report/index.html') != ''
         name: Upload S3
         id: s3
         with:
@@ -120,7 +120,7 @@ jobs:
           source_dir: apps/dotcom/client/playwright-report
 
       - name: Log report to summary
-        if: always()
+        if: always() && steps.s3.outputs.object_key != ''
         run: |
           report_url="https://playwright.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
           echo "Report: $report_url"

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -92,7 +92,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/**') != ''
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/index.html') != ''
         name: Upload S3
         id: s3
         with:
@@ -102,7 +102,7 @@ jobs:
           source_dir: apps/examples/playwright-report
 
       - name: Log report to summary
-        if: always()
+        if: always() && steps.s3.outputs.object_key != ''
         run: |
           report_url="https://playwright.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
           echo "Report: $report_url"

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -92,7 +92,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/**') != ''
         name: Upload S3
         id: s3
         with:

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -93,7 +93,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/**') != ''
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/index.html') != ''
         name: Upload S3
         id: s3
         with:
@@ -103,7 +103,7 @@ jobs:
           source_dir: apps/examples/playwright-report
 
       - name: Log report to summary
-        if: always()
+        if: always() && steps.s3.outputs.object_key != ''
         run: |
           report_url="https://playwright.tldraw.xyz/${{ steps.s3.outputs.object_key }}/index.html"
           echo "Report: $report_url"

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -93,7 +93,7 @@ jobs:
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}
-        if: always() && env.HAS_AWS_KEY == '1'
+        if: always() && env.HAS_AWS_KEY == '1' && hashFiles('apps/examples/playwright-report/**') != ''
         name: Upload S3
         id: s3
         with:


### PR DESCRIPTION
In order to stop noisy red ❌ on the `Upload S3` step whenever Playwright bails out before producing a report (build/setup failure, environment error, etc.), this PR gates the `shallwefootball/s3-upload-action@master` step on `hashFiles('…/playwright-report/index.html') != ''` so it's skipped cleanly when the report entrypoint doesn't exist. Previously the action would try to `readdirSync` the missing directory and crash with `ENOENT`.

The `Log report to summary` step is also now gated on a successful S3 upload (`steps.s3.outputs.object_key != ''`) so we no longer emit a broken `https://playwright.tldraw.xyz//index.html` summary URL when the upload was skipped.

Applied to all three Playwright workflows: `playwright-dotcom.yml`, `playwright-examples.yml`, and `playwright-perf.yml`.

### Change type

- [x] `other`

### Test plan

Cannot be manually tested without triggering a failing Playwright run on CI — the fix is observable the next time a run fails before producing a report, where the `Upload S3` and `Log report to summary` steps should both be skipped instead of erroring / printing a broken URL.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Config/tooling  | +6 / -6    |