### PR TITLE
feat(dotcom): show release name on admin panel

### DIFF
--- a/apps/dotcom/client/src/pages/admin.module.css
+++ b/apps/dotcom/client/src/pages/admin.module.css
@@ -15,6 +15,26 @@
 	background-color: var(--tla-color-panel);
 }
 
+.adminReleaseMeta {
+	margin: 10px 0 0 0;
+	font-size: 12px;
+	line-height: 1.4;
+	color: var(--tla-color-text-3);
+}
+
+.adminReleaseLabel {
+	font-weight: 500;
+	margin-right: 4px;
+}
+
+.adminReleaseValue {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 11px;
+	font-weight: 500;
+	color: var(--tla-color-text-2);
+	word-break: break-all;
+}
+
 .adminContent {
 	flex: 1;
 	padding: 24px 32px;

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -9,6 +9,7 @@ import {
 import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { fetch } from 'tldraw'
+import { sentryReleaseName } from '../../sentry-release-name'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { useTldrawCurrentUser } from '../tla/hooks/useUser'
 import { saveMigrationLog } from './migrationLogsDB'
@@ -166,6 +167,12 @@ export function Component() {
 		<div className={styles.adminContainer}>
 			<header className={styles.adminHeader}>
 				<h1 className="tla-text_ui__big">Admin Panel</h1>
+				<p className={styles.adminReleaseMeta}>
+					<span className={styles.adminReleaseLabel}>Release:</span>{' '}
+					<code className={styles.adminReleaseValue} translate="no">
+						{sentryReleaseName}
+					</code>
+				</p>
 			</header>
 
 			<main className={styles.adminContent}>


### PR DESCRIPTION
In order to let tldraw teammates see which dotcom SPA build they are on (the same string Sentry uses for releases), this PR shows that value under the admin panel title.

### Change type

- [x] `improvement`

### Test plan

1. Sign in as a tldraw user and open the admin panel.
2. Confirm a **Release:** line appears under “Admin Panel” with `local` in development, or the `production-<sha>` style string after a production deploy.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +0 / -0    |
| Tests           | +0 / -0    |
| Automated files | +0 / -0    |
| Documentation   | +0 / -0    |
| Apps            | +27 / -0   |
| Templates       | +0 / -0    |
| Config/tooling  | +0 / -0    |

Made with [Cursor](https://cursor.com)