### PR TITLE
perf(editor): reduce canvas render work

### DIFF
--- a/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
+++ b/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
@@ -1,27 +1,66 @@
-import { useQuickReactor } from '@tldraw/state-react'
-import { memo, useRef } from 'react'
+import { EffectScheduler, computed } from '@tldraw/state'
+import { memo, useEffect, useMemo, useRef } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import { Group2d } from '../../primitives/geometry/Group2d'
 import { debugFlags } from '../../utils/debug-flags'
+
+interface RenderInputs {
+	dpr: number
+	w: number
+	h: number
+	cx: number
+	cy: number
+	zoom: number
+}
 
 /** @internal @react */
 export const CanvasOverlays = memo(function CanvasOverlays() {
 	const editor = useEditor()
 	const canvasRef = useRef<HTMLCanvasElement>(null)
 
-	useQuickReactor(
-		'canvas overlays render',
-		() => {
+	// Bundle the primitive scalars the renderer needs into one computed so the
+	// effect only refires on actual visual change. Reading the whole instance
+	// state directly would otherwise wake the renderer on every cursor move,
+	// brush update, etc.
+	const renderInputs$ = useMemo(
+		() =>
+			computed<RenderInputs>(
+				'canvas overlays render inputs',
+				() => {
+					const instance = editor.getInstanceState()
+					const camera = editor.getCamera()
+					return {
+						dpr: instance.devicePixelRatio,
+						w: instance.screenBounds.w,
+						h: instance.screenBounds.h,
+						cx: camera.x,
+						cy: camera.y,
+						zoom: camera.z,
+					}
+				},
+				{
+					isEqual: (a, b) =>
+						a.dpr === b.dpr &&
+						a.w === b.w &&
+						a.h === b.h &&
+						a.cx === b.cx &&
+						a.cy === b.cy &&
+						a.zoom === b.zoom,
+				}
+			),
+		[editor]
+	)
+
+	useEffect(() => {
+		const scheduler = new EffectScheduler('canvas overlays render', () => {
 			const canvas = canvasRef.current
 			if (!canvas) return
 
 			const ctx = canvas.getContext('2d')
 			if (!ctx) return
 
-			const { w, h } = editor.getViewportScreenBounds()
-			const dpr = editor.getInstanceState().devicePixelRatio
-			const { x: cx, y: cy, z: zoom } = editor.getCamera()
+			const { dpr, w, h, cx, cy, zoom } = renderInputs$.get()
 
 			const canvasWidth = Math.ceil(w * dpr)
 			const canvasHeight = Math.ceil(h * dpr)
@@ -33,13 +72,12 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 				canvas.style.height = `${h}px`
 			}
 
-			ctx.resetTransform()
+			ctx.setTransform(1, 0, 0, 1, 0, 0)
 			ctx.clearRect(0, 0, canvas.width, canvas.height)
 
-			// Apply DPR scaling and camera transform to get into page space
-			ctx.scale(dpr, dpr)
-			ctx.scale(zoom, zoom)
-			ctx.translate(cx, cy)
+			// One setTransform = DPR scale * zoom scale * camera translate, into page space.
+			const s = dpr * zoom
+			ctx.setTransform(s, 0, 0, s, s * cx, s * cy)
 
 			// Render all active overlay utils in zIndex order (low to high).
 			for (const { util, overlays } of editor.overlays.getActiveOverlayEntries()) {
@@ -135,9 +173,12 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 				}
 				ctx.restore()
 			}
-		},
-		[editor]
-	)
+		})
+
+		scheduler.attach()
+		scheduler.execute()
+		return () => scheduler.detach()
+	}, [editor, renderInputs$])
 
 	return <canvas ref={canvasRef} className="tl-canvas-overlays" />
 })
