### PR TITLE
fix(clipboard): fall back when Cmd+V paste returns empty custom-format blob on Chrome 147

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -313,28 +313,30 @@ const handlePasteFromClipboardApi = async ({
 	const things: ClipboardThing[] = []
 
 	for (const item of clipboardItems) {
-		things.push({
-			type: 'blob',
-			source: (async () => {
-				for (const type of expectedPasteFileMimeTypes) {
-					if (!item.types.includes(type)) continue
-					const blob = await item.getType(type)
-					// Chrome 147 stable regression: web custom-format blobs come back as
-					// 0 bytes when clipboard.read() runs inside a paste event. Fixed in
-					// Chrome Canary; expected to ship to stable in a later release. Until
-					// then, skip empty payloads and fall back to the next preferred type
-					// (usually image/png, which means Cmd+V paste of a tldraw-copied PNG
-					// loses the pHYs DPI chunk and pastes at 2x size on affected Chrome
-					// stable versions). Right-click Paste continues to work at 1x because
-					// that path calls clipboard.read() from a click handler, not a paste
-					// event. Remove this workaround when the fix ships to stable.
-					// https://issues.chromium.org/issues/505045934
-					if (blob.size === 0) continue
-					return FileHelpers.rewriteMimeType(blob, getCanonicalClipboardReadType(type))
-				}
-				return null
-			})(),
-		})
+		const matchingTypes = expectedPasteFileMimeTypes.filter((t) => item.types.includes(t))
+		if (matchingTypes.length > 0) {
+			things.push({
+				type: 'blob',
+				source: (async () => {
+					for (const type of matchingTypes) {
+						const blob = await item.getType(type)
+						// Chrome 147 stable regression: web custom-format blobs come back as
+						// 0 bytes when clipboard.read() runs inside a paste event. Fixed in
+						// Chrome Canary; expected to ship to stable in a later release. Until
+						// then, skip empty payloads and fall back to the next preferred type
+						// (usually image/png, which means Cmd+V paste of a tldraw-copied PNG
+						// loses the pHYs DPI chunk and pastes at 2x size on affected Chrome
+						// stable versions). Right-click Paste continues to work at 1x because
+						// that path calls clipboard.read() from a click handler, not a paste
+						// event. Remove this workaround when the fix ships to stable.
+						// https://issues.chromium.org/issues/505045934
+						if (blob.size === 0) continue
+						return FileHelpers.rewriteMimeType(blob, getCanonicalClipboardReadType(type))
+					}
+					return null
+				})(),
+			})
+		}
 
 		if (item.types.includes('text/html')) {
 			things.push({

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -313,18 +313,28 @@ const handlePasteFromClipboardApi = async ({
 	const things: ClipboardThing[] = []
 
 	for (const item of clipboardItems) {
-		for (const type of expectedPasteFileMimeTypes) {
-			if (item.types.includes(type)) {
-				const blobPromise = item
-					.getType(type)
-					.then((blob) => FileHelpers.rewriteMimeType(blob, getCanonicalClipboardReadType(type)))
-				things.push({
-					type: 'blob',
-					source: blobPromise,
-				})
-				break
-			}
-		}
+		things.push({
+			type: 'blob',
+			source: (async () => {
+				for (const type of expectedPasteFileMimeTypes) {
+					if (!item.types.includes(type)) continue
+					const blob = await item.getType(type)
+					// Chrome 147 stable regression: web custom-format blobs come back as
+					// 0 bytes when clipboard.read() runs inside a paste event. Fixed in
+					// Chrome Canary; expected to ship to stable in a later release. Until
+					// then, skip empty payloads and fall back to the next preferred type
+					// (usually image/png, which means Cmd+V paste of a tldraw-copied PNG
+					// loses the pHYs DPI chunk and pastes at 2x size on affected Chrome
+					// stable versions). Right-click Paste continues to work at 1x because
+					// that path calls clipboard.read() from a click handler, not a paste
+					// event. Remove this workaround when the fix ships to stable.
+					// https://issues.chromium.org/issues/505045934
+					if (blob.size === 0) continue
+					return FileHelpers.rewriteMimeType(blob, getCanonicalClipboardReadType(type))
+				}
+				return null
+			})(),
+		})
 
 		if (item.types.includes('text/html')) {
 			things.push({


### PR DESCRIPTION
In order to unblock Cmd+V paste of tldraw-copied PNGs on Chrome 147 stable, this PR adds a defensive fallback in the paste-from-clipboard handler: when a preferred MIME type's blob resolves to 0 bytes, skip it and try the next preferred type. Closes #8544.

## Background

tldraw's "Copy as PNG" writes two entries into a single \`ClipboardItem\`: the standard \`image/png\` (sanitized by the browser) and \`web image/vnd.tldraw+png\` (an unsanitized "web " custom format that preserves the PNG \`pHYs\` chunk, so that tldraw→tldraw copy/paste doesn't come back at 2× size — see #4771).

Chrome 147 stable regressed this path: when \`navigator.clipboard.read()\` is called from inside a native \`paste\` event handler, the \`web \` custom-format entry comes back as a 0-byte Blob, while the co-written \`image/png\` is returned correctly. \`ClipboardItem.types\` still advertises the custom type — only the payload is dropped. The \`clipboard.read()\` path triggered by right-click → Paste (a click handler, not a paste event) returns the full payload and works fine.

Without this fix, Cmd+V paste of a tldraw-copied PNG silently fails: our paste code picks the preferred (empty) custom-format entry first and never falls through to the still-present \`image/png\`.

The upstream Chromium bug is filed at https://issues.chromium.org/issues/505045934. It's already fixed in Chrome Canary. This PR is a short-lived workaround for Chrome 147 stable users.

Verified via a minimal standalone HTML repro outside tldraw: the bug is reproducible using only the Async Clipboard API. Bisected via Chrome-for-Testing builds — \`146.0.7680.72\` handles all paste paths correctly; \`147.0.7727.57\` fails the paste-event-read path.

## Trade-off

With this change, Cmd+V paste of a tldraw-copied PNG on affected Chrome versions will paste at **2× size** (the sanitized \`image/png\` doesn't carry the \`pHYs\` DPI chunk). Right-click → Paste is unchanged — still pastes at 1× size because that path invokes \`clipboard.read()\` from a click handler. This degradation is temporary and will disappear when the Chrome fix ships to stable.

### Change type

- [x] \`bugfix\`

### Test plan

Tested on Chrome 147.0.7727.57 (macOS):

1. Open tldraw, draw a rectangle.
2. Right click → Copy as → PNG.
3. Press Cmd+V — shape should paste (at 2× size, acceptable). Without this fix, paste silently fails.
4. Right click → Paste — shape should paste at 1× size (unchanged).
5. Copy an image from another app (e.g. a screenshot), press Cmd+V in tldraw — should paste normally.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix Cmd+V paste of "Copy as PNG" content silently failing in Chrome 147 due to an upstream Chromium regression with unsanitized custom clipboard formats read from inside paste events.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +22 / -12  |