### PR TITLE
fix(scripts): prevent secret leaks in deploy Discord messages

### DIFF
--- a/internal/scripts/deploy-analytics.ts
+++ b/internal/scripts/deploy-analytics.ts
@@ -31,6 +31,7 @@ const discord = new Discord({
 	shouldNotify: env.TLDRAW_ENV === 'production',
 	totalSteps: 2,
 	messagePrefix: '[ANALYTICS]',
+	secretValues: Object.values(env),
 })
 
 const { previewId, sha } = getDeployInfo()

--- a/internal/scripts/deploy-bemo.ts
+++ b/internal/scripts/deploy-bemo.ts
@@ -33,6 +33,7 @@ const discord = new Discord({
 	webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 	shouldNotify: env.TLDRAW_ENV === 'production',
 	totalSteps: 3,
+	secretValues: Object.values(env),
 })
 
 const { previewId, sha } = getDeployInfo()

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -128,6 +128,7 @@ const discord = new Discord({
 	shouldNotify: env.TLDRAW_ENV === 'production',
 	totalSteps: previewId ? 10 : 9,
 	messagePrefix: '[DOTCOM]',
+	secretValues: Object.values(env),
 })
 
 const sentryReleaseName = `${env.TLDRAW_ENV}-${previewId ? previewId + '-' : ''}-${sha}`

--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -1,5 +1,17 @@
-function sanitizeVariables(errorOutput: string): string {
+const MASK_PLACEHOLDER = '\x00MASKED\x00'
+
+function sanitizeVariables(errorOutput: string, secretValues?: string[]): string {
 	let sanitized = errorOutput
+
+	// Value-based masking: replace any occurrence of known secret values (like GitHub Actions).
+	// Uses an internal placeholder so regex patterns below can't re-match masked output.
+	// Sort longest-first so a longer secret is masked before a shorter substring of it.
+	if (secretValues) {
+		const sorted = secretValues.filter((v) => v.length >= 8).sort((a, b) => b.length - a.length)
+		for (const value of sorted) {
+			sanitized = sanitized.replaceAll(value, MASK_PLACEHOLDER)
+		}
+	}
 
 	// Sanitize wrangler --var KEY:VALUE patterns
 	sanitized = sanitized.replace(/(--var\s+)(\w+):[^ \n]+/g, '$1$2:`***`')
@@ -17,6 +29,9 @@ function sanitizeVariables(errorOutput: string): string {
 		'$1://`***`'
 	)
 
+	// Replace internal placeholder with final mask
+	sanitized = sanitized.replaceAll(MASK_PLACEHOLDER, '`***`')
+
 	return sanitized
 }
 
@@ -28,11 +43,13 @@ export class Discord {
 		shouldNotify: boolean
 		totalSteps?: number
 		messagePrefix?: string
+		secretValues?: string[]
 	}) {
 		this.webhookUrl = opts.webhookUrl
 		this.shouldNotify = opts.shouldNotify
 		this.totalSteps = opts.totalSteps ?? 0
 		this.messagePrefix = opts.messagePrefix ?? ''
+		this.secretValues = opts.secretValues
 	}
 
 	webhookUrl: string
@@ -40,6 +57,7 @@ export class Discord {
 	totalSteps: number
 	currentStep = 0
 	messagePrefix: string
+	private secretValues?: string[]
 
 	private async send(method: string, url: string, body: unknown): Promise<any> {
 		const response = await fetch(`${this.webhookUrl}${url}`, {
@@ -64,7 +82,7 @@ export class Discord {
 
 		const prefixedContent = this.messagePrefix ? `${this.messagePrefix} ${content}` : content
 		const message = await this.send('POST', '?wait=true', {
-			content: sanitizeVariables(prefixedContent),
+			content: sanitizeVariables(prefixedContent, this.secretValues),
 		})
 
 		return {
@@ -73,7 +91,7 @@ export class Discord {
 					? `${this.messagePrefix} ${newContent}`
 					: newContent
 				await this.send('PATCH', `/messages/${message.id}`, {
-					content: sanitizeVariables(prefixedNewContent),
+					content: sanitizeVariables(prefixedNewContent, this.secretValues),
 				})
 			},
 		}

--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -30,6 +30,7 @@ async function main() {
 		webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 		totalSteps: 4,
 		shouldNotify: true,
+		secretValues: Object.values(env),
 	})
 	await discord.message(`🚀 Triggering dotcom hotfix for PR #${pr.number}...`)
 
@@ -148,10 +149,12 @@ Original Author: @${pr.user?.login}`,
 main().catch(async (e: Error) => {
 	console.error(e)
 
+	const env = getEnv()
 	const discord = new Discord({
-		webhookUrl: process.env.DISCORD_DEPLOY_WEBHOOK_URL!,
+		webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 		totalSteps: 3,
 		shouldNotify: true,
+		secretValues: Object.values(env),
 	})
 
 	await discord

--- a/internal/scripts/trigger-sdk-hotfix.ts
+++ b/internal/scripts/trigger-sdk-hotfix.ts
@@ -58,6 +58,7 @@ async function main() {
 		webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 		totalSteps: 3,
 		shouldNotify: true,
+		secretValues: Object.values(env),
 	})
 	await discord.message(`Triggering ${triggerType} hotfix...`)
 
@@ -139,10 +140,12 @@ async function main() {
 main().catch(async (e: Error) => {
 	console.error(e)
 
+	const env = getEnv()
 	const discord = new Discord({
-		webhookUrl: process.env.DISCORD_DEPLOY_WEBHOOK_URL!,
+		webhookUrl: env.DISCORD_DEPLOY_WEBHOOK_URL,
 		totalSteps: 8,
 		shouldNotify: true,
+		secretValues: Object.values(env),
 	})
 
 	await discord


### PR DESCRIPTION
In order to prevent secrets from leaking into Discord error notifications when deploy commands fail, this PR adds value-based masking to the Discord helper — replacing any occurrence of known secret values before sending messages, similar to how GitHub Actions masks secrets.

The existing regex-based sanitization (`KEY=VALUE` pattern matching) fails when a value contains spaces. For example, `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic ...` gets partially sanitized but the base64 token after the space leaks as an orphaned string in the Discord message. This is a whack-a-mole problem — we've fixed the regex multiple times but keep hitting edge cases.

**How it works:**
- `Discord` constructor accepts `secretValues: string[]` — all `Object.values(env)` from `makeEnv`
- Before sending, `sanitizeVariables` replaces every known secret value (≥8 chars, longest-first) with an internal null-byte placeholder
- Existing regex patterns still run as a fallback for secrets not in the env object
- Placeholder is swapped to `` `***` `` at the end, preventing regex patterns from re-matching masked output

Also fixes the catch blocks in hotfix scripts which previously created Discord instances without any secret masking — the exact leak vector this change is meant to close.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy script errors containing secret values are masked before reaching Discord
2. Normal progress messages may over-redact (acceptable tradeoff vs leaking)
3. Regex fallback still catches patterns not covered by value masking

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +32 / -5   |