### PR TITLE
refactor(editor): add CollaboratorsManager; split collaborator indicators

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -534,6 +534,15 @@ export class ClickManager {
 // @public
 export function clockwiseAngleDist(a0: number, a1: number): number;
 
+// @public
+export class CollaboratorsManager {
+    constructor(editor: Editor);
+    getCollaborators(): TLInstancePresence[];
+    getCollaboratorsOnCurrentPage(): TLInstancePresence[];
+    getVisibleCollaborators(): TLInstancePresence[];
+    getVisibleCollaboratorsOnCurrentPage(): TLInstancePresence[];
+}
+
 // @public (undocumented)
 export function ContainerProvider({ container, children }: ContainerProviderProps): JSX.Element;
 
@@ -911,8 +920,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     clearHistory(): this;
     // @internal
     protected _clickManager: ClickManager;
-    // @internal (undocumented)
-    readonly _collaboratorVisibilityClock: Atom<number, unknown>;
+    readonly collaborators: CollaboratorsManager;
     complete(): this;
     // (undocumented)
     readonly contextId: string;
@@ -3261,6 +3269,9 @@ export const stopEventPropagation: (e: any) => any;
 // @internal (undocumented)
 export type StoreName = (typeof Table)[keyof typeof Table];
 
+// @public
+export function strokeShapeIndicators(editor: Editor, ctx: CanvasRenderingContext2D, shapeIds: TLShapeId[]): void;
+
 // @public (undocumented)
 export function suffixSafeId(id: SafeId, suffix: string): SafeId;
 
@@ -4600,10 +4611,6 @@ export type TLShapeErrorFallbackComponent = ComponentType<{
 export interface TLShapeIndicatorOverlay extends TLOverlay {
     // (undocumented)
     props: {
-        collaboratorIndicators: Array<{
-            color: string;
-            shapeIds: TLShapeId[];
-        }>;
         hintingShapeIds: TLShapeId[];
         idsToDisplay: TLShapeId[];
     };

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -136,6 +136,7 @@ export {
 export { DEFAULT_THEME } from './lib/editor/managers/ThemeManager/defaultThemes'
 export { ThemeManager, resolveThemes } from './lib/editor/managers/ThemeManager/ThemeManager'
 export { TickManager } from './lib/editor/managers/TickManager/TickManager'
+export { CollaboratorsManager } from './lib/editor/managers/CollaboratorsManager/CollaboratorsManager'
 export { PerformanceApiAdapter } from './lib/editor/managers/PerformanceManager/PerformanceApiAdapter'
 export { PerformanceManager } from './lib/editor/managers/PerformanceManager/PerformanceManager'
 export {
@@ -182,6 +183,7 @@ export {
 } from './lib/editor/overlays/OverlayUtil'
 export {
 	ShapeIndicatorOverlayUtil,
+	strokeShapeIndicators,
 	type TLShapeIndicatorOverlay,
 } from './lib/editor/overlays/ShapeIndicatorOverlayUtil'
 export {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -89,7 +89,6 @@ import {
 	hasOwnProperty,
 	last,
 	lerp,
-	maxBy,
 	minBy,
 	sortById,
 	sortByIndex,
@@ -132,10 +131,6 @@ import { PI, approximately, areAnglesCompatible, clamp, pointInPolygon } from '.
 import { Vec, VecLike } from '../primitives/Vec'
 import { areShapesContentEqual } from '../utils/areShapesContentEqual'
 import { dataUrlToFile } from '../utils/assets'
-import {
-	getCollaboratorStateFromElapsedTime,
-	shouldShowCollaborator,
-} from '../utils/collaboratorState'
 import { debugFlags } from '../utils/debug-flags'
 import {
 	TLDeepLink,
@@ -156,6 +151,7 @@ import { notVisibleShapes } from './derivations/notVisibleShapes'
 import { parentsToChildren } from './derivations/parentsToChildren'
 import { deriveShapeIdsInCurrentPage } from './derivations/shapeIdsInCurrentPage'
 import { ClickManager } from './managers/ClickManager/ClickManager'
+import { CollaboratorsManager } from './managers/CollaboratorsManager/CollaboratorsManager'
 import { EdgeScrollManager } from './managers/EdgeScrollManager/EdgeScrollManager'
 import { FocusManager } from './managers/FocusManager/FocusManager'
 import { FontManager } from './managers/FontManager/FontManager'
@@ -422,9 +418,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.inputs = new InputsManager(this)
 		this.performance = new PerformanceManager(this)
 		this.disposables.add(() => this.performance.dispose())
-		this.timers.setInterval(() => {
-			this._collaboratorVisibilityClock.set(Date.now())
-		}, this.options.collaboratorCheckIntervalMs)
+		this.collaborators = new CollaboratorsManager(this)
 
 		class NewRoot extends RootState {
 			static override initial = initialState ?? ''
@@ -1057,8 +1051,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	readonly timers = tltime.forContext(this.contextId)
 
-	/** @internal */
-	readonly _collaboratorVisibilityClock = atom('collaboratorVisibilityClock', Date.now())
+	/**
+	 * A manager for remote peer collaborators connected to this editor.
+	 *
+	 * @public
+	 */
+	readonly collaborators: CollaboratorsManager
 
 	/**
 	 * A manager for the user and their preferences.
@@ -1946,11 +1944,23 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Set the cursor.
 	 *
+	 * No-op when the partial wouldn't change the current cursor — `setCursor`
+	 * is called from pointer-move hot paths (see `updateHoveredOverlayId`,
+	 * various tool states) and skipping redundant writes avoids needlessly
+	 * dirtying instance state.
+	 *
 	 * @param cursor - The cursor to set.
 	 * @public
 	 */
 	setCursor(cursor: Partial<TLCursor>) {
-		this.updateInstanceState({ cursor: { ...this.getInstanceState().cursor, ...cursor } })
+		const current = this.getInstanceState().cursor
+		if (
+			(cursor.type === undefined || cursor.type === current.type) &&
+			(cursor.rotation === undefined || cursor.rotation === current.rotation)
+		) {
+			return this
+		}
+		this.updateInstanceState({ cursor: { ...current, ...cursor } })
 		return this
 	}
 
@@ -4256,43 +4266,28 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 	// Collaborators
 
-	@computed
-	private _getCollaboratorsQuery() {
-		return this.store.query.records('instance_presence', () => ({
-			userId: { neq: this.user.getId() },
-		}))
-	}
-
 	/**
 	 * Returns a list of presence records for all peer collaborators.
 	 * This will return the latest presence record for each connected user.
 	 *
+	 * Convenience wrapper for {@link CollaboratorsManager.getCollaborators}.
+	 *
 	 * @public
 	 */
-	@computed
 	getCollaborators() {
-		const allPresenceRecords = this._getCollaboratorsQuery().get()
-		if (!allPresenceRecords.length) return EMPTY_ARRAY
-		const userIds = [...new Set(allPresenceRecords.map((c) => c.userId))].sort()
-		return userIds.map((id) => {
-			const latestPresence = maxBy(
-				allPresenceRecords.filter((c) => c.userId === id),
-				(p) => p.lastActivityTimestamp ?? 0
-			)
-			return latestPresence!
-		})
+		return this.collaborators.getCollaborators()
 	}
 
 	/**
 	 * Returns a list of presence records for all peer collaborators on the current page.
 	 * This will return the latest presence record for each connected user.
 	 *
+	 * Convenience wrapper for {@link CollaboratorsManager.getCollaboratorsOnCurrentPage}.
+	 *
 	 * @public
 	 */
-	@computed
 	getCollaboratorsOnCurrentPage() {
-		const currentPageId = this.getCurrentPageId()
-		return this.getCollaborators().filter((c) => c.currentPageId === currentPageId)
+		return this.collaborators.getCollaboratorsOnCurrentPage()
 	}
 
 	/**
@@ -4302,29 +4297,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * users. Re-evaluates on the collaborator visibility clock, so callers don't need to
 	 * drive their own activity timer.
 	 *
+	 * Convenience wrapper for {@link CollaboratorsManager.getVisibleCollaborators}.
+	 *
 	 * @public
 	 */
-	@computed
 	getVisibleCollaborators() {
-		this._collaboratorVisibilityClock.get()
-		const now = Date.now()
-		return this.getCollaborators().filter((presence) => {
-			const elapsed = Math.max(0, now - (presence.lastActivityTimestamp ?? Infinity))
-			const state = getCollaboratorStateFromElapsedTime(this, elapsed)
-			return shouldShowCollaborator(this, presence, state)
-		})
+		return this.collaborators.getVisibleCollaborators()
 	}
 
 	/**
 	 * Returns a list of presence records for peer collaborators who should currently be
 	 * shown in the UI, filtered to those on the current page.
 	 *
+	 * Convenience wrapper for {@link CollaboratorsManager.getVisibleCollaboratorsOnCurrentPage}.
+	 *
 	 * @public
 	 */
-	@computed
 	getVisibleCollaboratorsOnCurrentPage() {
-		const currentPageId = this.getCurrentPageId()
-		return this.getVisibleCollaborators().filter((c) => c.currentPageId === currentPageId)
+		return this.collaborators.getVisibleCollaboratorsOnCurrentPage()
 	}
 
 	// Attribution

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -1,0 +1,96 @@
+import { EMPTY_ARRAY, atom, computed } from '@tldraw/state'
+import { TLInstancePresence } from '@tldraw/tlschema'
+import { maxBy } from '@tldraw/utils'
+import {
+	getCollaboratorStateFromElapsedTime,
+	shouldShowCollaborator,
+} from '../../../utils/collaboratorState'
+import type { Editor } from '../../Editor'
+
+/**
+ * Tracks remote peers and exposes the collaborator-related queries used by the
+ * editor and its overlays. Encapsulates the visibility clock that periodically
+ * re-evaluates which collaborators should be visible based on activity.
+ *
+ * Accessed via {@link Editor.collaborators}.
+ *
+ * @public
+ */
+export class CollaboratorsManager {
+	constructor(private readonly editor: Editor) {
+		// Editor disposes `editor.timers` on its own teardown, so the interval is
+		// automatically cleared when the editor is disposed.
+		editor.timers.setInterval(() => {
+			this._visibilityClock.set(Date.now())
+		}, editor.options.collaboratorCheckIntervalMs)
+	}
+
+	/**
+	 * Drives reactive re-evaluation of {@link CollaboratorsManager.getVisibleCollaborators}.
+	 * Ticked on a fixed interval so callers don't need to manage their own activity timers.
+	 */
+	private readonly _visibilityClock = atom('collaboratorVisibilityClock', Date.now())
+
+	@computed
+	private _getCollaboratorsQuery() {
+		return this.editor.store.query.records('instance_presence', () => ({
+			userId: { neq: this.editor.user.getId() },
+		}))
+	}
+
+	/**
+	 * Returns a list of presence records for all peer collaborators.
+	 * This will return the latest presence record for each connected user.
+	 */
+	@computed
+	getCollaborators(): TLInstancePresence[] {
+		const allPresenceRecords = this._getCollaboratorsQuery().get()
+		if (!allPresenceRecords.length) return EMPTY_ARRAY
+		const userIds = [...new Set(allPresenceRecords.map((c) => c.userId))].sort()
+		return userIds.map((id) => {
+			const latestPresence = maxBy(
+				allPresenceRecords.filter((c) => c.userId === id),
+				(p) => p.lastActivityTimestamp ?? 0
+			)
+			return latestPresence!
+		})
+	}
+
+	/**
+	 * Returns a list of presence records for all peer collaborators on the current page.
+	 * This will return the latest presence record for each connected user.
+	 */
+	@computed
+	getCollaboratorsOnCurrentPage(): TLInstancePresence[] {
+		const currentPageId = this.editor.getCurrentPageId()
+		return this.getCollaborators().filter((c) => c.currentPageId === currentPageId)
+	}
+
+	/**
+	 * Returns a list of presence records for peer collaborators who should currently be
+	 * shown in the UI. Filters {@link CollaboratorsManager.getCollaborators} by activity
+	 * state (active / idle / inactive) and visibility rules such as following and
+	 * highlighted users. Re-evaluates on the visibility clock, so callers don't need to
+	 * drive their own activity timer.
+	 */
+	@computed
+	getVisibleCollaborators(): TLInstancePresence[] {
+		this._visibilityClock.get()
+		const now = Date.now()
+		return this.getCollaborators().filter((presence) => {
+			const elapsed = Math.max(0, now - (presence.lastActivityTimestamp ?? Infinity))
+			const state = getCollaboratorStateFromElapsedTime(this.editor, elapsed)
+			return shouldShowCollaborator(this.editor, presence, state)
+		})
+	}
+
+	/**
+	 * Returns a list of presence records for peer collaborators who should currently be
+	 * shown in the UI, filtered to those on the current page.
+	 */
+	@computed
+	getVisibleCollaboratorsOnCurrentPage(): TLInstancePresence[] {
+		const currentPageId = this.editor.getCurrentPageId()
+		return this.getVisibleCollaborators().filter((c) => c.currentPageId === currentPageId)
+	}
+}

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -78,7 +78,9 @@ export class CollaboratorsManager {
 		this._visibilityClock.get()
 		const now = Date.now()
 		return this.getCollaborators().filter((presence) => {
-			const elapsed = Math.max(0, now - (presence.lastActivityTimestamp ?? Infinity))
+			// Treat a missing `lastActivityTimestamp` as "active right now" (elapsed = 0)
+			// so newly-joined peers aren't immediately classified as idle/inactive.
+			const elapsed = Math.max(0, now - (presence.lastActivityTimestamp ?? now))
 			const state = getCollaboratorStateFromElapsedTime(this.editor, elapsed)
 			return shouldShowCollaborator(this.editor, presence, state)
 		})

--- a/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/editor/src/lib/editor/overlays/ShapeIndicatorOverlayUtil.ts
@@ -9,7 +9,6 @@ export interface TLShapeIndicatorOverlay extends TLOverlay {
 	props: {
 		idsToDisplay: TLShapeId[]
 		hintingShapeIds: TLShapeId[]
-		collaboratorIndicators: Array<{ color: string; shapeIds: TLShapeId[] }>
 	}
 }
 
@@ -22,9 +21,83 @@ const indicatorPathCache = createComputedCache(
 )
 
 /**
+ * Combine every batchable shape indicator into a single page-space `Path2D` and
+ * emit one stroke call. Shapes whose indicator needs an evenodd clip (e.g.
+ * arrows with labels or complex arrowheads) can't be batched — they still
+ * stroke individually inside a save/restore with `ctx.clip` applied.
+ *
+ * Shared by {@link ShapeIndicatorOverlayUtil} and any overlay util that paints
+ * shape indicators (e.g. collaborator selections).
+ *
+ * @public
+ */
+export function strokeShapeIndicators(
+	editor: Editor,
+	ctx: CanvasRenderingContext2D,
+	shapeIds: TLShapeId[]
+): void {
+	if (shapeIds.length === 0) return
+
+	const batched = new Path2D()
+
+	for (const shapeId of shapeIds) {
+		const shape = editor.getShape(shapeId)
+		if (!shape || shape.isLocked) continue
+
+		const pageTransform = editor.getShapePageTransform(shape)
+		if (!pageTransform) continue
+
+		const indicatorPath = indicatorPathCache.get(editor, shape.id)
+		if (!indicatorPath) continue
+
+		if (indicatorPath instanceof Path2D) {
+			batched.addPath(indicatorPath, pageTransform)
+			continue
+		}
+
+		const { path, clipPath, additionalPaths } = indicatorPath
+
+		if (!clipPath) {
+			batched.addPath(path, pageTransform)
+			if (additionalPaths) {
+				for (const p of additionalPaths) batched.addPath(p, pageTransform)
+			}
+			continue
+		}
+
+		// Clipped case: fall back to an individual stroke. Rare (arrows with
+		// labels / complex arrowheads), so the extra save/restore/stroke
+		// pair per such shape isn't worth batching away.
+		ctx.save()
+		ctx.transform(
+			pageTransform.a,
+			pageTransform.b,
+			pageTransform.c,
+			pageTransform.d,
+			pageTransform.e,
+			pageTransform.f
+		)
+		ctx.save()
+		ctx.clip(clipPath, 'evenodd')
+		ctx.stroke(path)
+		ctx.restore()
+		if (additionalPaths) {
+			for (const p of additionalPaths) ctx.stroke(p)
+		}
+		ctx.restore()
+	}
+
+	ctx.stroke(batched)
+}
+
+/**
  * Overlay util for shape indicators — the selection / hover / hint outlines drawn
  * under the selection foreground. Paints local indicators in the theme's
- * selection color and remote collaborator indicators in each peer's color.
+ * selection color.
+ *
+ * Remote collaborator selection indicators are drawn by a separate overlay util
+ * (e.g. `CollaboratorShapeIndicatorOverlayUtil` from `tldraw`) that runs at a
+ * lower z-index so peer selections appear under the local indicators.
  *
  * Non-interactive: contributes no hit-test geometry.
  *
@@ -72,22 +145,7 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 			renderingShapeIds.has(id)
 		)
 
-		// Remote collaborator indicators (only currently-visible peers).
-		const collaboratorIndicators: TLShapeIndicatorOverlay['props']['collaboratorIndicators'] = []
-		for (const presence of editor.getVisibleCollaboratorsOnCurrentPage()) {
-			const visibleShapeIds = presence.selectedShapeIds.filter(
-				(id) => renderingShapeIds.has(id) && !editor.isShapeHidden(id)
-			)
-			if (visibleShapeIds.length === 0) continue
-
-			collaboratorIndicators.push({ color: presence.color, shapeIds: visibleShapeIds })
-		}
-
-		if (
-			idsToDisplay.length === 0 &&
-			hintingShapeIds.length === 0 &&
-			collaboratorIndicators.length === 0
-		) {
+		if (idsToDisplay.length === 0 && hintingShapeIds.length === 0) {
 			return []
 		}
 
@@ -95,7 +153,7 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 			{
 				id: 'shape_indicator',
 				type: 'shape_indicator',
-				props: { idsToDisplay, hintingShapeIds, collaboratorIndicators },
+				props: { idsToDisplay, hintingShapeIds },
 			},
 		]
 	}
@@ -106,92 +164,20 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 
 		const editor = this.editor
 		const zoom = editor.getZoomLevel()
-		const { idsToDisplay, hintingShapeIds, collaboratorIndicators } = overlay.props
+		const { idsToDisplay, hintingShapeIds } = overlay.props
 
 		ctx.lineCap = 'round'
 		ctx.lineJoin = 'round'
 
-		// Remote collaborator indicators — under local indicators, slightly transparent.
-		// One stroke call per collaborator (per unique color).
-		ctx.lineWidth = this.options.lineWidth / zoom
-		ctx.globalAlpha = 0.7
-		for (const collaborator of collaboratorIndicators) {
-			ctx.strokeStyle = collaborator.color
-			this._strokeIndicatorBatch(ctx, collaborator.shapeIds)
-		}
-		ctx.globalAlpha = 1.0
-
 		// Local selected / hovered indicators — one stroke call for the whole batch.
 		ctx.strokeStyle = editor.getCurrentTheme().colors[editor.getColorMode()].selectionStroke
 		ctx.lineWidth = this.options.lineWidth / zoom
-		this._strokeIndicatorBatch(ctx, idsToDisplay)
+		strokeShapeIndicators(editor, ctx, idsToDisplay)
 
 		// Hinted shapes — thicker stroke, one call for the whole batch.
 		if (hintingShapeIds.length > 0) {
 			ctx.lineWidth = this.options.hintedLineWidth / zoom
-			this._strokeIndicatorBatch(ctx, hintingShapeIds)
+			strokeShapeIndicators(editor, ctx, hintingShapeIds)
 		}
-	}
-
-	// Combine every batchable shape indicator into a single page-space Path2D
-	// and emit one stroke call. Shapes whose indicator needs an evenodd clip
-	// (e.g. arrows with labels or complex arrowheads) can't be batched — they
-	// still stroke individually inside a save/restore with ctx.clip applied.
-	private _strokeIndicatorBatch(ctx: CanvasRenderingContext2D, shapeIds: TLShapeId[]): void {
-		if (shapeIds.length === 0) return
-
-		const editor = this.editor
-		const batched = new Path2D()
-
-		for (const shapeId of shapeIds) {
-			const shape = editor.getShape(shapeId)
-			if (!shape || shape.isLocked) continue
-
-			const pageTransform = editor.getShapePageTransform(shape)
-			if (!pageTransform) continue
-
-			const indicatorPath = indicatorPathCache.get(editor, shape.id)
-			if (!indicatorPath) continue
-
-			if (indicatorPath instanceof Path2D) {
-				batched.addPath(indicatorPath, pageTransform)
-				continue
-			}
-
-			const { path, clipPath, additionalPaths } = indicatorPath
-
-			if (!clipPath) {
-				// No clip: the main path and any additional paths can all join
-				// the batch directly.
-				batched.addPath(path, pageTransform)
-				if (additionalPaths) {
-					for (const p of additionalPaths) batched.addPath(p, pageTransform)
-				}
-				continue
-			}
-
-			// Clipped case: fall back to an individual stroke. Rare (arrows with
-			// labels / complex arrowheads), so the extra save/restore/stroke
-			// pair per such shape isn't worth batching away.
-			ctx.save()
-			ctx.transform(
-				pageTransform.a,
-				pageTransform.b,
-				pageTransform.c,
-				pageTransform.d,
-				pageTransform.e,
-				pageTransform.f
-			)
-			ctx.save()
-			ctx.clip(clipPath, 'evenodd')
-			ctx.stroke(path)
-			ctx.restore()
-			if (additionalPaths) {
-				for (const p of additionalPaths) ctx.stroke(p)
-			}
-			ctx.restore()
-		}
-
-		ctx.stroke(batched)
 	}
 }

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -751,6 +751,24 @@ export class CollaboratorScribbleOverlayUtil extends OverlayUtil<TLCollaboratorS
     static type: string;
 }
 
+// @public
+export class CollaboratorShapeIndicatorOverlayUtil extends OverlayUtil<TLCollaboratorShapeIndicatorOverlay> {
+    // (undocumented)
+    getOverlays(): TLCollaboratorShapeIndicatorOverlay[];
+    // (undocumented)
+    isActive(): boolean;
+    // (undocumented)
+    options: {
+        alpha: number;
+        lineWidth: number;
+        zIndex: number;
+    };
+    // (undocumented)
+    render(ctx: CanvasRenderingContext2D, overlays: TLCollaboratorShapeIndicatorOverlay[]): void;
+    // (undocumented)
+    static type: string;
+}
+
 // @public (undocumented)
 export function ColorSchemeMenu(): JSX.Element;
 
@@ -1236,7 +1254,7 @@ export function DefaultMinimap(): JSX.Element;
 export const DefaultNavigationPanel: NamedExoticComponent<object>;
 
 // @public (undocumented)
-export const defaultOverlayUtils: readonly [typeof ShapeIndicatorOverlayUtil, typeof SelectionForegroundOverlayUtil, typeof ShapeHandleOverlayUtil, typeof BrushOverlayUtil, typeof ZoomBrushOverlayUtil, typeof SnapIndicatorOverlayUtil, typeof ScribbleOverlayUtil, typeof CollaboratorBrushOverlayUtil, typeof CollaboratorScribbleOverlayUtil, typeof CollaboratorHintOverlayUtil, typeof ArrowHintOverlayUtil, typeof ArrowBindingHintOverlayUtil, typeof CollaboratorCursorOverlayUtil];
+export const defaultOverlayUtils: readonly [typeof CollaboratorShapeIndicatorOverlayUtil, typeof ShapeIndicatorOverlayUtil, typeof SelectionForegroundOverlayUtil, typeof ShapeHandleOverlayUtil, typeof BrushOverlayUtil, typeof ZoomBrushOverlayUtil, typeof SnapIndicatorOverlayUtil, typeof ScribbleOverlayUtil, typeof CollaboratorBrushOverlayUtil, typeof CollaboratorScribbleOverlayUtil, typeof CollaboratorHintOverlayUtil, typeof ArrowHintOverlayUtil, typeof ArrowBindingHintOverlayUtil, typeof CollaboratorCursorOverlayUtil];
 
 // @public (undocumented)
 export const DefaultPageMenu: NamedExoticComponent<object>;
@@ -3870,6 +3888,17 @@ export interface TLCollaboratorScribbleOverlay extends TLOverlay {
     props: {
         color: string;
         scribble: TLScribble;
+    };
+}
+
+// @public (undocumented)
+export interface TLCollaboratorShapeIndicatorOverlay extends TLOverlay {
+    // (undocumented)
+    props: {
+        indicators: Array<{
+            color: string;
+            shapeIds: TLShapeId[];
+        }>;
     };
 }
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -84,6 +84,10 @@ export {
 	type TLCollaboratorCursorOverlay,
 } from './lib/overlays/CollaboratorCursorOverlayUtil'
 export {
+	CollaboratorShapeIndicatorOverlayUtil,
+	type TLCollaboratorShapeIndicatorOverlay,
+} from './lib/overlays/CollaboratorShapeIndicatorOverlayUtil'
+export {
 	ShapeHandleOverlayUtil,
 	type TLShapeHandleOverlay,
 } from './lib/overlays/ShapeHandleOverlayUtil'

--- a/packages/tldraw/src/lib/defaultOverlayUtils.ts
+++ b/packages/tldraw/src/lib/defaultOverlayUtils.ts
@@ -6,6 +6,7 @@ import { CollaboratorBrushOverlayUtil } from './overlays/CollaboratorBrushOverla
 import { CollaboratorCursorOverlayUtil } from './overlays/CollaboratorCursorOverlayUtil'
 import { CollaboratorHintOverlayUtil } from './overlays/CollaboratorHintOverlayUtil'
 import { CollaboratorScribbleOverlayUtil } from './overlays/CollaboratorScribbleOverlayUtil'
+import { CollaboratorShapeIndicatorOverlayUtil } from './overlays/CollaboratorShapeIndicatorOverlayUtil'
 import { ScribbleOverlayUtil } from './overlays/ScribbleOverlayUtil'
 import { SelectionForegroundOverlayUtil } from './overlays/SelectionForegroundOverlayUtil'
 import { ShapeHandleOverlayUtil } from './overlays/ShapeHandleOverlayUtil'
@@ -14,6 +15,7 @@ import { ZoomBrushOverlayUtil } from './overlays/ZoomBrushOverlayUtil'
 
 /** @public */
 export const defaultOverlayUtils = [
+	CollaboratorShapeIndicatorOverlayUtil,
 	ShapeIndicatorOverlayUtil,
 	SelectionForegroundOverlayUtil,
 	ShapeHandleOverlayUtil,

--- a/packages/tldraw/src/lib/overlays/CollaboratorShapeIndicatorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorShapeIndicatorOverlayUtil.ts
@@ -1,0 +1,78 @@
+import { OverlayUtil, strokeShapeIndicators, TLOverlay, TLShapeId } from '@tldraw/editor'
+
+/** @public */
+export interface TLCollaboratorShapeIndicatorOverlay extends TLOverlay {
+	props: {
+		// Pre-flattened list of (color, shapeId) pairs so that overlay equality
+		// is shallow and a single render pass can iterate them in order.
+		indicators: Array<{ color: string; shapeIds: TLShapeId[] }>
+	}
+}
+
+/**
+ * Overlay util for remote collaborators' shape selection indicators.
+ *
+ * Renders a per-peer outline around each shape another user has selected,
+ * using the peer's color. Drawn under the local `ShapeIndicatorOverlayUtil`
+ * (lower z-index) so the local user's selection always appears on top.
+ *
+ * Non-interactive: contributes no hit-test geometry.
+ *
+ * @public
+ */
+export class CollaboratorShapeIndicatorOverlayUtil extends OverlayUtil<TLCollaboratorShapeIndicatorOverlay> {
+	static override type = 'collaborator_shape_indicator'
+	override options = { zIndex: 49, lineWidth: 1.5, alpha: 0.7 }
+
+	override isActive(): boolean {
+		return this.editor.getVisibleCollaboratorsOnCurrentPage().length > 0
+	}
+
+	override getOverlays(): TLCollaboratorShapeIndicatorOverlay[] {
+		const editor = this.editor
+		const renderingShapeIds = new Set(editor.getRenderingShapes().map((s) => s.id))
+
+		const indicators: TLCollaboratorShapeIndicatorOverlay['props']['indicators'] = []
+		for (const presence of editor.getVisibleCollaboratorsOnCurrentPage()) {
+			const visibleShapeIds = presence.selectedShapeIds.filter(
+				(id) => renderingShapeIds.has(id) && !editor.isShapeHidden(id)
+			)
+			if (visibleShapeIds.length === 0) continue
+			indicators.push({ color: presence.color, shapeIds: visibleShapeIds })
+		}
+
+		if (indicators.length === 0) return []
+
+		return [
+			{
+				id: 'collaborator_shape_indicator',
+				type: 'collaborator_shape_indicator',
+				props: { indicators },
+			},
+		]
+	}
+
+	override render(
+		ctx: CanvasRenderingContext2D,
+		overlays: TLCollaboratorShapeIndicatorOverlay[]
+	): void {
+		const overlay = overlays[0]
+		if (!overlay) return
+
+		const editor = this.editor
+		const zoom = editor.getZoomLevel()
+
+		ctx.lineCap = 'round'
+		ctx.lineJoin = 'round'
+		ctx.lineWidth = this.options.lineWidth / zoom
+		ctx.globalAlpha = this.options.alpha
+
+		// One stroke call per peer (per unique color).
+		for (const { color, shapeIds } of overlay.props.indicators) {
+			ctx.strokeStyle = color
+			strokeShapeIndicators(editor, ctx, shapeIds)
+		}
+
+		ctx.globalAlpha = 1
+	}
+}

--- a/packages/tldraw/src/lib/overlays/CollaboratorShapeIndicatorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorShapeIndicatorOverlayUtil.ts
@@ -3,8 +3,8 @@ import { OverlayUtil, strokeShapeIndicators, TLOverlay, TLShapeId } from '@tldra
 /** @public */
 export interface TLCollaboratorShapeIndicatorOverlay extends TLOverlay {
 	props: {
-		// Pre-flattened list of (color, shapeId) pairs so that overlay equality
-		// is shallow and a single render pass can iterate them in order.
+		// One entry per peer, batching the shape IDs they have selected so the
+		// renderer can issue a single stroke call per color.
 		indicators: Array<{ color: string; shapeIds: TLShapeId[] }>
 	}
 }


### PR DESCRIPTION
In order to clean up a few rough edges from the OverlayUtil system landed in #8633, this PR (a) encapsulates collaborator state in a new manager, (b) gets remote-collaborator rendering out of the local-indicator overlay util, and (c) makes `setCursor` cheap to call from pointer-move hot paths.

### Concepts

| Term | Type | Meaning |
| ---- | ---- | ------- |
| `CollaboratorsManager` | class | Lives on `editor.collaborators`; owns the visibility clock and exposes `getCollaborators*` queries |
| `CollaboratorShapeIndicatorOverlayUtil` | class | tldraw-package overlay util that draws remote collaborators' selection indicators (split out of `ShapeIndicatorOverlayUtil`) |
| `strokeShapeIndicators` | function | Shared canvas helper exported from `@tldraw/editor`, used by both local and collaborator indicator overlays |

### What changed

**`CollaboratorsManager`.** The visibility clock atom and the collaborator-presence queries used to live directly on `Editor`. They now live on a small dedicated manager, in the same style as `ClickManager` / `EdgeScrollManager` / `FocusManager` etc. The previously `@internal` `Editor._collaboratorVisibilityClock` is now a private field on the manager. The four `Editor.getCollaborators*()` methods stay as thin convenience wrappers that delegate to `editor.collaborators.*` so existing callers don't break.

**Collaborator indicators split out.** `ShapeIndicatorOverlayUtil` (in `@tldraw/editor`) used to also render remote collaborators' selected shapes via a third `collaboratorIndicators` prop on its overlay. That mixed two concerns: a generic editor-package util shouldn't know about presence records. Remote-indicator rendering is now its own `CollaboratorShapeIndicatorOverlayUtil` in `@tldraw/tldraw`, registered ahead of the local indicator util in `defaultOverlayUtils` and given a lower `zIndex` so local selection always paints on top. To avoid duplicating the canvas drawing code, the stroke logic was extracted into a public `strokeShapeIndicators(editor, ctx, shapeIds)` helper.

**`setCursor` equality guard.** `updateHoveredOverlayId` (and various tool states) call `editor.setCursor(...)` from pointer-move handlers. Without a guard, every pointer move builds a fresh cursor object, enters a history batch, spreads instance state, and walks the validator before the store deduplicates the no-op write. The guard short-circuits when the requested `type`/`rotation` already match `instanceState.cursor`, skipping all of that on the hot path. The store-level `validateUsingKnownGoodVersion` dedup is still the source of truth — this is purely a perf shortcut.

### Editor API

| Method / property | Description |
| ----------------- | ----------- |
| `editor.collaborators` | The `CollaboratorsManager` instance |
| `editor.collaborators.getCollaborators()` / `getCollaboratorsOnCurrentPage()` / `getVisibleCollaborators()` / `getVisibleCollaboratorsOnCurrentPage()` | Same shape as the existing `Editor.getCollaborators*()` methods (which now delegate here) |
| `strokeShapeIndicators(editor, ctx, shapeIds)` | Strokes the indicator path for each shape into the given 2D context. Uses the current stroke style — set color/`lineWidth`/`globalAlpha` on the context first |
| `CollaboratorShapeIndicatorOverlayUtil` | New default overlay util in `@tldraw/tldraw`. Subclass to customize remote-indicator rendering independently of local selection |

### Change type

- [x] `api`

### Test plan

1. Run `yarn dev` and confirm local selection / hover / hint indicators still render identically to before.
2. Open a multiplayer room (e.g. `yarn dev-app`); remote collaborators' selections should render below your own selection if you both select the same shape.
3. Move the pointer continuously over and off overlays — cursor should still update correctly, with no visible regression in responsiveness.
4. Confirm `editor.collaborators.getVisibleCollaborators()` and `editor.getVisibleCollaborators()` return identical results.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add `editor.collaborators` (`CollaboratorsManager`) owning the collaborator visibility clock and presence queries. `Editor.getCollaborators()` / `getCollaboratorsOnCurrentPage()` / `getVisibleCollaborators()` / `getVisibleCollaboratorsOnCurrentPage()` are unchanged and now delegate to it.
- Add `CollaboratorShapeIndicatorOverlayUtil` in `@tldraw/tldraw` for remote-collaborator selection indicators (split out of `ShapeIndicatorOverlayUtil`); add `strokeShapeIndicators` helper from `@tldraw/editor` for sharing indicator rendering between overlay utils.
- `Editor.setCursor` now skips redundant writes when the requested cursor type and rotation already match the current cursor.

### API changes

- Added `CollaboratorsManager` and `Editor.collaborators`.
- Added `strokeShapeIndicators(editor, ctx, shapeIds)`.
- Added `CollaboratorShapeIndicatorOverlayUtil` and `TLCollaboratorShapeIndicatorOverlay` to `@tldraw/tldraw`; added it to `defaultOverlayUtils` (registered before `ShapeIndicatorOverlayUtil`).
- Removed the `@internal` `Editor._collaboratorVisibilityClock` atom (now private to `CollaboratorsManager`).
- Removed the `collaboratorIndicators` prop from `TLShapeIndicatorOverlay`; remote-collaborator rendering moved to `CollaboratorShapeIndicatorOverlayUtil`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +295 / -137 |
| Automated files | +43 / -7   |

Relates to #8633.

Made with [Cursor](https://cursor.com)