@@ -145,7 +186,12 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 function drawGeometryStroke(ctx: CanvasRenderingContext2D, geometry: Geometry2d) {
 	if (geometry instanceof Group2d) {
 		const prevStroke = ctx.strokeStyle
-		for (const child of [...geometry.children, ...geometry.ignoredChildren]) {
+		for (const child of geometry.children) {
+			if (child.debugColor) ctx.strokeStyle = child.debugColor
+			drawGeometryStroke(ctx, child)
+			ctx.strokeStyle = prevStroke
+		}
+		for (const child of geometry.ignoredChildren) {
 			if (child.debugColor) ctx.strokeStyle = child.debugColor
 			drawGeometryStroke(ctx, child)
 			ctx.strokeStyle = prevStroke

--- a/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
+++ b/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
@@ -1,5 +1,5 @@
 import { EffectScheduler, computed } from '@tldraw/state'
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import { Group2d } from '../../primitives/geometry/Group2d'
@@ -19,40 +19,37 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 	const editor = useEditor()
 	const canvasRef = useRef<HTMLCanvasElement>(null)
 
-	// Bundle the primitive scalars the renderer needs into one computed so the
-	// effect only refires on actual visual change. Reading the whole instance
-	// state directly would otherwise wake the renderer on every cursor move,
-	// brush update, etc.
-	const renderInputs$ = useMemo(
-		() =>
-			computed<RenderInputs>(
-				'canvas overlays render inputs',
-				() => {
-					const instance = editor.getInstanceState()
-					const camera = editor.getCamera()
-					return {
-						dpr: instance.devicePixelRatio,
-						w: instance.screenBounds.w,
-						h: instance.screenBounds.h,
-						cx: camera.x,
-						cy: camera.y,
-						zoom: camera.z,
-					}
-				},
-				{
-					isEqual: (a, b) =>
-						a.dpr === b.dpr &&
-						a.w === b.w &&
-						a.h === b.h &&
-						a.cx === b.cx &&
-						a.cy === b.cy &&
-						a.zoom === b.zoom,
-				}
-			),
-		[editor]
-	)
-
 	useEffect(() => {
+		// Bundle the primitive scalars the renderer needs into one computed so the
+		// effect only refires on actual visual change. Reading the whole instance
+		// state directly would otherwise wake the renderer on every cursor move,
+		// brush update, etc.
+
+		const renderInputs$ = computed<RenderInputs>(
+			'canvas overlays render inputs',
+			() => {
+				const instance = editor.getInstanceState()
+				const camera = editor.getCamera()
+				return {
+					dpr: instance.devicePixelRatio,
+					w: instance.screenBounds.w,
+					h: instance.screenBounds.h,
+					cx: camera.x,
+					cy: camera.y,
+					zoom: camera.z,
+				}
+			},
+			{
+				isEqual: (a, b) =>
+					a.dpr === b.dpr &&
+					a.w === b.w &&
+					a.h === b.h &&
+					a.cx === b.cx &&
+					a.cy === b.cy &&
+					a.zoom === b.zoom,
+			}
+		)
+
 		const scheduler = new EffectScheduler('canvas overlays render', () => {
 			const canvas = canvasRef.current
 			if (!canvas) return
@@ -178,7 +175,7 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 		scheduler.attach()
 		scheduler.execute()
 		return () => scheduler.detach()
-	}, [editor, renderInputs$])
+	}, [editor])
 
 	return <canvas ref={canvasRef} className="tl-canvas-overlays" />
 })

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -118,6 +118,9 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 		[editor]
 	)
 
+	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
+	const { Grid } = useEditorComponents()
+
 	return (
 		<>
 			<div
@@ -140,11 +143,11 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 						<Background />
 					</div>
 				)}
-				<GridWrapper />
+				{isGridMode && Grid && <GridWrapper />}
 				<div ref={rHtmlLayer} className="tl-html-layer tl-shapes" draggable={false}>
 					<OnTheCanvasWrapper />
 					{SelectionBackground && <SelectionBackgroundWrapper />}
-					{hideShapes ? null : <ShapesLayer />}
+					{hideShapes ? null : <ShapesLayer canvasRef={rCanvas} />}
 				</div>
 				<div className="tl-overlays">
 					<CanvasOverlays />
@@ -183,7 +186,7 @@ function GridWrapper() {
 	return <Grid x={x} y={y} z={z} size={gridSize} />
 }
 
-function ShapesLayer() {
+function ShapesLayer({ canvasRef }: { canvasRef: { readonly current: HTMLDivElement | null } }) {
 	const editor = useEditor()
 	const debugSvg = useValue('debug svg', () => debugFlags.debugSvg.get(), [debugFlags])
 	const renderingShapes = useValue('rendering shapes', () => editor.getRenderingShapes(), [editor])
@@ -201,11 +204,11 @@ function ShapesLayer() {
 				)
 			)}
 			<CullingController />
-			{tlenv.isSafari && <ReflowIfNeeded />}
+			{tlenv.isSafari && <ReflowIfNeeded canvasRef={canvasRef} />}
 		</ShapeCullingProvider>
 	)
 }
