### PR TITLE
feat(dotcom): attach app feature flags to PostHog events

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_FLAG_KEYS } from '@tldraw/dotcom-shared'
 import posthog, { PostHogConfig, Properties } from 'posthog-js'
 import 'posthog-js/dist/web-vitals'
 import { useEffect } from 'react'
@@ -5,6 +6,7 @@ import ReactGA from 'react-ga4'
 import { useLocation } from 'react-router-dom'
 import { atom, getFromLocalStorage, react, setInLocalStorage, useValue, warnOnce } from 'tldraw'
 import { useApp } from '../tla/hooks/useAppState'
+import { getCurrentFlags, hasResolvedFlagsOnce } from '../tla/utils/FeatureFlagPoller'
 
 // Local storage key for cookie consent
 export const COOKIE_CONSENT_KEY = 'tldraw_cookie_consent'
@@ -84,6 +86,21 @@ function filterProperties(value: { [key: string]: any }) {
 	}, {})
 }
 
+/**
+ * App feature flags for PostHog event properties; null until `/api/app/feature-flags` has settled once.
+ * Only used for signed-in users — percentage flags are not evaluated for anonymous requests on the server.
+ * We attach here (not via setPersonProperties) so each event reflects the latest values when flags
+ * change mid-session from polling. Person-level cohorts from flags alone would need extra sync.
+ */
+function getAppFeatureFlagEventProperties(): Record<string, boolean> | null {
+	if (!hasResolvedFlagsOnce()) return null
+	const flags = getCurrentFlags()
+	return FEATURE_FLAG_KEYS.reduce<Record<string, boolean>>((acc, key) => {
+		acc[`ff_${key}`] = !!flags[key]?.enabled
+		return acc
+	}, {})
+}
+
 // Helper functions for localStorage consent management
 export function getStoredCookieConsent(): CookieConsent | null {
 	try {
@@ -147,9 +164,16 @@ function configurePosthog(options: AnalyticsOptions) {
 		disable_surveys: true,
 		before_send: (payload) => {
 			if (!payload) return null
-			payload.properties.is_signed_in = !!options.user
+			const props = payload.properties || {}
+			payload.properties = props
+			props.is_signed_in = !!options.user
 
-			const redactedProperties = filterProperties(payload.properties || {})
+			const flagProps = options.user ? getAppFeatureFlagEventProperties() : null
+			if (flagProps) {
+				Object.assign(props, flagProps)
+			}
+
+			const redactedProperties = filterProperties(props)
 			payload.properties = redactedProperties
 
 			// $set


### PR DESCRIPTION
In order to segment PostHog data by the same server-evaluated feature flags used in the dotcom client, this PR adds `ff_*` boolean properties to each outgoing PostHog payload in `before_send`, keyed from `FEATURE_FLAG_KEYS` in `@tldraw/dotcom-shared`. Properties are only merged after `hasResolvedFlagsOnce()` so we never send default flag values before the first `/api/app/feature-flags` response has settled. They are only merged when `options.user` is set (signed-in analytics), because percentage rollouts are not evaluated for anonymous requests on the server and would not be meaningful for logged-out events.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Sign in to dotcom with analytics consent; after the app loads, confirm PostHog captures include `ff_zero_enabled`, `ff_rum_enabled`, `ff_canvas_indicators_ab`, and `ff_zero_kill_switch` (booleans) once flags have resolved.
2. While logged out with analytics consent, confirm captures do not include `ff_*` properties.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +26 / -2   |

Made with [Cursor](https://cursor.com)