### PR TITLE
feat(perf): add memory usage tracking to RUM telemetry

### DIFF
--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -5,6 +5,7 @@ import {
 	TLInteractionEndPerfEvent,
 	TLPerfFrameTimeStats,
 } from 'tldraw'
+import { sentryReleaseName } from '../../sentry-release-name'
 import { fetchFeatureFlags } from '../tla/utils/FeatureFlagPoller'
 import { trackEvent } from '../utils/analytics'
 
@@ -49,6 +50,7 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
 		coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
+		release: sentryReleaseName,
 	}
 }
 
@@ -130,6 +132,7 @@ export function usePerformanceTracking() {
 							device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
 							coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
 							ab_indicators: abIndicators,
+							release: sentryReleaseName,
 						}
 						trackEvent('rum', event)
 						sampleIndex++

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -11,14 +11,6 @@ import { trackEvent } from '../utils/analytics'
 
 const r2 = (n: number) => Math.round(n * 100) / 100
 
-function getCoarsePlatform(): 'ios' | 'android' | 'desktop' {
-	if (typeof navigator === 'undefined') return 'desktop'
-	const ua = navigator.userAgent
-	if (/iPad|iPhone|iPod/.test(ua)) return 'ios'
-	if (/android/i.test(ua)) return 'android'
-	return 'desktop'
-}
-
 function getZoomBucket(zoom: number): string {
 	if (zoom <= 0.15) return 'lte_0.15'
 	if (zoom <= 0.35) return '0.15_0.35'
@@ -26,8 +18,6 @@ function getZoomBucket(zoom: number): string {
 	if (zoom <= 1) return '0.65_1'
 	return 'gt_1'
 }
-
-let coarsePlatform: ReturnType<typeof getCoarsePlatform> | null = null
 
 // Counts editor mounts (file navigations). First mount = 0.
 let editorMountCount = 0
@@ -49,7 +39,6 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		zoom_bucket: getZoomBucket(event.zoomLevel),
 		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
-		coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
 		release: sentryReleaseName,
 	}
 }
@@ -130,7 +119,6 @@ export function usePerformanceTracking() {
 							editor_mount_count: editorMountCount,
 							zoom_bucket: getZoomBucket(editor.getZoomLevel()),
 							device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
-							coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
 							ab_indicators: abIndicators,
 							release: sentryReleaseName,
 						}

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -11,14 +11,6 @@ import { trackEvent } from '../utils/analytics'
 
 const r2 = (n: number) => Math.round(n * 100) / 100
 
-function getZoomBucket(zoom: number): string {
-	if (zoom <= 0.15) return 'lte_0.15'
-	if (zoom <= 0.35) return '0.15_0.35'
-	if (zoom <= 0.65) return '0.35_0.65'
-	if (zoom <= 1) return '0.65_1'
-	return 'gt_1'
-}
-
 // Counts editor mounts (file navigations). First mount = 0.
 let editorMountCount = 0
 
@@ -36,7 +28,6 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		max_frame_time: r2(event.maxFrameTime),
 		shape_count: event.shapeCount,
 		zoom_level: r2(event.zoomLevel),
-		zoom_bucket: getZoomBucket(event.zoomLevel),
 		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
 		release: sentryReleaseName,
