### PR TITLE
chore(infra): prune R2 litestream backups for closed preview deploys

### DIFF
--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -50,3 +50,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PREVIEW_PROJECT_ID: ${{ vars.SUPABASE_PREVIEW_PROJECT_ID }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          ZERO_R2_ENDPOINT: ${{ secrets.ZERO_R2_ENDPOINT }}
+          ZERO_R2_BUCKET_NAME: ${{ secrets.ZERO_R2_BUCKET_NAME }}
+          ZERO_R2_ACCESS_KEY_ID: ${{ secrets.ZERO_R2_ACCESS_KEY_ID }}
+          ZERO_R2_SECRET_ACCESS_KEY: ${{ secrets.ZERO_R2_SECRET_ACCESS_KEY }}

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -1,4 +1,5 @@
 import * as github from '@actions/github'
+import { DeleteObjectsCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import { exec } from './lib/exec'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
@@ -11,6 +12,10 @@ const env = makeEnv([
 	'GH_TOKEN',
 	'SUPABASE_ACCESS_TOKEN',
 	'SUPABASE_PREVIEW_PROJECT_ID',
+	'ZERO_R2_ENDPOINT',
+	'ZERO_R2_BUCKET_NAME',
+	'ZERO_R2_ACCESS_KEY_ID',
+	'ZERO_R2_SECRET_ACCESS_KEY',
 ])
 
 interface ListWorkersResult {
@@ -184,6 +189,63 @@ async function listFlyioPreviewApps() {
 	return appNames.filter((name) => ZERO_CACHE_APP_REGEX.test(name))
 }
 
+const R2 = new S3Client({
+	region: 'auto',
+	endpoint: env.ZERO_R2_ENDPOINT,
+	credentials: {
+		accessKeyId: env.ZERO_R2_ACCESS_KEY_ID,
+		secretAccessKey: env.ZERO_R2_SECRET_ACCESS_KEY,
+	},
+})
+
+async function listR2BackupPrefixes(): Promise<string[]> {
+	const prefixes: string[] = []
+	let continuationToken: string | undefined
+	do {
+		const res = await R2.send(
+			new ListObjectsV2Command({
+				Bucket: env.ZERO_R2_BUCKET_NAME,
+				Prefix: 'pr-',
+				Delimiter: '/',
+				ContinuationToken: continuationToken,
+			})
+		)
+		for (const prefix of res.CommonPrefixes ?? []) {
+			if (prefix.Prefix) prefixes.push(prefix.Prefix)
+		}
+		continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined
+	} while (continuationToken)
+	return prefixes
+}
+
+async function deleteR2BackupData(prefix: string) {
+	let continuationToken: string | undefined
+	do {
+		const list = await R2.send(
+			new ListObjectsV2Command({
+				Bucket: env.ZERO_R2_BUCKET_NAME,
+				Prefix: prefix,
+				ContinuationToken: continuationToken,
+			})
+		)
+		const objects = list.Contents
+		if (objects && objects.length > 0) {
+			await R2.send(
+				new DeleteObjectsCommand({
+					Bucket: env.ZERO_R2_BUCKET_NAME,
+					Delete: { Objects: objects.map((o) => ({ Key: o.Key })) },
+				})
+			)
+		}
+		continuationToken = list.IsTruncated ? list.NextContinuationToken : undefined
+	} while (continuationToken)
+}
+
+async function deleteR2Backup(prefix: string) {
+	nicelog('Deleting R2 backup data:', prefix)
+	await deleteR2BackupData(prefix)
+}
+
 const deletionErrors: string[] = []
 
 async function main() {
@@ -193,6 +255,8 @@ async function main() {
 	await processItems(listPreviewDatabases, deletePreviewDatabase)
 	nicelog('\nPruning fly.io preview apps')
 	await processItems(listFlyioPreviewApps, deleteFlyioPreviewApp)
+	nicelog('\nPruning R2 litestream backups')
+	await processItems(listR2BackupPrefixes, deleteR2Backup)
 	nicelog('\nDone')
 	if (deletionErrors.length > 0) {
 		nicelog('\nDeletion errors:')

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -218,32 +218,29 @@ async function listR2BackupPrefixes(): Promise<string[]> {
 	return prefixes
 }
 
-async function deleteR2BackupData(prefix: string) {
-	let continuationToken: string | undefined
-	do {
+async function deleteR2Backup(prefix: string) {
+	nicelog('Deleting R2 backup data:', prefix)
+	while (true) {
 		const list = await R2.send(
 			new ListObjectsV2Command({
 				Bucket: env.ZERO_R2_BUCKET_NAME,
 				Prefix: prefix,
-				ContinuationToken: continuationToken,
 			})
 		)
 		const objects = list.Contents
-		if (objects && objects.length > 0) {
-			await R2.send(
-				new DeleteObjectsCommand({
-					Bucket: env.ZERO_R2_BUCKET_NAME,
-					Delete: { Objects: objects.map((o) => ({ Key: o.Key })) },
-				})
+		if (!objects || objects.length === 0) break
+		const result = await R2.send(
+			new DeleteObjectsCommand({
+				Bucket: env.ZERO_R2_BUCKET_NAME,
+				Delete: { Objects: objects.map((o) => ({ Key: o.Key })) },
+			})
+		)
+		if (result.Errors && result.Errors.length > 0) {
+			throw new Error(
+				`Failed to delete ${result.Errors.length} objects: ${JSON.stringify(result.Errors)}`
 			)
 		}
-		continuationToken = list.IsTruncated ? list.NextContinuationToken : undefined
-	} while (continuationToken)
-}
-
-async function deleteR2Backup(prefix: string) {
-	nicelog('Deleting R2 backup data:', prefix)
-	await deleteR2BackupData(prefix)
+	}
 }
 
 const deletionErrors: string[] = []


### PR DESCRIPTION
Closes #8496

When preview deploys are pruned, the Fly.io apps, CF Workers, and Supabase branches get cleaned up — but litestream backup data in R2 (`pr-<number>/`) is left behind indefinitely. This PR adds R2 cleanup to the prune script so backup data is deleted alongside other preview resources.

### Change type

- [x] `improvement`

### Test plan

- Cannot be manually tested (requires R2 credentials and closed PRs)
- Verified typecheck and lint pass

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +68 / -0   |