### PR TITLE
test(examples): add screenshot e2e coverage for canvas overlays

### DIFF
--- a/apps/examples/e2e/tests/test-overlay-screenshots.spec.ts
+++ b/apps/examples/e2e/tests/test-overlay-screenshots.spec.ts
@@ -1,0 +1,311 @@
+import { expect, Page } from '@playwright/test'
+import { Editor, TLAssetId, TLShapeId } from 'tldraw'
+import test from '../fixtures/fixtures'
+import { setupOrReset, sleepFrames } from '../shared-e2e'
+
+declare const editor: Editor
+
+// Visual regression tests for canvas overlays. Each test enters a specific
+// deterministic state, waits for the overlay to settle, then compares a
+// clipped canvas screenshot to a baseline.
+//
+// Strategy:
+//   - Place shapes at fixed page coordinates inside a "safe" region that
+//     is not covered by the default UI chrome (toolbar, style panel, etc.).
+//   - Clip the screenshot to that same region so the baseline captures the
+//     overlay geometry but little else.
+//   - Rely on overlay SVG geometry being deterministic across runs of the
+//     same platform. (Cross-OS baselines are managed by Playwright's
+//     per-platform snapshot naming, same as the existing snapshot tests.)
+//
+// The safe clip region. The default Tldraw UI places a toolbar at the top
+// and bottom and panels at the sides; a centred rectangle around
+// (100..700, 100..500) sits cleanly inside the canvas background with
+// no interactive UI overlapping.
+const CLIP = { x: 80, y: 80, width: 640, height: 440 }
+
+const isMobileProject = () => test.info().project.name.includes('Mobile')
+
+async function resetCanvas(page: Page) {
+	await page.evaluate(() => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor.setCurrentTool('select')
+		editor.setCamera({ x: 0, y: 0, z: 1 }, { immediate: true })
+		editor.updateInstanceState({ isChangingStyle: false })
+	})
+	// Park the mouse far outside the clip rect so it doesn't introduce a
+	// hover cursor into the screenshot.
+	await page.mouse.move(1200, 700)
+	await sleepFrames(2)
+}
+
+async function takeOverlayShot(page: Page, name: string) {
+	// Let any pending reactive updates flush before snapshotting.
+	await sleepFrames(2)
+	await expect(page).toHaveScreenshot(name, { clip: CLIP })
+}
+
+test.describe('Overlay screenshots', () => {
+	test.beforeEach(setupOrReset)
+	test.beforeEach(async ({ page }) => {
+		await resetCanvas(page)
+	})
+
+	test('selection foreground — resize and rotate handles on a geo shape', async ({ page }) => {
+		test.skip(isMobileProject(), 'Corner rotate handles are hidden on coarse pointer')
+		await page.evaluate(() => {
+			const id = 'shape:sel-fg' as TLShapeId
+			editor.createShapes([
+				{
+					id,
+					type: 'geo',
+					x: 260,
+					y: 220,
+					props: { w: 200, h: 150, geo: 'rectangle' },
+				},
+			])
+			editor.select(id)
+		})
+
+		await takeOverlayShot(page, 'selection-foreground-handles.png')
+	})
+
+	test('selection foreground — rotated selection keeps handles rotated', async ({ page }) => {
+		test.skip(isMobileProject(), 'Corner rotate handles are hidden on coarse pointer')
+		await page.evaluate(() => {
+			const id = 'shape:sel-fg-rot' as TLShapeId
+			editor.createShapes([
+				{
+					id,
+					type: 'geo',
+					x: 300,
+					y: 240,
+					rotation: Math.PI / 6,
+					props: { w: 200, h: 150, geo: 'rectangle' },
+				},
+			])
+			editor.select(id)
+		})
+
+		await takeOverlayShot(page, 'selection-foreground-rotated.png')
+	})
+
+	test('mobile rotate handle is rendered on coarse-pointer devices', async ({ page }) => {
+		test.skip(!isMobileProject(), 'Mobile rotate handle only appears on coarse pointer')
+		await page.evaluate(() => {
+			const id = 'shape:mobile-rot' as TLShapeId
+			editor.createShapes([
+				{
+					id,
+					type: 'geo',
+					x: 150,
+					y: 200,
+					props: { w: 160, h: 120, geo: 'rectangle' },
+				},
+			])
+			editor.select(id)
+		})
+		await takeOverlayShot(page, 'selection-foreground-mobile-rotate.png')
+	})
+
+	test('crop handles on an image shape', async ({ page }) => {
+		await page.evaluate(() => {
+			const imageAsBase64 =
+				'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+			const assetId = 'asset:overlay-shot' as TLAssetId
+			editor.createAssets([
+				{
+					id: assetId,
+					typeName: 'asset',
+					type: 'image',
+					props: {
+						src: imageAsBase64,
+						w: 200,
+						h: 160,
+						name: 'overlay-shot',
+						isAnimated: false,
+						mimeType: 'image/png',
+					},
+					meta: {},
+				},
+			])
+			const id = 'shape:crop' as TLShapeId
+			editor.createShape({
+				id,
+				type: 'image',
+				x: 260,
+				y: 220,
+				props: {
+					w: 200,
+					h: 160,
+					assetId,
+					crop: { topLeft: { x: 0, y: 0 }, bottomRight: { x: 1, y: 1 } },
+				},
+			})
+			editor.select(id)
+			editor.setCurrentTool('select.crop.idle')
+		})
+
+		await takeOverlayShot(page, 'crop-handles.png')
+	})
+
+	test('shape handles — arrow endpoints and midpoint virtual handle', async ({ page }) => {
+		test.skip(isMobileProject(), 'Virtual handles render differently on coarse pointer')
+		await page.evaluate(() => {
+			const id = 'shape:arrow-handles' as TLShapeId
+			editor.createShapes([
+				{
+					id,
+					type: 'arrow',
+					x: 200,
+					y: 300,
+					props: {
+						start: { x: 0, y: 0 },
+						end: { x: 300, y: 0 },
+					},
+				},
+			])
+			editor.select(id)
+		})
+
+		await takeOverlayShot(page, 'shape-handles-arrow.png')
+	})
+
+	test('brush overlay while drag-selecting on empty canvas', async ({ page }) => {
+		// Drag a marquee selection on an empty canvas. We snapshot mid-drag
+		// (before releasing) so the brush rect is on screen.
+		const start = { x: CLIP.x + 40, y: CLIP.y + 40 }
+		const end = { x: CLIP.x + 360, y: CLIP.y + 260 }
+
+		await page.mouse.move(start.x, start.y)
+		await page.mouse.down()
+		await page.mouse.move(end.x, end.y, { steps: 8 })
+
+		expect(await page.evaluate(() => editor.getPath())).toBe('select.brushing')
+		await takeOverlayShot(page, 'brush-overlay.png')
+		await page.mouse.up()
+	})
+
+	test('zoom brush overlay while zoom-drag on empty canvas', async ({ page }) => {
+		// Activate the zoom tool, then drag to open a zoom brush.
+		await page.evaluate(() => editor.setCurrentTool('zoom'))
+
+		const start = { x: CLIP.x + 60, y: CLIP.y + 60 }
+		const end = { x: CLIP.x + 320, y: CLIP.y + 240 }
+
+		await page.mouse.move(start.x, start.y)
+		await page.mouse.down()
+		await page.mouse.move(end.x, end.y, { steps: 8 })
+
+		expect(await page.evaluate(() => editor.getPath())).toContain('zoom.zoom_brushing')
+		await takeOverlayShot(page, 'zoom-brush-overlay.png')
+		await page.mouse.up()
+		// Leaving the zoom tool would zoom to the brushed rect; reset so the
+		// next test starts at z=1.
+		await page.evaluate(() => {
+			editor.setCurrentTool('select')
+			editor.setCamera({ x: 0, y: 0, z: 1 }, { immediate: true })
+		})
+	})
+
+	test('snap indicator while translating a shape into alignment', async ({ page }) => {
+		test.skip(isMobileProject(), 'Snap indicator geometry is desktop-only in this fixture')
+
+		// Force "always snap" so we don't depend on platform-specific modifier
+		// keys (meta on mac, ctrl elsewhere) to enable snapping.
+		await page.evaluate(() => {
+			editor.user.updateUserPreferences({ isSnapMode: true })
+			editor.createShapes([
+				{
+					id: 'shape:snap-a' as TLShapeId,
+					type: 'geo',
+					x: 200,
+					y: 220,
+					props: { w: 120, h: 120, geo: 'rectangle' },
+				},
+				{
+					id: 'shape:snap-b' as TLShapeId,
+					type: 'geo',
+					x: 500,
+					y: 260,
+					props: { w: 120, h: 120, geo: 'rectangle' },
+				},
+			])
+			// Pre-select shape B so pointer down immediately begins translate.
+			editor.select('shape:snap-b' as TLShapeId)
+		})
+
+		// Press down on shape B, then drag so its top edge lines up with
+		// shape A's top edge (y = 220). Move slowly — snapping only
+		// engages when the pointer velocity is low.
+		const shapeBCenter = { x: 560, y: 320 }
+		await page.mouse.move(shapeBCenter.x, shapeBCenter.y)
+		await page.mouse.down()
+		// Large number of steps keeps velocity below the snap threshold.
+		await page.mouse.move(shapeBCenter.x, 280, { steps: 40 })
+		// Park the pointer still for a bit so velocity falls to 0.
+		await sleepFrames(10)
+
+		await expect(page.locator('.tl-snap-indicator').first()).toBeVisible()
+		await takeOverlayShot(page, 'snap-indicator.png')
+
+		await page.mouse.up()
+		await page.evaluate(() => {
+			editor.user.updateUserPreferences({ isSnapMode: false })
+		})
+	})
+
+	test('arrow hint overlay while aiming an elbow arrow at a shape', async ({ page }) => {
+		test.skip(isMobileProject(), 'Arrow hint targets rely on fine-pointer hover geometry')
+
+		// Arrow hint circles (`tl-arrow-hint-handle`) only render for elbow
+		// arrows. Force the arrow tool to produce elbow arrows by writing
+		// directly to `stylesForNextShape` (bypasses having to marshal the
+		// StyleProp object through `page.evaluate`).
+		await page.evaluate(() => {
+			editor.createShapes([
+				{
+					id: 'shape:arrow-target' as TLShapeId,
+					type: 'geo',
+					x: 400,
+					y: 260,
+					props: { w: 200, h: 160, geo: 'rectangle' },
+				},
+			])
+			editor.updateInstanceState({
+				stylesForNextShape: {
+					...editor.getInstanceState().stylesForNextShape,
+					'tldraw:arrowKind': 'elbow',
+				},
+			})
+			editor.setCurrentTool('arrow')
+		})
+
+		// Start the arrow to the left of the rectangle and drag the end
+		// point inside the rectangle — the arrow-targeting machinery should
+		// recognise the rect as a target and render hint circles.
+		const start = { x: 200, y: 340 }
+		const end = { x: 500, y: 340 }
+		await page.mouse.move(start.x, start.y)
+		await page.mouse.down()
+		await page.mouse.move(end.x, end.y, { steps: 10 })
+		await sleepFrames(2)
+
+		// `.toBeVisible()` can flake for SVG children of a 0×0 overlay svg;
+		// assert on the DOM count instead.
+		await expect
+			.poll(async () => await page.locator('.tl-arrow-hint-handle').count())
+			.toBeGreaterThan(0)
+
+		await takeOverlayShot(page, 'arrow-hint-overlay.png')
+
+		await page.mouse.up()
+		await page.evaluate(() => {
+			const prev = editor.getInstanceState().stylesForNextShape
+			const next = { ...prev }
+			delete (next as any)['tldraw:arrowKind']
+			editor.updateInstanceState({ stylesForNextShape: next })
+			editor.setCurrentTool('select')
+		})
+	})
+})


