### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -303,3 +303,4 @@ New helpers `getOwnerDocument()` and `getOwnerWindow()` are exported from `@tldr
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))
 - Fix opacity slider drag not working on Safari due to `stopPropagation` blocking pointer events. ([#8519](https://github.com/tldraw/tldraw/pull/8519))
 - Fix sticky notes preserving stale attribution when cloned via a nib. ([#8614](https://github.com/tldraw/tldraw/pull/8614))
+- Fix Cmd+V paste of "Copy as PNG" content silently failing in Chrome 147 by falling back to `image/png` when the unsanitized custom-format blob comes back empty. ([#8615](https://github.com/tldraw/tldraw/pull/8615))


### PR DESCRIPTION
In order to keep the next release notes current with PRs on production since v4.5.10, this PR adds one new entry to the Bug fixes section: the Chrome 147 Cmd+V clipboard regression workaround (#8615). No stale entries needed pruning, no archival was needed, and no other SDK-relevant PRs landed since the previous update.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -0    |