### PR TITLE
fix(scripts): stage Fly.io secrets to prevent premature restarts

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -818,6 +818,7 @@ async function deployZeroViaFlyIoMultiNode() {
 		[
 			'secrets',
 			'set',
+			'--stage',
 			`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
 			`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
 			`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
@@ -849,6 +850,7 @@ async function deployZeroViaFlyIoMultiNode() {
 		[
 			'secrets',
 			'set',
+			'--stage',
 			`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
 			`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
 			`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,


### PR DESCRIPTION
In order to prevent Zero view syncer machines from restarting before the replication manager is ready, this PR adds `--stage` to both `flyctl secrets set` calls in the multi-node deploy function.

Previously, `flyctl secrets set` triggered an immediate release on both RM and VS apps. This caused a race condition where VS machines could come up while RM was still redeploying, leading to `ENOTFOUND` DNS errors when VS tried to reach `staging-zero-rm.internal`. With `--stage`, secrets are applied on the next `fly deploy` instead of triggering a separate release.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging and verify both RM and VS come up without DNS errors
2. Check `fly releases -a staging-zero-vs` to confirm no extra release from secrets set

### Release notes

- Fix Zero deploy race condition where view syncer could start before replication manager was ready

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +2 / -0    |