### PR DESCRIPTION
In order to lock in the visual appearance of canvas overlays before an upcoming overlay-utils refactor, this PR adds a Playwright screenshot-based spec at `apps/examples/e2e/tests/test-overlay-screenshots.spec.ts`. Each test drives the `/end-to-end` page into a specific overlay state and compares a clipped canvas screenshot to a per-platform baseline — same pattern the existing `export-snapshots.spec.tsx` / `export-mermaid-snapshots.spec.ts` suites use.

Determinism measures:

- Fixed shape coordinates inside a safe clip region `{ x: 80, y: 80, w: 640, h: 440 }` that avoids the toolbar and side panels.
- `setCamera({x:0,y:0,z:1}, {immediate:true})` + `animationSpeed: 0` (inherited from `setupPage`).
- Mouse parked at `(1200, 700)` before every snapshot to keep hover cursor out of the image.
- `sleepFrames(2)` flushes before each shot.
- Snap indicator test forces `isSnapMode: true` so it doesn't depend on platform modifier keys, and uses `{ steps: 40 }` + a settling pause so pointer velocity drops below the snap threshold.
- Arrow-hint test writes `stylesForNextShape['tldraw:arrowKind'] = 'elbow'` via `updateInstanceState` so the arrow tool produces elbow arrows (the only `kind` for which hint circles render).