@@ -117,7 +108,7 @@ export function usePerformanceTracking() {
 							page_count: editor.getPages().length,
 							page_change_count: pageChangeCount,
 							editor_mount_count: editorMountCount,
-							zoom_bucket: getZoomBucket(editor.getZoomLevel()),
+							zoom_level: r2(editor.getZoomLevel()),
 							device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
 							ab_indicators: abIndicators,
 							release: sentryReleaseName,

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -5,10 +5,28 @@ import {
 	TLInteractionEndPerfEvent,
 	TLPerfFrameTimeStats,
 } from 'tldraw'
+import { sentryReleaseName } from '../../sentry-release-name'
 import { fetchFeatureFlags } from '../tla/utils/FeatureFlagPoller'
 import { trackEvent } from '../utils/analytics'
 
 const r2 = (n: number) => Math.round(n * 100) / 100
+
+function getCoarsePlatform(): 'ios' | 'android' | 'desktop' {
+	const ua = navigator.userAgent
+	if (/iPad|iPhone|iPod/.test(ua)) return 'ios'
+	if (/android/i.test(ua)) return 'android'
+	return 'desktop'
+}
+
+function getZoomBucket(zoom: number): string {
+	if (zoom <= 0.15) return 'lte_0.15'
+	if (zoom <= 0.35) return '0.15_0.35'
+	if (zoom <= 0.65) return '0.35_0.65'
+	if (zoom <= 1) return '0.65_1'
+	return 'gt_1'
+}
+
+const coarsePlatform = getCoarsePlatform()
 
 function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLevel: number }) {
 	const loafs = event.longAnimationFrames
@@ -24,8 +42,11 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		max_frame_time: r2(event.maxFrameTime),
 		shape_count: event.shapeCount,
 		zoom_level: r2(event.zoomLevel),
+		zoom_bucket: getZoomBucket(event.zoomLevel),
 		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
+		coarse_platform: coarsePlatform,
+		release: sentryReleaseName,
 	}
 }
 
