### PR TITLE
perf(dotcom): add groupId indexes on group_user and group_file

### DIFF
--- a/apps/dotcom/zero-cache/migrations/031_group_id_indexes.sql
+++ b/apps/dotcom/zero-cache/migrations/031_group_id_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "group_user_group_id_idx" ON public."group_user" ("groupId");
+CREATE INDEX "group_file_group_id_idx" ON public."group_file" ("groupId");


### PR DESCRIPTION
In order to speed up the `groupUsers` synced query, this PR adds indexes on `groupId` for the `group_user` and `group_file` tables. The composite primary keys on these tables start with `userId`/`fileId`, so filtering by `groupId` alone falls back to full-table scans — visible in the Zero Cache SQLite plans as `SCAN group_user USING INDEX group_user_pkey` and `SCAN group_file USING INDEX group_file_pkey`. The new indexes let Zero replicate them to the replica and use proper index searches.

### Change type

- [x] `improvement`

### Test plan

1. Run the migration against a dev database.
2. Open a user session that has group memberships and file associations.
3. Inspect the `groupUsers` query's `sqlitePlans` — the `group_user` and `group_file` entries should show `SEARCH … USING INDEX` instead of `SCAN … USING INDEX *_pkey`.

### Release notes

- Internal: add `groupId` indexes to `group_user` and `group_file` for faster `groupUsers` sync queries.