-function ReflowIfNeeded() {
+function ReflowIfNeeded({ canvasRef }: { canvasRef: { readonly current: HTMLDivElement | null } }) {
 	const editor = useEditor()
 	const culledShapesRef = useRef<Set<TLShapeId>>(new Set())
 	useQuickReactor(
@@ -215,13 +218,13 @@ function ReflowIfNeeded() {
 			if (culledShapesRef.current === culledShapes) return
 
 			culledShapesRef.current = culledShapes
-			const canvas = editor.getContainerDocument().getElementsByClassName('tl-canvas')
-			if (canvas.length === 0) return
+			const canvas = canvasRef.current
+			if (!canvas) return
 			// This causes a reflow
 			// https://gist.github.com/paulirish/5d52fb081b3570c81e3a
-			const _height = (canvas[0] as HTMLDivElement).offsetHeight
+			const _height = canvas.offsetHeight
 		},
-		[editor]
+		[editor, canvasRef]
 	)
 	return null
 }

--- a/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
@@ -1,8 +1,14 @@
+import { computed } from '@tldraw/state'
 import { createComputedCache } from '@tldraw/store'
 import { TLShape, TLShapeId } from '@tldraw/tlschema'
-import { dedupe } from '@tldraw/utils'
 import type { Editor } from '../Editor'
 import { OverlayUtil, TLOverlay } from './OverlayUtil'
+
+interface RelevantInstanceFlags {
+	isChangingStyle: boolean
+	isHoveringCanvas: boolean | null
+	isCoarsePointer: boolean
+}
 
 /** @public */
 export interface TLShapeIndicatorOverlay extends TLOverlay {
@@ -39,6 +45,27 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 	static override type = 'shape_indicator'
 	override options = { zIndex: 50, lineWidth: 1.5, hintedLineWidth: 2.5 }
 
+	// Narrow projection of instance state. Reading the full record would
+	// re-fire getOverlays on every cursor move / brush update; gating on these
+	// three booleans means we only re-fire when one of them actually flips.
+	private _instanceFlags$ = computed<RelevantInstanceFlags>(
+		'shape indicator instance flags',
+		() => {
+			const i = this.editor.getInstanceState()
+			return {
+				isChangingStyle: i.isChangingStyle,
+				isHoveringCanvas: i.isHoveringCanvas,
+				isCoarsePointer: i.isCoarsePointer,
+			}
+		},
+		{
+			isEqual: (a, b) =>
+				a.isChangingStyle === b.isChangingStyle &&
+				a.isHoveringCanvas === b.isHoveringCanvas &&
+				a.isCoarsePointer === b.isCoarsePointer,
+		}
+	)
+
 	override isActive(): boolean {
 		return true
 	}
@@ -49,8 +76,7 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 
 		// Local selected / hovered indicators.
 		const idsToDisplay: TLShapeId[] = []
-		const instanceState = editor.getInstanceState()
-		const isChangingStyle = instanceState.isChangingStyle
+		const { isChangingStyle, isHoveringCanvas, isCoarsePointer } = this._instanceFlags$.get()
 		const isIdleOrEditing = editor.isInAny('select.idle', 'select.editing_shape')
 		const isInSelectState = editor.isInAny(
 			'select.brushing',
@@ -64,7 +90,7 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 			for (const id of editor.getSelectedShapeIds()) {
 				if (renderingShapeIds.has(id)) idsToDisplay.push(id)
 			}
-			if (isIdleOrEditing && instanceState.isHoveringCanvas && !instanceState.isCoarsePointer) {
+			if (isIdleOrEditing && isHoveringCanvas && !isCoarsePointer) {
 				const hovered = editor.getHoveredShapeId()
 				if (hovered && renderingShapeIds.has(hovered) && !idsToDisplay.includes(hovered)) {
 					idsToDisplay.push(hovered)
@@ -72,10 +98,12 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 			}
 		}
 
-		// Hinted shapes (drawn thicker). Deduped so repeated entries don't overdraw.
-		const hintingShapeIds = dedupe(editor.getHintingShapeIds()).filter((id) =>
-			renderingShapeIds.has(id)
-		)
+		// Hinted shapes (drawn thicker). Already deduped at write time in
+		// `updateHintingShapeIds`, so no need to dedupe again here.
+		const hintingShapeIds: TLShapeId[] = []
+		for (const id of editor.getHintingShapeIds()) {
+			if (renderingShapeIds.has(id)) hintingShapeIds.push(id)
+		}
 
 		// Remote collaborator indicators (only currently-visible peers).
 		const collaboratorIndicators: TLShapeIndicatorOverlay['props']['collaboratorIndicators'] = []

--- a/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
@@ -21,7 +21,7 @@ const indicatorPathCache = createComputedCache(
 	},
 	{
 		areRecordsEqual(a, b) {
-			return a.props !== b.props
+			return a.props === b.props
 		},
 	}
 )

--- a/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
@@ -18,6 +18,11 @@ const indicatorPathCache = createComputedCache(
 	(editor: Editor, shape: TLShape) => {
 		const util = editor.getShapeUtil(shape)
 		return util.getIndicatorPath(shape)
+	},
+	{
+		areRecordsEqual(a, b) {
+			return a.props !== b.props
+		},
 	}
 )
 

--- a/packages/editor/src/lib/hooks/useShapeCulling.tsx
+++ b/packages/editor/src/lib/hooks/useShapeCulling.tsx
@@ -62,12 +62,11 @@ export function ShapeCullingProvider({ children }: ShapeCullingProviderProps) {
 
 	const updateCulling = useCallback((culledShapes: Set<TLShapeId>) => {
 		let shouldBeCulled: boolean
-		let display = 'none'
 
 		for (const [id, entry] of containersRef.current) {
 			shouldBeCulled = culledShapes.has(id)
 			if (shouldBeCulled !== entry.isCulled) {
-				display = shouldBeCulled ? 'none' : 'block'
+				const display = shouldBeCulled ? 'none' : 'block'
 				setStyleProperty(entry.container, 'display', display)
 				setStyleProperty(entry.bgContainer, 'display', display)
 				entry.isCulled = shouldBeCulled

--- a/packages/editor/src/lib/hooks/useShapeCulling.tsx
+++ b/packages/editor/src/lib/hooks/useShapeCulling.tsx
@@ -61,10 +61,13 @@ export function ShapeCullingProvider({ children }: ShapeCullingProviderProps) {
 	}, [])
 
 	const updateCulling = useCallback((culledShapes: Set<TLShapeId>) => {
+		let shouldBeCulled: boolean
+		let display = 'none'
+
 		for (const [id, entry] of containersRef.current) {
-			const shouldBeCulled = culledShapes.has(id)
+			shouldBeCulled = culledShapes.has(id)
 			if (shouldBeCulled !== entry.isCulled) {
-				const display = shouldBeCulled ? 'none' : 'block'
+				display = shouldBeCulled ? 'none' : 'block'
 				setStyleProperty(entry.container, 'display', display)
 				setStyleProperty(entry.bgContainer, 'display', display)
 				entry.isCulled = shouldBeCulled


### PR DESCRIPTION
In order to reduce wasted reactivity and DOM work in the canvas render path, this PR narrows the inputs the overlay renderer subscribes to, skips the grid wrapper entirely while grid mode is off, scopes the Safari reflow read to the local canvas ref, and trims a few small allocations in the culling and indicator code paths.

- `CanvasOverlays` now reads a narrow `RenderInputs` computed (dpr, screen w/h, camera x/y/zoom) so the overlay redraw only fires on actual visual change instead of on every instance-state update (cursor moves, brush, etc.). The 2d context is also reset and rescaled in a single `setTransform` call.
- `GridWrapper` is no longer mounted while `isGridMode` is off, so it stops subscribing to camera/grid changes that have no visible effect.
- `ReflowIfNeeded` now reads `offsetHeight` from the local canvas ref instead of `getContainerDocument().getElementsByClassName('tl-canvas')`.
- `ShapeIndicatorOverlayUtil` uses a narrow `_instanceFlags$` projection of instance state (`isChangingStyle` / `isHoveringCanvas` / `isCoarsePointer`) and skips a redundant `dedupe` of hinting shape ids since they are already deduped at write time. The indicator path cache also gets an `areRecordsEqual` check so identical-prop shape updates don't bust it.
- `updateCulling` hoists per-iteration variable declarations out of the loop.

### Change type

- [x] `improvement`

### Test plan

- yarn lint (packages/editor)
- yarn typecheck

### Release notes

- Reduce canvas render work for smoother interactions, especially on large documents.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +118 / -36 |