### PR TITLE
chore(ci): default MCP app deploy workflow to production

### DIFF
--- a/.github/workflows/deploy-mcp-app.yml
+++ b/.github/workflows/deploy-mcp-app.yml
@@ -6,7 +6,7 @@ on:
       target:
         description: 'Target ref to deploy'
         required: true
-        default: 'main'
+        default: 'production'
 
 env:
   CI: 1


### PR DESCRIPTION
In order to make production the safe default when someone runs the Deploy MCP app workflow without changing inputs, this PR sets the workflow_dispatch `target` default from `main` to `production`.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +1 / -1    |

### Change type

- [x] `improvement`

### Test plan

1. In GitHub Actions, open **Deploy MCP app**, choose **Run workflow**, and confirm the **target** field defaults to `production`.

- [ ] Unit tests
- [ ] End to end tests

Made with [Cursor](https://cursor.com)