### PR TITLE
perf(editor): avoid canvas state rerenders

### DIFF
--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -45,6 +45,24 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 	useGestureEvents(rCanvas)
 	useFixSafariDoubleTapZoomPencilEvents(rCanvas)
 
+	useQuickReactor(
+		'update canvas state data attributes',
+		() => {
+			const canvas = rCanvas.current
+			if (!canvas) return
+
+			canvas.setAttribute(
+				'data-iseditinganything',
+				editor.getEditingShapeId() === null ? 'false' : 'true'
+			)
+			canvas.setAttribute(
+				'data-isselectinganything',
+				editor.getSelectedShapeIds().length === 0 ? 'false' : 'true'
+			)
+		},
+		[editor]
+	)
+
 	const rMemoizedStuff = useRef({ lodDisableTextOutline: false, allowTextOutline: true })
 
 	useQuickReactor(
@@ -107,16 +125,6 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 	)
 
 	const hideShapes = useValue('debug_shapes', () => debugFlags.hideShapes.get(), [debugFlags])
-	const isEditingAnything = useValue(
-		'isEditingAnything',
-		() => editor.getEditingShapeId() !== null,
-		[editor]
-	)
-	const isSelectingAnything = useValue(
-		'isSelectingAnything',
-		() => !!editor.getSelectedShapeIds().length,
-		[editor]
-	)
 
 	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	const { Grid } = useEditorComponents()
@@ -126,8 +134,6 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 			<div
 				ref={rCanvas}
 				draggable={false}
-				data-iseditinganything={isEditingAnything}
-				data-isselectinganything={isSelectingAnything}
 				className={classNames('tl-canvas', className)}
 				data-testid="canvas"
 				{...events}
@@ -178,10 +184,9 @@ function GridWrapper() {
 	const editor = useEditor()
 	const gridSize = useValue('gridSize', () => editor.getDocumentSettings().gridSize, [editor])
 	const { x, y, z } = useValue('camera', () => editor.getCamera(), [editor])
-	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	const { Grid } = useEditorComponents()
 
-	if (!(Grid && isGridMode)) return null
+	if (!Grid) return null
 
 	return <Grid x={x} y={y} z={z} size={gridSize} />
 }


### PR DESCRIPTION
In order to avoid re-rendering the entire canvas whenever the editing or selection state changes, this PR updates the `data-iseditinganything` and `data-isselectinganything` attributes on the canvas element from a signal reactor instead of from React render state. It also removes the redundant `isGridMode` subscription inside `GridWrapper`, which was already gated by the parent.

### Change type

- [x] `improvement`

### Test plan

1. Open the editor and inspect the `.tl-canvas` element
2. Enter and exit text editing — `data-iseditinganything` should toggle without triggering a canvas re-render
3. Select and deselect shapes — `data-isselectinganything` should toggle without triggering a canvas re-render
4. Toggle grid mode — the grid should still appear and disappear correctly

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +19 / -14  |
| Config/tooling | +11 / -11  |