### PR TITLE
fix(dotcom): remove unsafe v10 delete-class migration from sync-worker

### DIFF
--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -46,10 +46,6 @@ deleted_classes = ["TLAppDurableObject"]
 tag = "v9"
 new_sqlite_classes = ["TLFileDurableObject"]
 
-[[migrations]]
-tag = "v10"
-deleted_classes = ["TLDrawDurableObject"]
-
 [[analytics_engine_datasets]]
 binding = "MEASURE"
 


### PR DESCRIPTION
## Summary

The `Deploy dotcom to preview` job has been failing for any PR labeled `dotcom-preview-please` that creates a fresh preview worker. Cloudflare rejects the deploy with:

> Cannot apply delete-class migration to class 'TLDrawDurableObject' which was not exported in the previous version of the script [code: 10074]

Example failure: PR #8633, run https://github.com/tldraw/tldraw/actions/runs/24942126057/job/73037486083.

### Root cause

- #7346 removed `TLDrawDurableObject` from the worker's top-level exports.
- #7347 added migration `v10` to `apps/dotcom/sync-worker/wrangler.toml` to delete the class from existing workers.
- For an existing worker (staging/production) that previously exported the class, `v10` is fine. But a fresh preview worker (e.g. `pr-8633-tldraw-multiplayer`) has no prior version that exported `TLDrawDurableObject`, so Cloudflare's API rejects the migration and the deploy fails.
- #7834 hit the same class of issue in the multiplayer template and resolved it by removing the `deleted_classes` migration entry.

### Fix

Drop the `v10` `[[migrations]]` block from `apps/dotcom/sync-worker/wrangler.toml`. Wrangler migration tags are append-only, so existing migrations are left untouched. The empty `export class TLDrawDurableObject {}` stub in `worker.ts` (added in #8124) continues to satisfy the `v1` `new_classes` migration on existing workers.

## FAQ

**Doesn't this defeat the purpose of the v10 migration?**

No — v10's job was already done on the workers where it mattered. The deploy of #7347 to main on 2026-04-23 succeeded, and four subsequent main deploys have also succeeded, which means Cloudflare ran v10 against staging and production and deleted the `TLDrawDurableObject` storage there. Migration history is tracked server-side per worker: once a tag has been applied, future deploys that don't list it in `wrangler.toml` are fine — Cloudflare doesn't re-run it or roll it back.

**Is it safe to remove a migration tag from `wrangler.toml`?**

Removing a tag that has *already been applied to every live worker* is safe — Cloudflare's per-worker migration ledger keeps the result. What's not safe is reordering, renumbering, or rewriting tags that were previously published; tags are append-only and identified by their `tag` string. We're not doing either of those.

**What happens on fresh preview workers without v10?**

They keep `v1`'s `new_classes = ["TLDrawDurableObject"]` entry, so they carry the no-op `class TLDrawDurableObject {}` stub from #8124 in their migration ledger. No data is ever stored there (the class is empty), so there's nothing to clean up. This is the same trade-off #7834 made in the multiplayer template — its PR description says: *"The old class stays around unused."*

**Could we keep the cleanup intent for fresh workers too?**

Yes, but it's a follow-up, not part of this fix. Options include applying the migration only to environments that need it (e.g. via a separate overlay toml, or via the wrangler CLI as a one-off against staging/prod), so fresh workers never see it. Out of scope for unblocking preview deploys today.

**Where do I go for more information?**

- Cloudflare error code reference (10074 — "Cannot apply delete-class migration"): https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/
- Wrangler migrations docs (append-only tag semantics, `new_classes`, `deleted_classes`): https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
- Prior precedent in this repo: #7834 (multiplayer template), #8124 (no-op stub).
- Failing run that motivated this PR: https://github.com/tldraw/tldraw/actions/runs/24942126057/job/73037486083

## Test plan

- [ ] Add the `dotcom-preview-please` label so `Deploy dotcom to preview` runs against this PR
- [ ] Confirm the preview worker deploys successfully (no `code: 10074` error)
- [ ] `yarn typecheck` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)