### PR TITLE
cleanup: rm --font-body which is unused

### DIFF
--- a/apps/examples/src/examples/users/custom-user/custom-user.css
+++ b/apps/examples/src/examples/users/custom-user/custom-user.css
@@ -21,7 +21,6 @@
 	box-shadow: var(--shadow-2);
 	padding: 12px;
 	margin: 8px;
-	font: var(--font-body);
 	font-size: 12px;
 }
 

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -534,7 +534,6 @@ input,
 	overflow: hidden;
 	text-overflow: ellipsis;
 	font-size: 12px;
-	font-family: var(--font-body);
 	border-radius: var(--tl-radius-2);
 	color: var(--tl-color-selected-contrast);
 }
@@ -552,7 +551,6 @@ input,
 	overflow: hidden;
 	text-overflow: ellipsis;
 	font-size: 12px;
-	font-family: var(--font-body);
 	text-shadow: var(--tl-text-outline);
 	color: var(--tl-color-selected-contrast);
 }
@@ -568,7 +566,6 @@ input,
 	position: absolute;
 	padding: 3px 6px;
 	font-size: 12px;
-	font-family: var(--font-body);
 	opacity: 1;
 	border-radius: var(--tl-radius-2);
 }
@@ -579,7 +576,6 @@ input,
 	white-space: nowrap;
 	padding: 3px 6px;
 	font-size: 12px;
-	font-family: var(--font-body);
 	pointer-events: none;
 	z-index: var(--tl-layer-cursor);
 	margin-top: 16px;

--- a/packages/tldraw/src/lib/ui/components/CursorChatBubble.tsx
+++ b/packages/tldraw/src/lib/ui/components/CursorChatBubble.tsx
@@ -113,7 +113,7 @@ const CursorChatInput = track(function CursorChatInput({
 		if (!elm) return
 
 		const textMeasurement = editor.textMeasure.measureText(value || placeholder, {
-			fontFamily: 'var(--font-body)',
+			fontFamily: 'inherit',
 			fontSize: 12,
 			fontWeight: '500',
 			fontStyle: 'normal',


### PR DESCRIPTION
just a little nit i noticed. @steveruizok was this used somewhere before?

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- cleanup: rm `--font-body` which is unused