### PR TITLE
chore(dotcom): tighten zero replication-manager keepalive interval to 5s

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -12,7 +12,7 @@ min_machines_running = 1
 
 [[http_service.checks]]
 grace_period = "30s"
-interval = "15s"
+interval = "5s"
 method = "GET"
 timeout = "5s"
 path = "/keepalive"


### PR DESCRIPTION
In order to reduce the chance of the Zero replication-manager self-terminating after brief Fly/Consul probe gaps, this PR drops the `/keepalive` healthcheck interval from 15s to 5s — matching Rocicorp's own Cloud Zero setup.

Background: the `change-streamer-http-server` inside the RM has an internal watchdog that SIGTERMs the process if it hasn't received a `/keepalive` probe for >20s. With a 15s probe interval + 5s timeout, a single missed probe cycle is enough to cross the 20s threshold. We hit this twice in 24h on `production-zero-rm` (2026-04-24 14:25 UTC and 2026-04-25 13:58 UTC). With 5s interval, ~4 consecutive probes need to be missed to trip the watchdog, giving meaningful headroom for transient Consul prober hiccups.

Only the RM template is changed. The view-syncer template uses a different probe (`/` at 30s) and has no internal watchdog.

### Change type

- [x] `other`

### Test plan

1. Deploy to staging, confirm zero-rm machine stays up under normal load
2. Watch for unrequested restarts in production over the next 24-48h

### Release notes

- internal only, no user-facing change