Screenshot cases (per Playwright project):

| Case | chromium | Mobile Chrome |
| --- | --- | --- |
| selection-foreground-handles — resize + corner rotate handles | ✅ | skipped (coarse pointer) |
| selection-foreground-rotated — handles rotated with selection | ✅ | skipped (coarse pointer) |
| selection-foreground-mobile-rotate — mobile rotate circle | skipped | ✅ |
| crop-handles — image in `select.crop.idle` | ✅ | ✅ |
| shape-handles-arrow — arrow start/end/midpoint handles | ✅ | skipped (virtual-handle geometry differs) |
| brush-overlay — marquee mid-drag | ✅ | ✅ |
| zoom-brush-overlay — zoom tool brush mid-drag | ✅ | ✅ |
| snap-indicator — axis-aligned snap while translating | ✅ | skipped |
| arrow-hint-overlay — elbow arrow hint circles aimed at a shape | ✅ | skipped |

Darwin baselines generated and used locally; per `apps/examples/.gitignore` only `-linux` baselines are checked in, and CI regenerates its linux baselines on first run (same workflow as the existing snapshot suites).

Intentionally skipped:

- Collaborator cursor / hint / brush / scribble — no multiplayer harness in `apps/examples/e2e`; setting one up is not a minimal change.
- Minimap — not a canvas overlay; its thumbnails depend on full shape rendering (fonts, gradients) which isn't stable across OS.
- Scribble overlay (laser / eraser) — opacity decays via an animation that isn't frozen by `animationSpeed: 0`; baselines would flake.
- Text resize visual handles — coarse-pointer-only; redundant with the other mobile coverage.

### Change type

- [x] `other`

### Test plan

1. `cd apps/examples && yarn e2e --project=chromium ./e2e/tests/test-overlay-screenshots.spec.ts` — 8 passing, 1 skipped (mobile-only case)
2. `cd apps/examples && yarn e2e --project="Mobile Chrome" ./e2e/tests/test-overlay-screenshots.spec.ts` — 4 passing, 5 skipped (desktop-only cases)
3. Re-run without `--update-snapshots` and confirm baselines match.

- [x] End to end tests

### Code changes

| Section | LOC change |
| --- | --- |
| Tests | +311 / -0 |