@@ -56,6 +77,9 @@ export function usePerformanceTracking() {
 	return useCallback((editor: Editor) => {
 		let unsubInteraction: (() => void) | undefined
 		let unsubCamera: (() => void) | undefined
+		let memoryTimeout: ReturnType<typeof setTimeout> | undefined
+		let memoryInterval: ReturnType<typeof setInterval> | undefined
+		let visibilityHandler: (() => void) | undefined
 		let disposed = false
 
 		fetchFeatureFlags().then((flags) => {
@@ -71,12 +95,65 @@ export function usePerformanceTracking() {
 			unsubCamera = editor.performance.on('camera-end', (event) =>
 				handleCameraEnd(event, abIndicators)
 			)
+
+			// Memory sampling (Chrome-only via performance.memory)
+			const mem = (performance as any).memory
+			if (mem) {
+				const mountTime = Date.now()
+				let sampleIndex = 0
+				const toMb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 100) / 100
+				const deviceMemoryGb = (navigator as any).deviceMemory ?? null
+
+				const sampleMemory = (reason: 'interval' | 'visibility_hidden') => {
+					const m = (performance as any).memory
+					trackEvent('rum', {
+						type: 'memory',
+						sample_index: sampleIndex,
+						sample_reason: reason,
+						session_duration_s: Math.round((Date.now() - mountTime) / 1000),
+						used_js_heap_mb: toMb(m.usedJSHeapSize),
+						total_js_heap_mb: toMb(m.totalJSHeapSize),
+						heap_limit_mb: toMb(m.jsHeapSizeLimit),
+						heap_used_pct: r2(m.usedJSHeapSize / m.jsHeapSizeLimit),
+						shape_count: editor.getCurrentPageShapeIds().size,
+						store_record_count: editor.store.allRecords().length,
+						page_count: editor.getPages().length,
+						zoom_bucket: getZoomBucket(editor.getZoomLevel()),
+						device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
+						coarse_platform: coarsePlatform,
+						release: sentryReleaseName,
+						ab_indicators: abIndicators,
+					})
+					sampleIndex++
+				}
+
+				memoryTimeout = setTimeout(() => {
+					if (disposed) return
+					sampleMemory('interval')
+					memoryInterval = setInterval(() => {
+						if (disposed) return
+						sampleMemory('interval')
+					}, 60_000)
+				}, 10_000)
+
+				visibilityHandler = () => {
+					if (document.visibilityState === 'hidden' && !disposed) {
+						sampleMemory('visibility_hidden')
+					}
+				}
+				document.addEventListener('visibilitychange', visibilityHandler)
+			}
 		})
 
 		return () => {
 			disposed = true
 			unsubInteraction?.()
 			unsubCamera?.()
+			if (memoryTimeout) clearTimeout(memoryTimeout)
+			if (memoryInterval) clearInterval(memoryInterval)
+			if (visibilityHandler) {
+				document.removeEventListener('visibilitychange', visibilityHandler)
+			}
 		}
 	}, [])
 }

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -28,6 +28,10 @@ function getZoomBucket(zoom: number): string {
 
 const coarsePlatform = getCoarsePlatform()
 
+// Tracks how many times the editor mounts with a new document (file navigations).
+// First mount is the initial load, not a change, so we start at -1.
+let fileChangeCount = -1
+
 function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLevel: number }) {
 	const loafs = event.longAnimationFrames
 	return {
@@ -75,11 +79,14 @@ function handleCameraEnd(event: TLCameraEndPerfEvent, abIndicators: 'canvas' | '
 
 export function usePerformanceTracking() {
 	return useCallback((editor: Editor) => {
+		fileChangeCount++
+
 		let unsubInteraction: (() => void) | undefined
 		let unsubCamera: (() => void) | undefined
 		let memoryTimeout: ReturnType<typeof setTimeout> | undefined
 		let memoryInterval: ReturnType<typeof setInterval> | undefined
 		let visibilityHandler: (() => void) | undefined
+		let unsubPageChange: (() => void) | undefined
 		let disposed = false
 
 		fetchFeatureFlags().then((flags) => {
@@ -101,13 +108,14 @@ export function usePerformanceTracking() {
 			if (mem) {
 				const mountTime = Date.now()
 				let sampleIndex = 0
+				let pageChangeCount = 0
 				const toMb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 100) / 100
 				const deviceMemoryGb = (navigator as any).deviceMemory ?? null
 
-				const sampleMemory = (reason: 'interval' | 'visibility_hidden') => {
+				const sampleMemory = (reason: 'interval' | 'visibility_hidden' | 'page_change') => {
 					const m = (performance as any).memory
-					trackEvent('rum', {
-						type: 'memory',
+					const event = {
+						type: 'memory' as const,
 						sample_index: sampleIndex,
 						sample_reason: reason,
 						session_duration_s: Math.round((Date.now() - mountTime) / 1000),
@@ -118,14 +126,27 @@ export function usePerformanceTracking() {
 						shape_count: editor.getCurrentPageShapeIds().size,
 						store_record_count: editor.store.allRecords().length,
 						page_count: editor.getPages().length,
+						page_change_count: pageChangeCount,
+						file_change_count: fileChangeCount,
 						zoom_bucket: getZoomBucket(editor.getZoomLevel()),
 						device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
 						coarse_platform: coarsePlatform,
 						release: sentryReleaseName,
 						ab_indicators: abIndicators,
-					})
+					}
+					trackEvent('rum', event)
 					sampleIndex++
 				}
+
+				unsubPageChange = editor.sideEffects.registerAfterChangeHandler(
+					'instance',
+					(prev, next) => {
+						if (prev.currentPageId !== next.currentPageId) {
+							pageChangeCount++
+							sampleMemory('page_change')
+						}
+					}
+				)
 
 				memoryTimeout = setTimeout(() => {
 					if (disposed) return
@@ -151,6 +172,7 @@ export function usePerformanceTracking() {
 			unsubCamera?.()
 			if (memoryTimeout) clearTimeout(memoryTimeout)
 			if (memoryInterval) clearInterval(memoryInterval)
+			unsubPageChange?.()
 			if (visibilityHandler) {
 				document.removeEventListener('visibilitychange', visibilityHandler)
 			}

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -61,7 +61,6 @@ export function usePerformanceTracking() {
 	return useCallback((editor: Editor) => {
 		let unsubInteraction: (() => void) | undefined
 		let unsubCamera: (() => void) | undefined
-		let memoryTimeout: ReturnType<typeof setTimeout> | undefined
 		let memoryInterval: ReturnType<typeof setInterval> | undefined
 		let visibilityHandler: (() => void) | undefined
 		let unsubPageChange: (() => void) | undefined
@@ -93,8 +92,8 @@ export function usePerformanceTracking() {
 
 					const sampleMemory = (reason: 'interval' | 'visibility_hidden' | 'page_change') => {
 						const m = (performance as any).memory
-						if (!m) return
-						const limit = m.jsHeapSizeLimit || 1
+						// Non-cross-origin-isolated contexts get quantized (often 0) heap fields — skip.
+						if (!m || !m.jsHeapSizeLimit) return
 						const event = {
 							type: 'memory' as const,
 							sample_index: sampleIndex,
@@ -103,7 +102,7 @@ export function usePerformanceTracking() {
 							used_js_heap_mb: r2(m.usedJSHeapSize / MB),
 							total_js_heap_mb: r2(m.totalJSHeapSize / MB),
 							heap_limit_mb: r2(m.jsHeapSizeLimit / MB),
-							heap_used_pct: r2(m.usedJSHeapSize / limit),
+							heap_used_pct: r2(m.usedJSHeapSize / m.jsHeapSizeLimit),
 							shape_count: editor.getCurrentPageShapeIds().size,
 							page_count: editor.getPages().length,
 							page_change_count: pageChangeCount,
@@ -113,7 +112,11 @@ export function usePerformanceTracking() {
 							ab_indicators: abIndicators,
 							release: sentryReleaseName,
 						}
-						trackEvent('rum', event)
+						try {
+							trackEvent('rum', event)
+						} catch {
+							// PostHog errors shouldn't break the interval loop.
+						}
 						sampleIndex++
 					}
 
@@ -128,14 +131,10 @@ export function usePerformanceTracking() {
 						}
 					)
 
-					memoryTimeout = setTimeout(() => {
+					memoryInterval = setInterval(() => {
 						if (disposed) return
 						sampleMemory('interval')
-						memoryInterval = setInterval(() => {
-							if (disposed) return
-							sampleMemory('interval')
-						}, 60_000)
-					}, 10_000)
+					}, 60_000)
 
 					visibilityHandler = () => {
 						if (document.visibilityState === 'hidden' && !disposed) {
@@ -153,7 +152,6 @@ export function usePerformanceTracking() {
 			disposed = true
 			unsubInteraction?.()
 			unsubCamera?.()
-			if (memoryTimeout) clearTimeout(memoryTimeout)
 			if (memoryInterval) clearInterval(memoryInterval)
 			unsubPageChange?.()
 			if (visibilityHandler) {

--- a/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
+++ b/apps/dotcom/client/src/hooks/usePerformanceTracking.ts
@@ -5,13 +5,13 @@ import {
 	TLInteractionEndPerfEvent,
 	TLPerfFrameTimeStats,
 } from 'tldraw'
-import { sentryReleaseName } from '../../sentry-release-name'
 import { fetchFeatureFlags } from '../tla/utils/FeatureFlagPoller'
 import { trackEvent } from '../utils/analytics'
 
 const r2 = (n: number) => Math.round(n * 100) / 100
 
 function getCoarsePlatform(): 'ios' | 'android' | 'desktop' {
+	if (typeof navigator === 'undefined') return 'desktop'
 	const ua = navigator.userAgent
 	if (/iPad|iPhone|iPod/.test(ua)) return 'ios'
 	if (/android/i.test(ua)) return 'android'
@@ -26,11 +26,10 @@ function getZoomBucket(zoom: number): string {
 	return 'gt_1'
 }
 
-const coarsePlatform = getCoarsePlatform()
+let coarsePlatform: ReturnType<typeof getCoarsePlatform> | null = null
 
-// Tracks how many times the editor mounts with a new document (file navigations).
-// First mount is the initial load, not a change, so we start at -1.
-let fileChangeCount = -1
+// Counts editor mounts (file navigations). First mount = 0.
+let editorMountCount = 0
 
 function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLevel: number }) {
 	const loafs = event.longAnimationFrames
@@ -49,8 +48,7 @@ function commonStats(event: TLPerfFrameTimeStats & { shapeCount: number; zoomLev
 		zoom_bucket: getZoomBucket(event.zoomLevel),
 		has_loaf: (loafs?.length ?? 0) > 0,
 		loaf_count: loafs?.length ?? 0,
-		coarse_platform: coarsePlatform,
-		release: sentryReleaseName,
+		coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
 	}
 }
 
@@ -79,8 +77,6 @@ function handleCameraEnd(event: TLCameraEndPerfEvent, abIndicators: 'canvas' | '
 
 export function usePerformanceTracking() {
 	return useCallback((editor: Editor) => {
-		fileChangeCount++
-
 		let unsubInteraction: (() => void) | undefined
 		let unsubCamera: (() => void) | undefined
 		let memoryTimeout: ReturnType<typeof setTimeout> | undefined
@@ -89,82 +85,87 @@ export function usePerformanceTracking() {
 		let unsubPageChange: (() => void) | undefined
 		let disposed = false
 
-		fetchFeatureFlags().then((flags) => {
-			if (disposed || !flags.rum_enabled?.enabled) return
+		fetchFeatureFlags()
+			.then((flags) => {
+				if (disposed || !flags.rum_enabled?.enabled) return
 
-			// Derive from the editor option — this is the ground truth for what's
-			// actually rendering, so the RUM tag always matches the UI path.
-			const abIndicators = editor.options.useCanvasIndicators ? 'canvas' : 'svg'
+				// Derive from the editor option — this is the ground truth for what's
+				// actually rendering, so the RUM tag always matches the UI path.
+				const abIndicators = editor.options.useCanvasIndicators ? 'canvas' : 'svg'
 
-			unsubInteraction = editor.performance.on('interaction-end', (event) =>
-				handleInteractionEnd(event, abIndicators)
-			)
-			unsubCamera = editor.performance.on('camera-end', (event) =>
-				handleCameraEnd(event, abIndicators)
-			)
-
-			// Memory sampling (Chrome-only via performance.memory)
-			const mem = (performance as any).memory
-			if (mem) {
-				const mountTime = Date.now()
-				let sampleIndex = 0
-				let pageChangeCount = 0
-				const toMb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 100) / 100
-				const deviceMemoryGb = (navigator as any).deviceMemory ?? null
-
-				const sampleMemory = (reason: 'interval' | 'visibility_hidden' | 'page_change') => {
-					const m = (performance as any).memory
-					const event = {
-						type: 'memory' as const,
-						sample_index: sampleIndex,
-						sample_reason: reason,
-						session_duration_s: Math.round((Date.now() - mountTime) / 1000),
-						used_js_heap_mb: toMb(m.usedJSHeapSize),
-						total_js_heap_mb: toMb(m.totalJSHeapSize),
-						heap_limit_mb: toMb(m.jsHeapSizeLimit),
-						heap_used_pct: r2(m.usedJSHeapSize / m.jsHeapSizeLimit),
-						shape_count: editor.getCurrentPageShapeIds().size,
-						store_record_count: editor.store.allRecords().length,
-						page_count: editor.getPages().length,
-						page_change_count: pageChangeCount,
-						file_change_count: fileChangeCount,
-						zoom_bucket: getZoomBucket(editor.getZoomLevel()),
-						device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
-						coarse_platform: coarsePlatform,
-						release: sentryReleaseName,
-						ab_indicators: abIndicators,
-					}
-					trackEvent('rum', event)
-					sampleIndex++
-				}
-
-				unsubPageChange = editor.sideEffects.registerAfterChangeHandler(
-					'instance',
-					(prev, next) => {
-						if (prev.currentPageId !== next.currentPageId) {
-							pageChangeCount++
-							sampleMemory('page_change')
-						}
-					}
+				unsubInteraction = editor.performance.on('interaction-end', (event) =>
+					handleInteractionEnd(event, abIndicators)
+				)
+				unsubCamera = editor.performance.on('camera-end', (event) =>
+					handleCameraEnd(event, abIndicators)
 				)
 
-				memoryTimeout = setTimeout(() => {
-					if (disposed) return
-					sampleMemory('interval')
-					memoryInterval = setInterval(() => {
+				editorMountCount++
+				// Memory sampling (Chrome-only via performance.memory)
+				if ((performance as any).memory) {
+					const mountTime = Date.now()
+					let sampleIndex = 0
+					let pageChangeCount = 0
+					const deviceMemoryGb = (navigator as any).deviceMemory ?? null
+					const MB = 1024 * 1024
+
+					const sampleMemory = (reason: 'interval' | 'visibility_hidden' | 'page_change') => {
+						const m = (performance as any).memory
+						if (!m) return
+						const limit = m.jsHeapSizeLimit || 1
+						const event = {
+							type: 'memory' as const,
+							sample_index: sampleIndex,
+							sample_reason: reason,
+							session_duration_s: Math.round((Date.now() - mountTime) / 1000),
+							used_js_heap_mb: r2(m.usedJSHeapSize / MB),
+							total_js_heap_mb: r2(m.totalJSHeapSize / MB),
+							heap_limit_mb: r2(m.jsHeapSizeLimit / MB),
+							heap_used_pct: r2(m.usedJSHeapSize / limit),
+							shape_count: editor.getCurrentPageShapeIds().size,
+							page_count: editor.getPages().length,
+							page_change_count: pageChangeCount,
+							editor_mount_count: editorMountCount,
+							zoom_bucket: getZoomBucket(editor.getZoomLevel()),
+							device_memory_gb: sampleIndex === 0 ? deviceMemoryGb : null,
+							coarse_platform: (coarsePlatform ??= getCoarsePlatform()),
+							ab_indicators: abIndicators,
+						}
+						trackEvent('rum', event)
+						sampleIndex++
+					}
+
+					unsubPageChange = editor.sideEffects.registerAfterChangeHandler(
+						'instance',
+						(prev, next) => {
+							if (disposed) return
+							if (prev.currentPageId !== next.currentPageId) {
+								pageChangeCount++
+								sampleMemory('page_change')
+							}
+						}
+					)
+
+					memoryTimeout = setTimeout(() => {
 						if (disposed) return
 						sampleMemory('interval')
-					}, 60_000)
-				}, 10_000)
+						memoryInterval = setInterval(() => {
+							if (disposed) return
+							sampleMemory('interval')
+						}, 60_000)
+					}, 10_000)
 
-				visibilityHandler = () => {
-					if (document.visibilityState === 'hidden' && !disposed) {
-						sampleMemory('visibility_hidden')
+					visibilityHandler = () => {
+						if (document.visibilityState === 'hidden' && !disposed) {
+							sampleMemory('visibility_hidden')
+						}
 					}
+					document.addEventListener('visibilitychange', visibilityHandler)
 				}
-				document.addEventListener('visibilitychange', visibilityHandler)
-			}
-		})
+			})
+			.catch(() => {
+				// noop — flag fetch failures are already logged by FeatureFlagPoller
+			})
 
 		return () => {
 			disposed = true


### PR DESCRIPTION
In order to detect memory leaks in production (#8586, #8440), this PR extends the existing RUM telemetry in dotcom with periodic heap snapshots and richer slicing dimensions on all rum events.

**Memory sampling** (Chrome-only via `performance.memory`, no-ops elsewhere):
- 60s interval + samples on `visibilitychange` (hidden) and page switches
- Tracks heap size, shape/page counts, page change count
- Gated behind existing `rum_enabled` flag

**New properties on all rum events** (interaction, camera, memory):
- `release` — deploy tag from `sentryReleaseName` (`local` in dev, `{env}-{sha}` in prod) for correlating regressions to specific deploys

OS/platform slicing uses PostHog's built-in `$os` property instead of a custom field — it already provides Mac OS X / Windows / Linux / Chrome OS / iOS / Android breakdown.

Relates to #8586, #8440

### Change type

- [x] `improvement`

### Test plan

1. Run `yarn dev-app`, open Chrome
2. Enable `rum_enabled` flag (or temporarily set default to true in FeatureFlagPoller)
3. Verify PostHog captures `rum` events with `type: 'memory'` and `release: 'local'`
4. Verify interaction and camera events also include `release`
5. Switch pages → verify immediate `page_change` sample
6. Background tab → verify `visibility_hidden` sample
7. Open Firefox → verify no errors (graceful no-op)

- [ ] Unit tests
- [ ] End to end tests