### PR TITLE
fix(dotcom): replace hyphens in replication slot names

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -127,7 +127,8 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private getNewSlotName() {
 		const slotNameMaxLength = 63 // max postgres identifier length
-		const slotId = uniqueId().toLowerCase()
+		// PG slot names only allow [a-z0-9_], replace hyphens from nanoid
+		const slotId = uniqueId().toLowerCase().replace(/-/g, '_')
 		const slotNamePrefix = `tlpr_${slotId}_`
 		const durableObjectId = this.ctx.id.toString()
 		return slotNamePrefix + durableObjectId.slice(0, slotNameMaxLength - slotNamePrefix.length)


### PR DESCRIPTION
The nanoid alphabet used by `uniqueId()` includes hyphens, but PostgreSQL replication slot names only allow `[a-z0-9_]`. This caused ~28% of replicator boots to fail with:

```
error: replication slot name "tlpr_mia-fhgcapzmyuxopku9z_..." contains invalid character
```

This is the likely root cause of flaky `groups.spec.ts` e2e tests — when the slot name contains a hyphen, replication fails and mutations never resolve.

### Change type

- [x] `bugfix`

### Test plan

1. CI e2e tests should pass consistently now

### Release notes

- Fix replication slot creation failures caused by invalid characters in slot names